### PR TITLE
Wait to obtain unsubscribed attributes until finishing getting device identifiers

### DIFF
--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -197,17 +197,22 @@ class SubscriberAttributesManager(
             }
 
         private val listeners: ArrayList<() -> Unit> = arrayListOf()
+            @Synchronized
+            get
 
         init {
             addObserver { observable, _ ->
                 val numberOfProcesses = (observable as ObtainDeviceIdentifiersObservable).numberOfProcesses
                 if (numberOfProcesses == 0) {
-                    listeners.forEach { it() }
-                    listeners.clear()
+                    synchronized(this) {
+                        listeners.forEach { it() }
+                        listeners.clear()
+                    }
                 }
             }
         }
 
+        @Synchronized
         fun waitUntilIdle(completion: () -> Unit) {
             if (numberOfProcesses == 0) completion()
             listeners.add { completion() }

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -196,9 +196,8 @@ class SubscriberAttributesManager(
                 notifyObservers()
             }
 
+        @get:Synchronized
         private val listeners: ArrayList<() -> Unit> = arrayListOf()
-            @Synchronized
-            get
 
         init {
             addObserver { observable, _ ->

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -3,18 +3,22 @@ package com.revenuecat.purchases.subscriberattributes
 import android.app.Application
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.SubscriberAttributeError
-import com.revenuecat.purchases.common.subscriberattributes.DeviceIdentifiersFetcher
 import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.common.subscriberattributes.DeviceIdentifiersFetcher
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
 import com.revenuecat.purchases.strings.AttributionStrings
 import com.revenuecat.purchases.subscriberattributes.caching.AppUserID
+import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributeMap
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
+import java.util.Observable
 
 class SubscriberAttributesManager(
     val deviceCache: SubscriberAttributesCache,
     val backend: SubscriberAttributesPoster,
     private val deviceIdentifiersFetcher: DeviceIdentifiersFetcher
 ) {
+
+    private val obtainingDeviceIdentifiersObservable = ObtainDeviceIdentifiersObservable()
 
     @Synchronized
     fun setAttributes(attributesToSet: Map<String, String?>, appUserID: String) {
@@ -52,51 +56,59 @@ class SubscriberAttributesManager(
         currentAppUserID: AppUserID,
         completion: (() -> Unit)? = null
     ) {
-        val unsyncedStoredAttributesForAllUsers =
-            deviceCache.getUnsyncedSubscriberAttributes()
-        if (unsyncedStoredAttributesForAllUsers.isEmpty()) {
-            log(LogIntent.DEBUG, AttributionStrings.NO_SUBSCRIBER_ATTRIBUTES_TO_SYNCHRONIZE)
-            if (completion != null) {
-                completion()
-            }
-            return
-        }
-
-        val unsyncedStoredAttributesCount = unsyncedStoredAttributesForAllUsers.size
-        var currentSyncedAttributeCount = 0
-
-        unsyncedStoredAttributesForAllUsers.forEach { (syncingAppUserID, unsyncedAttributesForUser) ->
-            backend.postSubscriberAttributes(
-                unsyncedAttributesForUser.toBackendMap(),
-                syncingAppUserID,
-                {
-                    markAsSynced(syncingAppUserID, unsyncedAttributesForUser, emptyList())
-                    log(LogIntent.RC_SUCCESS, AttributionStrings.ATTRIBUTES_SYNC_SUCCESS.format(syncingAppUserID))
-                    if (currentAppUserID != syncingAppUserID) {
-                        deviceCache.clearSubscriberAttributesIfSyncedForSubscriber(syncingAppUserID)
-                    }
-                    currentSyncedAttributeCount++
-                    if (completion != null && currentSyncedAttributeCount == unsyncedStoredAttributesCount) {
-                        completion()
-                    }
-                },
-                { error, didBackendGetAttributes, attributeErrors ->
-                    if (didBackendGetAttributes) {
-                        markAsSynced(syncingAppUserID, unsyncedAttributesForUser, attributeErrors)
-                    }
-                    log(LogIntent.RC_ERROR, AttributionStrings.ATTRIBUTES_SYNC_ERROR.format(syncingAppUserID, error))
-                    currentSyncedAttributeCount++
-                    if (completion != null && currentSyncedAttributeCount == unsyncedStoredAttributesCount) {
-                        completion()
-                    }
+        obtainingDeviceIdentifiersObservable.waitUntilIdle {
+            val unsyncedStoredAttributesForAllUsers =
+                deviceCache.getUnsyncedSubscriberAttributes()
+            if (unsyncedStoredAttributesForAllUsers.isEmpty()) {
+                log(LogIntent.DEBUG, AttributionStrings.NO_SUBSCRIBER_ATTRIBUTES_TO_SYNCHRONIZE)
+                if (completion != null) {
+                    completion()
                 }
-            )
+                return@waitUntilIdle
+            }
+
+            val unsyncedStoredAttributesCount = unsyncedStoredAttributesForAllUsers.size
+            var currentSyncedAttributeCount = 0
+
+            unsyncedStoredAttributesForAllUsers.forEach { (syncingAppUserID, unsyncedAttributesForUser) ->
+                backend.postSubscriberAttributes(
+                    unsyncedAttributesForUser.toBackendMap(),
+                    syncingAppUserID,
+                    {
+                        markAsSynced(syncingAppUserID, unsyncedAttributesForUser, emptyList())
+                        log(LogIntent.RC_SUCCESS, AttributionStrings.ATTRIBUTES_SYNC_SUCCESS.format(syncingAppUserID))
+                        if (currentAppUserID != syncingAppUserID) {
+                            deviceCache.clearSubscriberAttributesIfSyncedForSubscriber(syncingAppUserID)
+                        }
+                        currentSyncedAttributeCount++
+                        if (completion != null && currentSyncedAttributeCount == unsyncedStoredAttributesCount) {
+                            completion()
+                        }
+                    },
+                    { error, didBackendGetAttributes, attributeErrors ->
+                        if (didBackendGetAttributes) {
+                            markAsSynced(syncingAppUserID, unsyncedAttributesForUser, attributeErrors)
+                        }
+                        log(
+                            LogIntent.RC_ERROR,
+                            AttributionStrings.ATTRIBUTES_SYNC_ERROR.format(syncingAppUserID, error)
+                        )
+                        currentSyncedAttributeCount++
+                        if (completion != null && currentSyncedAttributeCount == unsyncedStoredAttributesCount) {
+                            completion()
+                        }
+                    }
+                )
+            }
         }
     }
 
     @Synchronized
-    fun getUnsyncedSubscriberAttributes(appUserID: String) =
-        deviceCache.getUnsyncedSubscriberAttributes(appUserID)
+    fun getUnsyncedSubscriberAttributes(appUserID: String, completion: (SubscriberAttributeMap) -> Unit) {
+        obtainingDeviceIdentifiersObservable.waitUntilIdle {
+            completion(deviceCache.getUnsyncedSubscriberAttributes(appUserID))
+        }
+    }
 
     @Synchronized
     fun markAsSynced(
@@ -111,7 +123,8 @@ class SubscriberAttributesManager(
             return
         }
         log(
-            LogIntent.INFO, AttributionStrings.MARKING_ATTRIBUTES_SYNCED.format(appUserID) +
+            LogIntent.INFO,
+            AttributionStrings.MARKING_ATTRIBUTES_SYNCED.format(appUserID) +
                 attributesToMarkAsSynced.values.joinToString("\n")
         )
         val currentlyStoredAttributes = deviceCache.getAllStoredSubscriberAttributes(appUserID)
@@ -160,8 +173,44 @@ class SubscriberAttributesManager(
         applicationContext: Application,
         completion: (deviceIdentifiers: Map<String, String?>) -> Unit
     ) {
+        obtainingDeviceIdentifiersObservable.numberOfProcesses++
         deviceIdentifiersFetcher.getDeviceIdentifiers(applicationContext) { deviceIdentifiers ->
             completion(deviceIdentifiers)
+            obtainingDeviceIdentifiersObservable.numberOfProcesses--
+        }
+    }
+
+    // This was added to resolve: https://revenuecats.atlassian.net/browse/CSDK-433. To summarize it,
+    // setting advertising IDs happens on a non-main thread. If that process is delayed for any reason, the attributes
+    // won't be stored in the device cache in time for the sync with the backend. This is a mechanism added so we can
+    // wait until the device identifiers have been obtained before continuing with other processes.
+    private class ObtainDeviceIdentifiersObservable : Observable() {
+        var numberOfProcesses: Int = 0
+            @Synchronized
+            get
+            @Synchronized
+            set(value) {
+                if (field == value) return
+                field = value
+                setChanged()
+                notifyObservers()
+            }
+
+        private val listeners: ArrayList<() -> Unit> = arrayListOf()
+
+        init {
+            addObserver { observable, _ ->
+                val numberOfProcesses = (observable as ObtainDeviceIdentifiersObservable).numberOfProcesses
+                if (numberOfProcesses == 0) {
+                    listeners.forEach { it() }
+                    listeners.clear()
+                }
+            }
+        }
+
+        fun waitUntilIdle(completion: () -> Unit) {
+            if (numberOfProcesses == 0) completion()
+            listeners.add { completion() }
         }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1194,7 +1194,6 @@ class Purchases internal constructor(
         onSuccess: (SuccessfulPurchaseCallback)? = null,
         onError: (ErrorPurchaseCallback)? = null
     ) {
-        setAdjustID("test-adjust-id")
         subscriberAttributesManager.getUnsyncedSubscriberAttributes(appUserID) { unsyncedSubscriberAttributesByKey ->
             val receiptInfo = ReceiptInfo(
                 productIDs = purchase.skus,

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -97,10 +97,13 @@ class PostingTransactionsTests {
         }
 
         every {
-            subscriberAttributesManagerMock.getUnsyncedSubscriberAttributes(appUserId)
+            subscriberAttributesManagerMock.getUnsyncedSubscriberAttributes(appUserId, captureLambda())
         } answers {
-            expectedAttributes
+            lambda<(Map<String, SubscriberAttribute>) -> Unit>().captured.also {
+                it.invoke(expectedAttributes)
+            }
         }
+
         every {
             subscriberAttributesManagerMock.markAsSynced(
                 appUserId,

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -2698,8 +2698,12 @@ class PurchasesTest {
         purchases.allowSharingPlayStoreAccount = true
 
         every {
-            mockSubscriberAttributesManager.getUnsyncedSubscriberAttributes(appUserId)
-        } returns unsyncedSubscriberAttributes
+            mockSubscriberAttributesManager.getUnsyncedSubscriberAttributes(appUserId, captureLambda())
+        } answers {
+            lambda<(Map<String, SubscriberAttribute>) -> Unit>().captured.also {
+                it.invoke(unsyncedSubscriberAttributes)
+            }
+        }
 
         var capturedLambda: ((String) -> Unit)? = null
         every {
@@ -4250,8 +4254,12 @@ class PurchasesTest {
             mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(appUserId)
         } just Runs
         every {
-            mockSubscriberAttributesManager.getUnsyncedSubscriberAttributes(userIdToUse)
-        } returns emptyMap()
+            mockSubscriberAttributesManager.getUnsyncedSubscriberAttributes(userIdToUse, captureLambda())
+        } answers {
+            lambda<(Map<String, SubscriberAttribute>) -> Unit>().captured.also {
+                it.invoke(emptyMap())
+            }
+        }
         every {
             mockSubscriberAttributesManager.markAsSynced(userIdToUse, any(), any())
         } just runs

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -108,10 +108,13 @@ class SubscriberAttributesPurchasesTests {
         }
 
         every {
-            subscriberAttributesManagerMock.getUnsyncedSubscriberAttributes(appUserId)
+            subscriberAttributesManagerMock.getUnsyncedSubscriberAttributes(appUserId, captureLambda())
         } answers {
-            expectedAttributes
+            lambda<(Map<String, SubscriberAttribute>) -> Unit>().captured.also {
+                it.invoke(expectedAttributes)
+            }
         }
+
         every {
             subscriberAttributesManagerMock.markAsSynced(
                 appUserId,


### PR DESCRIPTION
### Description
Second attempt at dealing with https://revenuecats.atlassian.net/browse/CSDK-433

In this approach, we are adding an observable to know whether there is an ongoing operation to get device identifiers. Once all ongoing operations are done, we can get the unsubscribed attributes, which would include device identifiers.
