### PR TITLE
[On top of billing-client-3-amazon branch] Fix for Amazon observer mode missing price and currency

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,7 +1,3 @@
-- Skip registering listener in Amazon observer mode
-     https://github.com/RevenueCat/purchases-android/pull/478
-- Add new function (`syncObserverModeAmazonPurchase`) to sync a single Amazon purchase with our backend
-     https://github.com/RevenueCat/purchases-android/pull/470
-- Add DangerousSettings to configure function so automatic syncing of purchases can be disabled. 
-  Not recommended unless instructed by RevenueCat support.
-     https://github.com/RevenueCat/purchases-android/pull/451
+- Fix product price and currency not being reported in Amazon Appstore observer mode. `syncObserverModeAmazonPurchase` 
+  now accepts an `isoCurrencyCode` and a `price` to make sure we correctly track prices. 
+  https://github.com/RevenueCat/purchases-android/pull/519

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.0-amazon.alpha.6.billing3.iap2
+
+- Fix product price and currency not being reported in Amazon Appstore observer mode
+
 ## 5.0.0-amazon.alpha.5.billing3.iap2
 
 - Skip registering listener in Amazon observer mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 5.0.0-amazon.alpha.6.billing3.iap2
 
-- Fix product price and currency not being reported in Amazon Appstore observer mode
+- Fix product price and currency not being reported in Amazon Appstore observer mode. `syncObserverModeAmazonPurchase`
+  now accepts an `isoCurrencyCode` and a `price` to make sure we correctly track prices.
+  https://github.com/RevenueCat/purchases-android/pull/519
 
 ## 5.0.0-amazon.alpha.5.billing3.iap2
 

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = false
 
