### PR TITLE
[Final] Subscriber Attributes Part 4 (Public API and automatic synchronization)

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -139,7 +139,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
     /** @suppress */
     override fun onAppBackgrounded() {
         debugLog("App backgrounded")
-        synchronizeSubscriberAttributes()
+        synchronizeSubscriberAttributesIfNeeded()
     }
 
     /** @suppress */
@@ -154,7 +154,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
             fetchAndCacheOfferings(identityManager.currentAppUserID)
         }
         updatePendingPurchaseQueue()
-        synchronizeSubscriberAttributes()
+        synchronizeSubscriberAttributesIfNeeded()
     }
 
     // region Public Methods
@@ -1071,7 +1071,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         }
     }
 
-    private fun synchronizeSubscriberAttributes() {
+    private fun synchronizeSubscriberAttributesIfNeeded() {
         subscriberAttributesManager.synchronizeSubscriberAttributesIfNeeded(
             appUserID,
             {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/caching/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/caching/DeviceCache.kt
@@ -53,27 +53,35 @@ internal class DeviceCache(
     @Synchronized
     fun clearCachesForAppUserID() {
         preferences.edit()
-            // Purchaser info
-            .also { editor ->
-                getCachedAppUserID()?.let {
-                    editor.remove(purchaserInfoCacheKey(it))
-                }
-                getLegacyCachedAppUserID()?.let {
-                    editor.remove(purchaserInfoCacheKey(it))
-                }
-            }
-            // Subscriber attributes
-            .also { editor ->
-                getCachedAppUserID()?.let {
-                    editor.remove(subscriberAttributesCacheKey(it))
-                }
-            }
-            // App user id
-            .remove(appUserIDCacheKey)
-            .remove(legacyAppUserIDCacheKey)
+            .clearPurchaserInfo()
+            .clearSubscriberAttributes()
+            .clearAppUserID()
             .apply()
         clearPurchaserInfoCacheTimestamp()
         clearOfferingsCache()
+    }
+
+    private fun SharedPreferences.Editor.clearPurchaserInfo(): SharedPreferences.Editor {
+        getCachedAppUserID()?.let {
+            remove(purchaserInfoCacheKey(it))
+        }
+        getLegacyCachedAppUserID()?.let {
+            remove(purchaserInfoCacheKey(it))
+        }
+        return this
+    }
+
+    private fun SharedPreferences.Editor.clearSubscriberAttributes(): SharedPreferences.Editor {
+        getCachedAppUserID()?.let {
+            remove(subscriberAttributesCacheKey(it))
+        }
+        return this
+    }
+
+    private fun SharedPreferences.Editor.clearAppUserID(): SharedPreferences.Editor {
+        remove(appUserIDCacheKey)
+        remove(legacyAppUserIDCacheKey)
+        return this
     }
 
     // endregion

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/caching/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/caching/DeviceCache.kt
@@ -53,6 +53,7 @@ internal class DeviceCache(
     @Synchronized
     fun clearCachesForAppUserID() {
         preferences.edit()
+            // Purchaser info
             .also { editor ->
                 getCachedAppUserID()?.let {
                     editor.remove(purchaserInfoCacheKey(it))
@@ -61,6 +62,13 @@ internal class DeviceCache(
                     editor.remove(purchaserInfoCacheKey(it))
                 }
             }
+            // Subscriber attributes
+            .also { editor ->
+                getCachedAppUserID()?.let {
+                    editor.remove(subscriberAttributesCacheKey(it))
+                }
+            }
+            // App user id
             .remove(appUserIDCacheKey)
             .remove(legacyAppUserIDCacheKey)
             .apply()
@@ -246,13 +254,13 @@ internal class DeviceCache(
         }
 
         preferences.edit()
-            .putString(getSubscriberAttributesCacheKey(appUserID), attributesToBeSet.toJSONObject().toString())
+            .putString(subscriberAttributesCacheKey(appUserID), attributesToBeSet.toJSONObject().toString())
             .apply()
     }
 
     @Synchronized
     fun getAllStoredSubscriberAttributes(appUserID: String): Map<String, SubscriberAttribute> =
-        preferences.getString(getSubscriberAttributesCacheKey(appUserID), null)
+        preferences.getString(subscriberAttributesCacheKey(appUserID), null)
             ?.let { json ->
                 try {
                     JSONObject(json)
@@ -261,7 +269,7 @@ internal class DeviceCache(
                 }
             }?.buildSubscriberAttributes() ?: emptyMap()
 
-    private fun getSubscriberAttributesCacheKey(appUserID: String) =
+    internal fun subscriberAttributesCacheKey(appUserID: String) =
         "$subscriberAttributesCacheKey.$appUserID"
 
     private fun Map<String, SubscriberAttribute>.toJSONObject() =

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -18,6 +18,7 @@ import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryRecord
 import com.android.billingclient.api.SkuDetails
+import com.revenuecat.purchases.attributes.SubscriberAttributesManager
 import com.revenuecat.purchases.caching.DeviceCache
 import com.revenuecat.purchases.interfaces.Callback
 import com.revenuecat.purchases.interfaces.GetSkusResponseListener
@@ -66,6 +67,7 @@ class PurchasesTest {
         } returns mockApplication
     }
     private val mockIdentityManager = mockk<IdentityManager>()
+    private val mockSubscriberAttributesManager = mockk<SubscriberAttributesManager>()
 
     private var capturedPurchasesUpdatedListener = slot<BillingWrapper.PurchasesUpdatedListener>()
     private var capturedBillingWrapperStateListener = slot<BillingWrapper.StateListener>()
@@ -446,6 +448,7 @@ class PurchasesTest {
             queriedINAPP = emptyMap(),
             notInCache = emptyList()
         )
+        mockSubscriberAttributesManager()
         Purchases.sharedInstance.onAppForegrounded()
         verify (exactly = 1) {
             mockBackend.getPurchaserInfo(eq(appUserId), any(), any())
@@ -461,6 +464,7 @@ class PurchasesTest {
             queriedINAPP = emptyMap(),
             notInCache = emptyList()
         )
+        mockSubscriberAttributesManager()
         Purchases.sharedInstance.onAppForegrounded()
         verify (exactly = 1) {
             mockBackend.getOfferings(eq(appUserId), any(), any())
@@ -476,6 +480,7 @@ class PurchasesTest {
             queriedINAPP = emptyMap(),
             notInCache = emptyList()
         )
+        mockSubscriberAttributesManager()
         Purchases.sharedInstance.onAppForegrounded()
         verify (exactly = 0){
             mockBackend.getPurchaserInfo(eq(appUserId), any(), any())
@@ -491,6 +496,7 @@ class PurchasesTest {
             queriedINAPP = emptyMap(),
             notInCache = emptyList()
         )
+        mockSubscriberAttributesManager()
         Purchases.sharedInstance.onAppForegrounded()
         verify (exactly = 0){
             mockBackend.getOfferings(eq(appUserId), any(), any())
@@ -2686,6 +2692,7 @@ class PurchasesTest {
             queriedINAPP = emptyMap(),
             notInCache = emptyList()
         )
+        mockSubscriberAttributesManager()
         purchases.onAppForegrounded()
         verify (exactly = 1) {
             mockBillingWrapper.queryPurchases(PurchaseType.SUBS.toSKUType()!!)
@@ -3343,7 +3350,8 @@ class PurchasesTest {
             mockBillingWrapper,
             mockCache,
             executorService = mockExecutorService,
-            identityManager = mockIdentityManager
+            identityManager = mockIdentityManager,
+            subscriberAttributesManager = mockSubscriberAttributesManager
         )
         Purchases.sharedInstance = purchases
     }
@@ -3421,6 +3429,12 @@ class PurchasesTest {
         every {
             mockCache.isOfferingsCacheStale()
         } returns offeringsStale
+    }
+
+    private fun mockSubscriberAttributesManager() {
+        every {
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesIfNeeded(appUserId, any(), any())
+        } just Runs
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -135,6 +135,7 @@ class PurchasesTest {
             mockIdentityManager.currentUserIsAnonymous()
         } returns anonymous
         buildPurchases(anonymous)
+        mockSubscriberAttributesManager()
         return mockInfo
     }
 
@@ -448,7 +449,6 @@ class PurchasesTest {
             queriedINAPP = emptyMap(),
             notInCache = emptyList()
         )
-        mockSubscriberAttributesManager()
         Purchases.sharedInstance.onAppForegrounded()
         verify (exactly = 1) {
             mockBackend.getPurchaserInfo(eq(appUserId), any(), any())
@@ -464,7 +464,6 @@ class PurchasesTest {
             queriedINAPP = emptyMap(),
             notInCache = emptyList()
         )
-        mockSubscriberAttributesManager()
         Purchases.sharedInstance.onAppForegrounded()
         verify (exactly = 1) {
             mockBackend.getOfferings(eq(appUserId), any(), any())
@@ -480,7 +479,6 @@ class PurchasesTest {
             queriedINAPP = emptyMap(),
             notInCache = emptyList()
         )
-        mockSubscriberAttributesManager()
         Purchases.sharedInstance.onAppForegrounded()
         verify (exactly = 0){
             mockBackend.getPurchaserInfo(eq(appUserId), any(), any())
@@ -496,7 +494,6 @@ class PurchasesTest {
             queriedINAPP = emptyMap(),
             notInCache = emptyList()
         )
-        mockSubscriberAttributesManager()
         Purchases.sharedInstance.onAppForegrounded()
         verify (exactly = 0){
             mockBackend.getOfferings(eq(appUserId), any(), any())
@@ -2692,7 +2689,6 @@ class PurchasesTest {
             queriedINAPP = emptyMap(),
             notInCache = emptyList()
         )
-        mockSubscriberAttributesManager()
         purchases.onAppForegrounded()
         verify (exactly = 1) {
             mockBillingWrapper.queryPurchases(PurchaseType.SUBS.toSKUType()!!)

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesDeviceCacheTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesDeviceCacheTests.kt
@@ -9,6 +9,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
 import org.junit.Before
@@ -47,6 +48,13 @@ class SubscriberAttributesDeviceCacheTests {
         }
 
         underTest = DeviceCache(mockPrefs, apiKey)
+
+        every {
+            mockPrefs.getString(underTest.appUserIDCacheKey, isNull())
+        } returns "appUserID"
+        every {
+            mockPrefs.getString(underTest.legacyAppUserIDCacheKey, isNull())
+        } returns "legacyAppUserID"
     }
 
     @Test
@@ -156,6 +164,12 @@ class SubscriberAttributesDeviceCacheTests {
         underTest.setAttributes(appUserID, mapOf(expectedAttributes.keys.toList()[1] to expectedAttributes.values.toList()[1]))
 
         assertCapturedEqualsExpected(expectedAttributes)
+    }
+
+    @Test
+    fun `clearing caches also clears the subscriber attributes`() {
+        underTest.clearCachesForAppUserID()
+        verify { mockEditor.remove(underTest.subscriberAttributesCacheKey("appUserID")) }
     }
 
     private fun mockEmptyCache() {

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -1,0 +1,138 @@
+package com.revenuecat.purchases.attributes
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.IdentityManager
+import com.revenuecat.purchases.Purchases
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.ExecutorService
+
+@RunWith(AndroidJUnit4::class)
+class SubscriberAttributesPurchasesTests {
+    private lateinit var underTest: Purchases
+    private val appUserId = "juan"
+    private val subscriberAttributesManagerMock = mockk<SubscriberAttributesManager>()
+
+    @Before
+    fun setup() {
+        underTest = Purchases(
+            mockk(relaxed = true),
+            appUserId,
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            executorService = mockk<ExecutorService>().apply {
+                val capturedRunnable = slot<Runnable>()
+                every { execute(capture(capturedRunnable)) } answers { capturedRunnable.captured.run() }
+            },
+            identityManager = mockk<IdentityManager>(relaxed = true).apply {
+                every { currentAppUserID } returns appUserId
+            },
+            subscriberAttributesManager = subscriberAttributesManagerMock
+        )
+    }
+
+    @Test
+    fun `setting email attribute`() {
+        every {
+            subscriberAttributesManagerMock.setAttribute(any(), any(), appUserId)
+        } just Runs
+
+        val email = "email"
+        underTest.setEmail(email)
+
+        verify {
+            subscriberAttributesManagerMock.setAttribute(
+                SubscriberAttributeKey.Email,
+                email,
+                appUserId
+            )
+        }
+    }
+
+    @Test
+    fun `setting phone number attribute`() {
+        val phoneNumber = "3154589485"
+
+        every {
+            subscriberAttributesManagerMock.setAttribute(SubscriberAttributeKey.PhoneNumber, phoneNumber, appUserId)
+        } just Runs
+
+        underTest.setPhoneNumber(phoneNumber)
+
+        verify {
+            subscriberAttributesManagerMock.setAttribute(
+                SubscriberAttributeKey.PhoneNumber,
+                phoneNumber,
+                appUserId
+            )
+        }
+    }
+
+    @Test
+    fun `setting display name attribute`() {
+        every {
+            subscriberAttributesManagerMock.setAttribute(any(), any(), appUserId)
+        } just Runs
+
+        val displayName = "Cesar"
+        underTest.setDisplayName(displayName)
+
+        verify {
+            subscriberAttributesManagerMock.setAttribute(
+                SubscriberAttributeKey.DisplayName,
+                displayName,
+                appUserId
+            )
+        }
+    }
+
+    @Test
+    fun `setting push token attribute`() {
+        every {
+            subscriberAttributesManagerMock.setAttribute(any(), any(), appUserId)
+        } just Runs
+
+        val pushToken = "ajdjfh30203"
+        underTest.setPushToken(pushToken)
+
+        verify {
+            subscriberAttributesManagerMock.setAttribute(
+                SubscriberAttributeKey.FCMTokens,
+                pushToken,
+                appUserId
+            )
+        }
+    }
+
+    @Test
+    fun `on app foregrounded attributes are synced`() {
+        every {
+            subscriberAttributesManagerMock.synchronizeSubscriberAttributesIfNeeded(appUserId, any(), any())
+        } just Runs
+        setup()
+        underTest.onAppForegrounded()
+        verify (exactly = 1) {
+            subscriberAttributesManagerMock.synchronizeSubscriberAttributesIfNeeded(appUserId, any(), any())
+        }
+    }
+
+    @Test
+    fun `on app backgrounded attributes are synced`() {
+        every {
+            subscriberAttributesManagerMock.synchronizeSubscriberAttributesIfNeeded(appUserId, any(), any())
+        } just Runs
+        setup()
+        underTest.onAppBackgrounded()
+        verify (exactly = 1) {
+            subscriberAttributesManagerMock.synchronizeSubscriberAttributesIfNeeded(appUserId, any(), any())
+        }
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -23,11 +23,11 @@ class SubscriberAttributesPurchasesTests {
     @Before
     fun setup() {
         underTest = Purchases(
-            mockk(relaxed = true),
-            appUserId,
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
+            applicationContext = mockk(relaxed = true),
+            backingFieldAppUserID = appUserId,
+            backend = mockk(relaxed = true),
+            billingWrapper = mockk(relaxed = true),
+            deviceCache = mockk(relaxed = true),
             executorService = mockk<ExecutorService>().apply {
                 val capturedRunnable = slot<Runnable>()
                 every { execute(capture(capturedRunnable)) } answers { capturedRunnable.captured.run() }


### PR DESCRIPTION
Based on #118 

Adds the public methods to set attributes and automatic synchronization of attributes when the app goes to foreground/background