### PR TITLE
Makes sure we don't create alias or identify over the same app user id

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/DeviceCache.kt
@@ -53,9 +53,4 @@ internal class DeviceCache(
             ).apply()
     }
 
-    fun clearCachedAppUserID() {
-        preferences.edit()
-            .remove(appUserIDCacheKey)
-            .apply()
-    }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -280,21 +280,25 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      */
     @JvmOverloads
     fun createAlias(
-        newAppUserID: String,
-        listener: ReceivePurchaserInfoListener = receivePurchaserInfoListenerStub
+            newAppUserID: String,
+            listener: ReceivePurchaserInfoListener = receivePurchaserInfoListenerStub
     ) {
-        debugLog("Creating an alias to $appUserID from $newAppUserID")
-        backend.createAlias(
-            appUserID,
-            newAppUserID,
-            {
-                debugLog("Alias created")
-                identify(newAppUserID, listener)
-            },
-            { error ->
-                dispatch { listener.onError(error) }
-            }
-        )
+        if (this.appUserID != newAppUserID) {
+            debugLog("Creating an alias to $appUserID from $newAppUserID")
+            backend.createAlias(
+                    appUserID,
+                    newAppUserID,
+                    {
+                        debugLog("Alias created")
+                        identify(newAppUserID, listener)
+                    },
+                    { error ->
+                        dispatch { listener.onError(error) }
+                    }
+            )
+        } else {
+            dispatch { listener.onSuccess() }
+        }
     }
 
     /**
@@ -305,14 +309,20 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      */
     @JvmOverloads
     fun identify(
-        appUserID: String,
-        listener: ReceivePurchaserInfoListener = receivePurchaserInfoListenerStub
+            appUserID: String,
+            listener: ReceivePurchaserInfoListener = receivePurchaserInfoListenerStub
     ) {
-        debugLog("Changing App User ID: ${this.appUserID} -> $appUserID")
-        clearCaches()
-        this.appUserID = appUserID
-        purchaseCallbacks.clear()
-        updateCaches(listener)
+        if (this.appUserID != appUserID) {
+            debugLog("Changing App User ID: ${this.appUserID} -> $appUserID")
+            clearCaches()
+            this.appUserID = appUserID
+            purchaseCallbacks.clear()
+            updateCaches(listener)
+        } else {
+            if (listener != null) {
+                getCaches()
+            }
+        }
     }
 
     /**

--- a/purchases/src/test/java/com/revenuecat/purchases/DeviceCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/DeviceCacheTest.kt
@@ -134,15 +134,6 @@ class DeviceCacheTest {
         }
     }
 
-    @Test
-    fun `clear cache removes cached app user id`() {
-        cache.clearCachedAppUserID()
-        verify {
-            mockEditor.remove(eq(userIDCacheKey))
-            mockEditor.apply()
-        }
-    }
-
     private fun mockString(key: String, value: String?) {
         every {
             mockPrefs.getString(eq(key), isNull())


### PR DESCRIPTION
Looking at https://docs.revenuecat.com/discuss/5c479f9f9c2c64013f2836a2 

> I've been using the auto generated ID, what's the best way to retroactively add the UID to the account without having them to restore transactions?

The solution is:

>You can use the .createAlias method to attach your User ID to the purchase history of a previous randomly generated App User ID. After you get your account UID you can check to see if it equals the current App User Id for the Purchases instance - if not, call .createAlias.

To make things easier, I added this check in the code so that users that are calling `createAlias` are not triggering useless backend calls.