### PR TITLE
Fix SkuDetailsParceler

### DIFF
--- a/public/build.gradle
+++ b/public/build.gradle
@@ -17,4 +17,8 @@ dependencies {
     testImplementation "com.android.billingclient:billing:$billingVersion"
     testImplementation 'io.mockk:mockk:1.10.0'
     testImplementation 'org.assertj:assertj-core:3.13.2'
+
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.2'
+    androidTestImplementation project(":test-utils")
 }

--- a/public/src/androidTest/java/com/revenuecat/purchases/PackageTest.kt
+++ b/public/src/androidTest/java/com/revenuecat/purchases/PackageTest.kt
@@ -1,0 +1,55 @@
+package com.revenuecat.purchases
+
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.utils.stubSkuDetails
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PackageTest {
+
+    @Test
+    fun packageParcelizationWorks() = testParcelization(
+            Package(
+                    identifier = "test",
+                    packageType = PackageType.UNKNOWN,
+                    product = stubSkuDetails(),
+                    offering = "test"
+            )
+    )
+
+    private inline fun <reified T : Parcelable> testParcelization(value: T) {
+        val key = "key"
+
+        // We don't have a good way to access the CREATOR (especially if the
+        // tested Parcelable uses @Parcelize annotation), so we have to wrap
+        // it in a bundle.
+        val inputBundle = Bundle()
+        inputBundle.putParcelable(key, value)
+
+        val parcel = Parcel.obtain()
+        try {
+            inputBundle.writeToParcel(parcel, 0)
+
+            // rewind the parcel to be ready to be read
+            parcel.setDataPosition(0)
+
+            // extract the bundle and a wrapped parcelable
+            val outputBundle = parcel.readBundle()!!
+            outputBundle.classLoader = T::class.java.classLoader
+            val outputValue = outputBundle.getParcelable<T>(key)
+
+            // assert that the parcelization succeeded
+            assertNotSame(inputBundle, outputBundle)
+            assertNotSame(value, outputValue)
+            assertEquals(value, outputValue)
+        } finally {
+            parcel.recycle()
+        }
+    }
+}

--- a/public/src/main/java/com/revenuecat/purchases/parceler/SkuDetailsParceler.kt
+++ b/public/src/main/java/com/revenuecat/purchases/parceler/SkuDetailsParceler.kt
@@ -13,9 +13,6 @@ internal object SkuDetailsParceler :
     }
 
     override fun SkuDetails.write(parcel: Parcel, flags: Int) {
-        val field = SkuDetails::class.java.getDeclaredField("mOriginalJson")
-        field.isAccessible = true
-        val value = field.get(this) as String
-        parcel.writeString(value)
+        parcel.writeString(originalJson)
     }
 }


### PR DESCRIPTION
The billing library from google is obfuscated and the mOriginalJson
field cannot be accessed.

This leads to the following crash on saving any instance of Package as a Parcelable:

```
E/ThreadGroup: CRASH IN main!
    java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
     Caused by: java.lang.reflect.InvocationTargetException
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616) 
     Caused by: java.lang.NoSuchFieldException: No field mOriginalJson in class Lcom/android/billingclient/api/SkuDetails; (declaration of 'com.android.billingclient.api.SkuDetails' appears in /data/app/com.chess.chesscoach-1/base.apk)
        at java.lang.Class.getDeclaredField(Native Method)
        at com.revenuecat.purchases.parceler.SkuDetailsParceler.write(SkuDetailsParceler.kt:16)
        at com.revenuecat.purchases.parceler.SkuDetailsParceler.write(SkuDetailsParceler.kt:8)
        at com.revenuecat.purchases.Package.writeToParcel(Package.kt)
        at android.os.Parcel.writeParcelable(Parcel.java:1442)
        at SDK client code that tries to put the Package instance in a Parcel
```