### PR TITLE
Migrates some classes to use Parcelize

### DIFF
--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -107,5 +107,4 @@ dokka {
 
 androidExtensions {
     features = ["parcelize"]
-    experimental = true // Remove when kotlin 1.3.60 is released to fix false error on Parcelize
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases
 
 import android.os.Parcel
 import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
 import java.util.Date
 
 /**
@@ -25,6 +26,7 @@ import java.util.Date
  * no billing issue or an issue has been resolved. Note: Entitlement may still be active even if
  * there is a billing issue. Check the `isActive` property.
  */
+@Parcelize
 class EntitlementInfo internal constructor(
     val identifier: String,
     val isActive: Boolean,
@@ -39,43 +41,6 @@ class EntitlementInfo internal constructor(
     val unsubscribeDetectedAt: Date?,
     val billingIssueDetectedAt: Date?
 ) : Parcelable {
-
-    /** @suppress */
-    constructor(parcel: Parcel) : this(
-        parcel.readString() ?: "",
-        parcel.readByte() != 0.toByte(),
-        parcel.readByte() != 0.toByte(),
-        PeriodType.values()[parcel.readInt()],
-        Date(parcel.readLong()),
-        Date(parcel.readLong()),
-        parcel.readLong().let { date -> if (date == -1L) null else Date(date) },
-        Store.values()[parcel.readInt()],
-        parcel.readString() ?: "",
-        parcel.readByte() != 0.toByte(),
-        parcel.readLong().let { date -> if (date == -1L) null else Date(date) },
-        parcel.readLong().let { date -> if (date == -1L) null else Date(date) }
-    )
-
-    /** @suppress */
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeString(identifier)
-        parcel.writeByte(if (isActive) 1 else 0)
-        parcel.writeByte(if (willRenew) 1 else 0)
-        parcel.writeInt(periodType.ordinal)
-        parcel.writeLong(latestPurchaseDate.time)
-        parcel.writeLong(originalPurchaseDate.time)
-        parcel.writeLong(expirationDate?.time ?: -1)
-        parcel.writeInt(store.ordinal)
-        parcel.writeString(productIdentifier)
-        parcel.writeByte(if (isSandbox) 1 else 0)
-        parcel.writeLong(unsubscribeDetectedAt?.time ?: -1)
-        parcel.writeLong(billingIssueDetectedAt?.time ?: -1)
-    }
-
-    /** @suppress */
-    override fun describeContents(): Int {
-        return 0
-    }
 
     /** @suppress */
     override fun toString(): String {
@@ -133,19 +98,6 @@ class EntitlementInfo internal constructor(
         return result
     }
 
-    companion object {
-        /** @suppress */
-        @JvmField
-        val CREATOR = object : Parcelable.Creator<EntitlementInfo> {
-            override fun createFromParcel(parcel: Parcel): EntitlementInfo {
-                return EntitlementInfo(parcel)
-            }
-
-            override fun newArray(size: Int): Array<EntitlementInfo?> {
-                return arrayOfNulls(size)
-            }
-        }
-    }
 }
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases
 
-import android.os.Parcel
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 import java.util.Date
@@ -97,7 +96,6 @@ class EntitlementInfo internal constructor(
         result = 31 * result + (billingIssueDetectedAt?.hashCode() ?: 0)
         return result
     }
-
 }
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfos.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfos.kt
@@ -42,5 +42,4 @@ class EntitlementInfos internal constructor(
         result = 31 * result + active.hashCode()
         return result
     }
-
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfos.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfos.kt
@@ -1,13 +1,14 @@
 package com.revenuecat.purchases
 
-import android.os.Parcel
 import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
 
 /**
  * This class contains all the entitlements associated to the user.
  * @property all Map of all EntitlementInfo [EntitlementInfo] objects (active and inactive) keyed by
  * entitlement identifier.
  */
+@Parcelize
 class EntitlementInfos internal constructor(
     val all: Map<String, EntitlementInfo>
 ) : Parcelable {
@@ -22,21 +23,6 @@ class EntitlementInfos internal constructor(
      * accessing the `all` map by entitlement identifier.
      */
     operator fun get(s: String) = all[s]
-
-    /** @suppress */
-    constructor(parcel: Parcel) : this(
-        all = parcel.readStringParcelableMap(EntitlementInfo::class.java.classLoader)
-    )
-
-    /** @suppress */
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeStringParcelableMap(all)
-    }
-
-    /** @suppress */
-    override fun describeContents(): Int {
-        return 0
-    }
 
     /** @suppress */
     override fun equals(other: Any?): Boolean {
@@ -57,17 +43,4 @@ class EntitlementInfos internal constructor(
         return result
     }
 
-    /** @suppress */
-    companion object {
-        /** @suppress */
-        @JvmField val CREATOR = object : Parcelable.Creator<EntitlementInfos> {
-            override fun createFromParcel(parcel: Parcel): EntitlementInfos {
-                return EntitlementInfos(parcel)
-            }
-
-            override fun newArray(size: Int): Array<EntitlementInfos?> {
-                return arrayOfNulls(size)
-            }
-        }
-    }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
@@ -5,8 +5,9 @@
 
 package com.revenuecat.purchases
 
-import android.os.Parcel
 import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+import kotlinx.android.parcel.TypeParceler
 import org.json.JSONObject
 import java.util.Date
 
@@ -21,6 +22,8 @@ import java.util.Date
  * @property firstSeen The date this user was first seen in RevenueCat.
  * @property originalAppUserId The original App User Id recorded for this user.
  */
+@Parcelize
+@TypeParceler<JSONObject, JSONObjectParceler>()
 class PurchaserInfo internal constructor(
     val entitlements: EntitlementInfos,
     val purchasedNonSubscriptionSkus: Set<String>,
@@ -34,26 +37,6 @@ class PurchaserInfo internal constructor(
     val firstSeen: Date,
     val originalAppUserId: String
 ) : Parcelable {
-    /**
-     * @hide
-     */
-    constructor(parcel: Parcel) : this(
-        entitlements =
-            parcel.readParcelable<EntitlementInfos>(EntitlementInfos::class.java.classLoader)
-                ?: EntitlementInfos(emptyMap()),
-        purchasedNonSubscriptionSkus = parcel.readInt().let { size ->
-            (0 until size).map { parcel.readString() }.toSet()
-        },
-        allExpirationDatesByProduct = parcel.readStringDateMap(),
-        allPurchaseDatesByProduct = parcel.readStringDateMap(),
-        allExpirationDatesByEntitlement = parcel.readStringDateMap(),
-        allPurchaseDatesByEntitlement = parcel.readStringDateMap(),
-        requestDate = Date(parcel.readLong()),
-        jsonObject = JSONObject(parcel.readString()),
-        schemaVersion = parcel.readInt(),
-        firstSeen = Date(parcel.readLong()),
-        originalAppUserId = parcel.readString() ?: ""
-    )
 
     /**
      * @return Set of active subscription skus
@@ -156,33 +139,6 @@ class PurchaserInfo internal constructor(
                 "nonConsumablePurchases: $purchasedNonSubscriptionSkus,\n" +
                 "requestDate: $requestDate\n>"
 
-    /**
-     * @hide
-     */
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeParcelable(entitlements, flags)
-        parcel.writeInt(purchasedNonSubscriptionSkus.size)
-        purchasedNonSubscriptionSkus.forEach { entry -> parcel.writeString(entry) }
-        parcel.writeStringDateMap(allExpirationDatesByProduct)
-        parcel.writeStringDateMap(allPurchaseDatesByProduct)
-        @Suppress("DEPRECATION")
-        parcel.writeStringDateMap(allExpirationDatesByEntitlement)
-        @Suppress("DEPRECATION")
-        parcel.writeStringDateMap(allPurchaseDatesByEntitlement)
-        parcel.writeLong(requestDate.time)
-        parcel.writeString(jsonObject.toString())
-        parcel.writeInt(schemaVersion)
-        parcel.writeLong(firstSeen.time)
-        parcel.writeString(originalAppUserId)
-    }
-
-    /**
-     * @hide
-     */
-    override fun describeContents(): Int {
-        return 0
-    }
-
     override fun hashCode(): Int {
         var result = entitlements.hashCode()
         result = 31 * result + purchasedNonSubscriptionSkus.hashCode()
@@ -203,11 +159,5 @@ class PurchaserInfo internal constructor(
 
         internal const val SCHEMA_VERSION = 2
 
-        @JvmField
-        val CREATOR: Parcelable.Creator<PurchaserInfo> =
-            object : Parcelable.Creator<PurchaserInfo> {
-                override fun createFromParcel(source: Parcel): PurchaserInfo = PurchaserInfo(source)
-                override fun newArray(size: Int): Array<PurchaserInfo?> = arrayOfNulls(size)
-            }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
@@ -158,6 +158,5 @@ class PurchaserInfo internal constructor(
     companion object {
 
         internal const val SCHEMA_VERSION = 2
-
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils.kt
@@ -216,6 +216,21 @@ internal object SkuDetailsParceler : Parceler<SkuDetails> {
     }
 }
 
+/** @suppress */
+internal object JSONObjectParceler : Parceler<JSONObject> {
+
+    override fun create(parcel: Parcel): JSONObject {
+        return JSONObject(parcel.readString())
+    }
+
+    override fun JSONObject.write(parcel: Parcel, flags: Int) {
+        val field = JSONObject::class.java.getDeclaredField("jsonObject")
+        field.isAccessible = true
+        val value = field.get(this).toString()
+        parcel.writeString(value)
+    }
+}
+
 internal fun BillingResult.toHumanReadableDescription() =
     "DebugMessage: $debugMessage. ErrorCode: ${responseCode.getBillingResponseCodeName()}."
 


### PR DESCRIPTION
Some classes were still implementing `Parcelable` by hand, but we are already using `@Parcelize` to avoid boilerplate. I migrated all the classes to `Parcelize`