### PR TITLE
[CSDK-302] Fix: attempt to reconnect when billing response is error

### DIFF
--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -573,13 +573,19 @@ class BillingWrapper(
                         }
                     }
                 }
-                BillingClient.BillingResponseCode.SERVICE_DISCONNECTED,
-                BillingClient.BillingResponseCode.USER_CANCELED,
-                BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE,
-                BillingClient.BillingResponseCode.ITEM_UNAVAILABLE,
-                BillingClient.BillingResponseCode.ERROR,
-                BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED,
                 BillingClient.BillingResponseCode.SERVICE_TIMEOUT,
+                BillingClient.BillingResponseCode.ERROR,
+                BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE,
+                BillingClient.BillingResponseCode.USER_CANCELED,
+                BillingClient.BillingResponseCode.SERVICE_DISCONNECTED -> {
+                    log(
+                        LogIntent.GOOGLE_WARNING, BillingStrings.BILLING_CLIENT_ERROR
+                            .format(billingResult.toHumanReadableDescription())
+                    )
+                    retryBillingServiceConnectionWithExponentialBackoff()
+                }
+                BillingClient.BillingResponseCode.ITEM_UNAVAILABLE,
+                BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED,
                 BillingClient.BillingResponseCode.ITEM_NOT_OWNED -> {
                     log(
                         LogIntent.GOOGLE_WARNING, BillingStrings.BILLING_CLIENT_ERROR

--- a/feature/google/src/testLatestDependencies/java/com/revenuecat/purchases/google/BillingWrapperTestBillingClient4.kt
+++ b/feature/google/src/testLatestDependencies/java/com/revenuecat/purchases/google/BillingWrapperTestBillingClient4.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Handler
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.revenuecat.purchases.common.firstSku
 import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.AcknowledgePurchaseResponseListener
 import com.android.billingclient.api.BillingClient
@@ -25,16 +24,13 @@ import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.BillingAbstract
-import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.ReplaceSkuInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
-import com.revenuecat.purchases.common.errorLog
-import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.common.firstSku
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.sha256
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
-import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.utils.stubGooglePurchase
 import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
 import com.revenuecat.purchases.utils.stubSkuDetails
@@ -54,7 +50,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.lang.Thread.sleep
-import java.util.ArrayList
 import java.util.concurrent.CountDownLatch
 
 @RunWith(AndroidJUnit4::class)


### PR DESCRIPTION
Checking our code against [Google's example](https://github.com/android/play-billing-samples/blob/8f8792fe23e343883984f361a5ecb56e70653911/TrivialDriveKotlin/app/src/main/java/com/sample/android/trivialdrivesample/billing/BillingDataSource.kt#L151), it strikes me that there are a couple of instances where we're not actively retrying the connection, but Google is (and it seems reasonable). 

So I added those cases. 

https://revenuecats.atlassian.net/browse/CSDK-302

Another attempt at solving https://github.com/RevenueCat/purchases-android/issues/553