### PR TITLE
Update release plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
           name: Invalidate CloudFront caches
           command: aws cloudfront create-invalidation --distribution-id EPTW7F3CB566V --paths "/*"
 
-  upload-release:
+  deploy:
     executor: android-executor
     steps:
       - checkout
@@ -158,29 +158,7 @@ jobs:
             if [ "$CIRCLE_JDK_VERSION" != "oraclejdk8" ]; then
               echo "Skipping snapshot deployment: wrong JDK. Expected '$JDK' but was '$CIRCLE_JDK_VERSION'."
             else
-              bundle exec fastlane android upload_release
-            fi
-      - android-wordpress-orb/save-gradle-cache
-      - android/save-build-cache
-
-  upload-and-close-release:
-    executor: android-executor
-    steps:
-      - checkout
-      - setup-git-credentials
-      - trust-github-key
-      - install-gems
-      - prepare-signing-key
-      - android-wordpress-orb/restore-gradle-cache
-      - android/restore-build-cache
-      - download-amazon-dependency
-      - run:
-          name: Deployment
-          command: |
-            if [ "$CIRCLE_JDK_VERSION" != "oraclejdk8" ]; then
-              echo "Skipping snapshot deployment: wrong JDK. Expected '$JDK' but was '$CIRCLE_JDK_VERSION'."
-            else
-              bundle exec fastlane android upload_release
+              bundle exec fastlane android deploy
             fi
       - android-wordpress-orb/save-gradle-cache
       - android/save-build-cache
@@ -216,7 +194,7 @@ jobs:
             if [ "$CIRCLE_JDK_VERSION" != "oraclejdk8" ]; then
               echo "Skipping snapshot deployment: wrong JDK. Expected '$JDK' but was '$CIRCLE_JDK_VERSION'."
             else
-              bundle exec fastlane android upload_release
+              bundle exec fastlane android deploy_snapshot
             fi
       - android-wordpress-orb/save-gradle-cache
 
@@ -330,7 +308,7 @@ workflows:
 
   deploy:
     jobs:
-      - upload-release: *release-tags
+      - deploy: *release-tags
       - prepare-next-version: *release-tags
       - deploy-snapshot:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
           name: Invalidate CloudFront caches
           command: aws cloudfront create-invalidation --distribution-id EPTW7F3CB566V --paths "/*"
 
-  make-release:
+  upload-release:
     executor: android-executor
     steps:
       - checkout
@@ -158,7 +158,29 @@ jobs:
             if [ "$CIRCLE_JDK_VERSION" != "oraclejdk8" ]; then
               echo "Skipping snapshot deployment: wrong JDK. Expected '$JDK' but was '$CIRCLE_JDK_VERSION'."
             else
-              bundle exec fastlane android deploy
+              bundle exec fastlane android upload_release
+            fi
+      - android-wordpress-orb/save-gradle-cache
+      - android/save-build-cache
+
+  upload-and-close-release:
+    executor: android-executor
+    steps:
+      - checkout
+      - setup-git-credentials
+      - trust-github-key
+      - install-gems
+      - prepare-signing-key
+      - android-wordpress-orb/restore-gradle-cache
+      - android/restore-build-cache
+      - download-amazon-dependency
+      - run:
+          name: Deployment
+          command: |
+            if [ "$CIRCLE_JDK_VERSION" != "oraclejdk8" ]; then
+              echo "Skipping snapshot deployment: wrong JDK. Expected '$JDK' but was '$CIRCLE_JDK_VERSION'."
+            else
+              bundle exec fastlane android upload_release
             fi
       - android-wordpress-orb/save-gradle-cache
       - android/save-build-cache
@@ -194,7 +216,7 @@ jobs:
             if [ "$CIRCLE_JDK_VERSION" != "oraclejdk8" ]; then
               echo "Skipping snapshot deployment: wrong JDK. Expected '$JDK' but was '$CIRCLE_JDK_VERSION'."
             else
-              bundle exec fastlane android deploy
+              bundle exec fastlane android upload_release
             fi
       - android-wordpress-orb/save-gradle-cache
 
@@ -308,7 +330,7 @@ workflows:
 
   deploy:
     jobs:
-      - make-release: *release-tags
+      - upload-release: *release-tags
       - prepare-next-version: *release-tags
       - deploy-snapshot:
           filters:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,12 +7,7 @@ Automatic Releasing
  1. Make a PR, merge when approved
  1. Pull develop
  1. Make a tag and push, the rest will be performed automatically by CircleCI. If the automation fails, you can revert
