### PR TITLE
Add exported tag to receiver to fix builds targeting sdk 31

### DIFF
--- a/feature/amazon/src/main/AndroidManifest.xml
+++ b/feature/amazon/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
 
     <application>
         <receiver android:name = "com.amazon.device.iap.ResponseReceiver"
-                android:permission = "com.amazon.inapp.purchasing.Permission.NOTIFY" >
+                android:permission = "com.amazon.inapp.purchasing.Permission.NOTIFY"
+                android:exported = "false" >
             <intent-filter>
                 <action android:name = "com.amazon.inapp.purchasing.NOTIFY" />
             </intent-filter>


### PR DESCRIPTION
Fixes https://github.com/RevenueCat/purchases-android/issues/397

Builds targeting sdk 31 were failing due to missing the "exported" attribute on the amazon ResponseReceiver. Confirmed this via PurchaseTester

See [Behavior Changes](https://developer.android.com/about/versions/12/behavior-changes-12#exported) for more info

Will also hotfix coming for a new amazon alpha...