### PR TITLE
Downloads amazon jar automatically when building

### DIFF
--- a/feature/amazon/build.gradle
+++ b/feature/amazon/build.gradle
@@ -30,20 +30,25 @@ task getAmazonLibrary {
     outputs.file( destFile )
 
     doLast {
-        File destDir = destFile.parentFile
-        destDir.mkdirs()
+        if(!destFile.exists()) {
+            println 'Downloading Amazon dependency'
+            File destDir = destFile.parentFile
+            destDir.mkdirs()
 
-        File downloadFile = new File( temporaryDir, 'download.zip' )
-        new URL( downloadURL ).withInputStream { is ->
-            downloadFile.withOutputStream { it << is }
-        }
-
-        project.copy {
-            from {
-                zipTree(downloadFile).matching { include "**/$fileToExtract" }.singleFile
+            File downloadFile = new File( temporaryDir, 'download.zip' )
+            new URL( downloadURL ).withInputStream { is ->
+                downloadFile.withOutputStream { it << is }
             }
 
-            into( destDir )
+            project.copy {
+                from {
+                    zipTree(downloadFile).matching { include "**/$fileToExtract" }.singleFile
+                }
+
+                into( destDir )
+            }
         }
     }
 }
+
+preBuild.dependsOn getAmazonLibrary


### PR DESCRIPTION
I realized I forgot to commit this changes when merging Amazon. This PR basically adds downloading the Amazon dependency automatically when trying to build the `amazon` module. This won't release the .jar as part of our .aar.