### PR TITLE
Adds callback cache identity

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -6,12 +6,12 @@
 package com.revenuecat.purchases.common
 
 import android.net.Uri
-import android.util.Log
 import com.revenuecat.purchases.PurchaserInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import com.revenuecat.purchases.strings.NetworkStrings
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -409,7 +409,7 @@ class Backend(
             this[cacheKey] = mutableListOf(functions)
             enqueue(call, randomDelay)
         } else {
-            Log.d("Purchases", "Same call already in progress, adding to callbacks map with key: $cacheKey")
+            debugLog(String.format(NetworkStrings.SAME_CALL_ALREADY_IN_PROGRESS, cacheKey))
             this[cacheKey]!!.add(functions)
         }
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -6,6 +6,7 @@
 package com.revenuecat.purchases.common
 
 import android.net.Uri
+import android.util.Log
 import com.revenuecat.purchases.PurchaserInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -408,6 +409,7 @@ class Backend(
             this[cacheKey] = mutableListOf(functions)
             enqueue(call, randomDelay)
         } else {
+            Log.d("Purchases", "Same call already in progress, adding to callbacks map with key: $cacheKey")
             this[cacheKey]!!.add(functions)
         }
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -30,6 +30,10 @@ typealias OfferingsCallback = Pair<(JSONObject) -> Unit, (PurchasesError) -> Uni
 typealias PostReceiptDataSuccessCallback = (PurchaserInfo, body: JSONObject) -> Unit
 /** @suppress */
 typealias PostReceiptDataErrorCallback = (PurchasesError, shouldConsumePurchase: Boolean, body: JSONObject?) -> Unit
