### PR TITLE
Fixes purchases not being posted on restores and syncpurchases

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -220,7 +220,7 @@ internal class BillingWrapper internal constructor(
     }
 
     fun queryAllPurchases(
-        onReceivePurchaseHistory: (List<PurchaseWrapper>) -> Unit,
+        onReceivePurchaseHistory: (List<PurchaseHistoryRecordWrapper>) -> Unit,
         onReceivePurchaseHistoryError: (PurchasesError) -> Unit
     ) {
         queryPurchaseHistoryAsync(
@@ -230,8 +230,8 @@ internal class BillingWrapper internal constructor(
                     SkuType.INAPP,
                     { inAppPurchasesList ->
                         onReceivePurchaseHistory(
-                            subsPurchasesList.map { PurchaseWrapper(it, PurchaseType.SUBS) } +
-                                inAppPurchasesList.map { PurchaseWrapper(it, PurchaseType.INAPP) }
+                            subsPurchasesList.map { PurchaseHistoryRecordWrapper(it, PurchaseType.SUBS) } +
+                                inAppPurchasesList.map { PurchaseHistoryRecordWrapper(it, PurchaseType.INAPP) }
                         )
                     },
                     onReceivePurchaseHistoryError

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseHistoryRecordWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseHistoryRecordWrapper.kt
@@ -1,0 +1,24 @@
+package com.revenuecat.purchases
+
+import com.android.billingclient.api.PurchaseHistoryRecord
+
+internal data class PurchaseHistoryRecordWrapper(
+    val isConsumable: Boolean,
+    val purchaseToken: String,
+    val purchaseTime: Long,
+    val sku: String,
+    val purchaseHistoryRecord: PurchaseHistoryRecord,
+    val type: PurchaseType
+) {
+    constructor(
+        purchaseHistoryRecord: PurchaseHistoryRecord,
+        type: PurchaseType
+    ) : this(
+        isConsumable = type == PurchaseType.INAPP,
+        purchaseToken = purchaseHistoryRecord.purchaseToken,
+        purchaseTime = purchaseHistoryRecord.purchaseTime,
+        sku = purchaseHistoryRecord.sku,
+        purchaseHistoryRecord = purchaseHistoryRecord,
+        type = type
+    )
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseWrapper.kt
@@ -1,27 +1,21 @@
 package com.revenuecat.purchases
 
 import com.android.billingclient.api.Purchase
-import com.android.billingclient.api.PurchaseHistoryRecord
 
 internal data class PurchaseWrapper(
     val isConsumable: Boolean,
     val purchaseToken: String,
     val purchaseTime: Long,
     val sku: String,
-    val containedPurchase: Purchase?,
+    val containedPurchase: Purchase,
     val type: PurchaseType,
     val presentedOfferingIdentifier: String? = null
 ) {
-    constructor(purchaseHistoryRecord: PurchaseHistoryRecord, type: PurchaseType) : this(
-        isConsumable = type == PurchaseType.SUBS,
-        purchaseToken = purchaseHistoryRecord.purchaseToken,
-        purchaseTime = purchaseHistoryRecord.purchaseTime,
-        sku = purchaseHistoryRecord.sku,
-        containedPurchase = null,
-        type = type
-    )
-
-    constructor(purchase: Purchase, type: PurchaseType, presentedOfferingIdentifier: String?) : this(
+    constructor(
+        purchase: Purchase,
+        type: PurchaseType,
+        presentedOfferingIdentifier: String?
+    ) : this(
         isConsumable = type == PurchaseType.INAPP,
         purchaseToken = purchase.purchaseToken,
         purchaseTime = purchase.purchaseTime,
@@ -30,4 +24,5 @@ internal data class PurchaseWrapper(
         type = type,
         presentedOfferingIdentifier = presentedOfferingIdentifier
     )
+
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
@@ -635,7 +635,7 @@ class BillingWrapperTest {
             )
         }
 
-        var receivedPurchases = listOf<PurchaseWrapper>()
+        var receivedPurchases = listOf<PurchaseHistoryRecordWrapper>()
         wrapper.queryAllPurchases({
             receivedPurchases = it
         }, { fail("Shouldn't be error") })

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -13,6 +13,7 @@ import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.PurchaseHistoryRecord
 import com.android.billingclient.api.SkuDetails
 import com.revenuecat.purchases.PurchaseType
 import com.revenuecat.purchases.interfaces.Callback
@@ -496,14 +497,14 @@ class PurchasesTest {
     @Test
     fun restoringPurchasesGetsHistory() {
         setup()
-        var capturedLambda: ((List<PurchaseWrapper>) -> Unit)? = null
+        var capturedLambda: ((List<PurchaseHistoryRecordWrapper>) -> Unit)? = null
         every {
             mockBillingWrapper.queryAllPurchases(
                 captureLambda(),
                 any()
             )
         } answers {
-            capturedLambda = lambda<(List<PurchaseWrapper>) -> Unit>().captured.also {
+            capturedLambda = lambda<(List<PurchaseHistoryRecordWrapper>) -> Unit>().captured.also {
                 it.invoke(listOf(mockk(relaxed = true)))
             }
         }
@@ -527,17 +528,17 @@ class PurchasesTest {
         val skuSub = "sub"
         val purchaseTokenSub = "token_sub"
 
-        var capturedLambda: ((List<PurchaseWrapper>) -> Unit)? = null
+        var capturedLambda: ((List<PurchaseHistoryRecordWrapper>) -> Unit)? = null
         every {
             mockBillingWrapper.queryAllPurchases(
                 captureLambda(),
                 any()
             )
         } answers {
-            capturedLambda = lambda<(List<PurchaseWrapper>) -> Unit>().captured
+            capturedLambda = lambda<(List<PurchaseHistoryRecordWrapper>) -> Unit>().captured
             capturedLambda?.invoke(
-                getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
-                    getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
+                getMockedPurchaseHistoryList(sku, purchaseToken, PurchaseType.INAPP) +
+                    getMockedPurchaseHistoryList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
             )
         }
 
@@ -605,17 +606,17 @@ class PurchasesTest {
         val skuSub = "onemonth_freetrial_sub"
         val purchaseTokenSub = "crazy_purchase_token_sub"
 
-        var capturedLambda: ((List<PurchaseWrapper>) -> Unit)? = null
+        var capturedLambda: ((List<PurchaseHistoryRecordWrapper>) -> Unit)? = null
         every {
             mockBillingWrapper.queryAllPurchases(
                 captureLambda(),
                 any()
             )
         } answers {
-            capturedLambda = lambda<(List<PurchaseWrapper>) -> Unit>().captured.also {
+            capturedLambda = lambda<(List<PurchaseHistoryRecordWrapper>) -> Unit>().captured.also {
                 it.invoke(
-                    getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
-                        getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
+                    getMockedPurchaseHistoryList(sku, purchaseToken, PurchaseType.INAPP) +
+                        getMockedPurchaseHistoryList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
                 )
             }
         }
@@ -1772,17 +1773,17 @@ class PurchasesTest {
         val skuSub = "onemonth_freetrial_sub"
         val purchaseTokenSub = "crazy_purchase_token_sub"
 
-        var capturedLambda: ((List<PurchaseWrapper>) -> Unit)? = null
+        var capturedLambda: ((List<PurchaseHistoryRecordWrapper>) -> Unit)? = null
         every {
             mockBillingWrapper.queryAllPurchases(
                 captureLambda(),
                 any()
             )
         } answers {
-            capturedLambda = lambda<(List<PurchaseWrapper>) -> Unit>().captured.also {
+            capturedLambda = lambda<(List<PurchaseHistoryRecordWrapper>) -> Unit>().captured.also {
                 it.invoke(
-                    getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
-                    getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
+                    getMockedPurchaseHistoryList(sku, purchaseToken, PurchaseType.INAPP) +
+                    getMockedPurchaseHistoryList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
                 )
             }
         }
@@ -1824,17 +1825,17 @@ class PurchasesTest {
         val purchaseTokenSub = "crazy_purchase_token_sub"
         purchases.allowSharingPlayStoreAccount = true
 
-        var capturedLambda: ((List<PurchaseWrapper>) -> Unit)? = null
+        var capturedLambda: ((List<PurchaseHistoryRecordWrapper>) -> Unit)? = null
         every {
             mockBillingWrapper.queryAllPurchases(
                 captureLambda(),
                 any()
             )
         } answers {
-            capturedLambda = lambda<(List<PurchaseWrapper>) -> Unit>().captured.also {
+            capturedLambda = lambda<(List<PurchaseHistoryRecordWrapper>) -> Unit>().captured.also {
                 it.invoke(
-                    getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP) +
-                        getMockedPurchaseList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
+                    getMockedPurchaseHistoryList(sku, purchaseToken, PurchaseType.INAPP) +
+                        getMockedPurchaseHistoryList(skuSub, purchaseTokenSub, PurchaseType.SUBS)
                 )
             }
         }
@@ -1874,15 +1875,15 @@ class PurchasesTest {
         val purchaseToken = "crazy_purchase_token"
         purchases.allowSharingPlayStoreAccount = true
 
-        var capturedLambda: ((List<PurchaseWrapper>) -> Unit)? = null
+        var capturedLambda: ((List<PurchaseHistoryRecordWrapper>) -> Unit)? = null
         every {
             mockBillingWrapper.queryAllPurchases(
                 captureLambda(),
                 any()
             )
         } answers {
-            capturedLambda = lambda<(List<PurchaseWrapper>) -> Unit>().captured.also {
-                it.invoke(getMockedPurchaseList(sku, purchaseToken, PurchaseType.INAPP))
+            capturedLambda = lambda<(List<PurchaseHistoryRecordWrapper>) -> Unit>().captured.also {
+                it.invoke(getMockedPurchaseHistoryList(sku, purchaseToken, PurchaseType.INAPP))
             }
         }
 
@@ -2906,6 +2907,26 @@ class PurchasesTest {
         verifyOrder {
             mockBillingWrapper.purchasesUpdatedListener = capturedPurchasesUpdatedListener.captured
             mockBillingWrapper.purchasesUpdatedListener = null
+        }
+    }
+
+    private fun getMockedPurchaseHistoryList(
+        sku: String,
+        purchaseToken: String,
+        purchaseType: PurchaseType
+    ): ArrayList<PurchaseHistoryRecordWrapper> {
+        val p: PurchaseHistoryRecord = mockk()
+        every {
+            p.sku
+        } returns sku
+        every {
+            p.purchaseToken
+        } returns purchaseToken
+        every {
+            p.purchaseTime
+        } returns System.currentTimeMillis()
+        return ArrayList<PurchaseHistoryRecordWrapper>().also {
+            it.add(PurchaseHistoryRecordWrapper(p, purchaseType))
         }
     }
 


### PR DESCRIPTION
Choosing `PurchaseWrapper` to wrap both `Purchase` and `PurchaseHistoryRecord` wasn't a good idea. When posting the token to the backend, we were checking if the state of the purchase was `PURCHASED`. The problem is that for restores and syncing of purchases, the Purchase in the PurchaseWrapper is null and therefore, the status is unknown.

I refactored the code to not reuse the PurchaseWrapper and to make more clear what is happening in each of the cases. 

The unit tests didn't find this because they were wrong. They were creating PurchaseWrappers with Purchases inside, and mocking a PURCHASED purchase. 