### PR TITLE
Update latest fastlane plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
       - trust-github-key
       - run:
           name: Prepare next version
-          command: bundle exec fastlane prepare_next_version branch:$CIRCLE_BRANCH
+          command: bundle exec fastlane prepare_next_version
 
   deploy-snapshot:
     executor: android-executor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 086656f3a2cbf47ee2cdf9f6ee3cf6fb5d4275c0
+  revision: a271972db563fc91c682c235146afbc83cd82203
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -146,8 +146,7 @@ platform :android do
       current_version: current_version_number,
       repo_name: repo_name,
       github_pr_token: ENV["GITHUB_PULL_REQUEST_API_TOKEN"],
-      files_to_update: files_with_version_number,
-      branch: options[:branch] || 'main'
+      files_to_update: files_with_version_number
     )
   end
 


### PR DESCRIPTION
### Description
Updates to latest fastlane plugin with this change: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/12. Now we won't validate the current branch when running the `prepare_next_version` lane.
