### PR TITLE
Fix integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,8 +339,7 @@ workflows:
 
   integration-test:
     jobs:
-#      - integration-tests-build: *release-tags-and-branches
-      - integration-tests-build
+      - integration-tests-build: *release-tags-and-branches
       - run-firebase-tests-latest-dependencies:
           requires:
             - integration-tests-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,11 +265,13 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - integration-tests/build/outputs/apk/release/integration-tests-release.apk
-            - integration-tests/build/outputs/apk/androidTest/release/integration-tests-release-androidTest.apk
+            - integration-tests/build/outputs/apk/latestDependencies/release/integration-tests-latestDependencies-release.apk
+            - integration-tests/build/outputs/apk/unityIAP/release/integration-tests-unityIAP-release.apk
+            - integration-tests/build/outputs/apk/androidTest/latestDependencies/release/integration-tests-latestDependencies-release-androidTest.apk
+            - integration-tests/build/outputs/apk/androidTest/unityIAP/release/integration-tests-unityIAP-release-androidTest.apk
 
-  run-firebase-tests:
-    description: "Run integration tests for Android in Firebase"
+  run-firebase-tests-latest-dependencies:
+    description: "Run integration tests for Android in Firebase. Variant latestDependencies"
     executor: gcp-cli/google
     steps:
       - checkout
@@ -283,8 +285,38 @@ jobs:
           name: Test with Firebase Test Lab
           command: >
             gcloud firebase test android run --type instrumentation \
-              --app integration-tests/build/outputs/apk/release/integration-tests-release.apk \
-              --test integration-tests/build/outputs/apk/androidTest/release/integration-tests-release-androidTest.apk \
+              --app integration-tests/build/outputs/apk/latestDependencies/release/integration-tests-latestDependencies-release.apk \
+              --test integration-tests/build/outputs/apk/androidTest/latestDependencies/release/integration-tests-latestDependencies-release-androidTest.apk \
+              --timeout 2m \
+              --results-bucket cloud-test-${GOOGLE_PROJECT_ID}
+      - run:
+          name: Copy test results data
+          command: |
+            mkdir -p ~/gsutil/
+            gsutil -m cp -r -U `gsutil ls gs://cloud-test-$GOOGLE_PROJECT_ID | tail -1` ~/gsutil/ | true
+          when: always
+      - store_artifacts:
+          path: ~/gsutil/
+      - store_test_results:
+          path: ~/gsutil/
+
+  run-firebase-tests-unityIAP:
+    description: "Run integration tests for Android in Firebase. Variant unityIAP"
+    executor: gcp-cli/google
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - gcp-cli/initialize:
+          gcloud-service-key: GCLOUD_SERVICE_KEY
+          google-compute-zone: GOOGLE_COMPUTE_ZONE
+          google-project-id: GOOGLE_PROJECT_ID
+      - run:
+          name: Test with Firebase Test Lab
+          command: >
+            gcloud firebase test android run --type instrumentation \
+              --app integration-tests/build/outputs/apk/unityIAP/release/integration-tests-unityIAP-release.apk \
+              --test integration-tests/build/outputs/apk/androidTest/unityIAP/release/integration-tests-unityIAP-release-androidTest.apk \
               --timeout 2m \
               --results-bucket cloud-test-${GOOGLE_PROJECT_ID}
       - run:
@@ -308,7 +340,10 @@ workflows:
   integration-test:
     jobs:
       - integration-tests-build: *release-tags-and-branches
-      - run-firebase-tests:
+      - run-firebase-tests-latest-dependencies:
+          requires:
+            - integration-tests-build
+      - run-firebase-tests-unityIAP:
           requires:
             - integration-tests-build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,8 @@ workflows:
 
   integration-test:
     jobs:
-      - integration-tests-build: *release-tags-and-branches
+#      - integration-tests-build: *release-tags-and-branches
+      - integration-tests-build
       - run-firebase-tests-latest-dependencies:
           requires:
             - integration-tests-build


### PR DESCRIPTION
When we added two flavors of the library, we accidentally broke our integration tests. 

We thought the issue was the compilation version, as changed in #477 . But the problem is the paths.