### PR TITLE
Extract Purchases creation logic to factory to improve testability

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
@@ -10,7 +10,7 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.google.BillingWrapper
 
-@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+@VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
 object BillingFactory {
 
     fun createBilling(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -1,0 +1,110 @@
+package com.revenuecat.purchases
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.content.pm.PackageManager
+import android.preference.PreferenceManager
+import androidx.annotation.VisibleForTesting
+import com.revenuecat.purchases.common.AppConfig
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BillingAbstract
+import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.HTTPClient
+import com.revenuecat.purchases.common.PlatformInfo
+import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.networking.ETagManager
+import com.revenuecat.purchases.identity.IdentityManager
+import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
+import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesPoster
+import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
+import java.net.URL
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+internal class PurchasesFactory {
+
+    fun createPurchases(
+        configuration: PurchasesConfiguration,
+        platformInfo: PlatformInfo,
+        proxyURL: URL?
+    ): Purchases {
+        validateConfiguration(configuration)
+
+        with(configuration) {
+            val application = context.getApplication()
+            val appConfig = AppConfig(
+                context,
+                observerMode,
+                platformInfo,
+                proxyURL,
+                store,
+                dangerousSettings
+            )
+
+            val prefs = PreferenceManager.getDefaultSharedPreferences(application)
+
+            val sharedPreferencesForETags = ETagManager.initializeSharedPreferences(context)
+            val eTagManager = ETagManager(sharedPreferencesForETags)
+
+            val dispatcher = Dispatcher(service ?: createDefaultExecutor())
+            val backend = Backend(
+                apiKey,
+                dispatcher,
+                HTTPClient(appConfig, eTagManager)
+            )
+            val subscriberAttributesPoster = SubscriberAttributesPoster(backend)
+
+            val cache = DeviceCache(prefs, apiKey)
+
+            val billing: BillingAbstract = BillingFactory.createBilling(
+                store,
+                application,
+                backend,
+                cache,
+                observerMode
+            )
+            val attributionFetcher = AttributionFetcherFactory.createAttributionFetcher(store, dispatcher)
+
+            val subscriberAttributesCache = SubscriberAttributesCache(cache)
+            return Purchases(
+                application,
+                appUserID,
+                backend,
+                billing,
+                cache,
+                dispatcher,
+                IdentityManager(cache, subscriberAttributesCache, backend),
+                SubscriberAttributesManager(
+                    subscriberAttributesCache,
+                    subscriberAttributesPoster,
+                    attributionFetcher
+                ),
+                appConfig
+            )
+        }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun validateConfiguration(configuration: PurchasesConfiguration) {
+        with(configuration) {
+            require(context.hasPermission(Manifest.permission.INTERNET)) {
+                "Purchases requires INTERNET permission."
+            }
+
+            require(apiKey.isNotBlank()) { "API key must be set. Get this from the RevenueCat web app" }
+
+            require(context.applicationContext is Application) { "Needs an application context." }
+        }
+    }
+
+    private fun Context.getApplication() = applicationContext as Application
+
+    private fun Context.hasPermission(permission: String): Boolean {
+        return checkCallingOrSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun createDefaultExecutor(): ExecutorService {
+        return Executors.newSingleThreadScheduledExecutor()
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -1,0 +1,84 @@
+package com.revenuecat.purchases
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PurchasesFactoryTest {
+
+    private val contextMock = mockk<Context>()
+
+
+    private lateinit var purchasesFactory: PurchasesFactory
+
+    @Before
+    fun setup() {
+        purchasesFactory = PurchasesFactory()
+
+        clearAllMocks()
+    }
+
+    @Test
+    fun `creating purchase checks context has INTERNET permission`() {
+        val configuration = createConfiguration()
+        every {
+            contextMock.checkCallingOrSelfPermission(Manifest.permission.INTERNET)
+        } returns PackageManager.PERMISSION_DENIED
+        assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
+            purchasesFactory.validateConfiguration(configuration)
+        }.withMessage("Purchases requires INTERNET permission.")
+    }
+
+    @Test
+    fun `creating purchase checks api key is not empty`() {
+        val configuration = createConfiguration(apiKey = "")
+        every {
+            contextMock.checkCallingOrSelfPermission(Manifest.permission.INTERNET)
+        } returns PackageManager.PERMISSION_GRANTED
+        assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
+            purchasesFactory.validateConfiguration(configuration)
+        }.withMessage("API key must be set. Get this from the RevenueCat web app")
+    }
+
+    @Test
+    fun `creating purchase checks context application context is an application`() {
+        val configuration = createConfiguration()
+        val nonApplicationContextMock = mockk<Context>()
+        every {
+            contextMock.checkCallingOrSelfPermission(Manifest.permission.INTERNET)
+        } returns PackageManager.PERMISSION_GRANTED
+        every {
+            contextMock.applicationContext
+        } returns nonApplicationContextMock
+        assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
+            purchasesFactory.validateConfiguration(configuration)
+        }.withMessage("Needs an application context.")
+    }
+
+    @Test
+    fun `creating purchase passes all validations`() {
+        val configuration = createConfiguration()
+        val applicationContextMock = mockk<Application>()
+        every {
+            contextMock.checkCallingOrSelfPermission(Manifest.permission.INTERNET)
+        } returns PackageManager.PERMISSION_GRANTED
+        every {
+            contextMock.applicationContext
+        } returns applicationContextMock
+        purchasesFactory.validateConfiguration(configuration)
+    }
+
+    private fun createConfiguration(apiKey: String = "fakeApiKey"): PurchasesConfiguration {
+        return PurchasesConfiguration.Builder(contextMock, apiKey).build()
+    }
+}


### PR DESCRIPTION
### Description
https://revenuecats.atlassian.net/browse/CSDK-101

This PR moves the creation of the `Purchases` object to a factory class. This allows us to test the validation logic that happens during this process. In the future, it might be good to test the whole process, but for that, we will need to create factories for the different objects that are created during this initialization process which might take a bit longer. I judged the value of that not to be that big considering there is no more logic on that part of the code aside from the validations which are already tested with these changes.

