### PR TITLE
Updates BillingClient to 3.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     ext.kotlinVersion = "1.4.10"
     ext.compileVersion = 28
     ext.minVersion = 14
+    ext.billingVersion = "3.0.2"
     repositories {
         jcenter()
         google()

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation project(":strings")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.core:core-ktx:1.3.1'
-    implementation 'com.android.billingclient:billing:3.0.1'
+    implementation "com.android.billingclient:billing:$billingVersion"
     testImplementation project(":test-utils")
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test:runner:1.2.0'
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.2.0'
     testImplementation 'org.mockito:mockito-core:3.0.0'
-    testImplementation 'com.android.billingclient:billing:3.0.1'
+    testImplementation "com.android.billingclient:billing:$billingVersion"
     testImplementation 'io.mockk:mockk:1.10.0'
     testImplementation 'org.assertj:assertj-core:3.13.2'
 }

--- a/library.gradle
+++ b/library.gradle
@@ -41,7 +41,7 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.2.0'
     testImplementation 'org.mockito:mockito-core:3.0.0'
-    testImplementation 'com.android.billingclient:billing:3.0.1'
+    testImplementation "com.android.billingclient:billing:$billingVersion"
     testImplementation 'io.mockk:mockk:1.10.0'
     testImplementation 'org.assertj:assertj-core:3.13.2'
 }

--- a/public/build.gradle
+++ b/public/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     implementation project(":utils")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.core:core-ktx:1.3.1'
-    implementation 'com.android.billingclient:billing:3.0.1'
+    implementation "com.android.billingclient:billing:$billingVersion"
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test:runner:1.2.0'
     testImplementation 'androidx.test:rules:1.2.0'
@@ -13,7 +13,7 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.2.0'
     testImplementation 'org.mockito:mockito-core:3.0.0'
-    testImplementation 'com.android.billingclient:billing:3.0.1'
+    testImplementation "com.android.billingclient:billing:$billingVersion"
     testImplementation 'io.mockk:mockk:1.10.0'
     testImplementation 'org.assertj:assertj-core:3.13.2'
 }

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     api project(":public")
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation 'androidx.annotation:annotation:1.1.0'
-    api 'com.android.billingclient:billing:3.0.1'
+    api "com.android.billingclient:billing:$billingVersion"
     implementation "androidx.lifecycle:lifecycle-runtime:2.1.0"
     implementation "androidx.lifecycle:lifecycle-extensions:2.1.0"
     kapt "androidx.lifecycle:lifecycle-compiler:2.1.0"
@@ -23,7 +23,7 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.2.0'
     testImplementation 'org.mockito:mockito-core:3.0.0'
-    testImplementation 'com.android.billingclient:billing:3.0.1'
+    testImplementation "com.android.billingclient:billing:$billingVersion"
     testImplementation 'io.mockk:mockk:1.10.0'
     testImplementation 'org.assertj:assertj-core:3.13.2'
 }

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -3,5 +3,5 @@ apply from: "$rootProject.projectDir/library.gradle"
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation 'com.android.billingclient:billing:3.0.1'
+    implementation "com.android.billingclient:billing:$billingVersion"
 }


### PR DESCRIPTION
Looks like the changes don't affect us:

```
Version 3.0.2 of the Google Play Billing Library and Kotlin extension are now available.

Bug fixes

Fixed a bug in the Kotlin extension where the coroutine fails with error "Already resumed".
Fixed unresolved references when the Kotlin extension is used with the kotlinx.coroutines library version 1.4+.
```
https://developer.android.com/google/play/billing/release-notes