### PR TITLE
Adds test results consolidation step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ jobs:
 
   test:
     executor: android-executor
+    shell: /bin/bash --login -o pipefail
     steps:
       - checkout
       - android/accept-licenses
@@ -105,6 +106,11 @@ jobs:
       - run:
           name: Run Tests
           command: ./gradlew lint test
+      - run:
+          name: Consolidate artifacts
+          command: |
+              mkdir -p build/test-results/
+              find . -type f -regex ".*/build/test-results/.*xml" -exec cp --parents {} build/test-results/ \;
       - run:
           name: Detekt
           command: ./gradlew detektAll

--- a/library.gradle
+++ b/library.gradle
@@ -20,11 +20,6 @@ android {
         main.java.srcDirs += 'src/main/java'
         test.java.srcDirs += 'src/test/java'
     }
-    buildTypes {
-        debug {
-            testCoverageEnabled true
-        }
-    }
     testOptions {
         unitTests.includeAndroidResources = true
         unitTests.all {


### PR DESCRIPTION
Looks like when we added modularization we broke the test results storage in CircleCI. In a multi module project, the test results are stored in `module_name/build/test-results/` so I aded a step that should copy all test results into a single folder.

<img width="325" alt="Screen Shot 2021-04-09 at 12 30 53 PM" src="https://user-images.githubusercontent.com/664544/114231534-70358380-992f-11eb-8e9e-d163331230c9.png">
