### PR TITLE
Update Amazon observer mode log

### DIFF
--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -414,7 +414,7 @@ internal class AmazonBilling constructor(
 
     private fun checkObserverMode(): Boolean {
         return if (observerMode) {
-            log(LogIntent.AMAZON_ERROR, AmazonStrings.ERROR_OBSERVER_MODE_NOT_SUPPORTED)
+            log(LogIntent.AMAZON_WARNING, AmazonStrings.WARNING_AMAZON_OBSERVER_MODE)
             true
         } else false
     }

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
@@ -32,7 +32,7 @@ object AmazonStrings {
         "Failed to get user data. Call is not supported."
     const val ERROR_USER_DATA_STORE_PROBLEM =
         "Failed to get user data. There was an Amazon store problem."
-    const val ERROR_OBSERVER_MODE_NOT_SUPPORTED =
-        "Attempting to interact with Amazon App Store with an Amazon Purchases configuration in observer mode, " +
-            "but observer mode is not yet supported."
+    const val WARNING_AMAZON_OBSERVER_MODE =
+        "Attempting to interact with Amazon App Store with an Amazon Purchases configuration in observer mode " +
+            "won't do anything. Please use syncObserverModeAmazonPurchase to send purchases to RevenueCat instead."
 }


### PR DESCRIPTION
This updates the Amazon observer mode log to point customers to our new syncObserverModeAmazonPurchase. Also downgrades to a warning...since we skip registering the listener and making any calls into the App store anyway, it's not technically broken anymore.