### PR TITLE
Adds lifecycle observer and defers updating the caches until the app is foregrounded

### DIFF
--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: "kotlin-android-extensions"
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 28
@@ -27,6 +28,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.annotation:annotation:1.1.0'
     api 'com.android.billingclient:billing:2.0.3'
+    implementation "androidx.lifecycle:lifecycle-runtime:2.1.0"
+    implementation "androidx.lifecycle:lifecycle-extensions:2.1.0"
+    kapt "androidx.lifecycle:lifecycle-compiler:2.1.0"
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test:runner:1.2.0'
     testImplementation 'androidx.test:rules:1.2.0'

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/AppLifecycleHandler.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/AppLifecycleHandler.kt
@@ -1,49 +1,20 @@
 package com.revenuecat.purchases
 
-import android.app.Activity
-import android.app.Application
-import android.content.ComponentCallbacks2
-import android.content.res.Configuration
-import android.os.Bundle
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 
 internal class AppLifecycleHandler(private val lifecycleDelegate: LifecycleDelegate) :
-    Application.ActivityLifecycleCallbacks, ComponentCallbacks2 {
+    LifecycleObserver {
 
-    private var appInForeground = false
-
-    override fun onActivityPaused(p0: Activity?) {}
-
-    override fun onActivityResumed(p0: Activity?) {
-        if (!appInForeground) {
-            appInForeground = true
-            lifecycleDelegate.onAppForegrounded()
-        }
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
+    fun onMoveToForeground() {
+        lifecycleDelegate.onAppForegrounded()
     }
 
-    override fun onActivityStarted(p0: Activity?) {
-    }
-
-    override fun onActivityDestroyed(p0: Activity?) {
-    }
-
-    override fun onActivitySaveInstanceState(p0: Activity?, p1: Bundle?) {
-    }
-
-    override fun onActivityStopped(p0: Activity?) {
-    }
-
-    override fun onActivityCreated(p0: Activity?, p1: Bundle?) {
-    }
-
-    override fun onLowMemory() {}
-
-    override fun onConfigurationChanged(p0: Configuration?) {}
-
-    override fun onTrimMemory(level: Int) {
-        if (level == ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
-            appInForeground = false
-            lifecycleDelegate.onAppBackgrounded()
-        }
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+    fun onMoveToBackground() {
+        lifecycleDelegate.onAppBackgrounded()
     }
 }
 


### PR DESCRIPTION
This PR avoids fetching the purchaser info or the entitlements as soon as the SDK is initialized and defers it to whenever the app is foregrounded. This would prevent us from updating the caches in cases when the Application object is created but the app is in the background (like whenever there is a push notification or any broadcast service that wakes the app up).

