### PR TITLE
Hotfix: Add exported property to ResponseReceiver

### DIFF
--- a/feature/amazon/src/main/AndroidManifest.xml
+++ b/feature/amazon/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
 
     <application>
         <receiver android:name = "com.amazon.device.iap.ResponseReceiver"
-                android:permission = "com.amazon.inapp.purchasing.Permission.NOTIFY" >
+                android:permission = "com.amazon.inapp.purchasing.Permission.NOTIFY"
+                android:exported = "false">
             <intent-filter>
                 <action android:name = "com.amazon.inapp.purchasing.NOTIFY" />
             </intent-filter>


### PR DESCRIPTION
Same as https://github.com/RevenueCat/purchases-android/pull/402, but based off the latest alpha release tag, `5.0.0-amazon.alpha.3`, in order to make a "hotfix alpha".

Would love input on versioning, though. `5.0.0-amazon.alpha.4` feels like a "major alpha", in which case we might as well release off the `amazon-release` branch. Which I suppose is an option. It has a fair amount of changes, but since these are alphas anyway, maybe a hotfix is overkill?

`5.0.1-amazon.alpha.3` would take precedence over `5.0.0` based on [semver](https://semver.org/#spec-item-11)

I think the best option, if we do a hotfix, is `5.0.0-amazon.alpha.3.0.1` ("A larger set of pre-release fields has a higher precedence than a smaller set, if all of the preceding identifiers are equal.")

Thoughts?