### PR TITLE
Revert magicweather base-application.gradle changes

### DIFF
--- a/examples/MagicWeather/app/build.gradle
+++ b/examples/MagicWeather/app/build.gradle
@@ -1,11 +1,20 @@
-apply from: "$rootProject.projectDir/base-application.gradle"
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
 
 android {
+    compileSdkVersion 29
+    buildToolsVersion "30.0.3"
+
     defaultConfig {
         applicationId "com.revenuecat.purchases_sample"
         minSdkVersion 26
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -13,6 +22,13 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
     }
 }
 


### PR DESCRIPTION
In this PR https://github.com/RevenueCat/purchases-android/pull/448 I added a `base-application.gradle` to use as base for all Apps inside the repo. It turns out I broke MagicWeather since MagicWeather is its own project and `rootProject.projectDir` is the root of MagicWeather and not the root of the repository.

I am not sure if it's possible to reference to `base-application.gradle` (maybe using a `../../` path), but I actually thing that since we want MagicWeather to be an isolated sample app, we shouldn't reference anything relatively.