### PR TITLE
Updated 4.3.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Detailed docs about the new system are available [here](https://docs.revenuecat.
     https://github.com/RevenueCat/purchases-android/pull/335
 - Added `@Throws` annotation to `getPackage`, which could throw `NoSuchElementException`, but it wasn't documented.
     https://github.com/RevenueCat/purchases-android/pull/333
+- Updated BillingClient to version [4.0.0](https://developer.android.com/google/play/billing/release-notes#4-0).
+    https://github.com/RevenueCat/purchases-android/commit/f6554bbf7376c3fd492f0bc67183a9f35889ae78
 
 ## 4.2.1
 


### PR DESCRIPTION
Updated release notes for 4.3.0 since it wasn't mentioning an update to the Android Billing Library, from 3.0.2 to 4.0.0.

Relevant commit:
https://github.com/RevenueCat/purchases-android/commit/f6554bbf7376c3fd492f0bc67183a9f35889ae78
