### PR TITLE
Passes durations to backend in body of post receipt

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
@@ -120,14 +120,11 @@ internal class Backend(
     ) {
         val cacheKey = listOfNotNull(
             purchaseToken,
-            productInfo.productID,
             appUserID,
             isRestore.toString(),
-            productInfo.offeringIdentifier,
             observerMode.toString(),
-            productInfo.price?.toString(),
-            productInfo.currency,
-            subscriberAttributes.toString()
+            subscriberAttributes.toString(),
+            productInfo.toString()
         )
 
         val body = mapOf(
@@ -139,7 +136,10 @@ internal class Backend(
             "observer_mode" to observerMode,
             "price" to productInfo.price,
             "currency" to productInfo.currency,
-            "attributes" to subscriberAttributes.takeUnless { it.isEmpty() }?.toBackendMap()
+            "attributes" to subscriberAttributes.takeUnless { it.isEmpty() }?.toBackendMap(),
+            "normal_duration" to productInfo.duration,
+            "intro_duration" to productInfo.introDuration,
+            "trial_duration" to productInfo.trialDuration
         ).filterValues { value -> value != null }
 
         val call = object : Dispatcher.AsyncCall() {

--- a/purchases/src/test/java/com/revenuecat/purchases/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BackendTest.kt
@@ -140,37 +140,18 @@ class BackendTest {
         isRestore: Boolean,
         clientException: Exception?,
         resultBody: String?,
-        offeringIdentifier: String?,
         observerMode: Boolean,
-        price: Double?,
-        currency: String?,
-        duration: String? = null,
-        introDuration: String? = null,
-        trialDuration: String? = null
+        productInfo: ProductInfo
     ): PurchaserInfo {
-
-        val (fetchToken, productID, info) = mockPostReceiptResponse(
+        val (fetchToken, info) = mockPostReceiptResponse(
             isRestore,
             responseCode,
             clientException,
             resultBody = resultBody,
-            offeringIdentifier = offeringIdentifier,
             observerMode = observerMode,
-            price = price,
-            currency = currency,
-            duration = duration,
-            introDuration = introDuration,
-            trialDuration = trialDuration
+            productInfo = productInfo
         )
-        val productInfo = ProductInfo(
-            productID = productID,
-            offeringIdentifier = offeringIdentifier,
-            price = price,
-            currency = currency,
-            duration = duration,
-            introDuration = introDuration,
-            trialDuration = trialDuration
-        )
+
         backend.postReceiptData(
             purchaseToken = fetchToken,
             appUserID = appUserID,
@@ -185,34 +166,30 @@ class BackendTest {
         return info
     }
 
+    private val productID = "product_id"
+
     private fun mockPostReceiptResponse(
         isRestore: Boolean,
         responseCode: Int,
         clientException: Exception?,
         resultBody: String?,
         delayed: Boolean = false,
-        offeringIdentifier: String?,
         observerMode: Boolean,
-        price: Double?,
-        currency: String?,
-        duration: String? = null,
-        introDuration: String? = null,
-        trialDuration: String? = null
-    ): Triple<String, String, PurchaserInfo> {
+        productInfo: ProductInfo
+    ): Pair<String, PurchaserInfo> {
         val fetchToken = "fetch_token"
-        val productID = "product_id"
         val body = mapOf(
             "fetch_token" to fetchToken,
             "app_user_id" to appUserID,
-            "product_id" to productID,
+            "product_id" to productInfo.productID,
             "is_restore" to isRestore,
-            "presented_offering_identifier" to offeringIdentifier,
+            "presented_offering_identifier" to productInfo.offeringIdentifier,
             "observer_mode" to observerMode,
-            "price" to price,
-            "currency" to currency,
-            "normal_duration" to duration,
-            "intro_duration" to introDuration,
-            "trial_duration" to trialDuration
+            "price" to productInfo.price,
+            "currency" to productInfo.currency,
+            "normal_duration" to productInfo.duration,
+            "intro_duration" to productInfo.introDuration,
+            "trial_duration" to productInfo.trialDuration
         ).mapNotNull { entry: Map.Entry<String, Any?> ->
             entry.value?.let { entry.key to it }
         }.toMap()
@@ -225,7 +202,7 @@ class BackendTest {
             resultBody,
             delayed
         )
-        return Triple(fetchToken, productID, info)
+        return fetchToken to info
     }
 
     private fun getPurchaserInfo(
@@ -290,14 +267,12 @@ class BackendTest {
     @Test
     fun postReceiptCallsProperURL() {
         val info = postReceipt(
-            200,
-            false,
-            null,
-            null,
-            null,
-            false,
-            null,
-            null
+            responseCode = 200,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            observerMode = false,
+            productInfo = ProductInfo(productID)
         )
 
         assertThat(receivedPurchaserInfo).`as`("Received info is not null").isNotNull
@@ -307,14 +282,12 @@ class BackendTest {
     @Test
     fun postReceiptCallsFailsFor40X() {
         postReceipt(
-            401,
-            false,
-            null,
-            null,
-            null,
-            false,
-            null,
-            null
+            responseCode = 401,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            observerMode = false,
+            productInfo = ProductInfo(productID)
         )
 
         assertThat(receivedPurchaserInfo).`as`("Received info is null").isNull()
@@ -468,22 +441,24 @@ class BackendTest {
 
     @Test
     fun `given multiple post calls for same subscriber, only one is triggered`() {
-        val (fetchToken, productID, _) = mockPostReceiptResponse(
+        val productInfo = ProductInfo(
+            productID = productID,
+            offeringIdentifier = "offering_a"
+        )
+        val (fetchToken, _) = mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
             resultBody = null,
             delayed = true,
-            offeringIdentifier = "offering_a",
             observerMode = false,
-            price = null,
-            currency = null
+            productInfo = ProductInfo(
+                productID,
+                offeringIdentifier = "offering_a"
+            )
         )
         val lock = CountDownLatch(2)
-        val productInfo = ProductInfo(
-            productID = productID,
-            offeringIdentifier = "offering_a"
-        )
+
         asyncBackend.postReceiptData(
             purchaseToken = fetchToken,
             appUserID = appUserID,
@@ -588,16 +563,17 @@ class BackendTest {
 
     @Test
     fun `given multiple post calls for same subscriber different offering, both are triggered`() {
-        val (fetchToken, productID, _) = mockPostReceiptResponse(
+        val (fetchToken, _) = mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
             resultBody = null,
             delayed = true,
-            offeringIdentifier = "offering_a",
             observerMode = false,
-            price = null,
-            currency = null
+            productInfo = ProductInfo(
+                productID,
+                offeringIdentifier = "offering_a"
+            )
         )
         val lock = CountDownLatch(2)
         val productInfo = ProductInfo(
@@ -616,19 +592,20 @@ class BackendTest {
             },
             onError = postReceiptErrorCallback
         )
-        val (fetchToken1, productID1, _) = mockPostReceiptResponse(
+        val (fetchToken1, _) = mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
             resultBody = null,
             delayed = true,
-            offeringIdentifier = "offering_b",
             observerMode = false,
-            price = null,
-            currency = null
+            productInfo = ProductInfo(
+                productID,
+                offeringIdentifier = "offering_b"
+            )
         )
         val productInfo1 = ProductInfo(
-            productID = productID1,
+            productID = productID,
             offeringIdentifier = "offering_b"
         )
         asyncBackend.postReceiptData(
@@ -657,14 +634,12 @@ class BackendTest {
     @Test
     fun postReceiptObserverMode() {
         val info = postReceipt(
-            200,
-            false,
-            null,
-            null,
-            null,
-            true,
-            null,
-            null
+            responseCode = 200,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            observerMode = true,
+            productInfo = ProductInfo(productID)
         )
 
         assertThat(receivedPurchaserInfo).`as`("Received info is not null").isNotNull
@@ -674,14 +649,16 @@ class BackendTest {
     @Test
     fun `postReceipt passes price and currency`() {
         val info = postReceipt(
-            200,
-            false,
-            null,
-            null,
-            null,
-            true,
-            2.5,
-            "USD"
+            responseCode = 200,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            observerMode = true,
+            productInfo = ProductInfo(
+                productID,
+                price = 2.5,
+                currency = "USD"
+            )
         )
 
         assertThat(receivedPurchaserInfo).`as`("Received info is not null").isNotNull
@@ -690,27 +667,31 @@ class BackendTest {
 
     @Test
     fun `given multiple post calls for same subscriber different price, both are triggered`() {
-        val (fetchToken, productID, _) = mockPostReceiptResponse(
+        val (fetchToken, _) = mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
             resultBody = null,
             delayed = true,
-            offeringIdentifier = "offering_a",
             observerMode = false,
-            price = null,
-            currency = null
+            productInfo = ProductInfo(
+                productID,
+                offeringIdentifier = "offering_a"
+            )
         )
-        val (_, _, _) = mockPostReceiptResponse(
+        val (_, _) = mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
             resultBody = null,
             delayed = true,
-            offeringIdentifier = "offering_a",
             observerMode = false,
-            price = 2.5,
-            currency = "USD"
+            productInfo = ProductInfo(
+                productID,
+                offeringIdentifier = "offering_a",
+                price = 2.5,
+                currency = "USD"
+            )
         )
         val lock = CountDownLatch(2)
         val productInfo = ProductInfo(
@@ -760,30 +741,32 @@ class BackendTest {
 
     @Test
     fun `given multiple post calls for same subscriber different durations, both are triggered`() {
-        val (fetchToken, productID, _) = mockPostReceiptResponse(
+        val (fetchToken, _) = mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
             resultBody = null,
             delayed = true,
-            offeringIdentifier = "offering_a",
             observerMode = false,
-            price = null,
-            currency = null
+            productInfo = ProductInfo(
+                productID,
+                offeringIdentifier = "offering_a"
+            )
         )
-        val (_, _, _) = mockPostReceiptResponse(
+        val (_, _) = mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
             resultBody = null,
             delayed = true,
-            offeringIdentifier = "offering_a",
             observerMode = false,
-            price = null,
-            currency = null,
-            duration = "P1M",
-            introDuration = "P1M",
-            trialDuration = "P1M"
+            productInfo = ProductInfo(
+                productID,
+                offeringIdentifier = "offering_a",
+                duration = "P1M",
+                introDuration = "P1M",
+                trialDuration = "P1M"
+            )
         )
         val lock = CountDownLatch(2)
         val productInfo = ProductInfo(
@@ -834,19 +817,20 @@ class BackendTest {
 
     @Test
     fun `given multiple post calls for same subscriber same durations, only one is triggered`() {
-        val (fetchToken, productID, _) = mockPostReceiptResponse(
+        val (fetchToken, _) = mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
             resultBody = null,
             delayed = true,
-            offeringIdentifier = "offering_a",
             observerMode = false,
-            price = null,
-            currency = null,
-            duration = "P1M",
-            introDuration = "P1M",
-            trialDuration = "P1M"
+            productInfo = ProductInfo(
+                productID,
+                offeringIdentifier = "offering_a",
+                duration = "P1M",
+                introDuration = "P1M",
+                trialDuration = "P1M"
+            )
         )
         val lock = CountDownLatch(2)
         val productInfo = ProductInfo(
@@ -898,13 +882,15 @@ class BackendTest {
             isRestore = false,
             clientException = null,
             resultBody = null,
-            offeringIdentifier = null,
             observerMode = true,
-            price = 2.5,
-            currency = "USD",
-            duration = "P1M",
-            introDuration = "P2M",
-            trialDuration = "P3M"
+            productInfo = ProductInfo(
+                productID = productID,
+                price = 2.5,
+                currency = "USD",
+                duration = "P1M",
+                introDuration = "P2M",
+                trialDuration = "P3M"
+            )
         )
 
         assertThat(receivedPurchaserInfo).`as`("Received purchaser info is not null").isNotNull

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -103,7 +103,12 @@ class PostingTransactionsTests {
                 every { currentAppUserID } returns appUserId
             },
             subscriberAttributesManager = subscriberAttributesManagerMock,
-            appConfig = AppConfig("en-US", "1.0", PlatformInfo("native", "3.2.0"), true)
+            appConfig = AppConfig(
+                context = mockk(relaxed = true),
+                observerMode = false,
+                platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+                proxyURL = null
+            )
         )
     }
 


### PR DESCRIPTION
The backend part of https://github.com/RevenueCat/purchases-android/pull/148 was missing.

I added the corresponding changes and fixed the tests