### PR TITLE
Java 8 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@
 ## Installation
 
 Please follow the [Quickstart Guide](https://docs.revenuecat.com/docs/) for more information on how to use the SDK
+
+## Requirements
+
+`purchases` works on Android 4.0+ (API level 14+) and Java 8+.

--- a/library.gradle
+++ b/library.gradle
@@ -26,6 +26,13 @@ android {
             maxHeapSize = "1024m"
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Adds Java 8 target and source compatibility. We don't use any specific Java 8 feature at the moment, but we require this to update JUnit 4 to 5, which has new features like parameterized tests. 

We are releasing this as a major and most common Android libraries already required Java 8, so this change should be quite safe. Apart from that, I tried in the MagicWeather example to remove the 1.8 JVM target and got a message on build like:

```
e: /Users/cesar/Development/repos/purchases-android/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/MainActivity.kt: (24, 35): Cannot inline bytecode built with JVM target 1.8 into bytecode that is being built with JVM target 1.6. Please specify proper '-jvm-target' option
Adding support for Java 8 language features could solve this issue.
```

