### PR TITLE
Fixes Race Conditions on BillingWrapper

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -70,7 +70,7 @@ internal class BillingWrapper internal constructor(
 
     private fun endConnection() {
         mainHandler.post {
-            billingClient!!.takeIf { it.isReady }?.let {
+            billingClient?.let {
                 debugLog("Ending connection for $it")
                 it.endConnection()
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -8,6 +8,7 @@ package com.revenuecat.purchases
 import android.app.Activity
 import android.content.Context
 import android.os.Handler
+import androidx.annotation.UiThread
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingFlowParams
@@ -33,10 +34,10 @@ internal class BillingWrapper internal constructor(
             }
         }
 
-    private var clientConnected: Boolean = false
     private val serviceRequests = ConcurrentLinkedQueue<Runnable>()
 
     internal class ClientFactory(private val context: Context) {
+        @UiThread
         fun buildClient(listener: com.android.billingclient.api.PurchasesUpdatedListener): BillingClient {
             return BillingClient.newBuilder(context).setListener(listener).build()
         }
@@ -52,7 +53,7 @@ internal class BillingWrapper internal constructor(
     }
 
     private fun executePendingRequests() {
-        while (clientConnected && !serviceRequests.isEmpty()) {
+        while (billingClient?.isReady == true && !serviceRequests.isEmpty()) {
             val request = serviceRequests.remove()
             request.run()
         }
@@ -61,7 +62,7 @@ internal class BillingWrapper internal constructor(
     private fun executeRequest(request: Runnable) {
         if (purchasesUpdatedListener != null) {
             serviceRequests.add(request)
-            if (!clientConnected) {
+            if (billingClient?.isReady == false) {
                 startConnection()
             } else {
                 executePendingRequests()
@@ -73,20 +74,23 @@ internal class BillingWrapper internal constructor(
     }
 
     private fun startConnection() {
-        if (billingClient == null) {
-            billingClient = clientFactory.buildClient(this)
+        mainHandler.post {
+            if (billingClient == null) {
+                billingClient = clientFactory.buildClient(this)
+            }
+            debugLog("Starting connection for " + billingClient!!.toString())
+            billingClient!!.startConnection(this)
         }
-        debugLog("Starting connection for " + billingClient!!.toString())
-        billingClient!!.startConnection(this)
     }
 
     private fun endConnection() {
-        billingClient?.takeIf { it.isReady }?.let {
-            debugLog("Ending connection for $it")
-            it.endConnection()
+        mainHandler.post {
+            billingClient!!.takeIf { it.isReady }?.let {
+                debugLog("Ending connection for $it")
+                it.endConnection()
+            }
+            billingClient = null
         }
-        billingClient = null
-        clientConnected = false
     }
 
     private fun executeRequestOnUIThread(request: Runnable) {
@@ -100,7 +104,7 @@ internal class BillingWrapper internal constructor(
         onError: (PurchasesError) ->  Unit
     ) {
         debugLog("Requesting products with identifiers: ${skuList.joinToString()}")
-        executeRequest(Runnable {
+        executeRequestOnUIThread(Runnable {
             val params = SkuDetailsParams.newBuilder()
                 .setType(itemType).setSkusList(skuList).build()
             billingClient!!.querySkuDetailsAsync(params) { responseCode, skuDetailsList ->
@@ -127,7 +131,11 @@ internal class BillingWrapper internal constructor(
         oldSkus: ArrayList<String>,
         @BillingClient.SkuType skuType: String
     ) {
-
+        if (oldSkus.isNotEmpty()) {
+            debugLog("Upgrading old skus $oldSkus with sku: $sku")
+        } else {
+            debugLog("Making purchase for sku: $sku")
+        }
         executeRequestOnUIThread(Runnable {
             val builder = BillingFlowParams.newBuilder()
                 .setSku(sku)
@@ -154,8 +162,8 @@ internal class BillingWrapper internal constructor(
         onReceivePurchaseHistoryError: (PurchasesError) -> Unit
     ) {
         debugLog("Querying purchase history for type $skuType")
-        executeRequest(Runnable {
-            billingClient!!.queryPurchaseHistoryAsync(skuType) { responseCode, purchasesList ->
+        executeRequestOnUIThread(Runnable {
+            billingClient?.queryPurchaseHistoryAsync(skuType) { responseCode, purchasesList ->
                 if (responseCode == BillingClient.BillingResponse.OK) {
                     purchasesList.takeUnless { it.isEmpty() }?.forEach {
                         debugLog("Purchase history retrieved ${it.toHumanReadableDescription()}")
@@ -177,7 +185,7 @@ internal class BillingWrapper internal constructor(
 
     fun consumePurchase(token: String) {
         debugLog("Consuming purchase with token $token")
-        executeRequest(Runnable { billingClient!!.consumeAsync(token) { _, _ -> } })
+        executeRequestOnUIThread(Runnable { billingClient?.consumeAsync(token) { _, _ -> } })
     }
 
     override fun onPurchasesUpdated(@BillingClient.BillingResponse responseCode: Int, purchases: List<Purchase>?) {
@@ -185,7 +193,7 @@ internal class BillingWrapper internal constructor(
             purchases.forEach {
                 debugLog("BillingWrapper purchases updated: ${it.toHumanReadableDescription()}")
             }
-            purchasesUpdatedListener!!.onPurchasesUpdated(purchases)
+            purchasesUpdatedListener?.onPurchasesUpdated(purchases)
         } else {
             debugLog("BillingWrapper purchases failed to update: responseCode ${responseCode.getBillingResponseCodeName()}" +
                     "${purchases?.takeUnless { it.isEmpty() }?.let { purchase ->
@@ -196,7 +204,7 @@ internal class BillingWrapper internal constructor(
                     }}"
             )
 
-            purchasesUpdatedListener!!.onPurchasesFailedToUpdate(
+            purchasesUpdatedListener?.onPurchasesFailedToUpdate(
                 purchases,
                 if (purchases == null && responseCode == BillingClient.BillingResponse.OK)
                     BillingClient.BillingResponse.ERROR
@@ -210,7 +218,6 @@ internal class BillingWrapper internal constructor(
     override fun onBillingSetupFinished(@BillingClient.BillingResponse responseCode: Int) {
         if (responseCode == BillingClient.BillingResponse.OK) {
             debugLog("Billing Service Setup finished for ${billingClient?.toString()}")
-            clientConnected = true
             executePendingRequests()
         } else {
             errorLog("Billing Service Setup finished with error code: ${responseCode.getBillingResponseCodeName()}")
@@ -218,7 +225,6 @@ internal class BillingWrapper internal constructor(
     }
 
     override fun onBillingServiceDisconnected() {
-        clientConnected = false
         debugLog("Billing Service disconnected for ${billingClient?.toString()}")
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
@@ -22,9 +22,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import junit.framework.Assert.assertEquals
 import junit.framework.Assert.assertNotNull
-import junit.framework.Assert.assertNull
 import junit.framework.Assert.fail
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.junit.Test
@@ -86,6 +84,10 @@ class BillingWrapperTest {
             billingClientPurchaseHistoryListener = billingClientPurchaseHistoryListenerSlot.captured
         }
 
+        every{
+            mockClient.isReady
+        } returns true
+
         val mockDetails: SkuDetails = mockk(relaxed = true)
         mockDetailsList.add(mockDetails)
 
@@ -132,6 +134,7 @@ class BillingWrapperTest {
         setup()
 
         mockStandardSkuDetailsResponse()
+        every { mockClient.isReady } returns false
 
         val productIDs = ArrayList<String>()
         productIDs.add("product_a")
@@ -145,17 +148,20 @@ class BillingWrapperTest {
                 fail("shouldn't be an error")
             })
 
-        assertNull(skuDetailsList)
+        assertThat(skuDetailsList).`as`("SKUDetailsList is null").isNull()
+
+        every { mockClient.isReady } returns true
 
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
 
-        assertNotNull(skuDetailsList)
+        assertThat(skuDetailsList).`as`("SKUDetailsList is not null").isNotNull
     }
 
     @Test
     fun canDeferMultipleCalls() {
         setup()
         mockStandardSkuDetailsResponse()
+        every { mockClient.isReady } returns false
 
         val productIDs = ArrayList<String>()
         productIDs.add("product_a")
@@ -178,24 +184,24 @@ class BillingWrapperTest {
                 fail("shouldn't be an error")
             })
 
-        assertEquals(0, skuDetailsResponseCalled)
+        assertThat(skuDetailsResponseCalled).isZero()
+
+        every { mockClient.isReady } returns true
 
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
 
-        assertEquals(2, skuDetailsResponseCalled)
+        assertThat(skuDetailsResponseCalled).isEqualTo(2)
     }
 
     @Test
     fun makingARequestTriggersAConnectionAttempt() {
         setup()
         mockStandardSkuDetailsResponse()
-
-        val productIDs = ArrayList<String>()
-        productIDs.add("product_a")
+        every { mockClient.isReady } returns false
 
         wrapper!!.querySkuDetailsAsync(
             BillingClient.SkuType.SUBS,
-            productIDs,
+            listOf("product_a"),
             {
                 // DO NOTHING
             }, {
@@ -249,10 +255,10 @@ class BillingWrapperTest {
             mockClient.launchBillingFlow(eq(activity), capture(slot))
         } answers {
             val params = slot.captured
-            assertEquals(sku, params.sku)
-            assertEquals(skuType, params.skuType)
-            assertEquals(oldSkus, params.oldSkus)
-            assertEquals(appUserID, params.accountId)
+            assertThat(sku).isEqualTo(params.sku)
+            assertThat(skuType).isEqualTo(params.skuType)
+            assertThat(oldSkus).isEqualTo(params.oldSkus)
+            assertThat(appUserID).isEqualTo(params.accountId)
             BillingClient.BillingResponse.OK
         }
 
@@ -263,6 +269,13 @@ class BillingWrapperTest {
     @Test
     fun defersBillingFlowIfNotConnected() {
         setup()
+
+        every {
+            mockClient.launchBillingFlow(any(), any())
+        } returns BillingClient.BillingResponse.OK
+
+        every { mockClient.isReady } returns false
+
         val appUserID = "jerry"
         val sku = "product_a"
         @BillingClient.SkuType val skuType = BillingClient.SkuType.SUBS
@@ -277,6 +290,14 @@ class BillingWrapperTest {
         verify(exactly = 0) {
             mockClient.launchBillingFlow(eq(activity), any())
         }
+
+        every { mockClient.isReady } returns true
+
+        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+
+        verify(exactly = 1) {
+            mockClient.launchBillingFlow(eq(activity), any())
+        }
     }
 
     @Test
@@ -286,6 +307,8 @@ class BillingWrapperTest {
         every {
             mockClient.launchBillingFlow(any(), any())
         } returns BillingClient.BillingResponse.OK
+
+        every { mockClient.isReady } returns false
 
         val appUserID = "jerry"
         val sku = "product_a"
@@ -298,12 +321,15 @@ class BillingWrapperTest {
 
         wrapper!!.makePurchaseAsync(activity, appUserID, sku, oldSkus, skuType)
 
-        verify(exactly = 0) {
+        verify(exactly = 2) {
             handler.post(any())
         }
+
+        every { mockClient.isReady } returns true
+
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
 
-        verify {
+        verify(exactly = 3) {
             handler.post(any())
         }
     }
@@ -448,30 +474,16 @@ class BillingWrapperTest {
 
     @Test
     fun whenExecutingRequestAndThereIsNoListenerDoNotTryToStartConnection() {
-        val clientFactory: BillingWrapper.ClientFactory = mockk()
-        val billingClient: BillingClient = mockk()
-
+        setup()
         every {
-            clientFactory.buildClient(any())
-        } returns billingClient
+            mockClient.endConnection()
+        } just Runs
+        wrapper!!.purchasesUpdatedListener = null
+        wrapper!!.consumePurchase("token")
 
-        val billingWrapper = BillingWrapper(
-            clientFactory,
-            mockk()
-        )
-
-        billingWrapper.purchasesUpdatedListener = null
-        var exceptionCaught = false
-        try {
-            billingWrapper.consumePurchase("token")
-        } catch (e: Exception) {
-            exceptionCaught = true
+        verify(exactly = 1) { // Just the original connection
+            mockClient.startConnection(wrapper!!)
         }
-
-        verify(exactly = 0) {
-            billingClient.startConnection(eq(billingWrapper))
-        }
-        assertThat(exceptionCaught).isTrue()
     }
 
     @Test
@@ -528,6 +540,36 @@ class BillingWrapperTest {
         verify(exactly = 0) {
             mockClient.endConnection()
         }
+    }
+
+    @Test
+    fun `calling close before setup finishes doesn't crash`() {
+        setup()
+        every {
+            mockClient.isReady
+        } returns false
+
+        wrapper!!.querySkuDetailsAsync(
+            BillingClient.SkuType.SUBS,
+            listOf("product_a"),
+            {},
+            {
+                fail("shouldn't be an error")
+            })
+
+        wrapper!!.purchasesUpdatedListener = null
+        wrapper!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+    }
+
+    @Test
+    fun `calling close before purchase completes doesn't crash`() {
+        setup()
+        every {
+            mockClient.isReady
+        } returns false
+
+        wrapper!!.purchasesUpdatedListener = null
+        wrapper!!.onPurchasesUpdated(BillingClient.BillingResponse.DEVELOPER_ERROR, emptyList())
     }
 
     private fun mockNullSkuDetailsResponse() {


### PR DESCRIPTION
After this https://docs.revenuecat.com/discuss/5c9069317c710300447d2d7b and https://docs.revenuecat.com/discuss/5c9068a88e78ef00bf13be8f I looked deeper into the BillingWrapper code and realized there were some possible race conditions:

- Setting `purchasesUpdatedListener` to `null` (happens on `Purchases.sharedInstance.close()`) will call `endConnection`, which will set `clientConnected` to false.
- If `onBillingSetupFinished` gets called after this call to `endConnection`, `clientConnected` will be set to `true` and execute the pending requests, which most of them fail because the `BillingClient` and the `purchasesUpdatedListener` are `null`

If someone calls configure twice (which can certainly happen if it's being called in an Activity), the first instance gets closed.

Apart from that, there was a memory leak since when calling `endConnection` we were checking if the client was ready. That means that calling `endConnection` before the client is actually ready will not finish the connection, and therefore, will not remove the listener, thus causing a memory leak.

I also made sure all the calls to the billing client run on the UI thread since they are annotated as `@UIThread` in the BillingClient class.