### PR TITLE
Version 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 3.5.0
-
-- Deprecated `addAttribution` in favor of `setAdjustId`, `setAppsflyerId`, `setFbAnonymousId`, `setMparticleId`.
-- Added support for OneSignal via `setOnesignalId`
-     https://github.com/RevenueCat/purchases-android/pull/184
+- Attribution V2:
+    - Deprecated `addAttribution` in favor of `setAdjustId`, `setAppsflyerId`, `setFbAnonymousId`, `setMparticleId`.
+    - Added support for OneSignal via `setOnesignalId`
+    - Added `setMediaSource`, `setCampaign`, `setAdGroup`, `setAd`, `setKeyword`, `setCreative`, and `collectDeviceIdentifiers`
+         https://github.com/RevenueCat/purchases-android/pull/184
 - Fixed a RejectedExecutionException due to un-synchronized accesses to the ExecutorService 
     https://github.com/RevenueCat/purchases-android/pull/179
 - Fixed downgrades/upgrades https://github.com/RevenueCat/purchases-flutter/issues/93

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 3.5.0
+
+- Deprecated `addAttribution` in favor of `setAdjustId`, `setAppsflyerId`, `setFbAnonymousId`, `setMparticleId`.
+- Added support for OneSignal via `setOnesignalId`
+     https://github.com/RevenueCat/purchases-android/pull/184
+- Fixed a RejectedExecutionException due to un-synchronized accesses to the ExecutorService 
+    https://github.com/RevenueCat/purchases-android/pull/179
+- Fixed downgrades/upgrades https://github.com/RevenueCat/purchases-flutter/issues/93
+    https://github.com/RevenueCat/purchases-android/pull/179
+
+## 3.4.1
+
+- Addresses an issue where subscriber attributes might not sync correctly if subscriber info for the user hadn't been synced before the subscriber attributes sync was performed.
+     https://github.com/RevenueCat/purchases-android/pull/184
+
 ## 3.4.0
 
 - New properties added to the PurchaserInfo to better manage non-subscriptions.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@ Automatic Releasing
 =========
  1. Create a branch bump/x.y.z
  1. Create a CHANGELOG.latest.md with the changes for the current version (to be used by Fastlane for the github release notes)
- 1. Run `fastlane bump_and_update_changelog version:X.Y.Z` (where X.Y.Z is the new version) to update the version number in `gradle.properties`, `Purchases.kt` and in `purchases/build.gradle` 
+ 1. Run `fastlane bump_and_update_changelog version:X.Y.Z` (where X.Y.Z is the new version) to update the version number in `gradle.properties`, `Config.kt` and in `library/build.gradle` 
  1. Commit the changes `git commit -am "Version X.Y.Z"` (where X.Y.Z is the new version)
  1. Make a PR, merge when approved
  1. Pull main

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = false
 
-    const val frameworkVersion = "3.5.0-SNAPSHOT"
+    const val frameworkVersion = "3.5.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=3.5.0-SNAPSHOT
+VERSION_NAME=3.5.0
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/library.gradle
+++ b/library.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "3.5.0-SNAPSHOT"
+        versionName "3.5.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
- Deprecated `addAttribution` in favor of `setAdjustId`, `setAppsflyerId`, `setFbAnonymousId`, `setMparticleId`.
- Added support for OneSignal via `setOnesignalId`
     https://github.com/RevenueCat/purchases-android/pull/184
- Fixed a RejectedExecutionException due to un-synchronized accesses to the ExecutorService 
    https://github.com/RevenueCat/purchases-android/pull/179
- Fixed downgrades/upgrades https://github.com/RevenueCat/purchases-flutter/issues/93
    https://github.com/RevenueCat/purchases-android/pull/179