### PR TITLE
Release: 4.3.0-beta1

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -19,6 +19,3 @@
 ### Other changes: 
 - Fixed CI issues with creating pull requests
     https://github.com/RevenueCat/purchases-android/pull/324
-
-### HOLD
-This PR should not be merged. Instead, we'll make a regular release from develop once beta testing is complete. 

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,6 +1,24 @@
-- Temporarily disable ETags
-     https://github.com/RevenueCat/purchases-android/pull/322
-- Converts attribution data to use subscriber attributes
-     https://github.com/RevenueCat/purchases-android/pull/315
-- Clarify usage of sharedInstance
-     https://github.com/RevenueCat/purchases-android/pull/320
+### Identity V3:
+
+#### New methods
+- Introduces `logIn`, a new way of identifying users, which also returns whether a new user has been registered in the system. 
+`logIn` uses a new backend endpoint. 
+- Introduces `logOut`, a replacement for `reset`. 
+
+#### Deprecations / removals
+- removes `createAlias`
+- deprecates `identify` in favor of `logIn`
+- deprecates `reset` in favor of `logOut`
+- deprecates `allowSharingPlayStoreAccount` in favor of dashboard-side configuration
+
+    https://github.com/RevenueCat/purchases-android/pull/250
+    https://github.com/RevenueCat/purchases-android/pull/260
+    https://github.com/RevenueCat/purchases-android/pull/252
+
+
+### Other changes: 
+- Fixed CI issues with creating pull requests
+    https://github.com/RevenueCat/purchases-android/pull/324
+
+### HOLD
+This PR should not be merged. Instead, we'll make a regular release from develop once beta testing is complete. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.3.0-beta1
+## 4.3.0-beta.1
 
 ### Identity V3:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@
 - Fixed CI issues with creating pull requests
     https://github.com/RevenueCat/purchases-android/pull/324
 
-### HOLD
-This PR should not be merged. Instead, we'll make a regular release from develop once beta testing is complete. 
-
 ## 4.2.1
 
 - Temporarily disable ETags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## 4.3.0-beta1
+
+### Identity V3:
+
+#### New methods
+- Introduces `logIn`, a new way of identifying users, which also returns whether a new user has been registered in the system. 
+`logIn` uses a new backend endpoint. 
+- Introduces `logOut`, a replacement for `reset`. 
+
+#### Deprecations / removals
+- removes `createAlias`
+- deprecates `identify` in favor of `logIn`
+- deprecates `reset` in favor of `logOut`
+- deprecates `allowSharingPlayStoreAccount` in favor of dashboard-side configuration
+
+    https://github.com/RevenueCat/purchases-android/pull/250
+    https://github.com/RevenueCat/purchases-android/pull/260
+    https://github.com/RevenueCat/purchases-android/pull/252
+
+
+### Other changes: 
+- Fixed CI issues with creating pull requests
+    https://github.com/RevenueCat/purchases-android/pull/324
+
+### HOLD
+This PR should not be merged. Instead, we'll make a regular release from develop once beta testing is complete. 
+
 ## 4.2.1
 
 - Temporarily disable ETags

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = false
 
-    const val frameworkVersion = "4.3.0-SNAPSHOT"
+    const val frameworkVersion = "4.3.0-beta1"
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = false
 
-    const val frameworkVersion = "4.3.0-beta1"
+    const val frameworkVersion = "4.3.0-beta.1"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=4.3.0-SNAPSHOT
+VERSION_NAME=4.3.0-beta1
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=4.3.0-beta1
+VERSION_NAME=4.3.0-beta.1
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/library.gradle
+++ b/library.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "4.3.0-beta1"
+        versionName "4.3.0-beta.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/library.gradle
+++ b/library.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "4.3.0-SNAPSHOT"
+        versionName "4.3.0-beta1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -122,6 +122,11 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
     * default. If true treats all purchases as restores, aliasing together appUserIDs that share a
     * Play Store account.
     */
+
+    @Deprecated(
+            "Replaced with configuration in the RevenueCat dashboard",
+            ReplaceWith("configure through the RevenueCat dashboard")
+    )
     var allowSharingPlayStoreAccount: Boolean
         @Synchronized get() =
             state.allowSharingPlayStoreAccount ?: identityManager.currentUserIsAnonymous()
