### PR TITLE
Remove private typealiases to fix generated documentation

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -370,7 +370,7 @@ class Purchases internal constructor(
     }
 
     /**
-     * Make a purchase.
+     * Make a purchase upgrading from a previous sku.
      * @param [activity] Current activity
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
      * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional
@@ -407,7 +407,7 @@ class Purchases internal constructor(
     }
 
     /**
-     * Make a purchase.
+     * Make a purchase upgrading from a previous sku.
      * @param [activity] Current activity
      * @param [packageToPurchase] The Package you wish to purchase
      * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/deprecatedListenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/deprecatedListenerConversions.kt
@@ -10,6 +10,8 @@ import com.revenuecat.purchases.interfaces.ProductChangeListener
 private typealias DeprecatedPurchaseCompletedFunction = (purchase: Purchase, purchaserInfo: PurchaserInfo) -> Unit
 @Deprecated("Purchase replaced with StoreTransaction and PurchaserInfo with CustomerInfo")
 private typealias DeprecatedProductChangeCompletedFunction = (purchase: Purchase?, purchaserInfo: PurchaserInfo) -> Unit
+private typealias ErrorFunction = (error: PurchasesError) -> Unit
+private typealias PurchaseErrorFunction = (error: PurchasesError, userCancelled: Boolean) -> Unit
 
 @Deprecated("onCompleted Purchase changed with StoreTransaction")
 internal fun deprecatedPurchaseCompletedListener(


### PR DESCRIPTION
### Description
https://revenuecats.atlassian.net/browse/CSDK-300

This removes all private typealiases from the public api so Dokka can generate the docs appropriately. 

This is an example of how it looks:
![image](https://user-images.githubusercontent.com/808417/176852400-4463b214-fe3f-4f53-98a5-1565b4673ad9.png)
