### PR TITLE
Rename package name of purchase tester app to com.revenuecat.purchases_sample

### DIFF
--- a/examples/purchase-tester/build.gradle
+++ b/examples/purchase-tester/build.gradle
@@ -18,7 +18,7 @@ android {
         dataBinding true
     }
     defaultConfig {
-        applicationId "com.revenuecat.purchase_tester"
+        applicationId "com.revenuecat.purchases_sample"
         minSdkVersion 21
         versionCode 1
         versionName "1.0"
@@ -41,7 +41,7 @@ android {
         }
     }
     testBuildType obtainTestBuildType()
-    namespace 'com.revenuecat.purchase_tester'
+    namespace 'com.revenuecat.purchases_sample'
 }
 
 def obtainTestBuildType() {

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LoginFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LoginFragment.kt
@@ -6,10 +6,10 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
-import com.revenuecat.purchase_tester.databinding.FragmentLoginBinding
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.logInWith
 import com.revenuecat.purchases.logOutWith
+import com.revenuecat.purchases_sample.databinding.FragmentLoginBinding
 
 class LoginFragment : Fragment() {
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainActivity.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainActivity.kt
@@ -2,7 +2,7 @@ package com.revenuecat.purchasetester
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.revenuecat.purchase_tester.R
+import com.revenuecat.purchases_sample.R
 
 class MainActivity : AppCompatActivity() {
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingCardAdapter.kt
@@ -6,7 +6,7 @@ import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.revenuecat.purchases.Offering
-import com.revenuecat.purchase_tester.databinding.OfferingCardBinding
+import com.revenuecat.purchases_sample.databinding.OfferingCardBinding
 
 class OfferingCardAdapter(
     private val offerings: List<Offering>,

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -11,7 +11,6 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.transition.MaterialContainerTransform
-import com.revenuecat.purchase_tester.R
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.Purchases
@@ -19,7 +18,8 @@ import com.revenuecat.purchases.getCustomerInfoWith
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.purchasePackageWith
 import com.revenuecat.purchases.purchaseProductWith
-import com.revenuecat.purchase_tester.databinding.FragmentOfferingBinding
+import com.revenuecat.purchases_sample.R
+import com.revenuecat.purchases_sample.databinding.FragmentOfferingBinding
 
 class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListener {
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -13,8 +13,6 @@ import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.transition.MaterialElevationScale
-import com.revenuecat.purchase_tester.R
-import com.revenuecat.purchase_tester.databinding.FragmentOverviewBinding
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Purchases
@@ -22,6 +20,8 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.getCustomerInfoWith
 import com.revenuecat.purchases.getOfferingsWith
 import com.revenuecat.purchases.logOutWith
+import com.revenuecat.purchases_sample.R
+import com.revenuecat.purchases_sample.databinding.FragmentOverviewBinding
 
 class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterListener, OverviewInteractionHandler {
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
@@ -7,7 +7,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.models.StoreProduct
-import com.revenuecat.purchase_tester.databinding.PackageCardBinding
+import com.revenuecat.purchases_sample.databinding.PackageCardBinding
 
 class PackageCardAdapter(
     private val packages: List<Package>,


### PR DESCRIPTION
### Description
In order to test internally using the `purchase-tester` sample app, I was running into difficulties since we don't have a good setup for that app in the RC dashboard nor on the play console. This PR changes the package name of that app from `com.revenuecat.purchase_tester` to `com.revenuecat.purchases_sample` so we can reuse the existing setup we have in RC and the play console for that app.

Note that I didn't rename the actual code package name, since using an underscore in a package name is not recommended...

**Important Note:** this will cause apps with the same package name in other repos to overwrite each other. I think it's an acceptable compromise but lmk if you think otherwise
