### PR TITLE
Update README and add MagicWeather README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ Sign up to [get started for free](https://app.revenuecat.com/signup).
 📝 | [Online documentation](https://docs.revenuecat.com/docs) up to date  
 🔀 | [Integrations](https://www.revenuecat.com/integrations) - over a dozen integrations to easily send purchase data where you need it  
 💯 | Well maintained - [frequent releases](https://github.com/RevenueCat/purchases-android/releases)  
-📮 | Great support - [Help Center](https://revenuecat.zendesk.com)
-🤩 | Awesome [new features](https://trello.com/b/RZRnWRbI/revenuecat-product-roadmap)  
-
+📮 | Great support - [Help Center](https://revenuecat.zendesk.com) 
 
 ## Getting Started
 For more detailed information, you can view our complete documentation at [docs.revenuecat.com](https://docs.revenuecat.com/docs).

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Or view our Android sample app:
 - Minimum target: Android 4.0+ (API level 14+)
 
 ## SDK Reference
-Our full SDK reference [can be found here](https://sdk.revenuecat.com/android/5.4.1/index.html).
+Our full SDK reference [can be found here](https://sdk.revenuecat.com/android/index.html).
 
 ## Contributing
 Contributions are always welcome! To learn how you can contribute, please see the [Contributing Guide](./Contributing/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,26 @@
-<h3 align="center">😻 In-App Subscriptions Made Easy 😻</h1>
+<h3 align="center">😻 In-App Subscriptions Made Easy 😻</h3>
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?style=flat)](https://github.com/RevenueCat/purchases-android/releases)
 [![License](https://img.shields.io/github/license/RevenueCat/purchases-android.svg?style=flat)](https://github.com/RevenueCat/purchases-android/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?style=flat)](https://github.com/RevenueCat/purchases-android/releases)
+
+RevenueCat is a powerful, reliable, and free to use in-app purchase server with cross-platform support. Our open-source framework provides a backend and a wrapper around StoreKit and Google Play Billing to make implementing in-app purchases and subscriptions easy. 
+
+Whether you are building a new app or already have millions of customers, you can use RevenueCat to:
+
+  * Fetch products, make purchases, and check subscription status with our [native SDKs](https://docs.revenuecat.com/docs/installation). 
+  * Host and [configure products](https://docs.revenuecat.com/docs/entitlements) remotely from our dashboard. 
+  * Analyze the most important metrics for your app business [in one place](https://docs.revenuecat.com/docs/charts).
+  * See customer transaction histories, chart lifetime value, and [grant promotional subscriptions](https://docs.revenuecat.com/docs/customers).
+  * Get notified of real-time events through [webhooks](https://docs.revenuecat.com/docs/webhooks).
+  * Send enriched purchase events to analytics and attribution tools with our easy integrations.
+
+Sign up to [get started for free](https://app.revenuecat.com/signup).
 
 ## Purchases
 
-*Purchases* is a client for the [RevenueCat](https://www.revenuecat.com/) subscription and purchase tracking system. It is an open source framework that provides a wrapper around `BillingClient` and the RevenueCat backend to make implementing in-app subscriptions in `Android` easy - receipt validation and status tracking included!
+*Purchases* is the client for the [RevenueCat](https://www.revenuecat.com/) subscription and purchase tracking system. It is an open source framework that provides a wrapper around `BillingClient` and the RevenueCat backend to make implementing in-app subscriptions in `Android` easy - receipt validation and status tracking included!
 
-## Features
+## RevenueCat SDK Features
 |   | RevenueCat |
 | --- | --- |
 ✅ | Server-side receipt validation
@@ -21,10 +34,20 @@
 🤩 | Awesome [new features](https://trello.com/b/RZRnWRbI/revenuecat-product-roadmap)  
 
 
-## Installation
+## Getting Started
+For more detailed information, you can view our complete documentation at [docs.revenuecat.com](https://docs.revenuecat.com/docs).
 
-Please follow the [Quickstart Guide](https://docs.revenuecat.com/docs/) for more information on how to use the SDK
+Please follow the [Quickstart Guide](https://docs.revenuecat.com/docs/) for more information on how to install the SDK.
+
+Or view our Android sample app:
+- [MagicWeather](examples/MagicWeather)
 
 ## Requirements
+- Java 8+
+- Minimum target: Android 4.0+ (API level 14+)
 
-`purchases` works on Android 4.0+ (API level 14+) and Java 8+.
+## SDK Reference
+Our full SDK reference [can be found here](https://sdk.revenuecat.com/android/5.4.1/index.html).
+
+## Contributing
+Contributions are always welcome! To learn how you can contribute, please see the [Contributing Guide](./Contributing/CONTRIBUTING.md).

--- a/examples/MagicWeather/README.md
+++ b/examples/MagicWeather/README.md
@@ -1,0 +1,79 @@
+# Magic Weather Android - RevenueCat Sample
+
+Magic Weather is a sample app demonstrating the proper methods for using RevenueCat's *Purchases* SDK. This sample uses only native platform components - no third-party SDKs other than the *Purchases* SDK.
+
+Sign up for a free RevenueCat account [here](https://www.revenuecat.com).
+
+## Requirements
+
+This sample uses:
+
+- Android Studio
+- Android (API 8.0+)
+- Kotlin 1.6.21
+
+See minimum platform version requirements for RevenueCat's *Purchases* SDK [here](https://github.com/RevenueCat/purchases-android/blob/main/examples/MagicWeather/build.gradle).
+
+## Features
+
+| Feature                          | Sample Project Location                   |
+| -------------------------------- | ----------------------------------------- |
+| 🕹 Configuring the *Purchases* SDK  | [MainActivity.kt](MagicWeather/app/src/main/java/com/revenuecat/sample/MainActivity.kt) |
+| 💰 Building a basic paywall         | [paywall/PaywallFragment.kt](MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallFragment.kt) |
+| 🔐 Checking subscription status     | [weather/WeatherFragment.kt](MagicWeather/app/src/main/java/com/revenuecat/sample/ui/weather/WeatherFragment.kt#L69) |
+| 🤑 Restoring transactions           | [user/UserFragment.kt](MagicWeather/app/src/main/java/com/revenuecat/sample/ui/user/UserFragment.kt#L81) |
+| 👥 Identifying the user             | [user/UserFragment.kt](MagicWeather/app/src/main/java/com/revenuecat/sample/ui/user/UserFragment.kt#L97) |
+| 🚪 Logging out the user             | [user/UserFragment.kt](MagicWeather/app/src/main/java/com/revenuecat/sample/ui/user/UserFragment.kt#L97) |
+
+## Setup & Run
+
+### Prerequisites
+- Be sure to have a [Google Play Console Account](https://play.google.com/console/developers).
+- Be sure to set up at least one subscription on the Play Store following our [guide](https://docs.revenuecat.com/docs/google-play-store) and link it to RevenueCat:
+    - Add the [product](https://docs.revenuecat.com/docs/entitlements#products) (e.g. `rc_3999_1y`) to RevenueCat's dashboard. It should match the product ID on the Play Store.
+    - Attach the product to an [entitlement](https://docs.revenuecat.com/docs/entitlements#creating-an-entitlement), e.g. `premium`.
+    - Attach the product to a [package](https://docs.revenuecat.com/docs/entitlements#adding-packages) (e.g. `Annual`) inside an [offering](https://docs.revenuecat.com/docs/entitlements#creating-an-offering) (e.g. `sale` or `default`).
+- Get your [API key](https://docs.revenuecat.com/docs/authentication#obtaining-api-keys) from your RevenueCat project.
+
+### Steps to Run
+1. Download or clone this repository
+    >git clone https://github.com/RevenueCat/purchases-android.git
+
+2. Open the MagicWeather project in Android Studio
+
+    <img src="https://i.imgur.com/dDSod4g.png" alt="Android Studio open file navigation" width="250px" />
+
+3. In `build.gradle`, match `applicationId` to your Google Play package in Google Play Console and RevenueCat.
+    
+    <img src="https://i.imgur.com/1iI5MaA.png" alt="Build Gradle with applicationId" width="250px" />
+
+4. In the `Constants.kt` file: 
+    - Replace the value for `GOOGLE_API_KEY` with the API key from your RevenueCat project.
+    - Replace the value for `AMAZON_API_KEY` with the API key from your RevenueCat project (if applicable).
+    - Replace the value for `entitlementID` with the entitlement ID of your product in RevenueCat's dashboard.
+
+    <img src="https://i.imgur.com/LXsH3tL.png" alt="Constants.kt file" width="250px" />
+
+5. Run the app on a simulator or physical device.
+
+    <img src="https://i.imgur.com/GlazHU5.png" alt="Run Android Studio project" width="250px" />
+    <img src="https://i.imgur.com/lGQYmKK.png" alt="Run Android Studio project" width="180px" />
+
+
+### Example Flow: Purchasing a Subscription
+
+1. On the home page, select **Change the Weather**.
+2. On the prompted payment sheet, select the product listed.
+3. On the next modal, select **Subscribe**.
+4. On the next modal, sign in with your Sandbox User ID.
+5. On the next modal, select **Ok**.
+6. Return to the home page and select **Change the Weather** to see the weather change!
+
+#### Purchase Flow Demo (`iOS` version)
+<img src="https://i.imgur.com/SSbRLhr.gif" width="220px" />
+
+## Support
+
+For more technical resources, check out our [documentation](https://docs.revenuecat.com).
+
+Looking for RevenueCat Support? Visit our [community](https://community.revenuecat.com/).

--- a/examples/MagicWeather/README.md
+++ b/examples/MagicWeather/README.md
@@ -9,7 +9,7 @@ Sign up for a free RevenueCat account [here](https://www.revenuecat.com).
 This sample uses:
 
 - Android Studio
-- Android (API 8.0+)
+- Android 8.0+ (API level 26+)
 - Kotlin 1.6.21
 
 See minimum platform version requirements for RevenueCat's *Purchases* SDK [here](https://github.com/RevenueCat/purchases-android/blob/main/examples/MagicWeather/build.gradle).

--- a/examples/MagicWeather/README.md
+++ b/examples/MagicWeather/README.md
@@ -18,12 +18,12 @@ See minimum platform version requirements for RevenueCat's *Purchases* SDK [here
 
 | Feature                          | Sample Project Location                   |
 | -------------------------------- | ----------------------------------------- |
-| 🕹 Configuring the *Purchases* SDK  | [MainActivity.kt](MagicWeather/app/src/main/java/com/revenuecat/sample/MainActivity.kt) |
-| 💰 Building a basic paywall         | [paywall/PaywallFragment.kt](MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallFragment.kt) |
-| 🔐 Checking subscription status     | [weather/WeatherFragment.kt](MagicWeather/app/src/main/java/com/revenuecat/sample/ui/weather/WeatherFragment.kt#L69) |
-| 🤑 Restoring transactions           | [user/UserFragment.kt](MagicWeather/app/src/main/java/com/revenuecat/sample/ui/user/UserFragment.kt#L81) |
-| 👥 Identifying the user             | [user/UserFragment.kt](MagicWeather/app/src/main/java/com/revenuecat/sample/ui/user/UserFragment.kt#L97) |
-| 🚪 Logging out the user             | [user/UserFragment.kt](MagicWeather/app/src/main/java/com/revenuecat/sample/ui/user/UserFragment.kt#L97) |
+| 🕹 Configuring the *Purchases* SDK  | [MainActivity.kt](app/src/main/java/com/revenuecat/sample/MainActivity.kt) |
+| 💰 Building a basic paywall         | [paywall/PaywallFragment.kt](app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallFragment.kt) |
+| 🔐 Checking subscription status     | [weather/WeatherFragment.kt](app/src/main/java/com/revenuecat/sample/ui/weather/WeatherFragment.kt#L69) |
+| 🤑 Restoring transactions           | [user/UserFragment.kt](app/src/main/java/com/revenuecat/sample/ui/user/UserFragment.kt#L81) |
+| 👥 Identifying the user             | [user/UserFragment.kt](app/src/main/java/com/revenuecat/sample/ui/user/UserFragment.kt#L97) |
+| 🚪 Logging out the user             | [user/UserFragment.kt](app/src/main/java/com/revenuecat/sample/ui/user/UserFragment.kt#L97) |
 
 ## Setup & Run
 


### PR DESCRIPTION
### Checklist
- [ x ] If applicable, unit tests
- [ x ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
The main README was tweaked to be consistent with the purchases-ios README and to point to the MagicWeather example app. The MagicWeather README was written to be consistent with the iOS example app README (with Android instructions). 

### Description
<!-- Describe your changes in detail -->
The changes to the main README were mainly changes in the ordering of information or adding additional links to docs.revenuecat.com

The MagicWeather README was written using the purchases-ios README as a template. Screenshots of steps in Android Studio are included.

<!-- Please describe in detail how you tested your changes -->
I pulled the most current repo and got MagicWeather working on a simulator using the instructions written.
