### PR TITLE
[HOLD] Set attribution ids immediately as subscriber attributes

### DIFF
--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -150,10 +150,8 @@ class SubscriberAttributesManager(
         appUserID: String,
         applicationContext: Application
     ) {
-        getDeviceIdentifiers(applicationContext) { deviceIdentifiers ->
-            val attributesToSet = mapOf(attributionKey.backendKey to value) + deviceIdentifiers
-            setAttributes(attributesToSet, appUserID)
-        }
+        setAttribute(attributionKey, value, appUserID)
+        collectDeviceIdentifiers(appUserID, applicationContext)
     }
 
     private fun getDeviceIdentifiers(


### PR DESCRIPTION
### Description
Resolves:  https://revenuecats.atlassian.net/browse/CSDK-433

When we set an attribution ID, we are also collecting device identifiers, which happens asynchronously before actually setting the attribute in the cache. While getting device identifiers is usually very fast according to all my tests, if it gets delayed, it can cause the attribution ids information to be delayed to be sent to the backend. 

This PR changes the behavior so we set the attribution id immediately, but still set device identifiers asynchronously right after. I'm not sure of this approach, since it means we would get the attribution id, but device identifiers can still be delayed to get sent to the backend. I wanted to check if this would be an issue or it would be acceptable @aboedo. If we need device identifiers to be sent immediately as well, it would be a much bigger change and increase complexity a lot.

Another possible solution is to not automatically collect device identifiers when setting attribution ids and change the API of the `Purchases.collectDeviceIdentifiers` to accept a completion block, so devs can handle this on their end.

### TODO
- [ ] Confirm whether fix is acceptable