### PR TITLE
Return Purchase object when making purchase

### DIFF
--- a/purchases/src/main/java/com/revenuecat/purchases/interfaces/MakePurchaseListener.java
+++ b/purchases/src/main/java/com/revenuecat/purchases/interfaces/MakePurchaseListener.java
@@ -5,23 +5,21 @@
 
 package com.revenuecat.purchases.interfaces;
 
+import androidx.annotation.NonNull;
+import com.android.billingclient.api.Purchase;
 import com.revenuecat.purchases.PurchaserInfo;
 import com.revenuecat.purchases.PurchasesError;
 
-import androidx.annotation.NonNull;
-
 /**
  * Interface to be implemented when making purchases.
- *  @deprecated  As of release 2.0.2, replaced by [MakePurchaseListener] to return full Purchase object in the onCompleted function.
  */
-@Deprecated
-public interface PurchaseCompletedListener {
+public interface MakePurchaseListener {
     /**
      * Will be called after the purchase has completed
-     * @param sku Sku for the purchased product.
+     * @param purchase Purchase object for the purchased product.
      * @param purchaserInfo Updated [PurchaserInfo].
      */
-    void onCompleted(@NonNull String sku, @NonNull PurchaserInfo purchaserInfo);
+    void onCompleted(@NonNull Purchase purchase, @NonNull PurchaserInfo purchaserInfo);
 
     /**
      * Will be called after the purchase has completed with error

--- a/purchases/src/main/java/com/revenuecat/purchases/interfaces/PurchaseCompletedListener.java
+++ b/purchases/src/main/java/com/revenuecat/purchases/interfaces/PurchaseCompletedListener.java
@@ -12,7 +12,7 @@ import androidx.annotation.NonNull;
 
 /**
  * Interface to be implemented when making purchases.
- *  @deprecated  As of release 2.0.2, replaced by [MakePurchaseListener] to return full Purchase object in the onCompleted function.
+ *  @deprecated  As of release 2.1.0, replaced by [MakePurchaseListener] to return full Purchase object in the onCompleted function.
  */
 @Deprecated
 public interface PurchaseCompletedListener {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -21,6 +21,7 @@ import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.SkuDetails
 import com.revenuecat.purchases.interfaces.GetSkusResponseListener
+import com.revenuecat.purchases.interfaces.MakePurchaseListener
 import com.revenuecat.purchases.interfaces.PurchaseCompletedListener
 import com.revenuecat.purchases.interfaces.ReceiveEntitlementsListener
 import com.revenuecat.purchases.interfaces.ReceivePurchaserInfoListener
@@ -65,7 +66,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      */
     lateinit var appUserID: String
 
-    private var purchaseCallbacks: MutableMap<String, PurchaseCompletedListener> = mutableMapOf()
+    private var purchaseCallbacks: MutableMap<String, MakePurchaseListener> = mutableMapOf()
     private var lastSentPurchaserInfo: PurchaserInfo? = null
 
     private val receivePurchaserInfoListenerStub = object : ReceivePurchaserInfoListener {
@@ -202,12 +203,39 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * @param [oldSkus] The skus you wish to upgrade from.
      * @param [listener] The listener that will be called when purchase completes.
      */
+    @Deprecated("use makePurchase accepting a MakePurchaseListener instead")
     fun makePurchase(
         activity: Activity,
         sku: String,
         @BillingClient.SkuType skuType: String,
         oldSkus: ArrayList<String>,
         listener: PurchaseCompletedListener
+    ) {
+        makePurchase(activity, sku, skuType, oldSkus, object : MakePurchaseListener {
+            override fun onCompleted(purchase: Purchase, purchaserInfo: PurchaserInfo) {
+                listener.onCompleted(purchase.sku, purchaserInfo)
+            }
+
+            override fun onError(error: PurchasesError) {
+                listener.onError(error)
+            }
+        })
+    }
+
+    /**
+     * Make a purchase.
+     * @param [activity] Current activity
+     * @param [sku] The sku you wish to purchase
+     * @param [skuType] The type of sku, INAPP or SUBS
+     * @param [oldSkus] The skus you wish to upgrade from.
+     * @param [listener] The listener that will be called when purchase completes.
+     */
+    fun makePurchase(
+        activity: Activity,
+        sku: String,
+        @BillingClient.SkuType skuType: String,
+        oldSkus: ArrayList<String>,
+        listener: MakePurchaseListener
     ) {
         debugLog("makePurchase - $sku")
         synchronized(this) {
@@ -235,11 +263,30 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * @param [skuType] The type of sku, INAPP or SUBS
      * @param [listener] The listener that will be called when purchase completes.
      */
+    @Deprecated("use makePurchase accepting a MakePurchaseListener instead",
+        ReplaceWith("makePurchase(activity, sku, skuType, listener)", "import com.revenuecat.purchases.interfaces.MakePurchaseListener")
+    )
     fun makePurchase(
         activity: Activity,
         sku: String,
         @BillingClient.SkuType skuType: String,
         listener: PurchaseCompletedListener
+    ) {
+        makePurchase(activity, sku, skuType, ArrayList(), listener)
+    }
+
+    /**
+     * Make a purchase.
+     * @param [activity] Current activity
+     * @param [sku] The sku you wish to purchase
+     * @param [skuType] The type of sku, INAPP or SUBS
+     * @param [listener] The listener that will be called when purchase completes.
+     */
+    fun makePurchase(
+        activity: Activity,
+        sku: String,
+        @BillingClient.SkuType skuType: String,
+        listener: MakePurchaseListener
     ) {
         makePurchase(activity, sku, skuType, ArrayList(), listener)
     }
@@ -631,7 +678,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
                     { purchase, info ->
                         synchronized(this) {
                             dispatch {
-                                purchaseCallbacks.remove(purchase.sku)?.onCompleted(purchase.sku, info)
+                                purchaseCallbacks.remove(purchase.sku)?.onCompleted(purchase, info)
                             }
                         }
                     },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -2,15 +2,16 @@ package com.revenuecat.purchases
 
 import android.app.Activity
 import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.SkuDetails
 import com.revenuecat.purchases.interfaces.GetSkusResponseListener
-import com.revenuecat.purchases.interfaces.PurchaseCompletedListener
+import com.revenuecat.purchases.interfaces.MakePurchaseListener
 import com.revenuecat.purchases.interfaces.ReceiveEntitlementsListener
 import com.revenuecat.purchases.interfaces.ReceivePurchaserInfoListener
 import com.revenuecat.purchases.interfaces.UpdatedPurchaserInfoListener
 import java.util.ArrayList
 
-private typealias PurchaseCompletedSuccessFunction = (sku: String, purchaserInfo: PurchaserInfo) -> Unit
+private typealias MakePurchaseCompletedSuccessFunction = (purchase: Purchase, purchaserInfo: PurchaserInfo) -> Unit
 private typealias ReceiveEntitlementsSuccessFunction = (entitlementMap: Map<String, Entitlement>) -> Unit
 private typealias ReceivePurchaserInfoSuccessFunction = (purchaserInfo: PurchaserInfo) -> Unit
 private typealias ErrorFunction = (error: PurchasesError) -> Unit
@@ -18,11 +19,11 @@ private typealias ErrorFunction = (error: PurchasesError) -> Unit
 private val onErrorStub: ErrorFunction = {}
 
 internal fun purchaseCompletedListener(
-    onSuccess: PurchaseCompletedSuccessFunction,
+    onSuccess: MakePurchaseCompletedSuccessFunction,
     onError: ErrorFunction
-) = object : PurchaseCompletedListener {
-    override fun onCompleted(sku: String, purchaserInfo: PurchaserInfo) {
-        onSuccess(sku, purchaserInfo)
+) = object : MakePurchaseListener {
+    override fun onCompleted(purchase: Purchase, purchaserInfo: PurchaserInfo) {
+        onSuccess(purchase, purchaserInfo)
     }
 
     override fun onError(error: PurchasesError) {
@@ -107,7 +108,7 @@ fun Purchases.makePurchaseWith(
     @BillingClient.SkuType skuType: String,
     oldSkus: ArrayList<String>,
     onError: ErrorFunction = onErrorStub,
-    onSuccess: PurchaseCompletedSuccessFunction
+    onSuccess: MakePurchaseCompletedSuccessFunction
 ) {
     makePurchase(activity, sku, skuType, oldSkus, purchaseCompletedListener(onSuccess, onError))
 }
@@ -125,7 +126,7 @@ fun Purchases.makePurchaseWith(
     sku: String,
     @BillingClient.SkuType skuType: String,
     onError: ErrorFunction = onErrorStub,
-    onSuccess: PurchaseCompletedSuccessFunction
+    onSuccess: MakePurchaseCompletedSuccessFunction
 ) {
     makePurchase(activity, sku, skuType, ArrayList(), purchaseCompletedListener(onSuccess, onError))
 }


### PR DESCRIPTION
Related to https://github.com/RevenueCat/purchases-android/pull/56 and https://github.com/RevenueCat/purchases-android/issues/55

Note this breaks API for kotlin since function overloading by just changing a parameter function is not available in Kotlin, or in other words, I can't overload makePurchaseWith.