### PR TITLE
Release 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 3.3.0
+
+- Added mParticle as one of the attribution options  
+https://github.com/RevenueCat/purchases-android/pull/163
+- Added original_purchase_date to JSON response
+https://github.com/RevenueCat/purchases-android/pull/164
+- Updated BillingClient to 3.0.0
+https://github.com/RevenueCat/purchases-android/pull/166
+- Moved the SKUDetails inside the ProductInfo that's passed to the Backend class when posting tokens
+https://github.com/RevenueCat/purchases-android/pull/167
+
 ## 3.2.0
 
 - Added `proxyKey`, useful for kids category apps, so that they can set up a proxy to send requests through. **Do not use this** unless you've talked to RevenueCat support about it. 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ Automatic Releasing
  1. Run `fastlane bump_and_update_changelog version:X.Y.Z` (where X.Y.Z is the new version) to update the version number in `gradle.properties`, `Purchases.kt` and in `purchases/build.gradle` 
  1. Commit the changes `git commit -am "Version X.Y.Z"` (where X.Y.Z is the new version)
  1. Make a PR, merge when approved
- 1. Pull master
+ 1. Pull main
  1. cd bin
  1. `./release_version.sh -c x.y.z -n a.b.c`, where a.b.c will be the next release after this one. If you're releasing version 3.0.2, for example, this would be ./release_version.sh -c 3.0.2 -n 3.1.0. This will do all of the other steps in the manual process.
  1. Visit [Sonatype Nexus](https://oss.sonatype.org/)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=3.3.0-SNAPSHOT
+VERSION_NAME=3.3.0
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         versionCode 1
-        versionName "3.3.0-SNAPSHOT"
+        versionName "3.3.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-proguard-rules.pro'

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1313,7 +1313,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
          * Current version of the Purchases SDK
          */
         @JvmStatic
-        val frameworkVersion = "3.3.0-SNAPSHOT"
+        val frameworkVersion = "3.3.0"
 
         /**
          * Set this property to your proxy URL before configuring Purchases *only*


### PR DESCRIPTION
- Added mParticle as one of the attribution options  
https://github.com/RevenueCat/purchases-android/pull/163
- Added original_purchase_date to JSON response
https://github.com/RevenueCat/purchases-android/pull/164
- Updated BillingClient to 3.0.0
https://github.com/RevenueCat/purchases-android/pull/166
- Moved the SKUDetails inside the ProductInfo that's passed to the Backend class when posting tokens
https://github.com/RevenueCat/purchases-android/pull/167