- to manually calling `bundle exec fastlane deploy`.
- 1. Visit [Sonatype Nexus](https://oss.sonatype.org/)
- 1. Click on Staging Repositories on the left side
- 1. Scroll down to find the purchase repository
- 1. Select and click "Close" from the top menu. Why is it called close?
- 1. Once close is complete, press the "Release" button. It's safe to choose "Automatically drop".
+ to manually calling `bundle exec fastlane upload_release`.
 
 Hotfix Releases
 =========

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,7 @@ Automatic Releasing
  1. Make a PR, merge when approved
  1. Pull develop
  1. Make a tag and push, the rest will be performed automatically by CircleCI. If the automation fails, you can revert
- to manually calling `bundle exec fastlane upload_release`.
+ to manually calling `bundle exec fastlane deploy`.
 
 Hotfix Releases
 =========

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     repositories {
         jcenter()
         google()
-        maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
+        mavenCentral()
     }
     dependencies {
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.15.1"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
     }
     dependencies {
-        classpath "com.vanniktech:gradle-maven-publish-plugin:0.9.0"
+        classpath "com.vanniktech:gradle-maven-publish-plugin:0.15.1"
         classpath "com.android.tools.build:gradle:4.1.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.0"

--- a/build.gradle
+++ b/build.gradle
@@ -21,17 +21,8 @@ plugins {
     id "io.gitlab.arturbosch.detekt" version "1.7.2"
     id "com.github.kt3k.coveralls" version "2.10.0"
     id "com.savvasdalkitsis.module-dependency-graph" version "0.9"
-    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 
-group = "com.revenuecat.purchases"
-version = "$VERSION_NAME"
-
-nexusPublishing {
-    repositories {
-        sonatype()
-    }
-}
 dependencies {
     detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:1.8.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,17 @@ plugins {
     id "io.gitlab.arturbosch.detekt" version "1.7.2"
     id "com.github.kt3k.coveralls" version "2.10.0"
     id "com.savvasdalkitsis.module-dependency-graph" version "0.9"
+    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 
+group = "com.revenuecat.purchases"
+version = "$VERSION_NAME"
+
+nexusPublishing {
+    repositories {
+        sonatype()
+    }
+}
 dependencies {
     detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:1.8.0"
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,8 +83,8 @@ platform :android do
         "signing.keyId" => ENV['GPG_SIGNING_KEY_ID_NEW'],
         "signing.password" => ENV['GPG_SIGNING_KEY_PW_NEW'],
         "signing.secretKeyRingFile" => "/home/circleci/.gnupg/secring.gpg",
-        "SONATYPE_NEXUS_USERNAME" => ENV['SONATYPE_NEXUS_TOKEN_USERNAME'],
-        "SONATYPE_NEXUS_PASSWORD" => ENV['SONATYPE_NEXUS_TOKEN_PASSWORD'],
+        "mavenCentralUsername" => ENV['SONATYPE_NEXUS_TOKEN_USERNAME'],
+        "mavenCentralPassword" => ENV['SONATYPE_NEXUS_TOKEN_PASSWORD'],
         "RELEASE_SIGNING_ENABLED" => true,
       }
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -70,26 +70,47 @@ platform :android do
     )
   end
 
-  desc "Deploy a release"
-  lane :deploy do |options|
+  desc "Upload a release"
+  lane :upload_release do |options|
     version = android_get_version_name(gradle_file: gradle_file_path)
     is_snapshot_version = version.end_with?("-SNAPSHOT")
     puts "Deploying #{version}"
     gradle(
       tasks: [
-          "androidSourcesJar", "androidJavadocsJar", "uploadArchives"
+          "androidSourcesJar", "androidJavadocsJar", "publish"
       ],
       properties: {
         "signing.keyId" => ENV['GPG_SIGNING_KEY_ID_NEW'],
         "signing.password" => ENV['GPG_SIGNING_KEY_PW_NEW'],
         "signing.secretKeyRingFile" => "/home/circleci/.gnupg/secring.gpg",
-        "SONATYPE_NEXUS_USERNAME" => ENV['SONATYPE_NEXUS_USERNAME'],
-        "SONATYPE_NEXUS_PASSWORD" => ENV['SONATYPE_NEXUS_PASSWORD'],
+        "SONATYPE_NEXUS_USERNAME" => ENV['SONATYPE_NEXUS_TOKEN_USERNAME'],
+        "SONATYPE_NEXUS_PASSWORD" => ENV['SONATYPE_NEXUS_TOKEN_PASSWORD'],
         "RELEASE_SIGNING_ENABLED" => true,
       }
     )
     if !is_snapshot_version then github_release(version: version) end
   end
+
+    desc "Upload and close a release"
+    lane :upload_and_close_release do |options|
+      version = android_get_version_name(gradle_file: gradle_file_path)
+      is_snapshot_version = version.end_with?("-SNAPSHOT")
+      puts "Deploying #{version}"
+      gradle(
+        tasks: [
+            "androidSourcesJar", "androidJavadocsJar", "publish", "closeAndReleaseRepository"
+        ],
+        properties: {
+          "signing.keyId" => ENV['GPG_SIGNING_KEY_ID_NEW'],
+          "signing.password" => ENV['GPG_SIGNING_KEY_PW_NEW'],
+          "signing.secretKeyRingFile" => "/home/circleci/.gnupg/secring.gpg",
+          "SONATYPE_NEXUS_USERNAME" => ENV['SONATYPE_NEXUS_TOKEN_USERNAME'],
+          "SONATYPE_NEXUS_PASSWORD" => ENV['SONATYPE_NEXUS_TOKEN_PASSWORD'],
+          "RELEASE_SIGNING_ENABLED" => true,
+        }
+      )
+      if !is_snapshot_version then github_release(version: version) end
+    end
 
   desc "Prepare next version"
   lane :prepare_next_version do |options|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -70,14 +70,14 @@ platform :android do
     )
   end
 
-  desc "Upload a release"
-  lane :upload_release do |options|
+  desc "Upload and close a release"
+  lane :deploy do |options|
     version = android_get_version_name(gradle_file: gradle_file_path)
     is_snapshot_version = version.end_with?("-SNAPSHOT")
     puts "Deploying #{version}"
     gradle(
       tasks: [
-          "androidSourcesJar", "androidJavadocsJar", "publish"
+          "androidSourcesJar", "androidJavadocsJar", "publish", "closeAndReleaseRepository"
       ],
       properties: {
         "signing.keyId" => ENV['GPG_SIGNING_KEY_ID_NEW'],
@@ -91,26 +91,13 @@ platform :android do
     if !is_snapshot_version then github_release(version: version) end
   end
 
-    desc "Upload and close a release"
-    lane :upload_and_close_release do |options|
-      version = android_get_version_name(gradle_file: gradle_file_path)
-      is_snapshot_version = version.end_with?("-SNAPSHOT")
-      puts "Deploying #{version}"
-      gradle(
-        tasks: [
-            "androidSourcesJar", "androidJavadocsJar", "publish", "closeAndReleaseRepository"
-        ],
-        properties: {
-          "signing.keyId" => ENV['GPG_SIGNING_KEY_ID_NEW'],
-          "signing.password" => ENV['GPG_SIGNING_KEY_PW_NEW'],
-          "signing.secretKeyRingFile" => "/home/circleci/.gnupg/secring.gpg",
-          "mavenCentralUsername" => ENV['SONATYPE_NEXUS_TOKEN_USERNAME'],
-          "mavenCentralPassword" => ENV['SONATYPE_NEXUS_TOKEN_PASSWORD'],
-          "RELEASE_SIGNING_ENABLED" => true,
-        }
-      )
-      if !is_snapshot_version then github_release(version: version) end
-    end
+  desc "Upload a snapshot release"
+  lane :deploy_snapshot do |options|
+    version = android_get_version_name(gradle_file: gradle_file_path)
+    is_snapshot_version = version.end_with?("-SNAPSHOT")
+    if !is_snapshot_version then return end
+    deploy
+  end
 
   desc "Prepare next version"
   lane :prepare_next_version do |options|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -104,8 +104,8 @@ platform :android do
           "signing.keyId" => ENV['GPG_SIGNING_KEY_ID_NEW'],
           "signing.password" => ENV['GPG_SIGNING_KEY_PW_NEW'],
           "signing.secretKeyRingFile" => "/home/circleci/.gnupg/secring.gpg",
-          "SONATYPE_NEXUS_USERNAME" => ENV['SONATYPE_NEXUS_TOKEN_USERNAME'],
-          "SONATYPE_NEXUS_PASSWORD" => ENV['SONATYPE_NEXUS_TOKEN_PASSWORD'],
+          "mavenCentralUsername" => ENV['SONATYPE_NEXUS_TOKEN_USERNAME'],
+          "mavenCentralPassword" => ENV['SONATYPE_NEXUS_TOKEN_PASSWORD'],
           "RELEASE_SIGNING_ENABLED" => true,
         }
       )

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip


### PR DESCRIPTION
Updates the `gradle-maven-publish-plugin` to make use of new `closeAndReleaseRepository` task.

Created a new `upload-and-close-release` job in CircleCI that calls the `closeAndReleaseRepository` task, and renamed the old `deploy` task to `upload-release` to be more specific and consistent.

Not sure if there's really a use case for the old upload-only task, but I wanted to keep it around for testing purposes. I call it from the CircleCI `deploy` workflow for now, but will update that to run `upload-and-close-release` once we've tested the other works as expected.