### PR TITLE
Adds management URL to Purchaser Info

### DIFF
--- a/purchases-sample-java/src/main/java/com/revenuecat/purchases/purchases_sample_java/CatsActivity.java
+++ b/purchases-sample-java/src/main/java/com/revenuecat/purchases/purchases_sample_java/CatsActivity.java
@@ -1,5 +1,8 @@
 package com.revenuecat.purchases.purchases_sample_java;
 
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -57,7 +60,7 @@ public class CatsActivity extends AppCompatActivity {
         });
     }
 
-    private void configureContent(PurchaserInfo purchaserInfo) {
+    private void configureContent(final PurchaserInfo purchaserInfo) {
         TextView purchaseDateView = findViewById(R.id.purchase_date_label);
         TextView expirationDateView = findViewById(R.id.expiration_date_label);
         TextView catIconView = findViewById(R.id.cat_content_label);
@@ -86,6 +89,24 @@ public class CatsActivity extends AppCompatActivity {
             restoreView.setVisibility(View.VISIBLE);
             expirationDateView.setVisibility(View.GONE);
             purchaseDateView.setVisibility(View.GONE);
+        }
+
+        Button manageSubscriptionButton = findViewById(R.id.manage_subscription);
+
+        if (purchaserInfo.getManagementURL() != null) {
+            manageSubscriptionButton.setVisibility(View.VISIBLE);
+            manageSubscriptionButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    try {
+                        startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(purchaserInfo.getManagementURL())));
+                    } catch (ActivityNotFoundException exception) {
+                        exception.printStackTrace();
+                    }
+                }
+            });
+        } else {
+            manageSubscriptionButton.setVisibility(View.GONE);
         }
     }
 

--- a/purchases-sample-java/src/main/java/com/revenuecat/purchases/purchases_sample_java/CatsActivity.java
+++ b/purchases-sample-java/src/main/java/com/revenuecat/purchases/purchases_sample_java/CatsActivity.java
@@ -99,7 +99,7 @@ public class CatsActivity extends AppCompatActivity {
                 @Override
                 public void onClick(View v) {
                     try {
-                        startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(purchaserInfo.getManagementURL())));
+                        startActivity(new Intent(Intent.ACTION_VIEW, purchaserInfo.getManagementURL()));
                     } catch (ActivityNotFoundException exception) {
                         exception.printStackTrace();
                     }

--- a/purchases-sample-java/src/main/res/layout/activity_cats.xml
+++ b/purchases-sample-java/src/main/res/layout/activity_cats.xml
@@ -83,9 +83,25 @@
             android:layout_marginRight="8dp"
             android:layout_marginBottom="8dp"
             android:text="Restore Purchases"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/manage_subscription"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/go_premium" />
+
+    <com.google.android.material.button.MaterialButton
+            android:id="@+id/manage_subscription"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_marginBottom="8dp"
+            android:text="Manage Subscription"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/purchase_restore" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/purchases-sample/src/main/java/com/revenuecat/sample/CatsActivity.kt
+++ b/purchases-sample/src/main/java/com/revenuecat/sample/CatsActivity.kt
@@ -2,7 +2,6 @@ package com.revenuecat.sample
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.View.GONE
@@ -13,7 +12,6 @@ import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.getPurchaserInfoWith
 import com.revenuecat.purchases.restorePurchasesWith
 import kotlinx.android.synthetic.main.activity_cats.*
-import java.net.URI
 
 class CatsActivity : AppCompatActivity() {
 

--- a/purchases-sample/src/main/java/com/revenuecat/sample/CatsActivity.kt
+++ b/purchases-sample/src/main/java/com/revenuecat/sample/CatsActivity.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.getPurchaserInfoWith
 import com.revenuecat.purchases.restorePurchasesWith
 import kotlinx.android.synthetic.main.activity_cats.*
+import java.net.URI
 
 class CatsActivity : AppCompatActivity() {
 
@@ -67,7 +68,7 @@ class CatsActivity : AppCompatActivity() {
             manage_subscription.visibility = VISIBLE
             manage_subscription.setOnClickListener {
                 try {
-                    startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(purchaserInfo.managementURL)))
+                    startActivity(Intent(Intent.ACTION_VIEW, purchaserInfo.managementURL))
                 } catch (e: ActivityNotFoundException) {
                     e.printStackTrace()
                 }

--- a/purchases-sample/src/main/java/com/revenuecat/sample/CatsActivity.kt
+++ b/purchases-sample/src/main/java/com/revenuecat/sample/CatsActivity.kt
@@ -1,5 +1,8 @@
 package com.revenuecat.sample
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.View.GONE
@@ -58,6 +61,19 @@ class CatsActivity : AppCompatActivity() {
             purchase_restore.visibility = VISIBLE
             expiration_date_label.visibility = GONE
             purchase_date_label.visibility = GONE
+        }
+
+        if (purchaserInfo.managementURL != null) {
+            manage_subscription.visibility = VISIBLE
+            manage_subscription.setOnClickListener {
+                try {
+                    startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(purchaserInfo.managementURL)))
+                } catch (e: ActivityNotFoundException) {
+                    e.printStackTrace()
+                }
+            }
+        } else {
+            manage_subscription.visibility = GONE
         }
     }
 }

