### PR TITLE
Catch exceptions when getting stringSet from sharedPreferences

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -192,7 +192,7 @@ class DeviceCache(
             (preferences.getStringSet(tokensCacheKey, emptySet())?.toSet() ?: emptySet()).also {
                 log(LogIntent.DEBUG, ReceiptStrings.TOKENS_ALREADY_POSTED.format(it))
             }
-        } catch (e: Exception) {
+        } catch (e: ClassCastException) {
             emptySet()
         }
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -188,8 +188,12 @@ class DeviceCache(
 
     @Synchronized
     fun getPreviouslySentHashedTokens(): Set<String> {
-        return (preferences.getStringSet(tokensCacheKey, emptySet())?.toSet() ?: emptySet()).also {
-            log(LogIntent.DEBUG, ReceiptStrings.TOKENS_ALREADY_POSTED.format(it))
+        return try {
+            (preferences.getStringSet(tokensCacheKey, emptySet())?.toSet() ?: emptySet()).also {
+                log(LogIntent.DEBUG, ReceiptStrings.TOKENS_ALREADY_POSTED.format(it))
+            }
+        } catch (e: Exception) {
+            emptySet()
         }
     }
 


### PR DESCRIPTION
This PR catches "cannot cast String to Set" exceptions. This will alleviate crashes from this [issue](https://github.com/RevenueCat/purchases-flutter/issues/24) that I and other Flutter devs have encountered. This issue occurs after utilizing a forked version of the flutter SharedPreferences package, which unfortunately corrupts StringSet preferences. Rather than crashing when querying the token cache, this will simply return an empty set.