### PR TITLE
[FINAL] Fix Error Edge Case

### DIFF
--- a/purchases/src/main/java/com/revenuecat/purchases/BillingWrapper.java
+++ b/purchases/src/main/java/com/revenuecat/purchases/BillingWrapper.java
@@ -182,12 +182,12 @@ public class BillingWrapper implements PurchasesUpdatedListener, BillingClientSt
 
     @Override
     public void onPurchasesUpdated(int responseCode, @Nullable List<Purchase> purchases) {
-        if (responseCode == BillingClient.BillingResponse.OK) {
-            if (purchases == null) {
-                purchases = new ArrayList<>();
-            }
+        if (responseCode == BillingClient.BillingResponse.OK && purchases != null) {
             purchasesUpdatedListener.onPurchasesUpdated(purchases);
         } else {
+            if (purchases == null && responseCode == BillingClient.BillingResponse.OK) {
+                responseCode = BillingClient.BillingResponse.ERROR;
+            }
             purchasesUpdatedListener.onPurchasesFailedToUpdate(responseCode, "Error updating purchases " + responseCode);
         }
     }

--- a/purchases/src/main/java/com/revenuecat/purchases/BillingWrapper.java
+++ b/purchases/src/main/java/com/revenuecat/purchases/BillingWrapper.java
@@ -182,7 +182,10 @@ public class BillingWrapper implements PurchasesUpdatedListener, BillingClientSt
 
     @Override
     public void onPurchasesUpdated(int responseCode, @Nullable List<Purchase> purchases) {
-        if (responseCode == BillingClient.BillingResponse.OK && purchases != null) {
+        if (responseCode == BillingClient.BillingResponse.OK) {
+            if (purchases == null) {
+                purchases = new ArrayList<>();
+            }
             purchasesUpdatedListener.onPurchasesUpdated(purchases);
         } else {
             purchasesUpdatedListener.onPurchasesFailedToUpdate(responseCode, "Error updating purchases " + responseCode);

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.java
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.java
@@ -283,6 +283,16 @@ public class BillingWrapperTest {
     }
 
     @Test
+    public void purchasesUpdatedCallsAreForwardedWithEmptyIfOkNull() {
+        List<Purchase> purchases = null;
+        List<Purchase> emptyList = new ArrayList<>();
+
+        purchasesUpdatedListener.onPurchasesUpdated(BillingClient.BillingResponse.OK, purchases);
+
+        verify(mockPurchasesListener).onPurchasesUpdated(emptyList);
+    }
+
+    @Test
     public void purchaseUpdateFailedCalledIfNotOK() {
         purchasesUpdatedListener.onPurchasesUpdated(BillingClient.BillingResponse.FEATURE_NOT_SUPPORTED, null);
 

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.java
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.java
@@ -284,12 +284,10 @@ public class BillingWrapperTest {
 
     @Test
     public void purchasesUpdatedCallsAreForwardedWithEmptyIfOkNull() {
-        List<Purchase> purchases = null;
-        List<Purchase> emptyList = new ArrayList<>();
 
-        purchasesUpdatedListener.onPurchasesUpdated(BillingClient.BillingResponse.OK, purchases);
+        purchasesUpdatedListener.onPurchasesUpdated(BillingClient.BillingResponse.OK, null);
 
-        verify(mockPurchasesListener).onPurchasesUpdated(emptyList);
+        verify(mockPurchasesListener).onPurchasesFailedToUpdate(eq(BillingClient.BillingResponse.ERROR), any(String.class));
     }
 
     @Test


### PR DESCRIPTION
In some cases, the `BillingClient` will respond with an OK but have a null purchases object. This creates an odd situation where we can error with code OK.

This detects that case and switches the code to ERROR.