### PR TITLE
Catches NullPointerException on DeviceCache.findKeysThatStartWith

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.models.PurchaseDetails
 import com.revenuecat.purchases.strings.ReceiptStrings
 import org.json.JSONException
 import org.json.JSONObject
+import java.lang.NullPointerException
 import java.util.Date
 
 private const val CACHE_REFRESH_PERIOD_IN_FOREGROUND = 60000 * 5
@@ -320,9 +321,13 @@ open class DeviceCache(
     fun findKeysThatStartWith(
         cacheKey: String
     ): Set<String> {
-        return preferences.all
-            ?.filterKeys { it.startsWith(cacheKey) }
-            ?.keys ?: emptySet()
+        return try {
+            preferences.all
+                ?.filterKeys { it.startsWith(cacheKey) }
+                ?.keys ?: emptySet()
+        } catch (e: NullPointerException) {
+            emptySet()
+        }
     }
 
     fun newKey(

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -440,6 +440,16 @@ class DeviceCacheTest {
         assertThat(sentTokens).isEmpty()
     }
 
+    @Test
+    fun `If getting all preferences throws NullPointerException when calling findKeysThatStartWith, an empty set is returned`() {
+        every {
+            mockPrefs.all
+        } throws NullPointerException("NullPointerException")
+
+        val returnedSetOfKeys = cache.findKeysThatStartWith("any_cache_key")
+        assertThat(returnedSetOfKeys).isEmpty()
+    }
+
     private fun mockString(key: String, value: String?) {
         every {
             mockPrefs.getString(eq(key), isNull())

--- a/config/detekt/detekt-baseline.xml
+++ b/config/detekt/detekt-baseline.xml
@@ -48,6 +48,7 @@
     <ID>NoWildcardImports:com.revenuecat.sample.ui.user.UserFragment.kt:14</ID>
     <ID>ReturnCount:BillingWrapper.kt$BillingWrapper$internal fun getPurchaseType(purchaseToken: String): ProductType</ID>
     <ID>TooGenericExceptionCaught:AdvertisingIdClient.kt$AdvertisingIdClient$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:DeviceCache.kt$DeviceCache$e: NullPointerException</ID>
     <ID>TooGenericExceptionThrown:HTTPClient.kt$HTTPClient$throw RuntimeException(e)</ID>
     <ID>TooManyFunctions:AmazonBilling.kt$AmazonBilling$AmazonBilling</ID>
     <ID>TooManyFunctions:Backend.kt$Backend$Backend</ID>


### PR DESCRIPTION
We got this stacktrace:

```
Caused by: java.lang.NullPointerException: 
at com.revenuecat.purchases.common.caching.DeviceCache.findKeysThatStartWith (DeviceCache.kt:325) 
at com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesMigrationExtensionsKt.getAllLegacyStoredSubscriberAttributes (SubscriberAttributesMigrationExtensions.kt:40) 
at com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesMigrationExtensionsKt.migrateSubscriberAttributesIfNeeded (SubscriberAttributesMigrationExtensions.kt:7) 
at com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache.cleanUpSubscriberAttributeCache (SubscriberAttributesCache.kt:77) 
at com.revenuecat.purchases.identity.IdentityManager.configure (IdentityManager.kt:30) 
at com.revenuecat.purchases.Purchases.<init> (Purchases.kt:168) 
at com.revenuecat.purchases.Purchases$Companion.configure (Purchases.kt:1745) 
at com.revenuecat.purchases.Purchases$Companion.configure$default (Purchases.kt:1712) 
at com.revenuecat.purchases.Purchases.configure (Unknown Source:10) 
at com.seacloud.bc.BCApplication.onCreate (BCApplication.java:78) 
at android.app.Instrumentation.callApplicationOnCreate (Instrumentation.java:1154) 
at android.app.ActivityThread.handleBindApplication (ActivityThread.java:6245)
```

I really don't know how prefs.all could throw an NPE. Maybe with some modified devices or something like that. I added a try catch to prevent developer's apps from crashing.