### PR TITLE
Removes automatic restore of purchases and makes sure identify and reset force an update of caches

### DIFF
--- a/purchases/src/main/java/com/revenuecat/purchases/DeviceCache.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/DeviceCache.kt
@@ -37,9 +37,7 @@ internal class DeviceCache(
 
     fun cacheAppUserID(appUserID: String?) {
         if (appUserID == null) {
-            preferences.edit()
-                .remove(appUserIDCacheKey)
-                .apply()
+            clearCachedAppUserID()
         } else {
             preferences.edit()
                 .putString(
@@ -47,5 +45,11 @@ internal class DeviceCache(
                     appUserID
                 ).apply()
         }
+    }
+
+    fun clearCachedAppUserID() {
+        preferences.edit()
+            .remove(appUserIDCacheKey)
+            .apply()
     }
 }

--- a/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
@@ -439,7 +439,6 @@ class Purchases @JvmOverloads internal constructor(
             billingWrapper.setListener(this)
             application.registerActivityLifecycleCallbacks(this)
             getCaches()
-            restorePurchasesForPlayStoreAccount()
         } else {
             billingWrapper.setListener(null)
             application.unregisterActivityLifecycleCallbacks(this)

--- a/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
@@ -35,7 +35,7 @@ class Purchases @JvmOverloads internal constructor(
     private val billingWrapper: BillingWrapper,
     private val deviceCache: DeviceCache,
     internal var usingAnonymousID: Boolean = false,
-    private val postedTokens: HashSet<String> = HashSet(),
+    internal val postedTokens: HashSet<String> = HashSet(),
     private var cachesLastChecked: Date? = null,
     private var cachedEntitlements: Map<String, Entitlement>? = null
 ) : BillingWrapper.PurchasesUpdatedListener, Application.ActivityLifecycleCallbacks {

--- a/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
@@ -248,7 +248,7 @@ class Purchases @JvmOverloads internal constructor(
         clearCachedRandomId()
         this.appUserID = appUserID
         postedTokens.clear()
-        forceGetCaches()
+        makeCachesOutdatedAndNotifyIfNeeded()
     }
 
     /**
@@ -258,7 +258,7 @@ class Purchases @JvmOverloads internal constructor(
         this.appUserID = createRandomIDAndCacheIt()
         setIsUsingAnonymousID(true)
         postedTokens.clear()
-        forceGetCaches()
+        makeCachesOutdatedAndNotifyIfNeeded()
     }
 
     /**
@@ -403,7 +403,7 @@ class Purchases @JvmOverloads internal constructor(
     }
 
     private fun clearCachedRandomId() {
-        deviceCache.cacheAppUserID(null)
+        deviceCache.clearCachedAppUserID()
     }
 
     private fun getSkuDetails(entitlements: Map<String, Entitlement>, onCompleted: (HashMap<String, SkuDetails>) -> Unit) {
@@ -447,9 +447,11 @@ class Purchases @JvmOverloads internal constructor(
         }
     }
 
-    private fun forceGetCaches() {
+    private fun makeCachesOutdatedAndNotifyIfNeeded() {
         cachesLastChecked = null
-        getCaches()
+        if (listener != null) {
+            getCaches()
+        }
     }
 
     // endregion

--- a/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
@@ -246,8 +246,9 @@ class Purchases @JvmOverloads internal constructor(
      */
     fun identify(appUserID: String) {
         clearCachedRandomId()
-        postedTokens.clear()
         this.appUserID = appUserID
+        postedTokens.clear()
+        forceGetCaches()
     }
 
     /**
@@ -257,6 +258,7 @@ class Purchases @JvmOverloads internal constructor(
         this.appUserID = createRandomIDAndCacheIt()
         setIsUsingAnonymousID(true)
         postedTokens.clear()
+        forceGetCaches()
     }
 
     /**
@@ -444,6 +446,12 @@ class Purchases @JvmOverloads internal constructor(
             application.unregisterActivityLifecycleCallbacks(this)
         }
     }
+
+    private fun forceGetCaches() {
+        cachesLastChecked = null
+        getCaches()
+    }
+
     // endregion
     // region Overriden methods
     override fun onPurchasesUpdated(purchases: List<@JvmSuppressWildcards Purchase>) {

--- a/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
@@ -246,6 +246,7 @@ class Purchases @JvmOverloads internal constructor(
      */
     fun identify(appUserID: String) {
         clearCachedRandomId()
+        postedTokens.clear()
         this.appUserID = appUserID
     }
 
@@ -255,6 +256,7 @@ class Purchases @JvmOverloads internal constructor(
     fun reset() {
         this.appUserID = createRandomIDAndCacheIt()
         setIsUsingAnonymousID(true)
+        postedTokens.clear()
     }
 
     /**

--- a/purchases/src/test/java/com/revenuecat/purchases/DeviceCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/DeviceCacheTest.kt
@@ -37,10 +37,17 @@ class DeviceCacheTest {
         every {
             mockEditor.putString(any(), any())
         } returns mockEditor
+        every {
+            mockEditor.remove(any())
+        } returns mockEditor
 
         every {
             mockPrefs.edit()
         } returns mockEditor
+
+        every {
+            mockEditor.apply()
+        } just runs
 
         cache = DeviceCache(mockPrefs, apiKey)
     }
@@ -83,10 +90,6 @@ class DeviceCacheTest {
     @Test
     @Throws(JSONException::class)
     fun `given a purchaser info, the information is cached`() {
-        every {
-            mockEditor.apply()
-        } just runs
-
         val jsonObject = JSONObject(validFullPurchaserResponse)
         val info = PurchaserInfo.Factory.build(jsonObject)
 
@@ -123,7 +126,14 @@ class DeviceCacheTest {
         }
     }
 
-
+    @Test
+    fun `clear cache removes cached app user id`() {
+        cache.clearCachedAppUserID()
+        verify {
+            mockEditor.remove(eq(userIDCacheKey))
+            mockEditor.apply()
+        }
+    }
 
     private fun mockString(key: String, value: String?) {
         every {

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -1292,6 +1292,21 @@ class PurchasesTest {
         }
     }
 
+    @Test
+    fun `when reset, posted tokens are cleared`() {
+        setup()
+        purchases!!.reset()
+        assertThat(purchases!!.postedTokens.size).isEqualTo(0)
+    }
+
+
+    @Test
+    fun `when identify, posted tokens are cleared`() {
+        setup()
+        purchases!!.identify("new")
+        assertThat(purchases!!.postedTokens.size).isEqualTo(0)
+    }
+
     private fun verifyIdentifyIsSuccessful(appUserID: String) {
         verify {
             mockCache.cacheAppUserID(null)

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -1217,14 +1217,14 @@ class PurchasesTest {
             "new_id",
             null
         )
-        verifyIdentifyIsSuccessful("new_id")
+        verifyIdentifyIsSuccessful("new_id", 2)
     }
 
     @Test
     fun `when identifying, appUserID is identified`() {
         setup()
         purchases!!.identify("new_id")
-        verifyIdentifyIsSuccessful("new_id")
+        verifyIdentifyIsSuccessful("new_id", 2)
     }
 
     @Test
@@ -1243,7 +1243,7 @@ class PurchasesTest {
     @Test
     fun `when setting up, and passing a appUserID, user is identified`() {
         setup()
-        verifyIdentifyIsSuccessful(appUserId)
+        verifyIdentifyIsSuccessful(appUserId, 1)
     }
 
 
@@ -1307,8 +1307,8 @@ class PurchasesTest {
         assertThat(purchases!!.postedTokens.size).isEqualTo(0)
     }
 
-    private fun verifyIdentifyIsSuccessful(appUserID: String) {
-        verify {
+    private fun verifyIdentifyIsSuccessful(appUserID: String, timesCached: Int) {
+        verify (exactly = timesCached) {
             mockCache.cacheAppUserID(null)
         }
         assertThat(purchases!!.usingAnonymousID).isEqualTo(false)

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -522,7 +522,7 @@ class PurchasesTest {
 
         purchases!!.restorePurchasesForPlayStoreAccount()
 
-        verify(exactly = 2) {
+        verify {
             mockBillingWrapper.queryPurchaseHistoryAsync(
                 eq(BillingClient.SkuType.SUBS),
                 any()
@@ -672,7 +672,7 @@ class PurchasesTest {
 
         purchases!!.restorePurchasesForPlayStoreAccount()
 
-        verify(exactly = 3) {
+        verify(exactly = 2) {
             mockBillingWrapper.queryPurchaseHistoryAsync(any(), any())
         }
 
@@ -1273,9 +1273,9 @@ class PurchasesTest {
     }
 
     @Test
-    fun `when setting listener, purchases are restores`() {
+    fun `when setting listener, purchases are restored`() {
         setup()
-        verify {
+        verify (exactly = 0) {
             mockBillingWrapper.queryPurchaseHistoryAsync(any(), any())
         }
     }


### PR DESCRIPTION
This Pull Request removes the automatic call to `restorePurchasesForPlayStoreAccount()` that gets triggered when setting a listener.

It also makes sure when calling `identify` and `reset` force a reset of the caches, which will eventually trigger a call to PurchaserUpdatedListener if any