### PR TITLE
release: 4.6.0

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,2 +1,4 @@
-- Added `isConfigured` to be able to check if there is an instance of Purchases already configured
-    https://github.com/RevenueCat/purchases-android/pull/378
+- Added `EntitlementInfo.ownershipType`, which can be used to determine whether an entitlement was granted by a direct purchase or shared through a family member.
+    https://github.com/RevenueCat/purchases-android/pull/382
+- Added a log warning when `configure` is called with an empty string as `appUserID`, to make it clear that the user will be considered an anonymous user.
+    https://github.com/RevenueCat/purchases-android/pull/384

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.6.0
+
+- Added `EntitlementInfo.ownershipType`, which can be used to determine whether an entitlement was granted by a direct purchase or shared through a family member.
+    https://github.com/RevenueCat/purchases-android/pull/382
+- Added a log warning when `configure` is called with an empty string as `appUserID`, to make it clear that the user will be considered an anonymous user.
+    https://github.com/RevenueCat/purchases-android/pull/384
+
 ## 4.5.0
 
 - Added `isConfigured` to be able to check if there is an instance of Purchases already configured

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = false
 
-    const val frameworkVersion = "4.6.0-SNAPSHOT"
+    const val frameworkVersion = "4.6.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=4.6.0-SNAPSHOT
+VERSION_NAME=4.6.0
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/library.gradle
+++ b/library.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "4.6.0-SNAPSHOT"
+        versionName "4.6.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
- Added `EntitlementInfo.ownershipType`, which can be used to determine whether an entitlement was granted by a direct purchase or shared through a family member.
    https://github.com/RevenueCat/purchases-android/pull/382
- Added a log warning when `configure` is called with an empty string as `appUserID`, to make it clear that the user will be considered an anonymous user.
    https://github.com/RevenueCat/purchases-android/pull/384
