### PR TITLE
Add exported attribute to manifest

### DIFF
--- a/feature/amazon/src/main/AndroidManifest.xml
+++ b/feature/amazon/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
 
     <application>
         <receiver android:name = "com.amazon.device.iap.ResponseReceiver"
-                android:permission = "com.amazon.inapp.purchasing.Permission.NOTIFY" >
+                android:permission = "com.amazon.inapp.purchasing.Permission.NOTIFY"
+                android:exported = "false" >
             <intent-filter>
                 <action android:name = "com.amazon.inapp.purchasing.NOTIFY" />
             </intent-filter>


### PR DESCRIPTION
Didn't realize yesterday that this Receiver was in 4.6.0. Even though the receiver isn't "active" since amazon isn't enabled, it'll still cause a build error. 

This will be for a 4.6.1 hotfix.