### PR TITLE
Added run configurations for tests

### DIFF
--- a/.run/All tests.run.xml
+++ b/.run/All tests.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="All tests" type="GradleRunConfiguration" factoryName="Gradle" singleton="false">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="--tests &quot;com.revenuecat.purchases.*&quot;" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Common tests.run.xml
+++ b/.run/Common tests.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Common tests" type="GradleRunConfiguration" factoryName="Gradle" singleton="false">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="--tests &quot;com.revenuecat.purchases.common.*&quot;" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
I've added these 2 for now:
<img width="122" alt="Screen Shot 2021-12-22 at 13 03 10" src="https://user-images.githubusercontent.com/685609/147154826-819b5f20-9b22-4157-8fb4-a068b4eefa92.png">

But it would be nice to add more, maybe excluding `features` which seem to be slower tests (some of them take several seconds?)

I'll update our [internal docs](https://www.notion.so/revenuecat/Running-Tests-9433d87cd7b94517bc490544202a28d3) when this is merged.

<img width="726" alt="Screen Shot 2021-12-22 at 13 08 03" src="https://user-images.githubusercontent.com/685609/147155290-ce8355c3-cc92-4828-b0fc-93bca5273435.png">