### PR TITLE
Fix length check for logging multi-line subs

### DIFF
--- a/feature/google/src/main/java/com/revenuecat/purchases/google/purchaseExtensions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/purchaseExtensions.kt
@@ -13,7 +13,7 @@ import com.revenuecat.purchases.strings.BillingStrings
  */
 val PurchaseHistoryRecord.sku: String
     get() = skus[0].also {
-        if (skus.size > 0) {
+        if (skus.size > 1) {
             log(LogIntent.GOOGLE_WARNING, BillingStrings.BILLING_PURCHASE_HISTORY_RECORD_MORE_THAN_ONE_SKU)
         }
     }
@@ -25,7 +25,7 @@ val PurchaseHistoryRecord.sku: String
  */
 val Purchase.sku: String
     get() = skus[0].also {
-        if (skus.size > 0) {
+        if (skus.size > 1) {
             log(LogIntent.GOOGLE_WARNING, BillingStrings.BILLING_PURCHASE_MORE_THAN_ONE_SKU)
         }
     }


### PR DESCRIPTION
I noticed we are logging about more than one sku being returned when there's only one. Looks like the length check was off by 1.