### PR TITLE
CF-241  Amazon is swallowing all exceptions that happen in the listeners

### DIFF
--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/ProductDataHandler.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/ProductDataHandler.kt
@@ -55,6 +55,7 @@ class ProductDataHandler(
     }
 
     override fun onProductDataResponse(response: ProductDataResponse) {
+        // Amazon is catching all exceptions and swallowing them so we have to catch ourselves and log
         try {
             log(LogIntent.DEBUG, AmazonStrings.PRODUCTS_REQUEST_FINISHED.format(response.requestStatus.name))
 
@@ -78,7 +79,7 @@ class ProductDataHandler(
                 }
             }
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            errorLog("Error in onProductDataResponse", e)
+            errorLog("Exception in onProductDataResponse", e)
             throw e
         }
     }


### PR DESCRIPTION
[CF-241]

[CF-241]: https://revenuecats.atlassian.net/browse/CF-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

I noticed offerings were not loading. Products were failing to load. There was no exceptions or anything. But after a lot of debugging I found this little gem in Amazon's code:

```
                     try {
                        if (var1 instanceof ProductDataResponse) {
                            var3.onProductDataResponse((ProductDataResponse)var1);
                        } else if (var1 instanceof UserDataResponse) {
                            var3.onUserDataResponse((UserDataResponse)var1);
                        } else if (var1 instanceof PurchaseUpdatesResponse) {
                            var3.onPurchaseUpdatesResponse((PurchaseUpdatesResponse)var1);
                        } else if (var1 instanceof PurchaseResponse) {
                            var3.onPurchaseResponse((PurchaseResponse)var1);
                        } else {
                            e.b(c.a, "Unknown response type:" + var1.getClass().getName());
                        }
                    } catch (Exception var2) {
                        e.b(c.a, "Error in sendResponse: " + var2);
                    }
```

They are basically catching all Exceptions that happen in the listener we implemented. I also noticed they display a short log while in App Tester but not when the app is downloaded from Live App Testing.