### PR TITLE
Update InvalidPackageNameError mapping

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/errors.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/errors.kt
@@ -76,7 +76,7 @@ fun BackendErrorCode.toPurchasesErrorCode(): PurchasesErrorCode {
         BackendErrorCode.BackendProductIdForGoogleReceiptNotProvided -> PurchasesErrorCode.PurchaseInvalidError
         BackendErrorCode.BackendEmptyAppUserId -> PurchasesErrorCode.InvalidAppUserIdError
         BackendErrorCode.BackendPlayStoreQuotaExceeded -> PurchasesErrorCode.StoreProblemError
-        BackendErrorCode.BackendPlayStoreInvalidPackageName -> PurchasesErrorCode.StoreProblemError
+        BackendErrorCode.BackendPlayStoreInvalidPackageName -> PurchasesErrorCode.ConfigurationError
         BackendErrorCode.BackendPlayStoreGenericError -> PurchasesErrorCode.StoreProblemError
         BackendErrorCode.BackendUserIneligibleForPromoOffer -> PurchasesErrorCode.IneligibleError
         BackendErrorCode.BackendInvalidAppleSubscriptionKey -> PurchasesErrorCode.InvalidAppleSubscriptionKeyError

--- a/common/src/main/java/com/revenuecat/purchases/common/errors.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/errors.kt
@@ -64,11 +64,9 @@ fun HTTPClient.Result.toPurchasesError(): PurchasesError {
 @Suppress("ComplexMethod")
 fun BackendErrorCode.toPurchasesErrorCode(): PurchasesErrorCode {
     return when (this) {
-        BackendErrorCode.BackendInvalidPlatform -> PurchasesErrorCode.UnknownError
         BackendErrorCode.BackendStoreProblem -> PurchasesErrorCode.StoreProblemError
         BackendErrorCode.BackendCannotTransferPurchase -> PurchasesErrorCode.ReceiptAlreadyInUseError
         BackendErrorCode.BackendInvalidReceiptToken -> PurchasesErrorCode.InvalidReceiptError
-        BackendErrorCode.BackendInvalidAppStoreSharedSecret,
         BackendErrorCode.BackendInvalidPlayStoreCredentials,
         BackendErrorCode.BackendInvalidAuthToken,
         BackendErrorCode.BackendInvalidAPIKey -> PurchasesErrorCode.InvalidCredentialsError
@@ -76,12 +74,14 @@ fun BackendErrorCode.toPurchasesErrorCode(): PurchasesErrorCode {
         BackendErrorCode.BackendProductIdForGoogleReceiptNotProvided -> PurchasesErrorCode.PurchaseInvalidError
         BackendErrorCode.BackendEmptyAppUserId -> PurchasesErrorCode.InvalidAppUserIdError
         BackendErrorCode.BackendPlayStoreQuotaExceeded -> PurchasesErrorCode.StoreProblemError
-        BackendErrorCode.BackendPlayStoreInvalidPackageName -> PurchasesErrorCode.ConfigurationError
+        BackendErrorCode.BackendPlayStoreInvalidPackageName,
+        BackendErrorCode.BackendInvalidPlatform -> PurchasesErrorCode.ConfigurationError
         BackendErrorCode.BackendPlayStoreGenericError -> PurchasesErrorCode.StoreProblemError
         BackendErrorCode.BackendUserIneligibleForPromoOffer -> PurchasesErrorCode.IneligibleError
-        BackendErrorCode.BackendInvalidAppleSubscriptionKey -> PurchasesErrorCode.InvalidAppleSubscriptionKeyError
         BackendErrorCode.BackendInvalidSubscriberAttributes,
         BackendErrorCode.BackendInvalidSubscriberAttributesBody -> PurchasesErrorCode.InvalidSubscriberAttributesError
+        BackendErrorCode.BackendInvalidAppStoreSharedSecret,
+        BackendErrorCode.BackendInvalidAppleSubscriptionKey,
         BackendErrorCode.BackendBadRequest,
         BackendErrorCode.BackendInternalServerError -> PurchasesErrorCode.UnexpectedBackendResponseError
     }

--- a/public/src/main/java/com/revenuecat/purchases/errors.kt
+++ b/public/src/main/java/com/revenuecat/purchases/errors.kt
@@ -48,4 +48,5 @@ enum class PurchasesErrorCode(val code: Int, val description: String) {
     PaymentPendingError(20, "The payment is pending."),
     InvalidSubscriberAttributesError(21, "One or more of the attributes sent could not be saved."),
     LogOutWithAnonymousUserError(22, "Called logOut but the current user is anonymous."),
+    ConfigurationError(23, "There is an issue with your configuration. Check the underlying error for more details.")
 }


### PR DESCRIPTION
InvalidPackageName was being mapped to StoreProblemError, which is misleading to the user. 

* created a new ConfigurationError type and mapped InvalidPackageName to it
* changed BackendInvalidPlatform to map to ConfigurationError as well
* changed any Apple-specific errors to map to UnexpectedBackendResponseError, since we shouldn't receive those from an Android app

[iOS PR](https://github.com/RevenueCat/purchases-ios/pull/494)
