### PR TITLE
Removes mock-maker-inline

### DIFF
--- a/utils/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/utils/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline


### PR DESCRIPTION
This file was unnecessary and I believe it was causing issues to people using version 1.x.x of the mockito SDK. Should be safe to remove because this module doesn't even have tests. It's originally intended to be able to mock final classes in Kotlin.

We originally had it in the `test` folder https://github.com/RevenueCat/purchases-android/blob/3.4.1/purchases/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker and somehow it ended up in the main folder when doing the modularization.