### PR TITLE
New public convenience setter for Firebase app instance ID

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -178,6 +178,7 @@ private class PurchasesAPI {
             setOnesignalID("")
             setAirshipChannelID("")
             setMixpanelDistinctID("")
+            setFirebaseAppInstanceID("")
             setMediaSource("")
             setCampaign("")
             setAdGroup("")

--- a/common/src/main/java/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
@@ -33,6 +33,7 @@ enum class ReservedSubscriberAttribute(val value: String) {
      * Integration IDs
      */
     MIXPANEL_DISTINCT_ID("\$mixpanelDistinctId"),
+    FIREBASE_APP_INSTANCE_ID("\$firebaseAppInstanceId"),
 
     /**
      * Optional campaign parameters
@@ -71,6 +72,7 @@ sealed class SubscriberAttributeKey(val backendKey: String) {
 
     sealed class IntegrationIds(backendKey: ReservedSubscriberAttribute) : SubscriberAttributeKey(backendKey.value) {
         object MixpanelDistinctId : IntegrationIds(ReservedSubscriberAttribute.MIXPANEL_DISTINCT_ID)
+        object FirebaseAppInstanceId : IntegrationIds(ReservedSubscriberAttribute.FIREBASE_APP_INSTANCE_ID)
     }
 
     sealed class CampaignParameters(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -711,6 +711,21 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         )
     }
 
+    /**
+     * Subscriber attribute associated with the Firebase App Instance ID for the user
+     * Required for the RevenueCat Firebase integration
+     *
+     * @param firebaseAppInstanceID null or an empty string will delete the subscriber attribute.
+     */
+    fun setFirebaseAppInstanceID(firebaseAppInstanceID: String?) {
+        log(LogIntent.DEBUG, AttributionStrings.METHOD_CALLED.format("setFirebaseAppInstanceID"))
+        subscriberAttributesManager.setAttribute(
+            SubscriberAttributeKey.IntegrationIds.FirebaseAppInstanceId,
+            firebaseAppInstanceID,
+            appUserID
+        )
+    }
+
     // endregion
     // region Attribution IDs
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -741,6 +741,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
 		)
 	}
 
+    /**
      * Subscriber attribute associated with the Firebase App Instance ID for the user
      * Required for the RevenueCat Firebase integration
      *

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -567,6 +567,13 @@ class SubscriberAttributesPurchasesTests {
         }
     }
 
+    @Test
+    fun `setFirebaseAppInstanceID`() {
+        integrationIDTest(SubscriberAttributeKey.IntegrationIds.FirebaseAppInstanceId) { parameter ->
+            underTest.setFirebaseAppInstanceID(parameter)
+        }
+    }
+
     // endregion
 
     // region Campaign parameters


### PR DESCRIPTION
For CF-566

### Motivation
We have convenience setter methods for reserved attributes, and `$firebaseAppInstanceID` is another reserved attribute that needs a setter.

### Description
Adds new public method to Purchases: `setFirebaseAppInstanceID`
