### PR TITLE
Update to Android Gradle plugin 7.0.2 and buildToolsVersion 3.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.15.1"
-        classpath "com.android.tools.build:gradle:4.1.1"
+        classpath 'com.android.tools.build:gradle:7.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.32"
     }
@@ -18,7 +18,6 @@ buildscript {
 
 plugins {
     id "io.gitlab.arturbosch.detekt" version "1.17.0-RC3"
-    id "com.github.kt3k.coveralls" version "2.10.0"
     id "com.savvasdalkitsis.module-dependency-graph" version "0.9"
 }
 

--- a/examples/purchase-tester/build.gradle
+++ b/examples/purchase-tester/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.4"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,6 @@ POM_DEVELOPER_NAME=RevenueCat, Inc.
 
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8.libraries = false
 
 #Do not sign releases. When calling uploadArchives pass -PRELEASE_SIGNING_ENABLED=true
 RELEASE_SIGNING_ENABLED=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.revenuecat.purchases.integrationtests"

--- a/library.gradle
+++ b/library.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion compileVersion
-    buildToolsVersion "30.0.2"
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion minVersion


### PR DESCRIPTION
Updated to the latest stable version of the Android Gradle plugin 7.0.2 and the build tools version to 3.0.3

Changes introduced by AGP 7 are outlined here https://android-developers.googleblog.com/2020/12/announcing-android-gradle-plugin.html

One of the main changes is that now we require JDK 11. In order to install it, the best way is to use sdkman. Instructions on that are here https://github.com/RevenueCat/purchases-android/blob/e2e4df2db2612d015a41db710e2a2afccd396c19/CONTRIBUTING.md#environment-setup