### PR TITLE
Add Amazon + example configuration to MagicWeather

### DIFF
--- a/examples/MagicWeather/app/build.gradle
+++ b/examples/MagicWeather/app/build.gradle
@@ -23,6 +23,20 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    flavorDimensions "store"
+    productFlavors {
+        amazon {
+            dimension "store"
+            buildConfigField "String", "STORE", "\"amazon\""
+        }
+
+        google {
+            dimension "store"
+            buildConfigField "String", "STORE", "\"google\""
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -30,10 +44,12 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+
 }
 
 dependencies {
     implementation 'com.revenuecat.purchases:purchases:5.0.0-rc1'
+    implementation 'com.revenuecat.purchases:purchases-store-amazon:5.0.0-rc1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/MainApplication.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/MainApplication.kt
@@ -26,16 +26,15 @@ class MainApplication : Application() {
         */
         val builder = when (BuildConfig.STORE) {
             "amazon" -> AmazonConfiguration.Builder(this, Constants.AMAZON_API_KEY)
-                .observerMode(false)
-                .appUserID(null)
             "google" -> PurchasesConfiguration.Builder(this, Constants.GOOGLE_API_KEY)
+            else -> throw IllegalArgumentException("Invalid store.")
+        }
+        Purchases.configure(
+            builder
                 .observerMode(false)
                 .appUserID(null)
-            else -> {
-                throw IllegalArgumentException("Invalid store.")
-            }
-        }
-        Purchases.configure(builder.build())
+                .build()
+        )
 
         /*
         Whenever the `sharedInstance` of Purchases updates the CustomerInfo cache, this method will be called.

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/MainApplication.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/MainApplication.kt
@@ -6,6 +6,8 @@ import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.sample.data.Constants
 import com.revenuecat.sample.ui.user.UserViewModel
+import com.revenuecat.purchases.amazon.AmazonConfiguration
+import java.lang.IllegalArgumentException
 
 class MainApplication : Application() {
     override fun onCreate() {
@@ -22,9 +24,17 @@ class MainApplication : Application() {
         - appUserID is nil, so an anonymous ID will be generated automatically by the Purchases SDK. Read more about Identifying Users here: https://docs.revenuecat.com/docs/user-ids
         - observerMode is false, so Purchases will automatically handle finishing transactions. Read more about Observer Mode here: https://docs.revenuecat.com/docs/observer-mode
         */
-        val builder = PurchasesConfiguration.Builder(this, Constants.API_KEY)
-            .appUserID(null)
-            .observerMode(false)
+        val builder = when (BuildConfig.STORE) {
+            "amazon" -> AmazonConfiguration.Builder(this, Constants.AMAZON_API_KEY)
+                .observerMode(false)
+                .appUserID(null)
+            "google" -> PurchasesConfiguration.Builder(this, Constants.GOOGLE_API_KEY)
+                .observerMode(false)
+                .appUserID(null)
+            else -> {
+                throw IllegalArgumentException("Invalid store.")
+            }
+        }
         Purchases.configure(builder.build())
 
         /*

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/data/Constants.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/data/Constants.kt
@@ -2,11 +2,20 @@ package com.revenuecat.sample.data
 
 object Constants {
     /*
-     The API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
+     The API key for your Google Play app. This can be found in via Project Settings > API keys >
+     App specific keys in the RevenueCat dashboard.
 
-     Modify this property to reflect your app's API key, then comment this line out.
+     Modify this property to reflect your Google Play app's API key.
     */
-    const val API_KEY = "api_key"
+    const val GOOGLE_API_KEY = "googl_api_key"
+
+    /*
+    The API key for your Amazon App Store app. This can be found in via Project Settings >
+    API keys > App specific keys in the RevenueCat dashboard.
+
+    Modify this property to reflect your Amazon App Store app's API key.
+    */
+    const val AMAZON_API_KEY = "amzn_api_key"
 
     /*
      The entitlement ID from the RevenueCat dashboard that is activated upon successful in-app purchase for the duration of the purchase.


### PR DESCRIPTION
Update our MagicWeather app to follow best practices for Amazon as outlined in our [docs](https://docs.revenuecat.com/docs/configuring-sdk#initialization)
