### PR TITLE
InvalidePurchaserInfoCaches fix

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -124,6 +124,14 @@ class DeviceCache(
     }
 
     @Synchronized
+    fun clearPurchaserInfoCache(appUserID: String) {
+        clearPurchaserInfoCacheTimestamp()
+        val editor = preferences.edit()
+        editor.remove(purchaserInfoCacheKey(appUserID))
+        editor.apply()
+    }
+
+    @Synchronized
     fun setPurchaserInfoCacheTimestampToNow() {
         purchaserInfoCachesLastUpdated = Date()
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -365,6 +365,15 @@ class DeviceCacheTest {
         assertThat(cache.purchaserInfoCachesLastUpdated).isNotNull()
     }
 
+    @Test
+    fun `clearing purchaser info caches clears the shared preferences`() {
+        cache.cachePurchaserInfo(appUserID, mockk(relaxed = true))
+        assertThat(cache.purchaserInfoCachesLastUpdated).isNotNull()
+        cache.clearPurchaserInfoCache(appUserID)
+        verify { mockEditor.remove(cache.purchaserInfoCacheKey(appUserID)) }
+        assertThat(cache.purchaserInfoCachesLastUpdated).isNull()
+    }
+
     private fun mockString(key: String, value: String?) {
         every {
             mockPrefs.getString(eq(key), isNull())

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -596,7 +596,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      */
     fun invalidatePurchaserInfoCache() {
         debugLog("Invalidating Purchaser info cache")
-        deviceCache.clearPurchaserInfoCacheTimestamp()
+        deviceCache.clearPurchaserInfoCache(appUserID)
     }
 
     // region Subscriber Attributes

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -3231,7 +3231,7 @@ class PurchasesTest {
         setup()
         Purchases.sharedInstance.invalidatePurchaserInfoCache()
         verify(exactly = 1) {
-            mockCache.clearPurchaserInfoCacheTimestamp()
+            mockCache.clearPurchaserInfoCache(appUserId)
         }
     }
 
@@ -3527,6 +3527,9 @@ class PurchasesTest {
             } just Runs
             every {
                 clearPurchaserInfoCacheTimestamp()
+            } just Runs
+            every {
+                clearPurchaserInfoCache(appUserId)
             } just Runs
             every {
                 clearOfferingsCacheTimestamp()


### PR DESCRIPTION
Fixes an issue where after calling `invalidatePurchaserInfoCache` and then `purchaserInfoWithCompletion`, the invalidated cached version of purchaserInfo would be returned first, and only the delegate would get the updated version. 

This is fixed by entirely removing the cached version from storage, so that the SDK forcibly only returns a new version, if communication with the backend succeeds. 

iOS counterpart: https://github.com/RevenueCat/purchases-ios/pull/333