### PR TITLE
[FINAL] Makes sure unbindService runs in the main thread when getting AdvertisingIDInfo

### DIFF
--- a/purchases/src/main/java/com/revenuecat/purchases/util/AdvertisingIdClient.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/util/AdvertisingIdClient.kt
@@ -4,6 +4,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
+import android.os.Handler
 import android.os.IBinder
 import android.os.IInterface
 import android.os.Looper
@@ -45,7 +46,9 @@ object AdvertisingIdClient {
                 } catch(e: Exception) {
                     Log.e("Purchases", "Error getting AdvertisingIdInfo", e)
                 } finally {
-                    context.unbindService(connection)
+                    Handler(Looper.getMainLooper()).post {
+                        context.unbindService(connection)
+                    }
                 }
             }
             completion(null)


### PR DESCRIPTION
Another try to fix https://github.com/RevenueCat/purchases-android/issues/98

What I think it's happening is that since bindService is running in a separate thread (and probably running stuff on the main thread) `unbindService` could get called before the `bindService` finishes doing its things and crash

I also realized the completion blocks were running before `unbindService` and in a different thread but that should be fine since this is internal anyway