### PR TITLE
Remove isBillingSupported and isFeatureSupported

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -2076,6 +2076,8 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
                                             billingClient.endConnection()
                                             return@post
                                         }
+                                        // If billing is supported, IN-APP purchases are supported.
+
 
                                         var featureSupportedResultOk = features.all {
                                             billingClient.isFeatureSupported(it.playBillingClientName).isSuccessful()
@@ -2093,137 +2095,6 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
 
                             override fun onBillingServiceDisconnected() {
                                 val mainHandler = Handler(context.mainLooper)
-                                mainHandler.post {
-                                    try {
-                                        billingClient.endConnection()
-                                    } catch (e: IllegalArgumentException) {
-                                    } finally {
-                                        callback.onReceived(false)
-                                    }
-                                }
-                            }
-                        })
-                }
-        }
-
-        /**
-         * Note: This method only works for the Google Play Store. There is no Amazon equivalent at this time.
-         * Calling from an Amazon-configured app will return false.
-         *
-         * Check if billing is supported in the device. This method is asynchronous since it tries
-         * to connect the billing client and checks for the result of the connection.
-         * If billing is supported, IN-APP purchases are supported.
-         * If you want to check if SUBSCRIPTIONS or other type defined in [BillingClient.FeatureType],
-         * call [isFeatureSupported].
-         * @param context A context object that will be used to connect to the billing client
-         * @param callback Callback that will be notified when the check is complete.
-         */
-        @Deprecated(
-            message = "use canMakePayments instead",
-            replaceWith = ReplaceWith("canMakePayments(context, features, Callback<Boolean>)")
-        )
-        @JvmStatic
-        fun isBillingSupported(context: Context, callback: Callback<Boolean>) {
-            if (!checkMethodAvailability(
-                    listOf(Store.PLAY_STORE),
-                    "isBillingSupported",
-                    "Returning false.")) {
-                callback.onReceived(false)
-                return
-            }
-
-            BillingClient.newBuilder(context)
-                .enablePendingPurchases()
-                .setListener { _, _ -> }
-                .build()
-                .let { billingClient ->
-                    // BillingClient 4 calls the listener functions in a thread instead of in main
-                    // https://github.com/RevenueCat/purchases-android/issues/348
-                    val mainHandler = Handler(context.mainLooper)
-                    billingClient.startConnection(
-                        object : BillingClientStateListener {
-                            override fun onBillingSetupFinished(billingResult: BillingResult) {
-                                mainHandler.post {
-                                    // It also means that IN-APP items are supported for purchasing
-                                    try {
-                                        billingClient.endConnection()
-                                        val resultIsOK = billingResult.isSuccessful()
-                                        callback.onReceived(resultIsOK)
-                                    } catch (e: IllegalArgumentException) {
-                                        // Play Services not available
-                                        callback.onReceived(false)
-                                    }
-                                }
-                            }
-
-                            override fun onBillingServiceDisconnected() {
-                                mainHandler.post {
-                                    try {
-                                        billingClient.endConnection()
-                                    } catch (e: IllegalArgumentException) {
-                                    } finally {
-                                        callback.onReceived(false)
-                                    }
-                                }
-                            }
-                        })
-                }
-        }
-
-        /**
-         * Note: This method only works for the Google Play Store. There is no Amazon equivalent at this time.
-         * Calling from an Amazon-configured app will return false.
-         *
-         * Use this method if you want to check if Subscriptions or other type defined in
-         * [BillingClient.FeatureType] is supported.
-         * This method is asynchronous since it requires a connected billing client.
-         * @param feature A feature type to check for support. Must be one of [BillingClient.FeatureType]
-         * @param context A context object that will be used to connect to the billing client
-         * @param callback Callback that will be notified when the check is complete.
-         */
-        @Deprecated(
-            message = "use canMakePayments instead",
-            replaceWith = ReplaceWith("canMakePayments(context, features, Callback<Boolean>)")
-        )
-        @JvmStatic
-        fun isFeatureSupported(
-            @BillingClient.FeatureType feature: String,
-            context: Context,
-            callback: Callback<Boolean>
-        ) {
-            if (!checkMethodAvailability(
-                    listOf(Store.PLAY_STORE),
-                    "isFeatureSupported",
-                    "Returning false.")) {
-                callback.onReceived(false)
-                return
-            }
-
-            BillingClient.newBuilder(context)
-                .enablePendingPurchases()
-                .setListener { _, _ -> }
-                .build()
-                .let { billingClient ->
-                    // BillingClient 4 calls the listener functions in a thread instead of in main
-                    // https://github.com/RevenueCat/purchases-android/issues/348
-                    val mainHandler = Handler(context.mainLooper)
-                    billingClient.startConnection(
-                        object : BillingClientStateListener {
-                            override fun onBillingSetupFinished(billingResult: BillingResult) {
-                                mainHandler.post {
-                                    try {
-                                        val featureSupportedResult = billingClient.isFeatureSupported(feature)
-                                        billingClient.endConnection()
-                                        val responseIsOK = featureSupportedResult.isSuccessful()
-                                        callback.onReceived(responseIsOK)
-                                    } catch (e: IllegalArgumentException) {
-                                        // Play Services not available
-                                        callback.onReceived(false)
-                                    }
-                                }
-                            }
-
-                            override fun onBillingServiceDisconnected() {
                                 mainHandler.post {
                                     try {
                                         billingClient.endConnection()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -2077,8 +2077,6 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
                                             return@post
                                         }
                                         // If billing is supported, IN-APP purchases are supported.
-
-
                                         var featureSupportedResultOk = features.all {
                                             billingClient.isFeatureSupported(it.playBillingClientName).isSuccessful()
                                         }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -31,11 +31,12 @@ import com.revenuecat.purchases.common.buildCustomerInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
 import com.revenuecat.purchases.common.sha1
+import com.revenuecat.purchases.google.sku
 import com.revenuecat.purchases.google.toSKUType
 import com.revenuecat.purchases.google.toStoreProduct
 import com.revenuecat.purchases.google.toStoreTransaction
 import com.revenuecat.purchases.identity.IdentityManager
-import com.revenuecat.purchases.interfaces.Callback
+import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -1943,7 +1943,7 @@ class PurchasesTest {
         var receivedCanMakePayments = true
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
 
-        val listener = setUpBillingClientAndGetListener(mockLocalBillingClient)
+        val listener = setUpMockBillingClientBuilderAndListener(mockLocalBillingClient)
 
         Purchases.canMakePayments(mockContext, listOf()) {
             receivedCanMakePayments = it
@@ -1957,7 +1957,7 @@ class PurchasesTest {
     fun `canMakePayments with no features and OK BillingResponse returns true`() {
         var receivedCanMakePayments = false
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
-        val listener = setUpBillingClientAndGetListener(mockLocalBillingClient)
+        val listener = setUpMockBillingClientBuilderAndListener(mockLocalBillingClient)
 
         Purchases.canMakePayments(mockContext, listOf()) {
             receivedCanMakePayments = it
@@ -1972,7 +1972,7 @@ class PurchasesTest {
     fun `when no play services, canMakePayments returns false`() {
         var receivedCanMakePayments = true
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
-        val listener = setUpBillingClientAndGetListener(mockLocalBillingClient)
+        val listener = setUpMockBillingClientBuilderAndListener(mockLocalBillingClient)
 
         every { mockLocalBillingClient.endConnection() } throws mockk<IllegalArgumentException>()
         Purchases.canMakePayments(mockContext, listOf(BillingFeature.SUBSCRIPTIONS)) {
@@ -2003,7 +2003,13 @@ class PurchasesTest {
     }
 
     fun `canMakePayments returns false for Amazon configurations`() {
-        purchases.appConfig = AppConfig(mockContext, false, PlatformInfo("", null), null, Store.AMAZON)
+        purchases.appConfig = AppConfig(
+            mockContext,
+            false,
+            PlatformInfo("", null),
+            null,
+            Store.AMAZON
+        )
         Purchases.canMakePayments(mockContext, listOf()) {
             assertThat(it).isFalse()
         }
@@ -2013,7 +2019,7 @@ class PurchasesTest {
     fun `when billing is not supported, canMakePayments is false`() {
         var receivedCanMakePayments = true
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
-        val listener = setUpBillingClientAndGetListener(mockLocalBillingClient)
+        val listener = setUpMockBillingClientBuilderAndListener(mockLocalBillingClient)
 
         every {
             mockLocalBillingClient.isFeatureSupported(BillingClient.FeatureType.SUBSCRIPTIONS)
@@ -2035,7 +2041,7 @@ class PurchasesTest {
     fun `when feature is not supported, canMakePayments is false`() {
         var receivedCanMakePayments = true
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
-        val listener = setUpBillingClientAndGetListener(mockLocalBillingClient)
+        val listener = setUpMockBillingClientBuilderAndListener(mockLocalBillingClient)
 
         every {
             mockLocalBillingClient.isFeatureSupported(BillingClient.FeatureType.SUBSCRIPTIONS)
@@ -2055,7 +2061,7 @@ class PurchasesTest {
     fun `when one feature in list is not supported, canMakePayments is false`() {
         var receivedCanMakePayments = true
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
-        val listener = setUpBillingClientAndGetListener(mockLocalBillingClient)
+        val listener = setUpMockBillingClientBuilderAndListener(mockLocalBillingClient)
 
         every {
             mockLocalBillingClient.isFeatureSupported(BillingClient.FeatureType.SUBSCRIPTIONS)
@@ -2080,10 +2086,10 @@ class PurchasesTest {
     }
 
     @Test
-    fun `when feature is supported and billing is supported, canMakePayments is true`() {
+    fun `when single feature is supported and billing is supported, canMakePayments is true`() {
         var receivedCanMakePayments = false
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
-        val listener = setUpBillingClientAndGetListener(mockLocalBillingClient)
+        val listener = setUpMockBillingClientBuilderAndListener(mockLocalBillingClient)
 
         every {
             mockLocalBillingClient.isFeatureSupported(BillingClient.FeatureType.SUBSCRIPTIONS)
@@ -2103,7 +2109,7 @@ class PurchasesTest {
     @Test
     fun `when feature list is empty, canMakePayments does not check billing client for feature support`() {
         val mockLocalBillingClient = mockk<BillingClient>(relaxed = true)
-        val listener = setUpBillingClientAndGetListener(mockLocalBillingClient)
+        val listener = setUpMockBillingClientBuilderAndListener(mockLocalBillingClient)
 
         Purchases.canMakePayments(mockContext, listOf()) {}
 
@@ -4034,7 +4040,7 @@ class PurchasesTest {
         return oldPurchase
     }
 
-    private fun setUpBillingClientAndGetListener(
+    private fun setUpMockBillingClientBuilderAndListener(
         mockLocalBillingClient: BillingClient
     ): CapturingSlot<BillingClientStateListener> {
         mockkStatic(BillingClient::class)


### PR DESCRIPTION
[sc-12368]

isBillingSupported & isFeatureSupported have been deprecated for ~8 months, so this upcoming major feels like a good time to fully remove them.

I repurposed a couple of their tests for canMakePayments to use.