### PR TITLE
Fixes NoSuchElementException

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -731,7 +731,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
                         BillingClient.SkuType.INAPP,
                         listOf(purchase.sku),
                         { skuDetailsList ->
-                            postToBackend(purchase, skuDetailsList.first { it.sku == purchase.sku }, allowSharingPlayStoreAccount, consumeAllTransactions, onSuccess, onError)
+                            postToBackend(purchase, skuDetailsList.firstOrNull { it.sku == purchase.sku }, allowSharingPlayStoreAccount, consumeAllTransactions, onSuccess, onError)
                         },
                         { postToBackend(purchase, null, allowSharingPlayStoreAccount, consumeAllTransactions, onSuccess, onError) }
                     )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -3065,6 +3065,37 @@ class PurchasesTest {
         verify (exactly = 1) { mockCache.clearPurchaserInfoCacheTimestamp() }
     }
 
+    @Test
+    fun `product not found when querying sku details while purchasing`() {
+        setup()
+        val sku = "sku"
+        val purchaseToken = "token"
+
+        mockSkuDetails(listOf(sku), emptyList(), PurchaseType.INAPP)
+
+        capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(getMockedPurchaseList(
+            sku,
+            purchaseToken,
+            PurchaseType.INAPP,
+            "offering_a"
+        ))
+
+        verify (exactly = 1) {
+            mockBackend.postReceiptData(
+                purchaseToken,
+                appUserId,
+                sku,
+                false,
+                "offering_a",
+                false,
+                null,
+                null,
+                any(),
+                any()
+            )
+        }
+    }
+
     // region Private Methods
     private fun mockBillingWrapper() {
         with(mockBillingWrapper) {


### PR DESCRIPTION
Should fix #114 . 

It's possible the SKUDetails cannot be retrieved. We should not assume that we can fetch all SKUDetails associated with a purchase.