### PR TITLE
Release process updates

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,5 +1,3 @@
-## 4.0.4
-
 - Updated willRenew property in the PurchaserInfo to be false also for Consumabled and Promotionals.
   https://github.com/RevenueCat/purchases-android/pull/259
 - Added a numeric code to PurchasesErrorCode so that the code numbers are consistent between platforms.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,39 +2,15 @@ Automatic Releasing
 =========
  1. Create a branch release/x.y.z
  1. Create a CHANGELOG.latest.md with the changes for the current version (to be used by Fastlane for the github release notes)
- 1. Run `fastlane bump_and_update_changelog version:X.Y.Z` (where X.Y.Z is the new version) to update the version number in `gradle.properties`, `Config.kt` and in `library/build.gradle` 
+ 1. Run `bundle exec fastlane bump_and_update_changelog version:X.Y.Z` (where X.Y.Z is the new version) to update the version number in `gradle.properties`, `Config.kt` and in `library/build.gradle`
  1. Commit the changes `git commit -am "Version X.Y.Z"` (where X.Y.Z is the new version)
  1. Make a PR, merge when approved
  1. Pull main and develop
- 1. cd bin
- 1. `./release_version.sh -c x.y.z -n a.b.c`, where a.b.c will be the next release after this one. If you're releasing version 3.0.2, for example, this would be ./release_version.sh -c 3.0.2 -n 3.1.0. This will do all of the other steps in the manual process.
  1. Update the main branch. You can do this by pushing develop to main.
+ 1. Make a tag and push, the rest will be performed automatically by CircleCI. If the automation fails, you can revert
+ to manually calling `bundle exec fastlane deploy`.
  1. Visit [Sonatype Nexus](https://oss.sonatype.org/)
  1. Click on Staging Repositories on the left side
  1. Scroll down to find the purchase repository
  1. Select and click "Close" from the top menu. Why is it called close?
- 1. Once close is complete, repeat but this time selecting "Release"
- 1. Make a PR for the snapshot bump, merge when approved
- 1. Update the version in the Quickstart guide https://docs.revenuecat.com/docs/android
-
-Manual Releasing
-=========
- 1. Change the version in `gradle.properties` to a non-SNAPSHOT version.
- 1. Change the version number in `Purchases.kt`
- 1. Change the versionName in `purchases/build.gradle`.
- 1. Update the `CHANGELOG.md` for the impending release.
- 1. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
- 1. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
- 1. `git push && git push --tags`
- 1. Visit [Sonatype Nexus](https://oss.sonatype.org/).
- 1. Click on Staging Repositories on the left side
- 1. Scroll down to find the purchase repository
- 1. Select and click "Close" from the top menu. Why is it called close?
- 1. Once close is complete, repeat but this time selecting "Release"
- 1. Update the `gradle.properties` to the next SNAPSHOT version.
- 1. Change the version number in Purchases.kt
- 1. Change the versionName in purchases/build.gradle.
- 1. `git commit -am "Prepare next development version."`
- 1. `git push`
- 1. Update the version in the Quickstart guide https://docs.revenuecat.com/docs/android
- 1. Create a Release in GitHub
+ 1. Once close is complete, press the "Release" button. It's safe to choose "Automatically drop".

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,7 +112,7 @@ def increment_version_in(previous_version, new_version, path)
   sh "sed -i'#{backup_extension}' #{sed_regex} #{path}"
 end
 
-def attach_changelog_to_main
+def attach_changelog_to_main(version_number)
   current_changelog = File.open("../CHANGELOG.latest.md", 'r')
   master_changelog = File.open("../CHANGELOG.md", 'r')
 
@@ -123,7 +123,8 @@ def attach_changelog_to_main
   master_changelog.close
 
   File.open("../CHANGELOG.md", 'w') { |master_changelog_write_mode|
-    whole_file_data = "#{current_changelog_data}\n#{master_changelog_data}"
+    version_header = "## #{version_number}"
+    whole_file_data = "#{version_header}\n#{current_changelog_data}\n#{master_changelog_data}"
     puts "going to save. Contents - #{whole_file_data}"
     
     master_changelog_write_mode.write(whole_file_data)


### PR DESCRIPTION
- Cleaned up the RELEASING.md document. I removed the Manual process stuff, like in the iOS releasing document. Removed references to releasing script.
- Automatically add the version number when attaching the changelog