### PR TITLE
Changes exported of the Amazon receiver to true

### DIFF
--- a/feature/amazon/src/main/AndroidManifest.xml
+++ b/feature/amazon/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <application>
         <receiver android:name = "com.amazon.device.iap.ResponseReceiver"
                 android:permission = "com.amazon.inapp.purchasing.Permission.NOTIFY"
-                android:exported = "false">
+                android:exported = "true">
             <intent-filter>
                 <action android:name = "com.amazon.inapp.purchasing.NOTIFY" />
             </intent-filter>


### PR DESCRIPTION
I was testing this in the amazon-release branch, and in the latest alpha, and fetching products doesn't work unless exported is true.