### PR TITLE
Adds proxy URL static property

### DIFF
--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.2.0'
     testImplementation 'org.mockito:mockito-core:3.0.0'
     testImplementation 'com.android.billingclient:billing:2.0.3'
-    testImplementation 'io.mockk:mockk:1.9.3.kotlin12'
+    testImplementation 'io.mockk:mockk:1.10.0'
     testImplementation 'org.assertj:assertj-core:3.13.2'
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/AppConfig.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/AppConfig.kt
@@ -1,0 +1,52 @@
+package com.revenuecat.purchases
+
+import android.content.Context
+import java.net.URL
+
+internal class AppConfig(
+    context: Context,
+    observerMode: Boolean,
+    val platformInfo: PlatformInfo,
+    proxyURL: URL?
+) {
+
+    val languageTag: String = context.getLocale()?.toBCP47() ?: ""
+    val versionName: String = context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: ""
+    var finishTransactions: Boolean = !observerMode
+    val baseURL: URL = proxyURL?.also {
+        debugLog("Purchases is being configured using a proxy for RevenueCat")
+    } ?: URL("https://api.revenuecat.com/")
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AppConfig
+
+        if (platformInfo != other.platformInfo) return false
+        if (languageTag != other.languageTag) return false
+        if (versionName != other.versionName) return false
+        if (finishTransactions != other.finishTransactions) return false
+        if (baseURL != other.baseURL) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = platformInfo.hashCode()
+        result = 31 * result + languageTag.hashCode()
+        result = 31 * result + versionName.hashCode()
+        result = 31 * result + finishTransactions.hashCode()
+        result = 31 * result + baseURL.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "AppConfig(" +
+            "platformInfo=$platformInfo, " +
+            "languageTag='$languageTag', " +
+            "versionName='$versionName', " +
+            "finishTransactions=$finishTransactions, " +
+            "baseURL=$baseURL)"
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/AppConfig.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/AppConfig.kt
@@ -11,7 +11,7 @@ internal class AppConfig(
 ) {
 
     val languageTag: String = context.getLocale()?.toBCP47() ?: ""
-    val versionName: String = context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: ""
+    val versionName: String = context.versionName ?: ""
     var finishTransactions: Boolean = !observerMode
     val baseURL: URL = proxyURL?.also {
         debugLog("Purchases is being configured using a proxy for RevenueCat")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
@@ -38,7 +38,7 @@ internal typealias PostReceiptDataErrorCallback = (
 internal class Backend(
     private val apiKey: String,
     private val dispatcher: Dispatcher,
-    private val httpClient: HTTPClient
+    @JvmSynthetic internal val httpClient: HTTPClient
 ) {
 
     internal val authenticationHeaders = mapOf("Authorization" to "Bearer ${this.apiKey}")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
@@ -38,7 +38,7 @@ internal typealias PostReceiptDataErrorCallback = (
 internal class Backend(
     private val apiKey: String,
     private val dispatcher: Dispatcher,
-    @JvmSynthetic internal val httpClient: HTTPClient
+    private val httpClient: HTTPClient
 ) {
 
     internal val authenticationHeaders = mapOf("Authorization" to "Bearer ${this.apiKey}")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/HTTPClient.kt
@@ -21,7 +21,7 @@ import java.net.URL
 
 internal class HTTPClient(
     private val appConfig: AppConfig,
-    private val baseURL: URL = URL("https://api.revenuecat.com/")
+    @JvmSynthetic internal val baseURL: URL = URL("https://api.revenuecat.com/")
 ) {
 
     private fun buffer(inputStream: InputStream): BufferedReader {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/HTTPClient.kt
@@ -20,8 +20,7 @@ import java.net.MalformedURLException
 import java.net.URL
 
 internal class HTTPClient(
-    private val appConfig: AppConfig,
-    @JvmSynthetic internal val baseURL: URL = URL("https://api.revenuecat.com/")
+    private val appConfig: AppConfig
 ) {
 
     private fun buffer(inputStream: InputStream): BufferedReader {
@@ -81,7 +80,7 @@ internal class HTTPClient(
         val fullURL: URL
         val connection: HttpURLConnection
         try {
-            fullURL = URL(baseURL, "/v1$path")
+            fullURL = URL(appConfig.baseURL, "/v1$path")
             connection = getConnection(fullURL, headers, jsonBody)
         } catch (e: MalformedURLException) {
             throw RuntimeException(e)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1278,7 +1278,8 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         val frameworkVersion = "3.2.0-SNAPSHOT"
 
         /**
-         * Override to use your own proxy. BEWARE
+         * Set this property to your proxy URL before configuring Purchases *only*
+         * if you've received a proxy key value from your RevenueCat contact.
          */
         @JvmStatic
         var proxyURL: URL? = null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -53,7 +53,7 @@ import java.util.concurrent.TimeUnit
 class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) internal constructor(
     private val application: Application,
     backingFieldAppUserID: String?,
-    @JvmSynthetic internal val backend: Backend,
+    private val backend: Backend,
     private val billingWrapper: BillingWrapper,
     private val deviceCache: DeviceCache,
     private val executorService: ExecutorService,
@@ -1312,21 +1312,16 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
             require(context.applicationContext is Application) { "Needs an application context." }
             val application = context.getApplication()
             val appConfig = AppConfig(
-                context.getLocale()?.toBCP47() ?: "",
-                context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "",
+                context,
+                !observerMode,
                 platformInfo,
-                !observerMode
+                proxyURL
             )
-
-            val httpClient = proxyURL?.let {
-                debugLog("Purchases is being configured using a proxy for RevenueCat")
-                HTTPClient(appConfig, baseURL = it)
-            } ?: HTTPClient(appConfig)
 
             val backend = Backend(
                 apiKey,
                 Dispatcher(service),
-                httpClient
+                HTTPClient(appConfig)
             )
 
             val billingWrapper = BillingWrapper(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -33,6 +33,7 @@ import com.revenuecat.purchases.interfaces.UpdatedPurchaserInfoListener
 import com.revenuecat.purchases.util.AdvertisingIdClient
 import org.json.JSONException
 import org.json.JSONObject
+import java.net.URL
 import java.util.Collections.emptyMap
 import java.util.HashMap
 import java.util.concurrent.ExecutorService
@@ -1235,8 +1236,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
             version = null
         )
 
-        @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
-        @set:VisibleForTesting(otherwise = VisibleForTesting.NONE)
+        @JvmSynthetic
         internal var postponedAttributionData = mutableListOf<AttributionData>()
 
         /**
@@ -1245,8 +1245,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         @JvmStatic
         var debugLogsEnabled = false
 
-        @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
-        @set:VisibleForTesting(otherwise = VisibleForTesting.NONE)
+        @JvmSynthetic
         internal var backingFieldSharedInstance: Purchases? = null
 
         /**
@@ -1278,6 +1277,12 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
          */
         @JvmStatic
         val frameworkVersion = "3.2.0-SNAPSHOT"
+
+        /**
+         * Override to use your own proxy. BEWARE
+         */
+        @JvmStatic
+        var proxyURL: String? = null
 
         /**
          * Configures an instance of the Purchases SDK with a specified API key. The instance will
@@ -1313,10 +1318,13 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
                 platformInfo,
                 !observerMode
             )
+            if (proxyURL != null) {
+                debugLog("Purchases is being configured using a proxy for RevenueCat")
+            }
             val backend = Backend(
                 apiKey,
                 Dispatcher(service),
-                HTTPClient(appConfig)
+                HTTPClient(appConfig, baseURL = URL(proxyURL))
             )
 
             val billingWrapper = BillingWrapper(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit
  * guide to setup your RevenueCat account.
  * @warning Only one instance of Purchases should be instantiated at a time!
  */
+@Suppress("LongParameterList")
 class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) internal constructor(
     private val application: Application,
     backingFieldAppUserID: String?,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils.kt
@@ -217,3 +217,6 @@ internal fun PurchaseHistoryRecord.toHumanReadableDescription() =
 
 val SkuDetails.priceAmount: Double
     get() = this.priceAmountMicros.div(1000000.0)
+
+internal val Context.versionName: String?
+    get() = this.packageManager.getPackageInfo(this.packageName, 0).versionName

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils.kt
@@ -181,13 +181,6 @@ internal fun Locale.toBCP47(): String {
     return bcp47Tag.toString()
 }
 
-internal data class AppConfig(
-    val languageTag: String,
-    val versionName: String,
-    val platformInfo: PlatformInfo,
-    var finishTransactions: Boolean
-)
-
 data class PlatformInfo(
     val flavor: String,
     val version: String?

--- a/purchases/src/test/java/com/revenuecat/purchases/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/AppConfigTest.kt
@@ -1,0 +1,133 @@
+package com.revenuecat.purchases
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.URL
+
+@RunWith(AndroidJUnit4::class)
+class AppConfigTest {
+
+    @Test
+    fun `languageTag is created successfully`() {
+        val expected = "en-US"
+        val mockContext = mockk<Context>(relaxed = true)
+        mockkStatic("com.revenuecat.purchases.UtilsKt")
+        every {
+            mockContext.getLocale()?.toBCP47()
+        } returns expected
+        val appConfig = AppConfig(
+            context = mockContext,
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+        assertThat(appConfig.languageTag).isEqualTo(expected)
+    }
+
+    @Test
+    fun `languageTag defaults to empty string`() {
+        val expected = ""
+        val mockContext = mockk<Context>(relaxed = true)
+        mockkStatic("com.revenuecat.purchases.UtilsKt")
+        every {
+            mockContext.getLocale()?.toBCP47()
+        } returns null
+        val appConfig = AppConfig(
+            context = mockContext,
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+        assertThat(appConfig.languageTag).isEqualTo(expected)
+    }
+
+    @Test
+    fun `versionName is created successfully`() {
+        val expected = "1.0.0"
+        mockkStatic("com.revenuecat.purchases.UtilsKt")
+        val mockContext = mockk<Context>(relaxed = true) {
+            every {
+                versionName
+            } returns expected
+        }
+
+        val appConfig = AppConfig(
+            context = mockContext,
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+        assertThat(appConfig.versionName).isEqualTo(expected)
+    }
+
+    @Test
+    fun `versionName defaults to empty string`() {
+        val expected = ""
+        mockkStatic("com.revenuecat.purchases.UtilsKt")
+        val mockContext = mockk<Context>(relaxed = true) {
+            every {
+                versionName
+            } returns null
+        }
+        val appConfig = AppConfig(
+            context = mockContext,
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+        assertThat(appConfig.versionName).isEqualTo(expected)
+    }
+
+    @Test
+    fun `finishTransactions is set correctly when observer mode is false`() {
+        val appConfig = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+        assertThat(appConfig.finishTransactions).isTrue()
+    }
+
+    @Test
+    fun `finishTransactions is set correctly when observer mode is true`() {
+        val appConfig = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = true,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+        assertThat(appConfig.finishTransactions).isFalse()
+    }
+
+    @Test
+    fun `proxyURL is set as a baseURL`() {
+        val expected = URL("https://a-proxy")
+        val appConfig = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = expected
+        )
+        assertThat(appConfig.baseURL).isEqualTo(expected)
+    }
+
+    @Test
+    fun `default baseURL is correct`() {
+        val expected = URL("https://api.revenuecat.com/")
+        val appConfig = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+        assertThat(appConfig.baseURL).isEqualTo(expected)
+    }
+
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/AppConfigTest.kt
@@ -200,4 +200,15 @@ class AppConfigTest {
         )
         assertThat(x.hashCode() == y.hashCode())
     }
+
+    @Test
+    fun `toString works`() {
+        val x = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+        assertThat(x.toString()).isNotNull()
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/AppConfigTest.kt
@@ -130,4 +130,74 @@ class AppConfigTest {
         assertThat(appConfig.baseURL).isEqualTo(expected)
     }
 
+    @Test
+    fun `Given two app configs with same data, both are equal`() {
+        val x = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+        val y = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+
+        assertThat(x).isEqualTo(y)
+    }
+
+    @Test
+    fun `Given two app configs with different data, both are not equal`() {
+        val x = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+        var y = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = true,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+
+        assertThat(x).isNotEqualTo(y)
+
+        y = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.1.0"),
+            proxyURL = null
+        )
+
+        assertThat(x).isNotEqualTo(y)
+
+        y = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = URL("https://a.com")
+        )
+
+        assertThat(x).isNotEqualTo(y)
+    }
+
+    @Test
+    fun `Given two same app configs, their hashcodes are the same`() {
+        val x = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+        val y = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null
+        )
+        assertThat(x.hashCode() == y.hashCode())
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/HTTPClientTest.kt
@@ -56,7 +56,7 @@ class HTTPClientTest {
             context = mockk(relaxed = true),
             observerMode = false,
             platformInfo = expectedPlatformInfo,
-            proxyURL = null
+            proxyURL = baseURL
         )
     }
 
@@ -165,7 +165,7 @@ class HTTPClientTest {
             context = mockk(relaxed = true),
             observerMode = false,
             platformInfo = PlatformInfo("native", null),
-            proxyURL = null
+            proxyURL = baseURL
         )
         val response = MockResponse().setBody("{}")
         server.enqueue(response)

--- a/purchases/src/test/java/com/revenuecat/purchases/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/HTTPClientTest.kt
@@ -7,6 +7,7 @@ package com.revenuecat.purchases
 
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
@@ -51,12 +52,17 @@ class HTTPClientTest {
     
     @Before
     fun setupBefore() {
-        appConfig = AppConfig("en-US", "1.0", expectedPlatformInfo, true)
+        appConfig = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = expectedPlatformInfo,
+            proxyURL = null
+        )
     }
 
     @Test
     fun canBeCreated() {
-        HTTPClient(appConfig, baseURL)
+        HTTPClient(appConfig)
     }
 
     @Test
@@ -64,7 +70,7 @@ class HTTPClientTest {
         val response = MockResponse().setBody("{}")
         server.enqueue(response)
 
-        HTTPClient(appConfig, baseURL)
+        HTTPClient(appConfig)
             .apply {
                 this.performRequest("/resource", null, mapOf("" to ""))
             }
@@ -79,7 +85,7 @@ class HTTPClientTest {
         val response = MockResponse().setBody("{}").setResponseCode(223)
         server.enqueue(response)
 
-        val client = HTTPClient(appConfig, baseURL)
+        val client = HTTPClient(appConfig)
         val result = client.performRequest("/resource", null, mapOf("" to ""))
 
         server.takeRequest()
@@ -92,7 +98,7 @@ class HTTPClientTest {
         val response = MockResponse().setBody("{'response': 'OK'}").setResponseCode(223)
         server.enqueue(response)
 
-        val client = HTTPClient(appConfig, baseURL)
+        val client = HTTPClient(appConfig)
         val result = client.performRequest("/resource", null, mapOf("" to ""))
 
         server.takeRequest()
@@ -107,7 +113,7 @@ class HTTPClientTest {
         val response = MockResponse().setBody("not uh jason")
         server.enqueue(response)
 
-        val client = HTTPClient(appConfig, baseURL)
+        val client = HTTPClient(appConfig)
         try {
             client.performRequest("/resource", null, mapOf("" to ""))
         } finally {
@@ -124,7 +130,7 @@ class HTTPClientTest {
         val headers = HashMap<String, String>()
         headers["Authentication"] = "Bearer todd"
 
-        val client = HTTPClient(appConfig, baseURL)
+        val client = HTTPClient(appConfig)
         client.performRequest("/resource", null, headers)
 
         val request = server.takeRequest()
@@ -137,7 +143,7 @@ class HTTPClientTest {
         val response = MockResponse().setBody("{}")
         server.enqueue(response)
 
-        val client = HTTPClient(appConfig, baseURL)
+        val client = HTTPClient(appConfig)
         client.performRequest("/resource", null, mapOf("" to ""))
 
         val request = server.takeRequest()
@@ -156,15 +162,15 @@ class HTTPClientTest {
     @Test
     fun `Given there is no flavor version, flavor version header is not set`() {
         appConfig = AppConfig(
-            languageTag = "en-US",
-            versionName = "1.0",
+            context = mockk(relaxed = true),
+            observerMode = false,
             platformInfo = PlatformInfo("native", null),
-            finishTransactions = true
+            proxyURL = null
         )
         val response = MockResponse().setBody("{}")
         server.enqueue(response)
 
-        val client = HTTPClient(appConfig, baseURL)
+        val client = HTTPClient(appConfig)
         client.performRequest("/resource", null, mapOf("" to ""))
 
         val request = server.takeRequest()
@@ -180,7 +186,7 @@ class HTTPClientTest {
         val body = HashMap<String, String>()
         body["user_id"] = "jerry"
 
-        val client = HTTPClient(appConfig, baseURL)
+        val client = HTTPClient(appConfig)
         client.performRequest("/resource", body, mapOf("" to ""))
 
         val request = server.takeRequest()
@@ -195,7 +201,7 @@ class HTTPClientTest {
         val response = MockResponse().setBody("{}")
         server.enqueue(response)
 
-        val client = HTTPClient(appConfig, baseURL)
+        val client = HTTPClient(appConfig)
         client.performRequest("/resource", null, mapOf("" to ""))
 
         val request = server.takeRequest()

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -52,6 +52,7 @@ import java.util.ConcurrentModificationException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
+import java.net.URL
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -3211,6 +3212,14 @@ class PurchasesTest {
         Purchases.platformInfo = expected
         Purchases.configure(mockContext, "api")
         assertThat(Purchases.sharedInstance.appConfig.platformInfo).isEqualTo(expected)
+    }
+
+    @Test
+    fun `Setting proxy URL info sets it in the HttpClient when configuring the SDK`() {
+        val expected = URL("https://a-proxy.com")
+        Purchases.proxyURL = expected
+        Purchases.configure(mockContext, "api")
+        assertThat(Purchases.sharedInstance.backend.httpClient.baseURL).isEqualTo(expected)
     }
 
     // region Private Methods

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -3219,7 +3219,7 @@ class PurchasesTest {
         val expected = URL("https://a-proxy.com")
         Purchases.proxyURL = expected
         Purchases.configure(mockContext, "api")
-        assertThat(Purchases.sharedInstance.backend.httpClient.baseURL).isEqualTo(expected)
+        assertThat(Purchases.sharedInstance.appConfig.baseURL).isEqualTo(expected)
     }
 
     // region Private Methods
@@ -3514,7 +3514,12 @@ class PurchasesTest {
             executorService = mockExecutorService,
             identityManager = mockIdentityManager,
             subscriberAttributesManager = mockSubscriberAttributesManager,
-            appConfig = AppConfig("en-US", "1.0", PlatformInfo("native", "3.2.0"), true)
+            appConfig = AppConfig(
+                context = mockContext,
+                observerMode = false,
+                platformInfo = PlatformInfo("native", "3.2.0"),
+                proxyURL = null
+            )
         )
         Purchases.sharedInstance = purchases
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -119,7 +119,12 @@ class SubscriberAttributesPurchasesTests {
                 every { currentAppUserID } returns appUserId
             },
             subscriberAttributesManager = subscriberAttributesManagerMock,
-            appConfig = AppConfig("en-US", "1.0", PlatformInfo("native", "3.2.0"), true)
+            appConfig = AppConfig(
+                context = mockk(relaxed = true),
+                observerMode = false,
+                platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+                proxyURL = null
+            )
         )
     }
 


### PR DESCRIPTION
# Problem
Some apps have additional security requirements (specifically kids apps) that require them to proxy all traffic from their parties through their own servers.

Right now, apps can override the hostname in the SDK to their proxy URL, but they need to remember to do this every time they upgrade SDK versions.

# SDK Changes
We should make an "official way" of setting a proxy URL that will persist for the user between SDK updates.

Add a static property that is called proxyURL

Log whenever someone calls configure with a configured proxyURL.