### PR TITLE
BillingClient 5 Update

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -159,4 +159,12 @@ final class PurchasesAPI {
         );
         final LogHandler handler = Purchases.getLogHandler();
     }
+
+    static void check(final BillingFeature feature) {
+        switch (feature) {
+            case SUBSCRIPTIONS:
+            case SUBSCRIPTIONS_UPDATE:
+            case PRICE_CHANGE_CONFIRMATION:
+        }
+    }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -230,4 +230,13 @@ private class PurchasesAPI {
         }
         val handler = Purchases.logHandler
     }
+
+    fun check(billingFeature: BillingFeature) {
+        when (billingFeature) {
+            BillingFeature.PRICE_CHANGE_CONFIRMATION,
+            BillingFeature.SUBSCRIPTIONS,
+            BillingFeature.SUBSCRIPTIONS_UPDATE
+            -> {}
+        }.exhaustive
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext.compileVersion = 31
     ext.buildToolsVersion = "30.0.3"
     ext.minVersion = 14
-    ext.billingVersion = "4.1.0"
+    ext.billingVersion = "5.0.0"
     ext.lifecycleVersion = "2.5.0"
     ext.testLibrariesVersion = "1.4.0"
     ext.testJUnitVersion  = "1.1.3"

--- a/feature/google/src/test/java/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/BillingWrapperTest.kt
@@ -110,7 +110,7 @@ class BillingWrapperTest {
         val billingClientPurchaseHistoryListenerSlot = slot<PurchaseHistoryResponseListener>()
         every {
             mockClient.queryPurchaseHistoryAsync(
-                any(),
+                any<String>(),
                 capture(billingClientPurchaseHistoryListenerSlot)
             )
         } answers {
@@ -658,7 +658,7 @@ class BillingWrapperTest {
         val billingClientPurchaseHistoryListenerSlot = slot<PurchaseHistoryResponseListener>()
         every {
             mockClient.queryPurchaseHistoryAsync(
-                any(),
+                any<String>(),
                 capture(billingClientPurchaseHistoryListenerSlot)
             )
         } answers {
@@ -1609,7 +1609,7 @@ class BillingWrapperTest {
         val slot = slot<PurchaseHistoryResponseListener>()
         every {
             mockClient.queryPurchaseHistoryAsync(
-                any(),
+                any<String>(),
                 capture(slot)
             )
         } answers {
@@ -1636,7 +1636,7 @@ class BillingWrapperTest {
         val lock = CountDownLatch(2)
         every {
             mockClient.queryPurchaseHistoryAsync(
-                any(),
+                any<String>(),
                 capture(slot)
             )
         } answers {

--- a/public/src/main/java/com/revenuecat/purchases/BillingFeature.kt
+++ b/public/src/main/java/com/revenuecat/purchases/BillingFeature.kt
@@ -9,7 +9,5 @@ import com.android.billingclient.api.BillingClient
 enum class BillingFeature(@BillingClient.FeatureType val playBillingClientName: String) {
     SUBSCRIPTIONS(BillingClient.FeatureType.SUBSCRIPTIONS),
     SUBSCRIPTIONS_UPDATE(BillingClient.FeatureType.SUBSCRIPTIONS_UPDATE),
-    IN_APP_ITEMS_ON_VR(BillingClient.FeatureType.IN_APP_ITEMS_ON_VR),
-    SUBSCRIPTIONS_ON_VR(BillingClient.FeatureType.SUBSCRIPTIONS_ON_VR),
     PRICE_CHANGE_CONFIRMATION(BillingClient.FeatureType.PRICE_CHANGE_CONFIRMATION)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -2092,7 +2092,7 @@ class Purchases internal constructor(
                                             return@post
                                         }
                                         // If billing is supported, IN-APP purchases are supported.
-                                        var featureSupportedResultOk = features.all {
+                                        val featureSupportedResultOk = features.all {
                                             billingClient.isFeatureSupported(it.playBillingClientName).isSuccessful()
                                         }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -1964,13 +1964,13 @@ class PurchasesTest {
         } returns BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED.buildResult()
 
         every {
-            mockLocalBillingClient.isFeatureSupported(BillingClient.FeatureType.IN_APP_ITEMS_ON_VR)
+            mockLocalBillingClient.isFeatureSupported(BillingClient.FeatureType.SUBSCRIPTIONS_UPDATE)
         } returns BillingClient.BillingResponseCode.OK.buildResult()
 
         Purchases.canMakePayments(
             mockContext,
             listOf(BillingFeature.SUBSCRIPTIONS,
-                BillingFeature.IN_APP_ITEMS_ON_VR)
+                BillingFeature.SUBSCRIPTIONS_UPDATE)
         ) {
             receivedCanMakePayments = it
         }


### PR DESCRIPTION
This is the first PR of the BillingClient 5 changes. It updates the version and fixes breaking changes, but does not yet take advantage of any of the new APIs.

Note that I'm going to keep BC5 stuff on the billing-client-5 branch for now.