### PR TITLE
Removes setObfuscatedAccountId from the parameters. Should fix upgrades/downgrades

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/BillingWrapper.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/BillingWrapper.kt
@@ -184,7 +184,8 @@ class BillingWrapper(
         executeRequestOnUIThread {
             val params = BillingFlowParams.newBuilder()
                 .setSkuDetails(skuDetails)
-                .setObfuscatedAccountId(appUserID.sha256())
+                // Causing issues with downgrades/upgrades https://issuetracker.google.com/issues/155005449
+//                .setObfuscatedAccountId(appUserID.sha256())
                 .apply {
                     replaceSkuInfo?.apply {
                         setOldSku(oldPurchase.sku, oldPurchase.purchaseToken)

--- a/common/src/main/java/com/revenuecat/purchases/common/BillingWrapper.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/BillingWrapper.kt
@@ -185,7 +185,7 @@ class BillingWrapper(
             val params = BillingFlowParams.newBuilder()
                 .setSkuDetails(skuDetails)
                 // Causing issues with downgrades/upgrades https://issuetracker.google.com/issues/155005449
-//                .setObfuscatedAccountId(appUserID.sha256())
+                // .setObfuscatedAccountId(appUserID.sha256())
                 .apply {
                     replaceSkuInfo?.apply {
                         setOldSku(oldPurchase.sku, oldPurchase.purchaseToken)


### PR DESCRIPTION
https://issuetracker.google.com/issues/155005449

Turns out that upgrades/downgrades only work if the obfuscatedAccountId is the same as the original purchase. I have commented it out for now until it's fixed, since it's an optional parameter (https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder?hl=id#setobfuscatedaccountid). I can remove it if necessary. I am not sure they will ever fix it.

Reported in https://github.com/RevenueCat/purchases-flutter/issues/93
