### PR TITLE
Fixes deploy CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,22 +236,10 @@ jobs:
 
 workflows:
   version: 2
-  test-assemble-deploy-docs:
+  build-test:
     jobs:
       - test
       - assemble-sample-app
-      - deploy:
-          <<: *release-tags
-          requires:
-            - assemble-sample-app
-      - deploy-snapshot:
-          requires:
-            - assemble-sample-app
-          filters:
-            branches:
-              only:
-                - develop
-      - docs-deploy: *release-tags
 
   integration-test:
     jobs:
@@ -259,3 +247,13 @@ workflows:
       - run-firebase-tests:
           requires:
             - integration-tests-build
+
+  deploy:
+    jobs:
+      - deploy: *release-tags
+      - deploy-snapshot:
+          filters:
+            branches:
+              only:
+                - develop
+      - docs-deploy: *release-tags


### PR DESCRIPTION
The deploy jobs were not running on tags because the `assemble-sample-app` job wasn't running in tags. I cleaned up the workflows a little bit:

- Moved the deploys to its own workflow
- Removed the requirement to do the deploy after the `assemble-sample-app`. That is going to be run in the develop branch anyhow 