### PR TITLE
Fix prepare_next_version lane and tagging latest tag

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,7 +41,7 @@ platform :android do
 
   desc "Tag release version with latest if necessary"
   lane :tag_release_with_latest_if_needed do |options|
-    release_version = options[:version]
+    release_version = options[:release_version]
     puts "Release version is #{release_version}"
 
     sh("git", "checkout", "tags/latest")
@@ -91,7 +91,7 @@ platform :android do
       upload_assets: []
     )
 
-    tag_release_with_latest_if_needed(options)
+    tag_release_with_latest_if_needed(release_version: release_version)
   end
 
   desc "Upload and close a release"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,6 +48,7 @@ platform :android do
     latest_version = android_get_version_name(gradle_file: gradle_file_path)
     puts "Latest version is #{latest_version}"
 
+    # We assume there's already a tag for the version we are tagging as latest
     sh("git", "checkout", release_version)
 
     unless Gem::Version.new(release_version) > Gem::Version.new(latest_version)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,17 +41,18 @@ platform :android do
 
   desc "Tag release version with latest if necessary"
   lane :tag_release_with_latest_if_needed do |options|
-    release_version = options[:release_version]
+    release_version = options[:version]
+    puts "Release version is #{release_version}"
 
-    current_branch = git_branch
     sh("git", "checkout", "tags/latest")
     latest_version = android_get_version_name(gradle_file: gradle_file_path)
-    sh("git", "checkout", current_branch)
-
     puts "Latest version is #{latest_version}"
+
+    sh("git", "checkout", release_version)
 
     unless Gem::Version.new(release_version) > Gem::Version.new(latest_version)
       puts "There's a more recent version. Skipping tagging."
+      next
     end
     latest_version_commit = sh("git", "rev-list", "--tags=#{release_version}*", "--max-count=1").chomp
     puts "Tagging #{release_version}, with commit #{latest_version_commit} with latest"
@@ -89,7 +90,7 @@ platform :android do
       upload_assets: []
     )
 
-    tag_release_with_latest_if_needed(release_version: release_version)
+    tag_release_with_latest_if_needed(options)
   end
 
   desc "Upload and close a release"
@@ -140,7 +141,11 @@ platform :android do
     bump(version: next_version_snapshot)
 
     sh("git", "commit", "-am", "Preparing for next version")
-    push_to_git_remote
+    push_to_git_remote(
+      remote: "origin",
+      local_branch: branch_name,
+      remote_branch: branch_name,
+    )
 
     create_pull_request(
       repo: "revenuecat/purchases-android",


### PR DESCRIPTION
There were issues when creating the pull request with the bump to next version so I explicitely added some "optional" parameters to the lane and now it's working fine.

The tagging of the latest release was also broken, it was missing an early exit and had some issues switching back to the current branch.