### PR TITLE
Better Attribution Data

### DIFF
--- a/purchases/src/main/java/com/revenuecat/purchases/util/AdvertisingIdClient.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/util/AdvertisingIdClient.kt
@@ -35,11 +35,15 @@ object AdvertisingIdClient {
             try {
                 if (context.bindService(intent, connection, Context.BIND_AUTO_CREATE)) {
                     with(AdvertisingInterface(connection.binder)) {
-                        id?.let { id -> completion(AdInfo(id, isLimitAdTrackingEnabled())) }
+                        id?.let { id ->
+                            completion(AdInfo(id, isLimitAdTrackingEnabled()))
+                            return@Runnable
+                        }
                     }
                 }
             } catch(e: Exception) {
                 completion(null)
+                return@Runnable
             } finally {
                 context.unbindService(connection)
             }

--- a/purchases/src/main/java/com/revenuecat/purchases/util/AdvertisingIdClient.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/util/AdvertisingIdClient.kt
@@ -1,0 +1,114 @@
+package com.revenuecat.purchases.util
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import android.os.IInterface
+import android.os.Looper
+import android.os.Parcel
+import android.os.RemoteException
+import java.util.concurrent.LinkedBlockingQueue
+
+object AdvertisingIdClient {
+
+    data class AdInfo internal constructor(val id: String, val isLimitAdTrackingEnabled: Boolean)
+
+    @Throws(IllegalStateException::class)
+    fun getAdvertisingIdInfo(context: Context, completion: (AdInfo?) -> Unit) {
+        Thread(Runnable {
+            if (Looper.myLooper() == Looper.getMainLooper())
+                throw IllegalStateException("Cannot be called from the main thread")
+
+            try {
+                context.packageManager.getPackageInfo("com.android.vending", 0)
+            } catch (e: Exception) {
+                completion(null)
+                return@Runnable
+            }
+
+            val connection = AdvertisingConnection()
+            val intent = Intent("com.google.android.gms.ads.identifier.service.START").apply {
+                setPackage("com.google.android.gms")
+            }
+            try {
+                if (context.bindService(intent, connection, Context.BIND_AUTO_CREATE)) {
+                    with(AdvertisingInterface(connection.binder)) {
+                        id?.let { id -> completion(AdInfo(id, isLimitAdTrackingEnabled())) }
+                    }
+                }
+            } catch(e: Exception) {
+                completion(null)
+            } finally {
+                context.unbindService(connection)
+            }
+            completion(null)
+        }).start()
+    }
+
+    private class AdvertisingConnection : ServiceConnection {
+        internal var retrieved = false
+        private val queue = LinkedBlockingQueue<IBinder>(1)
+
+        internal val binder: IBinder
+            @Throws(InterruptedException::class)
+            get() {
+                if (this.retrieved) throw IllegalStateException()
+                this.retrieved = true
+                return this.queue.take() as IBinder
+            }
+
+        override fun onServiceConnected(name: ComponentName, service: IBinder) {
+            try {
+                this.queue.put(service)
+            } catch (localInterruptedException: InterruptedException) {
+            }
+        }
+
+        override fun onServiceDisconnected(name: ComponentName) {}
+    }
+
+    private class AdvertisingInterface(private val binder: IBinder) : IInterface {
+
+        val id: String?
+            @Throws(RemoteException::class)
+            get() {
+                val data = Parcel.obtain()
+                val reply = Parcel.obtain()
+                val id: String?
+                try {
+                    data.writeInterfaceToken("com.google.android.gms.ads.identifier.internal.IAdvertisingIdService")
+                    binder.transact(1, data, reply, 0)
+                    reply.readException()
+                    id = reply.readString()
+                } finally {
+                    reply.recycle()
+                    data.recycle()
+                }
+                return id
+            }
+
+        override fun asBinder(): IBinder {
+            return binder
+        }
+
+        @Throws(RemoteException::class)
+        fun isLimitAdTrackingEnabled(): Boolean {
+            val data = Parcel.obtain()
+            val reply = Parcel.obtain()
+            val limitAdTracking: Boolean
+            try {
+                data.writeInterfaceToken("com.google.android.gms.ads.identifier.internal.IAdvertisingIdService")
+                data.writeInt(1)
+                binder.transact(2, data, reply, 0)
+                reply.readException()
+                limitAdTracking = 0 != reply.readInt()
+            } finally {
+                reply.recycle()
+                data.recycle()
+            }
+            return limitAdTracking
+        }
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
@@ -183,7 +183,8 @@ internal class Backend(
     fun postAttributionData(
         appUserID: String,
         network: Purchases.AttributionNetwork,
-        data: JSONObject
+        data: JSONObject,
+        onSuccessHandler: () -> Unit
     ) {
         if (data.length() == 0) return
 
@@ -202,6 +203,12 @@ internal class Backend(
                     body,
                     authenticationHeaders
                 )
+            }
+
+            override fun onCompletion(result: HTTPClient.Result) {
+                if (result.isSuccessful()) {
+                    onSuccessHandler()
+                }
             }
         })
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -281,6 +281,7 @@ internal class BillingWrapper internal constructor(
             BillingClient.BillingResponse.ITEM_UNAVAILABLE,
             BillingClient.BillingResponse.ERROR,
             BillingClient.BillingResponse.ITEM_ALREADY_OWNED,
+            BillingClient.BillingResponse.SERVICE_TIMEOUT,
             BillingClient.BillingResponse.ITEM_NOT_OWNED -> {
                 log("Billing Service Setup finished with error code: ${responseCode.getBillingResponseCodeName()}")
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/DeviceCache.kt
@@ -15,6 +15,7 @@ internal class DeviceCache(
     apiKey: String
 ) {
     private val appUserIDCacheKey = "com.revenuecat.purchases.$apiKey"
+    private val attributionCacheKey = "com.revenuecat.purchases.attribution"
 
     private fun purchaserInfoCacheKey(appUserID: String) = "$appUserIDCacheKey.$appUserID"
 
@@ -51,6 +52,13 @@ internal class DeviceCache(
                 appUserIDCacheKey,
                 appUserID
             ).apply()
+    }
+
+    fun getCachedAttributionData(network: Purchases.AttributionNetwork, userId: String): String? =
+        preferences.getString("$attributionCacheKey.$userId.$network", null)
+
+    fun cacheAttributionData(network: Purchases.AttributionNetwork, userId: String, cacheValue: String) {
+        preferences.edit().putString("$attributionCacheKey.$userId.$network", cacheValue).apply()
     }
 
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/DeviceCache.kt
@@ -55,10 +55,22 @@ internal class DeviceCache(
     }
 
     fun getCachedAttributionData(network: Purchases.AttributionNetwork, userId: String): String? =
-        preferences.getString("$attributionCacheKey.$userId.$network", null)
+        preferences.getString(getAttributionDataCacheKey(userId, network), null)
 
     fun cacheAttributionData(network: Purchases.AttributionNetwork, userId: String, cacheValue: String) {
-        preferences.edit().putString("$attributionCacheKey.$userId.$network", cacheValue).apply()
+        preferences.edit().putString(getAttributionDataCacheKey(userId, network), cacheValue).apply()
     }
 
+    fun clearLatestAttributionData(userId: String) {
+        val editor = preferences.edit()
+        Purchases.AttributionNetwork.values().forEach { network ->
+            editor.remove(getAttributionDataCacheKey(userId, network))
+        }
+        editor.apply()
+    }
+
+    private fun getAttributionDataCacheKey(
+        userId: String,
+        network: Purchases.AttributionNetwork
+    ) = "$attributionCacheKey.$userId.$network"
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -897,7 +897,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
                 backingFieldSharedInstance?.close()
                 backingFieldSharedInstance = value
                 val iterator = postponedAttributionData.iterator()
-                while(iterator.hasNext()) {
+                while (iterator.hasNext()) {
                     val next = iterator.next()
                     value.postAttributionData(next.data, next.network, next.networkUserId)
                     iterator.remove()
@@ -1053,7 +1053,6 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
          * @param [network] [AttributionNetwork] to post the data to
          * @param [networkUserId] User Id that should be sent to the network. Default is the current App User Id
          */
-        @Throws(JSONException::class)
         @JvmOverloads
         fun addAttributionData(
             data: Map<String, String>,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
@@ -101,7 +101,8 @@ internal fun BackendErrorCode.toPurchasesErrorCode(): PurchasesErrorCode {
     }
 }
 
-internal fun Int.getBillingResponseCodeName(): String {
+@BillingClient.BillingResponse
+internal fun @receiver:BillingClient.BillingResponse Int.getBillingResponseCodeName(): String {
     return when (this) {
         BillingClient.BillingResponse.FEATURE_NOT_SUPPORTED -> "FEATURE_NOT_SUPPORTED"
         BillingClient.BillingResponse.SERVICE_DISCONNECTED -> "SERVICE_DISCONNECTED"
@@ -114,6 +115,7 @@ internal fun Int.getBillingResponseCodeName(): String {
         BillingClient.BillingResponse.ERROR -> "ERROR"
         BillingClient.BillingResponse.ITEM_ALREADY_OWNED -> "ITEM_ALREADY_OWNED"
         BillingClient.BillingResponse.ITEM_NOT_OWNED -> "ITEM_NOT_OWNED"
+        BillingClient.BillingResponse.SERVICE_TIMEOUT -> "SERVICE_TIMEOUT"
         else -> "$this"
     }
 }
@@ -132,6 +134,7 @@ internal fun Int.billingResponseToPurchasesError(underlyingErrorMessage: String)
         BillingClient.BillingResponse.ERROR -> PurchasesErrorCode.StoreProblemError
         BillingClient.BillingResponse.ITEM_ALREADY_OWNED -> PurchasesErrorCode.ProductAlreadyPurchasedError
         BillingClient.BillingResponse.ITEM_NOT_OWNED -> PurchasesErrorCode.PurchaseNotAllowedError
+        BillingClient.BillingResponse.SERVICE_TIMEOUT -> PurchasesErrorCode.StoreProblemError
         else -> PurchasesErrorCode.UnknownError
     }
     return PurchasesError(errorCode, underlyingErrorMessage)

--- a/purchases/src/test/java/com/revenuecat/purchases/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BackendTest.kt
@@ -325,7 +325,9 @@ class BackendTest {
         expectedBody.put("network", Purchases.AttributionNetwork.APPSFLYER)
         expectedBody.put("data", `object`)
 
-        backend.postAttributionData(appUserID, Purchases.AttributionNetwork.APPSFLYER, `object`)
+        backend.postAttributionData(appUserID, Purchases.AttributionNetwork.APPSFLYER, `object`) {
+
+        }
 
         val headers = HashMap<String, String>()
         headers["Authorization"] = "Bearer $API_KEY"
@@ -348,7 +350,7 @@ class BackendTest {
             appUserID,
             Purchases.AttributionNetwork.APPSFLYER,
             JSONObject()
-        )
+        ) {}
         verify {
             mockClient wasNot Called
         }
@@ -368,7 +370,7 @@ class BackendTest {
             encodeableUserID,
             Purchases.AttributionNetwork.APPSFLYER,
             `object`
-        )
+        ) { }
 
         verify {
             mockClient.performRequest(
@@ -381,11 +383,11 @@ class BackendTest {
 
     @Test
     fun doesntDispatchIfClosed() {
-        backend.postAttributionData("id", Purchases.AttributionNetwork.APPSFLYER, JSONObject())
+        backend.postAttributionData("id", Purchases.AttributionNetwork.APPSFLYER, JSONObject()) { }
 
         backend.close()
 
-        backend.postAttributionData("id", Purchases.AttributionNetwork.APPSFLYER, JSONObject())
+        backend.postAttributionData("id", Purchases.AttributionNetwork.APPSFLYER, JSONObject()) { }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/DispatcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/DispatcherTest.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.ExecutorService
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
-class DispatcherTest {
+class  DispatcherTest {
     private var executorService: ExecutorService = mockk()
     private var dispatcher: Dispatcher = Dispatcher(executorService)
 

--- a/purchases/src/test/java/com/revenuecat/purchases/DispatcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/DispatcherTest.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.ExecutorService
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
-class  DispatcherTest {
+class DispatcherTest {
     private var executorService: ExecutorService = mockk()
     private var dispatcher: Dispatcher = Dispatcher(executorService)
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -16,10 +16,12 @@ import com.revenuecat.purchases.interfaces.Callback
 import com.revenuecat.purchases.interfaces.GetSkusResponseListener
 import com.revenuecat.purchases.interfaces.ReceivePurchaserInfoListener
 import com.revenuecat.purchases.interfaces.UpdatedPurchaserInfoListener
+import com.revenuecat.purchases.util.AdvertisingIdClient
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
@@ -27,6 +29,7 @@ import io.mockk.verifyOrder
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.AssertionsForClassTypes
 import org.json.JSONObject
+import org.junit.After
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -43,13 +46,21 @@ class PurchasesTest {
     private val mockBackend: Backend = mockk()
     private val mockCache: DeviceCache = mockk()
     private val listener: UpdatedPurchaserInfoListener = mockk()
+    private val mockContext = mockk<Context>(relaxed = true)
 
     private var capturedPurchasesUpdatedListener = slot<BillingWrapper.PurchasesUpdatedListener>()
 
     private val appUserId = "fakeUserID"
+    private val adID = "123"
     private lateinit var purchases: Purchases
     private var receivedSkus: List<SkuDetails>? = null
     private var receivedEntitlementMap: Map<String, Entitlement>? = null
+
+    @After
+    fun tearDown() {
+        Purchases.backingFieldSharedInstance = null
+        Purchases.postponedAttributionData = mutableListOf()
+    }
 
     private fun setup(): PurchaserInfo {
         val mockInfo = mockk<PurchaserInfo>()
@@ -62,11 +73,13 @@ class PurchasesTest {
         } just Runs
 
         purchases = Purchases(
+            mockContext,
             appUserId,
             mockBackend,
             mockBillingWrapper,
             mockCache
         )
+        Purchases.sharedInstance = purchases
         return mockInfo
     }
 
@@ -81,11 +94,13 @@ class PurchasesTest {
         } just Runs
 
         purchases = Purchases(
+            mockContext,
             null,
             mockBackend,
             mockBillingWrapper,
             mockCache
         )
+        Purchases.sharedInstance = purchases
     }
 
     @Test
@@ -334,6 +349,7 @@ class PurchasesTest {
         mockBillingWrapper()
 
         val purchases = Purchases(
+            mockContext,
             null,
             mockBackend,
             mockBillingWrapper,
@@ -356,6 +372,7 @@ class PurchasesTest {
         mockBillingWrapper()
 
         Purchases(
+            mockContext,
             null,
             mockBackend,
             mockBillingWrapper,
@@ -376,6 +393,7 @@ class PurchasesTest {
             mockCache.getCachedAppUserID()
         } returns appUserID
         val p = Purchases(
+            mockContext,
             null,
             mockBackend,
             mockBillingWrapper,
@@ -390,6 +408,7 @@ class PurchasesTest {
         setup()
 
         val purchases = Purchases(
+            mockContext,
             null,
             mockBackend,
             mockBillingWrapper,
@@ -430,6 +449,7 @@ class PurchasesTest {
         setup()
 
         val purchases = Purchases(
+            mockContext,
             "a_fixed_id",
             mockBackend,
             mockBillingWrapper,
@@ -470,6 +490,7 @@ class PurchasesTest {
         setup()
 
         val purchases = Purchases(
+            mockContext,
             "a_fixed_id",
             mockBackend,
             mockBillingWrapper,
@@ -839,16 +860,22 @@ class PurchasesTest {
     fun addAttributionPassesDataToBackend() {
         setup()
 
-        val jsonObject = mockk<JSONObject>()
+        val jsonObject = JSONObject()
+        jsonObject.put("key", "value")
         val network = Purchases.AttributionNetwork.APPSFLYER
 
+        val lst = slot<JSONObject>()
         every {
-            mockBackend.postAttributionData(appUserId, network, jsonObject)
+            mockBackend.postAttributionData(appUserId, network, capture(lst))
         } just Runs
 
-        purchases.addAttributionData(jsonObject, network)
+        val networkUserID = "networkid"
+        mockAdInfo(false, networkUserID)
 
-        verify { mockBackend.postAttributionData(eq(appUserId), eq(network), eq(jsonObject)) }
+        Purchases.addAttributionData(jsonObject, network, networkUserID)
+
+        verify { mockBackend.postAttributionData(appUserId, network, any()) }
+        assertThat(lst.captured["key"]).isEqualTo("value")
     }
 
     @Test
@@ -861,7 +888,10 @@ class PurchasesTest {
             mockBackend.postAttributionData(appUserId, network, any())
         } just Runs
 
-        purchases.addAttributionData(mapOf("key" to "value"), network)
+        val networkUserID = "networkUserID"
+        mockAdInfo(false, networkUserID)
+
+        Purchases.addAttributionData(mapOf("key" to "value"), network, networkUserID)
 
         verify {
             mockBackend.postAttributionData(
@@ -1538,7 +1568,6 @@ class PurchasesTest {
     @Test
     fun `when checking if Billing is supported, an OK response when starting connection means it's supported`() {
         setup()
-        val mockContext = mockk<Context>(relaxed = true)
         var receivedIsBillingSupported = false
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
         mockkStatic(BillingClient::class)
@@ -1559,7 +1588,6 @@ class PurchasesTest {
     @Test
     fun `when checking if Billing is supported, disconnections mean billing is not supported`() {
         setup()
-        val mockContext = mockk<Context>(relaxed = true)
         var receivedIsBillingSupported = true
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
         mockkStatic(BillingClient::class)
@@ -1580,7 +1608,6 @@ class PurchasesTest {
     @Test
     fun `when checking if Billing is supported, a non OK response when starting connection means it's not supported`() {
         setup()
-        val mockContext = mockk<Context>(relaxed = true)
         var receivedIsBillingSupported = true
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
         mockkStatic(BillingClient::class)
@@ -1601,7 +1628,6 @@ class PurchasesTest {
     @Test
     fun `when checking if feature is supported, an OK response when starting connection means it's supported`() {
         setup()
-        val mockContext = mockk<Context>(relaxed = true)
         var featureSupported = false
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
         every { mockLocalBillingClient.isFeatureSupported(BillingClient.FeatureType.SUBSCRIPTIONS) } returns BillingClient.BillingResponse.OK
@@ -1623,7 +1649,6 @@ class PurchasesTest {
     @Test
     fun `when checking if feature is supported, disconnections mean billing is not supported`() {
         setup()
-        val mockContext = mockk<Context>(relaxed = true)
         var featureSupported = true
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
         mockkStatic(BillingClient::class)
@@ -1645,7 +1670,6 @@ class PurchasesTest {
     @Test
     fun `when checking if feature is supported, a non OK response when starting connection means it's not supported`() {
         setup()
-        val mockContext = mockk<Context>(relaxed = true)
         var featureSupported = true
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
         every {
@@ -1669,7 +1693,6 @@ class PurchasesTest {
     @Test
     fun `when no play services, feature is not supported`() {
         setup()
-        val mockContext = mockk<Context>(relaxed = true)
         var featureSupported = true
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
         every {
@@ -1695,7 +1718,6 @@ class PurchasesTest {
     @Test
     fun `when no play services, billing is not supported`() {
         setup()
-        val mockContext = mockk<Context>(relaxed = true)
         var receivedIsBillingSupported = true
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
         mockkStatic(BillingClient::class)
@@ -1940,6 +1962,215 @@ class PurchasesTest {
             mockBillingWrapper.consumePurchase(eq(purchaseToken))
         }
     }
+
+    @Test
+    fun `Data is successfully postponed if no instance is set`() {
+        val jsonObject = JSONObject()
+        val network = Purchases.AttributionNetwork.APPSFLYER
+
+        every {
+            mockBackend.postAttributionData(appUserId, network, jsonObject)
+        } just Runs
+
+        val networkUserID = "networkUserID"
+        Purchases.addAttributionData(jsonObject, network, networkUserID)
+
+        mockAdInfo(false, networkUserID)
+
+        setup()
+
+        verify { mockBackend.postAttributionData(eq(appUserId), eq(network), eq(jsonObject)) }
+    }
+
+    @Test
+    fun `Data is successfully postponed if no instance is set when sending map`() {
+        val network = Purchases.AttributionNetwork.APPSFLYER
+        val capturedJSONObject = slot<JSONObject>()
+
+        every {
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
+        } just Runs
+
+        val networkUserID = "networkUserID"
+        mockAdInfo(false, networkUserID)
+        Purchases.addAttributionData(mapOf("key" to "value"), network, networkUserID)
+
+        setup()
+
+        verify {
+            mockBackend.postAttributionData(
+                eq(appUserId),
+                eq(network),
+                any()
+            )
+        }
+        assertThat(capturedJSONObject.captured.get("key")).isEqualTo("value")
+    }
+
+    @Test
+    fun `GPS ID is automatically added`() {
+        val network = Purchases.AttributionNetwork.APPSFLYER
+        val capturedJSONObject = slot<JSONObject>()
+
+        every {
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
+        } just Runs
+
+        val networkUserID = "networkUserID"
+        mockAdInfo(false, networkUserID)
+
+        Purchases.addAttributionData(mapOf("key" to "value"), network, networkUserID)
+
+        setup()
+
+        verify {
+            mockBackend.postAttributionData(
+                eq(appUserId),
+                eq(network),
+                any()
+            )
+        }
+        assertThat(capturedJSONObject.captured.get("key")).isEqualTo("value")
+        assertThat(capturedJSONObject.captured.get("rc_gps_adid")).isEqualTo(adID)
+    }
+
+    @Test
+    fun `GPS ID is not added if limited`() {
+        val network = Purchases.AttributionNetwork.APPSFLYER
+        val capturedJSONObject = slot<JSONObject>()
+
+        every {
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
+        } just Runs
+
+        val networkUserID = "networkUserID"
+        mockAdInfo(true, networkUserID)
+
+        Purchases.addAttributionData(mapOf("key" to "value"), network, networkUserID)
+
+        setup()
+
+        verify {
+            mockBackend.postAttributionData(
+                eq(appUserId),
+                eq(network),
+                any()
+            )
+        }
+        assertThat(capturedJSONObject.captured.get("key")).isEqualTo("value")
+        assertThat(capturedJSONObject.captured.has("rc_gps_adid")).isFalse()
+    }
+
+    @Test
+    fun `GPS ID is not added if not present`() {
+        val network = Purchases.AttributionNetwork.APPSFLYER
+        val capturedJSONObject = slot<JSONObject>()
+
+        every {
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
+        } just Runs
+
+        val networkUserID = "networkUserID"
+        mockAdInfo(true, networkUserID)
+
+        Purchases.addAttributionData(mapOf("key" to "value"), network, networkUserID)
+
+        setup()
+
+        verify {
+            mockBackend.postAttributionData(
+                eq(appUserId),
+                eq(network),
+                any()
+            )
+        }
+        assertThat(capturedJSONObject.captured.get("key")).isEqualTo("value")
+        assertThat(capturedJSONObject.captured.has("rc_gps_adid")).isFalse()
+    }
+
+    @Test
+    fun `do not resend last attribution data to backend`() {
+        setup()
+
+        val network = Purchases.AttributionNetwork.APPSFLYER
+        val capturedJSONObject = slot<JSONObject>()
+
+        every {
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
+        } just Runs
+
+        val networkUserID = "networkUserID"
+        mockAdInfo(false, networkUserID)
+
+        every {
+            mockCache.getCachedAttributionData(Purchases.AttributionNetwork.APPSFLYER, appUserId)
+        } returns "${adID}_networkUserID"
+
+        Purchases.addAttributionData(mapOf("key" to "value"), network, networkUserID)
+
+        verify (exactly = 0){
+            mockBackend.postAttributionData(appUserId, network, any())
+        }
+    }
+
+    @Test
+    fun `cache last sent attribution data`() {
+        setup()
+
+        val network = Purchases.AttributionNetwork.APPSFLYER
+        val capturedJSONObject = slot<JSONObject>()
+
+        every {
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
+        } just Runs
+
+        val networkUserID = "networkid"
+        mockAdInfo(false, networkUserID)
+
+        every {
+            mockCache.getCachedAttributionData(Purchases.AttributionNetwork.APPSFLYER, appUserId)
+        } returns null
+
+        Purchases.addAttributionData(mapOf("key" to "value"), network, networkUserID)
+
+        verify (exactly = 1){
+            mockBackend.postAttributionData(appUserId, network, any())
+        }
+
+        verify (exactly = 1){
+            mockCache.cacheAttributionData(network, appUserId, "${adID}_$networkUserID")
+        }
+    }
+
+    @Test
+    fun `network ID is set`() {
+        val network = Purchases.AttributionNetwork.APPSFLYER
+        val capturedJSONObject = slot<JSONObject>()
+
+        every {
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
+        } just Runs
+
+        val networkUserID = "networkUserID"
+        mockAdInfo(false, networkUserID)
+
+        Purchases.addAttributionData(mapOf("key" to "value"), network, networkUserID)
+
+        setup()
+
+        verify {
+            mockBackend.postAttributionData(
+                eq(appUserId),
+                eq(network),
+                any()
+            )
+        }
+        assertThat(capturedJSONObject.captured.get("key")).isEqualTo("value")
+        assertThat(capturedJSONObject.captured.get("rc_appsflyer_id")).isEqualTo(networkUserID)
+        assertThat(capturedJSONObject.captured.has("rc_gps_adid")).isTrue()
+    }
+
+
     // region Private Methods
     private fun mockSkuDetailFetch(details: List<SkuDetails>, skus: List<String>, skuType: String) {
         every {
@@ -1971,6 +2202,9 @@ class PurchasesTest {
             every {
                 consumePurchase(any())
             } just Runs
+            every {
+                purchasesUpdatedListener = null
+            } just Runs
         }
     }
 
@@ -1995,6 +2229,9 @@ class PurchasesTest {
             } answers {
                 lambda<(PurchaserInfo) -> Unit>().captured.invoke(mockInfo)
             }
+            every {
+                close()
+            } just Runs
         }
     }
 
@@ -2015,6 +2252,9 @@ class PurchasesTest {
             every {
                 clearCachedPurchaserInfo(any())
             } just Runs
+            every {
+                mockCache.getCachedAttributionData(Purchases.AttributionNetwork.APPSFLYER, appUserId)
+            } returns null
         }
     }
 
@@ -2054,6 +2294,25 @@ class PurchasesTest {
         } just Runs
         every {
             mockBillingWrapper.purchasesUpdatedListener = null
+        } just Runs
+    }
+
+    private fun mockAdInfo(limitAdTrackingEnabled: Boolean, networkUserID: String) {
+        val adInfo = mockk<AdvertisingIdClient.AdInfo>()
+        every { adInfo.isLimitAdTrackingEnabled } returns limitAdTrackingEnabled
+        every { adInfo.id } returns if (!limitAdTrackingEnabled) adID else ""
+
+        mockkObject(AdvertisingIdClient)
+
+        val lst = slot<(AdvertisingIdClient.AdInfo?) -> Unit>()
+        every {
+            AdvertisingIdClient.getAdvertisingIdInfo(any(), capture(lst))
+        } answers {
+            lst.captured.invoke(adInfo)
+        }
+
+        every {
+            mockCache.cacheAttributionData(Purchases.AttributionNetwork.APPSFLYER, appUserId, "${ if (limitAdTrackingEnabled) "" else adID }_$networkUserID")
         } just Runs
     }
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -864,18 +864,20 @@ class PurchasesTest {
         jsonObject.put("key", "value")
         val network = Purchases.AttributionNetwork.APPSFLYER
 
-        val lst = slot<JSONObject>()
+        val jsonSlot = slot<JSONObject>()
         every {
-            mockBackend.postAttributionData(appUserId, network, capture(lst))
-        } just Runs
+            mockBackend.postAttributionData(appUserId, network, capture(jsonSlot), captureLambda())
+        } answers {
+            lambda<() -> Unit>().captured.invoke()
+        }
 
         val networkUserID = "networkid"
         mockAdInfo(false, networkUserID)
 
         Purchases.addAttributionData(jsonObject, network, networkUserID)
 
-        verify { mockBackend.postAttributionData(appUserId, network, any()) }
-        assertThat(lst.captured["key"]).isEqualTo("value")
+        verify { mockBackend.postAttributionData(appUserId, network, any(), any()) }
+        assertThat(jsonSlot.captured["key"]).isEqualTo("value")
     }
 
     @Test
@@ -885,8 +887,10 @@ class PurchasesTest {
         val network = Purchases.AttributionNetwork.APPSFLYER
 
         every {
-            mockBackend.postAttributionData(appUserId, network, any())
-        } just Runs
+            mockBackend.postAttributionData(appUserId, network, any(), captureLambda())
+        } answers {
+            lambda<() -> Unit>().captured.invoke()
+        }
 
         val networkUserID = "networkUserID"
         mockAdInfo(false, networkUserID)
@@ -897,6 +901,7 @@ class PurchasesTest {
             mockBackend.postAttributionData(
                 eq(appUserId),
                 eq(network),
+                any(),
                 any()
             )
         }
@@ -1117,10 +1122,16 @@ class PurchasesTest {
     @Test
     fun `when resetting, random app user id is generated and saved`() {
         setup()
+        every {
+            mockCache.clearLatestAttributionData(appUserId)
+        } just Runs
         purchases.reset()
         val randomID = slot<String>()
         verify {
             mockCache.cacheAppUserID(capture(randomID))
+        }
+        verify {
+            mockCache.clearLatestAttributionData(appUserId)
         }
         assertThat(purchases.appUserID).isEqualTo(randomID.captured)
         assertThat(randomID.captured).isNotNull()
@@ -1969,8 +1980,10 @@ class PurchasesTest {
         val network = Purchases.AttributionNetwork.APPSFLYER
 
         every {
-            mockBackend.postAttributionData(appUserId, network, jsonObject)
-        } just Runs
+            mockBackend.postAttributionData(appUserId, network, jsonObject, captureLambda())
+        } answers {
+            lambda<() -> Unit>().captured.invoke()
+        }
 
         val networkUserID = "networkUserID"
         Purchases.addAttributionData(jsonObject, network, networkUserID)
@@ -1979,7 +1992,7 @@ class PurchasesTest {
 
         setup()
 
-        verify { mockBackend.postAttributionData(eq(appUserId), eq(network), eq(jsonObject)) }
+        verify { mockBackend.postAttributionData(eq(appUserId), eq(network), eq(jsonObject), any()) }
     }
 
     @Test
@@ -1988,8 +2001,10 @@ class PurchasesTest {
         val capturedJSONObject = slot<JSONObject>()
 
         every {
-            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
-        } just Runs
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject), captureLambda())
+        } answers {
+            lambda<() -> Unit>().captured.invoke()
+        }
 
         val networkUserID = "networkUserID"
         mockAdInfo(false, networkUserID)
@@ -1998,11 +2013,7 @@ class PurchasesTest {
         setup()
 
         verify {
-            mockBackend.postAttributionData(
-                eq(appUserId),
-                eq(network),
-                any()
-            )
+            mockBackend.postAttributionData(eq(appUserId), eq(network), any(), any())
         }
         assertThat(capturedJSONObject.captured.get("key")).isEqualTo("value")
     }
@@ -2013,8 +2024,10 @@ class PurchasesTest {
         val capturedJSONObject = slot<JSONObject>()
 
         every {
-            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
-        } just Runs
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject), captureLambda())
+        } answers {
+            lambda<() -> Unit>().captured.invoke()
+        }
 
         val networkUserID = "networkUserID"
         mockAdInfo(false, networkUserID)
@@ -2027,6 +2040,7 @@ class PurchasesTest {
             mockBackend.postAttributionData(
                 eq(appUserId),
                 eq(network),
+                any(),
                 any()
             )
         }
@@ -2040,8 +2054,10 @@ class PurchasesTest {
         val capturedJSONObject = slot<JSONObject>()
 
         every {
-            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
-        } just Runs
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject), captureLambda())
+        } answers {
+            lambda<() -> Unit>().captured.invoke()
+        }
 
         val networkUserID = "networkUserID"
         mockAdInfo(true, networkUserID)
@@ -2051,11 +2067,7 @@ class PurchasesTest {
         setup()
 
         verify {
-            mockBackend.postAttributionData(
-                eq(appUserId),
-                eq(network),
-                any()
-            )
+            mockBackend.postAttributionData(eq(appUserId), eq(network), any(), any())
         }
         assertThat(capturedJSONObject.captured.get("key")).isEqualTo("value")
         assertThat(capturedJSONObject.captured.has("rc_gps_adid")).isFalse()
@@ -2067,8 +2079,10 @@ class PurchasesTest {
         val capturedJSONObject = slot<JSONObject>()
 
         every {
-            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
-        } just Runs
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject), captureLambda())
+        } answers {
+            lambda<() -> Unit>().captured.invoke()
+        }
 
         val networkUserID = "networkUserID"
         mockAdInfo(true, networkUserID)
@@ -2081,6 +2095,7 @@ class PurchasesTest {
             mockBackend.postAttributionData(
                 eq(appUserId),
                 eq(network),
+                any(),
                 any()
             )
         }
@@ -2096,8 +2111,10 @@ class PurchasesTest {
         val capturedJSONObject = slot<JSONObject>()
 
         every {
-            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
-        } just Runs
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject), captureLambda())
+        } answers {
+            lambda<() -> Unit>().captured.invoke()
+        }
 
         val networkUserID = "networkUserID"
         mockAdInfo(false, networkUserID)
@@ -2109,7 +2126,7 @@ class PurchasesTest {
         Purchases.addAttributionData(mapOf("key" to "value"), network, networkUserID)
 
         verify (exactly = 0){
-            mockBackend.postAttributionData(appUserId, network, any())
+            mockBackend.postAttributionData(appUserId, network, any(), any())
         }
     }
 
@@ -2121,8 +2138,10 @@ class PurchasesTest {
         val capturedJSONObject = slot<JSONObject>()
 
         every {
-            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
-        } just Runs
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject), captureLambda())
+        } answers {
+            lambda<() -> Unit>().captured.invoke()
+        }
 
         val networkUserID = "networkid"
         mockAdInfo(false, networkUserID)
@@ -2134,7 +2153,7 @@ class PurchasesTest {
         Purchases.addAttributionData(mapOf("key" to "value"), network, networkUserID)
 
         verify (exactly = 1){
-            mockBackend.postAttributionData(appUserId, network, any())
+            mockBackend.postAttributionData(appUserId, network, any(), any())
         }
 
         verify (exactly = 1){
@@ -2148,8 +2167,10 @@ class PurchasesTest {
         val capturedJSONObject = slot<JSONObject>()
 
         every {
-            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject))
-        } just Runs
+            mockBackend.postAttributionData(appUserId, network, capture(capturedJSONObject), captureLambda())
+        } answers {
+            lambda<() -> Unit>().captured.invoke()
+        }
 
         val networkUserID = "networkUserID"
         mockAdInfo(false, networkUserID)
@@ -2159,14 +2180,10 @@ class PurchasesTest {
         setup()
 
         verify {
-            mockBackend.postAttributionData(
-                eq(appUserId),
-                eq(network),
-                any()
-            )
+            mockBackend.postAttributionData(eq(appUserId), eq(network), any(), any())
         }
         assertThat(capturedJSONObject.captured.get("key")).isEqualTo("value")
-        assertThat(capturedJSONObject.captured.get("rc_appsflyer_id")).isEqualTo(networkUserID)
+        assertThat(capturedJSONObject.captured.get("rc_attribution_network_id")).isEqualTo(networkUserID)
         assertThat(capturedJSONObject.captured.has("rc_gps_adid")).isTrue()
     }
 
@@ -2312,7 +2329,11 @@ class PurchasesTest {
         }
 
         every {
-            mockCache.cacheAttributionData(Purchases.AttributionNetwork.APPSFLYER, appUserId, "${ if (limitAdTrackingEnabled) "" else adID }_$networkUserID")
+            mockCache.cacheAttributionData(
+                Purchases.AttributionNetwork.APPSFLYER,
+                appUserId,
+                listOfNotNull(adID.takeUnless { limitAdTrackingEnabled }, networkUserID).joinToString("_")
+            )
         } just Runs
     }
     // endregion


### PR DESCRIPTION
Main changes are:

- Automatically adds `rc_gps_adid`. 
- Keeps track of posted attribution data by caching in shared preferences a combination of adid_networkuserid per attribution network and app user Id. If latest attribution data for a network was sent for the same ad id and network user ID, skip posting the attribution data.
- Makes `addAttributionData` a static method. If the Purchases instance is not initialized, cache the attribution data and post it once it's initialized. Deprecates the old `addAttributionData` instance methods 
