### PR TITLE
updates the billing client version to use for unity IAP compatibility…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.buildToolsVersion = "30.0.3"
     ext.minVersion = 14
     ext.billingVersion = "4.1.0"
-    ext.billingClient3Version = "3.0.2"
+    ext.billingClient3Version = "3.0.3"
     ext.lifecycleVersion = "2.3.0-rc01"
     ext.testLibrariesVersion = "1.4.0"
     ext.testJUnitVersion  = "1.1.3"


### PR DESCRIPTION
I was getting the following error while trying a Unity-IAP compatible build. 
It looks like Unity IAP updated their billing client version. The update was done in `[3.1.0] - 2021-04-15`, according [to this changelog](https://docs.unity3d.com/Packages/com.unity.purchasing@4.2/changelog/CHANGELOG.html)

```groovy
Duplicate class com.android.billingclient.BuildConfig found in modules 
billing-3.0.3-runtime.jar (:billing-3.0.3:) and 
com.android.billingclient.billing-3.0.2-runtime.jar (:com.android.billingclient.billing-3.0.2:)
```