### PR TITLE
Set obfuscatedAccountID for non upgrade/downgrade purchase

### DIFF
--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -34,6 +34,7 @@ import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.isSuccessful
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.sha1
+import com.revenuecat.purchases.common.sha256
 import com.revenuecat.purchases.common.toHumanReadableDescription
 import com.revenuecat.purchases.models.ProductDetails
 import com.revenuecat.purchases.models.PurchaseDetails
@@ -180,15 +181,15 @@ class BillingWrapper(
         executeRequestOnUIThread {
             val params = BillingFlowParams.newBuilder()
                 .setSkuDetails(productDetails.skuDetails)
-                // Causing issues with downgrades/upgrades https://issuetracker.google.com/issues/155005449
-                // .setObfuscatedAccountId(appUserID.sha256())
                 .apply {
                     replaceSkuInfo?.apply {
                         setOldSku(oldPurchase.sku, oldPurchase.purchaseToken)
                         prorationMode?.let { prorationMode ->
                             setReplaceSkusProrationMode(prorationMode)
                         }
-                    }
+                    } ?: setObfuscatedAccountId(appUserID.sha256())
+                    // only setObfuscatedAccountId for non-upgrade/downgrades:
+                    // https://revenuecat.zendesk.com/agent/tickets/8987
                 }.build()
 
             launchBillingFlow(activity, params)

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -188,8 +188,8 @@ class BillingWrapper(
                             setReplaceSkusProrationMode(prorationMode)
                         }
                     } ?: setObfuscatedAccountId(appUserID.sha256())
-                    // only setObfuscatedAccountId for non-upgrade/downgrades:
-                    // https://revenuecat.zendesk.com/agent/tickets/8987
+                    // only setObfuscatedAccountId for non-upgrade/downgrades until google issue is fixed:
+                    // https://issuetracker.google.com/issues/155005449
                 }.build()
 
             launchBillingFlow(activity, params)

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -33,6 +33,7 @@ import com.revenuecat.purchases.utils.stubGooglePurchase
 import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
 import com.revenuecat.purchases.utils.stubSkuDetails
 import io.mockk.Runs
+import io.mockk.clearStaticMockk
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -356,6 +357,8 @@ class BillingWrapperTest {
         verify {
             mockBuilder.setObfuscatedAccountId(appUserID.sha256())
         }
+
+        clearStaticMockk(BillingFlowParams::class)
     }
 
     @Test
@@ -398,6 +401,8 @@ class BillingWrapperTest {
         verify(exactly = 0) {
             mockBuilder.setObfuscatedAccountId(any())
         }
+
+        clearStaticMockk(BillingFlowParams::class)
     }
 
     @Test

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -334,8 +334,13 @@ class BillingWrapperTest {
             mockBuilder.setSkuDetails(any())
         } returns mockBuilder
 
+        val params = mockk<BillingFlowParams>(relaxed = true)
         every {
-            mockClient.launchBillingFlow(any(), any())
+            mockBuilder.build()
+        } returns params
+
+        every {
+            mockClient.launchBillingFlow(any(), params)
         } returns BillingClient.BillingResponseCode.OK.buildResult()
 
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
@@ -371,8 +376,13 @@ class BillingWrapperTest {
             mockBuilder.setSkuDetails(any())
         } returns mockBuilder
 
+        val params = mockk<BillingFlowParams>(relaxed = true)
         every {
-            mockClient.launchBillingFlow(any(), any())
+            mockBuilder.build()
+        } returns params
+
+        every {
+            mockClient.launchBillingFlow(any(), params)
         } returns BillingClient.BillingResponseCode.OK.buildResult()
 
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -32,12 +32,10 @@ import com.revenuecat.purchases.models.PurchaseDetails
 import com.revenuecat.purchases.utils.stubGooglePurchase
 import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
 import com.revenuecat.purchases.utils.stubSkuDetails
-import io.mockk.Called
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkClass
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
@@ -383,12 +381,12 @@ class BillingWrapperTest {
             activity,
             appUserID,
             skuDetails.toProductDetails(),
-            null,
+            mockReplaceSkuInfo(),
             null
         )
 
-        verify {
-            mockBuilder.setObfuscatedAccountId(any()) wasNot Called
+        verify(exactly = 0) {
+            mockBuilder.setObfuscatedAccountId(any())
         }
     }
 


### PR DESCRIPTION
  - Add back in the `setObfuscatedAccountId` call only for non-upgrade/downgrade purchases
  - See Zendesk ticket containing customer request here: https://revenuecat.zendesk.com/agent/tickets/8987