### PR TITLE
Disable ETags

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -39,10 +39,13 @@ class ETagManager(
 ) {
 
     internal fun getETagHeader(
+        @SuppressWarnings("UnusedPrivateMember")
         path: String,
+        @SuppressWarnings("UnusedPrivateMember")
         refreshETag: Boolean = false
     ): Map<String, String> {
-        val eTagHeader = ETAG_HEADER_NAME to if (refreshETag) "" else getETag(path)
+        // Always return "" until request date issue is figured out
+        val eTagHeader = ETAG_HEADER_NAME to ""
         return mapOf(eTagHeader)
     }
 
@@ -111,6 +114,7 @@ class ETagManager(
         }
     }
 
+    @SuppressWarnings("UnusedPrivateMember")
     private fun getETag(path: String): String {
         return getStoredResultSavedInSharedPreferences(path)?.eTag.orEmpty()
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -56,9 +56,9 @@ class ETagManagerTest {
     }
 
     @Test
-    fun `An ETag header is added if there is an ETag saved for that request`() {
+    fun `An ETag header is never added even if there is an ETag saved for that request`() {
         val path = "/v1/subscribers/appUserID"
-        val expectedETag = "etag"
+        val expectedETag = ""
         mockCachedHTTPResult(expectedETag, path)
 
         val requestWithETagHeader = underTest.getETagHeader(path)


### PR DESCRIPTION
I realized there's an issue with ETags so this PR disables them.

We use request date to determine if an entitlement is active, which means that we basically check if the entitlement is active at the moment the request is made to determine if we should grant the entitlement. This prevents users from losing access if there's no connectivity. 

The fact that the backend doesn't take into account the request date in order to calculate the hash used for the ETags means that it's possible the SDK keeps using an old cached request with a very old request date, and that we don't mark the entitlements as not active. For example:

- A request is retrieved on 05-26-2021 using ETags. We store the response and we associate it with that ETag. At this moment, the entitlement is active, with an expiration date on 06-15-2021.
- The user cancels renovation.
- On 07-01-2021 the request is made again. The response hasn't changed since the entitlement keeps having 06-15-2021 as the expiration date. The backend would therefore return a 304. 
- On the SDK we use the cached response and we use the request date in that response to determine if the entitlement is active. The request date in that response is 05-26-2021. We compare 05-26-2021 to 06-15-2021 and we determine the entitlement should be granted since the entitlement was active at the moment the request was made.

Luckily, looks like there's another bug in the backend that makes the backend return 200 most of the times, so this shouldn't be affecting anyone. While we work on determine how to solve this issue, we choose to disable ETags.

