### PR TITLE
Fix docs version in redirect html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/5.1.0/index.html" />
+    <meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/5.0.0/index.html" />
 </head>
 <body>
 </body>


### PR DESCRIPTION
I think this change got merged by mistake in https://github.com/RevenueCat/purchases-android/pull/504/files#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeR4

It should match the current version, so when deploying 5.0.0 docs broke and trying to access https://sdk.revenuecat.com/android/index.html gives a broken website.

 

