### PR TITLE
Update doc link to use rev.cat

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -599,7 +599,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * Invalidates the cache for customer information.
      *
      * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
-     * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
+     * Refer to https://rev.cat/customer-info-cache for more information on
      * using the cache properly.
      *
      * This is useful for cases where purchaser information might have been updated outside of the


### PR DESCRIPTION
Uses a rev.cat link for the customer info cache docs.