### PR TITLE
Fix "continue as random user" purchase tester button

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/Constants.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/Constants.kt
@@ -2,4 +2,5 @@ package com.revenuecat.purchasetester
 
 const val JSON_FORMATTER_INDENT_SPACES = 4
 const val ANIMATION_HALF_ROTATION_DEGREES = 180f
-const val API_KEY = "api_key"
+const val GOOGLE_API_KEY = ""
+const val AMAZON_API_KEY = ""

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/Constants.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/Constants.kt
@@ -2,3 +2,4 @@ package com.revenuecat.purchasetester
 
 const val JSON_FORMATTER_INDENT_SPACES = 4
 const val ANIMATION_HALF_ROTATION_DEGREES = 180f
+const val API_KEY = "api_key"

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LoginFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LoginFragment.kt
@@ -30,10 +30,14 @@ class LoginFragment : Fragment() {
         }
 
         binding.anonymousUserButton.setOnClickListener {
-            Purchases.sharedInstance.logOutWith(
-                { error -> showUserError(requireActivity(), error) },
-                { advanceToOverviewFragment() }
-            )
+            if (Purchases.sharedInstance.isAnonymous) {
+                advanceToOverviewFragment()
+            } else {
+                Purchases.sharedInstance.logOutWith(
+                    { error -> showUserError(requireActivity(), error) },
+                    { advanceToOverviewFragment() }
+                )
+            }
         }
 
         return binding.root

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
@@ -13,6 +13,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.amazon.AmazonConfiguration
+import java.lang.IllegalArgumentException
 
 class MainApplication : Application() {
 
@@ -26,7 +28,16 @@ class MainApplication : Application() {
                 .build()
         )
         Purchases.debugLogsEnabled = true
-        Purchases.configure(PurchasesConfiguration.Builder(this, API_KEY).build())
+
+        val purchasesConfigurationBuilder =
+            when {
+                GOOGLE_API_KEY.isNotEmpty() -> PurchasesConfiguration.Builder(this, GOOGLE_API_KEY)
+                AMAZON_API_KEY.isNotEmpty() -> AmazonConfiguration.Builder(this, AMAZON_API_KEY)
+                else -> {
+                    throw IllegalArgumentException("Set at least one API key in Constants.")
+                }
+            }
+        Purchases.configure(purchasesConfigurationBuilder.build())
         // set attributes to store additional, structured information for a user in RevenueCat.
         // More info: https://docs.revenuecat.com/docs/user-attributes
         Purchases.sharedInstance.setAttributes(mapOf("favorite_cat" to "garfield"))

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
@@ -2,9 +2,13 @@ package com.revenuecat.purchasetester
 
 import android.app.Activity
 import android.app.Application
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.os.StrictMode
 import android.os.StrictMode.VmPolicy
 import android.util.Log
+import androidx.core.content.ContextCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
@@ -22,7 +26,7 @@ class MainApplication : Application() {
                 .build()
         )
         Purchases.debugLogsEnabled = true
-        Purchases.configure(PurchasesConfiguration.Builder(this, "api_key").build())
+        Purchases.configure(PurchasesConfiguration.Builder(this, API_KEY).build())
         // set attributes to store additional, structured information for a user in RevenueCat.
         // More info: https://docs.revenuecat.com/docs/user-attributes
         Purchases.sharedInstance.setAttributes(mapOf("favorite_cat" to "garfield"))
@@ -42,4 +46,10 @@ fun showUserError(activity: Activity, error: PurchasesError) {
         .setMessage(error.message)
         .setPositiveButton("OK") { dialog, _ -> dialog.dismiss() }
         .show()
+}
+
+fun copyToClipboard(context: Context, label: String, text: String) {
+    val clipboard = ContextCompat.getSystemService(context, ClipboardManager::class.java)
+    val clip = ClipData.newPlainText(label, text)
+    clipboard?.primaryClip = clip
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -1,13 +1,10 @@
 package com.revenuecat.purchasetester
 
-import android.content.ClipData
-import android.content.ClipboardManager
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat.getSystemService
 import androidx.core.view.doOnPreDraw
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.FragmentNavigatorExtras
@@ -18,8 +15,8 @@ import com.revenuecat.purchases.EntitlementInfo
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Purchases
-import com.revenuecat.purchases.getOfferingsWith
 import com.revenuecat.purchases.getCustomerInfoWith
+import com.revenuecat.purchases.getOfferingsWith
 import com.revenuecat.purchases.logOutWith
 import com.revenuecat.purchasetester.databinding.FragmentOverviewBinding
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -46,10 +46,14 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
         }
 
         binding.customerInfoLogoutButton.setOnClickListener {
-            Purchases.sharedInstance.logOutWith(
-                { error -> showUserError(requireActivity(), error) },
-                { findNavController().navigateUp() }
-            )
+            if (Purchases.sharedInstance.isAnonymous) {
+                findNavController().navigateUp()
+            } else {
+                Purchases.sharedInstance.logOutWith(
+                    { error -> showUserError(requireActivity(), error) },
+                    { findNavController().navigateUp() }
+                )
+            }
         }
 
         return binding.root
@@ -65,12 +69,10 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
                 customerInfo = info
 
                 customerInfoCopyUserIdButton.setOnClickListener {
-                    val clipboard = getSystemService(requireContext(), ClipboardManager::class.java)
-                    val clip = ClipData.newPlainText("RevenueCat userId", info.originalAppUserId)
-                    clipboard?.primaryClip = clip
+                    copyToClipboard(requireContext(), "RevenueCat userId", info.originalAppUserId)
                 }
 
-                customerInfoJsonObject.detail = info.jsonObject.toString(JSON_FORMATTER_INDENT_SPACES)
+                customerInfoJsonObject.detail = info.rawData.toString(JSON_FORMATTER_INDENT_SPACES)
 
                 customerInfoActiveEntitlements.detail = formatEntitlements(info.entitlements.active.values)
                 customerInfoAllEntitlements.detail = formatEntitlements(info.entitlements.all.values)

--- a/examples/purchase-tester/src/main/res/layout/fragment_login.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_login.xml
@@ -56,7 +56,7 @@
                 android:id="@+id/anonymous_user_button"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Continue as new random user"
+                android:text="Continue as random user"
                 app:layout_constraintTop_toBottomOf="@+id/login_button"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent" />


### PR DESCRIPTION
[sc-12862]

Fixes the "continue as random user" button in purchase tester -- previously we'd get an error for logging out from anonymous user.

Also:
* pulled API keys into constants and throw exception if no API key set 
* pull out copyToClipboard method for reuse
