### PR TITLE
Handle missing INTERNET permissions when making network requests.

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Dispatcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Dispatcher.kt
@@ -27,6 +27,9 @@ internal open class Dispatcher(
                 onError(e.toPurchasesError())
             } catch (e: IOException) {
                 onError(e.toPurchasesError())
+            } catch (e: SecurityException) {
+                // This can happen if a user disables the INTERNET permission.
+                onError(e.toPurchasesError())
             }
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
@@ -39,6 +39,7 @@ enum class PurchasesErrorCode(val description: String) {
     InvalidAppUserIdError("The app user id is not valid."),
     OperationAlreadyInProgressError("The operation is already in progress."),
     UnknownBackendError("There was an unknown backend error."),
+    InsufficientPermissionsError("App does not have sufficient permissions to make purchases.")
 }
 
 internal enum class BackendErrorCode(val value: Int) {
@@ -67,6 +68,8 @@ internal enum class BackendErrorCode(val value: Int) {
 internal fun Exception.toPurchasesError(): PurchasesError {
     if (this is JSONException || this is IOException) {
         return PurchasesError(PurchasesErrorCode.NetworkError, localizedMessage)
+    } else if (this is SecurityException) {
+        return PurchasesError(PurchasesErrorCode.InsufficientPermissionsError, localizedMessage)
     }
     return PurchasesError(PurchasesErrorCode.UnknownError, localizedMessage)
 }


### PR DESCRIPTION
Some OEMs and roms allow users to change permissions granted for apps at runtime. This can result in SecurityExceptions where the app does not have the internet permission when making a network request.

This PR simply catches the exception in `Dispatcher` and then converts it into a `PurchasesError` with (`PurchasesErrorCode.InsufficientPermissionsError`). I thought this was simpler and more effcient then having to check for the permission before each request.

Testing:
* Added a new test in `DispatcherTest`.
* Reproduced the crash by removing the internet permission + permission check in the init method, verified that this fixes it and propagates the correct error.