### PR TITLE
`PurchasesAPI`: silenced a couple of warnings

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -32,7 +32,7 @@ import java.net.URL
 import java.util.ArrayList
 import java.util.concurrent.ExecutorService
 
-@Suppress("unused", "UNUSED_VARIABLE", "EmptyFunctionBlock")
+@Suppress("unused", "UNUSED_VARIABLE", "EmptyFunctionBlock", "RemoveExplicitTypeArguments", "RedundantLambdaArrow")
 private class PurchasesAPI {
     fun check(
         purchases: Purchases,


### PR DESCRIPTION
We provide explicit types in closures to check them.