### PR TITLE
Renames setIsUsingAnonymousID to allowSharingPlayStoreAccount

### DIFF
--- a/purchases-sample/src/main/java/com/revenuecat/purchases_sample/MainActivity.java
+++ b/purchases-sample/src/main/java/com/revenuecat/purchases_sample/MainActivity.java
@@ -11,7 +11,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.android.billingclient.api.SkuDetails;
 import com.revenuecat.purchases.Entitlement;
@@ -140,7 +139,7 @@ public class MainActivity extends AppCompatActivity implements Purchases.Purchas
     @Override
     public void onFailedPurchase(Purchases.ErrorDomains domain, int code, String reason) {
         Log.i("Purchases", reason);
-        purchases.setIsUsingAnonymousID(true);
+        purchases.setAllowSharingPlayStoreAccount(true);
     }
 
     @Override

--- a/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
@@ -28,13 +28,17 @@ import java.util.concurrent.TimeUnit
 
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 
+/**
+ * If true treats all purchases as restores, aliasing together appUserIDs that share a Play Store account.
+ * @property [allowSharingPlayStoreAccount] If it should allow sharing Play Store accounts. False by default
+ */
 class Purchases @JvmOverloads internal constructor(
     private val application: Application,
     _appUserID: String?,
     private val backend: Backend,
     private val billingWrapper: BillingWrapper,
     private val deviceCache: DeviceCache,
-    internal var usingAnonymousID: Boolean = false,
+    var allowSharingPlayStoreAccount: Boolean = false,
     private val postedTokens: HashSet<String> = HashSet(),
     private var cachesLastChecked: Date? = null,
     private var cachedEntitlements: Map<String, Entitlement>? = null
@@ -61,15 +65,7 @@ class Purchases @JvmOverloads internal constructor(
 
     init {
         this.appUserID = _appUserID?.also { identify(it) } ?:
-                getAnonymousID().also { setIsUsingAnonymousID(true) }
-    }
-
-    /**
-     * If true treats all purchases as restores, aliasing together appUserIDs that share a Play account.
-     * @param [isUsingAnonymousID] If it is using anonymous ID.
-     */
-    fun setIsUsingAnonymousID(isUsingAnonymousID: Boolean) {
-        this.usingAnonymousID = isUsingAnonymousID
+                getAnonymousID().also { allowSharingPlayStoreAccount = true }
     }
 
     /**
@@ -254,7 +250,7 @@ class Purchases @JvmOverloads internal constructor(
      */
     fun reset() {
         this.appUserID = createRandomIDAndCacheIt()
-        setIsUsingAnonymousID(true)
+        allowSharingPlayStoreAccount = true
     }
 
     /**
@@ -446,7 +442,7 @@ class Purchases @JvmOverloads internal constructor(
     // endregion
     // region Overriden methods
     override fun onPurchasesUpdated(purchases: List<@JvmSuppressWildcards Purchase>) {
-        postPurchases(purchases, usingAnonymousID, true)
+        postPurchases(purchases, allowSharingPlayStoreAccount, true)
     }
 
     /**

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -465,7 +465,7 @@ class PurchasesTest {
     }
 
     @Test
-    fun canOverideAnonMode() {
+    fun canOverrideAnonMode() {
         setup()
 
         val purchases = Purchases(
@@ -477,7 +477,7 @@ class PurchasesTest {
         ).also {
             it.listener = listener
         }
-        purchases.setIsUsingAnonymousID(true)
+        purchases.allowSharingPlayStoreAccount = true
 
         val p: Purchase = mockk()
         val sku = "onemonth_freetrial"
@@ -1235,7 +1235,7 @@ class PurchasesTest {
         verify {
             mockCache.cacheAppUserID(capture(randomID))
         }
-        assertThat(purchases!!.usingAnonymousID).isEqualTo(true)
+        assertThat(purchases!!.allowSharingPlayStoreAccount).isEqualTo(true)
         assertThat(purchases!!.appUserID).isEqualTo(randomID.captured)
         assertThat(randomID.captured).isNotNull()
     }
@@ -1296,7 +1296,7 @@ class PurchasesTest {
         verify {
             mockCache.cacheAppUserID(null)
         }
-        assertThat(purchases!!.usingAnonymousID).isEqualTo(false)
+        assertThat(purchases!!.allowSharingPlayStoreAccount).isEqualTo(false)
         assertThat(purchases!!.appUserID).isEqualTo(appUserID)
     }
 }


### PR DESCRIPTION
Name was confusing and non explanatory of what it is actually doing.