### PR TITLE
Added `Purchases.logHandler`

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -6,26 +6,21 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.android.billingclient.api.Purchase;
-import com.android.billingclient.api.SkuDetails;
 import com.revenuecat.purchases.BillingFeature;
 import com.revenuecat.purchases.CustomerInfo;
+import com.revenuecat.purchases.LogHandler;
 import com.revenuecat.purchases.Offerings;
 import com.revenuecat.purchases.Package;
 import com.revenuecat.purchases.Purchases;
 import com.revenuecat.purchases.PurchasesConfiguration;
 import com.revenuecat.purchases.PurchasesError;
 import com.revenuecat.purchases.UpgradeInfo;
-import com.revenuecat.purchases.interfaces.GetSkusResponseListener;
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback;
 import com.revenuecat.purchases.interfaces.LogInCallback;
-import com.revenuecat.purchases.interfaces.MakePurchaseListener;
 import com.revenuecat.purchases.interfaces.ProductChangeCallback;
-import com.revenuecat.purchases.interfaces.ProductChangeListener;
 import com.revenuecat.purchases.interfaces.PurchaseCallback;
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback;
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback;
-import com.revenuecat.purchases.interfaces.ReceiveOfferingsListener;
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener;
 import com.revenuecat.purchases.models.StoreProduct;
 import com.revenuecat.purchases.models.StoreTransaction;
@@ -160,5 +155,17 @@ final class PurchasesAPI {
             case FACEBOOK:
             case MPARTICLE:
         }
