### PR TITLE
Fixes finishTransactions regression

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1304,7 +1304,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
             val application = context.getApplication()
             val appConfig = AppConfig(
                 context,
-                !observerMode,
+                observerMode,
                 platformInfo,
                 proxyURL
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -3278,6 +3278,18 @@ class PurchasesTest {
         assertThat(Purchases.sharedInstance.appConfig.baseURL).isEqualTo(expected)
     }
 
+    @Test
+    fun `Setting observer mode on sets finish transactions to false`() {
+        Purchases.configure(mockContext, "api", observerMode = true)
+        assertThat(Purchases.sharedInstance.appConfig.finishTransactions).isFalse()
+    }
+
+    @Test
+    fun `Setting observer mode off sets finish transactions to true`() {
+        Purchases.configure(mockContext, "api", observerMode = false)
+        assertThat(Purchases.sharedInstance.appConfig.finishTransactions).isTrue()
+    }
+
     // region Private Methods
     private fun mockBillingWrapper() {
         with(mockBillingWrapper) {


### PR DESCRIPTION
This change https://github.com/RevenueCat/purchases-android/pull/152/files#diff-c2f78fa2df4dd98b44def5ad956966c6R8 changed the constructor of AppConfig to accept `observerMode` instead of `finishTransactions`, but we never changed what we send to the constructor, so no transactions were being consumed/acknowledged