### PR TITLE
identity V3: public facing changes

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -122,6 +122,11 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
     * default. If true treats all purchases as restores, aliasing together appUserIDs that share a
     * Play Store account.
     */
+
+    @Deprecated(
+            "Replaced with configuration in the RevenueCat dashboard",
+            ReplaceWith("configure through the RevenueCat dashboard")
+    )
     var allowSharingPlayStoreAccount: Boolean
         @Synchronized get() =
             state.allowSharingPlayStoreAccount ?: identityManager.currentUserIsAnonymous()
@@ -700,6 +705,10 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * @param newAppUserID The new appUserID that should be linked to the currently user
      * @param [listener] An optional listener to listen for successes or errors.
      */
+    @Deprecated(
+            "Use logIn instead",
+            ReplaceWith("logIn")
+    )
     @JvmOverloads
     fun identify(
         newAppUserID: String,
@@ -781,6 +790,10 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * id and save it in the cache.
      * @param [listener] An optional listener to listen for successes or errors.
      */
+    @Deprecated(
+            "Use logOut instead",
+            ReplaceWith("logOut")
+    )
     @JvmOverloads
     fun reset(
         listener: ReceivePurchaserInfoListener? = null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -737,7 +737,6 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * @param [callback] An optional listener to listen for successes or errors.
      */
     @JvmOverloads
-    @JvmSynthetic
     fun logIn(
         newAppUserID: String,
         callback: LogInCallback? = null
@@ -771,7 +770,6 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * @param [listener] An optional listener to listen for successes or errors.
      */
     @JvmOverloads
-    @JvmSynthetic
     fun logOut(listener: ReceivePurchaserInfoListener? = null) {
         val error: PurchasesError? = identityManager.logOut()
         if (error != null) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -738,7 +738,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      */
     @JvmOverloads
     @JvmSynthetic
-    internal fun logIn(
+    fun logIn(
         newAppUserID: String,
         callback: LogInCallback? = null
     ) {
@@ -772,7 +772,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      */
     @JvmOverloads
     @JvmSynthetic
-    internal fun logOut(listener: ReceivePurchaserInfoListener? = null) {
+    fun logOut(listener: ReceivePurchaserInfoListener? = null) {
         val error: PurchasesError? = identityManager.logOut()
         if (error != null) {
             listener?.onError(error)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -707,7 +707,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      */
     @Deprecated(
         "Use logIn instead",
-        ReplaceWith("Purchases.sharedInstance.logIn(newAppUserID, LogInCallback?")
+        ReplaceWith("Purchases.sharedInstance.logIn(newAppUserID, LogInCallback?)")
     )
     @JvmOverloads
     fun identify(
@@ -792,7 +792,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      */
     @Deprecated(
         "Use logOut instead",
-        ReplaceWith("Purchases.sharedInstance.logOut(ReceivePurchaserInfoListener")
+        ReplaceWith("Purchases.sharedInstance.logOut(ReceivePurchaserInfoListener?)")
     )
     @JvmOverloads
     fun reset(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -706,8 +706,8 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * @param [listener] An optional listener to listen for successes or errors.
      */
     @Deprecated(
-            "Use logIn instead",
-            ReplaceWith("logIn")
+        "Use logIn instead",
+        ReplaceWith("Purchases.sharedInstance.logIn(newAppUserID, LogInCallback?")
     )
     @JvmOverloads
     fun identify(
@@ -791,8 +791,8 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * @param [listener] An optional listener to listen for successes or errors.
      */
     @Deprecated(
-            "Use logOut instead",
-            ReplaceWith("logOut")
+        "Use logOut instead",
+        ReplaceWith("Purchases.sharedInstance.logOut(ReceivePurchaserInfoListener")
     )
     @JvmOverloads
     fun reset(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -333,7 +333,7 @@ fun Purchases.identifyWith(
  * @param [onError] Will be called after the call has completed with an error.
  */
 @Suppress("unused")
-internal fun Purchases.logInWith(
+fun Purchases.logInWith(
     appUserID: String,
     onError: ErrorFunction = ON_ERROR_STUB,
     onSuccess: ReceiveLogInSuccessFunction
@@ -348,7 +348,7 @@ internal fun Purchases.logInWith(
  * @param [onError] Will be called after the call has completed with an error.
  */
 @Suppress("unused")
-internal fun Purchases.logOutWith(
+fun Purchases.logOutWith(
     onError: ErrorFunction = ON_ERROR_STUB,
     onSuccess: ReceivePurchaserInfoSuccessFunction
 ) {


### PR DESCRIPTION
Makes `logIn` and `logOut` public, deprecates identity v2 methods. 

### Requirements: 
- [x] #250 
- [x] #260 
- [x] Backend support