### PR TITLE
Bump/3.0.6

### DIFF
--- a/.buildscripts/deploy_snapshot.sh
+++ b/.buildscripts/deploy_snapshot.sh
@@ -20,6 +20,6 @@ elif [ "$CIRCLE_JDK_VERSION" != "$JDK" ]; then
 else
   echo "Deploying snapshot..."
   ./gradlew androidSourcesJar androidJavadocsJar uploadArchives -P signing.keyId=$GPG_SIGNING_KEY_ID -Psigning.password=$GPG_SIGNING_KEY_PW -Psigning.secretKeyRingFile=./secring.gpg \
-                           -PSONATYPE_NEXUS_USERNAME=$SONATYPE_NEXUS_USERNAME -PSONATYPE_NEXUS_PASSWORD=$SONATYPE_NEXUS_PASSWORD
+                           -PSONATYPE_NEXUS_USERNAME=$SONATYPE_NEXUS_USERNAME -PSONATYPE_NEXUS_PASSWORD=$SONATYPE_NEXUS_PASSWORD -PRELEASE_SIGNING_ENABLED=true
   echo "Snapshot deployed!"
 fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,11 +91,9 @@ workflows:
           filters:
             branches:
               only: master
-      - docs-approval:
-          type: approval
-          filters:
-            branches:
-              only: master
       - docs-deploy:
-          requires:
-            - docs-approval
+          filters:
+            tags:
+              only: /^(\d+\.)(\d+\.)(\d+)$/
+            branches:
+              ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.6
+
+- Added new method to invalidate the purchaser info cache, useful when promotional purchases are granted from outside the app. #109
 ## 3.0.5
 
 - Fixes compatibility with AppsFlyer SDK https://github.com/RevenueCat/purchases-android/pull/97

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.6
 
 - Added new method to invalidate the purchaser info cache, useful when promotional purchases are granted from outside the app. #109
+
 ## 3.0.5
 
 - Fixes compatibility with AppsFlyer SDK https://github.com/RevenueCat/purchases-android/pull/97

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.9.0'
         classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8 = false
 android.enableR8.libraries = false
+
+#Do not sign releases. When calling uploadArchives pass -PRELEASE_SIGNING_ENABLED=true
+RELEASE_SIGNING_ENABLED=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=3.1.0-SNAPSHOT
+VERSION_NAME=3.0.6
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         versionCode 1
-        versionName "3.1.0-SNAPSHOT"
+        versionName "3.0.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-proguard-rules.pro'

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1087,7 +1087,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
          * Current version of the Purchases SDK
          */
         @JvmStatic
-        val frameworkVersion = "3.1.0-SNAPSHOT"
+        val frameworkVersion = "3.0.6"
 
         /**
          * Configures an instance of the Purchases SDK with a specified API key. The instance will

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -519,6 +519,11 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         this.updatedPurchaserInfoListener = null
     }
 
+    /**
+     * Invalidates the cache for purchaser information.
+     * This is useful for cases where purchaser information might have been updated outside of the
+     * app, like if a promotional subscription is granted through the RevenueCat dashboard.
+     */
     fun invalidatePurchaserInfoCache() {
         debugLog("Invalidating Purchaser info cache")
         deviceCache.clearPurchaserInfoCacheTimestamp()


### PR DESCRIPTION
- Bumps version
- Fixes CircleCI filter for docs-deploy
- Adds missing javadoc
- Fixes build https://github.com/vanniktech/gradle-maven-publish-plugin/issues/114. We were using the SNAPSHOT version. They just released a final one. It looks like the behavior has changed and it's now trying to sign when calling `gradle build`. We only want to sign when calling `uploadArchives`.