### PR TITLE
BillingClient update to 3.0.0

### DIFF
--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation 'androidx.annotation:annotation:1.1.0'
-    api 'com.android.billingclient:billing:2.0.3'
+    api 'com.android.billingclient:billing:3.0.0'
     implementation "androidx.lifecycle:lifecycle-runtime:2.1.0"
     implementation "androidx.lifecycle:lifecycle-extensions:2.1.0"
     kapt "androidx.lifecycle:lifecycle-compiler:2.1.0"
@@ -49,7 +49,7 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.2.0'
     testImplementation 'org.mockito:mockito-core:3.0.0'
-    testImplementation 'com.android.billingclient:billing:2.0.3'
+    testImplementation 'com.android.billingclient:billing:3.0.0'
     testImplementation 'io.mockk:mockk:1.10.0'
     testImplementation 'org.assertj:assertj-core:3.13.2'
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -320,7 +320,7 @@ internal class BillingWrapper internal constructor(
         }
     }
 
-    fun queryPurchaseHistoryBySku(
+    fun findPurchaseInPurchaseHistory(
         @SkuType skuType: String,
         sku: String,
         completion: (BillingResult, PurchaseHistoryRecordWrapper?) -> Unit

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -168,7 +168,7 @@ internal class BillingWrapper internal constructor(
         presentedOfferingIdentifier: String?
     ) {
         if (upgradeOrDowngradeInfo != null) {
-            debugLog("Upgrading old sku ${upgradeOrDowngradeInfo.oldPurchase.sku} to sku: ${skuDetails.sku}")
+            debugLog("Moving from old sku ${upgradeOrDowngradeInfo.oldPurchase.sku} to sku ${skuDetails.sku}")
         } else {
             debugLog("Making purchase for sku: ${skuDetails.sku}")
         }
@@ -181,11 +181,13 @@ internal class BillingWrapper internal constructor(
                 .setSkuDetails(skuDetails)
                 .setObfuscatedAccountId(appUserID.sha256())
                 .apply {
-                    upgradeOrDowngradeInfo?.oldPurchase?.let { oldPurchase ->
-                        setOldSku(oldPurchase.sku, oldPurchase.purchaseToken)
-                    }
-                    upgradeOrDowngradeInfo?.prorationMode?.let { prorationMode ->
-                        setReplaceSkusProrationMode(prorationMode)
+                    upgradeOrDowngradeInfo?.let { upgradeOrDowngradeInfo ->
+                        upgradeOrDowngradeInfo.oldPurchase.let { oldPurchase ->
+                            setOldSku(oldPurchase.sku, oldPurchase.purchaseToken)
+                        }
+                        upgradeOrDowngradeInfo.prorationMode?.let { prorationMode ->
+                            setReplaceSkusProrationMode(prorationMode)
+                        }
                     }
                 }.build()
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -213,10 +213,10 @@ internal class BillingWrapper internal constructor(
             if (connectionError == null) {
                 billingClient?.queryPurchaseHistoryAsync(skuType) { billingResult, purchaseHistoryRecordList ->
                     if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                        purchaseHistoryRecordList.takeUnless { it.isEmpty() }?.forEach {
+                        purchaseHistoryRecordList.takeUnless { it.isNullOrEmpty() }?.forEach {
                             debugLog("Purchase history retrieved ${it.toHumanReadableDescription()}")
                         } ?: debugLog("Purchase history is empty.")
-                        onReceivePurchaseHistory(purchaseHistoryRecordList)
+                        onReceivePurchaseHistory(purchaseHistoryRecordList ?: emptyList())
                     } else {
                         onReceivePurchaseHistoryError(
                             billingResult.responseCode.billingResponseToPurchasesError(
@@ -323,13 +323,13 @@ internal class BillingWrapper internal constructor(
         billingClient?.let { client ->
             val querySubsResult = client.queryPurchases(SkuType.SUBS)
             val subsResponseOK = querySubsResult.responseCode == BillingClient.BillingResponseCode.OK
-            val subFound = querySubsResult.purchasesList.any { it.purchaseToken == purchaseToken }
+            val subFound = querySubsResult.purchasesList?.any { it.purchaseToken == purchaseToken } ?: false
             if (subsResponseOK && subFound) {
                 return@getPurchaseType PurchaseType.SUBS
             }
             val queryInAppsResult = client.queryPurchases(SkuType.INAPP)
             val inAppsResponseIsOK = queryInAppsResult.responseCode == BillingClient.BillingResponseCode.OK
-            val inAppFound = queryInAppsResult.purchasesList.any { it.purchaseToken == purchaseToken }
+            val inAppFound = queryInAppsResult.purchasesList?.any { it.purchaseToken == purchaseToken } ?: false
             if (inAppsResponseIsOK && inAppFound) {
                 return@getPurchaseType PurchaseType.INAPP
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -179,7 +179,7 @@ internal class BillingWrapper internal constructor(
         executeRequestOnUIThread {
             val params = BillingFlowParams.newBuilder()
                 .setSkuDetails(skuDetails)
-                .setAccountId(appUserID)
+                .setObfuscatedAccountId(appUserID.sha256())
                 .apply {
                     upgradeOrDowngradeInfo?.oldPurchase?.let { oldPurchase ->
                         setOldSku(oldPurchase.sku, oldPurchase.purchaseToken)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -164,11 +164,11 @@ internal class BillingWrapper internal constructor(
         activity: Activity,
         appUserID: String,
         skuDetails: SkuDetails,
-        upgradeOrDowngradeInfo: UpgradeOrDowngradeInfo?,
+        replaceSkuInfo: ReplaceSkuInfo?,
         presentedOfferingIdentifier: String?
     ) {
-        if (upgradeOrDowngradeInfo != null) {
-            debugLog("Moving from old sku ${upgradeOrDowngradeInfo.oldPurchase.sku} to sku ${skuDetails.sku}")
+        if (replaceSkuInfo != null) {
+            debugLog("Moving from old sku ${replaceSkuInfo.oldPurchase.sku} to sku ${skuDetails.sku}")
         } else {
             debugLog("Making purchase for sku: ${skuDetails.sku}")
         }
@@ -181,11 +181,9 @@ internal class BillingWrapper internal constructor(
                 .setSkuDetails(skuDetails)
                 .setObfuscatedAccountId(appUserID.sha256())
                 .apply {
-                    upgradeOrDowngradeInfo?.let { upgradeOrDowngradeInfo ->
-                        upgradeOrDowngradeInfo.oldPurchase.let { oldPurchase ->
-                            setOldSku(oldPurchase.sku, oldPurchase.purchaseToken)
-                        }
-                        upgradeOrDowngradeInfo.prorationMode?.let { prorationMode ->
+                    replaceSkuInfo?.apply {
+                        setOldSku(oldPurchase.sku, oldPurchase.purchaseToken)
+                        prorationMode?.let { prorationMode ->
                             setReplaceSkusProrationMode(prorationMode)
                         }
                     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingWrapper.kt
@@ -21,6 +21,8 @@ import com.android.billingclient.api.PurchaseHistoryRecord
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.android.billingclient.api.SkuDetails
 import com.android.billingclient.api.SkuDetailsParams
+import java.io.PrintWriter
+import java.io.StringWriter
 import java.util.concurrent.ConcurrentLinkedQueue
 
 internal class BillingWrapper internal constructor(
@@ -462,6 +464,13 @@ internal class BillingWrapper internal constructor(
     private fun withConnectedClient(receivingFunction: BillingClient.() -> Unit) {
         billingClient?.takeIf { it.isReady }?.let {
             it.receivingFunction()
-        } ?: debugLog("Warning: billing client is null, purchase methods won't work")
+        } ?: debugLog("Warning: billing client is null, purchase methods won't work. Stacktrace: ${getStackTrace()}")
+    }
+
+    private fun getStackTrace(): String {
+        val stringWriter = StringWriter()
+        val printWriter = PrintWriter(stringWriter)
+        Throwable().printStackTrace(printWriter)
+        return stringWriter.toString()
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1157,7 +1157,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         }
         userPurchasing?.let { appUserID ->
             if (upgradeInfo != null) {
-                upgradeOrDowngradePurchase(
+                replaceOldPurchaseWithNewProduct(
                     product,
                     upgradeInfo,
                     activity,
@@ -1182,7 +1182,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         }
     }
 
-    private fun upgradeOrDowngradePurchase(
+    private fun replaceOldPurchaseWithNewProduct(
         product: SkuDetails,
         upgradeInfo: UpgradeInfo,
         activity: Activity,
@@ -1198,7 +1198,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
                         activity,
                         appUserID,
                         product,
-                        UpgradeOrDowngradeInfo(purchaseHistoryRecord, upgradeInfo.prorationMode),
+                        ReplaceSkuInfo(purchaseHistoryRecord, upgradeInfo.prorationMode),
                         presentedOfferingIdentifier
                     )
                 } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1190,15 +1190,15 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         presentedOfferingIdentifier: String?,
         listener: MakePurchaseListener
     ) {
-        billingWrapper.queryPurchaseHistoryBySku(product.type, upgradeInfo.oldSku) { result, purchaseHistoryRecord ->
+        billingWrapper.findPurchaseInPurchaseHistory(product.type, upgradeInfo.oldSku) { result, purchaseRecord ->
             if (result.isSuccessful()) {
-                if (purchaseHistoryRecord != null) {
+                if (purchaseRecord != null) {
                     debugLog("Found existing purchase for sku: ${upgradeInfo.oldSku}")
                     billingWrapper.makePurchaseAsync(
                         activity,
                         appUserID,
                         product,
-                        ReplaceSkuInfo(purchaseHistoryRecord, upgradeInfo.prorationMode),
+                        ReplaceSkuInfo(purchaseRecord, upgradeInfo.prorationMode),
                         presentedOfferingIdentifier
                     )
                 } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ReplaceSkuInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ReplaceSkuInfo.kt
@@ -2,7 +2,7 @@ package com.revenuecat.purchases
 
 import com.android.billingclient.api.BillingFlowParams
 
-internal data class UpgradeOrDowngradeInfo(
+internal data class ReplaceSkuInfo(
     val oldPurchase: PurchaseHistoryRecordWrapper,
     @BillingFlowParams.ProrationMode val prorationMode: Int? = null
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeOrDowngradeInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeOrDowngradeInfo.kt
@@ -1,0 +1,8 @@
+package com.revenuecat.purchases
+
+import com.android.billingclient.api.BillingFlowParams
+
+internal data class UpgradeOrDowngradeInfo(
+    val oldPurchase: PurchaseHistoryRecordWrapper,
+    @BillingFlowParams.ProrationMode val prorationMode: Int? = null
+)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils.kt
@@ -11,6 +11,7 @@ import android.os.Parcel
 import android.os.Parcelable
 import android.util.Base64
 import android.util.Log
+import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryRecord
@@ -192,6 +193,12 @@ internal fun String.sha1() =
             String(Base64.encode(it, Base64.NO_WRAP))
         }
 
+internal fun String.sha256() =
+    MessageDigest.getInstance("SHA-256")
+        .digest(this.toByteArray()).let {
+            String(Base64.encode(it, Base64.NO_WRAP))
+        }
+
 internal fun JSONObject.getNullableString(name: String): String? = this.getString(name).takeUnless { this.isNull(name) }
 
 /** @suppress */
@@ -235,3 +242,5 @@ val SkuDetails.priceAmount: Double
 
 internal val Context.versionName: String?
     get() = this.packageManager.getPackageInfo(this.packageName, 0).versionName
+
+internal fun BillingResult.isSuccessful() = responseCode == BillingClient.BillingResponseCode.OK

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils.kt
@@ -8,7 +8,6 @@ package com.revenuecat.purchases
 import android.content.Context
 import android.os.Build
 import android.os.Parcel
-import android.os.Parcelable
 import android.util.Base64
 import android.util.Log
 import com.android.billingclient.api.BillingClient
@@ -42,40 +41,6 @@ internal fun errorLog(message: String) {
 
 internal fun Purchase.toHumanReadableDescription() =
     "${this.sku} ${this.orderId} ${this.purchaseToken}"
-
-internal fun Parcel.readStringDateMap(): Map<String, Date?> {
-    return readInt().let { size ->
-        (0 until size).map {
-            readString() to readLong().let { date ->
-                if (date == -1L) null else Date(date)
-            }
-        }.toMap()
-    }
-}
-
-internal fun <T : Parcelable> Parcel.readStringParcelableMap(loader: ClassLoader?): Map<String, T> {
-    return readInt().let { size ->
-        (0 until size).map {
-            readString() to readParcelable<T>(loader)
-        }.toMap()
-    }
-}
-
-internal fun Parcel.writeStringDateMap(mapStringDate: Map<String, Date?>) {
-    writeInt(mapStringDate.size)
-    mapStringDate.forEach { (entry, date) ->
-        writeString(entry)
-        writeLong(date?.time ?: -1)
-    }
-}
-
-internal fun Parcel.writeStringParcelableMap(mapStringParcelable: Map<String, Parcelable>) {
-    writeInt(mapStringParcelable.size)
-    mapStringParcelable.forEach { (entry, parcelable) ->
-        writeString(entry)
-        writeParcelable(parcelable, 0)
-    }
-}
 
 /**
  * Parses expiration dates in a JSONObject

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
@@ -16,6 +16,7 @@ import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ConsumeParams
 import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.PurchaseHistoryRecord
 import com.android.billingclient.api.PurchaseHistoryResponseListener
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.android.billingclient.api.SkuDetails
@@ -28,12 +29,15 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.assertj.core.api.AssertionsForClassTypes.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.util.ArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -280,6 +284,7 @@ class BillingWrapperTest {
             assertThat(sku).isEqualTo(params.sku)
             assertThat(skuType).isEqualTo(params.skuType)
             assertThat(upgradeInfo.oldPurchase.sku).isEqualTo(params.oldSku)
+            assertThat(upgradeInfo.oldPurchase.purchaseToken).isEqualTo(params.oldSkuPurchaseToken)
             assertThat(upgradeInfo.prorationMode).isEqualTo(params.replaceSkusProrationMode)
             BillingClient.BillingResponseCode.OK.buildResult()
         }
@@ -853,6 +858,48 @@ class BillingWrapperTest {
 
         val purchaseType = wrapper.getPurchaseType("inapp")
         assertThat(purchaseType).isEqualTo(PurchaseType.INAPP)
+    }
+
+    @Test
+    fun `findPurchaseInPurchaseHistory works`() {
+        setup()
+        val sku = "aPurchase"
+        val purchaseHistoryRecord = mockk<PurchaseHistoryRecord>(relaxed = true).also {
+            every { it.sku } returns sku
+        }
+
+        var recordFound: PurchaseHistoryRecordWrapper? = null
+        wrapper.findPurchaseInPurchaseHistory(BillingClient.SkuType.SUBS, sku) { result, record ->
+            recordFound = record
+        }
+        billingClientPurchaseHistoryListener!!.onPurchaseHistoryResponse(
+            BillingClient.BillingResponseCode.OK.buildResult(),
+            listOf(purchaseHistoryRecord)
+        )
+        assertThat(recordFound).isNotNull
+        assertThat(recordFound!!.purchaseHistoryRecord).isEqualTo(purchaseHistoryRecord)
+    }
+
+    @Test
+    fun `findPurchaseInPurchaseHistory returns null if not found`() {
+        setup()
+        val sku = "aPurchase"
+        val purchaseHistoryRecord = mockk<PurchaseHistoryRecord>(relaxed = true).also {
+            every { it.sku } returns sku + "somethingrandom"
+        }
+
+        var recordFound: PurchaseHistoryRecordWrapper? = null
+        var completionCalled = false
+        wrapper.findPurchaseInPurchaseHistory(BillingClient.SkuType.SUBS, sku) { result, record ->
+            recordFound = record
+            completionCalled = true
+        }
+        billingClientPurchaseHistoryListener!!.onPurchaseHistoryResponse(
+            BillingClient.BillingResponseCode.OK.buildResult(),
+            listOf(purchaseHistoryRecord)
+        )
+        assertThat(completionCalled).isTrue()
+        assertThat(recordFound).isNull()
     }
 
     private fun mockNullSkuDetailsResponse() {

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingWrapperTest.kt
@@ -246,7 +246,7 @@ class BillingWrapperTest {
             activity,
             "jerry",
             skuDetails,
-            mockUpgradeOrDowngradeInfo(),
+            mockReplaceSkuInfo(),
             "offering_a"
         )
 
@@ -265,7 +265,7 @@ class BillingWrapperTest {
         val sku = "product_a"
         @BillingClient.SkuType val skuType = BillingClient.SkuType.SUBS
 
-        val upgradeInfo = mockUpgradeOrDowngradeInfo()
+        val upgradeInfo = mockReplaceSkuInfo()
         val activity: Activity = mockk()
         val skuDetails = mockk<SkuDetails>().also {
             every { it.sku } returns sku
@@ -316,7 +316,7 @@ class BillingWrapperTest {
             activity,
             appUserID,
             skuDetails,
-            mockUpgradeOrDowngradeInfo(),
+            mockReplaceSkuInfo(),
             null
         )
 
@@ -355,7 +355,7 @@ class BillingWrapperTest {
             activity,
             appUserID,
             skuDetails,
-            mockUpgradeOrDowngradeInfo(),
+            mockReplaceSkuInfo(),
             null
         )
 
@@ -756,7 +756,7 @@ class BillingWrapperTest {
             activity,
             "jerry",
             skuDetails,
-            mockUpgradeOrDowngradeInfo(),
+            mockReplaceSkuInfo(),
             "offering_a"
         )
         val purchases = listOf(mockk<Purchase>(relaxed = true).also {
@@ -878,8 +878,8 @@ class BillingWrapperTest {
         return oldPurchase
     }
 
-    private fun mockUpgradeOrDowngradeInfo(): UpgradeOrDowngradeInfo {
+    private fun mockReplaceSkuInfo(): ReplaceSkuInfo {
         val oldPurchase = mockPurchaseHistoryRecordWrapper()
-        return UpgradeOrDowngradeInfo(oldPurchase, BillingFlowParams.ProrationMode.DEFERRED)
+        return ReplaceSkuInfo(oldPurchase, BillingFlowParams.ProrationMode.DEFERRED)
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -281,7 +281,7 @@ class PurchasesTest {
         every { oldPurchase.type } returns PurchaseType.SUBS
 
         every {
-            mockBillingWrapper.queryPurchaseHistoryBySku(PurchaseType.SUBS.toSKUType()!!, "oldSku", captureLambda())
+            mockBillingWrapper.findPurchaseInPurchaseHistory(PurchaseType.SUBS.toSKUType()!!, "oldSku", captureLambda())
         } answers {
             lambda<(BillingResult, PurchaseHistoryRecordWrapper?) -> Unit>().captured.invoke(BillingResult(), oldPurchase)
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -297,7 +297,7 @@ class PurchasesTest {
                 eq(activity),
                 eq(appUserId),
                 skuDetails,
-                UpgradeOrDowngradeInfo(oldPurchase),
+                ReplaceSkuInfo(oldPurchase),
                 stubOfferingIdentifier
             )
         }


### PR DESCRIPTION
Main changes are:
- `setOldSku(oldSku)` replaced with `setOldSku(oldSku, purchaseToken)`
- `setAccountId` replaced with `setObfuscatedAccountId`.