### PR TITLE
Release: 5.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
           command: sudo pip install awscli
       - run:
           name: Deploy to S3
-          command: aws s3 sync ~/purchases-android/docs/5.3.0-SNAPSHOT s3://purchases-docs/android/5.3.0-SNAPSHOT --delete
+          command: aws s3 sync ~/purchases-android/docs/5.3.0 s3://purchases-docs/android/5.3.0 --delete
       - run:
           name: Update index.html
           command: aws s3 cp ~/purchases-android/docs/index.html s3://purchases-docs/android/index.html

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,1 +1,4 @@
-* Updates the `unityIAP` build flavor for compatibility with Unity IAP >= v3.1.0 for observer mode.
+* Updates the `unityIAP` build flavor so we don't include the billing client directly
+  * https://github.com/RevenueCat/purchases-android/pull/566
+* Fixes issue where SDK could not be initialized on a thread other than the main thread
+  * https://github.com/RevenueCat/purchases-android/pull/568

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.3.0
+
+* Updates the `unityIAP` build flavor so we don't include the billing client directly
+  * https://github.com/RevenueCat/purchases-android/pull/566
+* Fixes issue where SDK could not be initialized on a thread other than the main thread
+  * https://github.com/RevenueCat/purchases-android/pull/568
+
 ## 5.2.1
 
 * Updates the `unityIAP` build flavor for compatibility with Unity IAP >= v3.1.0 for observer mode.

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -4,5 +4,5 @@ object Config {
 
     var debugLogsEnabled = BuildConfig.DEBUG
 
-    const val frameworkVersion = "5.3.0-SNAPSHOT"
+    const val frameworkVersion = "5.3.0"
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/5.3.0-SNAPSHOT/index.html" />
+    <meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/5.3.0/index.html" />
 </head>
 <body>
 </body>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=5.3.0-SNAPSHOT
+VERSION_NAME=5.3.0
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/library.gradle
+++ b/library.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
         versionCode 1
-        versionName "5.3.0-SNAPSHOT"
+        versionName "5.3.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
## Changes from 5.2.1

* Updates the `unityIAP` build flavor so we don't include the billing client directly
  * https://github.com/RevenueCat/purchases-android/pull/566
* Fixes issue where SDK could not be initialized on a thread other than the main thread
  * https://github.com/RevenueCat/purchases-android/pull/568
