### PR TITLE
fixes unbindservice being called even if bindservice is false

### DIFF
--- a/purchases/src/main/java/com/revenuecat/purchases/util/AdvertisingIdClient.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/util/AdvertisingIdClient.kt
@@ -9,6 +9,7 @@ import android.os.IInterface
 import android.os.Looper
 import android.os.Parcel
 import android.os.RemoteException
+import android.util.Log
 import java.util.concurrent.LinkedBlockingQueue
 
 object AdvertisingIdClient {
@@ -24,6 +25,7 @@ object AdvertisingIdClient {
             try {
                 context.packageManager.getPackageInfo("com.android.vending", 0)
             } catch (e: Exception) {
+                Log.e("Purchases", "Error getting AdvertisingIdInfo", e)
                 completion(null)
                 return@Runnable
             }
@@ -41,7 +43,7 @@ object AdvertisingIdClient {
                         }
                     }
                 } catch(e: Exception) {
-
+                    Log.e("Purchases", "Error getting AdvertisingIdInfo", e)
                 } finally {
                     context.unbindService(connection)
                 }

--- a/purchases/src/main/java/com/revenuecat/purchases/util/AdvertisingIdClient.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/util/AdvertisingIdClient.kt
@@ -32,20 +32,19 @@ object AdvertisingIdClient {
             val intent = Intent("com.google.android.gms.ads.identifier.service.START").apply {
                 setPackage("com.google.android.gms")
             }
-            try {
-                if (context.bindService(intent, connection, Context.BIND_AUTO_CREATE)) {
+            if (context.bindService(intent, connection, Context.BIND_AUTO_CREATE)) {
+                try {
                     with(AdvertisingInterface(connection.binder)) {
                         id?.let { id ->
                             completion(AdInfo(id, isLimitAdTrackingEnabled()))
                             return@Runnable
                         }
                     }
+                } catch(e: Exception) {
+
+                } finally {
+                    context.unbindService(connection)
                 }
-            } catch(e: Exception) {
-                completion(null)
-                return@Runnable
-            } finally {
-                context.unbindService(connection)
             }
             completion(null)
         }).start()


### PR DESCRIPTION
Fixes https://github.com/RevenueCat/purchases-android/issues/98

We were calling `unbindService` even if the result of `bindService` is false. When I added this file to the project I converted the one we have in Unity https://github.com/RevenueCat/purchases-unity/blob/master/Android/purchasesunity/src/main/java/com/revenuecat/purchasesunity/AdvertisingIdClient.java to Kotlin. I realized the try/catch statement was inside the sucessful bindService. Extracting the if check should fix the problem and would make both Java and Kotlin implementations match.