### PR TITLE
Update test dependencies

### DIFF
--- a/library.gradle
+++ b/library.gradle
@@ -29,11 +29,11 @@ android {
 }
 
 dependencies {
-    testImplementation 'androidx.test:core:1.2.0'
-    testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation 'androidx.test.ext:junit:1.1.1'
-    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation 'androidx.test:core:1.4.0'
+    testImplementation 'androidx.test:runner:1.4.0'
+    testImplementation 'androidx.test:rules:1.4.0'
+    testImplementation 'androidx.test.ext:junit:1.1.3'
+    testImplementation 'org.robolectric:robolectric:4.6.1'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.2.0'
     testImplementation 'org.mockito:mockito-core:3.0.0'
     testImplementation "com.android.billingclient:billing:$billingVersion"


### PR DESCRIPTION
This updates robolectric and all of our other out-of-date testing dependencies

Robolectric was the forcing mechanism -- our tests wouldn't build because the version of robolectric that we were on referenced a deprecated maven URL.
