### PR TITLE
Prepares for version 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 4.0.3
+
+- Fixes JSONObjectParceler, SkuDetailsParceler and adds unit tests for other Parcelable classes.
+    https://github.com/RevenueCat/purchases-android/pull/249
+    https://github.com/RevenueCat/purchases-android/pull/253
+    https://github.com/RevenueCat/purchases-android/pull/254
+- Changes cache refresh period on background to 25 hours.
+    https://github.com/RevenueCat/purchases-android/pull/255
+
 ## 4.0.2
 
 - Update lifecycle version to 2.3.0-rc01 and made sure addObserver is called from the main thread. Should fix #240.

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = false
 
-    const val frameworkVersion = "4.1.0-SNAPSHOT"
+    const val frameworkVersion = "4.0.3"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=4.1.0-SNAPSHOT
+VERSION_NAME=4.0.3
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/library.gradle
+++ b/library.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "4.1.0-SNAPSHOT"
+        versionName "4.0.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
- Fixes JSONObjectParceler, SkuDetailsParceler and adds unit tests for other Parcelable classes.
    https://github.com/RevenueCat/purchases-android/pull/249
    https://github.com/RevenueCat/purchases-android/pull/253
    https://github.com/RevenueCat/purchases-android/pull/254
- Changes cache refresh period on background to 25 hours.
    https://github.com/RevenueCat/purchases-android/pull/255
