### PR TITLE
Renames defaultInstance to sharedInstance

### DIFF
--- a/purchases-sample/src/main/java/com/revenuecat/purchases_sample/MainActivity.java
+++ b/purchases-sample/src/main/java/com/revenuecat/purchases_sample/MainActivity.java
@@ -11,7 +11,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.android.billingclient.api.SkuDetails;
 import com.revenuecat.purchases.Entitlement;
@@ -43,7 +42,7 @@ public class MainActivity extends AppCompatActivity implements Purchases.Purchas
     }
 
     private void buildPurchases() {
-        purchases = Purchases.defaultInstance;
+        purchases = Purchases.getSharedInstance();
         purchases.setListener(this);
         Purchases.getFrameworkVersion();
     }

--- a/purchases-sample/src/main/java/com/revenuecat/purchases_sample/MainApplication.kt
+++ b/purchases-sample/src/main/java/com/revenuecat/purchases_sample/MainApplication.kt
@@ -9,8 +9,8 @@ class MainApplication: Application() {
 
     override fun onCreate() {
         super.onCreate()
-        Purchases.defaultInstance = Purchases.Builder(this, PURCHASES_KEY).build()
-        val instance = Purchases.defaultInstance
+        Purchases.sharedInstance = Purchases.Builder(this, PURCHASES_KEY).build()
+        val instance = Purchases.sharedInstance
     }
 
 }

--- a/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/Purchases.kt
@@ -586,7 +586,7 @@ class Purchases @JvmOverloads internal constructor(
          * Singleton instance of Purchases
          */
         @JvmStatic
-        lateinit var defaultInstance: Purchases
+        var sharedInstance: Purchases? = null
         /**
          * Current version of the Purchases SDK
          */


### PR DESCRIPTION
Since `defaultInstance` doesn't actually creates an instance if there's no instance, I decided to rename it to sharedInstance. Note it's also nullable now.