### PR TITLE
Add purchaseProduct button to purchasetester

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/EntitlementInfoExtensions.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/EntitlementInfoExtensions.kt
@@ -3,5 +3,5 @@ package com.revenuecat.purchasetester
 import com.revenuecat.purchases.EntitlementInfo
 
 fun EntitlementInfo.toBriefString(): String {
-    return "$productIdentifier -> expires $expirationDate"
+    return "$identifier -> expires $expirationDate"
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -85,11 +85,13 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
     }
 
     private fun handleSuccessfulPurchase(orderId: String?) {
-        Toast.makeText(
-            requireContext(),
-            "Successful purchase, order id: $orderId",
-            Toast.LENGTH_LONG
-        ).show()
+        context?.let {
+            Toast.makeText(
+                it,
+                "Successful purchase, order id: $orderId",
+                Toast.LENGTH_LONG
+            ).show()
+        }
         findNavController().navigateUp()
     }
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -15,7 +15,9 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.getCustomerInfoWith
+import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.purchasePackageWith
+import com.revenuecat.purchases.purchaseProductWith
 import com.revenuecat.purchasetester.databinding.FragmentOfferingBinding
 
 class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListener {
@@ -54,7 +56,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         return binding.root
     }
 
-    override fun onBuyPackageClicked(cardView: View, currentPackage: Package) {
+    override fun onPurchasePackageClicked(cardView: View, currentPackage: Package) {
         Purchases.sharedInstance.purchasePackageWith(
             requireActivity(),
             currentPackage,
@@ -64,13 +66,30 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
                 }
             },
             { storeTransaction, _ ->
-                Toast.makeText(
-                    requireContext(),
-                    "Successful purchase, order id: ${storeTransaction.orderId}",
-                    Toast.LENGTH_LONG
-                ).show()
-
-                findNavController().navigateUp()
+                handleSuccessfulPurchase(storeTransaction.orderId)
             })
