### PR TITLE
Updates willRenew logic

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Factories.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Factories.kt
@@ -130,15 +130,22 @@ private fun JSONObject.buildEntitlementInfo(
     val expirationDate = optDate("expires_date")
     val unsubscribeDetectedAt = productData.optDate("unsubscribe_detected_at")
     val billingIssueDetectedAt = productData.optDate("billing_issues_detected_at")
+
+    val store = productData.getStore("store")
+    val isPromo = store == Store.PROMOTIONAL
+    val isLifetime = expirationDate == null
+    val hasUnsubscribed = unsubscribeDetectedAt != null
+    val hasBillingIssues = billingIssueDetectedAt != null
+
     return EntitlementInfo(
         identifier = identifier,
         isActive = expirationDate == null || expirationDate.after(requestDate ?: Date()),
-        willRenew = expirationDate == null || (unsubscribeDetectedAt == null && billingIssueDetectedAt == null),
+        willRenew = !(isPromo || isLifetime || hasUnsubscribed || hasBillingIssues),
         periodType = productData.optPeriodType("period_type"),
         latestPurchaseDate = getDate("purchase_date"),
         originalPurchaseDate = productData.getDate("original_purchase_date"),
         expirationDate = expirationDate,
-        store = productData.getStore("store"),
+        store = store,
         productIdentifier = getString("product_identifier"),
         isSandbox = productData.getBoolean("is_sandbox"),
         unsubscribeDetectedAt = unsubscribeDetectedAt,

--- a/common/src/main/java/com/revenuecat/purchases/common/Factories.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Factories.kt
@@ -132,15 +132,12 @@ private fun JSONObject.buildEntitlementInfo(
     val billingIssueDetectedAt = productData.optDate("billing_issues_detected_at")
 
     val store = productData.getStore("store")
-    val isPromo = store == Store.PROMOTIONAL
-    val isLifetime = expirationDate == null
-    val hasUnsubscribed = unsubscribeDetectedAt != null
-    val hasBillingIssues = billingIssueDetectedAt != null
 
     return EntitlementInfo(
         identifier = identifier,
         isActive = expirationDate == null || expirationDate.after(requestDate ?: Date()),
-        willRenew = !(isPromo || isLifetime || hasUnsubscribed || hasBillingIssues),
+        willRenew = getWillRenew(store, expirationDate, unsubscribeDetectedAt,
+            billingIssueDetectedAt),
         periodType = productData.optPeriodType("period_type"),
         latestPurchaseDate = getDate("purchase_date"),
         originalPurchaseDate = productData.getDate("original_purchase_date"),
@@ -151,6 +148,19 @@ private fun JSONObject.buildEntitlementInfo(
         unsubscribeDetectedAt = unsubscribeDetectedAt,
         billingIssueDetectedAt = billingIssueDetectedAt
     )
+}
+
+private fun getWillRenew(
+    store: Store,
+    expirationDate: Date?,
+    unsubscribeDetectedAt: Date?,
+    billingIssueDetectedAt: Date?
+): Boolean {
+    val isPromo = store == Store.PROMOTIONAL
+    val isLifetime = expirationDate == null
+    val hasUnsubscribed = unsubscribeDetectedAt != null
+    val hasBillingIssues = billingIssueDetectedAt != null
+    return !(isPromo || isLifetime || hasUnsubscribed || hasBillingIssues)
 }
 
 fun JSONObject.createOfferings(products: Map<String, SkuDetails>): Offerings {

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
@@ -96,7 +96,7 @@ class EntitlementInfosTests {
         verifyProduct()
 
         verifyEntitlementActive(entitlement = "lifetime_cat")
-        verifyRenewal(entitlement = "lifetime_cat")
+        verifyRenewal(willRenew = false, entitlement = "lifetime_cat")
         verifyPeriodType(entitlement = "lifetime_cat")
         verifyStore(entitlement = "lifetime_cat")
         verifySandbox(entitlement = "lifetime_cat")
@@ -279,7 +279,7 @@ class EntitlementInfosTests {
 
         verifySubscriberInfo()
         verifyEntitlementActive()
-        verifyRenewal()
+        verifyRenewal(willRenew = false)
         verifyPeriodType()
         verifyStore()
         verifySandbox()
@@ -493,7 +493,7 @@ class EntitlementInfosTests {
 
         verifySubscriberInfo()
         verifyEntitlementActive()
-        verifyRenewal()
+        verifyRenewal(willRenew = false)
         verifyPeriodType()
         verifyStore()
         verifySandbox()
@@ -986,6 +986,33 @@ class EntitlementInfosTests {
         assertThat(x.hashCode() == y.hashCode())
     }
 
+    @Test
+    fun `promos won't renew`() {
+        stubResponse(
+            entitlements = JSONObject().apply {
+                put("pro_cat", JSONObject().apply {
+                    put("expires_date", "2221-01-10T02:35:25Z")
+                    put("product_identifier", "rc_promo_pro_cat_lifetime")
+                    put("purchase_date", "2021-02-27T02:35:25Z")
+                })
+            },
+            subscriptions = JSONObject().apply {
+                put("rc_promo_pro_cat_lifetime", JSONObject().apply {
+                    put("billing_issues_detected_at", JSONObject.NULL)
+                    put("expires_date", "2221-01-10T02:35:25Z")
+                    put("is_sandbox", false)
+                    put("original_purchase_date", "2021-02-27T02:35:25Z")
+                    put("period_type", "normal")
+                    put("purchase_date", "2021-02-27T02:35:25Z")
+                    put("store", "promotional")
+                    put("unsubscribe_detected_at", JSONObject.NULL)
+                })
+            }
+        )
+
+        verifyRenewal(willRenew = false)
+    }
+
     private fun verifySubscriberInfo() {
         val subscriberInfo = response.buildPurchaserInfo()
 
@@ -1008,7 +1035,7 @@ class EntitlementInfosTests {
     }
 
     private fun verifyRenewal(
-        matcher: Boolean = true,
+        willRenew: Boolean = true,
         unsubscribeDetectedAt: Date? = null,
         billingIssueDetectedAt: Date? = null,
         entitlement: String = "pro_cat"
@@ -1016,7 +1043,7 @@ class EntitlementInfosTests {
         val subscriberInfo = response.buildPurchaserInfo()
         val proCat = subscriberInfo.entitlements[entitlement]!!
 
-        assertThat(proCat.willRenew).isEqualTo(matcher)
+        assertThat(proCat.willRenew).isEqualTo(willRenew)
         assertThat(proCat.unsubscribeDetectedAt).isEqualTo(unsubscribeDetectedAt)
         assertThat(proCat.billingIssueDetectedAt).isEqualTo(billingIssueDetectedAt)
     }


### PR DESCRIPTION
Right now consumables and promotionals return willRenew as true. We should update so that:

1. Consumables always return willRenew as false
1. Promotionals always return willRenew as false
1. Subscriptions return willRenew as true if they don't have unsubscribe detected or billing issues.