+/** @suppress */
+typealias CreateAliasCallback = Pair<() -> Unit, (PurchasesError) -> Unit>
+/** @suppress */
+typealias IdentifyCallback = Pair<(PurchaserInfo, Boolean) -> Unit, (PurchasesError) -> Unit>
 
 class Backend(
     private val apiKey: String,
@@ -47,6 +51,12 @@ class Backend(
 
     @get:Synchronized @set:Synchronized
     @Volatile var offeringsCallbacks = mutableMapOf<String, MutableList<OfferingsCallback>>()
+
+    @get:Synchronized @set:Synchronized
+    @Volatile var createAliasCallbacks = mutableMapOf<CallbackCacheKey, MutableList<CreateAliasCallback>>()
+
+    @get:Synchronized @set:Synchronized
+    @Volatile var identifyCallbacks = mutableMapOf<CallbackCacheKey, MutableList<IdentifyCallback>>()
 
     fun close() {
         this.dispatcher.close()
@@ -280,7 +290,11 @@ class Backend(
         onSuccessHandler: () -> Unit,
         onErrorHandler: (PurchasesError) -> Unit
     ) {
-        enqueue(object : Dispatcher.AsyncCall() {
+        val cacheKey = listOfNotNull(
+            appUserID,
+            newAppUserID
+        )
+        val call = object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {
                 return httpClient.performRequest(
                     "/subscribers/" + encode(appUserID) + "/alias",
@@ -290,17 +304,32 @@ class Backend(
             }
 
             override fun onError(error: PurchasesError) {
-                onErrorHandler(error)
+                synchronized(this@Backend) {
+                    createAliasCallbacks.remove(cacheKey)
+                }?.forEach { (_, onErrorHandler) ->
+                    onErrorHandler(error)
+                }
             }
 
             override fun onCompletion(result: HTTPResult) {
                 if (result.isSuccessful()) {
-                    onSuccessHandler()
+                    synchronized(this@Backend) {
+                        createAliasCallbacks.remove(cacheKey)
+                    }?.forEach { (onSuccessHandler, _) ->
+                        onSuccessHandler()
+                    }
                 } else {
-                    onErrorHandler(result.toPurchasesError().also { errorLog(it) })
+                    synchronized(this@Backend) {
+                        createAliasCallbacks.remove(cacheKey)
+                    }?.forEach { (_, onErrorHandler) ->
+                        onErrorHandler(result.toPurchasesError().also { errorLog(it) })
+                    }
                 }
             }
-        })
+        }
+        synchronized(this@Backend) {
+            createAliasCallbacks.addCallback(call, cacheKey, onSuccessHandler to onErrorHandler)
+        }
     }
 
     fun logIn(
@@ -309,7 +338,11 @@ class Backend(
         onSuccessHandler: (PurchaserInfo, Boolean) -> Unit,
         onErrorHandler: (PurchasesError) -> Unit
     ) {
-        enqueue(object : Dispatcher.AsyncCall() {
+        val cacheKey = listOfNotNull(
+            appUserID,
+            newAppUserID
+        )
+        val call = object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {
                 return httpClient.performRequest(
                     "/subscribers/identify",
@@ -322,24 +355,39 @@ class Backend(
             }
 
             override fun onError(error: PurchasesError) {
-                onErrorHandler(error)
+                synchronized(this@Backend) {
+                    identifyCallbacks.remove(cacheKey)
+                }?.forEach { (_, onErrorHandler) ->
+                    onErrorHandler(error)
+                }
             }
 
             override fun onCompletion(result: HTTPResult) {
                 if (result.isSuccessful()) {
-                    val created = result.responseCode == RCHTTPStatusCodes.CREATED
-                    if (result.body.length() > 0) {
-                        val purchaserInfo = result.body.buildPurchaserInfo()
-                        onSuccessHandler(purchaserInfo, created)
-                    } else {
-                        onErrorHandler(PurchasesError(PurchasesErrorCode.UnknownError)
-                            .also { errorLog(it) })
+                    synchronized(this@Backend) {
+                        identifyCallbacks.remove(cacheKey)
+                    }?.forEach { (onSuccessHandler, onErrorHandler) ->
+                        val created = result.responseCode == RCHTTPStatusCodes.CREATED
+                        if (result.body.length() > 0) {
+                            val purchaserInfo = result.body.buildPurchaserInfo()
+                            onSuccessHandler(purchaserInfo, created)
+                        } else {
+                            onErrorHandler(PurchasesError(PurchasesErrorCode.UnknownError)
+                                .also { errorLog(it) })
+                        }
                     }
                 } else {
-                    onErrorHandler(result.toPurchasesError().also { errorLog(it) })
+                    synchronized(this@Backend) {
+                        identifyCallbacks.remove(cacheKey)
+                    }?.forEach { (_, onErrorHandler) ->
+                        onError(result.toPurchasesError().also { errorLog(it) })
+                    }
                 }
             }
-        })
+        }
+        synchronized(this@Backend) {
+            identifyCallbacks.addCallback(call, cacheKey, onSuccessHandler to onErrorHandler)
+        }
     }
 
     fun clearCaches() {

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -423,9 +423,10 @@ class BackendTest {
         mockResponse(
             "/subscribers/$appUserID/alias",
             body,
-            200,
-            null,
-            null
+            responseCode = 200,
+            clientException = null,
+            resultBody = null,
+            delayed = true
         )
         val newAppUserID = "newId"
         val lock = CountDownLatch(2)
@@ -1156,7 +1157,8 @@ class BackendTest {
             requestBody,
             responseCode = 200,
             clientException = null,
-            resultBody = resultBody
+            resultBody = resultBody,
+            delayed = true
         )
 
         val lock = CountDownLatch(2)

--- a/strings/src/main/java/com/revenuecat/purchases/strings/NetworkStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/NetworkStrings.kt
@@ -8,4 +8,5 @@ object NetworkStrings {
         "Retrying call with a new ETag"
     const val ETAG_CALL_ALREADY_RETRIED = "We can't find the cached response, but call has already been retried. " +
         "Returning result from backend: %s"
+    const val SAME_CALL_ALREADY_IN_PROGRESS = "Same call already in progress, adding to callbacks map with key: %s"
 }


### PR DESCRIPTION
We are getting some customers calling alias or identify too often. Sometimes with the same parameters. 

Something I have noticed while trying to replicate the issue with this code:

```kotlin
for (i in 1..10) {
    if (newUserId != Purchases.sharedInstance.appUserID) {
        Purchases.sharedInstance.loginWith {
            // Do other stuff
        }
    }
}
```

Is that most of the times the code will enter in the `if` clause. The reason is that we only update the appUserID when the API call has come back with a result, so the check would most of the times evaluate to the same.

In this PR, I have added the same caching mechanism we currently have for other API calls. It prevents the same calls being executed at the same time with the same parameters. This should prevent apps from hitting our servers with `/alias` and `/identify` calls that look the same too often.