### PR TITLE
Migrate OneSignal and Airship to IntegrationIds instead of AttributionIds

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
@@ -65,12 +65,12 @@ sealed class SubscriberAttributeKey(val backendKey: String) {
         object AppsFlyer : AttributionIds(ReservedSubscriberAttribute.APPSFLYER_ID)
         object Facebook : AttributionIds(ReservedSubscriberAttribute.FB_ANON_ID)
         object Mparticle : AttributionIds(ReservedSubscriberAttribute.MPARTICLE_ID)
-        object OneSignal : AttributionIds(ReservedSubscriberAttribute.ONESIGNAL_ID)
-        object Airship : AttributionIds(ReservedSubscriberAttribute.AIRSHIP_CHANNEL_ID)
     }
 
     sealed class IntegrationIds(backendKey: ReservedSubscriberAttribute) : SubscriberAttributeKey(backendKey.value) {
         object MixpanelDistinctId : IntegrationIds(ReservedSubscriberAttribute.MIXPANEL_DISTINCT_ID)
+        object OneSignal : IntegrationIds(ReservedSubscriberAttribute.ONESIGNAL_ID)
+        object Airship : IntegrationIds(ReservedSubscriberAttribute.AIRSHIP_CHANNEL_ID)
     }
 
     sealed class CampaignParameters(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -695,6 +695,36 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         )
     }
 
+    /**
+     * Subscriber attribute associated with the OneSignal Player Id for the user
+     * Required for the RevenueCat OneSignal integration
+     *
+     * @param onesignalID null or an empty string will delete the subscriber attribute
+     */
+    fun setOnesignalID(onesignalID: String?) {
+        log(LogIntent.DEBUG, AttributionStrings.METHOD_CALLED.format("setOnesignalID"))
+        subscriberAttributesManager.setAttribute(
+            SubscriberAttributeKey.IntegrationIds.OneSignal,
+            onesignalID,
+            appUserID
+        )
+    }
+
+    /**
+     * Subscriber attribute associated with the Airship Channel ID
+     * Required for the RevenueCat Airship integration
+     *
+     * @param airshipChannelID null or an empty string will delete the subscriber attribute
+     */
+    fun setAirshipChannelID(airshipChannelID: String?) {
+        log(LogIntent.DEBUG, AttributionStrings.METHOD_CALLED.format("setAirshipChannelID"))
+        subscriberAttributesManager.setAttribute(
+            SubscriberAttributeKey.IntegrationIds.Airship,
+            airshipChannelID,
+            appUserID
+        )
+    }
+
     // endregion
     // region Attribution IDs
 
@@ -772,38 +802,6 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         subscriberAttributesManager.setAttributionID(
             SubscriberAttributeKey.AttributionIds.Mparticle,
             mparticleID,
-            appUserID,
-            application
-        )
-    }
-
-    /**
-     * Subscriber attribute associated with the OneSignal Player Id for the user
-     * Required for the RevenueCat OneSignal integration
-     *
-     * @param onesignalID null or an empty string will delete the subscriber attribute
-     */
-    fun setOnesignalID(onesignalID: String?) {
-        log(LogIntent.DEBUG, AttributionStrings.METHOD_CALLED.format("setOnesignalID"))
-        subscriberAttributesManager.setAttributionID(
-            SubscriberAttributeKey.AttributionIds.OneSignal,
-            onesignalID,
-            appUserID,
-            application
-        )
-    }
-
-    /**
-     * Subscriber attribute associated with the Airship Channel ID
-     * Required for the RevenueCat Airship integration
-     *
-     * @param airshipChannelID null or an empty string will delete the subscriber attribute
-     */
-    fun setAirshipChannelID(airshipChannelID: String?) {
-        log(LogIntent.DEBUG, AttributionStrings.METHOD_CALLED.format("setAirshipChannelID"))
-        subscriberAttributesManager.setAttributionID(
-            SubscriberAttributeKey.AttributionIds.Airship,
-            airshipChannelID,
             appUserID,
             application
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -542,20 +542,6 @@ class SubscriberAttributesPurchasesTests {
         }
     }
 
-    @Test
-    fun `setOnesignalID`() {
-        attributionIDTest(SubscriberAttributeKey.AttributionIds.OneSignal) { id ->
-            underTest.setOnesignalID(id)
-        }
-    }
-
-    @Test
-    fun `setAirshipChannelID`() {
-        attributionIDTest(SubscriberAttributeKey.AttributionIds.Airship) { id ->
-            underTest.setAirshipChannelID(id)
-        }
-    }
-
     // endregion
 
     // region Integration IDs
@@ -564,6 +550,20 @@ class SubscriberAttributesPurchasesTests {
     fun `setMixpanelDistinctID`() {
         integrationIDTest(SubscriberAttributeKey.IntegrationIds.MixpanelDistinctId) { parameter ->
             underTest.setMixpanelDistinctID(parameter)
+        }
+    }
+
+    @Test
+    fun `setOnesignalID`() {
+        integrationIDTest(SubscriberAttributeKey.IntegrationIds.OneSignal) { id ->
+            underTest.setOnesignalID(id)
+        }
+    }
+
+    @Test
+    fun `setAirshipChannelID`() {
+        integrationIDTest(SubscriberAttributeKey.IntegrationIds.Airship) { id ->
+            underTest.setAirshipChannelID(id)
         }
     }
 


### PR DESCRIPTION
For [CF-473](https://revenuecats.atlassian.net/browse/CF-473?atlOrigin=eyJpIjoiYjMyMmE2ZTY3Y2M5NDUwMjllODFhYjIxNmJmMjNjMTQiLCJwIjoiaiJ9)

### Motivation
OneSignal and Airship aren't attribution providers, but we were treating them as such and setting attributes that are not necessary for the integrations to function correctly.

### Description
Migrates OneSignal and Airship attributes to be `IntegrationIds` instead of `AttributionIds`, and tweaks how we're setting the attributes from the `subscriberAttributesManager` to only set the single attributes needed for the integrations.
