### PR TITLE
Fix queryPurchases for Amazon

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1097,7 +1097,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         onError: (ErrorPurchaseCallback)? = null
     ) {
         purchases.forEach { purchase ->
-            if (purchase.purchaseState == PurchaseState.PURCHASED) {
+            if (purchase.purchaseState != PurchaseState.PENDING) {
                 billing.querySkuDetailsAsync(
                     productType = purchase.type,
                     skus = purchase.skus.toSet(),


### PR DESCRIPTION
We found a small bug in our Amazon implementation.
The Amazon queryPurchases method doesn't return a Purchase State. When we call queryPurchases on app start, we were only posting those with state == PURCHASED to the backend. This means someone migrating to RevenueCat (or without identity after a re-install) won't get their purchases synced.

The fix is to just send all purchases that aren't in the PENDING state (Amazon will be in UNSPECIFIED_STATE). This shouldn't break anything for Play Store, since they properly return a state, which will either be pending or purchased.

[sc-13525]