### PR TITLE
Updated ReplaceWith annotation

### DIFF
--- a/public/src/main/java/com/revenuecat/purchases/PurchaserInfo.kt
+++ b/public/src/main/java/com/revenuecat/purchases/PurchaserInfo.kt
@@ -37,7 +37,7 @@ data class PurchaserInfo constructor(
     val entitlements: EntitlementInfos,
     @Deprecated(
         "Use nonSubscriptionTransactions instead",
-        ReplaceWith("nonSubscriptionTransactions.keys")
+        ReplaceWith("nonSubscriptionTransactions.map{ it.productId }.toSet()")
     ) val purchasedNonSubscriptionSkus: Set<String>,
     val allExpirationDatesByProduct: Map<String, Date?>,
     val allPurchaseDatesByProduct: Map<String, Date?>,


### PR DESCRIPTION
The `ReplaceWith` hint for the deprecated `purchasedNonSubscriptionSkus` property was invalid: `nonSubscriptionTransactions` is not a Set, so in order to return a set of identifiers it's necessary to properly transform the `List<Transaction>` into the expected `Set<String>`.