### PR TITLE
Fix log when failing to fetch offerings

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1061,7 +1061,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
             PurchasesErrorCode.ConfigurationError,
             PurchasesErrorCode.UnexpectedBackendResponseError
         )
-            .contains(error)
+            .contains(error.code)
 
         log(
             if (errorCausedByPurchases) LogIntent.RC_ERROR else LogIntent.GOOGLE_ERROR,


### PR DESCRIPTION
Upgrading the Kotlin version triggers a compilation error. We were comparing a PurchasesError against error codes.