### PR TITLE
Fixes incompatibility with latest AppsFlyer SDK

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1223,14 +1223,16 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
          */
         @JvmStatic
         fun addAttributionData(
-            data: Map<String, String>,
+            data: Map<String, Any?>,
             network: AttributionNetwork,
             networkUserId: String? = null
         ) {
             val jsonObject = JSONObject()
             for (key in data.keys) {
                 try {
-                    jsonObject.put(key, data[key])
+                    data[key]?.let {
+                        jsonObject.put(key, it)
+                    } ?: jsonObject.put(key, JSONObject.NULL)
                 } catch (e: JSONException) {
                     Log.e("Purchases", "Failed to add key $key to attribution map")
                 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -701,25 +701,23 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         onSuccess: ((PurchaseWrapper, PurchaserInfo) -> Unit)? = null,
         onError: ((PurchaseWrapper, PurchasesError) -> Unit)? = null
     ) {
-        identityManager.currentAppUserID.let { appUserID ->
-            purchases.forEach { purchase ->
-                if (purchase.containedPurchase.purchaseState == Purchase.PurchaseState.PURCHASED) {
-                    if (purchase.type == PurchaseType.INAPP) {
-                        billingWrapper.querySkuDetailsAsync(
-                            BillingClient.SkuType.INAPP,
-                            listOf(purchase.sku),
-                            { skuDetailsList ->
-                                postToBackend(purchase, skuDetailsList.first { it.sku == purchase.sku }, allowSharingPlayStoreAccount, consumeAllTransactions, onSuccess, onError)
-                            },
-                            { postToBackend(purchase, null, allowSharingPlayStoreAccount, consumeAllTransactions, onSuccess, onError) }
-                        )
-                    } else {
-                        postToBackend(purchase,null, allowSharingPlayStoreAccount, consumeAllTransactions, onSuccess, onError)
-                    }
+        purchases.forEach { purchase ->
+            if (purchase.containedPurchase.purchaseState == Purchase.PurchaseState.PURCHASED) {
+                if (purchase.type == PurchaseType.INAPP) {
+                    billingWrapper.querySkuDetailsAsync(
+                        BillingClient.SkuType.INAPP,
+                        listOf(purchase.sku),
+                        { skuDetailsList ->
+                            postToBackend(purchase, skuDetailsList.first { it.sku == purchase.sku }, allowSharingPlayStoreAccount, consumeAllTransactions, onSuccess, onError)
+                        },
+                        { postToBackend(purchase, null, allowSharingPlayStoreAccount, consumeAllTransactions, onSuccess, onError) }
+                    )
                 } else {
-                    onError?.let { onError ->
-                        onError(purchase, PurchasesError(PurchasesErrorCode.PaymentPendingError))
-                    }
+                    postToBackend(purchase,null, allowSharingPlayStoreAccount, consumeAllTransactions, onSuccess, onError)
+                }
+            } else {
+                onError?.let { onError ->
+                    onError(purchase, PurchasesError(PurchasesErrorCode.PaymentPendingError))
                 }
             }
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -993,9 +993,14 @@ class PurchasesTest {
         setup()
 
         val network = Purchases.AttributionNetwork.APPSFLYER
-
+        val capturedJSONObject = slot<JSONObject>()
         every {
-            mockBackend.postAttributionData(appUserId, network, any(), captureLambda())
+            mockBackend.postAttributionData(
+                appUserId,
+                network,
+                capture(capturedJSONObject),
+                captureLambda()
+            )
         } answers {
             lambda<() -> Unit>().captured.invoke()
         }
@@ -1003,7 +1008,16 @@ class PurchasesTest {
         val networkUserID = "networkUserID"
         mockAdInfo(false, networkUserID)
 
-        Purchases.addAttributionData(mapOf("key" to "value"), network, networkUserID)
+        Purchases.addAttributionData(
+            mapOf(
+                "adgroup" to null,
+                "campaign" to "awesome_campaign",
+                "campaign_id" to 1234,
+                "iscache" to true
+            ),
+            network,
+            networkUserID
+        )
 
         verify {
             mockBackend.postAttributionData(
@@ -1013,6 +1027,11 @@ class PurchasesTest {
                 any()
             )
         }
+        assertThat(capturedJSONObject.isCaptured).isTrue()
+        assertThat(capturedJSONObject.captured.get("adgroup")).isEqualTo(null)
+        assertThat(capturedJSONObject.captured.get("campaign")).isEqualTo("awesome_campaign")
+        assertThat(capturedJSONObject.captured.get("campaign_id")).isEqualTo(1234)
+        assertThat(capturedJSONObject.captured.get("iscache")).isEqualTo(true)
     }
 
     @Test


### PR DESCRIPTION
https://trello.com/c/BUfBUMAe/433-fix-appsflyer-sdk-compatibility

Appsflyer released a new version of their SDK and made some changes that affect us a little bit. The main change is that they renamed their callback and it now returns a map object that contains all the conversion data keys. Previously it had returned only parameters that had a value.

We need to make a change, since Appsflyer now returns a Map<String, Object> but the addAttribution method expects a Map<String, String>.