### PR TITLE
Move to SNAPSHOT version on every commit to main if needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,13 @@ aliases:
       branches:
         only: /^release\/.*/
 
+  only-main-branch: &only-main-branch
+    filters:
+      tags:
+        ignore: /.*/
+      branches:
+        only: main
+
 version: 2.1
 orbs:
   android: circleci/android@0.2.1
@@ -359,13 +366,21 @@ workflows:
             - hold
           <<: *release-branches
       - deploy: *release-tags
-      - prepare-next-version: *release-tags
       - deploy-snapshot:
           filters:
             branches:
               only:
                 - main
       - docs-deploy: *release-tags
+
+  snapshot-bump:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    jobs:
+      - prepare-next-version:
+          <<: *only-main-branch
+
   weekly-run-workflow:
     when:
       and:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 562dbc8d71bba33ec58b5c999d15e4c39b09bc7f
+  revision: 1269f49ad16be4fc7b38ff8b75e17f819f6af6c8
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 
@@ -9,13 +9,13 @@ GEM
   specs:
     CFPropertyList (3.0.5)
       rexml
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.614.0)
-    aws-sdk-core (3.131.5)
+    aws-partitions (1.626.0)
+    aws-sdk-core (3.141.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
@@ -62,7 +62,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.92.4)
-    faraday (1.10.0)
+    faraday (1.10.2)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -93,7 +93,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.2.6)
-    fastlane (2.208.0)
+    fastlane (2.209.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -152,7 +152,7 @@ GEM
       google-apis-core (>= 0.7, < 2.a)
     google-apis-playcustomapp_v1 (0.10.0)
       google-apis-core (>= 0.7, < 2.a)
-    google-apis-storage_v1 (0.18.0)
+    google-apis-storage_v1 (0.17.0)
       google-apis-core (>= 0.7, < 2.a)
     google-cloud-core (1.6.0)
       google-cloud-env (~> 1.0)
@@ -160,11 +160,11 @@ GEM
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
     google-cloud-errors (1.2.0)
-    google-cloud-storage (1.37.0)
+    google-cloud-storage (1.39.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
-      google-apis-storage_v1 (~> 0.1)
+      google-apis-storage_v1 (~> 0.17.0)
       google-cloud-core (~> 1.6)
       googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
@@ -181,7 +181,7 @@ GEM
     httpclient (2.8.3)
     jmespath (1.6.1)
     json (2.6.2)
-    jwt (2.4.1)
+    jwt (2.5.0)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -202,7 +202,7 @@ GEM
     optparse (0.1.1)
     os (1.1.4)
     plist (3.6.0)
-    public_suffix (4.0.7)
+    public_suffix (5.0.0)
     rake (13.0.6)
     rchardet (1.8.0)
     representable (3.2.0)


### PR DESCRIPTION
### Description
This PR updates the fastlane plugin to include https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/31. With this, every time we commit to `main`, if the version is not a SNAPSHOT, it will create a PR updating to the next SNAPSHOT version. Additionally, I moved this job to a different workflow to keep the `deploy` workflow a bit more tidy. This PR also bumps fastlane to the latest version.
