### PR TITLE
Adds action parameter to CircleCI config to be able to trigger the automatic bump manually

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,12 @@ orbs:
   gcp-cli: circleci/gcp-cli@2.1.0
   revenuecat: revenuecat/sdks-common-config@2.0.0
 
+parameters:
+  action:
+    type: enum
+    enum: [default, bump]
+    default: default
+
 executors:
   android-executor:
     docker:
@@ -386,5 +392,11 @@ workflows:
       and:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "release-train", << pipeline.schedule.name >> ]
+    jobs:
+      - revenuecat/automatic-bump
+  
+  manual-trigger-bump:
+    when:
+      equal: [ bump, << pipeline.parameters.action >> ]
     jobs:
       - revenuecat/automatic-bump

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,26 @@
-Automatic Releasing
+Automatic Releasing using CircleCI
+=========
+For an almost fully automated release process, use the trigger pipeline feature in CircleCI passing name `action` and value `bump`
+
+![Screenshot!](https://user-images.githubusercontent.com/664544/191806930-07737e3d-8c44-4bfd-8cef-b471b72643a4.png "CircleCI screenshot")
+
+You can achieve the same using CircleCI API:
+
+```
+curl --location --request POST 'https://circleci.com/api/v2/project/github/RevenueCat/purchases-android/pipeline' \
+            --header 'Content-Type: application/json' \
+            -u "your_circleci_personal_token:" \
+            -d '{
+              "branch": "main",
+              "parameters": {
+                "action": "bump"
+              }
+            }'
+```
+
+More info on triggering pipelines in [CircleCI docs](https://circleci.com/docs/triggers-overview).
+
+Automatic Releasing using your machine
 =========
 1. Create a `fastlane/.env` file with your GitHub API token (see `fastlane/.env.SAMPLE`). This will be used to create the PR, so you should use your own token so the PR gets assigned to you.
 2. Run `bundle exec fastlane android bump`


### PR DESCRIPTION
This change lets you run a pipeline manually from CircleCI using the Trigger Pipeline feature

<img width="786" alt="Screen Shot 2022-09-22 at 6 55 00 PM" src="https://user-images.githubusercontent.com/664544/191806930-07737e3d-8c44-4bfd-8cef-b471b72643a4.png">
