### PR TITLE
Empty SKU list bug

### DIFF
--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -127,6 +127,7 @@ class BillingWrapper(
     ) {
         if (skus.none { it.isNotEmpty() }) {
             log(LogIntent.DEBUG, OfferingStrings.EMPTY_SKU_LIST)
+            onReceive(emptyList())
             return
         }
 

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -125,7 +125,9 @@ class BillingWrapper(
         onReceive: ProductDetailsListCallback,
         onError: PurchasesErrorCallback
     ) {
-        if (skus.none { it.isNotEmpty() }) {
+        val nonEmptySkus = skus.filter { it.isNotEmpty() }
+
+        if (nonEmptySkus.isEmpty()) {
             log(LogIntent.DEBUG, OfferingStrings.EMPTY_SKU_LIST)
             onReceive(emptyList())
             return
@@ -136,7 +138,7 @@ class BillingWrapper(
             if (connectionError == null) {
                 val params = SkuDetailsParams.newBuilder()
                     .setType(productType.toSKUType() ?: SkuType.INAPP)
-                    .setSkusList(skus.toList()).build()
+                    .setSkusList(nonEmptySkus).build()
 
                 withConnectedClient {
                     querySkuDetailsAsync(params) { billingResult, skuDetailsList ->

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -136,7 +136,7 @@ class BillingWrapper(
             if (connectionError == null) {
                 val params = SkuDetailsParams.newBuilder()
                     .setType(productType.toSKUType() ?: SkuType.INAPP)
-                    .setSkusList(skus.toList().filter { it.isNotEmpty() }).build()
+                    .setSkusList(skus.toList()).build()
 
                 withConnectedClient {
                     querySkuDetailsAsync(params) { billingResult, skuDetailsList ->

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -125,12 +125,17 @@ class BillingWrapper(
         onReceive: ProductDetailsListCallback,
         onError: PurchasesErrorCallback
     ) {
+        if (skus.none { it.isNotEmpty() }) {
+            log(LogIntent.DEBUG, OfferingStrings.EMPTY_SKU_LIST)
+            return
+        }
+
         log(LogIntent.DEBUG, OfferingStrings.FETCHING_PRODUCTS.format(skus.joinToString()))
         executeRequestOnUIThread { connectionError ->
             if (connectionError == null) {
                 val params = SkuDetailsParams.newBuilder()
                     .setType(productType.toSKUType() ?: SkuType.INAPP)
-                    .setSkusList(skus.toList()).build()
+                    .setSkusList(skus.toList().filter { it.isNotEmpty() }).build()
 
                 withConnectedClient {
                     querySkuDetailsAsync(params) { billingResult, skuDetailsList ->

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -313,8 +313,9 @@ class BillingWrapperTest {
             null
         )
 
+        val expectedUserId = appUserId.sha256()
         verify {
-            mockBuilder.setObfuscatedAccountId(appUserId.sha256())
+            mockBuilder.setObfuscatedAccountId(expectedUserId)
         }
 
         clearStaticMockk(BillingFlowParams::class)
@@ -1425,7 +1426,7 @@ class BillingWrapperTest {
     }
 
     @Test
-    fun `do not query BillingClient for any empty skus`() {
+    fun `querySkuDetails filters empty skus before querying BillingClient`() {
         val skuSet = setOf("abcd", "", "1", "")
 
         val slot = slot<SkuDetailsParams>()
@@ -1436,9 +1437,7 @@ class BillingWrapperTest {
         wrapper.querySkuDetailsAsync(
             ProductType.SUBS,
             skuSet,
-            {
-                this@BillingWrapperTest.productDetailsList = it
-            }, {
+            {}, {
                 fail("shouldn't be an error")
             })
 
@@ -1446,7 +1445,7 @@ class BillingWrapperTest {
     }
 
     @Test
-    fun `querySkuDetails with empty list returns empty list and does not query billingclient`() {
+    fun `querySkuDetails with empty list returns empty list and does not query BillingClient`() {
         wrapper.querySkuDetailsAsync(
             ProductType.SUBS,
             emptySet(),
@@ -1462,7 +1461,7 @@ class BillingWrapperTest {
     }
 
     @Test
-    fun `querySkuDetails with only empty skus returns empty list and does not query client`() {
+    fun `querySkuDetails with only empty skus returns empty list and does not query BillingClient`() {
         wrapper.querySkuDetailsAsync(
             ProductType.SUBS,
             setOf("", ""),

--- a/strings/src/main/java/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -16,5 +16,5 @@ object OfferingStrings {
     const val OFFERINGS_UPDATED_FROM_NETWORK = "Offerings updated from network."
     const val RETRIEVED_PRODUCTS = "Retrieved skuDetailsList: %s"
     const val VENDING_OFFERINGS_CACHE = "Vending Offerings from cache"
-    const val EMPTY_SKU_LIST = "SKU list is empty, skipping fetchSkuDetailsAsync call"
+    const val EMPTY_SKU_LIST = "SKU list is empty, skipping querySkuDetailsAsync call"
 }

--- a/strings/src/main/java/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -16,4 +16,5 @@ object OfferingStrings {
     const val OFFERINGS_UPDATED_FROM_NETWORK = "Offerings updated from network."
     const val RETRIEVED_PRODUCTS = "Retrieved skuDetailsList: %s"
     const val VENDING_OFFERINGS_CACHE = "Vending Offerings from cache"
+    const val EMPTY_SKU_LIST = "SKU list is empty, skipping fetchSkuDetailsAsync call"
 }


### PR DESCRIPTION
Addresses this ticket: https://spectrum.chat/revenuecat/general/android-crash-sku-must-be-set~7faa56e8-2ec4-4c8d-b37a-2d525c41d8f6?authed=true

BillingClient throws an exception if an empty string sku is passed to querySkuDetailsAsync
* filter out empty skus from the list
* don't bother querying if list is empty 
* unit tests


Also pulled in a unit test fix from the 4.1.0 release -- pulling sha256() out of the verify block