### PR TITLE
Fix price parsing of prices with "nbsp" characters

### DIFF
--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
@@ -78,11 +78,14 @@ internal fun String.parsePriceUsingRegex(): BigDecimal? {
     val matcher = pattern.matcher(this)
     return matcher.takeIf { it.find() }?.let {
         val dirtyPrice = matcher.group()
+        // Amazon sends a nbsp character in countries with euros "5,80 €"
+        // Android devices will match the nbsp, JVM (when running on unit tests will not match the nbsp)
+        // So we remove them and trim just in case
         var price =
             dirtyPrice.replace(" ", "")
-            .replace(" ", "")
-            .replace("${Typography.nbsp}", "")
-        price = price.trim()
+                .replace(" ", "") // This is a NBSP, some editors might render it as a space or a tab
+                .replace("${Typography.nbsp}", "")
+                .trim()
         val split = price.split(".", ",")
         if (split.size != 1) {
             // Assuming all prices we get have 2 decimal points

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
@@ -78,7 +78,11 @@ internal fun String.parsePriceUsingRegex(): BigDecimal? {
     val matcher = pattern.matcher(this)
     return matcher.takeIf { it.find() }?.let {
         val dirtyPrice = matcher.group()
-        var price = dirtyPrice.replace(" ", "")
+        var price =
+            dirtyPrice.replace(" ", "")
+            .replace(" ", "")
+            .replace("${Typography.nbsp}", "")
+        price = price.trim()
         val split = price.split(".", ",")
         if (split.size != 1) {
             // Assuming all prices we get have 2 decimal points

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/PriceExtractorTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/PriceExtractorTest.kt
@@ -729,6 +729,10 @@ class PriceExtractorTest {
         val (currencyCode, priceAmountMicros) = "7.00${nbsp}US$".extractPrice("US")
         assertThat(currencyCode).isEqualTo("USD")
         assertThat(priceAmountMicros).isEqualTo(7_000_000)
+        val anotherPriceWithNBSP = "5,80 €"
+        val (anotherCurrencyCode, anotherPriceAmountMicros) = anotherPriceWithNBSP.extractPrice("DE")
+        assertThat(anotherCurrencyCode).isEqualTo("EUR")
+        assertThat(anotherPriceAmountMicros).isEqualTo(5_800_000)
     }
 
 }

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/PriceExtractorTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/PriceExtractorTest.kt
@@ -726,6 +726,8 @@ class PriceExtractorTest {
 
     @Test
     fun `US marketplace 7 USD US$ space symbol after and nbsp`() {
+        // This test was passing in unit test but failing when executed instrumented before the following bugfix
+        // https://github.com/RevenueCat/purchases-android/pull/538
         val (currencyCode, priceAmountMicros) = "7.00${nbsp}US$".extractPrice("US")
         assertThat(currencyCode).isEqualTo("USD")
         assertThat(priceAmountMicros).isEqualTo(7_000_000)


### PR DESCRIPTION
We had a test that covered this, but the code behaves differently in an Android device and during unit testing.

I thought I was crazy, but https://stackoverflow.com/questions/27402616/how-to-get-plain-price-value-with-amazon-in-app-purchasing-api#comment43795089_27449971 this comment corroborates my theory.

We have to migrate this test to be instrumented but I encountered a bunch of issues doing that:

- Adding a simple instrumented test brings the number of methods above 64k, which means we need to enable multidex.
- After enabling multidex I started getting Java out of memory errors when compiling.
- I gave more memory allocation to the JVM and then Kotlin started to fail so I had to increase the Kotlin version
- I looked into some dependencies we have using a dependencies plugin and realized that we have a bunch of dependencies that are not used, specially  testing dependencies. I managed to remove some but the +64k methods were still there
- So then when I ran the project with multidex, updated dependencies and more memory, I noticed how executing connectedAndroidTest gradle task also runs the integration tests, because they are part of the project and connectedAndroidTest runs all tests in the project.
- I thought about moving these new tests into the integration-test app but the function I am testing is not public, plus this is not really an integratino test where we hit our backend.

In summary, the solution I think it is to extract the integration-test and the purchase-tester apps outside of the project and into their own projects. This will probably reduce the number of methods by a lot, compilation time too and will let us ran the instrumented tests of the project without running the integration tests too.

This will take me some time to adjust because of CI, and having a relative dependency to purchases-android (which I think we can do with includeBuild but I am not sure).