### PR TITLE
[CF-822] Use queryPurchaseAsync

### DIFF
--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -544,14 +544,24 @@ class BillingWrapper(
             LogIntent.DEBUG, BillingStrings.BILLING_WRAPPER_PURCHASES_UPDATED
                 .format(purchase.toHumanReadableDescription())
         )
-        synchronized(this@BillingWrapper) {
-            val presentedOffering = presentedOfferingsByProductIdentifier[purchase.firstSku]
 
+        val presentedOffering = presentedOfferingsByProductIdentifier[purchase.firstSku]
+        productTypes[purchase.firstSku]?.let { productType ->
+            getMappedPurchaseListener.onMapped(
+                purchase.toStoreTransaction(
+                    productType,
+                    presentedOffering
+                )
+            )
+            return
+        }
+        
+        synchronized(this@BillingWrapper) {
             getPurchaseType(purchase.purchaseToken, object : GetProductTypeListener {
                 override fun onReceived(productType: ProductType) {
                     getMappedPurchaseListener.onMapped(
                         purchase.toStoreTransaction(
-                            productTypes[purchase.firstSku] ?: productType,
+                            productType,
                             presentedOffering
                         )
                     )

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -638,18 +638,18 @@ class BillingWrapper(
                 .format(purchase.toHumanReadableDescription())
         )
 
-        val presentedOffering = presentedOfferingsByProductIdentifier[purchase.firstSku]
-        productTypes[purchase.firstSku]?.let { productType ->
-            mapPurchaseListener(
-                purchase.toStoreTransaction(
-                    productType,
-                    presentedOffering
-                )
-            )
-            return
-        }
-
         synchronized(this@BillingWrapper) {
+            val presentedOffering = presentedOfferingsByProductIdentifier[purchase.firstSku]
+            productTypes[purchase.firstSku]?.let { productType ->
+                mapPurchaseListener(
+                    purchase.toStoreTransaction(
+                        productType,
+                        presentedOffering
+                    )
+                )
+                return
+            }
+
             getPurchaseType(purchase.purchaseToken) { type ->
                 mapPurchaseListener(
                     purchase.toStoreTransaction(

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -9,6 +9,8 @@ import android.app.Activity
 import android.content.Context
 import android.os.Handler
 import androidx.annotation.UiThread
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.PRIVATE
 import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClient.SkuType
@@ -464,6 +466,7 @@ class BillingWrapper(
         }
     }
 
+    @VisibleForTesting(otherwise = PRIVATE)
     internal fun getPurchaseType(purchaseToken: String, listener: (ProductType) -> Unit) {
         billingClient?.let { client ->
             client.queryPurchasesAsync(SkuType.SUBS) { querySubsResult, subsPurchasesList ->

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -555,7 +555,7 @@ class BillingWrapper(
             )
             return
         }
-        
+
         synchronized(this@BillingWrapper) {
             getPurchaseType(purchase.purchaseToken, object : GetProductTypeListener {
                 override fun onReceived(productType: ProductType) {
@@ -714,4 +714,3 @@ interface GetProductTypeListener {
 interface MapPurchaseToStoreTransactionListener {
     fun onMapped(storeTxn: StoreTransaction)
 }
-

--- a/feature/google/src/test/java/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/BillingWrapperTest.kt
@@ -187,7 +187,7 @@ class BillingWrapperTest {
 
         every { mockClient.isReady } returns true
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
 
         assertThat(storeProducts).`as`("SKUDetailsList is not null").isNotNull
     }
@@ -221,7 +221,7 @@ class BillingWrapperTest {
 
         every { mockClient.isReady } returns true
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
 
         assertThat(skuDetailsResponseCalled).isEqualTo(2)
     }
@@ -253,7 +253,7 @@ class BillingWrapperTest {
 
         val skuDetails = stubSkuDetails(productId = "product_a")
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
         wrapper.makePurchaseAsync(
             mockActivity,
             appUserId,
@@ -321,7 +321,7 @@ class BillingWrapperTest {
             billingClientOKResult
         }
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
         wrapper.makePurchaseAsync(
             mockActivity,
             appUserId,
@@ -394,7 +394,7 @@ class BillingWrapperTest {
 
         every { mockClient.isReady } returns true
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
 
         verify(exactly = 1) {
             mockClient.launchBillingFlow(eq(mockActivity), any())
@@ -426,7 +426,7 @@ class BillingWrapperTest {
 
         every { mockClient.isReady } returns true
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
 
         // ensure calls to launchBillingFlow - 1 in setup, 1 here
         verify(exactly = 2) {
@@ -489,7 +489,7 @@ class BillingWrapperTest {
 
     @Test
     fun queryHistoryCallsListenerIfOk() {
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
         var successCalled = false
         wrapper.queryPurchaseHistoryAsync(
             BillingClient.SkuType.SUBS,
@@ -509,7 +509,7 @@ class BillingWrapperTest {
 
     @Test
     fun queryHistoryNotCalledIfNotOK() {
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
         var errorCalled = false
         wrapper.queryPurchaseHistoryAsync(
             BillingClient.SkuType.SUBS,
@@ -537,7 +537,7 @@ class BillingWrapperTest {
             mockClient.consumeAsync(capture(capturingSlot), any())
         } just Runs
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
         wrapper.consumePurchase(token) { _, _ -> }
 
         assertThat(capturingSlot.isCaptured).isTrue()
@@ -596,7 +596,7 @@ class BillingWrapperTest {
             }, {
                 fail("shouldn't be an error")
             })
-        wrapper.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        wrapper.onBillingSetupFinished(billingClientOKResult)
         assertThat(receivedList).isNotNull
         assertThat(receivedList!!.size).isZero()
     }
@@ -636,7 +636,7 @@ class BillingWrapperTest {
             })
 
         wrapper.purchasesUpdatedListener = null
-        wrapper.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        wrapper.onBillingSetupFinished(billingClientOKResult)
     }
 
     @Test
@@ -694,7 +694,7 @@ class BillingWrapperTest {
 
     @Test
     fun `on successfully connected billing client, listener is called`() {
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
         assertThat(onConnectedCalled).isTrue()
     }
 
@@ -847,7 +847,7 @@ class BillingWrapperTest {
 
         val skuDetails = stubSkuDetails(productId = "product_a")
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
         wrapper.makePurchaseAsync(
             mockActivity,
             appUserId,
@@ -886,7 +886,7 @@ class BillingWrapperTest {
     fun `Acknowledge works`() {
         val token = "token"
 
-        billingClientStateListener!!.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
         wrapper.acknowledge(token) { _, _ -> }
 
         assertThat(capturedAcknowledgePurchaseParams.isCaptured).isTrue()
@@ -1730,7 +1730,7 @@ class BillingWrapperTest {
         assertThat(secondRetryMillisecondsSlot.captured).isGreaterThan(firstRetryMillisecondsSlot.captured)
 
         // ensure milliseconds backoff gets reset to default after successful connection
-        wrapper.onBillingSetupFinished(BillingClient.BillingResponseCode.OK.buildResult())
+        wrapper.onBillingSetupFinished(billingClientOKResult)
         val afterSuccessfulConnectionRetryMillisecondsSlot = slot<Long>()
         every {
             handler.postDelayed(any(), capture(afterSuccessfulConnectionRetryMillisecondsSlot))

--- a/feature/google/src/test/java/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/BillingWrapperTest.kt
@@ -442,7 +442,7 @@ class BillingWrapperTest {
             mockPurchasesListener.onPurchasesUpdated(capture(slot))
         } just Runs
 
-        mockQueryPurchasesAsyncResult(BillingClient.SkuType.SUBS, BillingClient.BillingResponseCode.OK, purchases)
+        mockQueryPurchasesAsyncResult(BillingClient.SkuType.SUBS, billingClientOKResult, purchases)
 
         purchasesUpdatedListener!!.onPurchasesUpdated(billingClientOKResult, purchases)
 
@@ -692,7 +692,7 @@ class BillingWrapperTest {
 
     @Test
     fun `when querying anything and billing client returns an empty list, returns an empty list`() {
-        mockQueryPurchasesAsyncResult(null, BillingClient.BillingResponseCode.OK, listOf())
+        mockQueryPurchasesAsyncResult(null, billingClientOKResult, listOf())
 
         var purchasesByHashedToken: Map<String, StoreTransaction>? = null
         wrapper.queryPurchases(
@@ -724,13 +724,13 @@ class BillingWrapperTest {
 
         mockQueryPurchasesAsyncResult(
             BillingClient.SkuType.INAPP,
-            BillingClient.BillingResponseCode.OK,
+            billingClientOKResult,
             listOf(purchase)
         )
-        mockQueryPurchasesAsyncResult(BillingClient.SkuType.SUBS,
-            BillingClient.BillingResponseCode.OK,
-            listOf()
-        )
+        mockQueryPurchasesAsyncResult(
+            BillingClient.SkuType.SUBS,
+            billingClientOKResult,
+            listOf())
 
         var purchasesByHashedToken: Map<String, StoreTransaction>? = null
         wrapper.queryPurchases(
@@ -756,7 +756,6 @@ class BillingWrapperTest {
 
     @Test
     fun `when querying SUBS result is created properly`() {
-        val resultCode = BillingClient.BillingResponseCode.OK
         val token = "token"
         val type = BillingClient.SkuType.SUBS
         val time = System.currentTimeMillis()
@@ -768,8 +767,8 @@ class BillingWrapperTest {
             productIds = listOf(sku)
         )
 
-        mockQueryPurchasesAsyncResult(BillingClient.SkuType.SUBS, resultCode, listOf(purchase))
-        mockQueryPurchasesAsyncResult(BillingClient.SkuType.INAPP, resultCode, emptyList())
+        mockQueryPurchasesAsyncResult(BillingClient.SkuType.SUBS, billingClientOKResult, listOf(purchase))
+        mockQueryPurchasesAsyncResult(BillingClient.SkuType.INAPP, billingClientOKResult, emptyList())
 
         var purchasesByHashedToken: Map<String, StoreTransaction>? = null
         wrapper.queryPurchases(
@@ -849,76 +848,52 @@ class BillingWrapperTest {
 
     @Test
     fun `Getting subscriptions type`() {
-        val queryInAppPurchasesListenerSlot = slot<PurchasesResponseListener>()
-        every {
-            mockClient.queryPurchasesAsync(
-                BillingClient.SkuType.INAPP,
-                capture(queryInAppPurchasesListenerSlot)
-            )
-        } answers {
-            queryInAppPurchasesListenerSlot.captured.onQueryPurchasesResponse(
-                billingClientOKResult, listOf(mockk(
-                    relaxed = true
-                ) {
-                    every { this@mockk.purchaseToken } returns "inapp"
-                })
-            )
-        }
+        mockQueryPurchasesAsyncResult(
+            BillingClient.SkuType.INAPP,
+            billingClientOKResult,
+            listOf(mockk(
+                relaxed = true
+            ) {
+                every { this@mockk.purchaseToken } returns "inapp"
+            })
+        )
 
-        val querySubsPurchasesListenerSlot = slot<PurchasesResponseListener>()
-        every {
-            mockClient.queryPurchasesAsync(
-                BillingClient.SkuType.SUBS,
-                capture(querySubsPurchasesListenerSlot)
-            )
-        } answers {
-            querySubsPurchasesListenerSlot.captured.onQueryPurchasesResponse(
-                billingClientOKResult, listOf(mockk(
-                    relaxed = true
-                ) {
-                    every { this@mockk.purchaseToken } returns "sub"
-                }))
-        }
+        mockQueryPurchasesAsyncResult(
+            BillingClient.SkuType.SUBS,
+            billingClientOKResult,
+            listOf(mockk(
+                relaxed = true
+            ) {
+                every { this@mockk.purchaseToken } returns "sub"
+            })
+        )
 
         wrapper.getPurchaseType("sub") { productType ->
             assertThat(productType).isEqualTo(ProductType.SUBS)
         }
-
     }
 
     @Test
     fun `Getting INAPPs type`() {
-        val queryInAppPurchasesListenerSlot = slot<PurchasesResponseListener>()
-        every {
-            mockClient.queryPurchasesAsync(
-                BillingClient.SkuType.INAPP,
-                capture(queryInAppPurchasesListenerSlot)
-            )
-        } answers {
-            queryInAppPurchasesListenerSlot.captured.onQueryPurchasesResponse(
-                billingClientOKResult, listOf(mockk(
-                    relaxed = true
-                ) {
-                    every { this@mockk.purchaseToken } returns "inapp"
-                })
-            )
-        }
+        mockQueryPurchasesAsyncResult(
+            BillingClient.SkuType.INAPP,
+            billingClientOKResult,
+            listOf(mockk(
+                relaxed = true
+            ) {
+                every { this@mockk.purchaseToken } returns "inapp"
+            })
+        )
 
-        val querySubsPurchasesListenerSlot = slot<PurchasesResponseListener>()
-        every {
-            mockClient.queryPurchasesAsync(
-                BillingClient.SkuType.SUBS,
-                capture(querySubsPurchasesListenerSlot)
-            )
-        } answers {
-            querySubsPurchasesListenerSlot.captured.onQueryPurchasesResponse(
-                billingClientOKResult, listOf(mockk(
-                    relaxed = true
-                ) {
-                    every { this@mockk.purchaseToken } returns "sub"
-                })
-            )
-        }
+        mockQueryPurchasesAsyncResult(
+            BillingClient.SkuType.SUBS,
+            billingClientOKResult,
+            listOf(mockk(
+                relaxed = true
+            ) {
+                every { this@mockk.purchaseToken } returns "sub"
+            })
+        )
 
         wrapper.getPurchaseType("inapp") { productType ->
             assertThat(productType).isEqualTo(ProductType.INAPP)
@@ -927,37 +902,26 @@ class BillingWrapperTest {
 
     @Test
     fun `getPurchaseType returns UNKNOWN if sub and inapps response not OK`() {
-        val querySubsPurchasesListenerSlot = slot<PurchasesResponseListener>()
-        every {
-            mockClient.queryPurchasesAsync(
-                BillingClient.SkuType.SUBS,
-                capture(querySubsPurchasesListenerSlot)
-            )
-        } answers {
-            querySubsPurchasesListenerSlot.captured.onQueryPurchasesResponse(
-                BillingClient.BillingResponseCode.ERROR.buildResult(), listOf(mockk(
-                    relaxed = true
-                ) {
-                    every { this@mockk.purchaseToken } returns "sub"
-                })
-            )
-        }
+        val errorResult = BillingClient.BillingResponseCode.ERROR.buildResult()
+        mockQueryPurchasesAsyncResult(
+            BillingClient.SkuType.SUBS,
+            errorResult,
+            listOf(mockk(
+                relaxed = true
+            ) {
+                every { this@mockk.purchaseToken } returns "sub"
+            })
+        )
 
-        val queryInAppPurchasesListenerSlot = slot<PurchasesResponseListener>()
-        every {
-            mockClient.queryPurchasesAsync(
-                BillingClient.SkuType.INAPP,
-                capture(queryInAppPurchasesListenerSlot)
-            )
-        } answers {
-            queryInAppPurchasesListenerSlot.captured.onQueryPurchasesResponse(
-                BillingClient.BillingResponseCode.ERROR.buildResult(), listOf(mockk(
-                    relaxed = true
-                ) {
-                    every { this@mockk.purchaseToken } returns "inapp"
-                })
-            )
-        }
+        mockQueryPurchasesAsyncResult(
+            BillingClient.SkuType.INAPP,
+            errorResult,
+            listOf(mockk(
+                relaxed = true
+            ) {
+                every { this@mockk.purchaseToken } returns "inapp"
+            })
+        )
 
         wrapper.getPurchaseType("inapp") { productType ->
             assertThat(productType).isEqualTo(ProductType.UNKNOWN)
@@ -966,37 +930,26 @@ class BillingWrapperTest {
 
     @Test
     fun `getPurchaseType returns UNKNOWN if sub not found and inapp responses not OK`() {
-        val queryInAppPurchasesListenerSlot = slot<PurchasesResponseListener>()
-        every {
-            mockClient.queryPurchasesAsync(
-                BillingClient.SkuType.INAPP,
-                capture(queryInAppPurchasesListenerSlot)
-            )
-        } answers {
-            queryInAppPurchasesListenerSlot.captured.onQueryPurchasesResponse(
-                BillingClient.BillingResponseCode.ERROR.buildResult(), listOf(mockk(
-                    relaxed = true
-                ) {
-                    every { this@mockk.purchaseToken } returns "inapp"
-                })
-            )
-        }
+        val errorResult = BillingClient.BillingResponseCode.ERROR.buildResult()
+        mockQueryPurchasesAsyncResult(
+            BillingClient.SkuType.INAPP,
+            errorResult,
+            listOf(mockk(
+                relaxed = true
+            ) {
+                every { this@mockk.purchaseToken } returns "inapp"
+            })
+        )
 
-        val querySubsPurchasesListenerSlot = slot<PurchasesResponseListener>()
-        every {
-            mockClient.queryPurchasesAsync(
-                BillingClient.SkuType.SUBS,
-                capture(querySubsPurchasesListenerSlot)
-            )
-        } answers {
-            querySubsPurchasesListenerSlot.captured.onQueryPurchasesResponse(
-                billingClientOKResult, listOf(mockk(
-                    relaxed = true
-                ) {
-                    every { this@mockk.purchaseToken } returns "sub"
-                })
-            )
-        }
+        mockQueryPurchasesAsyncResult(
+            BillingClient.SkuType.SUBS,
+            billingClientOKResult,
+            listOf(mockk(
+                relaxed = true
+            ) {
+                every { this@mockk.purchaseToken } returns "sub"
+            })
+        )
 
         wrapper.getPurchaseType("inapp") { productType ->
             assertThat(productType).isEqualTo(ProductType.UNKNOWN)
@@ -1849,7 +1802,7 @@ class BillingWrapperTest {
 
     private fun mockQueryPurchasesAsyncResult(
         @BillingClient.SkuType skuType: String?,
-        @BillingClient.BillingResponseCode resultCode: Int,
+        result: BillingResult,
         purchases: List<Purchase>
     ) {
         val queryPurchasesListenerSlot = slot<PurchasesResponseListener>()
@@ -1860,7 +1813,7 @@ class BillingWrapperTest {
             )
         } answers {
             queryPurchasesListenerSlot.captured.onQueryPurchasesResponse(
-                BillingResult.newBuilder().setResponseCode(resultCode).build(),
+                result,
                 purchases
             )
         }

--- a/feature/google/src/test/java/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/BillingWrapperTest.kt
@@ -926,11 +926,10 @@ class BillingWrapperTest {
                 }))
         }
 
-        wrapper.getPurchaseType("sub", object : GetProductTypeListener {
-            override fun onReceived(productType: ProductType) {
-                assertThat(productType).isEqualTo(ProductType.SUBS)
-            }
-        })
+        wrapper.getPurchaseType("sub") { productType ->
+            assertThat(productType).isEqualTo(ProductType.SUBS)
+        }
+
     }
 
     @Test
@@ -967,11 +966,9 @@ class BillingWrapperTest {
             )
         }
 
-        wrapper.getPurchaseType("inapp", object : GetProductTypeListener {
-            override fun onReceived(productType: ProductType) {
-                assertThat(productType).isEqualTo(ProductType.INAPP)
-            }
-        })
+        wrapper.getPurchaseType("inapp") { productType ->
+            assertThat(productType).isEqualTo(ProductType.INAPP)
+        }
     }
 
     @Test

--- a/feature/google/src/test/java/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/BillingWrapperTest.kt
@@ -848,54 +848,43 @@ class BillingWrapperTest {
 
     @Test
     fun `Getting subscriptions type`() {
+        val inAppToken = "inAppToken"
         mockQueryPurchasesAsyncResult(
             BillingClient.SkuType.INAPP,
             billingClientOKResult,
-            listOf(mockk(
-                relaxed = true
-            ) {
-                every { this@mockk.purchaseToken } returns "inapp"
-            })
+            getMockedPurchaseList(inAppToken)
         )
 
+        val subsToken = "subsToken"
         mockQueryPurchasesAsyncResult(
             BillingClient.SkuType.SUBS,
             billingClientOKResult,
-            listOf(mockk(
-                relaxed = true
-            ) {
-                every { this@mockk.purchaseToken } returns "sub"
-            })
+            getMockedPurchaseList(subsToken)
+
         )
 
-        wrapper.getPurchaseType("sub") { productType ->
+        wrapper.getPurchaseType(subsToken) { productType ->
             assertThat(productType).isEqualTo(ProductType.SUBS)
         }
     }
 
     @Test
     fun `Getting INAPPs type`() {
+        val inAppToken = "inAppToken"
         mockQueryPurchasesAsyncResult(
             BillingClient.SkuType.INAPP,
             billingClientOKResult,
-            listOf(mockk(
-                relaxed = true
-            ) {
-                every { this@mockk.purchaseToken } returns "inapp"
-            })
+            getMockedPurchaseList(inAppToken)
         )
 
+        val subToken = "subToken"
         mockQueryPurchasesAsyncResult(
             BillingClient.SkuType.SUBS,
             billingClientOKResult,
-            listOf(mockk(
-                relaxed = true
-            ) {
-                every { this@mockk.purchaseToken } returns "sub"
-            })
+            getMockedPurchaseList(subToken)
         )
 
-        wrapper.getPurchaseType("inapp") { productType ->
+        wrapper.getPurchaseType(inAppToken) { productType ->
             assertThat(productType).isEqualTo(ProductType.INAPP)
         }
     }
@@ -903,27 +892,21 @@ class BillingWrapperTest {
     @Test
     fun `getPurchaseType returns UNKNOWN if sub and inapps response not OK`() {
         val errorResult = BillingClient.BillingResponseCode.ERROR.buildResult()
+        val subToken = "subToken"
         mockQueryPurchasesAsyncResult(
             BillingClient.SkuType.SUBS,
             errorResult,
-            listOf(mockk(
-                relaxed = true
-            ) {
-                every { this@mockk.purchaseToken } returns "sub"
-            })
+            getMockedPurchaseList(subToken)
         )
 
+        val inAppToken = "abcd"
         mockQueryPurchasesAsyncResult(
             BillingClient.SkuType.INAPP,
             errorResult,
-            listOf(mockk(
-                relaxed = true
-            ) {
-                every { this@mockk.purchaseToken } returns "inapp"
-            })
+            getMockedPurchaseList(inAppToken)
         )
 
-        wrapper.getPurchaseType("inapp") { productType ->
+        wrapper.getPurchaseType(inAppToken) { productType ->
             assertThat(productType).isEqualTo(ProductType.UNKNOWN)
         }
     }
@@ -931,27 +914,21 @@ class BillingWrapperTest {
     @Test
     fun `getPurchaseType returns UNKNOWN if sub not found and inapp responses not OK`() {
         val errorResult = BillingClient.BillingResponseCode.ERROR.buildResult()
+        val inAppPurchaseToken = "inAppToken"
         mockQueryPurchasesAsyncResult(
             BillingClient.SkuType.INAPP,
             errorResult,
-            listOf(mockk(
-                relaxed = true
-            ) {
-                every { this@mockk.purchaseToken } returns "inapp"
-            })
+            getMockedPurchaseList(inAppPurchaseToken)
         )
 
+        val subPurchaseToken = "subToken"
         mockQueryPurchasesAsyncResult(
             BillingClient.SkuType.SUBS,
             billingClientOKResult,
-            listOf(mockk(
-                relaxed = true
-            ) {
-                every { this@mockk.purchaseToken } returns "sub"
-            })
+            getMockedPurchaseList(subPurchaseToken)
         )
 
-        wrapper.getPurchaseType("inapp") { productType ->
+        wrapper.getPurchaseType(inAppPurchaseToken) { productType ->
             assertThat(productType).isEqualTo(ProductType.UNKNOWN)
         }
     }
@@ -1817,6 +1794,14 @@ class BillingWrapperTest {
                 purchases
             )
         }
+    }
+
+    private fun getMockedPurchaseList(purchaseToken: String): List<Purchase> {
+        return listOf(mockk(
+            relaxed = true
+        ) {
+            every { this@mockk.purchaseToken } returns purchaseToken
+        })
     }
 
     private fun mockNullSkuDetailsResponse() {


### PR DESCRIPTION
This is a step to prepare for the BillingClient 5 update. `queryPurchases` is obsoleted in BC5, replaced with an async version (deprecated in 5).

The deprecated async function will eventually be replaced with the new one, accepting a different parameter type. But migrating to the async version (and remaining on BC4) is a testable step. Once we feel the async code is clean, upgrading to the BC5 version will be easier.

This is definitely a little messy with all the nested callbacks and makes me wonder if we should start using coroutines internally..


Note: this is PR'ed into the `drop-bc3-support` branch, which I'll be using for BC5 work. We are waiting to merge that until Unity has updated their IAP plugin to BC4.