### PR TITLE
Pass along release_version variable

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -81,8 +81,9 @@ platform :android do
 
   desc "Creates github release and updates the latest tag"
   lane :github_release do |options|
+    release_version = options[:version]
     create_github_release(
-      version: options[:version],
+      version: release_version,
       repo_name: repo_name,
       github_api_token: ENV["GITHUB_TOKEN"],
       changelog_latest_path: changelog_latest_path


### PR DESCRIPTION
Fixes: Could not find action, lane or variable 'release_version'. Check out the documentation for more details: https://docs.fastlane.tools/actions

resolves [SDKONCALL-83]

[SDKONCALL-83]: https://revenuecats.atlassian.net/browse/SDKONCALL-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