### PR TITLE
[FINAL] Unsubscribe From Lifecycle Methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 29 10:10:47 PDT 2018
+#Mon Oct 08 16:45:10 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/purchases/src/main/java/com/revenuecat/purchases/Purchases.java
+++ b/purchases/src/main/java/com/revenuecat/purchases/Purchases.java
@@ -337,6 +337,10 @@ public final class Purchases implements BillingWrapper.PurchasesUpdatedListener,
 
         cachesLastChecked = new Date();
 
+        // We do this here to ensure we've always sent all tokens since there is no finish concept
+        // on Android.
+        restorePurchasesForPlayStoreAccount();
+
         backend.getSubscriberInfo(appUserID, new Backend.BackendResponseHandler() {
             @Override
             public void onReceivePurchaserInfo(PurchaserInfo info) {
@@ -422,7 +426,6 @@ public final class Purchases implements BillingWrapper.PurchasesUpdatedListener,
     @Override
     public void onActivityResumed(Activity activity) {
         getCaches();
-        restorePurchasesForPlayStoreAccount();
     }
 
     @Override

--- a/purchases/src/main/java/com/revenuecat/purchases/Purchases.java
+++ b/purchases/src/main/java/com/revenuecat/purchases/Purchases.java
@@ -113,7 +113,7 @@ public final class Purchases implements BillingWrapper.PurchasesUpdatedListener,
         this.deviceCache = deviceCache;
 
         application.registerActivityLifecycleCallbacks(this);
-        
+
         emitCachedPurchaserInfo();
         getCaches();
     }

--- a/purchases/src/main/java/com/revenuecat/purchases/Purchases.java
+++ b/purchases/src/main/java/com/revenuecat/purchases/Purchases.java
@@ -118,6 +118,7 @@ public final class Purchases implements BillingWrapper.PurchasesUpdatedListener,
 
         emitCachedPurchaserInfo();
         getCaches();
+        restorePurchasesForPlayStoreAccount();
     }
 
     /**
@@ -336,10 +337,6 @@ public final class Purchases implements BillingWrapper.PurchasesUpdatedListener,
         }
 
         cachesLastChecked = new Date();
-
-        // We do this here to ensure we've always sent all tokens since there is no finish concept
-        // on Android.
-        restorePurchasesForPlayStoreAccount();
 
         backend.getSubscriberInfo(appUserID, new Backend.BackendResponseHandler() {
             @Override

--- a/purchases/src/main/java/com/revenuecat/purchases/Purchases.java
+++ b/purchases/src/main/java/com/revenuecat/purchases/Purchases.java
@@ -38,6 +38,7 @@ public final class Purchases implements BillingWrapper.PurchasesUpdatedListener,
 
     private final String appUserID;
     private final DeviceCache deviceCache;
+    private final Application application;
     private Boolean usingAnonymousID = false;
     private final PurchasesListener listener;
     private final Backend backend;
@@ -112,7 +113,8 @@ public final class Purchases implements BillingWrapper.PurchasesUpdatedListener,
         this.billingWrapper = billingWrapperFactory.buildWrapper(this);
         this.deviceCache = deviceCache;
 
-        application.registerActivityLifecycleCallbacks(this);
+        this.application = application;
+        this.application.registerActivityLifecycleCallbacks(this);
 
         emitCachedPurchaserInfo();
         getCaches();
@@ -323,6 +325,7 @@ public final class Purchases implements BillingWrapper.PurchasesUpdatedListener,
     public void close() {
         this.billingWrapper.close();
         this.backend.close();
+        this.application.unregisterActivityLifecycleCallbacks(this);
     }
 
     /// Private Methods

--- a/purchases/src/main/java/com/revenuecat/purchases/Purchases.java
+++ b/purchases/src/main/java/com/revenuecat/purchases/Purchases.java
@@ -113,7 +113,7 @@ public final class Purchases implements BillingWrapper.PurchasesUpdatedListener,
         this.deviceCache = deviceCache;
 
         application.registerActivityLifecycleCallbacks(this);
-
+        
         emitCachedPurchaserInfo();
         getCaches();
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.java
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.java
@@ -254,6 +254,13 @@ public class PurchasesTest {
     }
 
     @Test
+    public void closingUnregistersLifecycleListener() {
+        setup();
+
+        verify(mockApplication).unregisterActivityLifecycleCallbacks(any(Application.ActivityLifecycleCallbacks.class));
+    }
+
+    @Test
     public void onResumeGetsSubscriberInfo() {
         setup();
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.java
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.java
@@ -257,6 +257,8 @@ public class PurchasesTest {
     public void closingUnregistersLifecycleListener() {
         setup();
 
+        purchases.close();
+
         verify(mockApplication).unregisterActivityLifecycleCallbacks(any(Application.ActivityLifecycleCallbacks.class));
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.java
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.java
@@ -404,7 +404,7 @@ public class PurchasesTest {
 
         purchases.restorePurchasesForPlayStoreAccount();
 
-        verify(mockBillingWrapper).queryPurchaseHistoryAsync(eq(BillingClient.SkuType.SUBS),
+        verify(mockBillingWrapper, times(2)).queryPurchaseHistoryAsync(eq(BillingClient.SkuType.SUBS),
                 any(BillingWrapper.PurchaseHistoryResponseListener.class));
 
         verify(mockBillingWrapper).queryPurchaseHistoryAsync(eq(BillingClient.SkuType.INAPP),
@@ -521,7 +521,7 @@ public class PurchasesTest {
 
         purchases.restorePurchasesForPlayStoreAccount();
 
-        verify(mockBillingWrapper, times(2)).queryPurchaseHistoryAsync(
+        verify(mockBillingWrapper, times(3)).queryPurchaseHistoryAsync(
                 any(String.class),
                 any(BillingWrapper.PurchaseHistoryResponseListener.class));
         verify(listener, times(1)).onRestoreTransactions(any(PurchaserInfo.class));


### PR DESCRIPTION
When closing an `RCPurchases` object, close everything out.