### PR TITLE
Removes BILLING permission from AndroidManifest

### DIFF
--- a/purchases/src/main/AndroidManifest.xml
+++ b/purchases/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.revenuecat.purchases.api">
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="com.android.vending.BILLING" />
 </manifest>
 


### PR DESCRIPTION
BillingClient includes the BILLING permission directly, we don't need to request it from our side https://github.com/RevenueCat/purchases-android/issues/210

I don't think this will change anything but hopefully the warning they see in that issue will go away