### PR TITLE
Remove some of the unused dependencies for tests in each module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,11 @@ buildscript {
     ext.billingVersion = "4.1.0"
     ext.billingClient3Version = "3.0.2"
     ext.lifecycleVersion = "2.3.0-rc01"
+    ext.testLibrariesVersion = "1.4.0"
+    ext.testJUnitVersion  = "1.1.3"
+    ext.robolectricVersion = "4.6.1"
+    ext.mockkVersion = "1.10.0"
+    ext.assertJVersion = "3.13.2"
     repositories {
         mavenCentral()
         google()

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     testImplementation 'androidx.test.ext:junit:1.1.1'
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.2.0'
-    testImplementation 'org.mockito:mockito-core:3.0.0'
     testLatestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
     testUnityIAPCompileOnly "com.android.billingclient:billing:$billingClient3Version"
     testImplementation 'io.mockk:mockk:1.10.0'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,14 +10,15 @@ dependencies {
     latestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
     unityIAPCompileOnly "com.android.billingclient:billing:$billingClient3Version"
     testImplementation project(":test-utils")
-    testImplementation 'androidx.test:core:1.2.0'
-    testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation 'androidx.test.ext:junit:1.1.1'
-    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation "androidx.test:core:$testLibrariesVersion"
+    testImplementation "androidx.test:runner:$testLibrariesVersion"
+    testImplementation "androidx.test:rules:$testLibrariesVersion"
+    testImplementation "androidx.test.ext:junit:$testJUnitVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "io.mockk:mockk:$mockkVersion"
+    testImplementation "org.assertj:assertj-core:$assertJVersion"
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.2.0'
     testLatestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
     testUnityIAPCompileOnly "com.android.billingclient:billing:$billingClient3Version"
-    testImplementation 'io.mockk:mockk:1.10.0'
-    testImplementation 'org.assertj:assertj-core:3.13.2'
+
 }

--- a/examples/purchase-tester/build.gradle
+++ b/examples/purchase-tester/build.gradle
@@ -68,10 +68,4 @@ dependencies {
 
     implementation "androidx.navigation:navigation-fragment-ktx:2.3.4"
     implementation "androidx.navigation:navigation-ui-ktx:2.3.4"
-
-    androidTestImplementation 'androidx.test:runner:1.3.0'
-    androidTestImplementation 'androidx.test:rules:1.3.0'
-    androidTestImplementation 'androidx.test:core-ktx:1.3.0'
-    androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.2'
-    androidTestImplementation 'org.assertj:assertj-core:3.13.2'
 }

--- a/feature/amazon/build.gradle
+++ b/feature/amazon/build.gradle
@@ -19,6 +19,13 @@ dependencies {
 
     testImplementation "com.amazon.device:amazon-appstore-sdk:$amazonVersion"
     testImplementation project(":test-utils")
+    testImplementation "androidx.test:core:$testLibrariesVersion"
+    testImplementation "androidx.test:runner:$testLibrariesVersion"
+    testImplementation "androidx.test:rules:$testLibrariesVersion"
+    testImplementation "androidx.test.ext:junit:$testJUnitVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "io.mockk:mockk:$mockkVersion"
+    testImplementation "org.assertj:assertj-core:$assertJVersion"
 }
 
 // Not running with this flag causes verification issues due to the way the Amazon jar is compiled

--- a/feature/google/build.gradle
+++ b/feature/google/build.gradle
@@ -15,5 +15,14 @@ dependencies {
     unityIAPCompileOnly "com.android.billingclient:billing:$billingClient3Version"
 
     testImplementation project(":test-utils")
+    testImplementation "androidx.test:core:$testLibrariesVersion"
+    testImplementation "androidx.test:runner:$testLibrariesVersion"
+    testImplementation "androidx.test:rules:$testLibrariesVersion"
+    testImplementation "androidx.test.ext:junit:$testJUnitVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "io.mockk:mockk:$mockkVersion"
+    testImplementation "org.assertj:assertj-core:$assertJVersion"
     testImplementation 'com.google.android.gms:play-services-ads-identifier:17.0.1'
+    testLatestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
+    testUnityIAPCompileOnly "com.android.billingclient:billing:$billingClient3Version"
 }

--- a/feature/identity/build.gradle
+++ b/feature/identity/build.gradle
@@ -10,8 +10,4 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.core:core-ktx:1.3.1'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-
 }

--- a/feature/identity/build.gradle
+++ b/feature/identity/build.gradle
@@ -10,4 +10,11 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.core:core-ktx:1.3.1'
     implementation 'androidx.appcompat:appcompat:1.2.0'
+    testImplementation "androidx.test:core:$testLibrariesVersion"
+    testImplementation "androidx.test:runner:$testLibrariesVersion"
+    testImplementation "androidx.test:rules:$testLibrariesVersion"
+    testImplementation "androidx.test.ext:junit:$testJUnitVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "io.mockk:mockk:$mockkVersion"
+    testImplementation "org.assertj:assertj-core:$assertJVersion"
 }

--- a/feature/subscriber-attributes/build.gradle
+++ b/feature/subscriber-attributes/build.gradle
@@ -11,9 +11,5 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.1'
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
-    testImplementation 'junit:junit:4.12'
     testImplementation project(":test-utils")
-
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/feature/subscriber-attributes/build.gradle
+++ b/feature/subscriber-attributes/build.gradle
@@ -12,4 +12,11 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
     testImplementation project(":test-utils")
