### PR TITLE
Bump/3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 3.1.1
+
+- Fix a subscriber attributes bug where the attributes are deleted when an alias is created. https://github.com/RevenueCat/purchases-android/pull/135
+- New headers for observer mode and platform version https://github.com/RevenueCat/purchases-android/pull/136
+- Fixed purchase buttons in Sample App https://github.com/RevenueCat/purchases-android/pull/141
+- Fixed enablePendingPurchases not being called when calling isFeatureSupported https://github.com/RevenueCat/purchases-android/pull/138
+- Adds a Java sample https://github.com/RevenueCat/purchases-android/pull/129
+- Updates invalidatePurchaserInfoCache https://github.com/RevenueCat/purchases-android/pull/131
+
 ## 3.1.0
 
 - Another fix for NoSuchElementException when retrieving Advertising ID #124

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed enablePendingPurchases not being called when calling isFeatureSupported https://github.com/RevenueCat/purchases-android/pull/138
 - Adds a Java sample https://github.com/RevenueCat/purchases-android/pull/129
 - Updates invalidatePurchaserInfoCache https://github.com/RevenueCat/purchases-android/pull/131
+- Fixed Subscriber Attributes JSON in Android < 19 https://github.com/RevenueCat/purchases-android/pull/144
 
 ## 3.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=3.2.0-SNAPSHOT
+VERSION_NAME=3.1.1
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         versionCode 1
-        versionName "3.2.0-SNAPSHOT"
+        versionName "3.1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-proguard-rules.pro'

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1277,7 +1277,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
          * Current version of the Purchases SDK
          */
         @JvmStatic
-        val frameworkVersion = "3.2.0-SNAPSHOT"
+        val frameworkVersion = "3.1.1"
 
         /**
          * Configures an instance of the Purchases SDK with a specified API key. The instance will


### PR DESCRIPTION
## 3.1.1

- Fix a subscriber attributes bug where the attributes are deleted when an alias is created. https://github.com/RevenueCat/purchases-android/pull/135
- New headers for observer mode and platform version https://github.com/RevenueCat/purchases-android/pull/136
- Fixed purchase buttons in Sample App https://github.com/RevenueCat/purchases-android/pull/141
- Fixed enablePendingPurchases not being called when calling isFeatureSupported https://github.com/RevenueCat/purchases-android/pull/138
- Adds a Java sample https://github.com/RevenueCat/purchases-android/pull/129
- Updates invalidatePurchaserInfoCache https://github.com/RevenueCat/purchases-android/pull/131
- Fixed Subscriber Attributes JSON in Android < 19 https://github.com/RevenueCat/purchases-android/pull/144
