### PR TITLE
Better error when Amazon price is missing

### DIFF
--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
@@ -34,7 +34,7 @@ object AmazonStrings {
         "Failed to get user data. There was an Amazon store problem."
     const val PRODUCT_PRICE_MISSING = "Product %s is missing a price. This is common if you're trying to load a " +
         "product SKU instead of a subscription term SKU. Make sure you configure the subscription term SKUs " +
-        "in the RevenueCat dashboard"
+        "in the RevenueCat dashboard."
     const val WARNING_AMAZON_OBSERVER_MODE =
         "Attempting to interact with Amazon App Store with an Amazon Purchases configuration in observer mode " +
             "won't do anything. Please use syncObserverModeAmazonPurchase to send purchases to RevenueCat instead."

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
@@ -35,4 +35,7 @@ object AmazonStrings {
     const val ERROR_OBSERVER_MODE_NOT_SUPPORTED =
         "Attempting to interact with Amazon App Store with an Amazon Purchases configuration in observer mode, " +
             "but observer mode is not yet supported."
+    const val PRODUCT_PRICE_MISSING = "Product %s is missing a price. This is common if you're trying to load a " +
+        "product SKU instead of a subscription term SKU. Make sure you configure the subscription term SKUs " +
+        "in the RevenueCat dashboard"
 }

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/ProductDataHandler.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/ProductDataHandler.kt
@@ -95,7 +95,7 @@ class ProductDataHandler(
             log(LogIntent.DEBUG, AmazonStrings.RETRIEVED_PRODUCT_DATA_EMPTY)
         }
 
-        val storeProducts = productData.values.map { it.toStoreProduct(marketplace) }
+        val storeProducts = productData.values.mapNotNull { it.toStoreProduct(marketplace) }
         onReceive(storeProducts)
     }
 

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
@@ -1,8 +1,11 @@
 package com.revenuecat.purchases.amazon
 
+import android.util.Log
 import com.amazon.device.iap.internal.model.ProductBuilder
 import com.amazon.device.iap.model.Product
+import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.MICROS_MULTIPLIER
+import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.models.StoreProduct
 import org.json.JSONObject
 import java.math.BigDecimal
@@ -19,7 +22,11 @@ val StoreProduct.amazonProduct: Product
         .setTitle(originalJson.getString("title"))
         .setCoinsRewardAmount(originalJson.getInt("coinsRewardAmount")).build()
 
