### PR TITLE
Replace jcenter repository with mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.billingVersion = "3.0.2"
     ext.lifecycleVersion = "2.3.0-rc01"
     repositories {
-        jcenter()
+        mavenCentral()
         google()
         maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
     }
@@ -29,7 +29,7 @@ dependencies {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,13 +18,13 @@ buildscript {
 }
 
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "1.7.2"
+    id "io.gitlab.arturbosch.detekt" version "1.17.0-RC3"
     id "com.github.kt3k.coveralls" version "2.10.0"
     id "com.savvasdalkitsis.module-dependency-graph" version "0.9"
 }
 
 dependencies {
-    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:1.8.0"
+    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:1.17.0-RC3"
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        mavenCentral()
     }
     dependencies {
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.15.1"

--- a/config/detekt/detekt-baseline.xml
+++ b/config/detekt/detekt-baseline.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
-  <Blacklist></Blacklist>
-  <Whitelist>
-    <ID>ComplexMethod:EntitlementInfo.kt$EntitlementInfo$equals</ID>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>ComplexMethod:EntitlementInfo.kt$EntitlementInfo$ override fun equals(other: Any?): Boolean</ID>
     <ID>EmptyCatchBlock:AdvertisingIdClient.kt$AdvertisingIdClient.AdvertisingConnection${ }</ID>
     <ID>EmptyCatchBlock:Purchases.kt$Purchases.Companion.&lt;no name provided&gt;${ }</ID>
     <ID>EmptyFunctionBlock:AdvertisingIdClient.kt$AdvertisingIdClient.AdvertisingConnection${}</ID>
     <ID>ForbiddenComment:AmazonConfiguration.kt$AmazonConfiguration$// TODO: make public</ID>
     <ID>ForbiddenComment:AmazonConfiguration.kt$AmazonConfiguration$// TODO: uncomment</ID>
     <ID>ForbiddenComment:PurchasesConfiguration.kt$PurchasesConfiguration.Builder$// TODO: make public</ID>
-    <ID>LargeClass:Purchases.kt$Purchases$Purchases</ID>
-    <ID>LongMethod:Purchases.kt$Purchases$restorePurchases</ID>
+    <ID>LargeClass:Purchases.kt$Purchases : LifecycleDelegate</ID>
+    <ID>LongMethod:Purchases.kt$Purchases$ fun restorePurchases( listener: ReceivePurchaserInfoListener )</ID>
     <ID>LongParameterList:EntitlementInfo.kt$EntitlementInfo$( val identifier: String, val isActive: Boolean, val willRenew: Boolean, val periodType: PeriodType, val latestPurchaseDate: Date, val originalPurchaseDate: Date, val expirationDate: Date?, val store: Store, val productIdentifier: String, val isSandbox: Boolean, val unsubscribeDetectedAt: Date?, val billingIssueDetectedAt: Date? )</ID>
     <ID>LongParameterList:ProductDetails.kt$ProductDetails$( /** * The product ID. */ val sku: String, /** * Type of product. One of [ProductType]. */ val type: ProductType, /** * Formatted price of the item, including its currency sign. For example $3.00. */ val price: String, /** * Price in micro-units, where 1,000,000 micro-units equal one unit of the currency. * * For example, if price is "€7.99", price_amount_micros is 7,990,000. This value represents * the localized, rounded price for a particular currency. */ val priceAmountMicros: Long, /** * Returns ISO 4217 currency code for price and original price. * * For example, if price is specified in British pounds sterling, price_currency_code is "GBP". */ val priceCurrencyCode: String, /** * Formatted original price of the item, including its currency sign. * * Note: returned only for Google products. */ val originalPrice: String?, /** * Returns the original price in micro-units, where 1,000,000 micro-units equal one unit * of the currency. * * Note: returned only for Google products. */ val originalPriceAmountMicros: Long, /** * Title of the product. */ val title: String, /** * The description of the product. */ val description: String, /** * Subscription period, specified in ISO 8601 format. For example, P1W equates to one week, * P1M equates to one month, P3M equates to three months, P6M equates to six months, * and P1Y equates to one year. * * Note: Returned only for subscriptions. */ val subscriptionPeriod: String?, /** * Subscription period, specified in ISO 8601 format. For example, P1W equates to one week, * P1M equates to one month, P3M equates to three months, P6M equates to six months, * and P1Y equates to one year. * * Note: null for non subscriptions. */ val freeTrialPeriod: String?, /** * The billing period of the introductory price, specified in ISO 8601 format. * * Note: Returned only for Google subscriptions which have an introductory period configured. */ val introductoryPrice: String?, /** * Introductory price in micro-units. The currency is the same as price_currency_code. * * Note: Returns 0 if the product is not Google a subscription or doesn't * have an introductory period. */ val introductoryPriceAmountMicros: Long, /** * The billing period of the introductory price, specified in ISO 8601 format. * * Note: Returned only for Google subscriptions which have an introductory period configured. */ val introductoryPricePeriod: String?, /** * The number of subscription billing periods for which the user will be given the * introductory price, such as 3. * * Note: Returns 0 if the SKU is not a Google subscription or doesn't * have an introductory period. */ val introductoryPriceCycles: Int, /** * The icon of the product if present. */ val iconUrl: String, /** * JSONObject representing the original product class from Google. * * Note: there's a convenience extension property that can be used to get the original * SkuDetails class: `ProductDetails.skuDetails`. * Alternatively, the original SkuDetails can be built doing the following: * `SkuDetails(this.originalJson.toString())` */ val originalJson: JSONObject )</ID>
     <ID>LongParameterList:StubGooglePurchase.kt$( productId: String = "com.revenuecat.lifetime", purchaseTime: Long = System.currentTimeMillis(), purchaseToken: String = "abcdefghijipehfnbbnldmai.AO-J1OxqriTepvB7suzlIhxqPIveA0IHtX9amMedK0KK9CsO0S3Zk5H6gdwvV" + "7HzZIJeTzqkY4okyVk8XKTmK1WZKAKSNTKop4dgwSmFnLWsCxYbahUmADg", signature: String = "signature${System.currentTimeMillis()}", purchaseState: Int = Purchase.PurchaseState.PURCHASED, acknowledged: Boolean = true, orderId: String = "GPA.3372-4150-8203-17209" )</ID>
@@ -43,21 +43,31 @@
     <ID>MagicNumber:errors.kt$BackendErrorCode.BackendProductIdForGoogleReceiptNotProvided$7106</ID>
     <ID>MagicNumber:errors.kt$BackendErrorCode.BackendStoreProblem$7101</ID>
     <ID>MagicNumber:errors.kt$BackendErrorCode.BackendUserIneligibleForPromoOffer$7232</ID>
-    <ID>MaxLineLength:Constants.kt$com.revenuecat.sample.data.Constants.kt</ID>
+    <ID>MaxLineLength:Constants.kt$Constants$/* The entitlement ID from the RevenueCat dashboard that is activated upon successful in-app purchase for the duration of the purchase. Modify this property to reflect your app's entitlement identifier. */</ID>
     <ID>NoWildcardImports:com.revenuecat.sample.ui.paywall.PaywallFragment.kt:10</ID>
     <ID>NoWildcardImports:com.revenuecat.sample.ui.user.UserFragment.kt:14</ID>
     <ID>ReturnCount:BillingWrapper.kt$BillingWrapper$internal fun getPurchaseType(purchaseToken: String): ProductType</ID>
+    <ID>SwallowedException:DeviceCache.kt$DeviceCache$catch (e: ClassCastException) { emptySet() }</ID>
+    <ID>SwallowedException:DeviceCache.kt$DeviceCache$catch (e: JSONException) { null }</ID>
+    <ID>SwallowedException:DeviceCache.kt$DeviceCache$catch (e: NullPointerException) { emptySet() }</ID>
+    <ID>SwallowedException:HTTPClient.kt$HTTPClient$catch (e: IOException) { connection.errorStream }</ID>
+    <ID>SwallowedException:Purchases.kt$Purchases.Companion.&lt;no name provided&gt;$catch (e: IllegalArgumentException) { // Play Services not available callback.onReceived(false) }</ID>
+    <ID>SwallowedException:Purchases.kt$Purchases.Companion.&lt;no name provided&gt;$catch (e: IllegalArgumentException) { }</ID>
+    <ID>ThrowingExceptionsWithoutMessageOrCause:AdvertisingIdClient.kt$AdvertisingIdClient.AdvertisingConnection$IllegalStateException()</ID>
     <ID>TooGenericExceptionCaught:AdvertisingIdClient.kt$AdvertisingIdClient$e: Exception</ID>
     <ID>TooGenericExceptionCaught:DeviceCache.kt$DeviceCache$e: NullPointerException</ID>
     <ID>TooGenericExceptionThrown:HTTPClient.kt$HTTPClient$throw RuntimeException(e)</ID>
-    <ID>TooManyFunctions:AmazonBilling.kt$AmazonBilling$AmazonBilling</ID>
-    <ID>TooManyFunctions:Backend.kt$Backend$Backend</ID>
-    <ID>TooManyFunctions:BillingWrapper.kt$BillingWrapper$BillingWrapper</ID>
-    <ID>TooManyFunctions:DeviceCache.kt$DeviceCache$DeviceCache</ID>
-    <ID>TooManyFunctions:HTTPClient.kt$HTTPClient$HTTPClient</ID>
-    <ID>TooManyFunctions:Purchases.kt$Purchases$Purchases</ID>
+    <ID>TooManyFunctions:AmazonBilling.kt$AmazonBilling : BillingAbstractProductDataResponseListenerPurchaseResponseListenerPurchaseUpdatesResponseListenerUserDataResponseListener</ID>
+    <ID>TooManyFunctions:Backend.kt$Backend</ID>
+    <ID>TooManyFunctions:BillingWrapper.kt$BillingWrapper : BillingAbstractPurchasesUpdatedListenerBillingClientStateListener</ID>
+    <ID>TooManyFunctions:DeviceCache.kt$DeviceCache</ID>
+    <ID>TooManyFunctions:HTTPClient.kt$HTTPClient</ID>
+    <ID>TooManyFunctions:Purchases.kt$Purchases : LifecycleDelegate</ID>
     <ID>TooManyFunctions:listenerConversions.kt$com.revenuecat.purchases.listenerConversions.kt</ID>
+    <ID>UnusedPrivateMember:LoginFragment.kt$LoginFragment$purchaserInfo: PurchaserInfo</ID>
+    <ID>UnusedPrivateMember:SampleWeatherData.kt$SampleWeatherData.Companion$environment: Environment</ID>
+    <ID>VarCouldBeVal:Purchases.kt$Purchases.Companion.&lt;no name provided&gt;$var featureSupportedResultOk = features.all { billingClient.isFeatureSupported(it.playBillingClientName).isSuccessful() }</ID>
     <ID>WildcardImport:PaywallFragment.kt$import com.revenuecat.purchases.*</ID>
     <ID>WildcardImport:UserFragment.kt$import com.revenuecat.purchases.*</ID>
-  </Whitelist>
+  </CurrentIssues>
 </SmellBaseline>

--- a/examples/MagicWeather/build.gradle
+++ b/examples/MagicWeather/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext.kotlin_version = "1.3.72"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.2"
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/examples/purchase-tester/build.gradle
+++ b/examples/purchase-tester/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'androidx.navigation.safeargs.kotlin'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.4"


### PR DESCRIPTION
JCenter has been sunset https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

The alternative is to add `mavenCentral` instead of jCenter's bintray (https://onesignal.com/blog/android-migrate-jcenter-to-maven-central/). The version of the detekt we were running had a dependency only available in Bintray, so I also updated it to the most recent version which has a dependency available in mavenCentral 