### PR TITLE
Fix null intent crash

### DIFF
--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -222,6 +222,9 @@ class BillingWrapper(
         activity: Activity,
         params: BillingFlowParams
     ) {
+        if (activity.intent == null) {
+            log(LogIntent.WARNING, BillingStrings.NULL_ACTIVITY_INTENT)
+        }
         withConnectedClient {
             launchBillingFlow(activity, params)
                 .takeIf { billingResult -> billingResult.responseCode != BillingClient.BillingResponseCode.OK }

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -7,7 +7,6 @@ package com.revenuecat.purchases.google
 
 import android.app.Activity
 import android.content.Context
-import android.content.Intent
 import android.os.Handler
 import androidx.annotation.UiThread
 import com.android.billingclient.api.AcknowledgePurchaseParams
@@ -224,7 +223,6 @@ class BillingWrapper(
         params: BillingFlowParams
     ) {
         if (activity.intent == null) {
-            activity.intent = Intent()
             log(LogIntent.WARNING, BillingStrings.NULL_ACTIVITY_INTENT)
         }
         withConnectedClient {

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -7,6 +7,7 @@ package com.revenuecat.purchases.google
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.os.Handler
 import androidx.annotation.UiThread
 import com.android.billingclient.api.AcknowledgePurchaseParams
@@ -223,6 +224,7 @@ class BillingWrapper(
         params: BillingFlowParams
     ) {
         if (activity.intent == null) {
+            activity.intent = Intent()
             log(LogIntent.WARNING, BillingStrings.NULL_ACTIVITY_INTENT)
         }
         withConnectedClient {

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases.google
 
 import android.app.Activity
 import android.content.Context
-import android.content.Intent
 import android.os.Handler
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.AcknowledgePurchaseParams
@@ -81,7 +80,6 @@ class BillingWrapperTest {
 
     private val billingClientOKResult = BillingClient.BillingResponseCode.OK.buildResult()
     private val appUserId = "jerry"
-    private var mockActivity = mockk<Activity>()
 
     @Before
     fun setup() {
@@ -147,10 +145,6 @@ class BillingWrapperTest {
                 onConnectedCalled = true
             }
         }
-
-        every {
-            mockActivity.intent
-        } returns Intent()
     }
 
     @Test
@@ -258,9 +252,11 @@ class BillingWrapperTest {
 
         val skuDetails = stubSkuDetails(productId = "product_a")
 
+        val activity: Activity = mockk()
+
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         wrapper.makePurchaseAsync(
-            mockActivity,
+            activity,
             appUserId,
             skuDetails.toStoreProduct(),
             mockReplaceSkuInfo(),
@@ -269,7 +265,7 @@ class BillingWrapperTest {
 
         verify {
             mockClient.launchBillingFlow(
-                eq(mockActivity),
+                eq(activity),
                 any()
             )
         }
@@ -309,11 +305,12 @@ class BillingWrapperTest {
         @BillingClient.SkuType val skuType = BillingClient.SkuType.SUBS
 
         val upgradeInfo = mockReplaceSkuInfo()
+        val activity: Activity = mockk()
         val skuDetails = stubSkuDetails(productId = sku, type = skuType)
 
         val slot = slot<BillingFlowParams>()
         every {
-            mockClient.launchBillingFlow(eq(mockActivity), capture(slot))
+            mockClient.launchBillingFlow(eq(activity), capture(slot))
         } answers {
             val capturedSkuDetails = skuDetailsSlot.captured
 
@@ -327,7 +324,7 @@ class BillingWrapperTest {
 
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         wrapper.makePurchaseAsync(
-            mockActivity,
+            activity,
             appUserId,
             skuDetails.toStoreProduct(),
             upgradeInfo,
@@ -340,7 +337,7 @@ class BillingWrapperTest {
         val mockBuilder = setUpForObfuscatedAccountIDTests()
 
         wrapper.makePurchaseAsync(
-            mockActivity,
+            mockk(),
             appUserId,
             stubSkuDetails(productId = "product_a").toStoreProduct(),
             null,
@@ -360,7 +357,7 @@ class BillingWrapperTest {
         val mockBuilder = setUpForObfuscatedAccountIDTests()
 
         wrapper.makePurchaseAsync(
-            mockActivity,
+            mockk(),
             appUserId,
             stubSkuDetails(productId = "product_a").toStoreProduct(),
             mockReplaceSkuInfo(),
@@ -382,10 +379,11 @@ class BillingWrapperTest {
 
         every { mockClient.isReady } returns false
 
+        val activity: Activity = mockk()
         val skuDetails = stubSkuDetails(productId = "product_a")
 
         wrapper.makePurchaseAsync(
-            mockActivity,
+            activity,
             appUserId,
             skuDetails.toStoreProduct(),
             mockReplaceSkuInfo(),
@@ -393,7 +391,7 @@ class BillingWrapperTest {
         )
 
         verify(exactly = 0) {
-            mockClient.launchBillingFlow(eq(mockActivity), any())
+            mockClient.launchBillingFlow(eq(activity), any())
         }
 
         every { mockClient.isReady } returns true
@@ -401,7 +399,7 @@ class BillingWrapperTest {
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
 
         verify(exactly = 1) {
-            mockClient.launchBillingFlow(eq(mockActivity), any())
+            mockClient.launchBillingFlow(eq(activity), any())
         }
     }
 
@@ -415,8 +413,10 @@ class BillingWrapperTest {
 
         val skuDetails = stubSkuDetails(productId = "product_a")
 
+        val activity: Activity = mockk()
+
         wrapper.makePurchaseAsync(
-            mockActivity,
+            activity,
             appUserId,
             skuDetails.toStoreProduct(),
             mockReplaceSkuInfo(),
@@ -809,9 +809,11 @@ class BillingWrapperTest {
 
         val skuDetails = stubSkuDetails(productId = "product_a")
 
+        val activity: Activity = mockk()
+
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         wrapper.makePurchaseAsync(
-            mockActivity,
+            activity,
             appUserId,
             skuDetails.toStoreProduct(),
             mockReplaceSkuInfo(),

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.google
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.os.Handler
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.AcknowledgePurchaseParams
@@ -80,6 +81,7 @@ class BillingWrapperTest {
 
     private val billingClientOKResult = BillingClient.BillingResponseCode.OK.buildResult()
     private val appUserId = "jerry"
+    private var mockActivity = mockk<Activity>()
 
     @Before
     fun setup() {
@@ -145,6 +147,10 @@ class BillingWrapperTest {
                 onConnectedCalled = true
             }
         }
+
+        every {
+            mockActivity.intent
+        } returns Intent()
     }
 
     @Test
@@ -252,11 +258,9 @@ class BillingWrapperTest {
 
         val skuDetails = stubSkuDetails(productId = "product_a")
 
-        val activity: Activity = mockk()
-
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         wrapper.makePurchaseAsync(
-            activity,
+            mockActivity,
             appUserId,
             skuDetails.toStoreProduct(),
             mockReplaceSkuInfo(),
@@ -265,7 +269,7 @@ class BillingWrapperTest {
 
         verify {
             mockClient.launchBillingFlow(
-                eq(activity),
+                eq(mockActivity),
                 any()
             )
         }
@@ -305,12 +309,11 @@ class BillingWrapperTest {
         @BillingClient.SkuType val skuType = BillingClient.SkuType.SUBS
 
         val upgradeInfo = mockReplaceSkuInfo()
-        val activity: Activity = mockk()
         val skuDetails = stubSkuDetails(productId = sku, type = skuType)
 
         val slot = slot<BillingFlowParams>()
         every {
-            mockClient.launchBillingFlow(eq(activity), capture(slot))
+            mockClient.launchBillingFlow(eq(mockActivity), capture(slot))
         } answers {
             val capturedSkuDetails = skuDetailsSlot.captured
 
@@ -324,7 +327,7 @@ class BillingWrapperTest {
 
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         wrapper.makePurchaseAsync(
-            activity,
+            mockActivity,
             appUserId,
             skuDetails.toStoreProduct(),
             upgradeInfo,
@@ -337,7 +340,7 @@ class BillingWrapperTest {
         val mockBuilder = setUpForObfuscatedAccountIDTests()
 
         wrapper.makePurchaseAsync(
-            mockk(),
+            mockActivity,
             appUserId,
             stubSkuDetails(productId = "product_a").toStoreProduct(),
             null,
@@ -357,7 +360,7 @@ class BillingWrapperTest {
         val mockBuilder = setUpForObfuscatedAccountIDTests()
 
         wrapper.makePurchaseAsync(
-            mockk(),
+            mockActivity,
             appUserId,
             stubSkuDetails(productId = "product_a").toStoreProduct(),
             mockReplaceSkuInfo(),
@@ -379,11 +382,10 @@ class BillingWrapperTest {
 
         every { mockClient.isReady } returns false
 
-        val activity: Activity = mockk()
         val skuDetails = stubSkuDetails(productId = "product_a")
 
         wrapper.makePurchaseAsync(
-            activity,
+            mockActivity,
             appUserId,
             skuDetails.toStoreProduct(),
             mockReplaceSkuInfo(),
@@ -391,7 +393,7 @@ class BillingWrapperTest {
         )
 
         verify(exactly = 0) {
-            mockClient.launchBillingFlow(eq(activity), any())
+            mockClient.launchBillingFlow(eq(mockActivity), any())
         }
 
         every { mockClient.isReady } returns true
@@ -399,7 +401,7 @@ class BillingWrapperTest {
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
 
         verify(exactly = 1) {
-            mockClient.launchBillingFlow(eq(activity), any())
+            mockClient.launchBillingFlow(eq(mockActivity), any())
         }
     }
 
@@ -413,10 +415,8 @@ class BillingWrapperTest {
 
         val skuDetails = stubSkuDetails(productId = "product_a")
 
-        val activity: Activity = mockk()
-
         wrapper.makePurchaseAsync(
-            activity,
+            mockActivity,
             appUserId,
             skuDetails.toStoreProduct(),
             mockReplaceSkuInfo(),
@@ -809,11 +809,9 @@ class BillingWrapperTest {
 
         val skuDetails = stubSkuDetails(productId = "product_a")
 
-        val activity: Activity = mockk()
-
         billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
         wrapper.makePurchaseAsync(
-            activity,
+            mockActivity,
             appUserId,
             skuDetails.toStoreProduct(),
             mockReplaceSkuInfo(),

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1642,6 +1642,39 @@ class BillingWrapperTest {
         assertThat(numCallbacks).isEqualTo(1)
     }
 
+    @Test
+    fun `test BillingClients launchBillingFlow activity never has null intent`() {
+        val slot = slot<Activity>()
+
+        mockkStatic(BillingFlowParams::class)
+        val mockBuilder = mockk<BillingFlowParams.Builder>(relaxed = true)
+        every {
+            BillingFlowParams.newBuilder()
+        } returns mockBuilder
+
+        every {
+            mockBuilder.setSkuDetails(any())
+        } returns mockBuilder
+
+        val params = mockk<BillingFlowParams>(relaxed = true)
+        every {
+            mockBuilder.build()
+        } returns params
+
+        every {
+            mockClient.launchBillingFlow(capture(slot), params)
+        } returns billingClientOKResult
+
+        val activityWithNullIntent = Activity().apply { intent = null }
+        wrapper.makePurchaseAsync(activityWithNullIntent,
+            "",
+            stubSkuDetails(productId = "product_a").toStoreProduct(),
+            null,
+            null)
+
+        assertThat(slot.captured.intent != null)
+    }
+
     private fun mockNullSkuDetailsResponse() {
         val slot = slot<SkuDetailsResponseListener>()
         every {

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1640,39 +1640,6 @@ class BillingWrapperTest {
         assertThat(numCallbacks).isEqualTo(1)
     }
 
-    @Test
-    fun `test BillingClients launchBillingFlow activity never has null intent`() {
-        val slot = slot<Activity>()
-
-        mockkStatic(BillingFlowParams::class)
-        val mockBuilder = mockk<BillingFlowParams.Builder>(relaxed = true)
-        every {
-            BillingFlowParams.newBuilder()
-        } returns mockBuilder
-
-        every {
-            mockBuilder.setSkuDetails(any())
-        } returns mockBuilder
-
-        val params = mockk<BillingFlowParams>(relaxed = true)
-        every {
-            mockBuilder.build()
-        } returns params
-
-        every {
-            mockClient.launchBillingFlow(capture(slot), params)
-        } returns billingClientOKResult
-
-        val activityWithNullIntent = Activity().apply { intent = null }
-        wrapper.makePurchaseAsync(activityWithNullIntent,
-            "",
-            stubSkuDetails(productId = "product_a").toStoreProduct(),
-            null,
-            null)
-
-        assertThat(slot.captured.intent != null)
-    }
-
     private fun mockNullSkuDetailsResponse() {
         val slot = slot<SkuDetailsResponseListener>()
         every {

--- a/strings/src/main/java/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -15,4 +15,6 @@ object BillingStrings {
         "PurchaseHistoryRecord, but only one will be used."
     const val BILLING_PURCHASE_MORE_THAN_ONE_SKU = "There's more than one sku in the PurchaseHistoryRecord, " +
         "but only one will be used."
+    const val NULL_ACTIVITY_INTENT = "Activity passed into launchBillingFlow has a null intent, which may cause " +
+        "a crash. See https://github.com/RevenueCat/purchases-android/issues/381 for more information."
 }

--- a/strings/src/main/java/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -15,7 +15,6 @@ object BillingStrings {
         "PurchaseHistoryRecord, but only one will be used."
     const val BILLING_PURCHASE_MORE_THAN_ONE_SKU = "There's more than one sku in the PurchaseHistoryRecord, " +
         "but only one will be used."
-    const val NULL_ACTIVITY_INTENT = "Activity passed into launchBillingFlow has a null intent. Setting a new " +
-        " intent to avoid crashing. See https://github.com/RevenueCat/purchases-android/issues/381 " +
-        "for more information."
+    const val NULL_ACTIVITY_INTENT = "Activity passed into launchBillingFlow has a null intent, which may cause " +
+        "a crash. See https://github.com/RevenueCat/purchases-android/issues/381 for more information."
 }

--- a/strings/src/main/java/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -15,6 +15,7 @@ object BillingStrings {
         "PurchaseHistoryRecord, but only one will be used."
     const val BILLING_PURCHASE_MORE_THAN_ONE_SKU = "There's more than one sku in the PurchaseHistoryRecord, " +
         "but only one will be used."
-    const val NULL_ACTIVITY_INTENT = "Activity passed into launchBillingFlow has a null intent, which may cause " +
-        "a crash. See https://github.com/RevenueCat/purchases-android/issues/381 for more information."
+    const val NULL_ACTIVITY_INTENT = "Activity passed into launchBillingFlow has a null intent. Setting a new " +
+        " intent to avoid crashing. See https://github.com/RevenueCat/purchases-android/issues/381 " +
+        "for more information."
 }


### PR DESCRIPTION
Fixes [sc-11657]

Related issues:
https://github.com/RevenueCat/purchases-android/issues/381
[community post](https://community.revenuecat.com/sdks-51/react-native-android-app-crash-after-purchase-1016?postid=3155#post3155)

BillingClient expects that the Activity passed into `launchBillingFlow` has a non-null intent. The fix is to detect a null intent and pass a new one in.

I'm unsure whether setting an empty intent could have unwanted side effects...maybe we want to only log here.