### PR TITLE
Version 4.5.0

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,2 +1,2 @@
-- Added support for Airship integration via `setAirshipChannelID`
-    https://github.com/RevenueCat/purchases-android/pull/375
+- Added `isConfigured` to be able to check if there is an instance of Purchases already configured
+    https://github.com/RevenueCat/purchases-android/pull/378

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.5.0
+
+- Added `isConfigured` to be able to check if there is an instance of Purchases already configured
+    https://github.com/RevenueCat/purchases-android/pull/378
+
 ## 4.4.0
 
 - Added support for Airship integration via `setAirshipChannelID`

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = false
 
-    const val frameworkVersion = "4.5.0-SNAPSHOT"
+    const val frameworkVersion = "4.5.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=4.5.0-SNAPSHOT
+VERSION_NAME=4.5.0
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/library.gradle
+++ b/library.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "4.5.0-SNAPSHOT"
+        versionName "4.5.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
- Added `isConfigured` to be able to check if there is an instance of Purchases already configured
    https://github.com/RevenueCat/purchases-android/pull/378