### PR TITLE
Deploy SNAPSHOTS when merging to develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,9 @@ workflows:
             - assemble
           filters:
             branches:
-              only: master
+              only: 
+               - master
+               - develop
       - docs-deploy:
           filters:
             tags:


### PR DESCRIPTION
Before moving to git flow, we would release SNAPSHOT releases when merging onto master. We should now release SNAPSHOT releases when merging to develop.