### PR TITLE
Fixes threading problem

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/DispatcherTest.java
+++ b/purchases/src/test/java/com/revenuecat/purchases/DispatcherTest.java
@@ -1,7 +1,11 @@
 package com.revenuecat.purchases;
 
+import android.support.test.runner.AndroidJUnit4;
+
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
 
 import java.util.concurrent.ExecutorService;
 
@@ -12,6 +16,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(AndroidJUnit4.class)
+@Config(manifest = Config.NONE)
 public class DispatcherTest {
     private Dispatcher dispatcher;
     private ExecutorService executorService;


### PR DESCRIPTION
onCompletion of the AsyncCall, we were calling the callback in the same background thread as the Runnable. I dispatched the callback call to the main thread as we do in the iOS SDK