### PR TITLE
Release/4.2.0

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,11 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <option name="OTHER_INDENT_OPTIONS">
-      <value>
-        <option name="INDENT_SIZE" value="2" />
-        <option name="TAB_SIZE" value="2" />
-      </value>
-    </option>
     <option name="RIGHT_MARGIN" value="120" />
     <option name="SOFT_MARGINS" value="120" />
     <JetCodeStyleSettings>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,11 +1,17 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="OTHER_INDENT_OPTIONS">
+      <value>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </value>
+    </option>
     <option name="RIGHT_MARGIN" value="120" />
     <option name="SOFT_MARGINS" value="120" />
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,7 +1,9 @@
-- Updated purchase-tester sample app and modified structure of the examples folder.
-     https://github.com/RevenueCat/purchases-android/pull/296
-     https://github.com/RevenueCat/purchases-android/pull/297
- - Added back the call setObfuscatedAccountID when purchasing for non-upgrades/downgrades.
-     https://github.com/RevenueCat/purchases-android/pull/294
- - Updated error mapping and created a new ConfigurationError for cases when the package name is wrongly configured in the dashboard.
-     https://github.com/RevenueCat/purchases-android/pull/298
+- Update incorrect ReplaceWith annotation
+     https://github.com/RevenueCat/purchases-android/pull/303
+- Fix crash on empty SKUs in list passed to querySkuDetailsAsync
+     https://github.com/RevenueCat/purchases-android/pull/302
+- Add eTags support to avoid unnecessary backend responses
+     https://github.com/RevenueCat/purchases-android/pull/292
+     https://github.com/RevenueCat/purchases-android/pull/305
+- Add canMakePayments method to check for billing and feature support
+     https://github.com/RevenueCat/purchases-android/pull/304

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 4.2.0
+
+- Update incorrect ReplaceWith annotation
+     https://github.com/RevenueCat/purchases-android/pull/303
+- Fix crash on empty SKUs in list passed to querySkuDetailsAsync
+     https://github.com/RevenueCat/purchases-android/pull/302
+- Add eTags support to avoid unnecessary backend responses
+     https://github.com/RevenueCat/purchases-android/pull/292
+     https://github.com/RevenueCat/purchases-android/pull/305
+- Add canMakePayments method to check for billing and feature support
+     https://github.com/RevenueCat/purchases-android/pull/304
+
 ## 4.1.0
 
  - Updated purchase-tester sample app and modified structure of the examples folder.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@ Automatic Releasing
  1. Create a CHANGELOG.latest.md with the changes for the current version (to be used by Fastlane for the github release notes)
  1. Run `bundle exec fastlane bump_and_update_changelog version:X.Y.Z` (where X.Y.Z is the new version) to update the version number in `gradle.properties`, `Config.kt` and in `library/build.gradle`
  1. Commit the changes `git commit -am "Version X.Y.Z"` (where X.Y.Z is the new version)
- 1. Make a PR, merge when approved
+ 1. Make a PR into develop, merge when approved
  1. Pull develop
  1. Make a tag and push, the rest will be performed automatically by CircleCI. If the automation fails, you can revert
  to manually calling `bundle exec fastlane deploy`.

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = false
 
-    const val frameworkVersion = "4.1.0-SNAPSHOT"
+    const val frameworkVersion = "4.2.0"
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -77,7 +77,7 @@ platform :android do
     puts "Deploying #{version}"
     gradle(
       tasks: [
-          "androidSourcesJar", "androidJavadocsJar", "publish", "closeAndReleaseRepository"
+          "androidSourcesJar", "androidJavadocJar", "publish", "closeAndReleaseRepository"
       ],
       properties: {
         "signing.keyId" => ENV['GPG_SIGNING_KEY_ID_NEW'],

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -40,7 +40,12 @@ Make github release
 ```
 fastlane android deploy
 ```
-Deploy a release
+Upload and close a release
+### android deploy_snapshot
+```
+fastlane android deploy_snapshot
+```
+Upload a snapshot release
 ### android prepare_next_version
 ```
 fastlane android prepare_next_version

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=4.1.0-SNAPSHOT
+VERSION_NAME=4.2.0
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/library.gradle
+++ b/library.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "4.1.0-SNAPSHOT"
+        versionName "4.2.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
- Update incorrect ReplaceWith annotation
     https://github.com/RevenueCat/purchases-android/pull/303
- Fix crash on empty SKUs in list passed to querySkuDetailsAsync
     https://github.com/RevenueCat/purchases-android/pull/302
- Add eTags support to avoid unnecessary backend responses
     https://github.com/RevenueCat/purchases-android/pull/292
     https://github.com/RevenueCat/purchases-android/pull/305
- Add canMakePayments method to check for billing and feature support
     https://github.com/RevenueCat/purchases-android/pull/304