### PR TITLE
Fix integration tests

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -1,6 +1,7 @@
 apply from: "$rootProject.projectDir/base-application.gradle"
 
 android {
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.revenuecat.purchases.integrationtests"
         minSdkVersion 16

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -5,6 +5,7 @@ android {
     defaultConfig {
         applicationId "com.revenuecat.purchases.integrationtests"
         minSdkVersion 16
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
Integration tests are failing, appears to be due to our downgrading the compileSdkVersion. We should eventually update everything to compileSdk 30, but that would require more testing