### PR TITLE
Fixes Pending purchases

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -290,7 +290,7 @@ internal class BillingWrapper internal constructor(
         }
     }
 
-    private fun getPurchaseType(purchaseToken: String): PurchaseType {
+    internal fun getPurchaseType(purchaseToken: String): PurchaseType {
         billingClient?.let { client ->
             val querySubsResult = client.queryPurchases(SkuType.SUBS)
             if (querySubsResult.responseCode == BillingClient.BillingResponseCode.OK && querySubsResult.purchasesList.any { it.purchaseToken == purchaseToken }) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -47,7 +47,7 @@ internal class BillingWrapper internal constructor(
             }
         }
 
-    private val productTypes = mutableMapOf<String, String>()
+    private val productTypes = mutableMapOf<String, PurchaseType>()
     private val presentedOfferingsByProductIdentifier = mutableMapOf<String, String?>()
 
     private val serviceRequests = ConcurrentLinkedQueue<(connectionError: PurchasesError?) -> Unit>()
@@ -165,7 +165,7 @@ internal class BillingWrapper internal constructor(
             debugLog("Making purchase for sku: ${skuDetails.sku}")
         }
         synchronized(this@BillingWrapper) {
-            productTypes[skuDetails.sku] = skuDetails.type
+            productTypes[skuDetails.sku] = PurchaseType.fromSKUType(skuDetails.type)
             presentedOfferingsByProductIdentifier[skuDetails.sku] = presentedOfferingIdentifier
         }
         executeRequestOnUIThread {
@@ -225,8 +225,8 @@ internal class BillingWrapper internal constructor(
                     SkuType.INAPP,
                     { inAppPurchasesList ->
                         onReceivePurchaseHistory(
-                            subsPurchasesList.map { PurchaseWrapper(it, SkuType.SUBS) } +
-                                inAppPurchasesList.map { PurchaseWrapper(it, SkuType.INAPP) }
+                            subsPurchasesList.map { PurchaseWrapper(it, PurchaseType.SUBS) } +
+                                inAppPurchasesList.map { PurchaseWrapper(it, PurchaseType.INAPP) }
                         )
                     },
                     onReceivePurchaseHistoryError
@@ -284,10 +284,24 @@ internal class BillingWrapper internal constructor(
                 purchasesList.map { purchase ->
                     val hash = purchase.purchaseToken.sha1()
                     debugLog("[QueryPurchases] Purchase of type $skuType with hash $hash")
-                    hash to PurchaseWrapper(purchase, skuType, null)
+                    hash to PurchaseWrapper(purchase, PurchaseType.fromSKUType(skuType), null)
                 }.toMap()
             )
         }
+    }
+
+    private fun getPurchaseType(purchaseToken: String): PurchaseType {
+        billingClient?.let { client ->
+            val querySubsResult = client.queryPurchases(SkuType.SUBS)
+            if (querySubsResult.responseCode == BillingClient.BillingResponseCode.OK && querySubsResult.purchasesList.any { it.purchaseToken == purchaseToken }) {
+                return PurchaseType.SUBS
+            }
+            val queryINAPPsResult = client.queryPurchases(SkuType.INAPP)
+            if (queryINAPPsResult.responseCode == BillingClient.BillingResponseCode.OK && queryINAPPsResult.purchasesList.any { it.purchaseToken == purchaseToken }) {
+                return PurchaseType.INAPP
+            }
+        }
+        return PurchaseType.UNKNOWN
     }
 
     override fun onPurchasesUpdated(
@@ -297,13 +311,17 @@ internal class BillingWrapper internal constructor(
         if (billingResult.responseCode == BillingClient.BillingResponseCode.OK && purchases != null) {
             purchases.map { purchase ->
                 debugLog("BillingWrapper purchases updated. ${purchase.toHumanReadableDescription()}")
-                var type: String?
+                var type: PurchaseType?
                 var presentedOffering: String?
                 synchronized(this@BillingWrapper) {
                     type = productTypes[purchase.sku]
                     presentedOffering = presentedOfferingsByProductIdentifier[purchase.sku]
                 }
-                PurchaseWrapper(purchase, type, presentedOffering)
+                PurchaseWrapper(
+                    purchase,
+                    type ?: getPurchaseType(purchase.purchaseToken),
+                    presentedOffering
+                )
             }.let { mappedPurchases ->
                 purchasesUpdatedListener?.onPurchasesUpdated(mappedPurchases)
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseType.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseType.kt
@@ -1,0 +1,25 @@
+package com.revenuecat.purchases
+
+import com.android.billingclient.api.BillingClient
+
+internal enum class PurchaseType {
+    SUBS, INAPP, UNKNOWN;
+
+    companion object {
+        fun fromSKUType(@BillingClient.SkuType skuType: String?): PurchaseType {
+            return when (skuType) {
+                BillingClient.SkuType.INAPP -> INAPP
+                BillingClient.SkuType.SUBS -> SUBS
+                else -> UNKNOWN
+            }
+        }
+    }
+}
+
+internal fun PurchaseType.toSKUType(): String? {
+    return when (this) {
+        PurchaseType.INAPP -> BillingClient.SkuType.INAPP
+        PurchaseType.SUBS -> BillingClient.SkuType.SUBS
+        PurchaseType.UNKNOWN -> null
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseWrapper.kt
@@ -1,20 +1,19 @@
 package com.revenuecat.purchases
 
-import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryRecord
 
-data class PurchaseWrapper(
+internal data class PurchaseWrapper(
     val isConsumable: Boolean,
     val purchaseToken: String,
     val purchaseTime: Long,
     val sku: String,
     val containedPurchase: Purchase?,
-    @BillingClient.SkuType val type: String?,
+    val type: PurchaseType,
     val presentedOfferingIdentifier: String? = null
 ) {
-    constructor(purchaseHistoryRecord: PurchaseHistoryRecord, @BillingClient.SkuType type: String?) : this(
-        isConsumable = type == BillingClient.SkuType.INAPP,
+    constructor(purchaseHistoryRecord: PurchaseHistoryRecord, type: PurchaseType) : this(
+        isConsumable = type == PurchaseType.SUBS,
         purchaseToken = purchaseHistoryRecord.purchaseToken,
         purchaseTime = purchaseHistoryRecord.purchaseTime,
         sku = purchaseHistoryRecord.sku,
@@ -22,8 +21,8 @@ data class PurchaseWrapper(
         type = type
     )
 
-    constructor(purchase: Purchase, @BillingClient.SkuType type: String?, presentedOfferingIdentifier: String?) : this(
-        isConsumable = type == BillingClient.SkuType.INAPP,
+    constructor(purchase: Purchase, type: PurchaseType, presentedOfferingIdentifier: String?) : this(
+        isConsumable = type == PurchaseType.INAPP,
         purchaseToken = purchase.purchaseToken,
         purchaseTime = purchase.purchaseTime,
         sku = purchase.sku,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
@@ -39,7 +39,8 @@ enum class PurchasesErrorCode(val description: String) {
     InvalidAppUserIdError("The app user id is not valid."),
     OperationAlreadyInProgressError("The operation is already in progress."),
     UnknownBackendError("There was an unknown backend error."),
-    InsufficientPermissionsError("App does not have sufficient permissions to make purchases.")
+    InsufficientPermissionsError("App does not have sufficient permissions to make purchases."),
+    PaymentPendingError("The payment is pending.")
 }
 
 internal enum class BackendErrorCode(val value: Int) {

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
@@ -48,7 +48,7 @@ class BillingWrapperTest {
 
     private var mockPurchasesListener: BillingWrapper.PurchasesUpdatedListener = mockk()
 
-    private var wrapper: BillingWrapper? = null
+    private lateinit var wrapper: BillingWrapper
 
     private val mockDetailsList = ArrayList<SkuDetails>()
 
@@ -102,9 +102,9 @@ class BillingWrapperTest {
         mockDetailsList.add(mockDetails)
 
         wrapper = BillingWrapper(mockClientFactory, handler)
-        wrapper!!.purchasesUpdatedListener = mockPurchasesListener
+        wrapper.purchasesUpdatedListener = mockPurchasesListener
         onConnectedCalled = false
-        wrapper!!.stateListener = object : BillingWrapper.StateListener {
+        wrapper.stateListener = object : BillingWrapper.StateListener {
             override fun onConnected() {
                 onConnectedCalled = true
             }
@@ -154,7 +154,7 @@ class BillingWrapperTest {
         val productIDs = ArrayList<String>()
         productIDs.add("product_a")
 
-        wrapper!!.querySkuDetailsAsync(
+        wrapper.querySkuDetailsAsync(
             BillingClient.SkuType.SUBS,
             productIDs,
             {
@@ -181,7 +181,7 @@ class BillingWrapperTest {
         val productIDs = ArrayList<String>()
         productIDs.add("product_a")
 
-        wrapper!!.querySkuDetailsAsync(
+        wrapper.querySkuDetailsAsync(
             BillingClient.SkuType.SUBS,
             productIDs,
             {
@@ -190,7 +190,7 @@ class BillingWrapperTest {
             {
                 fail("shouldn't be an error")
             })
-        wrapper!!.querySkuDetailsAsync(
+        wrapper.querySkuDetailsAsync(
             BillingClient.SkuType.SUBS,
             productIDs
             , {
@@ -213,7 +213,7 @@ class BillingWrapperTest {
         mockStandardSkuDetailsResponse()
         every { mockClient.isReady } returns false
 
-        wrapper!!.querySkuDetailsAsync(
+        wrapper.querySkuDetailsAsync(
             BillingClient.SkuType.SUBS,
             listOf("product_a"),
             {
@@ -243,7 +243,7 @@ class BillingWrapperTest {
         val activity: Activity = mockk()
 
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
-        wrapper!!.makePurchaseAsync(
+        wrapper.makePurchaseAsync(
             activity,
             "jerry",
             skuDetails,
@@ -286,7 +286,7 @@ class BillingWrapperTest {
         }
 
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
-        wrapper!!.makePurchaseAsync(
+        wrapper.makePurchaseAsync(
             activity,
             appUserID,
             skuDetails,
@@ -313,7 +313,7 @@ class BillingWrapperTest {
             every { it.type } returns BillingClient.SkuType.SUBS
         }
 
-        wrapper!!.makePurchaseAsync(
+        wrapper.makePurchaseAsync(
             activity,
             appUserID,
             skuDetails,
@@ -354,7 +354,7 @@ class BillingWrapperTest {
 
         val activity: Activity = mockk()
 
-        wrapper!!.makePurchaseAsync(
+        wrapper.makePurchaseAsync(
             activity,
             appUserID,
             skuDetails,
@@ -435,7 +435,7 @@ class BillingWrapperTest {
         setup()
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         var successCalled = false
-        wrapper!!.queryPurchaseHistoryAsync(
+        wrapper.queryPurchaseHistoryAsync(
             BillingClient.SkuType.SUBS,
             {
                 successCalled = true
@@ -457,7 +457,7 @@ class BillingWrapperTest {
 
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         var errorCalled = false
-        wrapper!!.queryPurchaseHistoryAsync(
+        wrapper.queryPurchaseHistoryAsync(
             BillingClient.SkuType.SUBS,
             {
                 fail("should go to on error")
@@ -485,7 +485,7 @@ class BillingWrapperTest {
         } just Runs
 
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
-        wrapper!!.consumePurchase(token) { _, _ -> }
+        wrapper.consumePurchase(token) { _, _ -> }
 
         assertThat(capturingSlot.isCaptured).isTrue()
         assertThat(capturingSlot.captured.purchaseToken).isEqualTo(token)
@@ -501,20 +501,20 @@ class BillingWrapperTest {
             mockClient.isReady
         } returns true
 
-        wrapper!!.purchasesUpdatedListener = null
+        wrapper.purchasesUpdatedListener = null
         verify {
             mockClient.endConnection()
         }
-        assertThat(wrapper!!.purchasesUpdatedListener).isNull()
+        assert(wrapper.purchasesUpdatedListener == null)
     }
 
     @Test
     fun whenSettingListenerStartConnection() {
         setup()
         verify {
-            mockClient.startConnection(eq(wrapper!!))
+            mockClient.startConnection(eq(wrapper))
         }
-        assertThat(wrapper!!.purchasesUpdatedListener).isNotNull
+        assertThat(wrapper.purchasesUpdatedListener).isNotNull
     }
 
     @Test
@@ -523,11 +523,11 @@ class BillingWrapperTest {
         every {
             mockClient.endConnection()
         } just Runs
-        wrapper!!.purchasesUpdatedListener = null
-        wrapper!!.consumePurchase("token") { _, _ -> }
+        wrapper.purchasesUpdatedListener = null
+        wrapper.consumePurchase("token") { _, _ -> }
 
         verify(exactly = 1) { // Just the original connection
-            mockClient.startConnection(wrapper!!)
+            mockClient.startConnection(wrapper)
         }
     }
 
@@ -540,14 +540,14 @@ class BillingWrapperTest {
         productIDs.add("product_a")
 
         var receivedList: List<SkuDetails>? = null
-        wrapper!!.querySkuDetailsAsync(
+        wrapper.querySkuDetailsAsync(
             BillingClient.SkuType.SUBS,
             productIDs, {
                 receivedList = it
             }, {
                 fail("shouldn't be an error")
             })
-        wrapper!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        wrapper.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         assertThat(receivedList).isNotNull
         assertThat(receivedList!!.size).isZero()
     }
@@ -561,17 +561,17 @@ class BillingWrapperTest {
         every {
             mockClient.isReady
         } returns true
-        wrapper!!.purchasesUpdatedListener = null
+        wrapper.purchasesUpdatedListener = null
 
-        assertThat<BillingClient>(wrapper!!.billingClient).isNull()
+        assertThat<BillingClient>(wrapper.billingClient).isNull()
     }
 
     @Test
     fun newBillingClientIsCreatedWhenSettingListener() {
         setup()
-        wrapper!!.purchasesUpdatedListener = mockPurchasesListener
+        wrapper.purchasesUpdatedListener = mockPurchasesListener
 
-        assertThat<BillingClient>(wrapper!!.billingClient).isNotNull
+        assertThat<BillingClient>(wrapper.billingClient).isNotNull
     }
 
     @Test
@@ -581,7 +581,7 @@ class BillingWrapperTest {
             mockClient.isReady
         } returns false
 
-        wrapper!!.querySkuDetailsAsync(
+        wrapper.querySkuDetailsAsync(
             BillingClient.SkuType.SUBS,
             listOf("product_a"),
             {},
@@ -589,8 +589,8 @@ class BillingWrapperTest {
                 fail("shouldn't be an error")
             })
 
-        wrapper!!.purchasesUpdatedListener = null
-        wrapper!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        wrapper.purchasesUpdatedListener = null
+        wrapper.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
     }
 
     @Test
@@ -600,8 +600,8 @@ class BillingWrapperTest {
             mockClient.isReady
         } returns false
 
-        wrapper!!.purchasesUpdatedListener = null
-        wrapper!!.onPurchasesUpdated(BillingClient.BillingResponseCode.DEVELOPER_ERROR.buildResult(), emptyList())
+        wrapper.purchasesUpdatedListener = null
+        wrapper.onPurchasesUpdated(BillingClient.BillingResponseCode.DEVELOPER_ERROR.buildResult(), emptyList())
     }
 
     @Test
@@ -611,7 +611,7 @@ class BillingWrapperTest {
             mockClient.isReady
         } returns false
 
-        wrapper!!.purchasesUpdatedListener = null
+        wrapper.purchasesUpdatedListener = null
         verify {
             mockClient.endConnection()
         }
@@ -635,7 +635,7 @@ class BillingWrapperTest {
         }
 
         var receivedPurchases = listOf<PurchaseWrapper>()
-        wrapper!!.queryAllPurchases({
+        wrapper.queryAllPurchases({
             receivedPurchases = it
         }, { fail("Shouldn't be error") })
 
@@ -662,13 +662,13 @@ class BillingWrapperTest {
     fun `when querying INAPPs and there is no billing client, don't return anything`() {
         wrapper = BillingWrapper(mockClientFactory, handler)
 
-        assertThat(wrapper!!.queryPurchases(BillingClient.SkuType.INAPP)).isNull()
+        assertThat(wrapper.queryPurchases(BillingClient.SkuType.INAPP)).isNull()
     }
 
     @Test
     fun `when querying SUBs and there is no billing client, don't return anything`() {
         wrapper = BillingWrapper(mockClientFactory, handler)
-        assertThat(wrapper!!.queryPurchases(BillingClient.SkuType.SUBS)).isNull()
+        assertThat(wrapper.queryPurchases(BillingClient.SkuType.SUBS)).isNull()
     }
 
     @Test
@@ -679,7 +679,7 @@ class BillingWrapperTest {
             mockClient.queryPurchases(any())
         } returns Purchase.PurchasesResult(BillingClient.BillingResponseCode.OK.buildResult(), null)
 
-        assertThat(wrapper!!.queryPurchases(BillingClient.SkuType.SUBS)!!.purchasesByHashedToken).isNotNull
+        assertThat(wrapper.queryPurchases(BillingClient.SkuType.SUBS)!!.purchasesByHashedToken).isNotNull
     }
 
     @Test
@@ -698,7 +698,7 @@ class BillingWrapperTest {
         every {
             mockClient.queryPurchases(type)
         } returns Purchase.PurchasesResult(resultCode.buildResult(), listOf(purchase))
-        val queryPurchasesResult = wrapper!!.queryPurchases(type)
+        val queryPurchasesResult = wrapper.queryPurchases(type)
         assertThat(queryPurchasesResult).isNotNull
         assertThat(queryPurchasesResult!!.responseCode).isEqualTo(resultCode)
         assertThat(queryPurchasesResult.isSuccessful()).isTrue()
@@ -727,7 +727,7 @@ class BillingWrapperTest {
         every {
             mockClient.queryPurchases(type)
         } returns Purchase.PurchasesResult(resultCode.buildResult(), listOf(purchase))
-        val queryPurchasesResult = wrapper!!.queryPurchases(type)
+        val queryPurchasesResult = wrapper.queryPurchases(type)
         assertThat(queryPurchasesResult).isNotNull
         assertThat(queryPurchasesResult!!.responseCode).isEqualTo(resultCode)
         assertThat(queryPurchasesResult.isSuccessful()).isTrue()
@@ -756,7 +756,7 @@ class BillingWrapperTest {
         val activity: Activity = mockk()
 
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
-        wrapper!!.makePurchaseAsync(
+        wrapper.makePurchaseAsync(
             activity,
             "jerry",
             skuDetails,
@@ -801,10 +801,62 @@ class BillingWrapperTest {
         } just Runs
 
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
-        wrapper!!.acknowledge(token) { _, _ -> }
+        wrapper.acknowledge(token) { _, _ -> }
 
         assertThat(capturingSlot.isCaptured).isTrue()
         assertThat(capturingSlot.captured.purchaseToken).isEqualTo(token)
+    }
+
+    @Test
+    fun `Getting subscriptions type`() {
+        setup()
+        every {
+            mockClient.queryPurchases(BillingClient.SkuType.INAPP)
+        } returns Purchase.PurchasesResult(
+            BillingClient.BillingResponseCode.OK.buildResult(), listOf(mockk(
+                relaxed = true
+            ) {
+                every { this@mockk.purchaseToken } returns "inapp"
+            })
+        )
+        every {
+            mockClient.queryPurchases(BillingClient.SkuType.SUBS)
+        } returns Purchase.PurchasesResult(
+            BillingClient.BillingResponseCode.OK.buildResult(), listOf(mockk(
+                relaxed = true
+            ) {
+                every { this@mockk.purchaseToken } returns "sub"
+            })
+        )
+
+        val purchaseType = wrapper.getPurchaseType("sub")
+        assertThat(purchaseType).isEqualTo(PurchaseType.SUBS)
+    }
+
+    @Test
+    fun `Getting INAPPs type`() {
+        setup()
+        every {
+            mockClient.queryPurchases(BillingClient.SkuType.INAPP)
+        } returns Purchase.PurchasesResult(
+            BillingClient.BillingResponseCode.OK.buildResult(), listOf(mockk(
+                relaxed = true
+            ) {
+                every { this@mockk.purchaseToken } returns "inapp"
+            })
+        )
+        every {
+            mockClient.queryPurchases(BillingClient.SkuType.SUBS)
+        } returns Purchase.PurchasesResult(
+            BillingClient.BillingResponseCode.OK.buildResult(), listOf(mockk(
+                relaxed = true
+            ) {
+                every { this@mockk.purchaseToken } returns "sub"
+            })
+        )
+
+        val purchaseType = wrapper.getPurchaseType("inapp")
+        assertThat(purchaseType).isEqualTo(PurchaseType.INAPP)
     }
 
     private fun mockNullSkuDetailsResponse() {

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
@@ -383,6 +383,11 @@ class BillingWrapperTest {
         every {
             mockPurchasesListener.onPurchasesUpdated(capture(slot))
         } just Runs
+
+        every {
+            mockClient.queryPurchases(BillingClient.SkuType.SUBS)
+        } returns Purchase.PurchasesResult(BillingClient.BillingResponseCode.OK.buildResult(), purchases)
+
         purchasesUpdatedListener!!.onPurchasesUpdated(BillingClient.BillingResponseCode.OK.buildResult(), purchases)
 
         assertThat(slot.captured.size).isOne()
@@ -700,7 +705,7 @@ class BillingWrapperTest {
         assertThat(queryPurchasesResult.purchasesByHashedToken.isNotEmpty()).isTrue()
         val purchaseWrapper = queryPurchasesResult.purchasesByHashedToken[token.sha1()]
         assertThat(purchaseWrapper).isNotNull
-        assertThat(purchaseWrapper!!.type).isEqualTo(type)
+        assertThat(purchaseWrapper!!.type).isEqualTo(PurchaseType.fromSKUType(type))
         assertThat(purchaseWrapper.purchaseToken).isEqualTo(token)
         assertThat(purchaseWrapper.purchaseTime).isEqualTo(time)
         assertThat(purchaseWrapper.sku).isEqualTo(sku)
@@ -729,7 +734,7 @@ class BillingWrapperTest {
         assertThat(queryPurchasesResult.purchasesByHashedToken.isNotEmpty()).isTrue()
         val purchaseWrapper = queryPurchasesResult.purchasesByHashedToken[token.sha1()]
         assertThat(purchaseWrapper).isNotNull
-        assertThat(purchaseWrapper!!.type).isEqualTo(type)
+        assertThat(purchaseWrapper!!.type).isEqualTo(PurchaseType.fromSKUType(type))
         assertThat(purchaseWrapper.purchaseToken).isEqualTo(token)
         assertThat(purchaseWrapper.purchaseTime).isEqualTo(time)
         assertThat(purchaseWrapper.sku).isEqualTo(sku)

--- a/purchases/src/test/java/com/revenuecat/purchases/DeviceCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/DeviceCacheTest.kt
@@ -7,8 +7,6 @@ package com.revenuecat.purchases
 
 import android.content.SharedPreferences
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.billingclient.api.BillingClient.SkuType.INAPP
-import com.android.billingclient.api.BillingClient.SkuType.SUBS
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -248,11 +246,11 @@ class DeviceCacheTest {
         every {
             mockPrefs.getStringSet(cache.tokensCacheKey, any())
         } returns setOf("token1", "hash2", "token3")
-        val activeSub = PurchaseWrapper(mockk(relaxed = true), SUBS, null)
+        val activeSub = PurchaseWrapper(mockk(relaxed = true), PurchaseType.SUBS, null)
         val activePurchasesNotInCache =
             cache.getActivePurchasesNotInCache(
                 mapOf("hash1" to activeSub),
-                mapOf("hash2" to PurchaseWrapper(mockk(relaxed = true), INAPP, null)))
+                mapOf("hash2" to PurchaseWrapper(mockk(relaxed = true), PurchaseType.INAPP, null)))
         assertThat(activePurchasesNotInCache).contains(activeSub)
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -10,12 +10,11 @@ import android.app.Application
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.BillingClient
-import com.android.billingclient.api.BillingClient.SkuType.INAPP
-import com.android.billingclient.api.BillingClient.SkuType.SUBS
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.SkuDetails
+import com.revenuecat.purchases.PurchaseType
 import com.revenuecat.purchases.interfaces.Callback
 import com.revenuecat.purchases.interfaces.GetSkusResponseListener
 import com.revenuecat.purchases.interfaces.ReceivePurchaserInfoListener
@@ -109,7 +108,7 @@ class PurchasesTest {
         mockCache(mockInfo)
         mockBackend(mockInfo, errorGettingPurchaserInfo)
         mockBillingWrapper()
-        mockSkuDetails(skus, skus, SUBS)
+        mockSkuDetails(skus, skus, PurchaseType.SUBS)
 
         every {
             updatedPurchaserInfoListener.onReceived(any())
@@ -168,7 +167,7 @@ class PurchasesTest {
 
         val skuDetails = ArrayList<SkuDetails>()
 
-        mockSkuDetailFetch(skuDetails, skus, SUBS)
+        mockSkuDetailFetch(skuDetails, skus, PurchaseType.SUBS)
 
         purchases.getSubscriptionSkus(skus,
             object : GetSkusResponseListener {
@@ -193,7 +192,7 @@ class PurchasesTest {
 
         val skuDetails = ArrayList<SkuDetails>()
 
-        mockSkuDetailFetch(skuDetails, skus, INAPP)
+        mockSkuDetailFetch(skuDetails, skus, PurchaseType.INAPP)
 
         purchases.getNonSubscriptionSkus(skus,
             object : GetSkusResponseListener {
@@ -291,8 +290,8 @@ class PurchasesTest {
         val purchaseTokenSub = "token_sub"
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, INAPP) +
-                getMockedPurchaseList(skuSub, purchaseTokenSub, SUBS, "offering_a")
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
+                getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS, "offering_a")
         )
 
         verify (exactly = 1) {
@@ -353,7 +352,7 @@ class PurchasesTest {
             every {
                 p.isAcknowledged
             } returns false
-            val wrapper = PurchaseWrapper(p, SUBS, stubOfferingIdentifier)
+            val wrapper = PurchaseWrapper(p, PurchaseType.SUBS, stubOfferingIdentifier)
             purchasesList.add(wrapper)
         }
 
@@ -436,7 +435,7 @@ class PurchasesTest {
         val purchaseToken = "crazy_purchase_token"
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.SUBS)
         )
 
         verify {
@@ -460,7 +459,7 @@ class PurchasesTest {
         val purchaseToken = "crazy_purchase_token"
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.SUBS)
         )
 
         verify {
@@ -486,7 +485,7 @@ class PurchasesTest {
         val purchaseToken = "crazy_purchase_token"
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.SUBS)
         )
 
         verify {
@@ -537,8 +536,8 @@ class PurchasesTest {
         } answers {
             capturedLambda = lambda<(List<PurchaseWrapper>) -> Unit>().captured
             capturedLambda?.invoke(
-                getMockedPurchaseList(sku, purchaseToken, INAPP) +
-                    getMockedPurchaseList(skuSub, purchaseTokenSub, SUBS)
+                getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
+                    getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
             )
         }
 
@@ -615,8 +614,8 @@ class PurchasesTest {
         } answers {
             capturedLambda = lambda<(List<PurchaseWrapper>) -> Unit>().captured.also {
                 it.invoke(
-                    getMockedPurchaseList(sku, purchaseToken, INAPP) +
-                        getMockedPurchaseList(skuSub, purchaseTokenSub, SUBS)
+                    getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
+                        getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
                 )
             }
         }
@@ -660,7 +659,7 @@ class PurchasesTest {
         val purchaseToken = "crazy_purchase_token"
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.SUBS)
         )
 
         verify {
@@ -680,7 +679,7 @@ class PurchasesTest {
 
         val skus = listOf(stubProductIdentifier)
         mockProducts()
-        mockSkuDetails(skus, skus, SUBS)
+        mockSkuDetails(skus, skus, PurchaseType.SUBS)
         val (_, offerings) = stubOfferings("onemonth_freetrial")
 
         every {
@@ -710,7 +709,7 @@ class PurchasesTest {
 
         val skus = listOf(stubProductIdentifier)
         mockProducts()
-        mockSkuDetails(skus, skus, SUBS)
+        mockSkuDetails(skus, skus, PurchaseType.SUBS)
         val (_, offerings) = stubOfferings("onemonth_freetrial")
 
         every {
@@ -734,7 +733,7 @@ class PurchasesTest {
         setup()
 
         mockProducts()
-        mockSkuDetails(listOf(), listOf(), "subs")
+        mockSkuDetails(listOf(), listOf(), PurchaseType.SUBS)
         val (_, offerings) = stubOfferings("onemonth_freetrial")
 
         every {
@@ -790,8 +789,8 @@ class PurchasesTest {
 
         val skus = listOf(stubProductIdentifier)
         mockProducts()
-        mockSkuDetails(skus, ArrayList(), SUBS)
-        mockSkuDetails(skus, ArrayList(), INAPP)
+        mockSkuDetails(skus, ArrayList(), PurchaseType.SUBS)
+        mockSkuDetails(skus, ArrayList(), PurchaseType.INAPP)
 
         val errorMessage = emptyArray<PurchasesError>()
 
@@ -941,8 +940,8 @@ class PurchasesTest {
         }
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, INAPP) +
-                getMockedPurchaseList(skuSub, purchaseTokenSub, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
+                getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
         )
 
         verify (exactly = 1) {
@@ -1008,8 +1007,8 @@ class PurchasesTest {
         }
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, INAPP) +
-                getMockedPurchaseList(skuSub, purchaseTokenSub, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
+                getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
         )
 
         assertThat(capturedLambda).isNotNull
@@ -1219,7 +1218,7 @@ class PurchasesTest {
         val purchaseToken = "crazy_purchase_token"
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.SUBS)
         )
 
         verify(exactly = 2) {
@@ -1235,7 +1234,7 @@ class PurchasesTest {
         val purchaseToken = "crazy_purchase_token"
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.SUBS)
         )
 
         verify(exactly = 1) {
@@ -1293,10 +1292,10 @@ class PurchasesTest {
             }, onError = { _, _ -> fail("should be successful") })
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.SUBS)
         )
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.SUBS)
         )
 
         assertThat(callCount).isEqualTo(1)
@@ -1321,7 +1320,7 @@ class PurchasesTest {
             }, onError = { _, _ -> fail("should be successful") })
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku1, purchaseToken1, SUBS)
+            getMockedPurchaseList(sku1, purchaseToken1, PurchaseType.SUBS)
         )
 
         assertThat(callCount).isEqualTo(0)
@@ -1617,8 +1616,8 @@ class PurchasesTest {
         val purchaseTokenSub = "crazy_purchase_token_sub"
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, INAPP) +
-            getMockedPurchaseList(skuSub, purchaseTokenSub, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
+            getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
         )
         verify(exactly = 1){
             mockBackend.postReceiptData(
@@ -1696,8 +1695,8 @@ class PurchasesTest {
         purchases.finishTransactions = false
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, INAPP) +
-                getMockedPurchaseList(skuSub, purchaseTokenSub, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
+                getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
         )
 
         assertThat(capturedLambda).isNotNull
@@ -1745,8 +1744,8 @@ class PurchasesTest {
         purchases.finishTransactions = false
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, INAPP) +
-            getMockedPurchaseList(skuSub, purchaseTokenSub, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
+            getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
         )
 
         assertThat(captured).isNotNull
@@ -1782,8 +1781,8 @@ class PurchasesTest {
         } answers {
             capturedLambda = lambda<(List<PurchaseWrapper>) -> Unit>().captured.also {
                 it.invoke(
-                    getMockedPurchaseList(sku, purchaseToken, INAPP) +
-                    getMockedPurchaseList(skuSub, purchaseTokenSub, SUBS)
+                    getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
+                    getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
                 )
             }
         }
@@ -1834,8 +1833,8 @@ class PurchasesTest {
         } answers {
             capturedLambda = lambda<(List<PurchaseWrapper>) -> Unit>().captured.also {
                 it.invoke(
-                    getMockedPurchaseList(sku, purchaseToken, INAPP) +
-                        getMockedPurchaseList(skuSub, purchaseTokenSub, SUBS)
+                    getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
+                        getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
                 )
             }
         }
@@ -1883,7 +1882,7 @@ class PurchasesTest {
             )
         } answers {
             capturedLambda = lambda<(List<PurchaseWrapper>) -> Unit>().captured.also {
-                it.invoke(getMockedPurchaseList(sku, purchaseToken, INAPP))
+                it.invoke(getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP))
             }
         }
 
@@ -2134,7 +2133,7 @@ class PurchasesTest {
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(getMockedPurchaseList(
             sku,
             purchaseToken,
-            INAPP,
+            PurchaseType.INAPP,
             null
         ))
         capturedConsumeResponseListener.captured.invoke(BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(), purchaseToken)
@@ -2168,7 +2167,7 @@ class PurchasesTest {
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(getMockedPurchaseList(
             sku,
             purchaseToken,
-            INAPP,
+            PurchaseType.INAPP,
             null
         ))
         capturedLambda!!.invoke(
@@ -2190,7 +2189,7 @@ class PurchasesTest {
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(getMockedPurchaseList(
             sku,
             purchaseToken,
-            INAPP,
+            PurchaseType.INAPP,
             null
         ))
         capturedConsumeResponseListener.captured.invoke(BillingClient.BillingResponseCode.OK.buildResult(), purchaseToken)
@@ -2224,7 +2223,7 @@ class PurchasesTest {
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(getMockedPurchaseList(
             sku,
             purchaseToken,
-            INAPP,
+            PurchaseType.INAPP,
             null
         ))
         capturedLambda!!.invoke(
@@ -2234,6 +2233,9 @@ class PurchasesTest {
         capturedConsumeResponseListener.captured.invoke(BillingClient.BillingResponseCode.OK.buildResult(), "crazy_purchase_token")
         verify (exactly = 1) {
             mockCache.addSuccessfullyPostedToken("crazy_purchase_token")
+        }
+        verify (exactly = 1) {
+            mockBillingWrapper.consumePurchase("crazy_purchase_token", any())
         }
     }
 
@@ -2280,8 +2282,8 @@ class PurchasesTest {
         }
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, INAPP) +
-                getMockedPurchaseList(skuSub, purchaseTokenSub, SUBS)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
+                getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
         )
 
         assertThat(capturedLambda).isNotNull
@@ -2302,8 +2304,9 @@ class PurchasesTest {
         val purchase = mockk<Purchase>(relaxed = true).apply {
             every { purchaseToken } returns "token"
             every { sku } returns "product"
+            every { purchaseState } returns Purchase.PurchaseState.PURCHASED
         }
-        val activePurchase = PurchaseWrapper(purchase, SUBS, null)
+        val activePurchase = PurchaseWrapper(purchase, PurchaseType.SUBS, null)
         mockSuccessfulQueryPurchases(
             queriedSUBS = mapOf(purchase.purchaseToken.sha1() to activePurchase),
             queriedINAPP = emptyMap(),
@@ -2342,10 +2345,10 @@ class PurchasesTest {
         )
         purchases.updatePendingPurchaseQueue()
         verify (exactly = 1) {
-            mockBillingWrapper.queryPurchases(SUBS)
+            mockBillingWrapper.queryPurchases(PurchaseType.SUBS.toSKUType()!!)
         }
         verify (exactly = 1) {
-            mockBillingWrapper.queryPurchases(INAPP)
+            mockBillingWrapper.queryPurchases(PurchaseType.INAPP.toSKUType()!!)
         }
     }
 
@@ -2355,8 +2358,9 @@ class PurchasesTest {
         val purchase = mockk<Purchase>(relaxed = true).apply {
             every { purchaseToken } returns "token"
             every { sku } returns "product"
+            every { purchaseState } returns Purchase.PurchaseState.PURCHASED
         }
-        val newPurchase = PurchaseWrapper(purchase, SUBS, null)
+        val newPurchase = PurchaseWrapper(purchase, PurchaseType.SUBS, null)
         mockSuccessfulQueryPurchases(
             queriedSUBS = mapOf(purchase.purchaseToken.sha1() to newPurchase),
             queriedINAPP = emptyMap(),
@@ -2387,7 +2391,7 @@ class PurchasesTest {
         mockSuccessfulQueryPurchases(
             queriedSUBS = mapOf(purchase.purchaseToken.sha1() to PurchaseWrapper(
                 purchase,
-                SUBS,
+                PurchaseType.SUBS,
                 null
             )),
             queriedINAPP = emptyMap(),
@@ -2414,10 +2418,10 @@ class PurchasesTest {
             mockExecutorService.isShutdown
         } returns false
         every {
-            mockBillingWrapper.queryPurchases(SUBS)
+            mockBillingWrapper.queryPurchases(PurchaseType.SUBS.toSKUType()!!)
         } returns BillingWrapper.QueryPurchasesResult(-1, emptyMap())
         every {
-            mockBillingWrapper.queryPurchases(INAPP)
+            mockBillingWrapper.queryPurchases(PurchaseType.INAPP.toSKUType()!!)
         } returns BillingWrapper.QueryPurchasesResult(0, emptyMap())
         purchases.updatePendingPurchaseQueue()
         verify (exactly = 0) {
@@ -2432,10 +2436,10 @@ class PurchasesTest {
             mockExecutorService.isShutdown
         } returns false
         every {
-            mockBillingWrapper.queryPurchases(SUBS)
+            mockBillingWrapper.queryPurchases(PurchaseType.SUBS.toSKUType()!!)
         } returns BillingWrapper.QueryPurchasesResult(0, emptyMap())
         every {
-            mockBillingWrapper.queryPurchases(INAPP)
+            mockBillingWrapper.queryPurchases(PurchaseType.INAPP.toSKUType()!!)
         } returns BillingWrapper.QueryPurchasesResult(-1, emptyMap())
         purchases.updatePendingPurchaseQueue()
         verify (exactly = 0) {
@@ -2453,10 +2457,10 @@ class PurchasesTest {
         )
         capturedBillingWrapperStateListener.captured.onConnected()
         verify (exactly = 1) {
-            mockBillingWrapper.queryPurchases(SUBS)
+            mockBillingWrapper.queryPurchases(PurchaseType.SUBS.toSKUType()!!)
         }
         verify (exactly = 1) {
-            mockBillingWrapper.queryPurchases(INAPP)
+            mockBillingWrapper.queryPurchases(PurchaseType.INAPP.toSKUType()!!)
         }
     }
 
@@ -2470,10 +2474,10 @@ class PurchasesTest {
         )
         purchases.onAppForegrounded()
         verify (exactly = 1) {
-            mockBillingWrapper.queryPurchases(SUBS)
+            mockBillingWrapper.queryPurchases(PurchaseType.SUBS.toSKUType()!!)
         }
         verify (exactly = 1) {
-            mockBillingWrapper.queryPurchases(INAPP)
+            mockBillingWrapper.queryPurchases(PurchaseType.INAPP.toSKUType()!!)
         }
     }
 
@@ -2485,10 +2489,10 @@ class PurchasesTest {
         } returns false
         purchases.updatePendingPurchaseQueue()
         verify (exactly = 0) {
-            mockBillingWrapper.queryPurchases(SUBS)
+            mockBillingWrapper.queryPurchases(PurchaseType.SUBS.toSKUType()!!)
         }
         verify (exactly = 0) {
-            mockBillingWrapper.queryPurchases(INAPP)
+            mockBillingWrapper.queryPurchases(PurchaseType.INAPP.toSKUType()!!)
         }
     }
 
@@ -2505,7 +2509,7 @@ class PurchasesTest {
     }
 
     @Test
-    fun `Do not consume pending purchases`() {
+    fun `Do not post or consume pending purchases`() {
         setup()
         val sku = "inapp"
         val purchaseToken = "token_inapp"
@@ -2513,11 +2517,11 @@ class PurchasesTest {
         val purchaseTokenSub = "token_sub"
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(sku, purchaseToken, INAPP, purchaseState = Purchase.PurchaseState.PENDING) +
-                getMockedPurchaseList(skuSub, purchaseTokenSub, SUBS, "offering_a", purchaseState = Purchase.PurchaseState.PENDING)
+            getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP, purchaseState = Purchase.PurchaseState.PENDING) +
+                getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS, "offering_a", purchaseState = Purchase.PurchaseState.PENDING)
         )
 
-        verify (exactly = 1) {
+        verify (exactly = 0) {
             mockBackend.postReceiptData(
                 purchaseToken,
                 appUserId,
@@ -2529,7 +2533,7 @@ class PurchasesTest {
             )
         }
 
-        verify (exactly = 1) {
+        verify (exactly = 0) {
             mockBackend.postReceiptData(
                 purchaseTokenSub,
                 appUserId,
@@ -2561,7 +2565,7 @@ class PurchasesTest {
         val purchaseTokenSub = "token_sub"
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
-            getMockedPurchaseList(skuSub, purchaseTokenSub, SUBS, "offering_a", acknowledged = true)
+            getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS, "offering_a", acknowledged = true)
         )
 
         verify (exactly = 1) {
@@ -2595,7 +2599,7 @@ class PurchasesTest {
             getMockedPurchaseList(
                 skuSub,
                 purchaseTokenSub,
-                SUBS,
+                PurchaseType.SUBS,
                 "offering_a",
                 acknowledged = false
             )
@@ -2633,7 +2637,7 @@ class PurchasesTest {
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(getMockedPurchaseList(
             skuSub,
             purchaseTokenSub,
-            SUBS,
+            PurchaseType.SUBS,
             "offering_a"
         ))
         capturedAcknowledgeResponseListener.captured.invoke(
@@ -2670,7 +2674,7 @@ class PurchasesTest {
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(getMockedPurchaseList(
             skuSub,
             purchaseTokenSub,
-            SUBS,
+            PurchaseType.SUBS,
             "offering_a"
         ))
         capturedLambda!!.invoke(
@@ -2710,7 +2714,7 @@ class PurchasesTest {
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(getMockedPurchaseList(
             skuSub,
             purchaseTokenSub,
-            SUBS,
+            PurchaseType.SUBS,
             null
         ))
         capturedLambda!!.invoke(
@@ -2727,11 +2731,11 @@ class PurchasesTest {
     }
 
     // region Private Methods
-    private fun mockSkuDetailFetch(details: List<SkuDetails>, skus: List<String>, skuType: String) {
+    private fun mockSkuDetailFetch(details: List<SkuDetails>, skus: List<String>, purchaseType: PurchaseType) {
         every {
             mockBillingWrapper.querySkuDetailsAsync(
-                eq(skuType),
-                eq(skus),
+                purchaseType.toSKUType()!!,
+                skus,
                 captureLambda(),
                 any()
             )
@@ -2750,6 +2754,9 @@ class PurchasesTest {
             } just Runs
             every {
                 consumePurchase(any(), capture(capturedConsumeResponseListener))
+            } just Runs
+            every {
+                acknowledge(any(), capture(capturedAcknowledgeResponseListener))
             } just Runs
             every {
                 acknowledge(any(), capture(capturedAcknowledgeResponseListener))
@@ -2842,7 +2849,7 @@ class PurchasesTest {
     private fun mockSkuDetails(
         skus: List<String>,
         returnSkus: List<String>,
-        type: String
+        type: PurchaseType
     ): List<SkuDetails> {
         val skuDetailsList = returnSkus.map { sku ->
             mockk<SkuDetails>().also {
@@ -2905,7 +2912,7 @@ class PurchasesTest {
     private fun getMockedPurchaseList(
         sku: String,
         purchaseToken: String,
-        skuType: String,
+        purchaseType: PurchaseType,
         offeringIdentifier: String? = null,
         purchaseState: Int = Purchase.PurchaseState.PURCHASED,
         acknowledged: Boolean = false
@@ -2927,7 +2934,7 @@ class PurchasesTest {
             p.isAcknowledged
         } returns acknowledged
         val purchasesList = ArrayList<PurchaseWrapper>()
-        purchasesList.add(PurchaseWrapper(p, skuType, offeringIdentifier))
+        purchasesList.add(PurchaseWrapper(p, purchaseType, offeringIdentifier))
         return purchasesList
     }
 
@@ -2954,10 +2961,10 @@ class PurchasesTest {
             )
         } returns notInCache
         every {
-            mockBillingWrapper.queryPurchases(SUBS)
+            mockBillingWrapper.queryPurchases(PurchaseType.SUBS.toSKUType()!!)
         } returns queryPurchasesResultSUBS
         every {
-            mockBillingWrapper.queryPurchases(INAPP)
+            mockBillingWrapper.queryPurchases(PurchaseType.INAPP.toSKUType()!!)
         } returns queryPurchasesResultINAPP
     }
 


### PR DESCRIPTION
The key changes this PR introduces are:
- Added our own `PurchaseType` enum to not have a null purchaseType and to avoid having to deal with Strings
- If `onPurchasesUpdated` gets hit with a new purchase and the type of the purchase is unknown, we will try to get the type of the purchase by calling `queryPurchases` which is synchronous. We normally get the product type using `productTypes`, a Map whose values get set when making a purchase. When making a purchase for a subscription `productA` we will set the `productTypes[productA]` to be `SUBS`. It is possible the `onPurchasesUpdated` method gets hit with a purchase of a product that hasn't been recently purchased (like when a pending transaction succeeds and the app is open). It is also possible that `queryPurchases` fails for whatever reason, in that case, the purchase type will be unknown and querying purchases on the next app startup should figure out the type.
- We won't be posting PENDING purchases to our backend anymore. This is to avoid granting entitlements before a purchase has completed. We will instead send a `PaymentPendingError` so that the developers can show a message to the user explaining the payment needs to be completed  @MiguelCarranza 
