### PR TITLE
Version 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.6.0
+## 4.0.0
 
 - Removes Billing permission from AndroidManifest since it's added by the BillingClient
     https://github.com/RevenueCat/purchases-android/pull/211

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 4.0.0
 
-- Removes Billing permission from AndroidManifest since it's added by the BillingClient
+- Removes Billing permission from AndroidManifest since it's added by the BillingClient.
     https://github.com/RevenueCat/purchases-android/pull/211
 - Fixes Deferred downgrades. The Purchase object in the completion block of `purchaseProduct` and `purchasePackage` is now nullable when changing products.
     https://github.com/RevenueCat/purchases-android/pull/200
-- Deprecated makePurchase and getEntitlements have been removed
+- Deprecated makePurchase and getEntitlements have been removed. Use purchaseProduct/purchasePackage and getOfferings instead.
    
 ## 3.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     https://github.com/RevenueCat/purchases-android/pull/211
 - Fixes Deferred downgrades. The Purchase object in the completion block of `purchaseProduct` and `purchasePackage` is now nullable when changing products.
     https://github.com/RevenueCat/purchases-android/pull/200
+- Deprecated makePurchase and getEntitlements have been removed
    
 ## 3.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.6.0
+
+- Removes Billing permission from AndroidManifest since it's added by the BillingClient
+    https://github.com/RevenueCat/purchases-android/pull/211
+- Fixes Deferred downgrades. The Purchase object in the completion block of `purchaseProduct` and `purchasePackage` is now nullable when changing products.
+    https://github.com/RevenueCat/purchases-android/pull/200
+   
 ## 3.5.3
 
 - More aggressive caches and jittering for apps in background 

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = false
 
-    const val frameworkVersion = "3.6.0-SNAPSHOT"
+    const val frameworkVersion = "3.6.0"
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = false
 
-    const val frameworkVersion = "3.6.0"
+    const val frameworkVersion = "4.0.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=3.6.0-SNAPSHOT
+VERSION_NAME=3.6.0
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=3.6.0
+VERSION_NAME=4.0.0
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/library.gradle
+++ b/library.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "3.6.0-SNAPSHOT"
+        versionName "3.6.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/library.gradle
+++ b/library.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "3.6.0"
+        versionName "4.0.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -251,15 +251,6 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         }, { errorLog("Error syncing purchases $it") })
     }
 
-    @JvmName("-deprecated_getEntitlements")
-    @Deprecated(
-        message = "moved to getOfferings()",
-        replaceWith = ReplaceWith(expression = "getOfferings(listener)"),
-        level = DeprecationLevel.ERROR
-    )
-    fun getEntitlements() {
-    }
-
     /**
      * Fetch the configured offerings for this users. Offerings allows you to configure your in-app
      * products vis RevenueCat and greatly simplifies management. See
@@ -946,35 +937,6 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
 
     //endregion
     //endregion
-
-    @JvmName("-deprecated_makePurchase")
-    @Deprecated(
-        message = "moved to purchaseProduct()",
-        replaceWith = ReplaceWith(expression = "purchaseProduct(activity, skuDetails, upgradeInfo, listener)"),
-        level = DeprecationLevel.ERROR
-    )
-    fun makePurchase(
-        activity: Activity,
-        skuDetails: SkuDetails,
-        oldSku: String,
-        listener: MakePurchaseListener
-    ) {
-        purchaseProduct(activity, skuDetails, UpgradeInfo(oldSku), listener)
-    }
-
-    @JvmName("-deprecated_makePurchase")
-    @Deprecated(
-        message = "moved to purchaseProduct()",
-        replaceWith = ReplaceWith(expression = "purchaseProduct(activity, skuDetails, listener)"),
-        level = DeprecationLevel.ERROR
-    )
-    fun makePurchase(
-        activity: Activity,
-        skuDetails: SkuDetails,
-        listener: MakePurchaseListener
-    ) {
-        purchaseProduct(activity, skuDetails, listener)
-    }
 
     // region Internal Methods
 


### PR DESCRIPTION
- Removes Billing permission from AndroidManifest since it's added by the BillingClient
    https://github.com/RevenueCat/purchases-android/pull/211
- Fixes Deferred downgrades. The Purchase object in the completion block of `purchaseProduct` and `purchasePackage` is now nullable when changing products.
    https://github.com/RevenueCat/purchases-android/pull/200