+    }
+
+    static void checkLogHandler() {
+        Purchases.setLogHandler(
+                new LogHandler() {
+                    @Override public void d(@NonNull String tag, @NonNull String msg) {}
+                    @Override public void i(@NonNull String tag, @NonNull String msg) {}
+                    @Override public void w(@NonNull String tag, @NonNull String msg) {}
+                    @Override public void e(@NonNull String tag, @NonNull String msg, @Nullable Throwable throwable) {}
+                }
+        );
+        final LogHandler handler = Purchases.getLogHandler();
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import com.revenuecat.purchases.BillingFeature
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.Purchases
@@ -29,7 +30,6 @@ import com.revenuecat.purchases.purchasePackageWith
 import com.revenuecat.purchases.purchaseProductWith
 import com.revenuecat.purchases.restorePurchasesWith
 import java.net.URL
-import java.util.ArrayList
 import java.util.concurrent.ExecutorService
 
 @Suppress("unused", "UNUSED_VARIABLE", "EmptyFunctionBlock")
@@ -222,5 +222,15 @@ private class PurchasesAPI {
             Purchases.AttributionNetwork.MPARTICLE
             -> {}
         }.exhaustive
+    }
+
+    fun checkLogHandler() {
+        Purchases.logHandler = object : LogHandler {
+            override fun d(tag: String, msg: String) {}
+            override fun i(tag: String, msg: String) {}
+            override fun w(tag: String, msg: String) {}
+            override fun e(tag: String, msg: String, throwable: Throwable?) {}
+        }
+        val handler = Purchases.logHandler
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/logUtils.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/logUtils.kt
@@ -1,25 +1,24 @@
 package com.revenuecat.purchases.common
 
-import android.util.Log
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 
 fun debugLog(message: String) {
     if (Config.debugLogsEnabled) {
-        Log.d("[Purchases] - DEBUG", message)
+        currentLogHandler.d("[Purchases] - DEBUG", message)
     }
 }
 
 fun infoLog(message: String) {
-    Log.i("[Purchases] - INFO", message)
+    currentLogHandler.i("[Purchases] - INFO", message)
 }
 
 fun warnLog(message: String) {
-    Log.w("[Purchases] - WARN", message)
+    currentLogHandler.w("[Purchases] - WARN", message)
 }
 
-fun errorLog(message: String) {
-    Log.e("[Purchases] - ERROR", message)
+fun errorLog(message: String, throwable: Throwable? = null) {
+    currentLogHandler.e("[Purchases] - ERROR", message, throwable)
 }
 
 fun errorLog(error: PurchasesError) {

--- a/common/src/main/java/com/revenuecat/purchases/common/logWrapper.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/logWrapper.kt
@@ -1,6 +1,32 @@
 package com.revenuecat.purchases.common
 
+import android.util.Log
+import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.strings.Emojis
+
+var currentLogHandler: LogHandler = DefaultLogHandler()
+
+private class DefaultLogHandler : LogHandler {
+    override fun d(tag: String, msg: String) {
+        Log.d(tag, msg)
+    }
+
+    override fun i(tag: String, msg: String) {
+        Log.i(tag, msg)
+    }
+
+    override fun w(tag: String, msg: String) {
+        Log.w(tag, msg)
+    }
+
+    override fun e(tag: String, msg: String, throwable: Throwable?) {
+        if (throwable != null) {
+            Log.e(tag, msg, throwable)
+        } else {
+            Log.e(tag, msg)
+        }
+    }
+}
 
 fun log(intent: LogIntent, message: String) {
     val fullMessage = "${intent.emojiList.joinToString("")} $message"

--- a/common/src/test/java/com/revenuecat/purchases/common/LogHandlerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/LogHandlerTest.kt
@@ -1,0 +1,101 @@
+package com.revenuecat.purchases.common
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.LogHandler
+import com.revenuecat.purchases.common.Config.debugLogsEnabled
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class LogHandlerTest {
+    private class Handler : LogHandler {
+        var debugMessage: String? = null
+        var infoMessage: String? = null
+        var warningMessage: String? = null
+        var errorMessage: String? = null
+        var errorThrowable: Throwable? = null
+
+        override fun d(tag: String, msg: String) {
+            debugMessage = msg
+        }
+
+        override fun i(tag: String, msg: String) {
+            infoMessage = msg
+        }
+
+        override fun w(tag: String, msg: String) {
+            warningMessage = msg
+        }
+
+        override fun e(tag: String, msg: String, throwable: Throwable?) {
+            errorMessage = msg
+            errorThrowable = throwable
+        }
+    }
+
+    val message = "Logged message"
+
+    private val handler = Handler()
+    private lateinit var previousHandler: LogHandler
+
+    @Before
+    fun setUp() {
+        previousHandler = currentLogHandler
+        currentLogHandler = handler
+    }
+
+    @After
+    fun tearDown() {
+        currentLogHandler = previousHandler
+    }
+
+    @Test
+    fun debugWithDebugLogsDisabled() {
+        debugLog(message)
+        assertThat(handler.debugMessage).isNull()
+    }
+
+    @Test
+    fun debug() {
+        val enabled = debugLogsEnabled
+        debugLogsEnabled = true
+
+        debugLog(message)
+        assertThat(handler.debugMessage).isEqualTo(message)
+
+        debugLogsEnabled = enabled
+    }
+
+    @Test
+    fun info() {
+        infoLog(message)
+        assertThat(handler.infoMessage).isEqualTo(message)
+    }
+
+    @Test
+    fun warning() {
+        warnLog(message)
+        assertThat(handler.warningMessage).isEqualTo(message)
+    }
+
+    @Test
+    fun errorWithNoThrowable() {
+        errorLog(message)
+        assertThat(handler.errorMessage).isEqualTo(message)
+        assertThat(handler.errorThrowable).isNull()
+    }
+
+    @Test
+    fun errorWithThrowable() {
+        val throwable = ClassNotFoundException()
+
+        errorLog(message, throwable)
+        assertThat(handler.errorMessage).isEqualTo(message)
+        assertThat(handler.errorThrowable).isSameAs(throwable)
+    }
+}

--- a/public/src/main/java/com/revenuecat/purchases/LogHandler.kt
+++ b/public/src/main/java/com/revenuecat/purchases/LogHandler.kt
@@ -1,0 +1,12 @@
+package com.revenuecat.purchases
+
+/**
+ * Interface that allows handling logs manually.
+ * See also [Purchases.logHandler]
+ */
+interface LogHandler {
+    fun d(tag: String, msg: String)
+    fun i(tag: String, msg: String)
+    fun w(tag: String, msg: String)
+    fun e(tag: String, msg: String, throwable: Throwable?)
+}

--- a/purchases/src/main/java/com/revenuecat/purchases/util/AdvertisingIdClient.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/util/AdvertisingIdClient.kt
@@ -12,6 +12,7 @@ import android.os.Looper
 import android.os.Parcel
 import android.os.RemoteException
 import android.util.Log
+import com.revenuecat.purchases.common.errorLog
 import java.util.concurrent.LinkedBlockingQueue
 
 object AdvertisingIdClient {
@@ -46,7 +47,7 @@ object AdvertisingIdClient {
                         }
                     }
                 } catch (e: Exception) {
-                    Log.e("Purchases", "Error getting AdvertisingIdInfo", e)
+                    errorLog("Error getting AdvertisingIdInfo", e)
                 } finally {
                     Handler(Looper.getMainLooper()).post {
                         application.unbindService(connection)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/AttributionFetcherFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/AttributionFetcherFactory.kt
@@ -18,7 +18,7 @@ object AttributionFetcherFactory {
                     .getConstructor()
                     .newInstance() as DeviceIdentifiersFetcher
             } catch (e: ClassNotFoundException) {
-                errorLog("Make sure purchases-amazon is added as dependency")
+                errorLog("Make sure purchases-amazon is added as dependency", e)
                 throw e
             }
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
@@ -34,7 +34,7 @@ object BillingFactory {
                         Boolean::class.java
                     ).newInstance(application.applicationContext, backend, cache, observerMode) as BillingAbstract
             } catch (e: ClassNotFoundException) {
-                errorLog("Make sure purchases-amazon is added as dependency")
+                errorLog("Make sure purchases-amazon is added as dependency", e)
                 throw e
             }
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -35,6 +35,7 @@ import com.revenuecat.purchases.common.ReplaceSkuInfo
 import com.revenuecat.purchases.common.attribution.AttributionData
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
+import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.networking.ETagManager
@@ -1885,6 +1886,20 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
             get() = Config.debugLogsEnabled
             set(value) {
                 Config.debugLogsEnabled = value
+            }
+
+        /**
+         * Set a custom log handler for redirecting logs to your own logging system.
+         * Defaults to [android.util.Log].
+         *
+         * By default, this sends info, warning, and error messages.
+         * If you wish to receive Debug level messages, see [debugLogsEnabled].
+         */
+        @JvmStatic
+        var logHandler: LogHandler
+            @Synchronized get() = currentLogHandler
+            @Synchronized set(value) {
+                currentLogHandler = value
             }
 
         @JvmSynthetic


### PR DESCRIPTION
Fixes [sc-11102].

The default implementation is unchanged, using `android.util.Log`.
Users can provide their own implementation of `LogHandler`.

## Other changes:
- `errorLog` can now provide an optional `throwable`, which will be forwarded if set
- Added tests to verify the handler is used
- Removed ad-hoc usage of `Log.e`
- Added API to `apitester`