### PR TITLE
Revert handler nullability change

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -102,6 +102,7 @@ class Purchases internal constructor(
     private val subscriberAttributesManager: SubscriberAttributesManager,
     @set:JvmSynthetic @get:JvmSynthetic internal var appConfig: AppConfig,
     private val customerInfoHelper: CustomerInfoHelper,
+    // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper())
 ) : LifecycleDelegate {
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -102,7 +102,7 @@ class Purchases internal constructor(
     private val subscriberAttributesManager: SubscriberAttributesManager,
     @set:JvmSynthetic @get:JvmSynthetic internal var appConfig: AppConfig,
     private val customerInfoHelper: CustomerInfoHelper,
-    private val mainHandler: Handler = Handler(Looper.getMainLooper())
+    private val mainHandler: Handler? = Handler(Looper.getMainLooper())
 ) : LifecycleDelegate {
 
     /** @suppress */
@@ -1256,7 +1256,8 @@ class Purchases internal constructor(
 
     private fun dispatch(action: () -> Unit) {
         if (Thread.currentThread() != Looper.getMainLooper().thread) {
-            mainHandler.post(action)
+            val handler = mainHandler ?: Handler(Looper.getMainLooper())
+            handler.post(action)
         } else {
             action()
         }


### PR DESCRIPTION
### Description
After this change: https://github.com/RevenueCat/purchases-android/commit/2bed17a041994cedf7e370d0f186c1d7b0fce078#diff-e019410c58657f001e6ba8be4f066c84c928f4e017ae3b3b6366cebfd64b9716R1251 we run into a couple of issues. 
- First one happened during the `init` of `Purchases` and was fixed here: https://github.com/RevenueCat/purchases-android/pull/568. 
- We received another report (https://github.com/RevenueCat/purchases-flutter/issues/408) which seems related since it's also caused by a null `mainHandler`.

I couldn't find the cause for this second issue after trying a few things, so I'm reverting that change for now.

