### PR TITLE
Version 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.5.1
+
+- Fixes an issue where after calling invalidatePurchaserInfoCache and then purchaserInfoWithCompletion, the invalidated 
+  cached version of purchaserInfo would be returned first, and only the delegate would get the updated version.
+    https://github.com/RevenueCat/purchases-android/pull/189
+- Catch TimeoutException when calling getAdvertisingIdInfo
+    https://github.com/RevenueCat/purchases-android/pull/194
+   
 ## 3.5.0
 - Attribution V2:
     - Deprecated `addAttribution` in favor of `setAdjustId`, `setAppsflyerId`, `setFbAnonymousId`, `setMparticleId`.

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = false
 
-    const val frameworkVersion = "3.5.0"
+    const val frameworkVersion = "3.5.1"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=3.5.0
+VERSION_NAME=3.5.1
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/library.gradle
+++ b/library.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "3.5.0"
+        versionName "3.5.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
- Fixes an issue where after calling invalidatePurchaserInfoCache and then purchaserInfoWithCompletion, the invalidated 
  cached version of purchaserInfo would be returned first, and only the delegate would get the updated version.
    https://github.com/RevenueCat/purchases-android/pull/189
- Catch TimeoutException when calling getAdvertisingIdInfo
    https://github.com/RevenueCat/purchases-android/pull/194