### PR TITLE
Skip registering listener in amazon observer mode

### DIFF
--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -10,6 +10,7 @@ import com.amazon.device.iap.model.PurchaseUpdatesResponse
 import com.amazon.device.iap.model.Receipt
 import com.amazon.device.iap.model.UserData
 import com.amazon.device.iap.model.UserDataResponse
+import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCallback
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -65,7 +66,12 @@ internal class AmazonBilling constructor(
     var connected = false
 
     override fun startConnection() {
-        purchasingServiceProvider.registerListener(applicationContext, this)
+        if (!Purchases.sharedInstance.observerMode) {
+            purchasingServiceProvider.registerListener(applicationContext, this)
+        } else {
+            LogIntent.AMAZON_ERROR(AmazonStrings.ERROR_OBSERVER_MODE_NOT_SUPPORTED)
+        }
+
         connected = true
     }
 

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
@@ -32,4 +32,7 @@ object AmazonStrings {
         "Failed to get user data. Call is not supported."
     const val ERROR_USER_DATA_STORE_PROBLEM =
         "Failed to get user data. There was an Amazon store problem."
+    const val ERROR_OBSERVER_MODE_NOT_SUPPORTED =
+        "Attempting to connect to Amazon App Store with an Amazon Purchases configuration in observer mode, " +
+            "but observer mode is not yet supported. Skipping registering the purchases listener."
 }

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -6,6 +6,7 @@ import com.amazon.device.iap.model.FulfillmentResult
 import com.amazon.device.iap.model.ProductType
 import com.amazon.device.iap.model.Receipt
 import com.amazon.device.iap.model.UserData
+import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.amazon.handler.ProductDataHandler
@@ -596,6 +597,21 @@ class AmazonBillingTest {
             dummyUserData,
             RevenueCatPurchaseState.PURCHASED
         )
+    }
+
+    @Test
+    fun `if observerMode, registerListener not called`() {
+        verify(exactly = 0) {
+            mockPurchasingServiceProvider.registerListener(any(), any())
+        }
+    }
+
+    @Test
+    fun `if not observerMode, registerListener called`() {
+
+        verify(exactly = 1) {
+            mockPurchasingServiceProvider.registerListener(any(), any())
+        }
     }
 
     private fun verifyBackendCalled(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -140,6 +140,12 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         }
 
     /**
+     * Exposes the observerMode configuration option
+     */
+    val observerMode: Boolean
+        @Synchronized get() = !appConfig.finishTransactions
+
+    /**
      * The passed in or generated app user ID
      */
     val appUserID: String


### PR DESCRIPTION
First step of our workaround for Amazon observer mode. Avoid registering a listener when in observerMode, because Amazon does not support registering two listeners, and we want the user's listener to be triggered.

Next step is to provide another method for syncingPurchases in Amazon observer mode...meaning the error log here is temporary.

[sc-12917]