### PR TITLE
Update fastlane plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: a271972db563fc91c682c235146afbc83cd82203
+  revision: 078609b63c55ad91a674765e68937d805264a827
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,9 +2,10 @@ Automatic Releasing
 =========
 1. Create a `fastlane/.env` file with your GitHub API token (see `fastlane/.env.SAMPLE`). This will be used to create the PR, so you should use your own token so the PR gets assigned to you.
 2. Run `bundle exec fastlane android bump`
- 1. Input new version number
- 2. Update CHANGELOG.latest.md to include the latest changes. Call out API changes (if any). You can use the existing CHANGELOG.md as a base for formatting. To compile the changelog, you can compare the changes between the base branch for the release (usually main) against the latest release, by checking https://github.com/revenuecat/purchases-android/compare/<latest_release>...<base_branch>. For example, https://github.com/revenuecat/purchases-android/compare/5.1.1...main.
- 3. A new branch and PR will automatically be created
+ 1. Confirm base branch is correct
+ 2. Input new version number
+ 3. Update CHANGELOG.latest.md to include the latest changes. Call out API changes (if any). You can use the existing CHANGELOG.md as a base for formatting. To compile the changelog, you can compare the changes between the base branch for the release (usually main) against the latest release, by checking https://github.com/revenuecat/purchases-android/compare/<latest_release>...<base_branch>. For example, https://github.com/revenuecat/purchases-android/compare/5.1.1...main.
+ 4. A new branch and PR will automatically be created
 3. Merge PR when approved
 4. Pull main
 5. Make a tag and push, the rest will be performed automatically by CircleCI. If the automation fails, you can revert to manually calling `bundle exec fastlane deploy`.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -43,7 +43,6 @@ platform :android do
       files_to_update: files_with_version_number,
       repo_name: repo_name,
       github_rate_limit: options[:github_rate_limit],
-      branch: options[:branch],
       editor: options[:editor]
     )
   end


### PR DESCRIPTION
### Description
This PR bumps the fastlane internal plugin to use the latest version. One of the changes is that we won't be validating the base branch automatically in the `bump` lane anymore. Instead, we will ask for confirmation from the user in a prompt: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/20