### PR TITLE
More checks when tagging with latest

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -39,6 +39,34 @@ platform :android do
     attach_changelog_to_main(options)
   end
 
+  desc "Tag release version with latest if necessary"
+  lane :tag_release_with_latest_if_needed do |options|
+    release_version = options[:release_version]
+
+    lines_in_changelog = File.open("../CHANGELOG.md").to_a
+    first_line = lines_in_changelog.first
+    latest_version = first_line.split("## ").last.chomp
+    puts "Latest version is #{latest_version}"
+
+    if latest_version == release_version then
+      latest_version_commit = sh("git", "rev-list", "--tags=#{latest_version}*", "--max-count=1").chomp
+      puts "Tagging #{latest_version}, with commit #{latest_version_commit} with latest"
+
+      add_git_tag(
+        tag: "latest",
+        force: true,
+        grouping: "releases",
+        commit: latest_version_commit
+      )
+      push_git_tags(
+        tag: "latest",
+        force: true
+      )
+    else
+      puts "There's a more recent version. Skipping tagging."
+    end
+  end
+
   desc "Make github release"
   lane :github_release do |options|
     release_version = options[:version]
@@ -59,15 +87,8 @@ platform :android do
       commitish: "main",
       upload_assets: []
     )
-    add_git_tag(
-      tag: "latest",
-      force: true,
-      grouping: "releases"
-    )
-    push_git_tags(
-      tag: "latest",
-      force: true
-    )
+
+    tag_release_with_latest_if_needed(release_version: release_version)
   end
 
   desc "Upload and close a release"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -50,23 +50,22 @@ platform :android do
 
     puts "Latest version is #{latest_version}"
 
-    if Gem::Version.new(release_version) > Gem::Version.new(latest_version)
-      latest_version_commit = sh("git", "rev-list", "--tags=#{release_version}*", "--max-count=1").chomp
-      puts "Tagging #{release_version}, with commit #{latest_version_commit} with latest"
-
-      add_git_tag(
-        tag: "latest",
-        force: true,
-        grouping: "releases",
-        commit: latest_version_commit
-      )
-      push_git_tags(
-        tag: "latest",
-        force: true
-      )
-    else
+    unless Gem::Version.new(release_version) > Gem::Version.new(latest_version)
       puts "There's a more recent version. Skipping tagging."
     end
+    latest_version_commit = sh("git", "rev-list", "--tags=#{release_version}*", "--max-count=1").chomp
+    puts "Tagging #{release_version}, with commit #{latest_version_commit} with latest"
+
+    add_git_tag(
+      tag: "latest",
+      force: true,
+      grouping: "releases",
+      commit: latest_version_commit
+    )
+    push_git_tags(
+      tag: "latest",
+      force: true
+    )
   end
 
   desc "Make github release"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -43,14 +43,16 @@ platform :android do
   lane :tag_release_with_latest_if_needed do |options|
     release_version = options[:release_version]
 
-    lines_in_changelog = File.open("../CHANGELOG.md").to_a
-    first_line = lines_in_changelog.first
-    latest_version = first_line.split("## ").last.chomp
+    current_branch = git_branch
+    sh("git", "checkout", "tags/latest")
+    latest_version = android_get_version_name(gradle_file: gradle_file_path)
+    sh("git", "checkout", current_branch)
+
     puts "Latest version is #{latest_version}"
 
-    if latest_version == release_version then
-      latest_version_commit = sh("git", "rev-list", "--tags=#{latest_version}*", "--max-count=1").chomp
-      puts "Tagging #{latest_version}, with commit #{latest_version_commit} with latest"
+    if Gem::Version.new(release_version) > Gem::Version.new(latest_version)
+      latest_version_commit = sh("git", "rev-list", "--tags=#{release_version}*", "--max-count=1").chomp
+      puts "Tagging #{release_version}, with commit #{latest_version_commit} with latest"
 
       add_git_tag(
         tag: "latest",

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -31,6 +31,11 @@ Increment build number
 fastlane android bump_and_update_changelog
 ```
 Increment build number and update changelog
+### android tag_release_with_latest_if_needed
+```
+fastlane android tag_release_with_latest_if_needed
+```
+Tag release version with latest if necessary
 ### android github_release
 ```
 fastlane android github_release


### PR DESCRIPTION
I added a function to tag with latest the HEAD after a GitHub release is created from Fastlane. @aboedo brought a good point to indicate that that release might not always be the latest. This PR adds checks to make sure the release is actually the latest. 

In order to do that I checkout the latest branch and check the version and compare.

This made me realize that the CHANGELOG.latest.md will always be attached to the top of CHANGELOG.md, which would not be true for all releases (i.e. hotfixes). But we can solve that in another moment.