### PR TITLE
Adds missing cases to when statement in errorLog mapping

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/logUtils.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/logUtils.kt
@@ -30,6 +30,9 @@ fun errorLog(error: PurchasesError) {
         PurchasesErrorCode.InvalidAppUserIdError,
         PurchasesErrorCode.OperationAlreadyInProgressError,
         PurchasesErrorCode.UnknownBackendError,
+        PurchasesErrorCode.LogOutWithAnonymousUserError,
+        PurchasesErrorCode.ConfigurationError,
+        PurchasesErrorCode.UnsupportedError,
         PurchasesErrorCode.InvalidSubscriberAttributesError -> log(LogIntent.RC_ERROR, error.message)
         PurchasesErrorCode.PurchaseCancelledError,
         PurchasesErrorCode.StoreProblemError,


### PR DESCRIPTION
We were missing some cases in a when statement. I noticed when upgrading Kotlin version in https://github.com/RevenueCat/purchases-android/pull/474 . More recent versions of Kotlin will fail when missing cases in a when statement.