### PR TITLE
Synchronizes accesses to executorService

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Dispatcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Dispatcher.kt
@@ -35,12 +35,16 @@ internal open class Dispatcher(
     }
 
     open fun enqueue(call: AsyncCall) {
-        this.executorService.execute(call)
+        synchronized(this.executorService) {
+            this.executorService.execute(call)
+        }
     }
 
     open fun close() {
-        this.executorService.shutdownNow()
+        synchronized(this.executorService) {
+            this.executorService.shutdownNow()
+        }
     }
 
-    open fun isClosed() = this.executorService.isShutdown
+    open fun isClosed() = synchronized(this.executorService) { this.executorService.isShutdown }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1224,28 +1224,30 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
     internal fun updatePendingPurchaseQueue() {
         if (billingWrapper.isConnected()) {
             debugLog("[QueryPurchases] Updating pending purchase queue")
-            if (!executorService.isShutdown) {
-                executorService.execute {
-                    val queryActiveSubscriptionsResult =
-                        billingWrapper.queryPurchases(BillingClient.SkuType.SUBS)
-                    val queryUnconsumedInAppsRequest =
-                        billingWrapper.queryPurchases(BillingClient.SkuType.INAPP)
-                    if (queryActiveSubscriptionsResult?.isSuccessful() == true &&
-                        queryUnconsumedInAppsRequest?.isSuccessful() == true
-                    ) {
-                        deviceCache.cleanPreviouslySentTokens(
-                            queryActiveSubscriptionsResult.purchasesByHashedToken.keys,
-                            queryUnconsumedInAppsRequest.purchasesByHashedToken.keys
-                        )
-                        postPurchases(
-                            deviceCache.getActivePurchasesNotInCache(
-                                queryActiveSubscriptionsResult.purchasesByHashedToken,
-                                queryUnconsumedInAppsRequest.purchasesByHashedToken
-                            ),
-                            allowSharingPlayStoreAccount,
-                            finishTransactions,
-                            appUserID
-                        )
+            synchronized(executorService) {
+                if (!executorService.isShutdown) {
+                    executorService.execute {
+                        val queryActiveSubscriptionsResult =
+                            billingWrapper.queryPurchases(BillingClient.SkuType.SUBS)
+                        val queryUnconsumedInAppsRequest =
+                            billingWrapper.queryPurchases(BillingClient.SkuType.INAPP)
+                        if (queryActiveSubscriptionsResult?.isSuccessful() == true &&
+                            queryUnconsumedInAppsRequest?.isSuccessful() == true
+                        ) {
+                            deviceCache.cleanPreviouslySentTokens(
+                                queryActiveSubscriptionsResult.purchasesByHashedToken.keys,
+                                queryUnconsumedInAppsRequest.purchasesByHashedToken.keys
+                            )
+                            postPurchases(
+                                deviceCache.getActivePurchasesNotInCache(
+                                    queryActiveSubscriptionsResult.purchasesByHashedToken,
+                                    queryUnconsumedInAppsRequest.purchasesByHashedToken
+                                ),
+                                allowSharingPlayStoreAccount,
+                                finishTransactions,
+                                appUserID
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
We got a report of this stacktrace:

```
Fatal Exception: java.util.concurrent.RejectedExecutionException: Task com.revenuecat.purchases.Purchases$updatePendingPurchaseQueue$1@43f3b0f rejected from java.util.concurrent.ThreadPoolExecutor@f84e79c[Shutting down, pool size = 1, active threads = 1, queued tasks = 0, completed tasks = 0] 
at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2078) 
at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:843) 
at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1384) 
at com.revenuecat.purchases.Purchases.updatePendingPurchaseQueue$purchases_release(Purchases.kt:1180) 
at com.revenuecat.purchases.Purchases$1.onConnected(Purchases.kt:134) 
at com.revenuecat.purchases.BillingWrapper.onBillingSetupFinished(BillingWrapper.kt:387) 
at com.android.billingclient.api.BillingClientImpl$BillingServiceConnection$1.run(BillingClientImpl.java:1521) 
at android.os.Handler.handleCallback(Handler.java:790) 
at android.os.Handler.dispatchMessage(Handler.java:99) 
at android.os.Looper.loop(Looper.java:175) 
at android.app.ActivityThread.main(ActivityThread.java:6724) 
at java.lang.reflect.Method.invoke(Method.java) 
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438) 
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:810)
```

 I believe the issue is that between the `if (!executorService.isShutdown)` and the `executorService.execute` the executorService is actually shut down in the HtttClient.

I synchronized the access to `executorService` as a solution