### PR TITLE
fixes dokka

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -74,7 +74,7 @@ platform :android do
     puts "Deploying #{version}"
     gradle(
       tasks: [
-          "androidSourcesJar", "androidJavadocsJar", "uploadArchives"
+          "build", "androidSourcesJar", "androidJavadocsJar", "uploadArchives"
       ],
       properties: {
         "signing.keyId" => ENV['GPG_SIGNING_KEY_ID_NEW'],


### PR DESCRIPTION
There is an issue with dokka https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/1004/workflows/a34a96ce-0206-44b8-b990-f054a04e824c/jobs/2523

The fix is to run `build` before running dokka -> https://github.com/Kotlin/dokka/issues/777