### PR TITLE
Identity v3: update appUserID location in /identify

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -341,8 +341,11 @@ class Backend(
         enqueue(object : Dispatcher.AsyncCall() {
             override fun call(): HTTPClient.Result {
                 return httpClient.performRequest(
-                    "/subscribers/" + encode(appUserID) + "/identify",
-                    mapOf("new_app_user_id" to newAppUserID),
+                    "/subscribers/identify",
+                    mapOf(
+                        "new_app_user_id" to newAppUserID,
+                        "app_user_id" to appUserID
+                    ),
                     authenticationHeaders
                 )
             }

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -964,10 +964,11 @@ class BackendTest {
     fun `logIn makes the right http call`() {
         val newAppUserID = "newId"
         val body = mapOf(
-            "new_app_user_id" to newAppUserID
+            "new_app_user_id" to newAppUserID,
+            "app_user_id" to appUserID
         )
         mockResponse(
-            "/subscribers/$appUserID/identify",
+            "/subscribers/identify",
             body,
             201,
             null,
@@ -984,7 +985,7 @@ class BackendTest {
         )
         verify(exactly = 1) {
             mockClient.performRequest(
-                "/subscribers/$appUserID/identify",
+                "/subscribers/identify",
                 body,
                 any()
             )
@@ -995,11 +996,12 @@ class BackendTest {
     fun `logIn correctly parses purchaserInfo`() {
         val newAppUserID = "newId"
         val requestBody = mapOf(
-            "new_app_user_id" to newAppUserID
+            "new_app_user_id" to newAppUserID,
+            "app_user_id" to appUserID
         )
         val resultBody = Responses.validFullPurchaserResponse
         mockResponse(
-            "/subscribers/$appUserID/identify",
+            "/subscribers/identify",
             requestBody,
             responseCode = 201,
             clientException = null,
@@ -1054,11 +1056,12 @@ class BackendTest {
     fun `logIn returns created true if status is 201`() {
         val newAppUserID = "newId"
         val requestBody = mapOf(
-            "new_app_user_id" to newAppUserID
+            "new_app_user_id" to newAppUserID,
+            "app_user_id" to appUserID
         )
         val resultBody = Responses.validFullPurchaserResponse
         mockResponse(
-            "/subscribers/$appUserID/identify",
+            "/subscribers/identify",
             requestBody,
             responseCode = 201,
             clientException = null,
@@ -1080,11 +1083,12 @@ class BackendTest {
     fun `logIn returns created false if status isn't 201`() {
         val newAppUserID = "newId"
         val requestBody = mapOf(
-            "new_app_user_id" to newAppUserID
+            "new_app_user_id" to newAppUserID,
+            "app_user_id" to appUserID
         )
         val resultBody = Responses.validFullPurchaserResponse
         mockResponse(
-            "/subscribers/$appUserID/identify",
+            "/subscribers/identify",
             requestBody,
             responseCode = 200,
             clientException = null,


### PR DESCRIPTION
Android equivalent of https://github.com/RevenueCat/purchases-ios/pull/484

Updates the location of the old appUserID in `/identify` calls: 

| Before | After |
| :-: | :-: |
| included in the URL | included in the POST body as `app_user_id` |