### PR TITLE
Sync subscriber attributes before login and logout

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -587,15 +587,16 @@ class Purchases internal constructor(
      */
     @JvmOverloads
     fun logOut(callback: ReceiveCustomerInfoCallback? = null) {
-        val error: PurchasesError? = identityManager.logOut()
-        if (error != null) {
-            callback?.onError(error)
-        } else {
-            backend.clearCaches()
-            synchronized(this@Purchases) {
-                state = state.copy(purchaseCallbacks = emptyMap())
+        identityManager.logOut { error ->
+            if (error != null) {
+                callback?.onError(error)
+            } else {
+                backend.clearCaches()
+                synchronized(this@Purchases) {
+                    state = state.copy(purchaseCallbacks = emptyMap())
+                }
+                updateAllCaches(identityManager.currentAppUserID, callback)
             }
-            updateAllCaches(identityManager.currentAppUserID, callback)
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -70,7 +70,18 @@ internal class PurchasesFactory(
 
             val subscriberAttributesCache = SubscriberAttributesCache(cache)
 
-            val identityManager = IdentityManager(cache, subscriberAttributesCache, backend)
+            val subscriberAttributesManager = SubscriberAttributesManager(
+                subscriberAttributesCache,
+                subscriberAttributesPoster,
+                attributionFetcher
+            )
+
+            val identityManager = IdentityManager(
+                cache,
+                subscriberAttributesCache,
+                subscriberAttributesManager,
+                backend
+            )
 
             val customerInfoHelper = CustomerInfoHelper(cache, backend, identityManager)
 
@@ -82,11 +93,7 @@ internal class PurchasesFactory(
                 cache,
                 dispatcher,
                 identityManager,
-                SubscriberAttributesManager(
-                    subscriberAttributesCache,
-                    subscriberAttributesPoster,
-                    attributionFetcher
-                ),
+                subscriberAttributesManager,
                 appConfig,
                 customerInfoHelper
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -1733,9 +1733,7 @@ class PurchasesTest {
         every {
             mockCache.cleanupOldAttributionData()
         } just Runs
-        every {
-            mockIdentityManager.logOut()
-        } returns null
+        mockIdentityManagerLogout()
         val mockCompletion = mockk<ReceiveCustomerInfoCallback>(relaxed = true)
         purchases.logOut(mockCompletion)
 
@@ -1760,13 +1758,11 @@ class PurchasesTest {
         every {
             mockCache.cleanupOldAttributionData()
         } just Runs
-        every {
-            mockIdentityManager.logOut()
-        } returns null
+        mockIdentityManagerLogout()
 
         purchases.logOut()
         verify(exactly = 1) {
-            mockIdentityManager.logOut()
+            mockIdentityManager.logOut(any())
         }
     }
 
@@ -1775,9 +1771,7 @@ class PurchasesTest {
         every {
             mockCache.cleanupOldAttributionData()
         } just Runs
-        every {
-            mockIdentityManager.logOut()
-        } returns null
+        mockIdentityManagerLogout()
 
         purchases.logOut()
         verify(exactly = 1) {
@@ -1796,9 +1790,7 @@ class PurchasesTest {
         } just Runs
         val mockError = mockk<PurchasesError>(relaxed = true)
         val mockCompletion = mockk<ReceiveCustomerInfoCallback>(relaxed = true)
-        every {
-            mockIdentityManager.logOut()
-        } returns mockError
+        mockIdentityManagerLogout(mockError)
 
         purchases.logOut(mockCompletion)
         verify(exactly = 1) {
@@ -1813,9 +1805,7 @@ class PurchasesTest {
         } just Runs
 
         val mockCompletion = mockk<ReceiveCustomerInfoCallback>(relaxed = true)
-        every {
-            mockIdentityManager.logOut()
-        } returns null
+        mockIdentityManagerLogout()
 
         purchases.logOut(mockCompletion)
         verify(exactly = 1) {
@@ -1836,9 +1826,7 @@ class PurchasesTest {
         } just Runs
 
         val mockCompletion = mockk<ReceiveCustomerInfoCallback>(relaxed = true)
-        every {
-            mockIdentityManager.logOut()
-        } returns null
+        mockIdentityManagerLogout()
 
         purchases.logOut(mockCompletion)
         verify(exactly = 1) {
@@ -4332,6 +4320,14 @@ class PurchasesTest {
         } answers {
             lst.captured.run()
             true
+        }
+    }
+
+    private fun mockIdentityManagerLogout(error: PurchasesError? = null) {
+        every {
+            mockIdentityManager.logOut(captureLambda())
+        } answers {
+            lambda<(PurchasesError?) -> Unit>().captured.invoke(error)
         }
     }
 


### PR DESCRIPTION
### Description
https://revenuecats.atlassian.net/browse/CSDK-76

In this PR we modify the behavior during login and logout so we sync all unsynced subscriber attributes with the backend before actually performing the login/logout. I inspired the implementation on the iOS implementation here: https://github.com/RevenueCat/purchases-ios/pull/1716