+    }
+
+    override fun onPurchaseProductClicked(cardView: View, currentProduct: StoreProduct) {
+        Purchases.sharedInstance.purchaseProductWith(
+            requireActivity(),
+            currentProduct,
+            { error, userCancelled ->
+                if (!userCancelled) {
+                    showUserError(requireActivity(), error)
+                }
+            },
+            { storeTransaction, _ ->
+                handleSuccessfulPurchase(storeTransaction.orderId)
+            })
+    }
+
+    private fun handleSuccessfulPurchase(orderId: String?) {
+        Toast.makeText(
+            requireContext(),
+            "Successful purchase, order id: $orderId",
+            Toast.LENGTH_LONG
+        ).show()
+        findNavController().navigateUp()
     }
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -57,6 +57,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
     }
 
     override fun onPurchasePackageClicked(cardView: View, currentPackage: Package) {
+        binding.purchaseProgress.visibility = View.VISIBLE
         Purchases.sharedInstance.purchasePackageWith(
             requireActivity(),
             currentPackage,
@@ -71,6 +72,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
     }
 
     override fun onPurchaseProductClicked(cardView: View, currentProduct: StoreProduct) {
+        binding.purchaseProgress.visibility = View.VISIBLE
         Purchases.sharedInstance.purchaseProductWith(
             requireActivity(),
             currentProduct,
@@ -85,6 +87,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
     }
 
     private fun handleSuccessfulPurchase(orderId: String?) {
+        binding.purchaseProgress.visibility = View.GONE
         context?.let {
             Toast.makeText(
                 it,

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
@@ -47,6 +47,15 @@ class PackageCardAdapter(
             } else {
                 currentPackage.packageType.toString()
             }
+
+            binding.packageDetailsJsonObject.detail =
+                currentPackage.product.originalJson.toString(JSON_FORMATTER_INDENT_SPACES)
+
+            binding.root.setOnClickListener {
+                with(binding.packageDetailsContainer) {
+                    visibility = if (visibility == View.GONE) View.VISIBLE else View.GONE
+                }
+            }
         }
     }
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchasetester.databinding.PackageCardBinding
 
 class PackageCardAdapter(
@@ -34,7 +35,11 @@ class PackageCardAdapter(
             binding.isActive = activeSubscriptions.contains(currentPackage.product.sku)
 
             binding.packageBuyButton.setOnClickListener {
-                listener.onBuyPackageClicked(binding.root, currentPackage)
+                listener.onPurchasePackageClicked(binding.root, currentPackage)
+            }
+
+            binding.productBuyButton.setOnClickListener {
+                listener.onPurchaseProductClicked(binding.root, currentPackage.product)
             }
 
             binding.packageType.detail = if (currentPackage.packageType == PackageType.CUSTOM) {
@@ -46,6 +51,7 @@ class PackageCardAdapter(
     }
 
     interface PackageCardAdapterListener {
-        fun onBuyPackageClicked(cardView: View, currentPackage: Package)
+        fun onPurchasePackageClicked(cardView: View, currentPackage: Package)
+        fun onPurchaseProductClicked(cardView: View, currentProduct: StoreProduct)
     }
 }

--- a/examples/purchase-tester/src/main/res/layout/fragment_offering.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_offering.xml
@@ -72,6 +72,17 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@+id/offering_details_packages_header" />
 
+                <ProgressBar
+                        android:id="@+id/purchase_progress"
+                        android:layout_width="@dimen/padding_large"
+                        android:layout_height="@dimen/padding_large"
+                        android:elevation="8dp"
+                        android:visibility="gone"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
             </androidx.constraintlayout.widget.ConstraintLayout>
 
         </com.google.android.material.card.MaterialCardView>

--- a/examples/purchase-tester/src/main/res/layout/package_card.xml
+++ b/examples/purchase-tester/src/main/res/layout/package_card.xml
@@ -56,43 +56,43 @@
                     tools:text="Product with an introductory price" />
 
             <include
-                    layout="@layout/row_view"
                     android:id="@+id/package_product_sku"
+                    layout="@layout/row_view"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/padding_tiny"
                     android:layout_marginEnd="@dimen/padding_tiny"
-                    bind:header="@{`Sku:`}"
-                    bind:detail="@{currentPackage.product.sku}"
                     app:layout_constraintEnd_toStartOf="@+id/package_card_barrier"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/package_product_description"
+                    bind:detail="@{currentPackage.product.sku}"
+                    bind:header="@{`Sku:`}"
                     tools:text="$rc_monthly" />
 
             <include
-                    layout="@layout/row_view"
                     android:id="@+id/package_type"
+                    layout="@layout/row_view"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/padding_tiny"
                     android:layout_marginEnd="@dimen/padding_tiny"
-                    bind:header="@{`Package Type:`}"
                     app:layout_constraintEnd_toStartOf="@+id/package_card_barrier"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/package_product_sku"
+                    bind:header="@{`Package Type:`}"
                     tools:text="$rc_monthly" />
 
             <include
-                    layout="@layout/row_view"
                     android:id="@+id/package_price"
+                    layout="@layout/row_view"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/padding_tiny"
                     android:layout_marginEnd="@dimen/padding_tiny"
-                    bind:header="@{`Price: ` + currentPackage.product.price}"
                     app:layout_constraintEnd_toStartOf="@+id/package_card_barrier"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/package_type"
+                    bind:header="@{`Price: ` + currentPackage.product.price}"
                     tools:text="$1.99" />
 
             <androidx.constraintlayout.widget.Barrier
@@ -118,9 +118,33 @@
                     android:layout_height="wrap_content"
                     android:enabled="@{!isActive}"
                     android:text="Buy product"
-                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintBottom_toTopOf="@+id/package_details_container"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/package_buy_button" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/package_details_container"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/padding_tiny"
+                    android:layout_marginEnd="@dimen/padding_tiny"
+                    android:visibility="gone"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/package_price"
+                    app:layout_constraintVertical_bias="0">
+
+                <include
+                        android:id="@+id/package_details_json_object"
+                        layout="@layout/row_view"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        bind:header="@{`Product JSON`}"/>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/examples/purchase-tester/src/main/res/layout/package_card.xml
+++ b/examples/purchase-tester/src/main/res/layout/package_card.xml
@@ -82,6 +82,19 @@
                     app:layout_constraintTop_toBottomOf="@+id/package_product_sku"
                     tools:text="$rc_monthly" />
 
+            <include
+                    layout="@layout/row_view"
+                    android:id="@+id/package_price"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/padding_tiny"
+                    android:layout_marginEnd="@dimen/padding_tiny"
+                    bind:header="@{`Price: ` + currentPackage.product.price}"
+                    app:layout_constraintEnd_toStartOf="@+id/package_card_barrier"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/package_type"
+                    tools:text="$1.99" />
+
             <androidx.constraintlayout.widget.Barrier
                     android:id="@+id/package_card_barrier"
                     android:layout_width="wrap_content"
@@ -94,7 +107,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:enabled="@{!isActive}"
-                    android:text="@{currentPackage.product.price}"
+                    android:text="Buy package"
                     app:layout_constraintBottom_toTopOf="@+id/product_buy_button"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
@@ -104,7 +117,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:enabled="@{!isActive}"
-                    android:text="@{currentPackage.product.price}"
+                    android:text="Buy product"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/package_buy_button" />

--- a/examples/purchase-tester/src/main/res/layout/package_card.xml
+++ b/examples/purchase-tester/src/main/res/layout/package_card.xml
@@ -87,7 +87,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     app:barrierDirection="start"
-                    app:constraint_referenced_ids="package_buy_button" />
+                    app:constraint_referenced_ids="package_buy_button, product_buy_button" />
 
             <com.google.android.material.button.MaterialButton
                     android:id="@+id/package_buy_button"
@@ -95,9 +95,19 @@
                     android:layout_height="wrap_content"
                     android:enabled="@{!isActive}"
                     android:text="@{currentPackage.product.price}"
-                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintBottom_toTopOf="@+id/product_buy_button"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.button.MaterialButton
+                    android:id="@+id/product_buy_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:enabled="@{!isActive}"
+                    android:text="@{currentPackage.product.price}"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/package_buy_button" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/public/src/main/java/com/revenuecat/purchases/Package.kt
+++ b/public/src/main/java/com/revenuecat/purchases/Package.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases
 
 import android.os.Parcelable
-import com.android.billingclient.api.SkuDetails
 import com.revenuecat.purchases.models.StoreProduct
 import kotlinx.android.parcel.Parcelize
 

--- a/public/src/main/java/com/revenuecat/purchases/Package.kt
+++ b/public/src/main/java/com/revenuecat/purchases/Package.kt
@@ -9,7 +9,7 @@ import kotlinx.android.parcel.Parcelize
  * Contains information about the product available for the user to purchase. For more info see https://docs.revenuecat.com/docs/entitlements
  * @property identifier Unique identifier for this package. Can be one a predefined package type or a custom one.
  * @property packageType Package type for the product. Will be one of [PackageType].
- * @property product [SkuDetails] assigned to this package.
+ * @property product [StoreProduct] assigned to this package.
  */
 @Parcelize
 data class Package(


### PR DESCRIPTION
Add a purchaseProduct button under the purchasePackage button. 

Also: 
* fix parameter label
* print entitlement ID in active entitlements instead of productID -- was confused why i'd see 2 new active entitlements with the same ID after a single purchase
* fix crash if you navigate back before purchase success toast displays
* add progress bar for purchase in progress