### PR TITLE
Management url json fix

### DIFF
--- a/utils/src/main/java/com/revenuecat/purchases/utils/JSONObjectExtensions.kt
+++ b/utils/src/main/java/com/revenuecat/purchases/utils/JSONObjectExtensions.kt
@@ -43,6 +43,6 @@ fun JSONObject.getDate(jsonKey: String): Date = Iso8601Utils.parse(getString(jso
 
 fun JSONObject.optDate(jsonKey: String): Date? = takeUnless { this.isNull(jsonKey) }?.getDate(jsonKey)
 
-fun JSONObject.getNullableString(name: String): String? = this.getString(name).takeUnless { this.isNull(name) }
+fun JSONObject.getNullableString(name: String): String? = takeUnless { this.isNull(name) }?.getString(name)
 
-fun JSONObject.optNullableString(name: String): String? = this.optString(name).takeUnless { this.isNull(name) }
+fun JSONObject.optNullableString(name: String): String? = takeUnless { this.has(name) }?.getNullableString(name)

--- a/utils/src/main/java/com/revenuecat/purchases/utils/JSONObjectExtensions.kt
+++ b/utils/src/main/java/com/revenuecat/purchases/utils/JSONObjectExtensions.kt
@@ -45,4 +45,4 @@ fun JSONObject.optDate(jsonKey: String): Date? = takeUnless { this.isNull(jsonKe
 
 fun JSONObject.getNullableString(name: String): String? = takeUnless { this.isNull(name) }?.getString(name)
 
-fun JSONObject.optNullableString(name: String): String? = takeUnless { this.has(name) }?.getNullableString(name)
+fun JSONObject.optNullableString(name: String): String? = takeIf { this.has(name) }?.getNullableString(name)


### PR DESCRIPTION
I am not sure why this would break, but we are getting reports of someone having an exception that says:

"JSONObject["management_url"] is not a string"

I have tried for long and haven't been able to reproduce it, but I noticed that we changed this in https://github.com/RevenueCat/purchases-android/pull/164

They are actually reporting errors when upgrading flutter from 1.2.1. which uses Android 3.2.0 to 1.3.1 which uses 3.5.0. The change was released on https://github.com/RevenueCat/purchases-android/releases/tag/3.3.0