### PR TITLE
Ensure we only pass one querySkuDetails/PurchaseHistory response on

### DIFF
--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -8,7 +8,6 @@ package com.revenuecat.purchases.google
 import android.app.Activity
 import android.content.Context
 import android.os.Handler
-import androidx.annotation.NonNull
 import androidx.annotation.UiThread
 import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingClient

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1505,6 +1505,59 @@ class BillingWrapperTest {
         }
     }
 
+    @Test
+    fun `querySkuDetailsAsync only calls one response when BillingClient responds twice`() {
+        var numCallbacks = 0
+
+        val slot = slot<SkuDetailsResponseListener>()
+        every {
+            mockClient.querySkuDetailsAsync(
+                any(),
+                capture(slot)
+            )
+        } answers {
+            slot.captured.onSkuDetailsResponse(billingClientOKResult, null)
+            slot.captured.onSkuDetailsResponse(billingClientOKResult, null)
+        }
+
+        wrapper.querySkuDetailsAsync(
+            ProductType.SUBS,
+            setOf("", ""),
+            {
+                numCallbacks++
+            }, {
+                numCallbacks++
+            })
+
+        assertThat(numCallbacks == 1)
+    }
+
+    @Test
+    fun `queryPurchaseHistoryAsync only calls one response when BillingClient responds twice`() {
+        var numCallbacks = 0
+
+        val slot = slot<PurchaseHistoryResponseListener>()
+        every {
+            mockClient.queryPurchaseHistoryAsync(
+                any(),
+                capture(slot)
+            )
+        } answers {
+            slot.captured.onPurchaseHistoryResponse(billingClientOKResult, null)
+            slot.captured.onPurchaseHistoryResponse(billingClientOKResult, null)
+        }
+
+        wrapper.queryPurchaseHistoryAsync(
+            BillingClient.SkuType.SUBS,
+            {
+                numCallbacks++
+            }, {
+                numCallbacks++
+            })
+
+        assertThat(numCallbacks == 1)
+    }
+
     private fun mockNullSkuDetailsResponse() {
         val slot = slot<SkuDetailsResponseListener>()
         every {

--- a/strings/src/main/java/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -10,6 +10,7 @@ object OfferingStrings {
     const val FETCHING_PRODUCTS_FINISHED = "Products request finished for %s"
     const val JSON_EXCEPTION_ERROR = "JSONException when building Offerings object. Message: %s"
     const val LIST_PRODUCTS = "%s - %s"
+    const val EXTRA_QUERY_SKU_DETAILS_RESPONSE = "BillingClient querySkuDetails has returned more than once: %s"
     const val NO_CACHED_OFFERINGS_FETCHING_NETWORK = "No cached Offerings, fetching from network"
     const val OFFERINGS_STALE_UPDATING_IN_BACKGROUND = "Offerings cache is stale, updating from network in background"
     const val OFFERINGS_STALE_UPDATING_IN_FOREGROUND = "Offerings cache is stale, updating from network in foreground"

--- a/strings/src/main/java/com/revenuecat/purchases/strings/RestoreStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/RestoreStrings.kt
@@ -3,7 +3,8 @@ package com.revenuecat.purchases.strings
 object RestoreStrings {
     const val PURCHASE_HISTORY_EMPTY = "Purchase history is empty."
     const val PURCHASE_HISTORY_RETRIEVED = "Purchase history retrieved %s"
-    const val EXTRA_QUERY_PURCHASE_HISTORY_RESPONSE = "BillingClient queryPurchaseHistory has returned more than once: %s"
+    const val EXTRA_QUERY_PURCHASE_HISTORY_RESPONSE = "BillingClient queryPurchaseHistory has returned more than " +
+        "once: %s"
     const val PURCHASE_RESTORED = "Purchase %s restored"
     const val QUERYING_PURCHASE = "Querying purchases"
     const val QUERYING_PURCHASE_WITH_HASH = "Purchase of type %s with hash %s"

--- a/strings/src/main/java/com/revenuecat/purchases/strings/RestoreStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/RestoreStrings.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.strings
 object RestoreStrings {
     const val PURCHASE_HISTORY_EMPTY = "Purchase history is empty."
     const val PURCHASE_HISTORY_RETRIEVED = "Purchase history retrieved %s"
+    const val EXTRA_QUERY_PURCHASE_HISTORY_RESPONSE = "BillingClient queryPurchaseHistory has returned more than once: %s"
     const val PURCHASE_RESTORED = "Purchase %s restored"
     const val QUERYING_PURCHASE = "Querying purchases"
     const val QUERYING_PURCHASE_WITH_HASH = "Purchase of type %s with hash %s"


### PR DESCRIPTION
Fix for this github issue: https://github.com/flutter/flutter/issues/29092

We've opened a Google issue as well: https://issuetracker.google.com/issues/201628456

BillingClient, in some cases, issues multiple responses to the querySkuDetailsAsync and queryPurchaseHistoryAsync callbacks. This was causing crashes for Flutter users and is currently the top crash in the sdk console.

We added a flag so that we only pass one callback on to our users, and log the rest. We discussed adding this at a higher level for all BillingClient calls in the future, but for now wanted to get a fix out ASAP. 