### PR TITLE
Adds price string header to post receipt call

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.strings.NetworkStrings
+import com.revenuecat.purchases.utils.filterNotNullValues
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -163,6 +164,7 @@ class Backend(
         subscriberAttributes: Map<String, Map<String, Any?>>,
         receiptInfo: ReceiptInfo,
         storeAppUserID: String?,
+        marketplace: String? = null,
         onSuccess: PostReceiptDataSuccessCallback,
         onError: PostReceiptDataErrorCallback
     ) {
@@ -193,7 +195,7 @@ class Backend(
         ).filterValues { value -> value != null }
 
         val extraHeaders = receiptInfo.storeProduct?.price?.let { priceString ->
-            mapOf("price_string" to priceString)
+            mapOf("price_string" to priceString, "marketplace" to marketplace).filterNotNullValues()
         } ?: mapOf()
 
         val call = object : Dispatcher.AsyncCall() {

--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -192,13 +192,17 @@ class Backend(
             "store_user_id" to storeAppUserID
         ).filterValues { value -> value != null }
 
+        val extraHeaders = receiptInfo.storeProduct?.price?.let { priceString ->
+            mapOf("price_string" to priceString)
+        } ?: mapOf()
+
         val call = object : Dispatcher.AsyncCall() {
 
             override fun call(): HTTPResult {
                 return httpClient.performRequest(
                     "/receipts",
                     body,
-                    authenticationHeaders
+                    authenticationHeaders + extraHeaders
                 )
             }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -79,7 +79,7 @@ class HTTPClient(
     /** Performs a synchronous web request to the RevenueCat API
      * @param path The resource being requested
      * @param body The body of the request, for GET must be null
-     * @param authenticationHeaders Map of headers, basic headers are added automatically
+     * @param requestHeaders Map of headers, basic headers are added automatically
      * @return Result containing the HTTP response code and the parsed JSON body
      * @throws JSONException Thrown for any JSON errors, not thrown for returned HTTP error codes
      * @throws IOException Thrown for any unexpected errors, not thrown for returned HTTP error codes
@@ -88,7 +88,7 @@ class HTTPClient(
     fun performRequest(
         path: String,
         body: Map<String, Any?>?,
-        authenticationHeaders: Map<String, String>,
+        requestHeaders: Map<String, String>,
         refreshETag: Boolean = false
     ): HTTPResult {
         val jsonBody = body?.convert()
@@ -100,7 +100,7 @@ class HTTPClient(
         try {
             fullURL = URL(appConfig.baseURL, urlPathWithVersion)
 
-            val headers = getHeaders(authenticationHeaders, urlPathWithVersion, refreshETag)
+            val headers = getHeaders(requestHeaders, urlPathWithVersion, refreshETag)
             httpRequest = HTTPRequest(fullURL, headers, jsonBody)
 
             connection = getConnection(httpRequest)
@@ -135,7 +135,7 @@ class HTTPClient(
         )
         if (callResult == null) {
             log(LogIntent.WARNING, NetworkStrings.ETAG_RETRYING_CALL)
-            return performRequest(path, body, authenticationHeaders, refreshETag = true)
+            return performRequest(path, body, requestHeaders, refreshETag = true)
         }
         return callResult
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.utils.getNullableString
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Fail.fail
@@ -69,6 +70,8 @@ class BackendTest {
     private var receivedOfferingsJSON: JSONObject? = null
     private var receivedError: PurchasesError? = null
     private var receivedShouldConsumePurchase: Boolean? = null
+
+    private val headersSlot = slot<Map<String, String>>()
 
     private val onReceiveCustomerInfoSuccessHandler: (CustomerInfo) -> Unit = { info ->
             this@BackendTest.receivedCustomerInfo = info
@@ -124,9 +127,6 @@ class BackendTest {
 
         val result = HTTPResult(responseCode, resultBody ?: "{}")
 
-        val headers = HashMap<String, String>()
-        headers["Authorization"] = "Bearer $API_KEY"
-
         if (shouldMockCustomerInfo) {
             every {
                 result.body.buildCustomerInfo()
@@ -136,7 +136,7 @@ class BackendTest {
             mockClient.performRequest(
                 eq(path),
                 (if (body == null) any() else eq(body)),
-                eq<Map<String, String>>(headers)
+                capture(headersSlot)
             )
         }
 
@@ -1403,8 +1403,30 @@ class BackendTest {
         assertThat(receivedShouldConsumePurchase).`as`("Purchase shouldn't be consumed").isFalse()
     }
 
+    @Test
+    fun `postReceipt passes formatted price as header`() {
+        val storeProduct = mockStoreProduct()
+
+        postReceipt(
+            responseCode = 200,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            observerMode = true,
+            receiptInfo = ReceiptInfo(
+                productIDs,
+                storeProduct = storeProduct
+            ),
+            storeAppUserID = null,
+        )
+
+        assertThat(headersSlot.isCaptured).isTrue
+        assertThat(headersSlot.captured.keys).contains("price_string")
+        assertThat(headersSlot.captured["price_string"]).isEqualTo("$25")
+    }
+
     private fun mockStoreProduct(
-        price: Long = 25000000,
+        price: Long = 25_000_000,
         duration: String = "P1M",
         introDuration: String = "P1M",
         trialDuration: String = "P1M"
@@ -1415,6 +1437,7 @@ class BackendTest {
         every { storeProduct.subscriptionPeriod } returns duration
         every { storeProduct.introductoryPricePeriod } returns introDuration
         every { storeProduct.freeTrialPeriod } returns trialDuration
+        every { storeProduct.price } returns "$25"
         return storeProduct
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -159,7 +159,8 @@ class BackendTest {
         resultBody: String?,
         observerMode: Boolean,
         receiptInfo: ReceiptInfo,
-        storeAppUserID: String?
+        storeAppUserID: String?,
+        marketplace: String? = null
     ): CustomerInfo {
         val (fetchToken, info) = mockPostReceiptResponse(
             isRestore,
@@ -179,6 +180,7 @@ class BackendTest {
             subscriberAttributes = emptyMap(),
             receiptInfo = receiptInfo,
             storeAppUserID = storeAppUserID,
+            marketplace = marketplace,
             onSuccess = onReceivePostReceiptSuccessHandler,
             onError = postReceiptErrorCallback
         )
@@ -1423,6 +1425,30 @@ class BackendTest {
         assertThat(headersSlot.isCaptured).isTrue
         assertThat(headersSlot.captured.keys).contains("price_string")
         assertThat(headersSlot.captured["price_string"]).isEqualTo("$25")
+    }
+
+    @Test
+    fun `postReceipt passes marketplace as header`() {
+        val storeProduct = mockStoreProduct()
+
+        postReceipt(
+            responseCode = 200,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            observerMode = true,
+            receiptInfo = ReceiptInfo(
+                productIDs,
+                storeProduct = storeProduct
+            ),
+            storeAppUserID = null,
+            marketplace = "DE"
+        )
+
+        assertThat(headersSlot.isCaptured).isTrue
+        assertThat(headersSlot.captured.keys).contains("price_string")
+        assertThat(headersSlot.captured["price_string"]).isEqualTo("$25")
+        assertThat(headersSlot.captured["marketplace"]).isEqualTo("DE")
     }
 
     private fun mockStoreProduct(

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -305,7 +305,7 @@ internal class AmazonBilling constructor(
             sku = sku,
             presentedOfferingIdentifier = null,
             purchaseState = PurchaseState.UNSPECIFIED_STATE,
-            storeUserID = userData.userId
+            userData
         )
         val hash = receipt.receiptId.sha1()
         hash to amazonPurchaseWrapper
@@ -425,7 +425,7 @@ internal class AmazonBilling constructor(
                 sku = storeProduct.sku,
                 presentedOfferingIdentifier = presentedOfferingIdentifier,
                 purchaseState = PurchaseState.PURCHASED,
-                storeUserID = userData.userId
+                userData
             )
             purchasesUpdatedListener?.onPurchasesUpdated(listOf(amazonPurchaseWrapper))
             return
@@ -440,7 +440,7 @@ internal class AmazonBilling constructor(
                     sku = termSku,
                     presentedOfferingIdentifier = presentedOfferingIdentifier,
                     purchaseState = PurchaseState.PURCHASED,
-                    storeUserID = userData.userId
+                    userData
                 )
                 purchasesUpdatedListener?.onPurchasesUpdated(listOf(amazonPurchaseWrapper))
             },

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/paymentTransactionConversions.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/paymentTransactionConversions.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.amazon
 
 import com.amazon.device.iap.model.Receipt
+import com.amazon.device.iap.model.UserData
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.PurchaseType
@@ -10,7 +11,7 @@ fun Receipt.toStoreTransaction(
     sku: String,
     presentedOfferingIdentifier: String?,
     purchaseState: PurchaseState,
-    storeUserID: String?
+    userData: UserData
 ): StoreTransaction {
     val type = this.productType.toRevenueCatProductType()
     return StoreTransaction(
@@ -24,7 +25,8 @@ fun Receipt.toStoreTransaction(
         signature = null,
         originalJson = this.toJSON(),
         presentedOfferingIdentifier = presentedOfferingIdentifier,
-        storeUserID = storeUserID,
-        purchaseType = PurchaseType.AMAZON_PURCHASE
+        storeUserID = userData.userId,
+        purchaseType = PurchaseType.AMAZON_PURCHASE,
+        marketplace = userData.marketplace
     )
 }

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
@@ -71,7 +71,7 @@ class AmazonBackendTest {
             mockClient.performRequest(
                 path = "/receipts/amazon/store_user_id/receipt_id",
                 body = null,
-                authenticationHeaders = mapOf("Authorization" to "Bearer $API_KEY")
+                requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
             )
         } returns successfulResult
 
@@ -91,7 +91,7 @@ class AmazonBackendTest {
             mockClient.performRequest(
                 path = "/receipts/amazon/store_user_id/receipt_id",
                 body = null,
-                authenticationHeaders = mapOf("Authorization" to "Bearer $API_KEY")
+                requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
             )
         } returns unsuccessfulResult
 
@@ -112,7 +112,7 @@ class AmazonBackendTest {
             mockClient.performRequest(
                 path = "/receipts/amazon/store_user_id/receipt_id",
                 body = null,
-                authenticationHeaders = mapOf("Authorization" to "Bearer $API_KEY")
+                requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
             )
         } throws IOException()
 

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -427,7 +427,10 @@ class AmazonBillingTest {
                 sku = "sku.monthly",
                 presentedOfferingIdentifier = null,
                 purchaseState = PurchaseState.PENDING,
-                storeUserID = "store_user_id"
+                userData = dummyUserData(
+                    storeUserId = "store_user_id",
+                    marketplace = "US"
+                ),
             )
         )
 
@@ -455,7 +458,10 @@ class AmazonBillingTest {
                 sku = "sku.monthly",
                 presentedOfferingIdentifier = null,
                 purchaseState = PurchaseState.PURCHASED,
-                storeUserID = "store_user_id"
+                userData = dummyUserData(
+                    storeUserId = "store_user_id",
+                    marketplace = "US"
+                )
             )
         )
 
@@ -487,7 +493,10 @@ class AmazonBillingTest {
                 sku = "sku.monthly",
                 presentedOfferingIdentifier = null,
                 purchaseState = PurchaseState.PURCHASED,
-                storeUserID = "store_user_id"
+                userData = dummyUserData(
+                    storeUserId = "store_user_id",
+                    marketplace = "US"
+                )
             )
         )
 

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/ReceiptToStoreTransactionTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/ReceiptToStoreTransactionTest.kt
@@ -1,8 +1,10 @@
 package com.revenuecat.purchases.amazon
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amazon.device.iap.model.UserData
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.amazon.helpers.dummyReceipt
+import com.revenuecat.purchases.amazon.helpers.dummyUserData
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.PurchaseType
 import com.revenuecat.purchases.models.PurchaseState
@@ -23,7 +25,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.orderId).isNull()
@@ -40,7 +45,10 @@ class ReceiptToStoreTransactionTest {
             sku = expectedTermSku,
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.skus[0]).isEqualTo(expectedTermSku)
@@ -55,7 +63,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.type).isEqualTo(ProductType.SUBS)
@@ -66,7 +77,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.type).isEqualTo(ProductType.INAPP)
@@ -77,7 +91,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.type).isEqualTo(ProductType.INAPP)
@@ -92,7 +109,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.purchaseTime).isEqualTo(expectedPurchaseDate.time)
@@ -106,7 +126,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.purchaseToken).isEqualTo(receipt.receiptId)
@@ -121,7 +144,10 @@ class ReceiptToStoreTransactionTest {
                 sku = "sku",
                 presentedOfferingIdentifier = "offering",
                 purchaseState = expectedPurchaseState,
-                storeUserID = "store_user_id"
+                userData = dummyUserData(
+                    storeUserId = "store_user_id",
+                    marketplace = "US"
+                ),
             )
 
             assertThat(storeTransaction.purchaseState).isEqualTo(expectedPurchaseState)
@@ -136,7 +162,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.isAutoRenewing).isFalse
@@ -150,7 +179,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.isAutoRenewing).isTrue
@@ -164,7 +196,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.isAutoRenewing).isFalse
@@ -175,7 +210,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.isAutoRenewing).isFalse
@@ -189,7 +227,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.signature).isNull()
@@ -203,7 +244,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         val receivedJSON = storeTransaction.originalJson
@@ -224,7 +268,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = expectedPresentedOfferingIdentifier,
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.presentedOfferingIdentifier).isEqualTo(expectedPresentedOfferingIdentifier)
@@ -239,7 +286,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = expectedPresentedOfferingIdentifier,
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.presentedOfferingIdentifier).isEqualTo(expectedPresentedOfferingIdentifier)
@@ -255,10 +305,32 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = "offering",
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = expectedStoreUserID
+            userData = dummyUserData(
+                storeUserId = expectedStoreUserID,
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.storeUserID).isEqualTo(expectedStoreUserID)
+    }
+
+    @Test
+    fun `marketplace is correct`() {
+        val receipt = dummyReceipt()
+
+        val expectedMarketplace = "US"
+
+        val storeTransaction: StoreTransaction = receipt.toStoreTransaction(
+            sku = "sku",
+            presentedOfferingIdentifier = "offering",
+            purchaseState = PurchaseState.PURCHASED,
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = expectedMarketplace
+            )
+        )
+
+        assertThat(storeTransaction.marketplace).isEqualTo(expectedMarketplace)
     }
 
     @Test
@@ -268,7 +340,10 @@ class ReceiptToStoreTransactionTest {
             sku = "sku",
             presentedOfferingIdentifier = null,
             purchaseState = PurchaseState.PURCHASED,
-            storeUserID = "store_user_id"
+            userData = dummyUserData(
+                storeUserId = "store_user_id",
+                marketplace = "US"
+            )
         )
 
         assertThat(storeTransaction.purchaseType).isEqualTo(PurchaseType.AMAZON_PURCHASE)

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/paymenTransactionConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/paymenTransactionConversions.kt
@@ -24,7 +24,8 @@ fun Purchase.toStoreTransaction(
     originalJson = JSONObject(this.originalJson),
     presentedOfferingIdentifier = presentedOfferingIdentifier,
     storeUserID = null,
-    purchaseType = PurchaseType.GOOGLE_PURCHASE
+    purchaseType = PurchaseType.GOOGLE_PURCHASE,
+    marketplace = null
 )
 
 val StoreTransaction.originalGooglePurchase: Purchase?
@@ -48,6 +49,7 @@ fun PurchaseHistoryRecord.toStoreTransaction(
         originalJson = JSONObject(this.originalJson),
         presentedOfferingIdentifier = null,
         storeUserID = null,
-        purchaseType = PurchaseType.GOOGLE_RESTORED_PURCHASE
+        purchaseType = PurchaseType.GOOGLE_RESTORED_PURCHASE,
+        marketplace = null
     )
 }

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
@@ -69,14 +69,19 @@ data class StoreTransaction(
     val presentedOfferingIdentifier: String?,
 
     /**
-     * Null for Google
+     * Amazon's store user id. Null for Google
      */
     val storeUserID: String?,
 
     /**
      * One of [PurchaseType] indicating the type of purchase.
      */
-    val purchaseType: PurchaseType
+    val purchaseType: PurchaseType,
+
+    /**
+     * Amazon's marketplace. Null for Google
+     */
+    val marketplace: String?
 ) : Parcelable {
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -232,6 +232,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
                             purchase.storeUserID,
                             appUserID,
                             productInfo,
+                            purchase.marketplace,
                             {
                                 log(LogIntent.PURCHASE, PurchaseStrings.PURCHASE_SYNCED.format(purchase))
                             },
@@ -291,6 +292,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
                     amazonUserID,
                     appUserID,
                     receiptInfo,
+                    marketplace = null,
                     {
                         val logMessage = PurchaseStrings.PURCHASE_SYNCED_USER_ID.format(receiptID, amazonUserID)
                         log(LogIntent.PURCHASE, logMessage)
@@ -496,6 +498,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
                                     subscriberAttributes = unsyncedSubscriberAttributesByKey.toBackendMap(),
                                     receiptInfo = receiptInfo,
                                     storeAppUserID = purchase.storeUserID,
+                                    marketplace = purchase.marketplace,
                                     onSuccess = { info, body ->
                                         subscriberAttributesManager.markAsSynced(
                                             appUserID,
@@ -1212,6 +1215,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
             subscriberAttributes = unsyncedSubscriberAttributesByKey.toBackendMap(),
             receiptInfo = receiptInfo,
             storeAppUserID = purchase.storeUserID,
+            marketplace = purchase.marketplace,
             onSuccess = { info, body ->
                 subscriberAttributesManager.markAsSynced(
                     appUserID,
@@ -1559,6 +1563,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
         storeUserID: String?,
         appUserID: String,
         productInfo: ReceiptInfo,
+        marketplace: String?,
         onSuccess: () -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -1572,6 +1577,7 @@ class Purchases @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) intern
             subscriberAttributes = unsyncedSubscriberAttributesByKey.toBackendMap(),
             receiptInfo = productInfo,
             storeAppUserID = storeUserID,
+            marketplace = marketplace,
             onSuccess = { info, body ->
                 subscriberAttributesManager.markAsSynced(
                     appUserID,

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -3905,6 +3905,7 @@ class PurchasesTest {
                     subscriberAttributes = any(),
                     receiptInfo = any(),
                     storeAppUserID = any(),
+                    marketplace = any(),
                     onSuccess = captureLambda(),
                     onError = any()
                 )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -3079,7 +3079,7 @@ class PurchasesTest {
             mockBillingAbstract.queryPurchases(appUserId, any(), any())
         }
         verify(exactly = 0) {
-            mockBackend.postReceiptData(any(), any(), any(), any(), any(), any(), any(), any(), any())
+            mockBackend.postReceiptData(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -93,6 +93,7 @@ class SubscriberAttributesPurchasesTests {
                 subscriberAttributes = capture(postedAttributesSlot),
                 receiptInfo = any(),
                 storeAppUserID = any(),
+                marketplace = any(),
                 onSuccess = capture(successSlot),
                 onError = capture(errorSlot)
             )
@@ -251,6 +252,7 @@ class SubscriberAttributesPurchasesTests {
                 subscriberAttributes = expectedAttributes.toBackendMap(),
                 receiptInfo = any(),
                 storeAppUserID = any(),
+                marketplace = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -324,6 +326,7 @@ class SubscriberAttributesPurchasesTests {
                 subscriberAttributes = expectedAttributes.toBackendMap(),
                 receiptInfo = any(),
                 storeAppUserID = any(),
+                marketplace = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -416,6 +419,7 @@ class SubscriberAttributesPurchasesTests {
                 subscriberAttributes = expectedAttributes.toBackendMap(),
                 receiptInfo = any(),
                 storeAppUserID = any(),
+                marketplace = any(),
                 onSuccess = any(),
                 onError = any()
             )

--- a/purchases/src/testLatestDependencies/java/com/revenuecat/purchases/PostingTransactionsTestsBillingClient4.kt
+++ b/purchases/src/testLatestDependencies/java/com/revenuecat/purchases/PostingTransactionsTestsBillingClient4.kt
@@ -84,6 +84,7 @@ class PostingTransactionsTests {
                 subscriberAttributes = any(),
                 receiptInfo = capture(postedProductInfoSlot),
                 storeAppUserID = any(),
+                marketplace = any(),
                 onSuccess = capture(successSlot),
                 onError = capture(errorSlot)
             )
@@ -169,6 +170,7 @@ class PostingTransactionsTests {
                 subscriberAttributes = expectedAttributes.toBackendMap(),
                 storeAppUserID = any(),
                 receiptInfo = any(),
+                marketplace = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -209,6 +211,7 @@ class PostingTransactionsTests {
                 subscriberAttributes = expectedAttributes.toBackendMap(),
                 receiptInfo = any(),
                 storeAppUserID = any(),
+                marketplace = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -255,6 +258,7 @@ class PostingTransactionsTests {
                 subscriberAttributes = expectedAttributes.toBackendMap(),
                 receiptInfo = any(),
                 storeAppUserID = expectedStoreUserID,
+                marketplace = any(),
                 onSuccess = any(),
                 onError = any()
             )


### PR DESCRIPTION
We have been getting reports of wrong prices for Amazon transactions. This PR adds a header that would send whatever we get from the Amazon SDK as a header so we can do better debugging.