### PR TITLE
Catch IOException when getAdvertisingIdInfo

### DIFF
--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/AttributionFetcher.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/AttributionFetcher.kt
@@ -8,7 +8,7 @@ import com.google.android.gms.common.GooglePlayServicesNotAvailableException
 import com.google.android.gms.common.GooglePlayServicesRepairableException
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.errorLog
-import java.util.concurrent.TimeoutException
+import java.io.IOException
 
 class AttributionFetcher(
     private val dispatcher: Dispatcher
@@ -46,9 +46,9 @@ class AttributionFetcher(
                 "GooglePlayServicesRepairableException when getting advertising identifier. " +
                     "Message: ${e.localizedMessage}"
             )
-        } catch (e: TimeoutException) {
+        } catch (e: IOException) {
             errorLog(
-                "TimeoutException when getting advertising identifier. " +
+                "IOException when getting advertising identifier. " +
                     "Message: ${e.localizedMessage}"
             )
         }

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/AttributionFetcher.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/AttributionFetcher.kt
@@ -9,6 +9,7 @@ import com.google.android.gms.common.GooglePlayServicesRepairableException
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.errorLog
 import java.io.IOException
+import java.util.concurrent.TimeoutException
 
 class AttributionFetcher(
     private val dispatcher: Dispatcher
@@ -44,6 +45,11 @@ class AttributionFetcher(
         } catch (e: GooglePlayServicesRepairableException) {
             errorLog(
                 "GooglePlayServicesRepairableException when getting advertising identifier. " +
+                    "Message: ${e.localizedMessage}"
+            )
+        } catch (e: TimeoutException) {
+            errorLog(
+                "TimeoutException when getting advertising identifier. " +
                     "Message: ${e.localizedMessage}"
             )
         } catch (e: IOException) {

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/AttributionFetcherTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/AttributionFetcherTests.kt
@@ -128,6 +128,27 @@ class AttributionFetcherTests {
         assertThat(completionCalled).isTrue()
     }
 
+    @Test
+    fun `TimeoutException when getting device identifiers`() {
+        val mockContext = mockk<Application>(relaxed = true)
+        mockAdvertisingInfo(
+            mockContext = mockContext,
+            expectedAdID = "12345",
+            expectedAndroidID = "androidid",
+            expectedException = TimeoutException()
+        )
+
+        var completionCalled = false
+        underTest.getDeviceIdentifiers(mockContext) { advertisingID, androidID ->
+            completionCalled = true
+
+            assertThat(advertisingID).isNull()
+            assertThat(androidID).isEqualTo("androidid")
+        }
+
+        assertThat(completionCalled).isTrue()
+    }
+
     private fun mockAdvertisingInfo(
         mockContext: Context,
         expectedAdID: String?,

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/AttributionFetcherTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/AttributionFetcherTests.kt
@@ -11,6 +11,7 @@ import io.mockk.mockkStatic
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import java.io.IOException
 import java.util.concurrent.TimeoutException
 
 class AttributionFetcherTests {
@@ -107,13 +108,13 @@ class AttributionFetcherTests {
     }
 
     @Test
-    fun `TimeoutException when getting device identifiers`() {
+    fun `IOException when getting device identifiers`() {
         val mockContext = mockk<Application>(relaxed = true)
         mockAdvertisingInfo(
             mockContext = mockContext,
             expectedAdID = "12345",
             expectedAndroidID = "androidid",
-            expectedException = TimeoutException()
+            expectedException = IOException(TimeoutException())
         )
 
         var completionCalled = false


### PR DESCRIPTION
https://github.com/RevenueCat/purchases-android/pull/194 added a catch for `TimeoutException`. It turns out, what's being thrown in this report https://github.com/RevenueCat/purchases-android/issues/193 is actually a `IOException` with a `TimeoutException` inside.

This PR adds another catch, just in case `TimeoutException` gets thrown in some cases.