### PR TITLE
Update invalidatePurchaserInfoCache docs

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -559,6 +559,11 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
 
     /**
      * Invalidates the cache for purchaser information.
+     * 
+     * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
+     * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
+     * using the cache properly.
+     * 
      * This is useful for cases where purchaser information might have been updated outside of the
      * app, like if a promotional subscription is granted through the RevenueCat dashboard.
      */


### PR DESCRIPTION
  - [ ] A description about what and why you are contributing, even if it's trivial.

Invalidating the cache is simultaneously an advanced technique and attractive to beginners who might think they need to invalidate the cache on every app launch, so I added a link to our docs that explains how to work with the cache in normal circumstances. 

  - [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

https://github.com/RevenueCat/purchases-ios/pull/223

  - [ ] If applicable, unit tests.

N/A
