### PR TITLE
Close sharedinstance if it's already set

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -590,6 +590,10 @@ class Purchases @JvmOverloads internal constructor(
          */
         @JvmStatic
         var sharedInstance: Purchases? = null
+            set(value) {
+                field?.close()
+                field = value
+            }
         /**
          * Current version of the Purchases SDK
          */


### PR DESCRIPTION
To avoid having unclosed instances in memory, I added this `close` call if someone tries to set a shared instance and there is already one set.