### PR TITLE
updated gemfile.lock to fix deploys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.1.1)
-    aws-partitions (1.433.0)
+    aws-partitions (1.434.0)
     aws-sdk-core (3.113.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -16,7 +16,7 @@ GEM
     aws-sdk-kms (1.43.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.91.0)
+    aws-sdk-s3 (1.92.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -29,7 +29,7 @@ GEM
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
     declarative (0.0.20)
-    declarative-option (0.1.1)
+    declarative-option (0.1.0)
     digest-crc (0.6.3)
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.5.20190701)
@@ -201,4 +201,4 @@ DEPENDENCIES
   fastlane-plugin-versioning_android
 
 BUNDLED WITH
-   2.2.12
+   2.2.14


### PR DESCRIPTION
Deploys are failing because there's a version of a gem missing 
https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/1519/workflows/ca471bd9-506d-4ddc-a70c-29c09aa79217/jobs/3918

It got pulled from the servers. This PR updates the lock file, which actually reverts to use `declarative-option-0.1.0`