### PR TITLE
Migrate from kotlin-android-extensions to kotlin-parcelize

### DIFF
--- a/base-application.gradle
+++ b/base-application.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 
 android {
     compileSdkVersion compileVersion

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = "1.4.10"
+    ext.kotlinVersion = "1.4.20"
     ext.compileVersion = 28
     ext.buildToolsVersion = "30.0.3"
     ext.minVersion = 14

--- a/library.gradle
+++ b/library.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 
 android {
     compileSdkVersion compileVersion

--- a/public/build.gradle
+++ b/public/build.gradle
@@ -1,5 +1,6 @@
 apply from: "$rootProject.projectDir/library.gradle"
 apply plugin: 'org.jetbrains.dokka'
+apply plugin: 'kotlin-parcelize'
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])

--- a/public/build.gradle
+++ b/public/build.gradle
@@ -1,6 +1,5 @@
 apply from: "$rootProject.projectDir/library.gradle"
 apply plugin: 'org.jetbrains.dokka'
-apply plugin: 'kotlin-parcelize'
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])

--- a/public/src/main/java/com/revenuecat/purchases/CustomerInfo.kt
+++ b/public/src/main/java/com/revenuecat/purchases/CustomerInfo.kt
@@ -10,9 +10,9 @@ import android.os.Parcelable
 import com.revenuecat.purchases.models.RawDataContainer
 import com.revenuecat.purchases.models.Transaction
 import com.revenuecat.purchases.parceler.JSONObjectParceler
-import kotlinx.android.parcel.IgnoredOnParcel
-import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.TypeParceler
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
 import org.json.JSONObject
 import java.util.Date
 

--- a/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt
@@ -3,9 +3,9 @@ package com.revenuecat.purchases
 import android.os.Parcelable
 import com.revenuecat.purchases.models.RawDataContainer
 import com.revenuecat.purchases.parceler.JSONObjectParceler
-import kotlinx.android.parcel.IgnoredOnParcel
-import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.TypeParceler
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
 import org.json.JSONObject
 import java.util.Date
 

--- a/public/src/main/java/com/revenuecat/purchases/EntitlementInfos.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementInfos.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * This class contains all the entitlements associated to the user.

--- a/public/src/main/java/com/revenuecat/purchases/Offering.kt
+++ b/public/src/main/java/com/revenuecat/purchases/Offering.kt
@@ -7,7 +7,7 @@ package com.revenuecat.purchases
 
 import android.os.Parcelable
 import kotlinx.android.parcel.IgnoredOnParcel
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * An offering is a collection of [Package] available for the user to purchase.

--- a/public/src/main/java/com/revenuecat/purchases/Offerings.kt
+++ b/public/src/main/java/com/revenuecat/purchases/Offerings.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * This class contains all the offerings configured in RevenueCat dashboard.

--- a/public/src/main/java/com/revenuecat/purchases/Package.kt
+++ b/public/src/main/java/com/revenuecat/purchases/Package.kt
@@ -2,7 +2,7 @@ package com.revenuecat.purchases
 
 import android.os.Parcelable
 import com.revenuecat.purchases.models.StoreProduct
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * Contains information about the product available for the user to purchase. For more info see https://docs.revenuecat.com/docs/entitlements

--- a/public/src/main/java/com/revenuecat/purchases/PurchaserInfo.kt
+++ b/public/src/main/java/com/revenuecat/purchases/PurchaserInfo.kt
@@ -9,9 +9,9 @@ import android.net.Uri
 import android.os.Parcelable
 import com.revenuecat.purchases.models.Transaction
 import com.revenuecat.purchases.parceler.JSONObjectParceler
-import kotlinx.android.parcel.IgnoredOnParcel
-import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.TypeParceler
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
 import org.json.JSONObject
 import java.util.Date
 

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
@@ -3,8 +3,8 @@ package com.revenuecat.purchases.models
 import android.os.Parcelable
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.parceler.JSONObjectParceler
-import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.TypeParceler
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
 import org.json.JSONObject
 
 /**

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
@@ -3,8 +3,8 @@ package com.revenuecat.purchases.models
 import android.os.Parcelable
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.parceler.JSONObjectParceler
-import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.TypeParceler
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
 import org.json.JSONObject
 
 /**

--- a/public/src/main/java/com/revenuecat/purchases/models/Transaction.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/Transaction.kt
@@ -2,7 +2,7 @@ package com.revenuecat.purchases.models
 
 import android.os.Parcelable
 import com.revenuecat.purchases.utils.getDate
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.Date
 

--- a/public/src/main/java/com/revenuecat/purchases/parceler/JSONObjectParceler.kt
+++ b/public/src/main/java/com/revenuecat/purchases/parceler/JSONObjectParceler.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases.parceler
 
 import android.os.Parcel
-import kotlinx.android.parcel.Parceler
+import kotlinx.parcelize.Parceler
 import org.json.JSONObject
 
 /** @suppress */

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -52,7 +52,3 @@ tasks.dokkaHtmlPartial.configure {
         }
     }
 }
-
-androidExtensions {
-    features = ["parcelize"]
-}


### PR DESCRIPTION
### Description
https://revenuecats.atlassian.net/browse/CSDK-123

`kotlin-android-extensions` was deprecated a while back. We only used the `parcelize` functionalities of that plugin, which were moved to the `kotlin-parcelize` plugin. With this PR we use that new plugin. In order to use the new plugin I had to update our kotlin version from 1.4.10 to 1.4.20. Didn't see any changes there that should cause problems 

The changes mostly involved changing the imports to the new package.