### PR TITLE
Add missing packageName to helper methods in AppConfig

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
@@ -34,6 +34,7 @@ class AppConfig(
         if (dangerousSettings != other.dangerousSettings) return false
         if (languageTag != other.languageTag) return false
         if (versionName != other.versionName) return false
+        if (packageName != other.packageName) return false
         if (finishTransactions != other.finishTransactions) return false
         if (baseURL != other.baseURL) return false
 
@@ -46,6 +47,7 @@ class AppConfig(
         result = 31 * result + dangerousSettings.hashCode()
         result = 31 * result + languageTag.hashCode()
         result = 31 * result + versionName.hashCode()
+        result = 31 * result + packageName.hashCode()
         result = 31 * result + finishTransactions.hashCode()
         result = 31 * result + baseURL.hashCode()
         return result
@@ -58,6 +60,7 @@ class AppConfig(
             "dangerousSettings=$dangerousSettings, " +
             "languageTag='$languageTag', " +
             "versionName='$versionName', " +
+            "packageName='$packageName', " +
             "finishTransactions=$finishTransactions, " +
             "baseURL=$baseURL)"
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -259,6 +259,15 @@ class AppConfigTest {
             proxyURL = null,
             store = Store.PLAY_STORE
         )
-        assertThat(x.toString()).isNotNull()
+        assertThat(x.toString()).isEqualTo(
+            "AppConfig(" +
+                "platformInfo=PlatformInfo(flavor=native, version=3.2.0), " +
+                "store=PLAY_STORE, " +
+                "dangerousSettings=DangerousSettings(autoSyncPurchases=true), " +
+                "languageTag='', " +
+                "versionName='', " +
+                "packageName='', " +
+                "finishTransactions=true, " +
+                "baseURL=https://api.revenuecat.com/)")
     }
 }


### PR DESCRIPTION
### Description
`packageName` was added in #618 but we didn't add it to the `equals` and `toString` method. This adds it to those missing methods.
