### PR TITLE
Checks whether purchasesList is null before using it

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -253,14 +253,16 @@ internal class BillingWrapper internal constructor(
         return billingClient?.let {
             debugLog("[QueryPurchases] Querying $skuType")
             val result = it.queryPurchases(skuType)
-            QueryPurchasesResult(
-                result.responseCode,
-                result.purchasesList.map { purchase ->
-                    val hash = purchase.purchaseToken.sha1()
-                    debugLog("[QueryPurchases] Purchase of type $skuType with hash $hash")
-                    hash to PurchaseWrapper(purchase, skuType)
-                }.toMap()
-            )
+            result.purchasesList?.let { purchasesList ->
+                QueryPurchasesResult(
+                    result.responseCode,
+                    purchasesList.map { purchase ->
+                        val hash = purchase.purchaseToken.sha1()
+                        debugLog("[QueryPurchases] Purchase of type $skuType with hash $hash")
+                        hash to PurchaseWrapper(purchase, skuType)
+                    }.toMap()
+                )
+            }
         }
     }
 


### PR DESCRIPTION
`PurchasesResult` from the billing library can return `null` for the list of purchases. Based on the source code of `BillingClientImpl` it might happen in case of a timeout, task cancellation or a generic exception. The NPE was also reported in our crash reporting tool.

This PR just checks whether `result.purchasesList` is `null` before using it.