### PR TITLE
Adds warnings for collecting Advertising ID

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -684,6 +684,12 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
     /**
      * Automatically collect subscriber attributes associated with the device identifiers
      * $gpsAdId, $androidId, $ip
+     *
+     * @warning In accordance with [Google Play's data safety guidelines] (https://rev.cat/google-plays-data-safety),
+     * you should not be calling this function if your app targets children.
+     *
+     * @warning You must declare the [AD_ID Permission](https://rev.cat/google-advertising-id) when your app targets
+     * Android 13 or above. Apps that don’t declare the permission will get a string of zeros.
      */
     fun collectDeviceIdentifiers() {
         log(LogIntent.DEBUG, AttributionStrings.METHOD_CALLED.format("collectDeviceIdentifiers"))


### PR DESCRIPTION
[CF-363]

Google made the following announcement:

- If you use an advertising ID, you must declare the [AD_ID Permission](https://notifications.google.com/g/p/AD-FnExFIeKajosxiqsy-MrtrabL2IRO46OkDhHL5JATpByWtiYnmwUkWjBU9SNEglAg1dTndpYpRdwFPTHngDRvAmID5fVENY2rokXEF4_unFfRfkopSis-08ixU-I2QV8hiAcCQlw71iOZ6PbMO7DevUQY) when your app targets Android 13 or above. Apps that don’t declare the permission will get a string of zeros. Note: You’ll be able to target Android 13 later this year.If your app’s [target audience](https://notifications.google.com/g/p/AD-FnEyCHyziYRF-dBi6BcDI0-9ibYDScV6buzW0DGqRw3WPuPCPEkyJPpq1Cmx1fPOUL1Adc5l3Piow1cAVT1hxRCanA8WE5zZjfSRqD50uTaWqAUKHQXLEgqWwEIGUGamlx2P3ZGFJcR_6SoEKhjlzJ0r4) includes children, you must not transmit Android Advertising ID (AAID) from children or users of unknown age. [Learn more](https://notifications.google.com/g/p/AD-FnEyKB5_lozAKGo_EGZJTEv21tBk7IUV_yHK973Jfld0ViLPWcILC74JRZ_3Tn_duJmJL9owahcYYMgTO3Yj-xLmbafrUICtE13JQ8WKtEozQkywefsV4XLGpSay1BdqwTm0z4hQp-vVy5RcrA6d9hv5rgg).
- If your app uses an SDK that has declared the Ad ID permission, it will acquire the permission declaration through manifest merge.
- If your app’s [target audience](https://notifications.google.com/g/p/AD-FnEyCHyziYRF-dBi6BcDI0-9ibYDScV6buzW0DGqRw3WPuPCPEkyJPpq1Cmx1fPOUL1Adc5l3Piow1cAVT1hxRCanA8WE5zZjfSRqD50uTaWqAUKHQXLEgqWwEIGUGamlx2P3ZGFJcR_6SoEKhjlzJ0r4) includes children, you must not transmit Android Advertising ID (AAID) from children or users of unknown age. [Learn more](https://notifications.google.com/g/p/AD-FnEyKB5_lozAKGo_EGZJTEv21tBk7IUV_yHK973Jfld0ViLPWcILC74JRZ_3Tn_duJmJL9owahcYYMgTO3Yj-xLmbafrUICtE13JQ8WKtEozQkywefsV4XLGpSay1BdqwTm0z4hQp-vVy5RcrA6d9hv5rgg).

As I explained in https://revenuecats.atlassian.net/browse/CF-318?focusedCommentId=10436, we are not adding the permission automatically to apps due to how our dependencies are set up, so we need to be more clear around how the permission is added and wether devs should be calling `collectDevideIdentifiers`.



[CF-363]: https://revenuecats.atlassian.net/browse/CF-363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