--- a/purchases-sample/src/main/res/layout/activity_cats.xml
+++ b/purchases-sample/src/main/res/layout/activity_cats.xml
@@ -83,9 +83,25 @@
         android:layout_marginRight="8dp"
         android:layout_marginBottom="8dp"
         android:text="Restore Purchases"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/manage_subscription"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/go_premium" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/manage_subscription"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginBottom="8dp"
+        android:text="Manage Subscription"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/purchase_restore" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Factories.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Factories.kt
@@ -8,7 +8,6 @@ import com.revenuecat.purchases.caching.SubscriberAttributesPerAppUserIDMap
 import com.revenuecat.purchases.util.Iso8601Utils
 import org.json.JSONException
 import org.json.JSONObject
-import java.net.URL
 import java.util.Collections.emptyMap
 import java.util.Date
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Factories.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Factories.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.caching.SubscriberAttributesPerAppUserIDMap
 import com.revenuecat.purchases.util.Iso8601Utils
 import org.json.JSONException
 import org.json.JSONObject
+import java.net.URL
 import java.util.Collections.emptyMap
 import java.util.Date
 
@@ -71,7 +72,7 @@ internal fun JSONObject.buildPurchaserInfo(): PurchaserInfo {
         optInt("schema_version"),
         firstSeen,
         subscriber.optString("original_app_user_id"),
-        managementURL
+        managementURL?.let { URL(it) }
     )
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Factories.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Factories.kt
@@ -53,6 +53,12 @@ internal fun JSONObject.buildPurchaserInfo(): PurchaserInfo {
         EntitlementInfos(emptyMap())
     }
 
