### PR TITLE
Release/5.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
           command: sudo pip install awscli
       - run:
           name: Deploy to S3
-          command: aws s3 sync ~/purchases-android/docs/5.2.0-SNAPSHOT s3://purchases-docs/android/5.2.0-SNAPSHOT --delete
+          command: aws s3 sync ~/purchases-android/docs/5.2.0 s3://purchases-docs/android/5.2.0-SNAPSHOT --delete
       - run:
           name: Update index.html
           command: aws s3 cp ~/purchases-android/docs/index.html s3://purchases-docs/android/index.html

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,7 +1,7 @@
 ### API Updates
 
 * New API to get customer info with a given `CacheFetchPolicy`
-** https://github.com/RevenueCat/purchases-android/pull/546
+  * https://github.com/RevenueCat/purchases-android/pull/546
 
 
 ### Other

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -10,6 +10,14 @@
   * https://github.com/RevenueCat/purchases-android/pull/542
 * Migrate from kotlin-android-extensions to kotlin-parcelize
   * https://github.com/RevenueCat/purchases-android/pull/545
+* Removed private typealiases to fix generated documentation
+  * https://github.com/RevenueCat/purchases-android/pull/554
+* Fix for Amazon purchase dialog not showing up
+  * https://github.com/RevenueCat/purchases-android/pull/552
+* Added a log when `autoSyncPurchases` is disabled
+  * https://github.com/RevenueCat/purchases-android/pull/555
+* Attempt to reconnect to BillingClient when Billing response is error
+  * https://github.com/RevenueCat/purchases-android/pull/558
 
 
 [Full Changelog](https://github.com/revenuecat/purchases-android/compare/5.1.1...5.2.0)

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,4 +1,16 @@
-- Fix for Amazon prices that contain non breaking spaces. Transactions were being saved with the wrong price.
-  - https://github.com/RevenueCat/purchases-android/pull/538
+### API Updates
 
-[Full Changelog](https://github.com/revenuecat/purchases-android/compare/5.1.0...5.1.1)
+* New API to get customer info with a given `CacheFetchPolicy`
+** https://github.com/RevenueCat/purchases-android/pull/546
+
+
+### Other
+
+* Validate API key
+  * https://github.com/RevenueCat/purchases-android/pull/542
+* Migrate from kotlin-android-extensions to kotlin-parcelize
+  * https://github.com/RevenueCat/purchases-android/pull/545
+
+
+[Full Changelog](https://github.com/revenuecat/purchases-android/compare/5.1.1...5.2.0)
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 5.2.0
+### API Updates
+
+* New API to get customer info with a given `CacheFetchPolicy`
+** https://github.com/RevenueCat/purchases-android/pull/546
+
+
+### Other
+
+* Validate API key
+  * https://github.com/RevenueCat/purchases-android/pull/542
+* Migrate from kotlin-android-extensions to kotlin-parcelize
+  * https://github.com/RevenueCat/purchases-android/pull/545
+
+
+[Full Changelog](https://github.com/revenuecat/purchases-android/compare/5.1.1...5.2.0)
+
+
 ## 5.1.1
 
 - Fix for Amazon prices that contain non breaking spaces. Transactions were being saved with the wrong price.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### API Updates
 
 * New API to get customer info with a given `CacheFetchPolicy`
-** https://github.com/RevenueCat/purchases-android/pull/546
+  * https://github.com/RevenueCat/purchases-android/pull/546
 
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@
   * https://github.com/RevenueCat/purchases-android/pull/542
 * Migrate from kotlin-android-extensions to kotlin-parcelize
   * https://github.com/RevenueCat/purchases-android/pull/545
+* Removed private typealiases to fix generated documentation
+  * https://github.com/RevenueCat/purchases-android/pull/554
+* Fix for Amazon purchase dialog not showing up
+  * https://github.com/RevenueCat/purchases-android/pull/552
+* Added a log when `autoSyncPurchases` is disabled
+  * https://github.com/RevenueCat/purchases-android/pull/555
+* Attempt to reconnect to BillingClient when Billing response is error 
+  * https://github.com/RevenueCat/purchases-android/pull/558
 
 
 [Full Changelog](https://github.com/revenuecat/purchases-android/compare/5.1.1...5.2.0)

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = BuildConfig.DEBUG
 
-    const val frameworkVersion = "5.2.0-SNAPSHOT"
+    const val frameworkVersion = "5.2.0"
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/5.2.0-SNAPSHOT/index.html" />
+    <meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/5.2.0/index.html" />
 </head>
 <body>
 </body>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=5.2.0-SNAPSHOT
+VERSION_NAME=5.2.0
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/library.gradle
+++ b/library.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "5.2.0-SNAPSHOT"
+        versionName "5.2.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
### API Updates

* New API to get customer info with a given `CacheFetchPolicy`
** https://github.com/RevenueCat/purchases-android/pull/546


### Other

* Validate API key
  * https://github.com/RevenueCat/purchases-android/pull/542
* Migrate from kotlin-android-extensions to kotlin-parcelize
  * https://github.com/RevenueCat/purchases-android/pull/545
* Removed private typealiases to fix generated documentation
  * https://github.com/RevenueCat/purchases-android/pull/554
* Fix for Amazon purchase dialog not showing up
  * https://github.com/RevenueCat/purchases-android/pull/552
* Added a log when `autoSyncPurchases` is disabled
  * https://github.com/RevenueCat/purchases-android/pull/555
* Attempt to reconnect to BillingClient when Billing response is error
  * https://github.com/RevenueCat/purchases-android/pull/558


[Full Changelog](https://github.com/revenuecat/purchases-android/compare/5.1.1...5.2.0)

### TODO
- [ ] Hold until https://github.com/RevenueCat/purchases-android/pull/550 is merged.