### PR TITLE
Prevents uploading api-tester to maven

### DIFF
--- a/api-tester/build.gradle
+++ b/api-tester/build.gradle
@@ -1,4 +1,37 @@
-apply from: "$rootProject.projectDir/library.gradle"
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
+
+android {
+    compileSdkVersion compileVersion
+    buildToolsVersion buildToolsVersion
+
+    defaultConfig {
+        minSdkVersion minVersion
+        targetSdkVersion compileVersion
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles "consumer-rules.pro"
+    }
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+        main.java.srcDirs += 'src/main/java'
+        test.java.srcDirs += 'src/test/java'
+    }
+    testOptions {
+        unitTests.includeAndroidResources = true
+        unitTests.all {
+            maxHeapSize = "1024m"
+        }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}
 
 dependencies {
     implementation project(path: ':public')

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     ext.kotlinVersion = "1.4.10"
     ext.compileVersion = 28
+    ext.buildToolsVersion = "30.0.3"
     ext.minVersion = 14
     ext.billingVersion = "4.0.0"
     ext.lifecycleVersion = "2.3.0-rc01"

--- a/library.gradle
+++ b/library.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion compileVersion
-    buildToolsVersion "30.0.3"
+    buildToolsVersion buildToolsVersion
 
     defaultConfig {
         minSdkVersion minVersion


### PR DESCRIPTION
We were uploading the api-tester module to sonatype because the publishing plugin was being applied via `library.gradle`