### PR TITLE
Makes skuDetails empty when Google sends a null list when calling querySkuDetailsAsync

### DIFF
--- a/purchases/src/main/java/com/revenuecat/purchases/BillingWrapper.java
+++ b/purchases/src/main/java/com/revenuecat/purchases/BillingWrapper.java
@@ -69,11 +69,11 @@ public class BillingWrapper implements PurchasesUpdatedListener, BillingClientSt
             if (billingClient == null) {
                 billingClient = clientFactory.buildClient(this);
             }
-            Log.d("Purchases", "startConnection");
+            Log.d("Purchases", "starting connection for " + billingClient.toString());
             billingClient.startConnection(this);
         } else {
             if (billingClient != null) {
-                Log.d("Purchases", "endConnection");
+                Log.d("Purchases", "ending connection for " + billingClient.toString());
                 billingClient.endConnection();
             }
             billingClient = null;
@@ -95,7 +95,7 @@ public class BillingWrapper implements PurchasesUpdatedListener, BillingClientSt
                 if (billingClient == null) {
                     billingClient = clientFactory.buildClient(this);
                 }
-                Log.d("Purchases", "startConnection");
+                Log.d("Purchases", "starting connection for " + billingClient.toString());
                 billingClient.startConnection(this);
             } else {
                 executePendingRequests();
@@ -207,17 +207,17 @@ public class BillingWrapper implements PurchasesUpdatedListener, BillingClientSt
     @Override
     public void onBillingSetupFinished(int responseCode) {
         if (responseCode == BillingClient.BillingResponse.OK) {
-            Log.d("Purchases", "onBillingServiceConnected");
+            Log.d("Purchases", "Billing Service Setup finished for " + billingClient.toString());
             clientConnected = true;
             executePendingRequests();
         } else {
-            Log.w("Purchases", "onBillingSetupFinished() error code: " + responseCode);
+            Log.w("Purchases", "Billing Service Setup finished with error code: " + responseCode);
         }
     }
 
     @Override
     public void onBillingServiceDisconnected() {
         clientConnected = false;
-        Log.w("Purchases", "onBillingServiceDisconnected");
+        Log.w("Purchases", "Billing Service disconnected for " + billingClient.toString());
     }
 }

--- a/purchases/src/main/java/com/revenuecat/purchases/BillingWrapper.java
+++ b/purchases/src/main/java/com/revenuecat/purchases/BillingWrapper.java
@@ -3,6 +3,7 @@ package com.revenuecat.purchases;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Handler;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 import android.util.Log;
@@ -36,7 +37,7 @@ public class BillingWrapper implements PurchasesUpdatedListener, BillingClientSt
     }
 
     public interface SkuDetailsResponseListener {
-        void onReceiveSkuDetails(List<SkuDetails> skuDetails);
+        void onReceiveSkuDetails(@NonNull List<SkuDetails> skuDetails);
     }
 
     public interface PurchaseHistoryResponseListener {
@@ -110,7 +111,10 @@ public class BillingWrapper implements PurchasesUpdatedListener, BillingClientSt
                         .setType(itemType).setSkusList(skuList).build();
                 billingClient.querySkuDetailsAsync(params, new com.android.billingclient.api.SkuDetailsResponseListener() {
                     @Override
-                    public void onSkuDetailsResponse(int responseCode, List<SkuDetails> skuDetailsList) {
+                    public void onSkuDetailsResponse(int responseCode, @Nullable List<SkuDetails> skuDetailsList) {
+                        if (skuDetailsList == null) {
+                            skuDetailsList = new ArrayList<>();
+                        }
                         listener.onReceiveSkuDetails(skuDetailsList);
                     }
                 });

--- a/purchases/src/main/java/com/revenuecat/purchases/BillingWrapper.java
+++ b/purchases/src/main/java/com/revenuecat/purchases/BillingWrapper.java
@@ -50,7 +50,7 @@ public class BillingWrapper implements PurchasesUpdatedListener, BillingClientSt
         void onPurchasesFailedToUpdate(@BillingClient.BillingResponse int responseCode, String message);
     }
 
-    @Nullable private BillingClient billingClient = null;
+    @Nullable @VisibleForTesting BillingClient billingClient = null;
     final private ClientFactory clientFactory;
     @VisibleForTesting PurchasesUpdatedListener purchasesUpdatedListener;
     final private Handler mainHandler;
@@ -72,8 +72,10 @@ public class BillingWrapper implements PurchasesUpdatedListener, BillingClientSt
             Log.d("Purchases", "startConnection");
             billingClient.startConnection(this);
         } else {
-            Log.d("Purchases", "endConnection");
-            billingClient.endConnection();
+            if (billingClient != null) {
+                Log.d("Purchases", "endConnection");
+                billingClient.endConnection();
+            }
             billingClient = null;
             clientConnected = false;
         }
