### PR TITLE
Add isConfigured

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1799,6 +1799,13 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         var proxyURL: URL? = null
 
         /**
+         * True if [configure] has been called and [Purchases.sharedInstance] is set
+         */
+        @JvmStatic
+        val isConfigured: Boolean
+            get() = this.backingFieldSharedInstance != null
+
+        /**
          * Configures an instance of the Purchases SDK with a specified API key. The instance will
          * be set as a singleton. You should access the singleton instance using [Purchases.sharedInstance]
          * @param apiKey The API Key generated for your app from https://app.revenuecat.com/

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -4090,6 +4090,17 @@ class PurchasesTest {
         assertThat(receivedUserCancelled).isFalse()
     }
 
+    @Test
+    fun `isConfigured is true if there's an instance set`() {
+        assertThat(Purchases.isConfigured).isTrue()
+    }
+
+    @Test
+    fun `isConfigured is false if there's no instance set`() {
+        Purchases.backingFieldSharedInstance = null
+        assertThat(Purchases.isConfigured).isFalse()
+    }
+
     private fun mockBackend(errorGettingPurchaserInfo: PurchasesError? = null) {
         with(mockBackend) {
             if (errorGettingPurchaserInfo != null) {


### PR DESCRIPTION
Fixes [sc-11021]

Adds an `Purchases.isConfigured` to check if setup has been called.

Should be helpful for folks wanting to prevent https://github.com/RevenueCat/purchases-android/issues/377 when race conditions occur.

