### PR TITLE
Add missing dependency from integration tests

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.2'
     androidTestImplementation 'org.assertj:assertj-core:3.13.2'
+    androidTestUnityIAPImplementation "com.android.billingclient:billing:$billingClient3Version"
 }
 
 def obtainTestBuildType() {


### PR DESCRIPTION
### Description
Followup to #566 

This fixes the integration tests so they run normally. With the change to `compileOnly`, we didn't have the billing client during integration tests for unity: https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/2925/workflows/f31a6715-2198-4451-8e21-63b4e7ef9886/jobs/7226