+    val managementURL = if (subscriber.has("management_url")) {
+        subscriber.getNullableString("management_url")
+    } else {
+        null
+    }
+
     return PurchaserInfo(
         entitlementInfos,
         nonSubscriptions.keys().asSequence().toSet(),
@@ -64,7 +70,8 @@ internal fun JSONObject.buildPurchaserInfo(): PurchaserInfo {
         this,
         optInt("schema_version"),
         firstSeen,
-        subscriber.optString("original_app_user_id")
+        subscriber.optString("original_app_user_id"),
+        managementURL
     )
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Factories.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Factories.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases
 
+import android.net.Uri
 import com.android.billingclient.api.SkuDetails
 import com.revenuecat.purchases.attributes.SubscriberAttribute
 import com.revenuecat.purchases.caching.SubscriberAttributeMap
@@ -72,7 +73,7 @@ internal fun JSONObject.buildPurchaserInfo(): PurchaserInfo {
         optInt("schema_version"),
         firstSeen,
         subscriber.optString("original_app_user_id"),
-        managementURL?.let { URL(it) }
+        managementURL?.let { Uri.parse(it) }
     )
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
@@ -20,6 +20,7 @@ import java.util.Date
  * @property requestDate Date when this info was requested
  * @property firstSeen The date this user was first seen in RevenueCat.
  * @property originalAppUserId The original App User Id recorded for this user.
+ * @property managementURL URL to manage active subscriptions of this user.
  */
 class PurchaserInfo internal constructor(
     val entitlements: EntitlementInfos,
@@ -32,7 +33,8 @@ class PurchaserInfo internal constructor(
     internal val jsonObject: JSONObject,
     internal val schemaVersion: Int,
     val firstSeen: Date,
-    val originalAppUserId: String
+    val originalAppUserId: String,
+    val managementURL: String?
 ) : Parcelable {
     /**
      * @hide
@@ -52,7 +54,8 @@ class PurchaserInfo internal constructor(
         jsonObject = JSONObject(parcel.readString()),
         schemaVersion = parcel.readInt(),
         firstSeen = Date(parcel.readLong()),
-        originalAppUserId = parcel.readString() ?: ""
+        originalAppUserId = parcel.readString() ?: "",
+        managementURL = ""
     )
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
@@ -10,8 +10,6 @@ import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 import kotlinx.android.parcel.TypeParceler
 import org.json.JSONObject
-import java.net.URI
-import java.net.URL
 import java.util.Date
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
@@ -22,7 +22,7 @@ import java.util.Date
  * @property originalAppUserId The original App User Id recorded for this user.
  * @property managementURL URL to manage active subscriptions of this user.
  */
-class PurchaserInfo internal constructor(
+data class PurchaserInfo internal constructor(
     val entitlements: EntitlementInfos,
     val purchasedNonSubscriptionSkus: Set<String>,
     val allExpirationDatesByProduct: Map<String, Date?>,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
@@ -9,6 +9,7 @@ import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 import kotlinx.android.parcel.TypeParceler
 import org.json.JSONObject
+import java.net.URL
 import java.util.Date
 
 /**
@@ -37,7 +38,7 @@ data class PurchaserInfo internal constructor(
     internal val schemaVersion: Int,
     val firstSeen: Date,
     val originalAppUserId: String,
-    val managementURL: String?
+    val managementURL: URL?
 ) : Parcelable {
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaserInfo.kt
@@ -5,10 +5,12 @@
 
 package com.revenuecat.purchases
 
+import android.net.Uri
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 import kotlinx.android.parcel.TypeParceler
 import org.json.JSONObject
+import java.net.URI
 import java.net.URL
 import java.util.Date
 
@@ -38,7 +40,7 @@ data class PurchaserInfo internal constructor(
     internal val schemaVersion: Int,
     val firstSeen: Date,
     val originalAppUserId: String,
-    val managementURL: URL?
+    val managementURL: Uri?
 ) : Parcelable {
 
     /**

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchaserInfoTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchaserInfoTest.kt
@@ -5,6 +5,7 @@
 
 package com.revenuecat.purchases
 
+import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONException
@@ -12,7 +13,6 @@ import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import java.net.URL
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -190,7 +190,7 @@ class PurchaserInfoTest {
     fun `Management url is properly retrieved`() {
         val jsonObject = JSONObject(Responses.validFullPurchaserResponse)
         val x = jsonObject.buildPurchaserInfo()
-        assertThat(x.managementURL).isEqualTo(URL("https://play.google.com/store/account/subscriptions"))
+        assertThat(x.managementURL).isEqualTo(Uri.parse("https://play.google.com/store/account/subscriptions"))
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchaserInfoTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchaserInfoTest.kt
@@ -184,4 +184,22 @@ class PurchaserInfoTest {
         val y = jsonObject.buildPurchaserInfo()
         assertThat(x.hashCode() == y.hashCode())
     }
+
+    @Test
+    fun `Management url is properly retrieved`() {
+        val jsonObject = JSONObject(Responses.validFullPurchaserResponse)
+        val x = jsonObject.buildPurchaserInfo()
+        assertThat(x.managementURL).isEqualTo("https://play.google.com/store/account/subscriptions")
+    }
+
+    @Test
+    fun `If management url is null in the JSON, the purchaser info is properly built`() {
+        val jsonObject = JSONObject(Responses.validFullPurchaserResponse)
+        val subscriber = jsonObject.getJSONObject("subscriber")
+        subscriber.put("management_url", JSONObject.NULL)
+        jsonObject.put("subscriber", subscriber)
+        val x = jsonObject.buildPurchaserInfo()
+        assertThat(x.managementURL).isNull()
+    }
+
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchaserInfoTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchaserInfoTest.kt
@@ -12,6 +12,7 @@ import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.net.URL
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -189,7 +190,7 @@ class PurchaserInfoTest {
     fun `Management url is properly retrieved`() {
         val jsonObject = JSONObject(Responses.validFullPurchaserResponse)
         val x = jsonObject.buildPurchaserInfo()
-        assertThat(x.managementURL).isEqualTo("https://play.google.com/store/account/subscriptions")
+        assertThat(x.managementURL).isEqualTo(URL("https://play.google.com/store/account/subscriptions"))
     }
 
     @Test

--- a/purchases/src/test/resources/responses/valid_empty_purchaser_response.json
+++ b/purchases/src/test/resources/responses/valid_empty_purchaser_response.json
@@ -8,6 +8,7 @@
     "original_app_user_id": "",
     "original_application_version": "1.0",
     "other_purchases": {},
-    "subscriptions": {}
+    "subscriptions": {},
+    "management_url": null
   }
 }

--- a/purchases/src/test/resources/responses/valid_full_purchaser_response.json
+++ b/purchases/src/test/resources/responses/valid_full_purchaser_response.json
@@ -54,6 +54,7 @@
         "product_identifier": "onetime_purchase",
         "purchase_date": "1990-08-30T02:40:36Z"
       }
-    }
+    },
+    "management_url": "https://play.google.com/store/account/subscriptions"
   }
 }


### PR DESCRIPTION
The backend returns a `management_url` in the Purchaser Info response. The logic behind it is:
- Use the user's active subscription store to determine the correct link to send.
- Users may have multiple, in that case we can fall back to the platform header.

This URL can be opened in Android apps like so:

```
try {
   startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(purchaserInfo.getManagementURL())));
   } catch (ActivityNotFoundException exception) {
      exception.printStackTrace();
}
```