### PR TITLE
Handle null purchase lists in BillingWrapper#queryPurchases.

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -255,7 +255,7 @@ internal class BillingWrapper internal constructor(
             val result = it.queryPurchases(skuType)
 
             // Purchases.PurchaseResult#purchasesList is not marked as nullable, but it does sometimes return null.
-            val purchasesList = if (result.purchasesList != null) result.purchasesList else emptyList<Purchase>()
+            val purchasesList = result.purchasesList ?: emptyList<Purchase>()
 
             QueryPurchasesResult(
                 result.responseCode,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -253,9 +253,13 @@ internal class BillingWrapper internal constructor(
         return billingClient?.let {
             debugLog("[QueryPurchases] Querying $skuType")
             val result = it.queryPurchases(skuType)
+
+            // Purchases.PurchaseResult#purchasesList is not marked as nullable, but it does sometimes return null.
+            val purchasesList = if (result.purchasesList != null) result.purchasesList else emptyList<Purchase>()
+
             QueryPurchasesResult(
                 result.responseCode,
-                result.purchasesList.map { purchase ->
+                purchasesList.map { purchase ->
                     val hash = purchase.purchaseToken.sha1()
                     debugLog("[QueryPurchases] Purchase of type $skuType with hash $hash")
                     hash to PurchaseWrapper(purchase, skuType)

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
@@ -638,6 +638,17 @@ class BillingWrapperTest {
     }
 
     @Test
+    fun `when querying anything and billing client returns a null list, returns an empty list`() {
+        setup()
+
+        every {
+            mockClient.queryPurchases(any())
+        } returns Purchase.PurchasesResult(BillingClient.BillingResponse.OK, null)
+
+        assertThat(wrapper!!.queryPurchases(BillingClient.SkuType.SUBS)!!.purchasesByHashedToken).isNotNull
+    }
+
+    @Test
     fun `when querying INAPPs result is created properly`() {
         setup()
         val resultCode = 0


### PR DESCRIPTION
This is oddly nullable (as far as I can tell, it's nowhere in the documentation). This adds a null check, if i'ts null we'll just build the map off an empty list.

I added a unit test to cover this, but was not able to manually reproduce (maybe it depends on the state the device is in? or whatever version of Google Play Services the device running?)