### PR TITLE
Creates a base-application.gradle 

### DIFF
--- a/api-tester/build.gradle
+++ b/api-tester/build.gradle
@@ -1,18 +1,6 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply from: "$rootProject.projectDir/base-application.gradle"
 
 android {
-    compileSdkVersion compileVersion
-    buildToolsVersion buildToolsVersion
-
-    defaultConfig {
-        minSdkVersion minVersion
-        targetSdkVersion compileVersion
-
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles "consumer-rules.pro"
-    }
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
         main.java.srcDirs += 'src/main/java'
@@ -23,13 +11,6 @@ android {
         unitTests.all {
             maxHeapSize = "1024m"
         }
-    }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = '1.8'
     }
 }
 

--- a/base-application.gradle
+++ b/base-application.gradle
@@ -1,0 +1,28 @@
+apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
+
+android {
+    compileSdkVersion compileVersion
+    buildToolsVersion buildToolsVersion
+
+    defaultConfig {
+        minSdkVersion minVersion
+        targetSdkVersion compileVersion
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+}

--- a/examples/MagicWeather/app/build.gradle
+++ b/examples/MagicWeather/app/build.gradle
@@ -4,7 +4,6 @@ android {
     defaultConfig {
         applicationId "com.revenuecat.purchases_sample"
         minSdkVersion 26
-        targetSdkVersion compileVersion
         versionCode 1
         versionName "1.0"
     }

--- a/examples/MagicWeather/app/build.gradle
+++ b/examples/MagicWeather/app/build.gradle
@@ -1,20 +1,12 @@
-plugins {
-    id 'com.android.application'
-    id 'kotlin-android'
-}
+apply from: "$rootProject.projectDir/base-application.gradle"
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "30.0.3"
-
     defaultConfig {
         applicationId "com.revenuecat.purchases_sample"
         minSdkVersion 26
-        targetSdkVersion 29
+        targetSdkVersion compileVersion
         versionCode 1
         versionName "1.0"
-
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -22,13 +14,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
-    }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = '1.8'
     }
 }
 

--- a/examples/purchase-tester-java/build.gradle
+++ b/examples/purchase-tester-java/build.gradle
@@ -1,16 +1,12 @@
+apply from: "$rootProject.projectDir/base-application.gradle"
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion compileVersion
-
     defaultConfig {
         applicationId "com.revenuecat.purchases_sample"
-        minSdkVersion minVersion
-        targetSdkVersion compileVersion
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }
 
@@ -24,7 +20,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(path: ':purchases')
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'

--- a/examples/purchase-tester/build.gradle
+++ b/examples/purchase-tester/build.gradle
@@ -1,6 +1,5 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply from: "$rootProject.projectDir/base-application.gradle"
+
 apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 buildscript {
@@ -15,8 +14,6 @@ buildscript {
 
 
 android {
-    compileSdkVersion compileVersion
-
     buildFeatures {
         dataBinding true
     }
@@ -24,10 +21,8 @@ android {
     defaultConfig {
         applicationId "com.revenuecat.purchase_tester"
         minSdkVersion 21
-        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }
     signingConfigs {
@@ -47,14 +42,6 @@ android {
         }
     }
     testBuildType obtainTestBuildType()
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
 }
 
 def obtainTestBuildType() {
@@ -72,7 +59,6 @@ repositories {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(path: ':purchases')
     implementation project(path: ':feature:amazon')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -1,16 +1,9 @@
-plugins {
-    id 'com.android.application'
-    id 'kotlin-android'
-}
+apply from: "$rootProject.projectDir/base-application.gradle"
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
-
     defaultConfig {
         applicationId "com.revenuecat.purchases.integrationtests"
         minSdkVersion 16
-        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 
@@ -33,13 +26,6 @@ android {
         }
     }
     testBuildType obtainTestBuildType()
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
 }
 
 dependencies {


### PR DESCRIPTION
Created a `base-application.gradle` to remove duplicated configuration in the applications we have in the repository.

Suggested by @NachoSoto in https://github.com/RevenueCat/purchases-android/pull/445#discussion_r785022898