### PR TITLE
Small fixes on attribution data conversion to subscriber attributes

### DIFF
--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/AttributionDataMigrator.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/AttributionDataMigrator.kt
@@ -76,7 +76,7 @@ class AttributionDataMigrator {
 
     private fun convertMParticleAttribution(data: JSONObject): Map<String, String> {
         val mapping: Map<Any, String> = mapOf(
-            (AttributionKeys.MParticle.ID or AttributionKeys.NETWORK_ID) to SPECIAL_KEY_MPARTICLE_ID,
+            (AttributionKeys.NETWORK_ID or AttributionKeys.MParticle.ID) to SPECIAL_KEY_MPARTICLE_ID,
         )
         return data.convertToSubscriberAttributes(mapping)
     }

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/AttributionDataMigratorTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/AttributionDataMigratorTests.kt
@@ -406,6 +406,47 @@ class AttributionDataMigratorTests {
         checkCommonAttributes(converted, expectedIdfv = null)
     }
 
+    @Test
+    fun `MParticle attribution is properly converted`() {
+        val jsonObject = getMParticleJSON()
+        val converted =
+            underTest.convertAttributionDataToSubscriberAttributes(data = jsonObject, AttributionNetwork.MPARTICLE)
+        assertThat(converted).isNotNull
+        checkCommonAttributes(converted)
+        assertThat(converted[SPECIAL_KEY_MPARTICLE_ID]).isEqualTo(jsonObject.getString(AttributionKeys.MParticle.ID))
+    }
+
+    @Test
+    fun `MParticle attribution gives preference to rc_attribution_network_id over MParticle ID`() {
+        val jsonObject = getMParticleJSON(
+            addNetworkID = true,
+            addMParticleId = true
+        )
+        val converted =
+            underTest.convertAttributionDataToSubscriberAttributes(data = jsonObject, AttributionNetwork.MPARTICLE)
+        assertThat(converted).isNotNull
+        checkCommonAttributes(converted)
+        assertThat(converted[SPECIAL_KEY_MPARTICLE_ID]).isEqualTo(jsonObject.getString(AttributionKeys.NETWORK_ID))
+    }
+
+    @Test
+    fun `MParticle attribution works with null rc_idfa`() {
+        val jsonObject = getMParticleJSON(idfa = null)
+        val converted =
+            underTest.convertAttributionDataToSubscriberAttributes(data = jsonObject, AttributionNetwork.MPARTICLE)
+        assertThat(converted).isNotNull
+        checkCommonAttributes(converted, expectedIdfa = null)
+    }
+
+    @Test
+    fun `MParticle attribution works with null rc_idfv`() {
+        val jsonObject = getMParticleJSON(idfv = null)
+        val converted =
+            underTest.convertAttributionDataToSubscriberAttributes(data = jsonObject, AttributionNetwork.MPARTICLE)
+        assertThat(converted).isNotNull
+        checkCommonAttributes(converted, expectedIdfv = null)
+    }
+
     private fun getAdjustJSON(
         idfa: String? = DEFAULT_IDFA,
         addAdId: Boolean = true,

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/AttributionDataMigratorTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/AttributionDataMigratorTests.kt
@@ -450,7 +450,6 @@ class AttributionDataMigratorTests {
                 "campaign_id": "23847301359200211",
                 "click_time": "2021-05-04 18:08:51.000", 
                 "iscache": false, 
-                "adset": "0111 - mm - aaa - US - best 10", 
                 "adgroup_id": "238473013556789090", 
                 "is_mobile_data_terms_signed": true, 
                 "match_type": "srn", 


### PR DESCRIPTION
Super tiny fixes to fix a couple things that I noticed while developing the same feature for iOS.

- First of all I noticed that we were giving preference to the MParticleID instead of the network ID. It should be the other way around.
- There was a duplicated JSON key in one of the JSONs used for testing.
- We didn't have tests for MParticle 🤕 