### PR TITLE
[FINAL] Subscriber Attributes Part 5 Sync before posting receipts

### DIFF
--- a/purchases-sample/src/main/java/com/revenuecat/sample/fasdf.java
+++ b/purchases-sample/src/main/java/com/revenuecat/sample/fasdf.java
@@ -1,4 +1,0 @@
-package com.revenuecat.sample;
-
-public class fasdf {
-}

--- a/purchases-sample/src/main/java/com/revenuecat/sample/fasdf.java
+++ b/purchases-sample/src/main/java/com/revenuecat/sample/fasdf.java
@@ -1,0 +1,4 @@
+package com.revenuecat.sample;
+
+public class fasdf {
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
@@ -333,28 +333,21 @@ internal class Backend(
     // returns an empty list
     private fun JSONObject.getAttributeErrors(): List<SubscriberAttributeError> {
         val attributeErrorsJSONObject =
-            if (has(ATTRIBUTES_ERROR_RESPONSE_KEY))
-                getJSONObject(ATTRIBUTES_ERROR_RESPONSE_KEY)
-            else
-                this
+            this.optJSONObject(ATTRIBUTES_ERROR_RESPONSE_KEY) ?: this
 
-        return if (attributeErrorsJSONObject.has(ATTRIBUTE_ERRORS_KEY)) {
-            attributeErrorsJSONObject.getJSONArray(ATTRIBUTE_ERRORS_KEY)
-                .let { jsonArray ->
-                    (0 until jsonArray.length())
-                        .map { index -> jsonArray.getJSONObject(index) }
-                        .filter { it.has("key_name") && it.has("message") }
-                        .map {
-                            SubscriberAttributeError(
-                                it.getString("key_name"),
-                                it.getString("message")
-                            )
-                        }
-                        .toList()
-                }
-        } else {
-            emptyList()
-        }
+        return attributeErrorsJSONObject.optJSONArray(ATTRIBUTE_ERRORS_KEY)
+            ?.let { jsonArray ->
+                (0 until jsonArray.length())
+                    .map { index -> jsonArray.getJSONObject(index) }
+                    .filter { it.has("key_name") && it.has("message") }
+                    .map {
+                        SubscriberAttributeError(
+                            it.getString("key_name"),
+                            it.getString("message")
+                        )
+                    }
+                    .toList()
+            } ?: emptyList()
     }
 
     private fun HTTPClient.Result.isSuccessful(): Boolean {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -61,11 +61,14 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
 ) : LifecycleDelegate {
 
     /** @suppress */
-    @get:Synchronized
-    @set:Synchronized
+    @Suppress("RedundantGetter", "RedundantSetter")
     @Volatile
     @JvmSynthetic
     internal var state = PurchasesState()
+        @JvmSynthetic @Synchronized get() = field
+        @JvmSynthetic @Synchronized set(value) {
+            field = value
+        }
 
     /*
     * If it should allow sharing Play Store accounts. False by
@@ -183,11 +186,11 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
                             null,
                             null,
                             unsyncedSubscriberAttributesByKey,
-                            { info, _ ->
+                            { info, attributeErrors ->
                                 subscriberAttributesManager.markAsSynced(
                                     appUserID,
                                     unsyncedSubscriberAttributesByKey,
-                                    emptyList()
+                                    attributeErrors
                                 )
                                 deviceCache.addSuccessfullyPostedToken(purchase.purchaseToken)
                                 cachePurchaserInfo(info)
@@ -626,6 +629,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
 
     // region Internal Methods
 
+    @JvmSynthetic
     internal fun postAttributionData(
         jsonObject: JSONObject,
         network: AttributionNetwork,
@@ -813,7 +817,8 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         }
     }
 
-    private fun postToBackend(
+    @JvmSynthetic
+    internal fun postToBackend(
         purchase: PurchaseWrapper,
         skuDetails: SkuDetails?,
         allowSharingPlayStoreAccount: Boolean,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesManager.kt
@@ -29,10 +29,7 @@ internal class SubscriberAttributesManager(
         onSuccessHandler: () -> Unit,
         onErrorHandler: (PurchasesError) -> Unit
     ) {
-        val unsyncedStoredAttributes = synchronized(this) {
-            deviceCache.getAllStoredSubscriberAttributes(appUserID)
-                .filter { (_, attribute) -> !attribute.isSynced }
-        }
+        val unsyncedStoredAttributes = getUnsyncedSubscriberAttributes(appUserID)
 
         if (unsyncedStoredAttributes.isNotEmpty()) {
             debugLog("Synchronizing subscriber attributes: $unsyncedStoredAttributes")
@@ -55,6 +52,11 @@ internal class SubscriberAttributesManager(
             onSuccessHandler()
         }
     }
+
+    @Synchronized
+    fun getUnsyncedSubscriberAttributes(appUserID: String) =
+        deviceCache.getAllStoredSubscriberAttributes(appUserID)
+            .filter { (_, attribute) -> !attribute.isSynced }
 
     @Synchronized
     fun markAsSynced(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases
 
 import com.android.billingclient.api.BillingClient
 import org.json.JSONException
+import org.json.JSONObject
 import java.io.IOException
 
 /**
@@ -155,3 +156,8 @@ internal fun Int.billingResponseToPurchasesError(underlyingErrorMessage: String)
     }
     return PurchasesError(errorCode, underlyingErrorMessage)
 }
+
+internal data class SubscriberAttributeError(
+    val keyName: String,
+    val message: String
+)

--- a/purchases/src/test/java/com/revenuecat/purchases/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BackendTest.kt
@@ -7,7 +7,6 @@ package com.revenuecat.purchases
 
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.revenuecat.purchases.attributes.SubscriberAttribute
 import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
@@ -68,7 +67,13 @@ class BackendTest {
             this@BackendTest.receivedPurchaserInfo = info
         }
 
-    private val postReceiptErrorCallback: (PurchasesError, Boolean) -> Unit = { error, _ ->
+    private val onReceivePostReceiptSuccessHandler: (PurchaserInfo, List<SubscriberAttributeError>) -> Unit =
+        { info, _ ->
+            this@BackendTest.receivedPurchaserInfo = info
+        }
+
+    private val postReceiptErrorCallback: (PurchasesError, Boolean, List<SubscriberAttributeError>) -> Unit =
+        { error, _, _ ->
         this@BackendTest.receivedError = error
     }
 
@@ -162,7 +167,7 @@ class BackendTest {
             price,
             currency,
             emptyMap(),
-            onReceivePurchaserInfoSuccessHandler,
+            onReceivePostReceiptSuccessHandler,
             postReceiptErrorCallback
         )
 
@@ -468,7 +473,7 @@ class BackendTest {
             null,
             null,
             emptyMap(),
-            {
+            { _, _ ->
                 lock.countDown()
             },
             postReceiptErrorCallback
@@ -483,7 +488,7 @@ class BackendTest {
             null,
             null,
             emptyMap(),
-            {
+            { _, _ ->
                 lock.countDown()
             },
             postReceiptErrorCallback
@@ -586,7 +591,7 @@ class BackendTest {
             null,
             null,
             emptyMap(),
-            {
+            { _, _ ->
                 lock.countDown()
             },
             postReceiptErrorCallback
@@ -612,7 +617,7 @@ class BackendTest {
             null,
             null,
             emptyMap(),
-            {
+            { _, _ ->
                 lock.countDown()
             },
             postReceiptErrorCallback
@@ -697,7 +702,7 @@ class BackendTest {
             null,
             null,
             emptyMap(),
-            {
+            { _, _ ->
                 lock.countDown()
             },
             postReceiptErrorCallback
@@ -712,7 +717,7 @@ class BackendTest {
             2.5,
             "USD",
             emptyMap(),
-            {
+            { _, _ ->
                 lock.countDown()
             },
             postReceiptErrorCallback

--- a/purchases/src/test/java/com/revenuecat/purchases/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BackendTest.kt
@@ -7,6 +7,7 @@ package com.revenuecat.purchases
 
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.attributes.SubscriberAttribute
 import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
@@ -25,7 +26,6 @@ import java.lang.Thread.sleep
 import java.util.HashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
@@ -161,6 +161,7 @@ class BackendTest {
             observerMode,
             price,
             currency,
+            emptyMap(),
             onReceivePurchaserInfoSuccessHandler,
             postReceiptErrorCallback
         )
@@ -466,6 +467,7 @@ class BackendTest {
             false,
             null,
             null,
+            emptyMap(),
             {
                 lock.countDown()
             },
@@ -480,6 +482,7 @@ class BackendTest {
             false,
             null,
             null,
+            emptyMap(),
             {
                 lock.countDown()
             },
@@ -582,6 +585,7 @@ class BackendTest {
             false,
             null,
             null,
+            emptyMap(),
             {
                 lock.countDown()
             },
@@ -607,6 +611,7 @@ class BackendTest {
             false,
             null,
             null,
+            emptyMap(),
             {
                 lock.countDown()
             },
@@ -691,6 +696,7 @@ class BackendTest {
             false,
             null,
             null,
+            emptyMap(),
             {
                 lock.countDown()
             },
@@ -705,6 +711,7 @@ class BackendTest {
             false,
             2.5,
             "USD",
+            emptyMap(),
             {
                 lock.countDown()
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -739,20 +739,20 @@ class PurchasesTest {
         val mockInfo = mockk<PurchaserInfo>()
         every {
             mockBackend.postReceiptData(
-                any(),
-                any(),
-                any(),
-                true,
-                null,
-                false,
-                null,
-                null,
-                emptyMap(),
-                captureLambda(),
-                any()
+                purchaseToken = any(),
+                appUserID = any(),
+                productID = any(),
+                isRestore = true,
+                offeringIdentifier = null,
+                observerMode = false,
+                price = null,
+                currency = null,
+                subscriberAttributes = emptyMap(),
+                onSuccess = captureLambda(),
+                onError = any()
             )
         } answers {
-            lambda<(PurchaserInfo) -> Unit>().captured.invoke(mockInfo)
+            lambda<PostReceiptDataSuccessCallback>().captured.invoke(mockInfo, emptyList())
         }
 
         var callbackCalled = false
@@ -1089,12 +1089,13 @@ class PurchasesTest {
 
         setup()
 
-        var capturedLambda: ((PurchasesError, Boolean) -> Unit)? = null
+        var capturedLambda: (PostReceiptDataErrorCallback)? = null
         mockInAppPostReceiptError(sku, purchaseToken, false) {
-            capturedLambda = lambda<(PurchasesError, Boolean) -> Unit>().captured
+            capturedLambda = lambda<PostReceiptDataErrorCallback>().captured
             capturedLambda?.invoke(
                 PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
-                true
+                true,
+                emptyList()
             )
         }
 
@@ -1126,16 +1127,17 @@ class PurchasesTest {
         val skuSub = "sub"
         val purchaseTokenSub = "token_sub"
 
-        var capturedLambda: ((PurchasesError, Boolean) -> Unit)? = null
+        var capturedLambda: (PostReceiptDataErrorCallback)? = null
         mockInAppPostReceiptError(sku, purchaseToken, false) {
-            capturedLambda = lambda<(PurchasesError, Boolean) -> Unit>().captured.also {
+            capturedLambda = lambda<PostReceiptDataErrorCallback>().captured.also {
                 it.invoke(
                     PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
-                    true
+                    true,
+                    emptyList()
                 )
             }
         }
-        var capturedLambda1: ((PurchasesError, Boolean) -> Unit)? = null
+        var capturedLambda1: (PostReceiptDataErrorCallback)? = null
         every {
             mockBackend.postReceiptData(
                 purchaseTokenSub,
@@ -1151,10 +1153,11 @@ class PurchasesTest {
                 captureLambda()
             )
         } answers {
-            capturedLambda1 = lambda<(PurchasesError, Boolean) -> Unit>().captured.also {
+            capturedLambda1 = lambda<PostReceiptDataErrorCallback>().captured.also {
                 it.invoke(
                     PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
-                    true
+                    true,
+                    emptyList()
                 )
             }
         }
@@ -1426,20 +1429,20 @@ class PurchasesTest {
         val info = mockk<PurchaserInfo>()
         every {
             mockBackend.postReceiptData(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                captureLambda(),
-                any()
+                purchaseToken = any(),
+                appUserID = any(),
+                productID = any(),
+                isRestore = any(),
+                offeringIdentifier = any(),
+                observerMode = any(),
+                price = any(),
+                currency = any(),
+                subscriberAttributes = any(),
+                onSuccess = captureLambda(),
+                onError = any()
             )
         } answers {
-            lambda<(PurchaserInfo) -> Unit>().captured.invoke(info)
+            lambda<PostReceiptDataSuccessCallback>().captured.invoke(info, emptyList())
         }
         purchases.updatedPurchaserInfoListener = updatedPurchaserInfoListener
         val sku = "onemonth_freetrial"
@@ -1884,17 +1887,18 @@ class PurchasesTest {
         val skuSub = "onemonth_freetrial_sub"
         val purchaseTokenSub = "crazy_purchase_token_sub"
 
-        var capturedLambda: ((PurchasesError, Boolean) -> Unit)? = null
+        var capturedLambda: (PostReceiptDataErrorCallback)? = null
         mockInAppPostReceiptError(sku, purchaseToken, true) {
-            capturedLambda = lambda<(PurchasesError, Boolean) -> Unit>().captured.also {
+            capturedLambda = lambda<PostReceiptDataErrorCallback>().captured.also {
                 it.invoke(
                     PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
-                    true
+                    true,
+                    emptyList()
                 )
             }
         }
 
-        var capturedLambda1: ((PurchasesError, Boolean) -> Unit)? = null
+        var capturedLambda1: (PostReceiptDataErrorCallback)? = null
         every {
             mockBackend.postReceiptData(
                 purchaseTokenSub,
@@ -1910,10 +1914,11 @@ class PurchasesTest {
                 captureLambda()
             )
         } answers {
-            capturedLambda1 = lambda<(PurchasesError, Boolean) -> Unit>().captured.also {
+            capturedLambda1 = lambda<PostReceiptDataErrorCallback>().captured.also {
                 it.invoke(
                     PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
-                    true
+                    true,
+                    emptyList()
                 )
             }
         }
@@ -1950,10 +1955,10 @@ class PurchasesTest {
         val skuSub = "onemonth_freetrial_sub"
         val purchaseTokenSub = "crazy_purchase_token_sub"
 
-        var captured: ((PurchasesError, Boolean) -> Unit)? = null
+        var captured: (PostReceiptDataErrorCallback)? = null
         mockInAppPostReceiptError(sku, purchaseToken, true) {
-            captured = lambda<(PurchasesError, Boolean) -> Unit>().captured.also {
-                it.invoke(PurchasesError(PurchasesErrorCode.InvalidCredentialsError), true)
+            captured = lambda<PostReceiptDataErrorCallback>().captured.also {
+                it.invoke(PurchasesError(PurchasesErrorCode.InvalidCredentialsError), true, emptyList())
             }
         }
 
@@ -2396,9 +2401,9 @@ class PurchasesTest {
 
         setup()
 
-        var capturedLambda: ((PurchasesError, Boolean) -> Unit)? = null
+        var capturedLambda: (PostReceiptDataErrorCallback)? = null
         mockInAppPostReceiptError(sku, purchaseToken, false) {
-            capturedLambda = lambda<(PurchasesError, Boolean) -> Unit>().captured
+            capturedLambda = lambda<PostReceiptDataErrorCallback>().captured
         }
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(getMockedPurchaseList(
@@ -2409,7 +2414,8 @@ class PurchasesTest {
         ))
         capturedLambda!!.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
-            true
+            true,
+            emptyList()
         )
         capturedConsumeResponseListener.captured.invoke(BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(), purchaseToken)
         verify (exactly = 0 ) {
@@ -2442,9 +2448,9 @@ class PurchasesTest {
 
         setup()
 
-        var capturedLambda: ((PurchasesError, Boolean) -> Unit)? = null
+        var capturedLambda: (PostReceiptDataErrorCallback)? = null
         mockInAppPostReceiptError(sku, purchaseToken, false) {
-            capturedLambda = lambda<(PurchasesError, Boolean) -> Unit>().captured
+            capturedLambda = lambda<PostReceiptDataErrorCallback>().captured
         }
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(getMockedPurchaseList(
@@ -2455,7 +2461,8 @@ class PurchasesTest {
         ))
         capturedLambda!!.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
-            true
+            true,
+            emptyList()
         )
         capturedConsumeResponseListener.captured.invoke(BillingClient.BillingResponseCode.OK.buildResult(), "crazy_purchase_token")
         verify (exactly = 1) {
@@ -2475,14 +2482,14 @@ class PurchasesTest {
 
         setup()
 
-        var capturedLambda: ((PurchasesError, Boolean) -> Unit)? = null
+        var capturedLambda: (PostReceiptDataErrorCallback)? = null
         mockInAppPostReceiptError(sku, purchaseToken, observerMode = false) {
-            capturedLambda = lambda<(PurchasesError, Boolean) -> Unit>().captured.also {
-                it.invoke(PurchasesError(PurchasesErrorCode.InvalidCredentialsError), false)
+            capturedLambda = lambda<PostReceiptDataErrorCallback>().captured.also {
+                it.invoke(PurchasesError(PurchasesErrorCode.InvalidCredentialsError), false, emptyList())
             }
         }
 
-        var capturedLambda1: ((PurchasesError, Boolean) -> Unit)? = null
+        var capturedLambda1: (PostReceiptDataErrorCallback)? = null
         every {
             mockBackend.postReceiptData(
                 purchaseTokenSub,
@@ -2498,8 +2505,8 @@ class PurchasesTest {
                 captureLambda()
             )
         } answers {
-            capturedLambda1 = lambda<(PurchasesError, Boolean) -> Unit>().captured.also {
-                it.invoke(PurchasesError(PurchasesErrorCode.InvalidCredentialsError), false)
+            capturedLambda1 = lambda<PostReceiptDataErrorCallback>().captured.also {
+                it.invoke(PurchasesError(PurchasesErrorCode.InvalidCredentialsError), false, emptyList())
             }
         }
 
@@ -2916,7 +2923,7 @@ class PurchasesTest {
         val skuSub = "sub"
         val purchaseTokenSub = "token_sub"
 
-        var capturedLambda: ((PurchasesError, Boolean) -> Unit)? = null
+        var capturedLambda: (PostReceiptDataErrorCallback)? = null
         every {
             mockBackend.postReceiptData(
                 purchaseTokenSub,
@@ -2932,7 +2939,7 @@ class PurchasesTest {
                 captureLambda()
             )
         } answers {
-            capturedLambda = lambda<(PurchasesError, Boolean) -> Unit>().captured
+            capturedLambda = lambda<PostReceiptDataErrorCallback>().captured
         }
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(getMockedPurchaseList(
@@ -2943,7 +2950,8 @@ class PurchasesTest {
         ))
         capturedLambda!!.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
-            true
+            true,
+            emptyList()
         )
         capturedAcknowledgeResponseListener.captured.invoke(
             BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
@@ -2961,7 +2969,7 @@ class PurchasesTest {
         val skuSub = "sub"
         val purchaseTokenSub = "token_sub"
 
-        var capturedLambda: ((PurchasesError, Boolean) -> Unit)? = null
+        var capturedLambda: (PostReceiptDataErrorCallback)? = null
         every {
             mockBackend.postReceiptData(
                 purchaseTokenSub,
@@ -2977,7 +2985,7 @@ class PurchasesTest {
                 captureLambda()
             )
         } answers {
-            capturedLambda = lambda<(PurchasesError, Boolean) -> Unit>().captured
+            capturedLambda = lambda<PostReceiptDataErrorCallback>().captured
         }
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(getMockedPurchaseList(
             skuSub,
@@ -2987,7 +2995,8 @@ class PurchasesTest {
         ))
         capturedLambda!!.invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
-            true
+            true,
+            emptyList()
         )
         capturedAcknowledgeResponseListener.captured.invoke(
             BillingClient.BillingResponseCode.OK.buildResult(),
@@ -3154,20 +3163,20 @@ class PurchasesTest {
             mockProducts()
             every {
                 postReceiptData(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    captureLambda(),
-                    any()
+                    purchaseToken = any(),
+                    appUserID = any(),
+                    productID = any(),
+                    isRestore = any(),
+                    offeringIdentifier = any(),
+                    observerMode = any(),
+                    price = any(),
+                    currency = any(),
+                    subscriberAttributes = any(),
+                    onSuccess = captureLambda(),
+                    onError = any()
                 )
             } answers {
-                lambda<(PurchaserInfo) -> Unit>().captured.invoke(mockInfo)
+                lambda<PostReceiptDataSuccessCallback>().captured.invoke(mockInfo, emptyList())
             }
             every {
                 close()
@@ -3450,20 +3459,20 @@ class PurchasesTest {
         } returns "USD"
         every {
             mockBackend.postReceiptData(
-                purchaseToken,
-                appUserId,
-                sku,
-                false,
-                null,
-                observerMode,
-                2.0,
-                "USD",
-                emptyMap(),
-                captureLambda(),
-                any()
+                purchaseToken = purchaseToken,
+                appUserID = appUserId,
+                productID = sku,
+                isRestore = false,
+                offeringIdentifier = null,
+                observerMode = observerMode,
+                price = 2.0,
+                currency = "USD",
+                subscriberAttributes = emptyMap(),
+                onSuccess = captureLambda(),
+                onError = any()
             )
         } answers {
-            lambda<(PurchaserInfo) -> Unit>().captured.invoke(mockInfo)
+            lambda<PostReceiptDataSuccessCallback>().captured.invoke(mockInfo, emptyList())
         }
     }
 
@@ -3484,7 +3493,7 @@ class PurchasesTest {
             mockSubscriberAttributesManager.getUnsyncedSubscriberAttributes(userIdToUse)
         } returns emptyMap()
         every {
-            mockSubscriberAttributesManager.markAsSynced(userIdToUse, any())
+            mockSubscriberAttributesManager.markAsSynced(userIdToUse, any(), any())
         } just runs
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -33,6 +33,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import io.mockk.verifyOrder
@@ -116,6 +117,7 @@ class PurchasesTest {
     ): PurchaserInfo {
         val mockInfo = mockk<PurchaserInfo>()
         val skus = listOf(stubProductIdentifier)
+        val userIdToUse = if (anonymous) randomAppUserId else appUserId
 
         mockCache(mockInfo)
         mockBackend(mockInfo, errorGettingPurchaserInfo)
@@ -130,12 +132,13 @@ class PurchasesTest {
         } just Runs
         every {
             mockIdentityManager.currentAppUserID
-        } returns if (anonymous) randomAppUserId else appUserId
+        } returns userIdToUse
         every {
             mockIdentityManager.currentUserIsAnonymous()
         } returns anonymous
         buildPurchases(anonymous)
-        mockSubscriberAttributesManager()
+        mockSubscriberAttributesManager(userIdToUse)
+
         return mockInfo
     }
 
@@ -313,6 +316,7 @@ class PurchasesTest {
                 false,
                 2.0,
                 "USD",
+                emptyMap(),
                 any(),
                 any()
             )
@@ -328,6 +332,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -383,6 +388,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -405,6 +411,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -529,6 +536,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -556,6 +564,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -585,6 +594,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -658,6 +668,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -673,6 +684,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -735,6 +747,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 captureLambda(),
                 any()
             )
@@ -779,6 +792,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -1132,6 +1146,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 captureLambda()
             )
@@ -1411,6 +1426,7 @@ class PurchasesTest {
         val info = mockk<PurchaserInfo>()
         every {
             mockBackend.postReceiptData(
+                any(),
                 any(),
                 any(),
                 any(),
@@ -1840,6 +1856,7 @@ class PurchasesTest {
                 true,
                 2.0,
                 "USD",
+                emptyMap(),
                 any(),
                 any()
             )
@@ -1888,6 +1905,7 @@ class PurchasesTest {
                 true,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 captureLambda()
             )
@@ -1999,6 +2017,7 @@ class PurchasesTest {
                 true,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -2013,6 +2032,7 @@ class PurchasesTest {
                 true,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -2058,6 +2078,7 @@ class PurchasesTest {
                 true,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -2072,6 +2093,7 @@ class PurchasesTest {
                 true,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -2110,6 +2132,7 @@ class PurchasesTest {
                 true,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -2470,6 +2493,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 captureLambda()
             )
@@ -2521,6 +2545,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -2588,6 +2613,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -2622,6 +2648,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -2748,6 +2775,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -2763,6 +2791,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -2801,6 +2830,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -2843,6 +2873,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -2896,6 +2927,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 captureLambda()
             )
@@ -2940,6 +2972,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 captureLambda()
             )
@@ -2998,6 +3031,7 @@ class PurchasesTest {
                 false,
                 2.0,
                 "USD",
+                emptyMap(),
                 any(),
                 any()
             )
@@ -3027,6 +3061,7 @@ class PurchasesTest {
                 false,
                 null,
                 null,
+                emptyMap(),
                 any(),
                 any()
             )
@@ -3118,7 +3153,19 @@ class PurchasesTest {
             }
             mockProducts()
             every {
-                postReceiptData(any(), any(), any(), any(), any(), any(), any(), any(), captureLambda(), any())
+                postReceiptData(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    captureLambda(),
+                    any()
+                )
             } answers {
                 lambda<(PurchaserInfo) -> Unit>().captured.invoke(mockInfo)
             }
@@ -3380,6 +3427,7 @@ class PurchasesTest {
                 observerMode,
                 2.0,
                 "USD",
+                emptyMap(),
                 any(),
                 captureLambda()
             )
@@ -3410,6 +3458,7 @@ class PurchasesTest {
                 observerMode,
                 2.0,
                 "USD",
+                emptyMap(),
                 captureLambda(),
                 any()
             )
@@ -3427,10 +3476,16 @@ class PurchasesTest {
         } returns offeringsStale
     }
 
-    private fun mockSubscriberAttributesManager() {
+    private fun mockSubscriberAttributesManager(userIdToUse: String) {
         every {
             mockSubscriberAttributesManager.synchronizeSubscriberAttributesIfNeeded(appUserId, any(), any())
         } just Runs
+        every {
+            mockSubscriberAttributesManager.getUnsyncedSubscriberAttributes(userIdToUse)
+        } returns emptyMap()
+        every {
+            mockSubscriberAttributesManager.markAsSynced(userIdToUse, any())
+        } just runs
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesBackendTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesBackendTests.kt
@@ -3,14 +3,20 @@ package com.revenuecat.purchases.attributes
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.Backend
 import com.revenuecat.purchases.HTTPClient
+import com.revenuecat.purchases.PurchaserInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.SyncDispatcher
+import com.revenuecat.purchases.buildPurchaserInfo
+import com.revenuecat.purchases.toBackendMap
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.json.JSONObject
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
@@ -26,6 +32,11 @@ class SubscriberAttributesBackendTests {
         SyncDispatcher(),
         mockClient
     )
+
+    @Before
+    fun setup() = mockkStatic("com.revenuecat.purchases.FactoriesKt")
+
+    // region posting attributes
 
     @Test
     fun `posting subscriber attributes works`() {
@@ -56,7 +67,7 @@ class SubscriberAttributesBackendTests {
             {
                 received = true
             },
-            { _,  _ ->
+            { _, _ ->
                 fail("should be success")
             }
         )
@@ -75,7 +86,7 @@ class SubscriberAttributesBackendTests {
             {
                 fail("should be failure")
             },
-            { error,  syncedSuccessfully ->
+            { error, syncedSuccessfully ->
                 receivedError = error
                 receivedSyncedSuccessfully = syncedSuccessfully
             }
@@ -85,29 +96,8 @@ class SubscriberAttributesBackendTests {
     }
 
     @Test
-    fun `backend error when posting attributes`() {
-        mockResponse("/subscribers/$appUserID/attributes", 503)
-
-        var receivedError: PurchasesError? = null
-        var receivedSyncedSuccessfully: Boolean? = null
-        underTest.postSubscriberAttributes(
-            mapOf("email" to SubscriberAttribute("email", null)),
-            appUserID,
-            {
-                fail("should be failure")
-            },
-            { error,  syncedSuccessfully ->
-                receivedError = error
-                receivedSyncedSuccessfully = syncedSuccessfully
-            }
-        )
-        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.UnknownBackendError)
-        assertThat(receivedSyncedSuccessfully).isFalse()
-    }
-
-    @Test
     fun `attributes validation error when posting attributes`() {
-        mockResponse("/subscribers/$appUserID/attributes", 400, resultBody = "{\n" +
+        mockResponse("/subscribers/$appUserID/attributes", 400, expectedResultBody = "{\n" +
             "  \"code\": 7262,\n" +
             "  \"message\": \"Some subscriber attributes keys were unable to saved.\",\n" +
             "  \"attribute_erors\": [\n" +
@@ -135,17 +125,111 @@ class SubscriberAttributesBackendTests {
         assertThat(receivedSyncedSuccessfully).isTrue()
     }
 
+    @Test
+    fun `backend error when posting attributes`() {
+        mockResponse("/subscribers/$appUserID/attributes", 503)
+
+        var receivedError: PurchasesError? = null
+        var receivedSyncedSuccessfully: Boolean? = null
+        underTest.postSubscriberAttributes(
+            mapOf("email" to SubscriberAttribute("email", null)),
+            appUserID,
+            {
+                fail("should be failure")
+            },
+            { error, syncedSuccessfully ->
+                receivedError = error
+                receivedSyncedSuccessfully = syncedSuccessfully
+            }
+        )
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.UnknownBackendError)
+        assertThat(receivedSyncedSuccessfully).isFalse()
+    }
+
+    // endregion
+
+    // region posting attributes when posting receipt
+
+    private val subscriberAttribute1 = SubscriberAttribute("key", "value")
+    private val subscriberAttribute2 = SubscriberAttribute("key1", null)
+    private val mapOfSubscriberAttributes = mapOf<String, SubscriberAttribute>(
+        "key" to subscriberAttribute1,
+        "key1" to subscriberAttribute2
+    )
+    private val fetchToken = "fetch_token"
+    private val productID = "product_id"
+
+    @Test
+    fun `posting receipt with attributes works`() {
+        mockPostReceiptResponse(mapOfSubscriberAttributes)
+
+        var receivedPurchaserInfo: PurchaserInfo? = null
+        underTest.postReceiptData(
+            fetchToken,
+            appUserID,
+            productID,
+            false,
+            null,
+            false,
+            null,
+            null,
+            mapOfSubscriberAttributes,
+            {
+                receivedPurchaserInfo = it
+            },
+            { _ , _ ->
+
+            }
+        )
+
+        assertThat(receivedPurchaserInfo).isNotNull
+        val actualPostReceiptBody = actualPostReceiptBodySlot.captured
+        assertThat(actualPostReceiptBody).isNotNull()
+        assertThat(actualPostReceiptBody["attributes"]).isNotNull
+    }
+
+    @Test
+    fun `posting receipt without attributes skips them`() {
+        mockPostReceiptResponse(mapOfSubscriberAttributes)
+
+        var receivedPurchaserInfo: PurchaserInfo? = null
+        underTest.postReceiptData(
+            fetchToken,
+            appUserID,
+            productID,
+            false,
+            null,
+            false,
+            null,
+            null,
+            emptyMap(),
+            {
+                receivedPurchaserInfo = it
+            },
+            { _ , _ ->
+
+            }
+        )
+
+        assertThat(receivedPurchaserInfo).isNotNull
+        val actualPostReceiptBody = actualPostReceiptBodySlot.captured
+        assertThat(actualPostReceiptBody).isNotNull()
+        assertThat(actualPostReceiptBody["attributes"]).isNull()
+    }
+
+    // endregion
+
     private fun mockResponse(
         path: String,
         responseCode: Int,
-        body: Map<String, Any?>? = null,
+        expectedBody: Map<String, Any?>? = null,
         clientException: Exception? = null,
-        resultBody: String? = null
+        expectedResultBody: String? = null
     ) {
         val everyMockedCall = every {
             mockClient.performRequest(
                 path,
-                (body ?: any()) as Map<*, *>,
+                (expectedBody ?: any()) as Map<*, *>,
                 mapOf("Authorization" to "Bearer $API_KEY")
             )
         }
@@ -154,11 +238,43 @@ class SubscriberAttributesBackendTests {
             everyMockedCall answers {
                 HTTPClient.Result().also {
                     it.responseCode = responseCode
-                    it.body = JSONObject(resultBody ?: "{}")
+                    it.body = JSONObject(expectedResultBody ?: "{}")
                 }
             }
         } else {
             everyMockedCall throws clientException
+        }
+    }
+
+    private val actualPostReceiptBodySlot = slot<Map<*, *>>()
+    private fun mockPostReceiptResponse(
+        attributes: Map<String, SubscriberAttribute>?
+    ) {
+        val expectedBody = mapOf(
+            "fetch_token" to fetchToken,
+            "app_user_id" to appUserID,
+            "product_id" to productID,
+            "is_restore" to false,
+            "observer_mode" to false,
+            "attributes" to attributes?.toBackendMap()
+        ).mapNotNull { (key, value) ->
+            value?.let { key to it }
+        }.toMap()
+
+        every {
+            mockClient.performRequest(
+                "/receipts",
+                capture(actualPostReceiptBodySlot),
+                mapOf("Authorization" to "Bearer $API_KEY")
+            )
+        } answers {
+            HTTPClient.Result().also {
+                it.responseCode = 200
+                it.body = JSONObject( "{}")
+                every {
+                    it.body!!.buildPurchaserInfo()
+                } returns mockk()
+            }
         }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -1,14 +1,28 @@
 package com.revenuecat.purchases.attributes
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.Backend
+import com.revenuecat.purchases.BillingWrapper
 import com.revenuecat.purchases.IdentityManager
+import com.revenuecat.purchases.PostReceiptDataErrorCallback
+import com.revenuecat.purchases.PostReceiptDataSuccessCallback
+import com.revenuecat.purchases.PurchaseHistoryRecordWrapper
+import com.revenuecat.purchases.PurchaserInfo
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.Responses
+import com.revenuecat.purchases.SubscriberAttributeError
+import com.revenuecat.purchases.buildPurchaserInfo
+import com.revenuecat.purchases.restorePurchasesWith
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,17 +30,84 @@ import java.util.concurrent.ExecutorService
 
 @RunWith(AndroidJUnit4::class)
 class SubscriberAttributesPurchasesTests {
+
     private lateinit var underTest: Purchases
     private val appUserId = "juan"
     private val subscriberAttributesManagerMock = mockk<SubscriberAttributesManager>()
+    private val backendMock = mockk<Backend>(relaxed = true)
+    private val billingWrapperMock = mockk<BillingWrapper>(relaxed = true)
+    private var postReceiptError: PostReceiptErrorContainer? = null
+    private var postReceiptSuccess: PostReceiptSuccessContainer? = null
+    private var subscriberAttribute = SubscriberAttribute("key", "value")
+    private var expectedAttributes = mapOf(
+        subscriberAttribute.key.backendKey to subscriberAttribute
+    )
+
+    private val attributesToMarkAsSyncSlot = slot<Map<String, SubscriberAttribute>>()
+    private val attributesErrorsSlot = slot<List<SubscriberAttributeError>>()
+    private val postedAttributesSlot = slot<Map<String, SubscriberAttribute>>()
+
+    internal data class PostReceiptErrorContainer(
+        val error: PurchasesError,
+        val shouldConsumePurchase: Boolean,
+        val subscriberAttributesErrors: List<SubscriberAttributeError>
+    )
+
+    internal data class PostReceiptSuccessContainer(
+        val info: PurchaserInfo = JSONObject(Responses.validFullPurchaserResponse).buildPurchaserInfo(),
+        val subscriberAttributeErrors: List<SubscriberAttributeError> = emptyList()
+    )
 
     @Before
     fun setup() {
+        postReceiptError = null
+        postReceiptSuccess = null
+
+        every {
+            billingWrapperMock.queryAllPurchases(captureLambda(), any())
+        } answers {
+            lambda<(List<PurchaseHistoryRecordWrapper>) -> Unit>().captured.also {
+                it.invoke(listOf(mockk(relaxed = true)))
+            }
+        }
+        val successSlot = slot<PostReceiptDataSuccessCallback>()
+        val errorSlot = slot<PostReceiptDataErrorCallback>()
+        every {
+            backendMock.postReceiptData(
+                purchaseToken = any(),
+                appUserID = appUserId,
+                productID = any(),
+                isRestore = any(),
+                offeringIdentifier = any(),
+                observerMode = any(),
+                price = any(),
+                currency = any(),
+                subscriberAttributes = capture(postedAttributesSlot),
+                onSuccess = capture(successSlot),
+                onError = capture(errorSlot)
+            )
+        } answers {
+            postReceiptError?.let {
+                errorSlot.captured(it.error, it.shouldConsumePurchase, it.subscriberAttributesErrors)
+            } ?: postReceiptSuccess?.let {
+                successSlot.captured(it.info, it.subscriberAttributeErrors)
+            }
+        }
+
+        every {
+            subscriberAttributesManagerMock.getUnsyncedSubscriberAttributes(appUserId)
+        } answers {
+            expectedAttributes
+        }
+        every {
+            subscriberAttributesManagerMock.markAsSynced(appUserId, capture(attributesToMarkAsSyncSlot), capture(attributesErrorsSlot))
+        } just runs
+
         underTest = Purchases(
             applicationContext = mockk(relaxed = true),
             backingFieldAppUserID = appUserId,
-            backend = mockk(relaxed = true),
-            billingWrapper = mockk(relaxed = true),
+            backend = backendMock,
+            billingWrapper = billingWrapperMock,
             deviceCache = mockk(relaxed = true),
             executorService = mockk<ExecutorService>().apply {
                 val capturedRunnable = slot<Runnable>()
@@ -135,4 +216,301 @@ class SubscriberAttributesPurchasesTests {
             subscriberAttributesManagerMock.synchronizeSubscriberAttributesIfNeeded(appUserId, any(), any())
         }
     }
+
+    // region syncing purchases
+    @Test
+    fun `attributes are sent when syncing purchases`() {
+        postReceiptSuccess = PostReceiptSuccessContainer()
+
+        underTest.syncPurchases()
+
+        verify (exactly = 1) {
+            backendMock.postReceiptData(
+                purchaseToken = any(),
+                appUserID = appUserId,
+                productID = any(),
+                isRestore = any(),
+                offeringIdentifier = any(),
+                observerMode = any(),
+                price = any(),
+                currency = any(),
+                subscriberAttributes = expectedAttributes,
+                onSuccess = any(),
+                onError = any()
+            )
+        }
+    }
+
+    @Test
+    fun `attributes are marked as synced when syncing purchases`() {
+        val expectedSubscriberAttributeErrors = listOf(
+            SubscriberAttributeError("key", "value")
+        )
+        postReceiptSuccess = PostReceiptSuccessContainer(
+            subscriberAttributeErrors = expectedSubscriberAttributeErrors
+        )
+        underTest.syncPurchases()
+
+        verify (exactly = 1) {
+            subscriberAttributesManagerMock.markAsSynced(
+                appUserId,
+                expectedAttributes,
+                expectedSubscriberAttributeErrors
+            )
+        }
+    }
+
+    @Test
+    fun `attributes are marked as synced when error is finishable when syncing purchases`() {
+        val expectedSubscriberAttributeErrors = listOf(
+            SubscriberAttributeError("key", "value")
+        )
+        postReceiptError = PostReceiptErrorContainer(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            true,
+            expectedSubscriberAttributeErrors
+        )
+        underTest.syncPurchases()
+
+        verify (exactly = 1) {
+            subscriberAttributesManagerMock.markAsSynced(
+                appUserId,
+                expectedAttributes,
+                expectedSubscriberAttributeErrors
+            )
+        }
+    }
+
+    @Test
+    fun `attributes are not marked as synced when backend did not get them when syncing purchases`() {
+        val expectedSubscriberAttributeErrors = listOf(
+            SubscriberAttributeError("key", "value")
+        )
+        postReceiptError = PostReceiptErrorContainer(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            false,
+            expectedSubscriberAttributeErrors
+        )
+        underTest.syncPurchases()
+
+        verify (exactly = 0) {
+            subscriberAttributesManagerMock.markAsSynced(
+                appUserId,
+                expectedAttributes,
+                expectedSubscriberAttributeErrors
+            )
+        }
+    }
+    // endregion
+
+    // region restoring purchases
+    @Test
+    fun `attributes are sent when restoring purchases`() {
+        postReceiptSuccess = PostReceiptSuccessContainer()
+
+        underTest.restorePurchasesWith { }
+
+        verify (exactly = 1) {
+            backendMock.postReceiptData(
+                purchaseToken = any(),
+                appUserID = appUserId,
+                productID = any(),
+                isRestore = any(),
+                offeringIdentifier = any(),
+                observerMode = any(),
+                price = any(),
+                currency = any(),
+                subscriberAttributes = expectedAttributes,
+                onSuccess = any(),
+                onError = any()
+            )
+        }
+    }
+
+    @Test
+    fun `attributes are marked as synced when restoring`() {
+        val expectedSubscriberAttributeErrors = listOf(
+            SubscriberAttributeError("key", "value")
+        )
+        postReceiptSuccess = PostReceiptSuccessContainer(
+            subscriberAttributeErrors = expectedSubscriberAttributeErrors
+        )
+        underTest.restorePurchasesWith { }
+
+        verify (exactly = 1) {
+            subscriberAttributesManagerMock.markAsSynced(
+                appUserId,
+                expectedAttributes,
+                expectedSubscriberAttributeErrors
+            )
+        }
+    }
+
+    @Test
+    fun `attributes are marked as synced when backend did not get them posting receipt when restoring`() {
+        val expectedSubscriberAttributeErrors = listOf(
+            SubscriberAttributeError("key", "value")
+        )
+        postReceiptError = PostReceiptErrorContainer(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            true,
+            expectedSubscriberAttributeErrors
+        )
+
+        underTest.restorePurchasesWith { }
+
+        verify (exactly = 1) {
+            subscriberAttributesManagerMock.markAsSynced(
+                appUserId,
+                expectedAttributes,
+                expectedSubscriberAttributeErrors
+            )
+        }
+    }
+
+    @Test
+    fun `attributes are not marked as synced when backend did not get them posting receipt when restoring`() {
+        val expectedSubscriberAttributeErrors = listOf(
+            SubscriberAttributeError("key", "value")
+        )
+        postReceiptError = PostReceiptErrorContainer(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            false,
+            expectedSubscriberAttributeErrors
+        )
+
+        underTest.restorePurchasesWith { }
+
+        verify (exactly = 0) {
+            subscriberAttributesManagerMock.markAsSynced(
+                appUserId,
+                expectedAttributes,
+                expectedSubscriberAttributeErrors
+            )
+        }
+    }
+    // endregion
+
+    // region purchasing
+
+    @Test
+    fun `attributes are sent when purchasing`() {
+        postReceiptSuccess = PostReceiptSuccessContainer()
+
+        underTest.postToBackend(
+            purchase = mockk(relaxed = true),
+            skuDetails = mockk(relaxed = true),
+            allowSharingPlayStoreAccount = true,
+            consumeAllTransactions = true,
+            appUserID = appUserId,
+            onSuccess = {_,_ -> },
+            onError = {_,_ -> }
+        )
+
+        verify (exactly = 1) {
+            backendMock.postReceiptData(
+                purchaseToken = any(),
+                appUserID = appUserId,
+                productID = any(),
+                isRestore = any(),
+                offeringIdentifier = any(),
+                observerMode = any(),
+                price = any(),
+                currency = any(),
+                subscriberAttributes = expectedAttributes,
+                onSuccess = any(),
+                onError = any()
+            )
+        }
+    }
+
+    @Test
+    fun `attributes are marked as synced when purchasing`() {
+        val expectedSubscriberAttributeErrors = listOf(
+            SubscriberAttributeError("key", "value")
+        )
+        postReceiptSuccess = PostReceiptSuccessContainer(
+            subscriberAttributeErrors = expectedSubscriberAttributeErrors
+        )
+        underTest.postToBackend(
+            purchase = mockk(relaxed = true),
+            skuDetails = mockk(relaxed = true),
+            allowSharingPlayStoreAccount = true,
+            consumeAllTransactions = true,
+            appUserID = appUserId,
+            onSuccess = {_,_ -> },
+            onError = {_,_ -> }
+        )
+
+        verify (exactly = 1) {
+            subscriberAttributesManagerMock.markAsSynced(
+                appUserId,
+                expectedAttributes,
+                expectedSubscriberAttributeErrors
+            )
+        }
+    }
+
+    @Test
+    fun `attributes are marked as synced when backend did not get them posting receipt when purchasing`() {
+        val expectedSubscriberAttributeErrors = listOf(
+            SubscriberAttributeError("key", "value")
+        )
+        postReceiptError = PostReceiptErrorContainer(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            true,
+            expectedSubscriberAttributeErrors
+        )
+
+        underTest.postToBackend(
+            purchase = mockk(relaxed = true),
+            skuDetails = mockk(relaxed = true),
+            allowSharingPlayStoreAccount = true,
+            consumeAllTransactions = true,
+            appUserID = appUserId,
+            onSuccess = {_,_ -> },
+            onError = {_,_ -> }
+        )
+
+        verify (exactly = 1) {
+            subscriberAttributesManagerMock.markAsSynced(
+                appUserId,
+                expectedAttributes,
+                expectedSubscriberAttributeErrors
+            )
+        }
+    }
+
+    @Test
+    fun `attributes are not marked as synced when backend did not get them posting receipt when purchasing`() {
+        val expectedSubscriberAttributeErrors = listOf(
+            SubscriberAttributeError("key", "value")
+        )
+        postReceiptError = PostReceiptErrorContainer(
+            PurchasesError(PurchasesErrorCode.NetworkError),
+            false,
+            expectedSubscriberAttributeErrors
+        )
+
+        underTest.postToBackend(
+            purchase = mockk(relaxed = true),
+            skuDetails = mockk(relaxed = true),
+            allowSharingPlayStoreAccount = true,
+            consumeAllTransactions = true,
+            appUserID = appUserId,
+            onSuccess = {_,_ -> },
+            onError = {_,_ -> }
+        )
+
+        verify (exactly = 0) {
+            subscriberAttributesManagerMock.markAsSynced(
+                appUserId,
+                expectedAttributes,
+                expectedSubscriberAttributeErrors
+            )
+        }
+    }
+
+    // endregion
+
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/responses.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/responses.kt
@@ -10,6 +10,9 @@ class Responses {
         val validEmptyPurchaserResponse by lazy {
             getJSONFromPath("responses/valid_empty_purchaser_response.json")
         }
+        val subscriberAttributesErrorsPostReceiptResponse by lazy {
+            getJSONFromPath("responses/attribute_errors_post_receipt_response.json")
+        }
 
         private fun getJSONFromPath(fileName: String): String {
             val classLoader = this::class.java.classLoader

--- a/purchases/src/test/resources/responses/attribute_errors_post_receipt_response.json
+++ b/purchases/src/test/resources/responses/attribute_errors_post_receipt_response.json
@@ -1,0 +1,67 @@
+{
+  "request_date": "2019-08-16T10:30:42Z",
+  "request_date_ms": 1565951442879,
+  "attributes_error_response": {
+    "attribute_errors": [{
+      "key_name": "invalid_name",
+      "message": "Attribute key name is not valid."
+    }],
+    "code": 7262,
+    "message": "Some subscriber attributes keys were unable to saved."
+  },
+  "subscriber": {
+    "original_app_user_id": "app_user_id",
+    "original_application_version": "2083",
+    "first_seen": "2019-06-17T16:05:33Z",
+    "non_subscriptions": {
+      "onetime_purchase": [
+        {
+          "id": "72c26cc69c",
+          "is_sandbox": true,
+          "original_purchase_date": "1990-08-30T02:40:36Z",
+          "purchase_date": "1990-08-30T02:40:36Z",
+          "store": "app_store"
+        }
+      ]
+    },
+    "subscriptions": {
+      "onemonth_freetrial": {
+        "billing_issues_detected_at": null,
+        "is_sandbox": true,
+        "original_purchase_date": "2019-07-26T23:30:41Z",
+        "purchase_date": "2019-07-26T23:45:40Z",
+        "store": "app_store",
+        "unsubscribe_detected_at": null,
+        "expires_date": "2100-04-06T20:54:45.975000Z",
+        "period_type": "normal"
+      },
+      "threemonth_freetrial": {
+        "billing_issues_detected_at": null,
+        "is_sandbox": true,
+        "original_purchase_date": "2019-07-26T23:30:41Z",
+        "purchase_date": "2019-07-26T23:45:40Z",
+        "store": "app_store",
+        "unsubscribe_detected_at": null,
+        "period_type": "normal",
+        "expires_date": "1990-08-30T02:40:36Z"
+      }
+    },
+    "entitlements": {
+      "pro": {
+        "expires_date": "2100-04-06T20:54:45.975000Z",
+        "product_identifier": "onemonth_freetrial",
+        "purchase_date": "2018-10-26T23:17:53Z"
+      },
+      "old_pro": {
+        "expires_date": "1990-08-30T02:40:36Z",
+        "product_identifier": "threemonth_freetrial",
+        "purchase_date": "1990-06-30T02:40:36Z"
+      },
+      "forever_pro": {
+        "expires_date": null,
+        "product_identifier": "onetime_purchase",
+        "purchase_date": "1990-08-30T02:40:36Z"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Adds attributes as a parameter to the post receipt call.
- Logs attribute errors
