### PR TITLE
Fixes Amazon jar download 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ plugins {
     id "io.gitlab.arturbosch.detekt" version "1.17.0-RC3"
     id "com.github.kt3k.coveralls" version "2.10.0"
     id "com.savvasdalkitsis.module-dependency-graph" version "0.9"
+    id "de.undercouch.download" version "4.1.1"
 }
 
 dependencies {

--- a/feature/amazon/build.gradle
+++ b/feature/amazon/build.gradle
@@ -18,24 +18,27 @@ dependencies {
     testImplementation project(":test-utils")
 }
 
-task downloadAmazonZipFile(type: Download) {
-    src 'https://amzndevresources.com/iap/sdk/AmazonInAppPurchasing_Android.zip'
-    dest new File(buildDir, 'download.zip')
-}
-
-task getAmazonLibrary(dependsOn: downloadAmazonZipFile, type: Copy) {
+task getAmazonLibrary(type: Download) {
     ext {
         fileToExtract = "in-app-purchasing-${iapVersion}.jar"
         destFile = new File( projectDir, "libs/$fileToExtract" )
     }
-    File destDir = destFile.parentFile
-    destDir.mkdirs()
-    project.copy {
-        from {
-            zipTree(downloadAmazonZipFile.dest).matching { include "**/$fileToExtract" }.singleFile
-        }
 
-        into( destDir )
+    if(!destFile.exists()) {
+        println 'Downloading Amazon dependency'
+        File destDir = destFile.parentFile
+        destDir.mkdirs()
+
+        src 'https://amzndevresources.com/iap/sdk/AmazonInAppPurchasing_Android.zip'
+        dest new File(temporaryDir, 'download.zip')
+
+        project.copy {
+            from {
+                zipTree(dest).matching { include "**/$fileToExtract" }.singleFile
+            }
+
+            into( destDir )
+        }
     }
 }
 

--- a/feature/amazon/build.gradle
+++ b/feature/amazon/build.gradle
@@ -18,37 +18,26 @@ dependencies {
     testImplementation project(":test-utils")
 }
 
-task getAmazonLibrary {
+task downloadAmazonZipFile(type: Download) {
+    src 'https://amzndevresources.com/iap/sdk/AmazonInAppPurchasing_Android.zip'
+    dest new File(buildDir, 'download.zip')
+}
+
+task getAmazonLibrary(dependsOn: downloadAmazonZipFile, type: Copy) {
     ext {
-        downloadURL = "https://amzndevresources.com/iap/sdk/AmazonInAppPurchasing_Android.zip"
         fileToExtract = "in-app-purchasing-${iapVersion}.jar"
         destFile = new File( projectDir, "libs/$fileToExtract" )
     }
-
-    inputs.property( 'downloadURL', downloadURL )
-    inputs.property( 'fileToExtract', fileToExtract )
-    outputs.file( destFile )
-
-    doLast {
-        if(!destFile.exists()) {
-            println 'Downloading Amazon dependency'
-            File destDir = destFile.parentFile
-            destDir.mkdirs()
-
-            File downloadFile = new File( temporaryDir, 'download.zip' )
-            new URL( downloadURL ).withInputStream { is ->
-                downloadFile.withOutputStream { it << is }
-            }
-
-            project.copy {
-                from {
-                    zipTree(downloadFile).matching { include "**/$fileToExtract" }.singleFile
-                }
-
-                into( destDir )
-            }
+    File destDir = destFile.parentFile
+    destDir.mkdirs()
+    project.copy {
+        from {
+            zipTree(downloadAmazonZipFile.dest).matching { include "**/$fileToExtract" }.singleFile
         }
+
+        into( destDir )
     }
 }
+
 
 preBuild.dependsOn getAmazonLibrary


### PR DESCRIPTION
The amazon jar wasn't downloading on my machine after we upgraded the gradle wrapper. I think something changed in the version of Java that I use that broke the download task.

I modified the task to something that works. I also added a new Gradle plugin that will take care of the download and will also display a progress bar, which I think is a good improvement.