@@ -700,6 +705,10 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * @param newAppUserID The new appUserID that should be linked to the currently user
      * @param [listener] An optional listener to listen for successes or errors.
      */
+    @Deprecated(
+            "Use logIn instead",
+            ReplaceWith("logIn")
+    )
     @JvmOverloads
     fun identify(
         newAppUserID: String,
@@ -781,6 +790,10 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * id and save it in the cache.
      * @param [listener] An optional listener to listen for successes or errors.
      */
+    @Deprecated(
+            "Use logOut instead",
+            ReplaceWith("logOut")
+    )
     @JvmOverloads
     fun reset(
         listener: ReceivePurchaserInfoListener? = null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -738,7 +738,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      */
     @JvmOverloads
     @JvmSynthetic
-    internal fun logIn(
+    fun logIn(
         newAppUserID: String,
         callback: LogInCallback? = null
     ) {
@@ -772,7 +772,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      */
     @JvmOverloads
     @JvmSynthetic
-    internal fun logOut(listener: ReceivePurchaserInfoListener? = null) {
+    fun logOut(listener: ReceivePurchaserInfoListener? = null) {
         val error: PurchasesError? = identityManager.logOut()
         if (error != null) {
             listener?.onError(error)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -707,7 +707,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      */
     @Deprecated(
         "Use logIn instead",
-        ReplaceWith("Purchases.sharedInstance.logIn(newAppUserID, LogInCallback?")
+        ReplaceWith("Purchases.sharedInstance.logIn(newAppUserID, LogInCallback?)")
     )
     @JvmOverloads
     fun identify(
@@ -792,7 +792,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      */
     @Deprecated(
         "Use logOut instead",
-        ReplaceWith("Purchases.sharedInstance.logOut(ReceivePurchaserInfoListener")
+        ReplaceWith("Purchases.sharedInstance.logOut(ReceivePurchaserInfoListener?)")
     )
     @JvmOverloads
     fun reset(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -706,8 +706,8 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * @param [listener] An optional listener to listen for successes or errors.
      */
     @Deprecated(
-            "Use logIn instead",
-            ReplaceWith("logIn")
+        "Use logIn instead",
+        ReplaceWith("Purchases.sharedInstance.logIn(newAppUserID, LogInCallback?")
     )
     @JvmOverloads
     fun identify(
@@ -791,8 +791,8 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * @param [listener] An optional listener to listen for successes or errors.
      */
     @Deprecated(
-            "Use logOut instead",
-            ReplaceWith("logOut")
+        "Use logOut instead",
+        ReplaceWith("Purchases.sharedInstance.logOut(ReceivePurchaserInfoListener")
     )
     @JvmOverloads
     fun reset(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -333,7 +333,7 @@ fun Purchases.identifyWith(
  * @param [onError] Will be called after the call has completed with an error.
  */
 @Suppress("unused")
-internal fun Purchases.logInWith(
+fun Purchases.logInWith(
     appUserID: String,
     onError: ErrorFunction = ON_ERROR_STUB,
     onSuccess: ReceiveLogInSuccessFunction
@@ -348,7 +348,7 @@ internal fun Purchases.logInWith(
  * @param [onError] Will be called after the call has completed with an error.
  */
 @Suppress("unused")
-internal fun Purchases.logOutWith(
+fun Purchases.logOutWith(
     onError: ErrorFunction = ON_ERROR_STUB,
     onSuccess: ReceivePurchaserInfoSuccessFunction
 ) {


### PR DESCRIPTION
### Identity V3:

#### New methods
- Introduces `logIn`, a new way of identifying users, which also returns whether a new user has been registered in the system. 
`logIn` uses a new backend endpoint. 
- Introduces `logOut`, a replacement for `reset`. 

#### Deprecations / removals
- removes `createAlias`
- deprecates `identify` in favor of `logIn`
- deprecates `reset` in favor of `logOut`
- deprecates `allowSharingPlayStoreAccount` in favor of dashboard-side configuration

    https://github.com/RevenueCat/purchases-android/pull/250
    https://github.com/RevenueCat/purchases-android/pull/260
    https://github.com/RevenueCat/purchases-android/pull/252


### Other changes: 
- Fixed CI issues with creating pull requests
    https://github.com/RevenueCat/purchases-android/pull/324

### HOLD
This PR should not be merged. Instead, we'll make a regular release from develop once beta testing is complete. 
