### PR TITLE
Fixes multiple crashes

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/HTTPClient.kt
@@ -99,7 +99,7 @@ internal class HTTPClient(
         }
 
         val inputStream = getInputStream(connection)
-        val result = HTTPClient.Result()
+        val result = Result()
 
         val payload: String?
         try {
@@ -110,7 +110,7 @@ internal class HTTPClient(
             connection.disconnect()
         }
 
-        result.body = JSONObject(payload)
+        result.body = payload?.let{ JSONObject(it) }
         debugLog("${connection.requestMethod} $path ${result.responseCode}")
 
         return result

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -667,9 +667,9 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         }
     }
 
-    private val handler = Handler()
+    private val handler = Handler(Looper.getMainLooper())
     private fun dispatch(action: () -> Unit) {
-        if (Thread.currentThread() !== Looper.getMainLooper().thread) {
+        if (Thread.currentThread() != Looper.getMainLooper().thread) {
             handler.post(action)
         } else {
             action()

--- a/purchases/src/test/java/com/revenuecat/purchases/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BackendTest.kt
@@ -87,7 +87,7 @@ class BackendTest {
 
         private var closed = false
 
-        override fun enqueue(call: Dispatcher.AsyncCall) {
+        override fun enqueue(call: AsyncCall) {
             if (closed) {
                 throw RejectedExecutionException()
             }


### PR DESCRIPTION
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference
       at org.json.JSONTokener.nextCleanInternal(JSONTokener.java:116)
       at org.json.JSONTokener.nextValue(JSONTokener.java:94)
       at org.json.JSONObject.(JSONObject.java:156)
       at org.json.JSONObject.(JSONObject.java:173)
       at com.revenuecat.purchases.HTTPClient.performRequest(HTTPClient.java:113)
       at com.revenuecat.purchases.HTTPClient.performRequest(HTTPClient.java:83)
       at com.revenuecat.purchases.Backend$getPurchaserInfo$call$1.call(Backend.java:52)
       at com.revenuecat.purchases.Dispatcher$AsyncCall.run(Dispatcher.java:25)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
       at java.lang.Thread.run(Thread.java:761)
```
fixed in 60d5978

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.os.Handler.post(java.lang.Runnable)' on a null object reference
       at com.revenuecat.purchases.Purchases.populateSkuDetails(Purchases.java:665)
       at com.revenuecat.purchases.Purchases.access$fetchAndCacheEntitlements(Purchases.java:54)
       at com.revenuecat.purchases.Purchases$fetchAndCachePurchaserInfo$2.invoke(Purchases.java:525)
       at com.revenuecat.purchases.Purchases$fetchAndCachePurchaserInfo$2.invoke(Purchases.java:54)
       at com.revenuecat.purchases.Backend$getPurchaserInfo$call$1.onCompletion(Backend.java:78)
       at com.revenuecat.purchases.Dispatcher$AsyncCall.run(Dispatcher.java:29)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
       at java.lang.Thread.run(Thread.java:761)
```
possibly fixed in e537a8d

```
Fatal Exception: java.util.NoSuchElementException
       at java.util.AbstractQueue.remove(AbstractQueue.java:117)
       at com.revenuecat.purchases.BillingWrapper.executePendingRequests(BillingWrapper.java:57)
       at com.revenuecat.purchases.BillingWrapper.executeRequestOnUIThread(BillingWrapper.java:87)
       at com.revenuecat.purchases.BillingWrapper.querySkuDetailsAsync(BillingWrapper.java:99)
       at com.revenuecat.purchases.Purchases.populateSkuDetails(Purchases.java:607)
       at com.revenuecat.purchases.Purchases.access$fetchAndCacheEntitlements(Purchases.java:54)
       at com.revenuecat.purchases.Purchases$fetchAndCacheEntitlements$1.invoke(Purchases.java:442)
       at com.revenuecat.purchases.Purchases$fetchAndCacheEntitlements$1.invoke(Purchases.java:54)
       at com.revenuecat.purchases.Backend$getEntitlements$call$1.onError(Backend.java:165)
       at com.revenuecat.purchases.Dispatcher$AsyncCall.run(Dispatcher.java:25)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
       at java.lang.Thread.run(Thread.java:764)
```
fixed in 706c3fc