### PR TITLE
Fix onError of unsuccessful /identify calls

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -320,11 +320,7 @@ class Backend(
                         onSuccessHandler()
                     }
                 } else {
-                    synchronized(this@Backend) {
-                        createAliasCallbacks.remove(cacheKey)
-                    }?.forEach { (_, onErrorHandler) ->
-                        onErrorHandler(result.toPurchasesError().also { errorLog(it) })
-                    }
+                    onError(result.toPurchasesError().also { errorLog(it) })
                 }
             }
         }
@@ -378,11 +374,7 @@ class Backend(
                         }
                     }
                 } else {
-                    synchronized(this@Backend) {
-                        identifyCallbacks.remove(cacheKey)
-                    }?.forEach { (_, onErrorHandler) ->
-                        onError(result.toPurchasesError().also { errorLog(it) })
-                    }
+                    onError(result.toPurchasesError().also { errorLog(it) })
                 }
             }
         }

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -10,17 +10,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.PurchaserInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
-import com.revenuecat.purchases.common.attribution.AttributionNetwork
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.models.ProductDetails
 import com.revenuecat.purchases.utils.Responses
 import com.revenuecat.purchases.utils.getNullableString
-import io.mockk.Called
-import io.mockk.ThrowingAnswer
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Fail.fail
@@ -30,7 +26,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.IOException
-import java.lang.RuntimeException
 import java.lang.Thread.sleep
 import java.util.HashMap
 import java.util.concurrent.CountDownLatch

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -506,7 +506,7 @@ class BackendTest {
             )
         } answers {
             sleep(200)
-            throw Exception()
+            throw IOException()
         }
 
         val newAppUserID = "newId"

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -498,6 +498,7 @@ class BackendTest {
         val headers = HashMap<String, String>()
         headers["Authorization"] = "Bearer $API_KEY"
 
+        val lockException = CountDownLatch(1)
         every {
             mockClient.performRequest(
                 "/subscribers/$appUserID/alias",
@@ -505,7 +506,7 @@ class BackendTest {
                 headers
             )
         } answers {
-            sleep(200)
+            lockException.await()
             throw IOException()
         }
 
@@ -521,6 +522,7 @@ class BackendTest {
         }, onErrorHandler = {
             lock.countDown()
         })
+        lockException.countDown()
         lock.await(2000, TimeUnit.MILLISECONDS)
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.models.ProductDetails
 import com.revenuecat.purchases.utils.Responses
 import com.revenuecat.purchases.utils.getNullableString
 import io.mockk.Called
+import io.mockk.ThrowingAnswer
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -29,6 +30,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.IOException
+import java.lang.RuntimeException
 import java.lang.Thread.sleep
 import java.util.HashMap
 import java.util.concurrent.CountDownLatch
@@ -492,14 +494,21 @@ class BackendTest {
         val body = mapOf(
             "new_app_user_id" to "newId"
         )
-        mockResponse(
-            "/subscribers/$appUserID/alias",
-            body,
-            responseCode = 500,
-            clientException = IOException(),
-            resultBody = null,
-            delayed = true
-        )
+
+        val headers = HashMap<String, String>()
+        headers["Authorization"] = "Bearer $API_KEY"
+
+        every {
+            mockClient.performRequest(
+                "/subscribers/$appUserID/alias",
+                body,
+                headers
+            )
+        } answers {
+            sleep(200)
+            throw Exception()
+        }
+
         val newAppUserID = "newId"
         val lock = CountDownLatch(2)
         asyncBackend.createAlias(appUserID, newAppUserID, onSuccessHandler = {


### PR DESCRIPTION
I broke the error treatment for unsuccessful `/identify` calls in this PR https://github.com/RevenueCat/purchases-android/pull/358

I was calling `onError` instead of the `onErrorHandler`. I added some tests since we didn't have any tests that could catch this.