### PR TITLE
Add bc5SupportDev flavor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,8 +268,10 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            - integration-tests/build/outputs/apk/bc5SupportDev/release/integration-tests-bc5SupportDev-release.apk
             - integration-tests/build/outputs/apk/latestDependencies/release/integration-tests-latestDependencies-release.apk
             - integration-tests/build/outputs/apk/unityIAP/release/integration-tests-unityIAP-release.apk
+            - integration-tests/build/outputs/apk/androidTest/bc5SupportDev/release/integration-tests-bc5SupportDev-release-androidTest.apk
             - integration-tests/build/outputs/apk/androidTest/latestDependencies/release/integration-tests-latestDependencies-release-androidTest.apk
             - integration-tests/build/outputs/apk/androidTest/unityIAP/release/integration-tests-unityIAP-release-androidTest.apk
 

--- a/api-tester/build.gradle
+++ b/api-tester/build.gradle
@@ -19,5 +19,5 @@ dependencies {
     implementation project(path: ':public')
     implementation project(path: ':purchases')
     implementation "androidx.annotation:annotation:$annotationVersion"
-    unityIAPCompileOnly "com.android.billingclient:billing:$billingVersion"
+    unityIAPCompileOnly "com.android.billingclient:billing:$billing4Version"
 }

--- a/base-application.gradle
+++ b/base-application.gradle
@@ -29,6 +29,9 @@ android {
         latestDependencies {
             dimension "dependencyVersions"
         }
+        bc5SupportDev {
+            dimension "dependencyVersions"
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,8 @@ buildscript {
     ext.compileVersion = 31
     ext.buildToolsVersion = "30.0.3"
     ext.minVersion = 14
-    ext.billingVersion = "5.0.0"
+    ext.billing5Version = "5.0.0"
+    ext.billing4Version = "4.1.0"
     ext.lifecycleVersion = "2.5.0"
     ext.testLibrariesVersion = "1.4.0"
     ext.testJUnitVersion  = "1.1.3"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,8 +10,9 @@ dependencies {
     implementation project(":strings")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
-    latestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
-    unityIAPCompileOnly "com.android.billingclient:billing:$billingVersion"
+    bc5SupportDevImplementation "com.android.billingclient:billing:$billing5Version"
+    latestDependenciesImplementation "com.android.billingclient:billing:$billing4Version"
+    unityIAPCompileOnly "com.android.billingclient:billing:$billing4Version"
     testImplementation project(":test-utils")
     testImplementation "androidx.test:core:$testLibrariesVersion"
     testImplementation "androidx.test:runner:$testLibrariesVersion"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/5.6.0-SNAPSHOT/index.html" />
-</head>
-<body>
-</body>
-</html>

--- a/feature/amazon/build.gradle
+++ b/feature/amazon/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.annotation:annotation:$annotationVersion"
 
+    bc5SupportDevImplementation "com.amazon.device:amazon-appstore-sdk:$amazonVersion"
     latestDependenciesImplementation "com.amazon.device:amazon-appstore-sdk:$amazonVersion"
     unityIAPCompileOnly files("libs/in-app-purchasing-${amazon2Version}.jar")
 
@@ -79,4 +80,6 @@ afterEvaluate {
     preUnityIAPReleaseBuild.dependsOn getAmazonLibrary
     preLatestDependenciesDebugBuild.dependsOn cleanAmazonLibrary
     preLatestDependenciesReleaseBuild.dependsOn cleanAmazonLibrary
+    preBc5SupportDevDebugBuild.dependsOn cleanAmazonLibrary
+    preBc5SupportDevReleaseBuild.dependsOn cleanAmazonLibrary
 }

--- a/feature/google/build.gradle
+++ b/feature/google/build.gradle
@@ -14,8 +14,9 @@ dependencies {
     implementation 'com.google.android.gms:play-services-ads-identifier:17.0.1'
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    latestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
-    unityIAPCompileOnly "com.android.billingclient:billing:$billingVersion"
+    bc5SupportDevImplementation "com.android.billingclient:billing:$billing5Version"
+    latestDependenciesImplementation "com.android.billingclient:billing:$billing4Version"
+    unityIAPCompileOnly "com.android.billingclient:billing:$billing4Version"
 
     testImplementation project(":test-utils")
     testImplementation "androidx.test:core:$testLibrariesVersion"
@@ -26,6 +27,6 @@ dependencies {
     testImplementation "io.mockk:mockk:$mockkVersion"
     testImplementation "org.assertj:assertj-core:$assertJVersion"
     testImplementation 'com.google.android.gms:play-services-ads-identifier:17.0.1'
-    testUnityIAPImplementation "com.android.billingclient:billing:$billingVersion"
+    testUnityIAPImplementation "com.android.billingclient:billing:$billing4Version"
 
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.3'
     androidTestImplementation 'org.assertj:assertj-core:3.22.0'
-    androidTestUnityIAPImplementation "com.android.billingclient:billing:$billingVersion"
+    androidTestUnityIAPImplementation "com.android.billingclient:billing:$billing4Version"
 }
 
 def obtainTestBuildType() {

--- a/library.gradle
+++ b/library.gradle
@@ -13,6 +13,9 @@ android {
         latestDependencies {
             dimension "dependencyVersions"
         }
+        bc5SupportDev {
+            dimension "dependencyVersions"
+        }
     }
     defaultConfig {
         minSdkVersion minVersion

--- a/public/build.gradle
+++ b/public/build.gradle
@@ -11,8 +11,9 @@ dependencies {
     implementation project(":strings")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
-    latestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
-    unityIAPCompileOnly "com.android.billingclient:billing:$billingVersion"
+    bc5SupportDevImplementation "com.android.billingclient:billing:$billing5Version"
+    latestDependenciesImplementation "com.android.billingclient:billing:$billing4Version"
+    unityIAPCompileOnly "com.android.billingclient:billing:$billing4Version"
     testImplementation project(":test-utils")
     testImplementation "androidx.test:core:$testLibrariesVersion"
     testImplementation "androidx.test:runner:$testLibrariesVersion"

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -18,8 +18,9 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.annotation:annotation:$annotationVersion"
-    latestDependenciesApi "com.android.billingclient:billing:$billingVersion"
-    unityIAPCompileOnly "com.android.billingclient:billing:$billingVersion"
+    bc5SupportDevApi "com.android.billingclient:billing:$billing5Version"
+    latestDependenciesApi "com.android.billingclient:billing:$billing4Version"
+    unityIAPCompileOnly "com.android.billingclient:billing:$billing4Version"
     implementation "androidx.lifecycle:lifecycle-runtime:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-common:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-process:$lifecycleVersion"
@@ -32,8 +33,9 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "io.mockk:mockk:$mockkVersion"
     testImplementation "org.assertj:assertj-core:$assertJVersion"
-    testLatestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
-    testUnityIAPImplementation "com.android.billingclient:billing:$billingVersion"
+    testBc5SupportDevImplementation "com.android.billingclient:billing:$billing5Version"
+    testLatestDependenciesImplementation "com.android.billingclient:billing:$billing4Version"
+    testUnityIAPImplementation "com.android.billingclient:billing:$billing4Version"
 }
 
 tasks.dokkaHtmlPartial.configure {

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -7,8 +7,9 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation project(":common")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    latestDependenciesImplementation "com.android.billingclient:billing:$billingVersion"
-    unityIAPCompileOnly "com.android.billingclient:billing:$billingVersion"
+    bc5SupportDevImplementation "com.android.billingclient:billing:$billing5Version"
+    latestDependenciesImplementation "com.android.billingclient:billing:$billing4Version"
+    unityIAPCompileOnly "com.android.billingclient:billing:$billing4Version"
     implementation "org.assertj:assertj-core:$assertJVersion"
     implementation "io.mockk:mockk:$mockkVersion"
     implementation "androidx.test.ext:junit:$testJUnitVersion"


### PR DESCRIPTION
### Description
This adds a new flavor to our setup, `bc5SupportDev`. This flavor will be used for all the work to support BC5. We won't be releasing this as a library, only work on it internally.

* Note 1: this will increase tests runtime by 50%... For devs, if you want to run tests on a single flavor/variant I suggest doing something like this: `./gradlew testLatestDependenciesReleaseUnitTest`
* Note 2: This is pointing to the `billing-client-5` branch. We can probably merge that branch soon and work off main.
