### PR TITLE
Prepares release 4.3.2

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,3 +1,3 @@
-- Moves the code of `onBillingSetupFinished` to the main thread. Changes the callback of `canMakePayments` to the main thread. 
-    https://github.com/RevenueCat/purchases-android/pull/349/
-    https://github.com/RevenueCat/purchases-android/issues/348
+- Makes improvements to prevent multiple HTTP requests with the same parameters to `/identify` and `/alias`. 
+    https://github.com/RevenueCat/purchases-android/pull/358
+    https://github.com/RevenueCat/purchases-android/pull/359

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.3.2
+
+- Makes improvements to prevent multiple HTTP requests with the same parameters to `/identify` and `/alias`. 
+    https://github.com/RevenueCat/purchases-android/pull/358
+    https://github.com/RevenueCat/purchases-android/pull/359
+
 ## 4.3.1
 
 - Moves the code of `onBillingSetupFinished` to the main thread. Changes the callback of `canMakePayments` to the main thread. 

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = false
 
-    const val frameworkVersion = "4.4.0-SNAPSHOT"
+    const val frameworkVersion = "4.3.2"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=4.4.0-SNAPSHOT
+VERSION_NAME=4.3.2
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/library.gradle
+++ b/library.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "4.4.0-SNAPSHOT"
+        versionName "4.3.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
- Makes improvements to prevent multiple HTTP requests with the same parameters to `/identify` and `/alias`. 
    https://github.com/RevenueCat/purchases-android/pull/358
    https://github.com/RevenueCat/purchases-android/pull/359