### PR TITLE
Fix: identity v3 bugs

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -341,7 +341,7 @@ class Backend(
         enqueue(object : Dispatcher.AsyncCall() {
             override fun call(): HTTPClient.Result {
                 return httpClient.performRequest(
-                    "/subscribers/" + encode(appUserID) + "/login",
+                    "/subscribers/" + encode(appUserID) + "/identify",
                     mapOf("new_app_user_id" to newAppUserID),
                     authenticationHeaders
                 )

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -967,7 +967,7 @@ class BackendTest {
             "new_app_user_id" to newAppUserID
         )
         mockResponse(
-            "/subscribers/$appUserID/login",
+            "/subscribers/$appUserID/identify",
             body,
             201,
             null,
@@ -984,7 +984,7 @@ class BackendTest {
         )
         verify(exactly = 1) {
             mockClient.performRequest(
-                "/subscribers/$appUserID/login",
+                "/subscribers/$appUserID/identify",
                 body,
                 any()
             )
@@ -999,7 +999,7 @@ class BackendTest {
         )
         val resultBody = Responses.validFullPurchaserResponse
         mockResponse(
-            "/subscribers/$appUserID/login",
+            "/subscribers/$appUserID/identify",
             requestBody,
             responseCode = 201,
             clientException = null,
@@ -1029,7 +1029,7 @@ class BackendTest {
         )
         val resultBody = "{}"
         mockResponse(
-            "/subscribers/$appUserID/login",
+            "/subscribers/$appUserID/identify",
             requestBody,
             responseCode = 201,
             clientException = null,
@@ -1058,7 +1058,7 @@ class BackendTest {
         )
         val resultBody = Responses.validFullPurchaserResponse
         mockResponse(
-            "/subscribers/$appUserID/login",
+            "/subscribers/$appUserID/identify",
             requestBody,
             responseCode = 201,
             clientException = null,
@@ -1084,7 +1084,7 @@ class BackendTest {
         )
         val resultBody = Responses.validFullPurchaserResponse
         mockResponse(
-            "/subscribers/$appUserID/login",
+            "/subscribers/$appUserID/identify",
             requestBody,
             responseCode = 200,
             clientException = null,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -254,8 +254,8 @@ internal fun Purchases.logInWith(
 }
 
 /**
- * This function will change the current appUserID.
- * Typically this would be used after a log out to identify a new user without calling configure
+ * Logs out the Purchases client clearing the save appUserID. This will generate a random user
+ * id and save it in the cache.
  * @param [onSuccess] Will be called after the call has completed.
  * @param [onError] Will be called after the call has completed with an error.
  */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -254,6 +254,20 @@ internal fun Purchases.logInWith(
 }
 
 /**
+ * This function will change the current appUserID.
+ * Typically this would be used after a log out to identify a new user without calling configure
+ * @param [onSuccess] Will be called after the call has completed.
+ * @param [onError] Will be called after the call has completed with an error.
+ */
+@Suppress("unused")
+internal fun Purchases.logOutWith(
+    onError: ErrorFunction = ON_ERROR_STUB,
+    onSuccess: ReceivePurchaserInfoSuccessFunction
+) {
+    logOut(receivePurchaserInfoListener(onSuccess, onError))
+}
+
+/**
  * Resets the Purchases client clearing the save appUserID. This will generate a random user
  * id and save it in the cache.
  * @param [onSuccess] Will be called after the call has completed.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -245,7 +245,7 @@ fun Purchases.identifyWith(
  * @param [onError] Will be called after the call has completed with an error.
  */
 @Suppress("unused")
-fun Purchases.logInWith(
+internal fun Purchases.logInWith(
     appUserID: String,
     onError: ErrorFunction = ON_ERROR_STUB,
     onSuccess: ReceiveLogInSuccessFunction


### PR DESCRIPTION
Fixes a couple of bugs with identity v3: 
- `logInWith` wasn't internal, but it's not meant to be public yet
- the endpoint url was updated from `login` to `identify`
- added `logOutWith` method