### PR TITLE
Updates to BillingClient 2.0.3

### DIFF
--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.annotation:annotation:1.1.0'
-    api 'com.android.billingclient:billing:1.2.2'
+    api 'com.android.billingclient:billing:2.0.3'
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test:runner:1.2.0'
     testImplementation 'androidx.test:rules:1.2.0'
@@ -34,7 +34,7 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.2.0'
     testImplementation 'org.mockito:mockito-core:3.0.0'
-    testImplementation 'com.android.billingclient:billing:1.2.2'
+    testImplementation 'com.android.billingclient:billing:2.0.3'
     testImplementation 'io.mockk:mockk:1.9.3.kotlin12'
     testImplementation 'org.assertj:assertj-core:3.13.2'
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -256,9 +256,7 @@ internal class BillingWrapper internal constructor(
         executeRequestOnUIThread { connectionError ->
             if (connectionError == null) {
                 billingClient?.acknowledgePurchase(
-                    AcknowledgePurchaseParams.newBuilder().setPurchaseToken(
-                        token
-                    ).build()
+                    AcknowledgePurchaseParams.newBuilder().setPurchaseToken(token).build()
                 ) { billingResult ->
                     onAcknowledged(billingResult, token)
                 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseWrapper.kt
@@ -2,14 +2,33 @@ package com.revenuecat.purchases
 
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.PurchaseHistoryRecord
 
 data class PurchaseWrapper(
-    val containedPurchase: Purchase,
+    val isConsumable: Boolean,
+    val purchaseToken: String,
+    val purchaseTime: Long,
+    val sku: String,
+    val containedPurchase: Purchase?,
     @BillingClient.SkuType val type: String?,
     val presentedOfferingIdentifier: String? = null
 ) {
-    val isConsumable: Boolean = type == BillingClient.SkuType.INAPP
-    val purchaseToken: String = containedPurchase.purchaseToken
-    val purchaseTime: Long = containedPurchase.purchaseTime
-    val sku: String = containedPurchase.sku
+    constructor(purchaseHistoryRecord: PurchaseHistoryRecord, @BillingClient.SkuType type: String?) : this(
+        isConsumable = type == BillingClient.SkuType.INAPP,
+        purchaseToken = purchaseHistoryRecord.purchaseToken,
+        purchaseTime = purchaseHistoryRecord.purchaseTime,
+        sku = purchaseHistoryRecord.sku,
+        containedPurchase = null,
+        type = type
+    )
+
+    constructor(purchase: Purchase, @BillingClient.SkuType type: String?, presentedOfferingIdentifier: String?) : this(
+        isConsumable = type == BillingClient.SkuType.INAPP,
+        purchaseToken = purchase.purchaseToken,
+        purchaseTime = purchase.purchaseTime,
+        sku = purchase.sku,
+        containedPurchase = purchase,
+        type = type,
+        presentedOfferingIdentifier = presentedOfferingIdentifier
+    )
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
@@ -104,21 +104,21 @@ internal fun BackendErrorCode.toPurchasesErrorCode(): PurchasesErrorCode {
     }
 }
 
-@BillingClient.BillingResponse
-internal fun @receiver:BillingClient.BillingResponse Int.getBillingResponseCodeName(): String {
+@BillingClient.BillingResponseCode
+internal fun @receiver:BillingClient.BillingResponseCode Int.getBillingResponseCodeName(): String {
     return when (this) {
-        BillingClient.BillingResponse.FEATURE_NOT_SUPPORTED -> "FEATURE_NOT_SUPPORTED"
-        BillingClient.BillingResponse.SERVICE_DISCONNECTED -> "SERVICE_DISCONNECTED"
-        BillingClient.BillingResponse.OK -> "OK"
-        BillingClient.BillingResponse.USER_CANCELED -> "USER_CANCELED"
-        BillingClient.BillingResponse.SERVICE_UNAVAILABLE -> "SERVICE_UNAVAILABLE"
-        BillingClient.BillingResponse.BILLING_UNAVAILABLE -> "BILLING_UNAVAILABLE"
-        BillingClient.BillingResponse.ITEM_UNAVAILABLE -> "ITEM_UNAVAILABLE"
-        BillingClient.BillingResponse.DEVELOPER_ERROR -> "DEVELOPER_ERROR"
-        BillingClient.BillingResponse.ERROR -> "ERROR"
-        BillingClient.BillingResponse.ITEM_ALREADY_OWNED -> "ITEM_ALREADY_OWNED"
-        BillingClient.BillingResponse.ITEM_NOT_OWNED -> "ITEM_NOT_OWNED"
-        BillingClient.BillingResponse.SERVICE_TIMEOUT -> "SERVICE_TIMEOUT"
+        BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED -> "FEATURE_NOT_SUPPORTED"
+        BillingClient.BillingResponseCode.SERVICE_DISCONNECTED -> "SERVICE_DISCONNECTED"
+        BillingClient.BillingResponseCode.OK -> "OK"
+        BillingClient.BillingResponseCode.USER_CANCELED -> "USER_CANCELED"
+        BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE -> "SERVICE_UNAVAILABLE"
+        BillingClient.BillingResponseCode.BILLING_UNAVAILABLE -> "BILLING_UNAVAILABLE"
+        BillingClient.BillingResponseCode.ITEM_UNAVAILABLE -> "ITEM_UNAVAILABLE"
+        BillingClient.BillingResponseCode.DEVELOPER_ERROR -> "DEVELOPER_ERROR"
+        BillingClient.BillingResponseCode.ERROR -> "ERROR"
+        BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED -> "ITEM_ALREADY_OWNED"
+        BillingClient.BillingResponseCode.ITEM_NOT_OWNED -> "ITEM_NOT_OWNED"
+        BillingClient.BillingResponseCode.SERVICE_TIMEOUT -> "SERVICE_TIMEOUT"
         else -> "$this"
     }
 }
@@ -126,18 +126,18 @@ internal fun @receiver:BillingClient.BillingResponse Int.getBillingResponseCodeN
 internal fun Int.billingResponseToPurchasesError(underlyingErrorMessage: String): PurchasesError {
     log(underlyingErrorMessage)
     val errorCode = when (this) {
-        BillingClient.BillingResponse.FEATURE_NOT_SUPPORTED -> PurchasesErrorCode.PurchaseNotAllowedError
-        BillingClient.BillingResponse.SERVICE_DISCONNECTED -> PurchasesErrorCode.StoreProblemError
-        BillingClient.BillingResponse.OK -> PurchasesErrorCode.UnknownError
-        BillingClient.BillingResponse.USER_CANCELED -> PurchasesErrorCode.PurchaseCancelledError
-        BillingClient.BillingResponse.SERVICE_UNAVAILABLE -> PurchasesErrorCode.StoreProblemError
-        BillingClient.BillingResponse.BILLING_UNAVAILABLE -> PurchasesErrorCode.PurchaseNotAllowedError
-        BillingClient.BillingResponse.ITEM_UNAVAILABLE -> PurchasesErrorCode.ProductNotAvailableForPurchaseError
-        BillingClient.BillingResponse.DEVELOPER_ERROR -> PurchasesErrorCode.PurchaseInvalidError
-        BillingClient.BillingResponse.ERROR -> PurchasesErrorCode.StoreProblemError
-        BillingClient.BillingResponse.ITEM_ALREADY_OWNED -> PurchasesErrorCode.ProductAlreadyPurchasedError
-        BillingClient.BillingResponse.ITEM_NOT_OWNED -> PurchasesErrorCode.PurchaseNotAllowedError
-        BillingClient.BillingResponse.SERVICE_TIMEOUT -> PurchasesErrorCode.StoreProblemError
+        BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED -> PurchasesErrorCode.PurchaseNotAllowedError
+        BillingClient.BillingResponseCode.SERVICE_DISCONNECTED -> PurchasesErrorCode.StoreProblemError
+        BillingClient.BillingResponseCode.OK -> PurchasesErrorCode.UnknownError
+        BillingClient.BillingResponseCode.USER_CANCELED -> PurchasesErrorCode.PurchaseCancelledError
+        BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE -> PurchasesErrorCode.StoreProblemError
+        BillingClient.BillingResponseCode.BILLING_UNAVAILABLE -> PurchasesErrorCode.PurchaseNotAllowedError
+        BillingClient.BillingResponseCode.ITEM_UNAVAILABLE -> PurchasesErrorCode.ProductNotAvailableForPurchaseError
+        BillingClient.BillingResponseCode.DEVELOPER_ERROR -> PurchasesErrorCode.PurchaseInvalidError
+        BillingClient.BillingResponseCode.ERROR -> PurchasesErrorCode.StoreProblemError
+        BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED -> PurchasesErrorCode.ProductAlreadyPurchasedError
+        BillingClient.BillingResponseCode.ITEM_NOT_OWNED -> PurchasesErrorCode.PurchaseNotAllowedError
+        BillingClient.BillingResponseCode.SERVICE_TIMEOUT -> PurchasesErrorCode.StoreProblemError
         else -> PurchasesErrorCode.UnknownError
     }
     return PurchasesError(errorCode, underlyingErrorMessage)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/testUtils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/testUtils.kt
@@ -11,7 +11,9 @@ import android.os.Parcel
 import android.os.Parcelable
 import android.util.Base64
 import android.util.Log
+import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.PurchaseHistoryRecord
 import com.android.billingclient.api.SkuDetails
 import com.revenuecat.purchases.util.Iso8601Utils
 import kotlinx.android.parcel.Parceler
@@ -205,3 +207,9 @@ object SkuDetailsParceler : Parceler<SkuDetails> {
         parcel.writeString(value)
     }
 }
+
+internal fun BillingResult.toHumanReadableDescription() =
+    "DebugMessage: $debugMessage. ErrorCode: ${responseCode.getBillingResponseCodeName()}."
+
+internal fun PurchaseHistoryRecord.toHumanReadableDescription() =
+    "${this.sku} ${this.purchaseTime} ${this.purchaseToken}"

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
@@ -11,6 +11,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingFlowParams
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ConsumeParams
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryResponseListener
 import com.android.billingclient.api.PurchasesUpdatedListener
@@ -136,7 +138,7 @@ class BillingWrapperTest {
                 capture(slot)
             )
         } answers {
-            slot.captured.onSkuDetailsResponse(BillingClient.BillingResponse.OK, mockDetailsList)
+            slot.captured.onSkuDetailsResponse(BillingClient.BillingResponseCode.OK.buildResult(), mockDetailsList)
         }
     }
 
@@ -162,7 +164,7 @@ class BillingWrapperTest {
 
         every { mockClient.isReady } returns true
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
 
         assertThat(skuDetailsList).`as`("SKUDetailsList is not null").isNotNull
     }
@@ -197,7 +199,7 @@ class BillingWrapperTest {
 
         every { mockClient.isReady } returns true
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
 
         assertThat(skuDetailsResponseCalled).isEqualTo(2)
     }
@@ -227,7 +229,7 @@ class BillingWrapperTest {
         setup()
         every {
             mockClient.launchBillingFlow(any(), any())
-        } returns BillingClient.BillingResponse.OK
+        } returns BillingClient.BillingResponseCode.OK.buildResult()
 
         val skuDetails = mockk<SkuDetails>().also {
             every { it.sku } returns "product_a"
@@ -237,7 +239,7 @@ class BillingWrapperTest {
 
         val activity: Activity = mockk()
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         wrapper!!.makePurchaseAsync(
             activity,
             "jerry",
@@ -277,10 +279,10 @@ class BillingWrapperTest {
             assertThat(skuType).isEqualTo(params.skuType)
             assertThat(oldSku).isEqualTo(params.oldSku)
             assertThat(appUserID).isEqualTo(params.accountId)
-            BillingClient.BillingResponse.OK
+            BillingClient.BillingResponseCode.OK.buildResult()
         }
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         wrapper!!.makePurchaseAsync(
             activity,
             appUserID,
@@ -296,7 +298,7 @@ class BillingWrapperTest {
 
         every {
             mockClient.launchBillingFlow(any(), any())
-        } returns BillingClient.BillingResponse.OK
+        } returns BillingClient.BillingResponseCode.OK.buildResult()
 
         every { mockClient.isReady } returns false
 
@@ -322,7 +324,7 @@ class BillingWrapperTest {
 
         every { mockClient.isReady } returns true
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
 
         verify(exactly = 1) {
             mockClient.launchBillingFlow(eq(activity), any())
@@ -335,7 +337,7 @@ class BillingWrapperTest {
 
         every {
             mockClient.launchBillingFlow(any(), any())
-        } returns BillingClient.BillingResponse.OK
+        } returns BillingClient.BillingResponseCode.OK.buildResult()
 
         every { mockClient.isReady } returns false
 
@@ -363,7 +365,7 @@ class BillingWrapperTest {
 
         every { mockClient.isReady } returns true
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
 
         verify(exactly = 3) {
             handler.post(any())
@@ -378,7 +380,7 @@ class BillingWrapperTest {
         every {
             mockPurchasesListener.onPurchasesUpdated(capture(slot))
         } just Runs
-        purchasesUpdatedListener!!.onPurchasesUpdated(BillingClient.BillingResponse.OK, purchases)
+        purchasesUpdatedListener!!.onPurchasesUpdated(BillingClient.BillingResponseCode.OK.buildResult(), purchases)
 
         assertThat(slot.captured.size).isOne()
     }
@@ -391,12 +393,12 @@ class BillingWrapperTest {
             mockPurchasesListener.onPurchasesFailedToUpdate(any(), any(), any())
         } just Runs
 
-        purchasesUpdatedListener!!.onPurchasesUpdated(BillingClient.BillingResponse.OK, null)
+        purchasesUpdatedListener!!.onPurchasesUpdated(BillingClient.BillingResponseCode.OK.buildResult(), null)
 
         verify {
             mockPurchasesListener.onPurchasesFailedToUpdate(
                 null,
-                eq(BillingClient.BillingResponse.ERROR),
+                eq(BillingClient.BillingResponseCode.ERROR),
                 any()
             )
         }
@@ -409,7 +411,7 @@ class BillingWrapperTest {
             mockPurchasesListener.onPurchasesFailedToUpdate(any(), any(), any())
         } just Runs
         purchasesUpdatedListener!!.onPurchasesUpdated(
-            BillingClient.BillingResponse.FEATURE_NOT_SUPPORTED,
+            BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED.buildResult(),
             null
         )
         verify(exactly = 0) {
@@ -423,7 +425,7 @@ class BillingWrapperTest {
     @Test
     fun queryHistoryCallsListenerIfOk() {
         setup()
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         var successCalled = false
         wrapper!!.queryPurchaseHistoryAsync(
             BillingClient.SkuType.SUBS,
@@ -435,7 +437,7 @@ class BillingWrapperTest {
             }
         )
         billingClientPurchaseHistoryListener!!.onPurchaseHistoryResponse(
-            BillingClient.BillingResponse.OK,
+            BillingClient.BillingResponseCode.OK.buildResult(),
             ArrayList()
         )
         assertThat(successCalled).isTrue()
@@ -445,7 +447,7 @@ class BillingWrapperTest {
     fun queryHistoryNotCalledIfNotOK() {
         setup()
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         var errorCalled = false
         wrapper!!.queryPurchaseHistoryAsync(
             BillingClient.SkuType.SUBS,
@@ -458,7 +460,7 @@ class BillingWrapperTest {
             }
         )
         billingClientPurchaseHistoryListener!!.onPurchaseHistoryResponse(
-            BillingClient.BillingResponse.FEATURE_NOT_SUPPORTED,
+            BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED.buildResult(),
             ArrayList()
         )
         assertThat(errorCalled).isTrue()
@@ -469,16 +471,16 @@ class BillingWrapperTest {
         setup()
         val token = "mockToken"
 
+        val capturingSlot = slot<ConsumeParams>()
         every {
-            mockClient.consumeAsync(eq(token), any())
+            mockClient.consumeAsync(capture(capturingSlot), any())
         } just Runs
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         wrapper!!.consumePurchase(token) { _, _ -> }
 
-        verify {
-            mockClient.consumeAsync(eq(token), any())
-        }
+        assertThat(capturingSlot.isCaptured).isTrue()
+        assertThat(capturingSlot.captured.purchaseToken).isEqualTo(token)
     }
 
     @Test
@@ -537,7 +539,7 @@ class BillingWrapperTest {
             }, {
                 fail("shouldn't be an error")
             })
-        wrapper!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        wrapper!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         assertThat(receivedList).isNotNull
         assertThat(receivedList!!.size).isZero()
     }
@@ -580,7 +582,7 @@ class BillingWrapperTest {
             })
 
         wrapper!!.purchasesUpdatedListener = null
-        wrapper!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        wrapper!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
     }
 
     @Test
@@ -591,7 +593,7 @@ class BillingWrapperTest {
         } returns false
 
         wrapper!!.purchasesUpdatedListener = null
-        wrapper!!.onPurchasesUpdated(BillingClient.BillingResponse.DEVELOPER_ERROR, emptyList())
+        wrapper!!.onPurchasesUpdated(BillingClient.BillingResponseCode.DEVELOPER_ERROR.buildResult(), emptyList())
     }
 
     @Test
@@ -619,7 +621,7 @@ class BillingWrapperTest {
             )
         } answers {
             billingClientPurchaseHistoryListenerSlot.captured.onPurchaseHistoryResponse(
-                BillingClient.BillingResponse.OK,
+                BillingClient.BillingResponseCode.OK.buildResult(),
                 listOf(mockk(relaxed = true))
             )
         }
@@ -644,7 +646,7 @@ class BillingWrapperTest {
     fun `on successfully connected billing client, listener is called`() {
         setup()
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         assertThat(onConnectedCalled).isTrue()
     }
 
@@ -667,7 +669,7 @@ class BillingWrapperTest {
 
         every {
             mockClient.queryPurchases(any())
-        } returns Purchase.PurchasesResult(BillingClient.BillingResponse.OK, null)
+        } returns Purchase.PurchasesResult(BillingClient.BillingResponseCode.OK.buildResult(), null)
 
         assertThat(wrapper!!.queryPurchases(BillingClient.SkuType.SUBS)!!.purchasesByHashedToken).isNotNull
     }
@@ -675,7 +677,7 @@ class BillingWrapperTest {
     @Test
     fun `when querying INAPPs result is created properly`() {
         setup()
-        val resultCode = 0
+        val resultCode = BillingClient.BillingResponseCode.OK
         val token = "token"
         val type = BillingClient.SkuType.INAPP
         val time = System.currentTimeMillis()
@@ -687,7 +689,7 @@ class BillingWrapperTest {
         }
         every {
             mockClient.queryPurchases(type)
-        } returns Purchase.PurchasesResult(resultCode, listOf(purchase))
+        } returns Purchase.PurchasesResult(resultCode.buildResult(), listOf(purchase))
         val queryPurchasesResult = wrapper!!.queryPurchases(type)
         assertThat(queryPurchasesResult).isNotNull
         assertThat(queryPurchasesResult!!.responseCode).isEqualTo(resultCode)
@@ -704,7 +706,7 @@ class BillingWrapperTest {
     @Test
     fun `when querying SUBS result is created properly`() {
         setup()
-        val resultCode = 0
+        val resultCode = BillingClient.BillingResponseCode.OK
         val token = "token"
         val type = BillingClient.SkuType.SUBS
         val time = System.currentTimeMillis()
@@ -716,7 +718,7 @@ class BillingWrapperTest {
         }
         every {
             mockClient.queryPurchases(type)
-        } returns Purchase.PurchasesResult(resultCode, listOf(purchase))
+        } returns Purchase.PurchasesResult(resultCode.buildResult(), listOf(purchase))
         val queryPurchasesResult = wrapper!!.queryPurchases(type)
         assertThat(queryPurchasesResult).isNotNull
         assertThat(queryPurchasesResult!!.responseCode).isEqualTo(resultCode)
@@ -735,7 +737,7 @@ class BillingWrapperTest {
         setup()
         every {
             mockClient.launchBillingFlow(any(), any())
-        } returns BillingClient.BillingResponse.OK
+        } returns BillingClient.BillingResponseCode.OK.buildResult()
 
         val skuDetails = mockk<SkuDetails>().also {
             every { it.sku } returns "product_a"
@@ -745,7 +747,7 @@ class BillingWrapperTest {
 
         val activity: Activity = mockk()
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         wrapper!!.makePurchaseAsync(
             activity,
             "jerry",
@@ -760,7 +762,7 @@ class BillingWrapperTest {
         every {
             mockPurchasesListener.onPurchasesUpdated(capture(slot))
         } just Runs
-        purchasesUpdatedListener!!.onPurchasesUpdated(BillingClient.BillingResponse.OK, purchases)
+        purchasesUpdatedListener!!.onPurchasesUpdated(BillingClient.BillingResponseCode.OK.buildResult(), purchases)
 
         assertThat(slot.captured.size).isOne()
         assertThat(slot.captured[0].presentedOfferingIdentifier).isEqualTo("offering_a")
@@ -774,7 +776,11 @@ class BillingWrapperTest {
                 capture(slot)
             )
         } answers {
-            slot.captured.onSkuDetailsResponse(BillingClient.BillingResponse.OK, null)
+            slot.captured.onSkuDetailsResponse(BillingClient.BillingResponseCode.OK.buildResult(), null)
         }
+    }
+
+    private fun Int.buildResult(): BillingResult {
+        return BillingResult.newBuilder().setResponseCode(this).build()
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -13,6 +13,7 @@ import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClient.SkuType.INAPP
 import com.android.billingclient.api.BillingClient.SkuType.SUBS
 import com.android.billingclient.api.BillingClientStateListener
+import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.SkuDetails
 import com.revenuecat.purchases.interfaces.Callback
@@ -63,7 +64,8 @@ class PurchasesTest {
 
     private var capturedPurchasesUpdatedListener = slot<BillingWrapper.PurchasesUpdatedListener>()
     private var capturedBillingWrapperStateListener = slot<BillingWrapper.StateListener>()
-    private var capturedConsumeResponseListener = slot<(Int, String) -> Unit>()
+    private var capturedConsumeResponseListener = slot<(BillingResult, String) -> Unit>()
+    private var captureAcknowledgeResponseListener = slot<(BillingResult, String) -> Unit>()
 
     private val randomAppUserId = "\$RCAnonymousID:ff68f26e432648369a713849a9f93b58"
     private val appUserId = "fakeUserID"
@@ -345,6 +347,12 @@ class PurchasesTest {
             every {
                 p.purchaseTime
             } returns System.currentTimeMillis()
+            every {
+                p.purchaseState
+            } returns Purchase.PurchaseState.PURCHASED
+            every {
+                p.isAcknowledged
+            } returns false
             val wrapper = PurchaseWrapper(p, SUBS, stubOfferingIdentifier)
             purchasesList.add(wrapper)
         }
@@ -944,6 +952,10 @@ class PurchasesTest {
         verify (exactly = 0) {
             mockBillingWrapper.consumePurchase(purchaseTokenSub,  any())
         }
+
+        verify (exactly = 1) {
+            mockBillingWrapper.acknowledge(purchaseTokenSub,  any())
+        }
         assertThat(capturedLambda).isNotNull
     }
 
@@ -1427,13 +1439,14 @@ class PurchasesTest {
         val mockBuilder = mockk<BillingClient.Builder>(relaxed = true)
         every { BillingClient.newBuilder(any()) } returns mockBuilder
         every { mockBuilder.setListener(any()) } returns mockBuilder
+        every { mockBuilder.enablePendingPurchases()} returns mockBuilder
         every { mockBuilder.build() } returns mockLocalBillingClient
         val listener = slot<BillingClientStateListener>()
         every { mockLocalBillingClient.startConnection(capture(listener)) } just Runs
         Purchases.isBillingSupported(mockContext, Callback {
             receivedIsBillingSupported = it
         })
-        listener.captured.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        listener.captured.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         AssertionsForClassTypes.assertThat(receivedIsBillingSupported).isTrue()
         verify (exactly = 1) { mockLocalBillingClient.endConnection() }
     }
@@ -1447,6 +1460,7 @@ class PurchasesTest {
         val mockBuilder = mockk<BillingClient.Builder>(relaxed = true)
         every { BillingClient.newBuilder(any()) } returns mockBuilder
         every { mockBuilder.setListener(any()) } returns mockBuilder
+        every { mockBuilder.enablePendingPurchases()} returns mockBuilder
         every { mockBuilder.build() } returns mockLocalBillingClient
         val listener = slot<BillingClientStateListener>()
         every { mockLocalBillingClient.startConnection(capture(listener)) } just Runs
@@ -1467,13 +1481,14 @@ class PurchasesTest {
         val mockBuilder = mockk<BillingClient.Builder>(relaxed = true)
         every { BillingClient.newBuilder(any()) } returns mockBuilder
         every { mockBuilder.setListener(any()) } returns mockBuilder
+        every { mockBuilder.enablePendingPurchases()} returns mockBuilder
         every { mockBuilder.build() } returns mockLocalBillingClient
         val listener = slot<BillingClientStateListener>()
         every { mockLocalBillingClient.startConnection(capture(listener)) } just Runs
         Purchases.isBillingSupported(mockContext, Callback {
             receivedIsBillingSupported = it
         })
-        listener.captured.onBillingSetupFinished(BillingClient.BillingResponse.FEATURE_NOT_SUPPORTED)
+        listener.captured.onBillingSetupFinished(BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED.buildResult())
         AssertionsForClassTypes.assertThat(receivedIsBillingSupported).isFalse()
         verify (exactly = 1) { mockLocalBillingClient.endConnection() }
     }
@@ -1483,7 +1498,9 @@ class PurchasesTest {
         setup()
         var featureSupported = false
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
-        every { mockLocalBillingClient.isFeatureSupported(BillingClient.FeatureType.SUBSCRIPTIONS) } returns BillingClient.BillingResponse.OK
+        every {
+            mockLocalBillingClient.isFeatureSupported(BillingClient.FeatureType.SUBSCRIPTIONS)
+        } returns BillingClient.BillingResponseCode.OK.buildResult()
         mockkStatic(BillingClient::class)
         val mockBuilder = mockk<BillingClient.Builder>(relaxed = true)
         every { BillingClient.newBuilder(any()) } returns mockBuilder
@@ -1494,7 +1511,7 @@ class PurchasesTest {
         Purchases.isFeatureSupported(BillingClient.FeatureType.SUBSCRIPTIONS, mockContext, Callback {
             featureSupported = it
         })
-        listener.captured.onBillingSetupFinished(BillingClient.BillingResponse.OK)
+        listener.captured.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         AssertionsForClassTypes.assertThat(featureSupported).isTrue()
         verify (exactly = 1) { mockLocalBillingClient.endConnection() }
     }
@@ -1527,7 +1544,7 @@ class PurchasesTest {
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
         every {
             mockLocalBillingClient.isFeatureSupported(BillingClient.FeatureType.SUBSCRIPTIONS)
-        } returns BillingClient.BillingResponse.FEATURE_NOT_SUPPORTED
+        } returns BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED.buildResult()
         mockkStatic(BillingClient::class)
         val mockBuilder = mockk<BillingClient.Builder>(relaxed = true)
         every { BillingClient.newBuilder(any()) } returns mockBuilder
@@ -1538,7 +1555,7 @@ class PurchasesTest {
         Purchases.isFeatureSupported(BillingClient.FeatureType.SUBSCRIPTIONS, mockContext, Callback {
             featureSupported = it
         })
-        listener.captured.onBillingSetupFinished(BillingClient.BillingResponse.FEATURE_NOT_SUPPORTED)
+        listener.captured.onBillingSetupFinished(BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED.buildResult())
         AssertionsForClassTypes.assertThat(featureSupported).isFalse()
         verify (exactly = 1) { mockLocalBillingClient.endConnection() }
     }
@@ -1550,7 +1567,7 @@ class PurchasesTest {
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
         every {
             mockLocalBillingClient.isFeatureSupported(BillingClient.FeatureType.SUBSCRIPTIONS)
-        } returns BillingClient.BillingResponse.FEATURE_NOT_SUPPORTED
+        } returns BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED.buildResult()
         mockkStatic(BillingClient::class)
         val mockBuilder = mockk<BillingClient.Builder>(relaxed = true)
         every { BillingClient.newBuilder(any()) } returns mockBuilder
@@ -1562,7 +1579,7 @@ class PurchasesTest {
         Purchases.isFeatureSupported(BillingClient.FeatureType.SUBSCRIPTIONS, mockContext, Callback {
             featureSupported = it
         })
-        listener.captured.onBillingSetupFinished(BillingClient.BillingResponse.FEATURE_NOT_SUPPORTED)
+        listener.captured.onBillingSetupFinished(BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED.buildResult())
         AssertionsForClassTypes.assertThat(featureSupported).isFalse()
         verify (exactly = 1) { mockLocalBillingClient.endConnection() }
     }
@@ -1577,6 +1594,7 @@ class PurchasesTest {
         val mockBuilder = mockk<BillingClient.Builder>(relaxed = true)
         every { BillingClient.newBuilder(any()) } returns mockBuilder
         every { mockBuilder.setListener(any()) } returns mockBuilder
+        every { mockBuilder.enablePendingPurchases()} returns mockBuilder
         every { mockBuilder.build() } returns mockLocalBillingClient
         every { mockLocalBillingClient.endConnection() } throws mockk<IllegalArgumentException>()
         val listener = slot<BillingClientStateListener>()
@@ -1584,7 +1602,7 @@ class PurchasesTest {
         Purchases.isBillingSupported(mockContext, Callback {
             receivedIsBillingSupported = it
         })
-        listener.captured.onBillingSetupFinished(BillingClient.BillingResponse.FEATURE_NOT_SUPPORTED)
+        listener.captured.onBillingSetupFinished(BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED.buildResult())
         AssertionsForClassTypes.assertThat(receivedIsBillingSupported).isFalse()
         verify (exactly = 1) { mockLocalBillingClient.endConnection() }
     }
@@ -2119,7 +2137,7 @@ class PurchasesTest {
             INAPP,
             null
         ))
-        capturedConsumeResponseListener.captured.invoke(2, purchaseToken)
+        capturedConsumeResponseListener.captured.invoke(BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(), purchaseToken)
         verify (exactly = 0) {
             mockCache.addSuccessfullyPostedToken(purchaseToken)
         }
@@ -2157,7 +2175,7 @@ class PurchasesTest {
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
             true
         )
-        capturedConsumeResponseListener.captured.invoke(2, purchaseToken)
+        capturedConsumeResponseListener.captured.invoke(BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(), purchaseToken)
         verify (exactly = 0 ) {
             mockCache.addSuccessfullyPostedToken(purchaseToken)
         }
@@ -2176,7 +2194,7 @@ class PurchasesTest {
             INAPP,
             null
         ))
-        capturedConsumeResponseListener.captured.invoke(0, purchaseToken)
+        capturedConsumeResponseListener.captured.invoke(BillingClient.BillingResponseCode.OK.buildResult(), purchaseToken)
         verify (exactly = 1) {
             mockCache.addSuccessfullyPostedToken(purchaseToken)
         }
@@ -2214,7 +2232,7 @@ class PurchasesTest {
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
             true
         )
-        capturedConsumeResponseListener.captured.invoke(0, "crazy_purchase_token")
+        capturedConsumeResponseListener.captured.invoke(BillingClient.BillingResponseCode.OK.buildResult(), "crazy_purchase_token")
         verify (exactly = 1) {
             mockCache.addSuccessfullyPostedToken("crazy_purchase_token")
         }
@@ -2513,6 +2531,9 @@ class PurchasesTest {
                 consumePurchase(any(), capture(capturedConsumeResponseListener))
             } just Runs
             every {
+                acknowledge(any(), capture(capturedConsumeResponseListener))
+            } just Runs
+            every {
                 purchasesUpdatedListener = null
             } just Runs
             every {
@@ -2676,6 +2697,12 @@ class PurchasesTest {
         every {
             p.purchaseTime
         } returns System.currentTimeMillis()
+        every {
+            p.purchaseState
+        } returns Purchase.PurchaseState.PURCHASED
+        every {
+            p.isAcknowledged
+        } returns false
         val purchasesList = ArrayList<PurchaseWrapper>()
         purchasesList.add(PurchaseWrapper(p, skuType, offeringIdentifier))
         return purchasesList
@@ -2722,6 +2749,10 @@ class PurchasesTest {
             identityManager = mockIdentityManager
         )
         Purchases.sharedInstance = purchases
+    }
+
+    private fun Int.buildResult(): BillingResult {
+        return BillingResult.newBuilder().setResponseCode(this).build()
     }
 
     // endregion


### PR DESCRIPTION
- Updated BillingClient library to version 2.0.3
- `BillingClient.BillingResponse` has been replaced with `BillingClient.BillingResponseCode`.
- BillingClient calls return now a `BillingResult`. This class contains a `debugMessage` and an error code.
- Added a `BillingResult.toHumanReadableDescription()` that prints both the `debugMessage` and the response code.
- Calling for `BillingWrapper.queryPurchaseHistoryAsync` now returns a `List<PurchaseHistoryRecord>`
- `BillingWrapper.consumeAsync` requires a `ConsumeParams` instead of a token.
- `PurchaseWrapper` has been updated to hold either a `Purchase` or a `PurchaseHistoryRecord`.
- Non consumable purchases need to be acknowledged
- Pending purchases need to be enabled in order to instantiate the BillingClient
- Entitlements shouldn't be granted if the purchase is pending (that's why we don't consume or acknowledge the purchase if the purchase is pending)
- Subscriptions shouldn't be acknowledged if they have already been acknowledged