### PR TITLE
changes to unityIAPCompileOnly

### DIFF
--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation "androidx.annotation:annotation:$annotationVersion"
     latestDependenciesApi "com.android.billingclient:billing:$billingVersion"
-    unityIAPApi "com.android.billingclient:billing:$billingClient3Version"
+    unityIAPCompileOnly "com.android.billingclient:billing:$billingClient3Version"
     implementation "androidx.lifecycle:lifecycle-runtime:$lifecycleVersion"
     kapt "androidx.lifecycle:lifecycle-compiler:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-process:$lifecycleVersion"


### PR DESCRIPTION
While testing an observer mode installation of Unity for https://github.com/RevenueCat/purchases-unity/pull/122 I noticed that billing client 3.0.3 is being downloaded, which requires extra installation steps by adding the following:

```
if (!project(":unityLibrary").fileTree(dir: 'libs', include: ['billing-3*.aar']).isEmpty()) {
        configurations.all {
            exclude group: 'com.android.billingclient', module: 'billing'
        }
    }
    ```
    
    This is a bug because the unityIAP variant is not supposed to download the billing client to the consumers. It turns out we were using `api` instead of `compileOnly` in one of the modules, and that was adding the billing client to the consumers.
    