-fun Product.toStoreProduct(marketplace: String): StoreProduct {
+fun Product.toStoreProduct(marketplace: String): StoreProduct? {
+    if (price == null) {
+        log(LogIntent.AMAZON_ERROR, AmazonStrings.PRODUCT_PRICE_MISSING.format(sku))
+        return null
+    }
     // By default, Amazon automatically converts the base list price of your IAP items into
     // the local currency of each marketplace where they can be sold, and customers will see IAP items in English.
     val (currencyCode, priceAmountMicros) = price.extractPrice(marketplace)

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -394,11 +394,12 @@ class AmazonBillingTest {
         }
 
         val marketplaceSlot = slot<String>()
-        val storeProduct = listOf(dummyAmazonProduct().toStoreProduct(marketplace))
+        val storeProducts = listOfNotNull(dummyAmazonProduct().toStoreProduct(marketplace))
+
         every {
             mockProductDataHandler.getProductData(skus, capture(marketplaceSlot), captureLambda(), any())
         } answers {
-            lambda<(List<StoreProduct>) -> Unit>().captured.invoke(storeProduct)
+            lambda<(List<StoreProduct>) -> Unit>().captured.invoke(storeProducts)
         }
 
         var onReceiveCalled = false
@@ -557,8 +558,10 @@ class AmazonBillingTest {
             }
         }
 
+        assertThat(storeProduct).isNotNull
+
         every {
-            mockPurchaseHandler.purchase(appUserID, storeProduct, null, captureLambda(), any())
+            mockPurchaseHandler.purchase(appUserID, storeProduct!!, null, captureLambda(), any())
         } answers {
             lambda<(Receipt, UserData) -> Unit>().captured.invoke(dummyReceipt, dummyUserData)
         }
@@ -568,7 +571,7 @@ class AmazonBillingTest {
         underTest.makePurchaseAsync(
             mockk(),
             appUserID,
-            storeProduct = storeProduct,
+            storeProduct = storeProduct!!,
             replaceSkuInfo = null,
             presentedOfferingIdentifier = null
         )
@@ -613,8 +616,10 @@ class AmazonBillingTest {
             }
         }
 
+        assertThat(storeProduct).isNotNull
+
         every {
-            mockPurchaseHandler.purchase(appUserID, storeProduct, null, captureLambda(), any())
+            mockPurchaseHandler.purchase(appUserID, storeProduct!!, null, captureLambda(), any())
         } answers {
             lambda<(Receipt, UserData) -> Unit>().captured.invoke(dummyReceipt, dummyUserData)
         }
@@ -622,7 +627,7 @@ class AmazonBillingTest {
         underTest.makePurchaseAsync(
             mockk(),
             appUserID,
-            storeProduct = storeProduct,
+            storeProduct = storeProduct!!,
             replaceSkuInfo = null,
             presentedOfferingIdentifier = null
         )

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/ProductConverterTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/ProductConverterTest.kt
@@ -16,22 +16,22 @@ class ProductConverterTest {
         val expectedSku = "sku"
         val product = dummyAmazonProduct(expectedSku)
         val storeProduct = product.toStoreProduct("US")
-        assertThat(storeProduct.sku).isEqualTo(expectedSku)
+        assertThat(storeProduct?.sku).isEqualTo(expectedSku)
     }
 
     @Test
     fun `product types are correctly assigned`() {
         var product = dummyAmazonProduct(productType = AmazonProductType.CONSUMABLE)
         var storeProduct = product.toStoreProduct("US")
-        assertThat(storeProduct.type).isEqualTo(RevenueCatProductType.INAPP)
+        assertThat(storeProduct?.type).isEqualTo(RevenueCatProductType.INAPP)
 
         product = dummyAmazonProduct(productType = AmazonProductType.ENTITLED)
         storeProduct = product.toStoreProduct("US")
-        assertThat(storeProduct.type).isEqualTo(RevenueCatProductType.INAPP)
+        assertThat(storeProduct?.type).isEqualTo(RevenueCatProductType.INAPP)
 
         product = dummyAmazonProduct(productType = AmazonProductType.SUBSCRIPTION)
         storeProduct = product.toStoreProduct("US")
-        assertThat(storeProduct.type).isEqualTo(RevenueCatProductType.SUBS)
+        assertThat(storeProduct?.type).isEqualTo(RevenueCatProductType.SUBS)
     }
 
     @Test
@@ -39,29 +39,29 @@ class ProductConverterTest {
         val expectedPrice = "$39.99"
         val product = dummyAmazonProduct(price = expectedPrice)
         val storeProduct = product.toStoreProduct("US")
-        assertThat(storeProduct.price).isEqualTo(expectedPrice)
+        assertThat(storeProduct?.price).isEqualTo(expectedPrice)
     }
 
     @Test
     fun `priceAmountMicros is correctly calculated`() {
         val product = dummyAmazonProduct(price = "$39.99")
         val storeProduct = product.toStoreProduct("US")
-        assertThat(storeProduct.priceAmountMicros).isEqualTo(39_990_000)
+        assertThat(storeProduct?.priceAmountMicros).isEqualTo(39_990_000)
     }
 
     @Test
     fun `priceCurrencyCode is correctly assigned`() {
         val product = dummyAmazonProduct(price = "$39.99")
         val storeProduct = product.toStoreProduct("US")
-        assertThat(storeProduct.priceCurrencyCode).isEqualTo("USD")
+        assertThat(storeProduct?.priceCurrencyCode).isEqualTo("USD")
     }
 
     @Test
     fun `originalPrice is null`() {
         val product = dummyAmazonProduct()
         val storeProduct = product.toStoreProduct("US")
-        assertThat(storeProduct.originalPrice).isNull()
-        assertThat(storeProduct.originalPriceAmountMicros).isZero()
+        assertThat(storeProduct?.originalPrice).isNull()
+        assertThat(storeProduct?.originalPriceAmountMicros).isZero()
     }
 
     @Test
@@ -69,7 +69,7 @@ class ProductConverterTest {
         val expectedTitle = "title"
         val product = dummyAmazonProduct(title = expectedTitle)
         val storeProduct = product.toStoreProduct("US")
-        assertThat(storeProduct.title).isEqualTo(expectedTitle)
+        assertThat(storeProduct?.title).isEqualTo(expectedTitle)
     }
 
     @Test
@@ -77,25 +77,25 @@ class ProductConverterTest {
         val expectedDescription = "description"
         val product = dummyAmazonProduct(description = expectedDescription)
         val storeProduct = product.toStoreProduct("US")
-        assertThat(storeProduct.description).isEqualTo(expectedDescription)
+        assertThat(storeProduct?.description).isEqualTo(expectedDescription)
     }
 
     @Test
     fun `subscription period is null`() {
         val product = dummyAmazonProduct()
         val storeProduct = product.toStoreProduct("US")
-        assertThat(storeProduct.subscriptionPeriod).isNull()
+        assertThat(storeProduct?.subscriptionPeriod).isNull()
     }
 
     @Test
     fun `introductory price and trial periods are not available for Amazon`() {
         val product = dummyAmazonProduct()
         val storeProduct = product.toStoreProduct("US")
-        assertThat(storeProduct.freeTrialPeriod).isNull()
-        assertThat(storeProduct.introductoryPrice).isNull()
-        assertThat(storeProduct.introductoryPriceAmountMicros).isZero
-        assertThat(storeProduct.introductoryPricePeriod).isNull()
-        assertThat(storeProduct.introductoryPriceCycles).isZero
+        assertThat(storeProduct?.freeTrialPeriod).isNull()
+        assertThat(storeProduct?.introductoryPrice).isNull()
+        assertThat(storeProduct?.introductoryPriceAmountMicros).isZero
+        assertThat(storeProduct?.introductoryPricePeriod).isNull()
+        assertThat(storeProduct?.introductoryPriceCycles).isZero
     }
 
     @Test
@@ -103,7 +103,7 @@ class ProductConverterTest {
         val expectedSmallIconUrl = "https://icon.url"
         val product = dummyAmazonProduct(smallIconUrl = expectedSmallIconUrl)
         val storeProduct = product.toStoreProduct("US")
-        assertThat(storeProduct.iconUrl).isEqualTo(expectedSmallIconUrl)
+        assertThat(storeProduct?.iconUrl).isEqualTo(expectedSmallIconUrl)
     }
 
     @Test
@@ -111,12 +111,21 @@ class ProductConverterTest {
         val product = dummyAmazonProduct()
         val storeProduct = product.toStoreProduct("US")
 
-        val receivedJSON = storeProduct.originalJson
+        val receivedJSON = storeProduct?.originalJson
         val expectedJSON = product.toJSON()
 
-        assertThat(receivedJSON.length()).isEqualTo(expectedJSON.length())
+        assertThat(receivedJSON).isNotNull
+        assertThat(receivedJSON!!.length()).isEqualTo(expectedJSON.length())
         receivedJSON.keys().forEach {
             assertThat(receivedJSON[it]).isEqualTo(expectedJSON[it])
         }
+    }
+
+    @Test
+    fun `if price is missing, product is not converted`() {
+        val product = dummyAmazonProduct(price = null)
+        val storeProduct = product.toStoreProduct("US")
+
+        assertThat(storeProduct).isNull()
     }
 }

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/PurchaseHandlerTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/PurchaseHandlerTest.kt
@@ -240,7 +240,7 @@ class PurchaseHandlerTest {
     }
 
     private fun dummyStoreProduct(): StoreProduct {
-        return dummyAmazonProduct().toStoreProduct("US")
+        return dummyAmazonProduct().toStoreProduct("US")!!
     }
 
     private fun getDummyPurchaseResponse(

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/helpers/dummies.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/helpers/dummies.kt
@@ -15,7 +15,7 @@ fun dummyAmazonProduct(
     productType: ProductType = ProductType.SUBSCRIPTION,
     description: String = "A product description",
     title: String = "A product title",
-    price: String = "$3.00",
+    price: String? = "$3.00",
     smallIconUrl: String = "https://icon.url",
     coinsRewardAmount: Int = 100
 ): Product {


### PR DESCRIPTION
If devs set the parent subscription instead of the term in the dashboard, Amazon will not provide a price (which makes sense since only terms have price) and we will crash when trying to get the product.

This PR prevents the crash and adds a nicer error message