### PR TITLE
Skip registering listener in Amazon observer mode - billing client 3

### DIFF
--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
@@ -32,4 +32,7 @@ object AmazonStrings {
         "Failed to get user data. Call is not supported."
     const val ERROR_USER_DATA_STORE_PROBLEM =
         "Failed to get user data. There was an Amazon store problem."
+    const val ERROR_OBSERVER_MODE_NOT_SUPPORTED =
+        "Attempting to interact with Amazon App Store with an Amazon Purchases configuration in observer mode, " +
+            "but observer mode is not yet supported."
 }

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -57,6 +57,7 @@ class AmazonBillingTest {
             applicationContext = mockContext,
             amazonBackend = mockAmazonBackend,
             cache = mockCache,
+            observerMode = false,
             purchasingServiceProvider = mockPurchasingServiceProvider,
             productDataHandler = mockProductDataHandler,
             purchaseHandler = mockPurchaseHandler,
@@ -595,6 +596,45 @@ class AmazonBillingTest {
             sku,
             dummyUserData,
             RevenueCatPurchaseState.PURCHASED
+        )
+    }
+
+    @Test
+    fun `if observerMode, registerListener not called`() {
+        observerModeSetup()
+        every {
+            mockPurchasingServiceProvider.registerListener(mockContext, any())
+        } just Runs
+
+        underTest.startConnection()
+        verify(exactly = 0) {
+            mockPurchasingServiceProvider.registerListener(any(), any())
+        }
+    }
+
+    @Test
+    fun `if not observerMode, registerListener called`() {
+        every {
+            mockPurchasingServiceProvider.registerListener(mockContext, any())
+        } just Runs
+
+        underTest.startConnection()
+        verify(exactly = 1) {
+            mockPurchasingServiceProvider.registerListener(any(), any())
+        }
+    }
+
+    private fun observerModeSetup() {
+        underTest = AmazonBilling(
+            applicationContext = mockContext,
+            amazonBackend = mockAmazonBackend,
+            cache = mockCache,
+            observerMode = true,
+            purchasingServiceProvider = mockPurchasingServiceProvider,
+            productDataHandler = mockProductDataHandler,
+            purchaseHandler = mockPurchaseHandler,
+            purchaseUpdatesHandler = mockPurchaseUpdatesHandler,
+            userDataHandler = mockUserDataHandler
         )
     }
 

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
@@ -19,6 +19,6 @@ class BillingFactoryAmazonTest {
         val mockBackend = mockk<Backend>(relaxed = true)
         val mockCache = mockk<DeviceCache>(relaxed = true)
 
-        BillingFactory.createBilling(Store.AMAZON, mockApplication, mockBackend, mockCache)
+        BillingFactory.createBilling(Store.AMAZON, mockApplication, mockBackend, mockCache, false)
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
@@ -17,7 +17,8 @@ object BillingFactory {
         store: Store,
         application: Application,
         backend: Backend,
-        cache: DeviceCache
+        cache: DeviceCache,
+        observerMode: Boolean
     ) = when (store) {
         Store.PLAY_STORE -> BillingWrapper(
             BillingWrapper.ClientFactory(application),
@@ -27,8 +28,11 @@ object BillingFactory {
         Store.AMAZON -> {
             try {
                 Class.forName("com.revenuecat.purchases.amazon.AmazonBilling")
-                    .getConstructor(Context::class.java, Backend::class.java, DeviceCache::class.java)
-                    .newInstance(application.applicationContext, backend, cache) as BillingAbstract
+                    .getConstructor(Context::class.java,
+                        Backend::class.java,
+                        DeviceCache::class.java,
+                        Boolean::class.java
+                    ).newInstance(application.applicationContext, backend, cache, observerMode) as BillingAbstract
             } catch (e: ClassNotFoundException) {
                 errorLog("Make sure purchases-amazon is added as dependency")
                 throw e

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1841,7 +1841,13 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
 
                 val cache = DeviceCache(prefs, apiKey)
 
-                val billing: BillingAbstract = BillingFactory.createBilling(store, application, backend, cache)
+                val billing: BillingAbstract = BillingFactory.createBilling(
+                    store,
+                    application,
+                    backend,
+                    cache,
+                    observerMode
+                )
 
                 val subscriberAttributesCache = SubscriberAttributesCache(cache)
                 val attributionFetcher = AttributionFetcher(dispatcher)

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
@@ -17,7 +17,7 @@ class BillingFactoryTest {
         val mockBackend = mockk<Backend>(relaxed = true)
         val mockCache = mockk<DeviceCache>(relaxed = true)
 
-        BillingFactory.createBilling(Store.PLAY_STORE, mockApplication, mockBackend, mockCache)
+        BillingFactory.createBilling(Store.PLAY_STORE, mockApplication, mockBackend, mockCache, false)
     }
 
 }


### PR DESCRIPTION
same as https://github.com/RevenueCat/purchases-android/pull/469, but for billing-client-3