### PR TITLE
Fix prepare next version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,7 @@ integration-tests/keystore
 # index.html is used to redirect to the latest docs version
 # when navigating to root
 !/docs/index.html
+
+# CircleCI folders
+vendor/
+.bundle/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 078609b63c55ad91a674765e68937d805264a827
+  revision: 0acf0aaf142737e2c2b43c74d1fa1de6941ea822
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,22 +6,19 @@ Automatic Releasing
  2. Input new version number
  3. Update CHANGELOG.latest.md to include the latest changes. Call out API changes (if any). You can use the existing CHANGELOG.md as a base for formatting. To compile the changelog, you can compare the changes between the base branch for the release (usually main) against the latest release, by checking https://github.com/revenuecat/purchases-android/compare/<latest_release>...<base_branch>. For example, https://github.com/revenuecat/purchases-android/compare/5.1.1...main.
  4. A new branch and PR will automatically be created
-3. Merge PR when approved
-4. Pull main
-5. Make a tag and push, the rest will be performed automatically by CircleCI. If the automation fails, you can revert to manually calling `bundle exec fastlane deploy`.
+3. Wait until PR is approved (don't merge yet) and pull branch from origin (to make sure you've got all the changes locally)
+4. Create a tag for the new release in the last commit of the branch and push the tag. The rest will be performed automatically by CircleCI. If the automation fails, you can revert to manually calling bundle exec fastlane release.
+5. After that, you can merge the release PR to main and merge the bump to the next snapshot version PR right after.
 
 Hotfix Releases
 =========
-Sometimes not all commits from main should be included in a release. This is a typical scenario
-with a hotfix release, where an urgent bugfix needs to be released and some features already merged
-are not ready to be released.
+Sometimes you might need to release a patch on a version that's not the latest. Or sometimes there might have been commits on main that shouldn't be released, but the latest version has a big bug. For example, let's say the last version is 4.0.0, but there's a bug on 3.9.0 that needs to be released as a 3.9.1:
 
-1. Open a branch from the latest release (or the last commit before the one that shouldn't be included). Name it release/x.x.x
-1. Cherry pick all other commits that should be included.
-1. Create a CHANGELOG.latest.md with the changes for the current version (to be used by Fastlane for the github release notes)
-1. Run `bundle exec fastlane bump_and_update_changelog version:X.Y.Z` (where X.Y.Z is the new version) to update the version number in `gradle.properties`, `Config.kt` and in `library/build.gradle`
-1. Commit the changes `git commit -am "Version X.Y.Z"` (where X.Y.Z is the new version)
-1. Make a PR, **don't merge** it when approved. Instead, close the PR.
-1. Tag the last commit in that branch and push. The rest of the process should be as in the automatic release.
-CircleCI will upload a release to Sonatype.
-1. Open a PR against main updating the changelog to include the changes from the hotfix release.
+1. Open a PR with the fix, merge it to main.
+1. Jump to 3.9.0 and create a new branch release/3.9.0. Push this branch since it will be used as base for the PR you will open in the next steps.
+1. Run bundle exec fastlane ios bump as you would do with any release. This will create a new PR release/3.9.1. Make sure the base branch of the PR is pointing to release/3.9.0 and that the PR is labeled with DO NOT MERGE (add it to the title too so it's not merged by mistake)
+1. Locally, while in branch the release branch (release/3.9.1 in this case), cherry pick the changes with your fix that you just merged to main using git cherry-pick <sha_of_the_squashed_commit_in_main>. Fix any conflicts if there are any. Push the cherry picked commit to the remote branch release/3.9.1.
+1. When the PR is approved, DO NOT MERGE IT. Create a tag and push it as you would do for any other release.
+1. CircleCI will start the deployment process
+1. Close the PR after the release has been completed and delete both release/3.9.0 and release/3.9.1 branches.
+1. Remember to edit the CHANGELOG.md in main to include the version that has been just released


### PR DESCRIPTION
### Description
There was an issue during the `prepare_next_version` job: https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/3021/workflows/dc01939b-d2b3-43d9-b0c9-1ab0df5bf070/jobs/7463. This was because there were some CircleCI only folders that caused git to be dirty and fail the process. We are adding those to `.gitignore` so it's not a problem anymore. 

Additionally, this PR updates the releasing documentation and the fastlane plugin to the lastest version.
