### PR TITLE
Rename revenueCatId and productId to transactionIdentifier and productIdentifier. Deprecate old properties

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/TransactionAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/TransactionAPI.java
@@ -7,7 +7,9 @@ import java.util.Date;
 @SuppressWarnings({"unused"})
 final class TransactionAPI {
     static void check(final Transaction transaction) {
+        final String transactionIdentifier = transaction.getTransactionIdentifier();
         final String revenuecatId = transaction.getRevenuecatId();
+        final String productIdentifier = transaction.getProductIdentifier();
         final String productId = transaction.getProductId();
         final Date purchaseDate = transaction.getPurchaseDate();
     }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/TransactionAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/TransactionAPI.kt
@@ -7,7 +7,9 @@ import java.util.Date
 private class TransactionAPI {
     fun check(transaction: Transaction) {
         with(transaction) {
+            val transactionIdentifier: String = transactionIdentifier
             val revenuecatId: String = revenuecatId
+            val productIdentifier: String = productIdentifier
             val productId: String = productId
             val purchaseDate: Date = purchaseDate
         }

--- a/common/src/test/java/com/revenuecat/purchases/common/CustomerInfoTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/CustomerInfoTest.kt
@@ -56,9 +56,15 @@ class CustomerInfoTest {
         assertThat(info.purchasedNonSubscriptionSkus).contains("lifetime_access")
 
         assertThat(info.nonSubscriptionTransactions.size).isEqualTo(5)
-        assertThat(info.nonSubscriptionTransactions.filter { it.productId == "100_coins_pack" }.size).isEqualTo(2)
-        assertThat(info.nonSubscriptionTransactions.filter { it.productId == "7_extra_lives" }.size).isEqualTo(2)
-        assertThat(info.nonSubscriptionTransactions.filter { it.productId == "lifetime_access" }.size).isEqualTo(1)
+        assertThat(
+            info.nonSubscriptionTransactions.filter { it.productIdentifier == "100_coins_pack" }.size
+        ).isEqualTo(2)
+        assertThat(
+            info.nonSubscriptionTransactions.filter { it.productIdentifier == "7_extra_lives" }.size
+        ).isEqualTo(2)
+        assertThat(
+            info.nonSubscriptionTransactions.filter { it.productIdentifier == "lifetime_access" }.size
+        ).isEqualTo(1)
     }
 
     @Test
@@ -260,23 +266,25 @@ class CustomerInfoTest {
         assertThat(fullCustomerInfo.nonSubscriptionTransactions.size).isEqualTo(5)
 
         val oneTimePurchaseTransactions = fullCustomerInfo.nonSubscriptionTransactions.filter {
-            it.productId == "100_coins_pack"
+            it.productIdentifier == "100_coins_pack"
         }
         assertThat(oneTimePurchaseTransactions.size).isEqualTo(2)
 
         val consumableTransactions = fullCustomerInfo.nonSubscriptionTransactions.filter {
-            it.productId == "7_extra_lives"
+            it.productIdentifier == "7_extra_lives"
         }
         assertThat(consumableTransactions.size).isEqualTo(2)
 
         assertThat((oneTimePurchaseTransactions + consumableTransactions)
-            .distinctBy { it.revenuecatId }.size).isEqualTo(4)
+            .distinctBy { it.transactionIdentifier }.size).isEqualTo(4)
     }
 
     @Test
     fun `Non subscription transactions list is correctly created`() {
         assertThat(fullCustomerInfo.nonSubscriptionTransactions).isNotEmpty
         assertThat(fullCustomerInfo.nonSubscriptionTransactions.size).isEqualTo(5)
-        assertThat((fullCustomerInfo.nonSubscriptionTransactions).distinctBy { it.revenuecatId }.size).isEqualTo(5)
+        assertThat(
+            (fullCustomerInfo.nonSubscriptionTransactions).distinctBy { it.transactionIdentifier }.size
+        ).isEqualTo(5)
     }
 }

--- a/public/src/main/java/com/revenuecat/purchases/CustomerInfo.kt
+++ b/public/src/main/java/com/revenuecat/purchases/CustomerInfo.kt
@@ -38,7 +38,7 @@ data class CustomerInfo constructor(
     val entitlements: EntitlementInfos,
     @Deprecated(
         "Use nonSubscriptionTransactions instead",
-        ReplaceWith("nonSubscriptionTransactions.map{ it.productId }.toSet()")
+        ReplaceWith("nonSubscriptionTransactions.map{ it.productIdentifier }.toSet()")
     ) val purchasedNonSubscriptionSkus: Set<String>,
     val allExpirationDatesByProduct: Map<String, Date?>,
     val allPurchaseDatesByProduct: Map<String, Date?>,
@@ -67,7 +67,7 @@ data class CustomerInfo constructor(
      */
     @IgnoredOnParcel
     val allPurchasedSkus: Set<String> by lazy {
-        this.nonSubscriptionTransactions.map { it.productId }.toSet() + allExpirationDatesByProduct.keys
+        this.nonSubscriptionTransactions.map { it.productIdentifier }.toSet() + allExpirationDatesByProduct.keys
     }
 
     /**

--- a/public/src/main/java/com/revenuecat/purchases/PurchaserInfo.kt
+++ b/public/src/main/java/com/revenuecat/purchases/PurchaserInfo.kt
@@ -41,7 +41,7 @@ data class PurchaserInfo constructor(
     val entitlements: EntitlementInfos,
     @Deprecated(
         "Use nonSubscriptionTransactions instead",
-        ReplaceWith("nonSubscriptionTransactions.map{ it.productId }.toSet()")
+        ReplaceWith("nonSubscriptionTransactions.map{ it.productIdentifier }.toSet()")
     ) val purchasedNonSubscriptionSkus: Set<String>,
     val allExpirationDatesByProduct: Map<String, Date?>,
     val allPurchaseDatesByProduct: Map<String, Date?>,
@@ -67,7 +67,7 @@ data class PurchaserInfo constructor(
      */
     @IgnoredOnParcel
     val allPurchasedSkus: Set<String> by lazy {
-        this.nonSubscriptionTransactions.map { it.productId }.toSet() + allExpirationDatesByProduct.keys
+        this.nonSubscriptionTransactions.map { it.productIdentifier }.toSet() + allExpirationDatesByProduct.keys
     }
 
     /**

--- a/public/src/main/java/com/revenuecat/purchases/models/Transaction.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/Transaction.kt
@@ -8,13 +8,25 @@ import java.util.Date
 
 @Parcelize
 data class Transaction(
+    val transactionIdentifier: String,
+    @Deprecated(
+        "Use transactionIdentifier instead",
+        ReplaceWith("transactionIdentifier")
+    )
     val revenuecatId: String,
+    val productIdentifier: String,
+    @Deprecated(
+        "Use productIdentifier instead",
+        ReplaceWith("productIdentifier")
+    )
     val productId: String,
     val purchaseDate: Date
 ) : Parcelable {
 
     internal constructor(productId: String, jsonObject: JSONObject) : this(
+        transactionIdentifier = jsonObject.getString("id"),
         revenuecatId = jsonObject.getString("id"),
+        productIdentifier = productId,
         productId = productId,
         purchaseDate = jsonObject.getDate("purchase_date")
     )

--- a/public/src/test/java/com/revenuecat/purchases/common/models/TransactionTest.kt
+++ b/public/src/test/java/com/revenuecat/purchases/common/models/TransactionTest.kt
@@ -30,9 +30,9 @@ class TransactionTest {
     fun `Can be created`() {
         val jsonObject = nonSubscriptionsJSONObject()
         val transaction = Transaction(productId, jsonObject)
-        assertThat(transaction.revenuecatId).isEqualTo(id)
+        assertThat(transaction.transactionIdentifier).isEqualTo(id)
         assertThat(transaction.purchaseDate).isEqualTo(Iso8601Utils.parse(dateString))
-        assertThat(transaction.productId).isEqualTo(productId)
+        assertThat(transaction.productIdentifier).isEqualTo(productId)
     }
 
 }


### PR DESCRIPTION
### Description
This is the first PR in https://revenuecats.atlassian.net/browse/CSDK-409. We want to rename `Transaction.revenueCatId` and `Transaction.productId` to `Transaction.transactionIdentifier` and `Transaction.productIdentifier` respectively. This adds those properties and deprecates the old properties to be removed in a future release.

