### PR TITLE
Version 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.0
+
+- Another fix for NoSuchElementException when retrieving Advertising ID #124
+- Added Subscriber Attributes, which allow developers to store additional, structured information 
+for a user in RevenueCat. More info: https://docs.revenuecat.com/docs/user-attributes
+
 ## 3.0.7
 
 - Fixes NoSuchElementException #115

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@ Automatic Releasing
 =========
  1. Create a branch bump/x.y.z
  1. Create a CHANGELOG.latest.md with the changes for the current version (to be used by Fastlane for the github release notes)
- 1. Update the version number in `gradle.properties`, `Purchases.kt` and in `purchases/build.gradle` by running `fastlane bump_and_update_changelog version:X.Y.Z` (where X.Y.Z is the new version)
+ 1. Run `fastlane bump_and_update_changelog version:X.Y.Z` (where X.Y.Z is the new version) to update the version number in `gradle.properties`, `Purchases.kt` and in `purchases/build.gradle` 
  1. Commit the changes `git commit -am "Version X.Y.Z"` (where X.Y.Z is the new version)
  1. Make a PR, merge when approved
  1. Pull master

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=3.1.0-SNAPSHOT
+VERSION_NAME=3.1.0
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         versionCode 1
-        versionName "3.1.0-SNAPSHOT"
+        versionName "3.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-proguard-rules.pro'

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1219,7 +1219,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
          * Current version of the Purchases SDK
          */
         @JvmStatic
-        val frameworkVersion = "3.1.0-SNAPSHOT"
+        val frameworkVersion = "3.1.0"
 
         /**
          * Configures an instance of the Purchases SDK with a specified API key. The instance will


### PR DESCRIPTION
- Another fix for NoSuchElementException when retrieving Advertising ID #124
- Added Subscriber Attributes, which allow developers to store additional, structured information 
for a user in RevenueCat. More info: https://docs.revenuecat.com/docs/user-attributes
