### PR TITLE
Fix subscriber attributes JSON for old Android devices

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
@@ -74,7 +74,7 @@ internal class Backend(
             override fun call(): HTTPClient.Result {
                 return httpClient.performRequest(
                     "/subscribers/" + encode(appUserID),
-                    null as Map<*, *>?,
+                    null,
                     authenticationHeaders
                 )
             }
@@ -148,7 +148,11 @@ internal class Backend(
         val call = object : Dispatcher.AsyncCall() {
 
             override fun call(): HTTPClient.Result {
-                return httpClient.performRequest("/receipts", body, authenticationHeaders)
+                return httpClient.performRequest(
+                    "/receipts",
+                    body,
+                    authenticationHeaders
+                )
             }
 
             override fun onCompletion(result: HTTPClient.Result) {
@@ -200,7 +204,7 @@ internal class Backend(
             override fun call(): HTTPClient.Result {
                 return httpClient.performRequest(
                     path,
-                    null as Map<*, *>?,
+                    null,
                     authenticationHeaders
                 )
             }
@@ -246,13 +250,10 @@ internal class Backend(
     ) {
         if (data.length() == 0) return
 
-        val body = JSONObject()
-        try {
-            body.put("network", network.serverValue)
-            body.put("data", data)
-        } catch (e: JSONException) {
-            return
-        }
+        val body = mapOf(
+            "network" to network.serverValue,
+            "data" to data
+        )
 
         enqueue(object : Dispatcher.AsyncCall() {
             override fun call(): HTTPClient.Result {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/HTTPClient.kt
@@ -112,6 +112,13 @@ internal class HTTPClient(
         return JSONObject(mapWithoutInnerMaps)
     }
 
+    // To avoid Java type erasure, we use a Kotlin inline function with a reified parameter
+    // so that we can check the type on runtime.
+    //
+    // Doing something like:
+    // if (value is Map<*, *>) (value as Map<String, Any?>).convert()
+    //
+    // Would give an unchecked cast warning due to Java type erasure
     private inline fun <reified T> Any?.tryCast(
         ifSuccess: T.() -> Any?
     ): Any? {

--- a/purchases/src/test/java/com/revenuecat/purchases/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BackendTest.kt
@@ -118,7 +118,7 @@ class BackendTest {
         val everyMockedCall = every {
             mockClient.performRequest(
                 eq(path),
-                (if (body == null) any() else eq(body)) as Map<*, *>,
+                (if (body == null) any() else eq(body)),
                 eq<Map<String, String>>(headers)
             )
         }
@@ -334,7 +334,7 @@ class BackendTest {
 
         val headers = HashMap<String, String>()
         headers["Authorization"] = "Bearer $API_KEY"
-        val slot = slot<JSONObject>()
+        val slot = slot<Map<String, Any?>>()
         verify {
             mockClient.performRequest(
                 eq(path),
@@ -343,8 +343,8 @@ class BackendTest {
             )
         }
         val captured = slot.captured
-        assertThat(captured.has("network") && captured.has("data") &&
-                captured.getInt("network") == Purchases.AttributionNetwork.APPSFLYER.serverValue).isTrue()
+        assertThat(captured.containsKey("network") && captured.containsKey("data") &&
+                captured["network"] == Purchases.AttributionNetwork.APPSFLYER.serverValue).isTrue()
     }
 
     @Test
@@ -378,7 +378,7 @@ class BackendTest {
         verify {
             mockClient.performRequest(
                 eq(path),
-                any() as JSONObject,
+                any(),
                 any()
             )
         }
@@ -443,7 +443,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 "/subscribers/" + Uri.encode(appUserID),
-                null as Map<*, *>?,
+                null,
                 any()
             )
         }
@@ -498,7 +498,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 "/receipts",
-                any() as Map<*, *>?,
+                any(),
                 any()
             )
         }
@@ -526,7 +526,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 "/subscribers/$appUserID/offerings",
-                null as Map<*, *>?,
+                null,
                 any()
             )
         }
@@ -554,14 +554,14 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 "/subscribers/$appUserID/offerings",
-                null as Map<*, *>?,
+                null,
                 any()
             )
         }
         verify(exactly = 1) {
             mockClient.performRequest(
                 "/subscribers/anotherUser/offerings",
-                null as Map<*, *>?,
+                null,
                 any()
             )
         }
@@ -627,7 +627,7 @@ class BackendTest {
         verify(exactly = 2) {
             mockClient.performRequest(
                 "/receipts",
-                any() as Map<*, *>?,
+                any(),
                 any()
             )
         }
@@ -727,7 +727,7 @@ class BackendTest {
         verify(exactly = 2) {
             mockClient.performRequest(
                 "/receipts",
-                any() as Map<*, *>?,
+                any() as Map<String, Any?>,
                 any()
             )
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/HTTPClientTest.kt
@@ -11,7 +11,6 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONException
-import org.junit.After
 import org.junit.AfterClass
 import org.junit.Before
 import org.junit.BeforeClass
@@ -67,7 +66,7 @@ class HTTPClientTest {
 
         HTTPClient(appConfig, baseURL)
             .apply {
-                performRequest("/resource", null as Map<*, *>?, mapOf("" to ""))
+                this.performRequest("/resource", null, mapOf("" to ""))
             }
 
         val request = server.takeRequest()
@@ -81,7 +80,7 @@ class HTTPClientTest {
         server.enqueue(response)
 
         val client = HTTPClient(appConfig, baseURL)
-        val result = client.performRequest("/resource", null as Map<*, *>?, mapOf("" to ""))
+        val result = client.performRequest("/resource", null, mapOf("" to ""))
 
         server.takeRequest()
 
@@ -94,7 +93,7 @@ class HTTPClientTest {
         server.enqueue(response)
 
         val client = HTTPClient(appConfig, baseURL)
-        val result = client.performRequest("/resource", null as Map<*, *>?, mapOf("" to ""))
+        val result = client.performRequest("/resource", null, mapOf("" to ""))
 
         server.takeRequest()
 
@@ -110,7 +109,7 @@ class HTTPClientTest {
 
         val client = HTTPClient(appConfig, baseURL)
         try {
-            client.performRequest("/resource", null as Map<*, *>?, mapOf("" to ""))
+            client.performRequest("/resource", null, mapOf("" to ""))
         } finally {
             server.takeRequest()
         }
@@ -126,7 +125,7 @@ class HTTPClientTest {
         headers["Authentication"] = "Bearer todd"
 
         val client = HTTPClient(appConfig, baseURL)
-        client.performRequest("/resource", null as Map<*, *>?, headers)
+        client.performRequest("/resource", null, headers)
 
         val request = server.takeRequest()
 
@@ -139,7 +138,7 @@ class HTTPClientTest {
         server.enqueue(response)
 
         val client = HTTPClient(appConfig, baseURL)
-        client.performRequest("/resource", null as Map<*, *>?, mapOf("" to ""))
+        client.performRequest("/resource", null, mapOf("" to ""))
 
         val request = server.takeRequest()
 
@@ -166,7 +165,7 @@ class HTTPClientTest {
         server.enqueue(response)
 
         val client = HTTPClient(appConfig, baseURL)
-        client.performRequest("/resource", null as Map<*, *>?, mapOf("" to ""))
+        client.performRequest("/resource", null, mapOf("" to ""))
 
         val request = server.takeRequest()
 
@@ -197,7 +196,7 @@ class HTTPClientTest {
         server.enqueue(response)
 
         val client = HTTPClient(appConfig, baseURL)
-        client.performRequest("/resource", null as Map<*, *>?, mapOf("" to ""))
+        client.performRequest("/resource", null, mapOf("" to ""))
 
         val request = server.takeRequest()
 

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesBackendTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesBackendTests.kt
@@ -347,7 +347,7 @@ class SubscriberAttributesBackendTests {
         val everyMockedCall = every {
             mockClient.performRequest(
                 path,
-                (expectedBody ?: any()) as Map<*, *>,
+                (expectedBody ?: any()),
                 mapOf("Authorization" to "Bearer $API_KEY")
             )
         }
@@ -364,7 +364,7 @@ class SubscriberAttributesBackendTests {
         }
     }
 
-    private val actualPostReceiptBodySlot = slot<Map<*, *>>()
+    private val actualPostReceiptBodySlot = slot<Map<String, Any?>>()
     private fun mockPostReceiptResponse(
         responseCode: Int = 200,
         responseBody: String = "{}"


### PR DESCRIPTION
https://stackoverflow.com/a/12155874

We are calling JSONObject(body) and body is Map<String, Map> so in Android < 19 we send this:

"attributes":"{$displayName={value=cesar, updated_at_ms=1589043738052}}"}

In Android >=19 we send it correctly:
{"attributes": {"$displayName": {"value": null, "updated_at_ms": 1589042480440}}}