### PR TITLE
Fixes 404 marking attributes as synced

### DIFF
--- a/.buildscripts/jacoco.gradle
+++ b/.buildscripts/jacoco.gradle
@@ -1,4 +1,8 @@
 apply plugin: 'jacoco'
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
+}
 jacoco { toolVersion = "0.8.5" }
 
 tasks.withType(Test) { jacoco.includeNoLocationClasses = true }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
       - image: circleci/android:api-28
     working_directory: ~/purchases-android
     environment:
-      JVM_OPTS: -Xmx3200m
+      JVM_OPTS: -Xmx4096m
       CIRCLE_JDK_VERSION: oraclejdk8
 
 jobs:
@@ -32,13 +32,13 @@ jobs:
       - android/restore-build-cache
       - run:
           name: Run Tests
-          command: ./gradlew lint test
+          command: ./gradlew lint test --no-daemon --max-workers=2
       - run:
           name: Test coverage report
           command: ./gradlew testDebugUnitTestCoverage coveralls
       - run:
           name: Detekt
-          command: ./gradlew detektAll
+          command: ./gradlew detektAll --no-daemon --max-workers=2
       - android/save-build-cache
       - store_artifacts:
           path: purchases/build/reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.1
+
+- Addresses an issue where subscriber attributes might not sync correctly if subscriber info for the user hadn't been synced before the subscriber attributes sync was performed.
+     https://github.com/RevenueCat/purchases-android/pull/184
 ## 3.4.0
 
 - New properties added to the PurchaserInfo to better manage non-subscriptions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=3.4.0
+VERSION_NAME=3.4.1
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         versionCode 1
-        versionName "3.4.0"
+        versionName "3.4.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-proguard-rules.pro'

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Backend.kt
@@ -12,6 +12,7 @@ import org.json.JSONObject
 
 private const val UNSUCCESSFUL_HTTP_STATUS_CODE = 300
 private const val HTTP_SERVER_ERROR_CODE = 500
+private const val HTTP_NOT_FOUND_ERROR_CODE = 404
 
 private const val ATTRIBUTES_ERROR_RESPONSE_KEY = "attributes_error_response"
 private const val ATTRIBUTE_ERRORS_KEY = "attribute_errors"
@@ -331,7 +332,10 @@ internal class Backend(
                         ?.let { body ->
                             attributeErrors = body.getAttributeErrors()
                         }
-                    onErrorHandler(error, result.responseCode < HTTP_SERVER_ERROR_CODE, attributeErrors)
+                    val internalServerError = result.responseCode >= HTTP_SERVER_ERROR_CODE
+                    val notFoundError = result.responseCode == HTTP_NOT_FOUND_ERROR_CODE
+                    val successfullySynced = !(internalServerError || notFoundError)
+                    onErrorHandler(error, successfullySynced, attributeErrors)
                 }
             }
         })

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1313,7 +1313,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
          * Current version of the Purchases SDK
          */
         @JvmStatic
-        val frameworkVersion = "3.4.0"
+        val frameworkVersion = "3.4.1"
 
         /**
          * Set this property to your proxy URL before configuring Purchases *only*

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesBackendTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesBackendTests.kt
@@ -193,6 +193,28 @@ class SubscriberAttributesBackendTests {
         assertThat(receivedAttributeErrors).isEmpty()
     }
 
+    @Test
+    fun `Not found error when posting attributes`() {
+        mockResponse(
+            "/subscribers/$appUserID/attributes",
+            404,
+            expectedResultBody = "{" +
+                "'code': 7259," +
+                "'message': 'Subscription not found for subscriber.'}"
+        )
+
+        underTest.postSubscriberAttributes(
+            mapOf("email" to SubscriberAttribute("email", null)),
+            appUserID,
+            unexpectedOnSuccess,
+            expectedOnError
+        )
+
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.UnknownBackendError)
+        assertThat(receivedSyncedSuccessfully).isFalse()
+        assertThat(receivedAttributeErrors!!.size).isEqualTo(0)
+    }
+
     // endregion
 
     // region posting attributes when posting receipt


### PR DESCRIPTION
- Addresses an issue where subscriber attributes might not sync correctly if subscriber info for the user hadn't been synced before the subscriber attributes sync was performed.
