### PR TITLE
Fixes exceptions swallowed by ExecutorService

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Dispatcher.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Dispatcher.kt
@@ -54,6 +54,7 @@ open class Dispatcher(
 
                 // Exceptions are being swallowed if using execute instead of submit
                 // Future.get is blocking so we create a Thread
+                // More info: https://github.com/RevenueCat/purchases-android/pull/234
                 Thread {
                     try {
                         future.get()


### PR DESCRIPTION
I realized exceptions that happen in the threads started to not show up when we changed the ExecutorService. 

We used to have a similar issue because we were using `submit` instead of `execute`. `submit` returns a `Future`, which contains the Exception. 

In `ScheduledExecutorService`, `schedule` acts like `submit`, returning a `Future`. I found out that calling `execute` is actually calling `schedule` with a 0 delay, so calling `execute` is the same as calling `submit` in `ScheduledExecutorService`.

Tried different solutions, like overriding `afterExecute` (I found it in this blogpost https://aozturk.medium.com/how-to-handle-uncaught-exceptions-in-java-abf819347906) but it only works for `execute` in a regular `ExecutorService`. Looking at the documentation https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ScheduledThreadPoolExecutor.html#schedule-java.lang.Runnable-long-java.util.concurrent.TimeUnit-

> A consequence of the use of ScheduledFuture objects is that afterExecute is always called with a null second Throwable argument, even if the command terminated abruptly. Instead, the Throwable thrown by such a task can be obtained via Future.get().

I also tried the solutions in here https://stackoverflow.com/a/12176282 , but I couldn’t force crash the app, I could catch all exceptions and print them in the logcat.

Another alternative, was to wrap everything in try catch and log in the logcat, which won't crash the app.

Another alternative, is to use the old executor service and do the delay with a sleep, but I don't think that's ideal since that would put the Thread to sleep, instead of adding a delay before starting the thread.

I thought the best solution was to use `Future.get()`and get the `Exception`. The problem is that `Future.get` is blocking 🤕 , so I wrapped it in a `Thread`.

If this gets merged, in the Future we should probably have a `NetworkService` that can get blocked while doing `Future.get`.