### PR TITLE
clarify usage of `sharedInstance`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1731,7 +1731,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
 
         /**
          * Singleton instance of Purchases. [configure] will set this
-         * @return A previously set singleton Purchases instance or null
+         * @return A previously set singleton Purchases instance
          * @throws UninitializedPropertyAccessException if the shared instance has not been configured. 
          */
         @JvmStatic

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1732,6 +1732,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         /**
          * Singleton instance of Purchases. [configure] will set this
          * @return A previously set singleton Purchases instance or null
+         * @throws UninitializedPropertyAccessException if the shared instance has not been configured. 
          */
         @JvmStatic
         var sharedInstance: Purchases

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1732,7 +1732,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         /**
          * Singleton instance of Purchases. [configure] will set this
          * @return A previously set singleton Purchases instance
-         * @throws UninitializedPropertyAccessException if the shared instance has not been configured. 
+         * @throws UninitializedPropertyAccessException if the shared instance has not been configured.
          */
         @JvmStatic
         var sharedInstance: Purchases


### PR DESCRIPTION
if you call `sharedInstance` but you haven't configured the SDK yet, the app will crash. 

However, the docs suggested that you'd get a `null` value for `sharedInstance`. This PR updates the docs to reflect the current behavior. 