### PR TITLE
Update lifecycle version and calls addObserver and removeObserver from Main thread

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
     ext.compileVersion = 28
     ext.minVersion = 14
     ext.billingVersion = "3.0.2"
+    ext.lifecycleVersion = "2.3.0-rc01"
     repositories {
         jcenter()
         google()

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -9,12 +9,14 @@ dependencies {
     implementation project(":feature:identity")
     implementation project(":strings")
     api project(":public")
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation 'androidx.annotation:annotation:1.1.0'
     api "com.android.billingclient:billing:$billingVersion"
-    implementation "androidx.lifecycle:lifecycle-runtime:2.1.0"
-    implementation "androidx.lifecycle:lifecycle-extensions:2.1.0"
-    kapt "androidx.lifecycle:lifecycle-compiler:2.1.0"
+    implementation "androidx.lifecycle:lifecycle-runtime:$lifecycleVersion"
+    kapt "androidx.lifecycle:lifecycle-compiler:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-process:$lifecycleVersion"
+
     testImplementation project(":test-utils")
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test:runner:1.2.0'

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -166,7 +166,11 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         log(LogIntent.DEBUG, ConfigureStrings.SDK_VERSION.format(frameworkVersion))
         log(LogIntent.USER, ConfigureStrings.INITIAL_APP_USER_ID.format(backingFieldAppUserID))
         identityManager.configure(backingFieldAppUserID)
-        ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleHandler)
+
+        dispatch {
+            ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleHandler)
+        }
+
         billingWrapper.stateListener = object : BillingWrapper.StateListener {
             override fun onConnected() {
                 updatePendingPurchaseQueue()
@@ -637,7 +641,10 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         this.backend.close()
         billingWrapper.purchasesUpdatedListener = null
         updatedPurchaserInfoListener = null // Do not call on state since the setter does more stuff
-        ProcessLifecycleOwner.get().lifecycle.removeObserver(lifecycleHandler)
+
+        dispatch {
+            ProcessLifecycleOwner.get().lifecycle.removeObserver(lifecycleHandler)
+        }
     }
 
     /**


### PR DESCRIPTION
Should fix https://github.com/RevenueCat/purchases-android/issues/240 and https://github.com/RevenueCat/react-native-purchases/issues/184

The newer version of the `lifecycle` library forces `addObserver` and `removeObserver` to be called from the Main thread



