### PR TITLE
Adds Mixpanel method and adds structure for integration IDs

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -177,6 +177,7 @@ private class PurchasesAPI {
             setMparticleID("")
             setOnesignalID("")
             setAirshipChannelID("")
+            setMixpanelDistinctID("")
             setMediaSource("")
             setCampaign("")
             setAdGroup("")

--- a/common/src/main/java/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
@@ -30,6 +30,11 @@ enum class ReservedSubscriberAttribute(val value: String) {
     AIRSHIP_CHANNEL_ID("\$airshipChannelId"),
 
     /**
+     * Integration IDs
+     */
+    MIXPANEL_DISTINCT_ID("\$mixpanelDistinctId"),
+
+    /**
      * Optional campaign parameters
      */
     MEDIA_SOURCE("\$mediaSource"),
@@ -62,6 +67,10 @@ sealed class SubscriberAttributeKey(val backendKey: String) {
         object Mparticle : AttributionIds(ReservedSubscriberAttribute.MPARTICLE_ID)
         object OneSignal : AttributionIds(ReservedSubscriberAttribute.ONESIGNAL_ID)
         object Airship : AttributionIds(ReservedSubscriberAttribute.AIRSHIP_CHANNEL_ID)
+    }
+
+    sealed class IntegrationIds(backendKey: ReservedSubscriberAttribute) : SubscriberAttributeKey(backendKey.value) {
+        object MixpanelDistinctId : IntegrationIds(ReservedSubscriberAttribute.MIXPANEL_DISTINCT_ID)
     }
 
     sealed class CampaignParameters(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -679,6 +679,23 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
     }
 
     // endregion
+    // region Integration IDs
+
+    /**
+     * Subscriber attribute associated with the Mixpanel Distinct ID for the user
+     *
+     * @param mixpanelDistinctID null or an empty string will delete the subscriber attribute.
+     */
+    fun setMixpanelDistinctID(mixpanelDistinctID: String?) {
+        log(LogIntent.DEBUG, AttributionStrings.METHOD_CALLED.format("setMixpanelDistinctID"))
+        subscriberAttributesManager.setAttribute(
+            SubscriberAttributeKey.IntegrationIds.MixpanelDistinctId,
+            mixpanelDistinctID,
+            appUserID
+        )
+    }
+
+    // endregion
     // region Attribution IDs
 
     /**

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -558,6 +558,17 @@ class SubscriberAttributesPurchasesTests {
 
     // endregion
 
+    // region Integration IDs
+
+    @Test
+    fun `setMixpanelDistinctID`() {
+        integrationIDTest(SubscriberAttributeKey.IntegrationIds.MixpanelDistinctId) { parameter ->
+            underTest.setMixpanelDistinctID(parameter)
+        }
+    }
+
+    // endregion
+
     // region Campaign parameters
 
     @Test
@@ -635,6 +646,27 @@ class SubscriberAttributesPurchasesTests {
                 id,
                 appUserId,
                 applicationMock
+            )
+        }
+    }
+
+    private fun integrationIDTest(
+        parameter: SubscriberAttributeKey.IntegrationIds,
+        functionToTest: (String) -> Unit
+    ) {
+        val parameterValue = "parametervalue"
+
+        every {
+            subscriberAttributesManagerMock.setAttribute(any(), parameterValue, appUserId)
+        } just Runs
+
+        functionToTest(parameterValue)
+
+        verify {
+            subscriberAttributesManagerMock.setAttribute(
+                parameter,
+                parameterValue,
+                appUserId
             )
         }
     }


### PR DESCRIPTION
### Motivation
We added support for setting the [Mixpanel Distinct ID](https://docs.revenuecat.com/docs/mixpanel) as a subscriber attribute, so we should have a convenience setter.

### Description
- Adds new reserved attribute for Mixpanel
- Adds new SubscriberAttributeKey class: `IntegrationIds` (Mixpanel isn't an attribution network, and shouldn't be categorized into the `AttributionIds`)
- Adds new convenience setter for the Mixpanel attribute
- Adds new tests flow for IntegrationIds (`integrationIDTest`)
