### PR TITLE
Not create release if next version should be skipped

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -88,7 +88,14 @@ platform :android do
     )
     options[:next_version] = next_version
     options[:automatic_release] = true
-    UI.user_error!('Skipping automatic bump since the next version is a major release') if type_of_bump == :major
+    if type_of_bump == :skip
+      UI.message('Skipping automatic bump since the next version doesn\'t include public facing changes')
+      next
+    end
+    if type_of_bump == :major
+      UI.message('Skipping automatic bump since the next version is a major release')
+      next
+    end
     bump(options)
   end
 


### PR DESCRIPTION
### Description
If the fastlane plugin indicates we should skip the release, we were not actually skipping and we were creating the PR, as we. noticed in #623. This should avoid creating unnecessary releases
