### PR TITLE
Adds tests to make sure we handle all BillingResponseCodes

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/errors.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/errors.kt
@@ -92,21 +92,11 @@ fun BackendErrorCode.toPurchasesErrorCode(): PurchasesErrorCode {
 }
 
 fun @receiver:BillingClient.BillingResponseCode Int.getBillingResponseCodeName(): String {
-    return when (this) {
-        BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED -> "FEATURE_NOT_SUPPORTED"
-        BillingClient.BillingResponseCode.SERVICE_DISCONNECTED -> "SERVICE_DISCONNECTED"
-        BillingClient.BillingResponseCode.OK -> "OK"
-        BillingClient.BillingResponseCode.USER_CANCELED -> "USER_CANCELED"
-        BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE -> "SERVICE_UNAVAILABLE"
-        BillingClient.BillingResponseCode.BILLING_UNAVAILABLE -> "BILLING_UNAVAILABLE"
-        BillingClient.BillingResponseCode.ITEM_UNAVAILABLE -> "ITEM_UNAVAILABLE"
-        BillingClient.BillingResponseCode.DEVELOPER_ERROR -> "DEVELOPER_ERROR"
-        BillingClient.BillingResponseCode.ERROR -> "ERROR"
-        BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED -> "ITEM_ALREADY_OWNED"
-        BillingClient.BillingResponseCode.ITEM_NOT_OWNED -> "ITEM_NOT_OWNED"
-        BillingClient.BillingResponseCode.SERVICE_TIMEOUT -> "SERVICE_TIMEOUT"
-        else -> "$this"
-    }
+    val allPossibleBillingResponseCodes = BillingClient.BillingResponseCode::class.java.declaredFields
+    return allPossibleBillingResponseCodes
+        .firstOrNull { it.getInt(it) == this }
+        ?.name
+        ?: "$this"
 }
 
 fun Int.billingResponseToPurchasesError(underlyingErrorMessage: String): PurchasesError {

--- a/common/src/test/java/com/revenuecat/purchases/common/BillingResponseCodeTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BillingResponseCodeTest.kt
@@ -1,0 +1,65 @@
+package com.revenuecat.purchases.common
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.billingclient.api.BillingClient
+import com.revenuecat.purchases.PurchasesErrorCode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ErrorUtilsTests {
+
+    @Test
+    fun `There are no new BillingResponseCodes`() {
+        val allPossibleBillingResponseCodes = BillingClient.BillingResponseCode::class.java.declaredFields
+        assertThat(allPossibleBillingResponseCodes)
+            .withFailMessage("It looks like there are new BillingResponseCodes, " +
+                "make sure to update the error conversions functions to include the new errors.")
+            .hasSize(12)
+    }
+
+    @Test
+    fun `All BillingResponseCodes are handled when converting to PurchasesError`() {
+        val allPossibleBillingResponseCodes = BillingClient.BillingResponseCode::class.java.declaredFields
+        allPossibleBillingResponseCodes.forEach { field ->
+            val value = field.getInt(field)
+            val billingResponseToPurchasesError = value.billingResponseToPurchasesError("")
+            if (value != BillingClient.BillingResponseCode.OK) {
+                assertThat(billingResponseToPurchasesError.code)
+                    .withFailMessage("BillingClient.BillingResponseCode.%s is unhandled", field.name)
+                    .isNotEqualTo(PurchasesErrorCode.UnknownError)
+            } else {
+                assertThat(billingResponseToPurchasesError.code).isEqualTo(PurchasesErrorCode.UnknownError)
+            }
+        }
+    }
+
+    @Test
+    fun `BillingResponseCodeNames are correctly generated`() {
+        val allResponseCodesToName = setOf(
+            BillingClient.BillingResponseCode.SERVICE_TIMEOUT to "SERVICE_TIMEOUT",
+            BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED to "FEATURE_NOT_SUPPORTED",
+            BillingClient.BillingResponseCode.SERVICE_DISCONNECTED to "SERVICE_DISCONNECTED",
+            BillingClient.BillingResponseCode.OK to "OK",
+            BillingClient.BillingResponseCode.USER_CANCELED to "USER_CANCELED",
+            BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE to "SERVICE_UNAVAILABLE",
+            BillingClient.BillingResponseCode.BILLING_UNAVAILABLE to "BILLING_UNAVAILABLE",
+            BillingClient.BillingResponseCode.ITEM_UNAVAILABLE to "ITEM_UNAVAILABLE",
+            BillingClient.BillingResponseCode.DEVELOPER_ERROR to "DEVELOPER_ERROR",
+            BillingClient.BillingResponseCode.ERROR to "ERROR",
+            BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED to "ITEM_ALREADY_OWNED",
+            BillingClient.BillingResponseCode.ITEM_NOT_OWNED to "ITEM_NOT_OWNED"
+        )
+
+        val allPossibleBillingResponseCodes = BillingClient.BillingResponseCode::class.java.declaredFields
+        assertThat(allPossibleBillingResponseCodes)
+            .withFailMessage("Looks like the test is not handling all BillingResponseCodes")
+            .hasSameSizeAs(allResponseCodesToName)
+
+        allResponseCodesToName.forEach { (billingResponseCode, name) ->
+            assertThat(billingResponseCode.getBillingResponseCodeName()).isEqualTo(name)
+        }
+    }
+
+}


### PR DESCRIPTION
It's not the first time this https://github.com/RevenueCat/purchases-android/pull/220 happens.

This PR adds tests that would fail if there are new `BillingResponseCodes`. Since `BillingResponseCode` is not an enum, we have to add an `else` to the `when` statement we use, and therefore, we don't get notified when there's a new code. 

I also changed the implementation of `getBillingResponseCodeName` so that's dynamic and we don't have to manually type the name of the codes. I added tests for it.