### PR TITLE
Fix issue with handler not being initialized on time on Purchases initialization

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -101,7 +101,8 @@ class Purchases internal constructor(
     private val identityManager: IdentityManager,
     private val subscriberAttributesManager: SubscriberAttributesManager,
     @set:JvmSynthetic @get:JvmSynthetic internal var appConfig: AppConfig,
-    private val customerInfoHelper: CustomerInfoHelper
+    private val customerInfoHelper: CustomerInfoHelper,
+    private val mainHandler: Handler = Handler(Looper.getMainLooper())
 ) : LifecycleDelegate {
 
     /** @suppress */
@@ -1252,10 +1253,9 @@ class Purchases internal constructor(
             })
     }
 
-    private val handler = Handler(Looper.getMainLooper())
     private fun dispatch(action: () -> Unit) {
         if (Thread.currentThread() != Looper.getMainLooper().thread) {
-            handler.post(action)
+            mainHandler.post(action)
         } else {
             action()
         }


### PR DESCRIPTION
### Description
This should deal with https://github.com/RevenueCat/purchases-hybrid-common/issues/176

The issue was added here: https://github.com/RevenueCat/purchases-android/commit/2bed17a041994cedf7e370d0f186c1d7b0fce078#diff-e019410c58657f001e6ba8be4f066c84c928f4e017ae3b3b6366cebfd64b9716R1251

Basically, we use the `dispatch` method during the `init` function, which requires the `handler` to not be null. However, `init` will be called before `handler` has been initialized, according to https://stackoverflow.com/a/33689543. Now, we weren't able to repro this locally because we initialize `Purchases` in the main thread for all our tests, and this issue will only happen if we initialize the sdk on a different thread.

