### PR TITLE
Catch TimeoutException when calling getAdvertisingIdInfo

### DIFF
--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/AttributionFetcher.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/AttributionFetcher.kt
@@ -8,6 +8,7 @@ import com.google.android.gms.common.GooglePlayServicesNotAvailableException
 import com.google.android.gms.common.GooglePlayServicesRepairableException
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.errorLog
+import java.util.concurrent.TimeoutException
 
 class AttributionFetcher(
     private val dispatcher: Dispatcher
@@ -43,6 +44,11 @@ class AttributionFetcher(
         } catch (e: GooglePlayServicesRepairableException) {
             errorLog(
                 "GooglePlayServicesRepairableException when getting advertising identifier. " +
+                    "Message: ${e.localizedMessage}"
+            )
+        } catch (e: TimeoutException) {
+            errorLog(
+                "TimeoutException when getting advertising identifier. " +
                     "Message: ${e.localizedMessage}"
             )
         }


### PR DESCRIPTION
Should prevent crashing if there is a timeout https://github.com/RevenueCat/purchases-android/issues/193