+    testImplementation "androidx.test:core:$testLibrariesVersion"
+    testImplementation "androidx.test:runner:$testLibrariesVersion"
+    testImplementation "androidx.test:rules:$testLibrariesVersion"
+    testImplementation "androidx.test.ext:junit:$testJUnitVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "io.mockk:mockk:$mockkVersion"
+    testImplementation "org.assertj:assertj-core:$assertJVersion"
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -39,8 +39,6 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    testImplementation 'junit:junit:4.13.1'
-
     androidTestImplementation project(path: ':purchases')
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test:runner:1.3.0'

--- a/library.gradle
+++ b/library.gradle
@@ -49,8 +49,6 @@ dependencies {
     testImplementation 'androidx.test:rules:1.4.0'
     testImplementation 'androidx.test.ext:junit:1.1.3'
     testImplementation 'org.robolectric:robolectric:4.6.1'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.2.0'
-    testImplementation 'org.mockito:mockito-core:3.0.0'
     testLatestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
     testUnityIAPCompileOnly "com.android.billingclient:billing:$billingClient3Version"
     testImplementation 'io.mockk:mockk:1.10.0'

--- a/library.gradle
+++ b/library.gradle
@@ -43,18 +43,6 @@ android {
     }
 }
 
-dependencies {
-    testImplementation 'androidx.test:core:1.4.0'
-    testImplementation 'androidx.test:runner:1.4.0'
-    testImplementation 'androidx.test:rules:1.4.0'
-    testImplementation 'androidx.test.ext:junit:1.1.3'
-    testImplementation 'org.robolectric:robolectric:4.6.1'
-    testLatestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
-    testUnityIAPCompileOnly "com.android.billingclient:billing:$billingClient3Version"
-    testImplementation 'io.mockk:mockk:1.10.0'
-    testImplementation 'org.assertj:assertj-core:3.13.2'
-}
-
 def artifactId = project.property("POM_ARTIFACT_ID")
 def publishVariant = project.property("PUBLISH_VARIANT")
 if (publishVariant == "unityIAPRelease") {

--- a/public/build.gradle
+++ b/public/build.gradle
@@ -9,16 +9,16 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.1'
     latestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
     unityIAPCompileOnly "com.android.billingclient:billing:$billingClient3Version"
-    testImplementation 'androidx.test:core:1.2.0'
-    testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation 'androidx.test.ext:junit:1.1.1'
-    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation project(":test-utils")
+    testImplementation "androidx.test:core:$testLibrariesVersion"
+    testImplementation "androidx.test:runner:$testLibrariesVersion"
+    testImplementation "androidx.test:rules:$testLibrariesVersion"
+    testImplementation "androidx.test.ext:junit:$testJUnitVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "io.mockk:mockk:$mockkVersion"
+    testImplementation "org.assertj:assertj-core:$assertJVersion"
     testLatestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
     testUnityIAPCompileOnly "com.android.billingclient:billing:$billingClient3Version"
-    testImplementation 'io.mockk:mockk:1.10.0'
-    testImplementation 'org.assertj:assertj-core:3.13.2'
-    testImplementation project(":test-utils")
 }
 
 tasks.dokkaHtmlPartial.configure {

--- a/public/build.gradle
+++ b/public/build.gradle
@@ -14,8 +14,6 @@ dependencies {
     testImplementation 'androidx.test:rules:1.2.0'
     testImplementation 'androidx.test.ext:junit:1.1.1'
     testImplementation 'org.robolectric:robolectric:4.3'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.2.0'
-    testImplementation 'org.mockito:mockito-core:3.0.0'
     testLatestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
     testUnityIAPCompileOnly "com.android.billingclient:billing:$billingClient3Version"
     testImplementation 'io.mockk:mockk:1.10.0'

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -26,8 +26,6 @@ dependencies {
     testImplementation 'androidx.test:rules:1.2.0'
     testImplementation 'androidx.test.ext:junit:1.1.1'
     testImplementation 'org.robolectric:robolectric:4.3'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.2.0'
-    testImplementation 'org.mockito:mockito-core:3.0.0'
     testLatestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
     testUnityIAPCompileOnly "com.android.billingclient:billing:$billingClient3Version"
     testImplementation 'io.mockk:mockk:1.10.0'

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -21,15 +21,15 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-process:$lifecycleVersion"
 
     testImplementation project(":test-utils")
-    testImplementation 'androidx.test:core:1.2.0'
-    testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation 'androidx.test.ext:junit:1.1.1'
-    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation "androidx.test:core:$testLibrariesVersion"
+    testImplementation "androidx.test:runner:$testLibrariesVersion"
+    testImplementation "androidx.test:rules:$testLibrariesVersion"
+    testImplementation "androidx.test.ext:junit:$testJUnitVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "io.mockk:mockk:$mockkVersion"
+    testImplementation "org.assertj:assertj-core:$assertJVersion"
     testLatestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
     testUnityIAPCompileOnly "com.android.billingclient:billing:$billingClient3Version"
-    testImplementation 'io.mockk:mockk:1.10.0'
-    testImplementation 'org.assertj:assertj-core:3.13.2'
 }
 
 tasks.dokkaHtmlPartial.configure {

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -4,7 +4,4 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.core:core-ktx:1.3.1'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }


### PR DESCRIPTION
### Description
We are adding a bunch of dependencies that are unused on each module. This PR removes some of the easier to remove dependencies. I also removed all the dependencies from `library.gradle` since those are imported on every module. I feel that dependencies belong to each module but lmk if you think otherwise.