-    const val frameworkVersion = "5.0.0-amazon.alpha.5.billing3.iap2"
+    const val frameworkVersion = "5.0.0-amazon.alpha.6.billing3.iap2"
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/ReceiptInfo.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/ReceiptInfo.kt
@@ -5,11 +5,11 @@ import com.revenuecat.purchases.models.ProductDetails
 class ReceiptInfo(
     val productID: String,
     val offeringIdentifier: String? = null,
-    val productDetails: ProductDetails? = null
+    val productDetails: ProductDetails? = null,
+    val price: Double? = productDetails?.priceAmountMicros?.div(MICROS_MULTIPLIER.toDouble()),
+    val currency: String? = productDetails?.priceCurrencyCode
 ) {
 
-    val price: Double? = productDetails?.priceAmountMicros?.div(MICROS_MULTIPLIER.toDouble())
-    val currency: String? = productDetails?.priceCurrencyCode
     val duration: String? = productDetails?.subscriptionPeriod?.takeUnless { it.isEmpty() }
     val introDuration: String? = productDetails?.introductoryPricePeriod?.takeUnless { it.isEmpty() }
     val trialDuration: String? = productDetails?.freeTrialPeriod?.takeUnless { it.isEmpty() }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=5.0.0-amazon.alpha.5.billing3.iap2
+VERSION_NAME=5.0.0-amazon.alpha.6.billing3.iap2
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/library.gradle
+++ b/library.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "5.0.0-amazon.alpha.5.billing3.iap2"
+        versionName "5.0.0-amazon.alpha.6.billing3.iap2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -311,6 +311,8 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
      * @param [productID] Product ID associated to the purchase.
      * @param [receiptId] ReceiptId that represents the Amazon purchase.
      * @param [amazonUserID] Amazon's userID. This parameter will be ignored when syncing a Google purchase.
+     * @param [isoCurrencyCode] Product's currency code in ISO 4217 format.
+     * @param [price] Product's price.
      */
     fun syncObserverModeAmazonPurchase(
         productID: String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -315,7 +315,9 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
     fun syncObserverModeAmazonPurchase(
         productID: String,
         receiptId: String,
-        amazonUserID: String
+        amazonUserID: String,
+        isoCurrencyCode: String,
+        price: Double
     ) {
         log(LogIntent.DEBUG, PurchaseStrings.SYNCING_PURCHASE_STORE_USER_ID.format(receiptId, amazonUserID))
 
@@ -330,23 +332,28 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
             receiptId,
             amazonUserID,
             { normalizedProductID ->
+                val receiptInfo = ReceiptInfo(
+                        productID = normalizedProductID,
+                        price = price,
+                        currency = isoCurrencyCode
+                )
                 syncPurchaseWithBackend(
-                    receiptId,
-                    amazonUserID,
-                    appUserID,
-                    ReceiptInfo(normalizedProductID),
-                    {
-                        val logMessage = PurchaseStrings.PURCHASE_SYNCED_USER_ID.format(receiptId, amazonUserID)
-                        log(LogIntent.PURCHASE, logMessage)
-                    },
-                    { error ->
-                        val logMessage = PurchaseStrings.SYNCING_PURCHASE_ERROR_DETAILS_USER_ID.format(
-                            receiptId,
-                            amazonUserID,
-                            error
-                        )
-                        log(LogIntent.RC_ERROR, logMessage)
-                    }
+                        receiptId,
+                        amazonUserID,
+                        appUserID,
+                        receiptInfo,
+                        {
+                            val logMessage = PurchaseStrings.PURCHASE_SYNCED_USER_ID.format(receiptId, amazonUserID)
+                            log(LogIntent.PURCHASE, logMessage)
+                        },
+                        { error ->
+                            val logMessage = PurchaseStrings.SYNCING_PURCHASE_ERROR_DETAILS_USER_ID.format(
+                                    receiptId,
+                                    amazonUserID,
+                                    error
+                            )
+                            log(LogIntent.RC_ERROR, logMessage)
+                        }
                 )
             },
             { error ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -316,8 +316,8 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         productID: String,
         receiptId: String,
         amazonUserID: String,
-        isoCurrencyCode: String,
-        price: Double
+        isoCurrencyCode: String?,
+        price: Double?
     ) {
         log(LogIntent.DEBUG, PurchaseStrings.SYNCING_PURCHASE_STORE_USER_ID.format(receiptId, amazonUserID))
 
@@ -334,8 +334,8 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
             { normalizedProductID ->
                 val receiptInfo = ReceiptInfo(
                         productID = normalizedProductID,
-                        price = price,
-                        currency = isoCurrencyCode
+                        price = price?.takeUnless { it == 0.0 },
+                        currency = isoCurrencyCode?.takeUnless { it.isBlank() }
                 )
                 syncPurchaseWithBackend(
                         receiptId,

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -3195,7 +3195,11 @@ class PurchasesTest {
             isoCurrencyCode = null
         )
 
-        val productInfo = ReceiptInfo(productID = skuTerm)
+        val productInfo = ReceiptInfo(
+            productID = skuTerm,
+            currency = null,
+            price = null
+        )
         verify(exactly = 1) {
             mockBackend.postReceiptData(
                 purchaseToken = purchaseToken,

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -2764,7 +2764,7 @@ class PurchasesTest {
     }
 
     @Test
-    fun `syncing a transaction posts normalized purchase data to backend`() {
+    fun `syncing an Amazon transaction posts normalized purchase data to backend`() {
         purchases.finishTransactions = false
 
         val skuParent = "sub"
@@ -2821,7 +2821,7 @@ class PurchasesTest {
     }
 
     @Test
-    fun `syncing a transaction respects allow sharing account settings`() {
+    fun `syncing an Amazon transaction respects allow sharing account settings`() {
         purchases.finishTransactions = false
 
         val skuParent = "sub"
@@ -2879,7 +2879,7 @@ class PurchasesTest {
     }
 
     @Test
-    fun `syncing a transaction never consumes it`() {
+    fun `syncing an Amazon transaction never consumes it`() {
         purchases.finishTransactions = false
 
         val skuParent = "sub"
@@ -2943,7 +2943,7 @@ class PurchasesTest {
     }
 
     @Test
-    fun `transaction is not synced again if it was already synced`() {
+    fun `Amazon transaction is not synced again if it was already synced`() {
         purchases.finishTransactions = false
 
         val skuParent = "sub"
@@ -3038,7 +3038,7 @@ class PurchasesTest {
     }
 
     @Test
-    fun `syncing a transaction sends subscriber attributes`() {
+    fun `syncing an Amazon transaction sends subscriber attributes`() {
         purchases.finishTransactions = false
 
         val skuParent = "sub"
@@ -3107,6 +3107,108 @@ class PurchasesTest {
             mockBillingAbstract.consumeAndSave(any(), any())
         }
         assertThat(capturedLambda).isNotNull
+    }
+
+    @Test
+    fun `syncing an Amazon transaction without price nor currency code posts purchase data to backend`() {
+        purchases.finishTransactions = false
+
+        val skuParent = "sub"
+        val skuTerm = "sub.monthly"
+        val purchaseToken = "crazy_purchase_token"
+        val amazonUserID = "amazon_user_id"
+
+        every {
+            mockBillingAbstract.normalizePurchaseData(
+                productID = skuParent,
+                purchaseToken = purchaseToken,
+                storeUserID = amazonUserID,
+                captureLambda(),
+                any()
+            )
+        } answers {
+            lambda<(String) -> Unit>().captured.also {
+                it.invoke(skuTerm)
+            }
+        }
+
+        every {
+            mockCache.getPreviouslySentHashedTokens()
+        } returns setOf()
+
+        purchases.syncObserverModeAmazonPurchase(
+            productID = skuParent,
+            receiptId = purchaseToken,
+            amazonUserID = amazonUserID,
+            price = null,
+            isoCurrencyCode = null
+        )
+
+        val productInfo = ReceiptInfo(productID = skuTerm)
+        verify(exactly = 1) {
+            mockBackend.postReceiptData(
+                purchaseToken = purchaseToken,
+                appUserID = appUserId,
+                isRestore = false,
+                observerMode = true,
+                subscriberAttributes = emptyMap(),
+                receiptInfo = productInfo,
+                storeAppUserID = amazonUserID,
+                onSuccess = any(),
+                onError = any()
+            )
+        }
+    }
+
+    @Test
+    fun `syncing an Amazon transaction with zero price posts correct purchase data to backend`() {
+        purchases.finishTransactions = false
+
+        val skuParent = "sub"
+        val skuTerm = "sub.monthly"
+        val purchaseToken = "crazy_purchase_token"
+        val amazonUserID = "amazon_user_id"
+
+        every {
+            mockBillingAbstract.normalizePurchaseData(
+                productID = skuParent,
+                purchaseToken = purchaseToken,
+                storeUserID = amazonUserID,
+                captureLambda(),
+                any()
+            )
+        } answers {
+            lambda<(String) -> Unit>().captured.also {
+                it.invoke(skuTerm)
+            }
+        }
+
+        every {
+            mockCache.getPreviouslySentHashedTokens()
+        } returns setOf()
+
+        purchases.syncObserverModeAmazonPurchase(
+            productID = skuParent,
+            receiptId = purchaseToken,
+            amazonUserID = amazonUserID,
+            price = 0.0,
+            isoCurrencyCode = null
+        )
+
+        val productInfo = ReceiptInfo(productID = skuTerm)
+        verify(exactly = 1) {
+            mockBackend.postReceiptData(
+                purchaseToken = purchaseToken,
+                appUserID = appUserId,
+                isRestore = false,
+                observerMode = true,
+                subscriberAttributes = emptyMap(),
+                receiptInfo = productInfo,
+                storeAppUserID = amazonUserID,
+                onSuccess = any(),
+                onError = any()
+            )
+        }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -2771,6 +2771,8 @@ class PurchasesTest {
         val skuTerm = "sub.monthly"
         val purchaseToken = "crazy_purchase_token"
         val amazonUserID = "amazon_user_id"
+        val price = 10.40
+        val currencyCode = "USD"
 
         every {
             mockBillingAbstract.normalizePurchaseData(
@@ -2793,11 +2795,15 @@ class PurchasesTest {
         purchases.syncObserverModeAmazonPurchase(
             productID = skuParent,
             receiptId = purchaseToken,
-            amazonUserID = amazonUserID
+            amazonUserID = amazonUserID,
+            price = price,
+            isoCurrencyCode = currencyCode
         )
 
         val productInfo = ReceiptInfo(
-            productID = skuTerm
+            productID = skuTerm,
+            price = price,
+            currency = currencyCode
         )
         verify(exactly = 1) {
             mockBackend.postReceiptData(
@@ -2822,6 +2828,8 @@ class PurchasesTest {
         val skuTerm = "sub.monthly"
         val purchaseToken = "crazy_purchase_token"
         val amazonUserID = "amazon_user_id"
+        val price = 10.40
+        val currencyCode = "USD"
         purchases.allowSharingPlayStoreAccount = true
 
         every {
@@ -2845,11 +2853,15 @@ class PurchasesTest {
         purchases.syncObserverModeAmazonPurchase(
             productID = skuParent,
             receiptId = purchaseToken,
-            amazonUserID = amazonUserID
+            amazonUserID = amazonUserID,
+            price = price,
+            isoCurrencyCode = currencyCode
         )
 
         val productInfo = ReceiptInfo(
-            productID = skuTerm
+            productID = skuTerm,
+            price = price,
+            currency = currencyCode
         )
         verify(exactly = 1) {
             mockBackend.postReceiptData(
@@ -2874,6 +2886,8 @@ class PurchasesTest {
         val skuTerm = "sub.monthly"
         val purchaseToken = "crazy_purchase_token"
         val amazonUserID = "amazon_user_id"
+        val price = 10.40
+        val currencyCode = "USD"
         purchases.allowSharingPlayStoreAccount = true
 
         var capturedLambda: ((String) -> Unit)? = null
@@ -2898,11 +2912,15 @@ class PurchasesTest {
         purchases.syncObserverModeAmazonPurchase(
             productID = skuParent,
             receiptId = purchaseToken,
-            amazonUserID = amazonUserID
+            amazonUserID = amazonUserID,
+            price = price,
+            isoCurrencyCode = currencyCode
         )
 
         val productInfo = ReceiptInfo(
-            productID = skuTerm
+            productID = skuTerm,
+            price = price,
+            currency = currencyCode
         )
         verify(exactly = 1) {
             mockBackend.postReceiptData(
@@ -2932,6 +2950,8 @@ class PurchasesTest {
         val skuTerm = "sub.monthly"
         val purchaseToken = "crazy_purchase_token"
         val amazonUserID = "amazon_user_id"
+        val price = 10.40
+        val currencyCode = "USD"
 
         every {
             mockCache.getPreviouslySentHashedTokens()
@@ -2954,11 +2974,15 @@ class PurchasesTest {
         purchases.syncObserverModeAmazonPurchase(
             productID = skuParent,
             receiptId = purchaseToken,
-            amazonUserID = amazonUserID
+            amazonUserID = amazonUserID,
+            price = price,
+            isoCurrencyCode = currencyCode
         )
 
         val productInfo = ReceiptInfo(
-            productID = skuTerm
+            productID = skuTerm,
+            price = price,
+            currency = currencyCode
         )
         verify(exactly = 1) {
             mockBackend.postReceiptData(
@@ -2985,7 +3009,9 @@ class PurchasesTest {
         purchases.syncObserverModeAmazonPurchase(
             productID = skuParent,
             receiptId = purchaseToken,
-            amazonUserID = amazonUserID
+            amazonUserID = amazonUserID,
+            price = price,
+            isoCurrencyCode = currencyCode
         )
 
         verify(exactly = 1) {
@@ -3019,6 +3045,8 @@ class PurchasesTest {
         val skuTerm = "sub.monthly"
         val purchaseToken = "crazy_purchase_token"
         val amazonUserID = "amazon_user_id"
+        val price = 10.40
+        val currencyCode = "USD"
         val subscriberAttributeKey = "favorite_cat"
         val subscriberAttributeValue = "gardfield"
         val subscriberAttribute = SubscriberAttribute(subscriberAttributeKey, subscriberAttributeValue)
@@ -3051,11 +3079,15 @@ class PurchasesTest {
         purchases.syncObserverModeAmazonPurchase(
             productID = skuParent,
             receiptId = purchaseToken,
-            amazonUserID = amazonUserID
+            amazonUserID = amazonUserID,
+            price = price,
+            isoCurrencyCode = currencyCode
         )
 
         val productInfo = ReceiptInfo(
-            productID = skuTerm
+            productID = skuTerm,
+            price = price,
+            currency = currencyCode
         )
         verify(exactly = 1) {
             mockBackend.postReceiptData(


### PR DESCRIPTION
We need to add currency and price to the `syncObserverModeAmazonPurchase` so we can track it