### PR TITLE
Map ITEM_ALREADY_OWNED error from BillingClient

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/errors.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/errors.kt
@@ -122,6 +122,7 @@ fun Int.billingResponseToPurchasesError(underlyingErrorMessage: String): Purchas
         BillingClient.BillingResponseCode.USER_CANCELED -> PurchasesErrorCode.PurchaseCancelledError
         BillingClient.BillingResponseCode.ITEM_UNAVAILABLE -> PurchasesErrorCode.ProductNotAvailableForPurchaseError
         BillingClient.BillingResponseCode.DEVELOPER_ERROR -> PurchasesErrorCode.PurchaseInvalidError
+        BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED -> PurchasesErrorCode.ProductAlreadyPurchasedError
         else -> PurchasesErrorCode.UnknownError
     }
     return PurchasesError(errorCode, underlyingErrorMessage)


### PR DESCRIPTION
This happens when a user changes ID but stays on the same device,
and tries to purchase a subscription again.  This maps to unknown
error, with ITEM_ALREADY_OWNED string in details.

Thank you for contributing to Purchases. Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.
