### PR TITLE
CF-99: Separate docs per version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,10 @@ jobs:
           command: sudo pip install awscli
       - run:
           name: Deploy to S3
-          command: aws s3 sync ~/purchases-android/docs s3://purchases-docs/android --delete
+          command: aws s3 sync ~/purchases-android/docs/5.1.0-SNAPSHOT s3://purchases-docs/android/5.1.0-SNAPSHOT --delete
+      - run:
+          name: Update index.html
+          command: aws s3 cp ~/purchases-android/docs/index.html s3://purchases-docs/android/index.html
       - run:
           name: Invalidate CloudFront caches
           command: aws cloudfront create-invalidation --distribution-id EPTW7F3CB566V --paths "/*"

--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,7 @@ integration-tests/keystore
 
 # share settings
 !/.idea/codeStyles/
+
+# index.html is used to redirect to the latest docs version
+# when navigating to root
+!/docs/index.html

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.15.1"
         classpath 'com.android.tools.build:gradle:7.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.32"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,6 @@ task detektAllBaseline(type: io.gitlab.arturbosch.detekt.DetektCreateBaselineTas
 apply plugin: 'org.jetbrains.dokka'
 
 tasks.dokkaHtmlMultiModule.configure {
-    outputDirectory.set(file("docs"))
+    outputDirectory.set(file("docs/" + project.property("VERSION_NAME")))
     includes.from("README.md")
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="refresh" content="0; url=https://docs.revenuecat.com/android/5.1.0-SNAPSHOT/index.html" />
+</head>
+<body>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="refresh" content="0; url=https://docs.revenuecat.com/android/5.1.0-SNAPSHOT/index.html" />
+    <meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/5.1.0/index.html" />
 </head>
 <body>
 </body>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -178,7 +178,7 @@ platform :android do
 end
 
 def increment_version_in(previous_version, new_version, path)
-  sed_regex = 's/' + previous_version + '/' + new_version + '/'
+  sed_regex = 's/' + previous_version + '/' + new_version + '/g'
   backup_extension = '.bck'
   sh "sed -i'#{backup_extension}' #{sed_regex} #{path}"
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -178,9 +178,9 @@ platform :android do
 end
 
 def increment_version_in(previous_version, new_version, path)
-    sed_regex = 's/' + previous_version + '/' + new_version + '/g'
-    backup_extension = '.bck'
-    sh "sed -i'#{backup_extension}' #{sed_regex} #{path}"
+  sed_regex = 's/' + previous_version + '/' + new_version + '/g'
+  backup_extension = '.bck'
+  sh "sed -i'#{backup_extension}' #{sed_regex} #{path}"
 end
 
 def attach_changelog_to_main(options)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,6 +30,8 @@ platform :android do
     previous_version = android_get_version_name(gradle_file: gradle_file_path)
     android_set_version_name(version_name: new_version, gradle_file: gradle_file_path)
     increment_version_in(previous_version, new_version, '../common/src/main/java/com/revenuecat/purchases/common/Config.kt')
+    increment_version_in(previous_version, new_version, '../.circleci/config.yml')
+    increment_version_in(previous_version, new_version, '../docs/index.html')
     increment_version_in(previous_version, new_version, '../gradle.properties')
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -179,8 +179,7 @@ end
 
 def increment_version_in(previous_version, new_version, path)
   sed_regex = 's/' + previous_version + '/' + new_version + '/g'
-  backup_extension = '.bck'
-  sh "sed -i'#{backup_extension}' #{sed_regex} #{path}"
+  sh "sed #{sed_regex} #{path}"
 end
 
 def attach_changelog_to_main(options)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -178,8 +178,9 @@ platform :android do
 end
 
 def increment_version_in(previous_version, new_version, path)
-  sed_regex = 's/' + previous_version + '/' + new_version + '/g'
-  sh "sed #{sed_regex} #{path}"
+    sed_regex = 's/' + previous_version + '/' + new_version + '/g'
+    backup_extension = '.bck'
+    sh "sed -i'#{backup_extension}' #{sed_regex} #{path}"
 end
 
 def attach_changelog_to_main(options)


### PR DESCRIPTION
updates the output directory for dokka to include the version number. 

This is the low-tech implementation. 

A high-tech implementation would be to use the [Versioning plugin](https://kotlin.github.io/dokka/1.4.30/user_guide/versioning/versioning/), but that might take a lot more effort to set up, so in the meantime, the idea is to manually update the docs in S3 for the first time, and use this to generate them in the correct subfolder until we get the high-tech implementation in place. 

Fixes [CF-99]


[CF-99]: https://revenuecats.atlassian.net/browse/CF-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