### PR TITLE
`createOfferings`: added log when there are no packages

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/CustomerInfoFactories.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/CustomerInfoFactories.kt
@@ -1,14 +1,15 @@
 package com.revenuecat.purchases.common
 
 import android.net.Uri
+import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.EntitlementInfos
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
-import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.skuDetails
+import com.revenuecat.purchases.strings.OfferingStrings
 import com.revenuecat.purchases.utils.Iso8601Utils
 import com.revenuecat.purchases.utils.optNullableString
 import com.revenuecat.purchases.utils.parseExpirations
@@ -84,6 +85,10 @@ fun JSONObject.createOfferings(products: Map<String, StoreProduct>): Offerings {
     for (i in 0 until jsonOfferings.length()) {
         jsonOfferings.getJSONObject(i).createOffering(products)?.let {
             offerings[it.identifier] = it
+
+            if (it.availablePackages.isEmpty()) {
+                warnLog(OfferingStrings.OFFERING_EMPTY.format(it.identifier))
+            }
         }
     }
 

--- a/strings/src/main/java/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -26,4 +26,8 @@ object OfferingStrings {
     const val CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND = "There's a problem with your configuration. " +
         "None of the products registered in the RevenueCat dashboard could be fetched from the Play Store.\n" +
         "More information: https://rev.cat/why-are-offerings-empty"
+    const val OFFERING_EMPTY = "There's a problem with your configuration. No packages could be found for offering " +
+        "with identifier %s. This could be due to Products not being configured correctly in " +
+        "the RevenueCat dashboard or Play Store.\nTo configure products, follow the instructions in " +
+        "https://rev.cat/how-to-configure-offerings.\nMore information: https://rev.cat/why-are-offerings-empty"
 }


### PR DESCRIPTION
Depends on #425.
Fixes [sc-11030]. This is equivalent to https://github.com/RevenueCat/purchases-ios/pull/879.
I've also verified that the behavior now matches all the changes in https://github.com/RevenueCat/purchases-ios/pull/879.