@@ -90,6 +92,10 @@ public class BillingWrapper implements PurchasesUpdatedListener, BillingClientSt
         if (purchasesUpdatedListener != null) {
             serviceRequests.add(request);
             if (!clientConnected) {
+                if (billingClient == null) {
+                    billingClient = clientFactory.buildClient(this);
+                }
+                Log.d("Purchases", "startConnection");
                 billingClient.startConnection(this);
             } else {
                 executePendingRequests();

--- a/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
@@ -300,11 +300,7 @@ class Purchases @JvmOverloads internal constructor(
         @BillingClient.SkuType skuType: String,
         handler: GetSkusResponseHandler
     ) {
-        billingWrapper.querySkuDetailsAsync(skuType, skus) { skuDetails ->
-            handler.onReceiveSkus(
-                skuDetails
-            )
-        }
+        billingWrapper.querySkuDetailsAsync(skuType, skus, handler::onReceiveSkus)
     }
 
     private fun getCaches() {

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.java
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.java
@@ -382,4 +382,33 @@ public class BillingWrapperTest {
 
         verify(billingClient, never()).startConnection(eq(billingWrapper));
     }
+
+    @Test
+    public void whenSkuDetailsIsNullPassAnEmptyListToTheListener() {
+        setup();
+        mockNullSkuDetailsResponse();
+
+        List<String> productIDs = new ArrayList<>();
+        productIDs.add("product_a");
+
+        wrapper.querySkuDetailsAsync(BillingClient.SkuType.SUBS, productIDs, new BillingWrapper.SkuDetailsResponseListener() {
+            @Override
+            public void onReceiveSkuDetails(List<SkuDetails> skuDetails) {
+                assertThat(skuDetails).isNotNull();
+                assertThat(skuDetails.size()).isEqualTo(0);
+            }
+        });
+    }
+
+    private void mockNullSkuDetailsResponse() {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                SkuDetailsResponseListener listener = invocation.getArgument(1);
+
+                listener.onSkuDetailsResponse(BillingClient.BillingResponse.OK, null);
+                return null;
+            }
+        }).when(mockClient).querySkuDetailsAsync(any(SkuDetailsParams.class), any(SkuDetailsResponseListener.class));
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.java
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.java
@@ -400,6 +400,22 @@ public class BillingWrapperTest {
         });
     }
 
+    @Test
+    public void nullifyBillingClientAfterEndingConnection() {
+        setup();
+        wrapper.setListener(null);
+
+        assertThat(wrapper.billingClient).isNull();
+    }
+
+    @Test
+    public void newBillingClientIsCreatedWhenSettingListener() {
+        setup();
+        wrapper.setListener(mockPurchasesListener);
+
+        assertThat(wrapper.billingClient).isNotNull();
+    }
+
     private void mockNullSkuDetailsResponse() {
         doAnswer(new Answer() {
             @Override


### PR DESCRIPTION
I noticed sometimes skudetails is null and I traced it down to google sending null when calling querySkuDetailsAsync. Since Kotlin crashes hard since skudetails is not marked as ?, I make sure we send an empty list of sku details instead of null.

