### PR TITLE
Pass $CIRCLE_BRANCH to prepare_next_version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
       - trust-github-key
       - run:
           name: Prepare next version
-          command: bundle exec fastlane prepare_next_version
+          command: bundle exec fastlane prepare_next_version branch:$CIRCLE_BRANCH
 
   deploy-snapshot:
     executor: android-executor


### PR DESCRIPTION
resolves [SDKONCALL-84]

[SDKONCALL-84]: https://revenuecats.atlassian.net/browse/SDKONCALL-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


It seems that CircleCI is calling:

`prepare_next_version` with no options, so the check here:
```
  lane :prepare_next_version do |options|
    create_next_snapshot_version(
      current_version: current_version_number,
      repo_name: repo_name,
      github_pr_token: ENV["GITHUB_PULL_REQUEST_API_TOKEN"],
      files_to_update: files_with_version_number,
      branch: options[:branch] || 'main'
    )
  end
  ```
  
  `branch: options[:branch] || 'main'` is falling back to main. When we're deploying from a tag, we're not on main.