### PR TITLE
[FINAL] makes cache stale after an error fetching skudetails

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -620,31 +620,32 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
                         dispatch {
                             completion?.onReceived(offerings)
                         }
-                    }, {
-                        dispatch {
-                            completion?.onError(it)
-                        }
+                    }, { error ->
+                        handleErrorFetchingOfferings(error, completion)
                     })
                 } catch (error: JSONException) {
-                    log("Error fetching offerings - $error")
-                    deviceCache.clearOfferingsCacheTimestamp()
-                    dispatch {
-                        completion?.onError(
-                            PurchasesError(
-                                PurchasesErrorCode.UnexpectedBackendResponseError,
-                                error.localizedMessage
-                            )
-                        )
-                    }
+                    handleErrorFetchingOfferings(
+                        PurchasesError(
+                            PurchasesErrorCode.UnexpectedBackendResponseError,
+                            error.localizedMessage
+                        ),
+                        completion
+                    )
                 }
-            },
-            { error ->
-                log("Error fetching offerings - $error")
-                deviceCache.clearOfferingsCacheTimestamp()
-                dispatch {
-                    completion?.onError(error)
-                }
+            }, { error ->
+                handleErrorFetchingOfferings(error, completion)
             })
+    }
+
+    private fun handleErrorFetchingOfferings(
+        error: PurchasesError,
+        completion: ReceiveOfferingsListener?
+    ) {
+        log("Error fetching offerings - $error")
+        deviceCache.clearOfferingsCacheTimestamp()
+        dispatch {
+            completion?.onError(error)
+        }
     }
 
     private fun logMissingProducts(


### PR DESCRIPTION
I was doing final manual testing when I encountered a regression introduced in the clear cached purchaser info PR.

`deviceCache.clearOfferingsCacheTimestamp()` wasn't being called when getting the SkuDetails fails while trying to construct the Offerings object