### PR TITLE
Release fixing observer mode for Amazon + BillingClient 3 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,12 +342,12 @@ workflows:
           filters:
             branches:
               only:
-                - amazon-billing-client-3
+                - billing-client-3-amazon
       - deploy-amazon:
           requires:
             - hold
           filters:
             branches:
               only:
-                - amazon-billing-client-3
+                - billing-client-3-amazon
       - docs-deploy: *release-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,24 +202,6 @@ jobs:
             fi
       - android-wordpress-orb/save-gradle-cache
 
-  deploy-amazon:
-    executor: android-executor
-    steps:
-      - checkout
-      - setup-git-credentials
-      - trust-github-key
-      - install-gems
-      - prepare-signing-key
-      - android-wordpress-orb/restore-gradle-cache
-      - android/restore-build-cache
-      - download-amazon-dependency
-      - run:
-          name: Deployment
-          command: |
-            bundle exec fastlane android deploy_amazon
-      - android-wordpress-orb/save-gradle-cache
-      - android/save-build-cache
-
   assemble-sample-app:
     executor: android-executor
     steps:
@@ -337,17 +319,4 @@ workflows:
             branches:
               only:
                 - main
-      - hold:
-          type: approval
-          filters:
-            branches:
-              only:
-                - billing-client-3-amazon
-      - deploy-amazon:
-          requires:
-            - hold
-          filters:
-            branches:
-              only:
-                - billing-client-3-amazon
       - docs-deploy: *release-tags

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,6 +1,7 @@
-- Temporarily disable ETags
-     https://github.com/RevenueCat/purchases-android/pull/322
-- Converts attribution data to use subscriber attributes
-     https://github.com/RevenueCat/purchases-android/pull/315
-- Clarify usage of sharedInstance
-     https://github.com/RevenueCat/purchases-android/pull/320
+- Skip registering listener in Amazon observer mode
+     https://github.com/RevenueCat/purchases-android/pull/478
+- Add new function (`syncObserverModeAmazonPurchase`) to sync a single Amazon purchase with our backend
+     https://github.com/RevenueCat/purchases-android/pull/470
+- Add DangerousSettings to configure function so automatic syncing of purchases can be disabled. 
+  Not recommended unless instructed by RevenueCat support.
+     https://github.com/RevenueCat/purchases-android/pull/451

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ## 5.0.0-amazon.alpha.5.billing3.iap2
 
-- Temporarily disable ETags
-     https://github.com/RevenueCat/purchases-android/pull/322
-- Converts attribution data to use subscriber attributes
-     https://github.com/RevenueCat/purchases-android/pull/315
-- Clarify usage of sharedInstance
-     https://github.com/RevenueCat/purchases-android/pull/320
-
+- Skip registering listener in Amazon observer mode
+  https://github.com/RevenueCat/purchases-android/pull/478
+- Add new function (`syncObserverModeAmazonPurchase`) to sync a single Amazon purchase with our backend
+  https://github.com/RevenueCat/purchases-android/pull/470
+- Add DangerousSettings to configure function so automatic syncing of purchases can be disabled.
+  Not recommended unless instructed by RevenueCat support.
+  https://github.com/RevenueCat/purchases-android/pull/451
+  
 ## 4.2.1
 
 - Temporarily disable ETags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 5.0.0-amazon.alpha.5.billing3.iap2
+
+- Temporarily disable ETags
+     https://github.com/RevenueCat/purchases-android/pull/322
+- Converts attribution data to use subscriber attributes
+     https://github.com/RevenueCat/purchases-android/pull/315
+- Clarify usage of sharedInstance
+     https://github.com/RevenueCat/purchases-android/pull/320
+
 ## 4.2.1
 
 - Temporarily disable ETags

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = false
 
-    const val frameworkVersion = "5.0.0-amazon.alpha.3.billing3.iap2"
+    const val frameworkVersion = "5.0.0-amazon.alpha.5.billing3.iap2"
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -151,12 +151,6 @@ platform :android do
     )
   end
 
-  desc "Deploy a release"
-  lane :deploy_amazon do |options|
-    version = android_get_version_name(gradle_file: gradle_file_path)
-    is_amazon_version = version.include?("-amazon.")
-    unless is_amazon_version then puts "#{version} is not an amazon version" else deploy end
-  end
 end
 
 def increment_version_in(previous_version, new_version, path)

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -56,6 +56,11 @@ Upload a snapshot release
 fastlane android prepare_next_version
 ```
 Prepare next version
+### android deploy_amazon
+```
+fastlane android deploy_amazon
+```
+Deploy a release
 
 ----
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=5.0.0-amazon.alpha.3.billing3.iap2
+VERSION_NAME=5.0.0-amazon.alpha.5.billing3.iap2
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/library.gradle
+++ b/library.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "5.0.0-amazon.alpha.3.billing3.iap2"
+        versionName "5.0.0-amazon.alpha.5.billing3.iap2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
- Skip registering listener in Amazon observer mode
     https://github.com/RevenueCat/purchases-android/pull/478
- Add new function (`syncObserverModeAmazonPurchase`) to sync a single Amazon purchase with our backend
     https://github.com/RevenueCat/purchases-android/pull/470
- Add DangerousSettings to configure function so automatic syncing of purchases can be disabled. 
  Not recommended unless instructed by RevenueCat support.
     https://github.com/RevenueCat/purchases-android/pull/451