### PR TITLE
Add Maestro UI test for simple purchase

### DIFF
--- a/examples/purchase-tester/maestro-tests/perform_purchase.yaml
+++ b/examples/purchase-tester/maestro-tests/perform_purchase.yaml
@@ -1,0 +1,25 @@
+appId: com.revenuecat.purchases_sample
+---
+- launchApp:
+    appId: "com.revenuecat.purchases_sample"
+    clearState: true
+- tapOn:
+    id: "anonymous_user_button"
+- assertNotVisible:
+    text: "Manage"
+- tapOn:
+    text: "Default offering"
+- tapOn:
+    text: "Buy package"
+    index: 0
+- scroll
+- tapOn:
+    text: "Subscribe"
+- tapOn:
+    text: "No, thanks"
+    optional: true
+- tapOn:
+    text: "OK"
+    optional: true
+- assertVisible:
+      text: "Manage"

--- a/examples/purchase-tester/maestro-tests/perform_purchase.yaml
+++ b/examples/purchase-tester/maestro-tests/perform_purchase.yaml
@@ -21,5 +21,9 @@ appId: com.revenuecat.purchases_sample
 - tapOn:
     text: "OK"
     optional: true
-- assertVisible:
+- extendedWaitUntil:
+    visible:
       text: "Manage"
+    timeout: 30000
+- assertVisible:
+    text: "Manage"

--- a/examples/purchase-tester/maestro-tests/play_store_login.yaml
+++ b/examples/purchase-tester/maestro-tests/play_store_login.yaml
@@ -1,20 +1,24 @@
 appId: com.revenuecat.purchases_sample
 ---
 - launchApp:
-      appId: "com.android.vending"
-      clearState: true
+    appId: "com.android.vending"
+    clearState: true
 - tapOn:
-      text: "Sign in"
-- tapOn:
-      # This is the id for the inputText in the play store.
+    text: "Sign in"
+- extendedWaitUntil:
+    visible:
       id: "identifierId"
+    timeout: 30000
+- tapOn:
+    # This is the id for the inputText in the play store.
+    id: "identifierId"
 - inputText: ${GOOGLE_EMAIL}
 - hideKeyboard
 - tapOn:
-      id: "password"
+    id: "password"
 - inputText: ${GOOGLE_PASSWORD}
 - hideKeyboard
 - tapOn:
-      text: "I agree"
+    text: "I agree"
 - tapOn:
-      text: "Accept"
+    text: "Accept"

--- a/examples/purchase-tester/maestro-tests/play_store_login.yaml
+++ b/examples/purchase-tester/maestro-tests/play_store_login.yaml
@@ -1,0 +1,20 @@
+appId: com.revenuecat.purchases_sample
+---
+- launchApp:
+      appId: "com.android.vending"
+      clearState: true
+- tapOn:
+      text: "Sign in"
+- tapOn:
+      # This is the id for the inputText in the play store.
+      id: "identifierId"
+- inputText: ${GOOGLE_EMAIL}
+- hideKeyboard
+- tapOn:
+      id: "password"
+- inputText: ${GOOGLE_PASSWORD}
+- hideKeyboard
+- tapOn:
+      text: "I agree"
+- tapOn:
+      text: "Accept"

--- a/fastlane/.env.SAMPLE
+++ b/fastlane/.env.SAMPLE
@@ -3,3 +3,8 @@ GITHUB_PULL_REQUEST_API_TOKEN=
 
 # Optional for updating changelog. Can be the same as GITHUB_PULL_REQUEST_API_TOKEN and improves issues with github api rate limits.
 RC_INTERNAL_GITHUB_TOKEN=
+
+# Maestro UI tests
+MAESTRO_EMULATOR_NAME=
+MAESTRO_GOOGLE_EMAIL=
+MAESTRO_GOOGLE_PASSWORD=

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -253,6 +253,33 @@ platform :android do
       sh("git clean -fd")
     end
   end
+
+  desc "Runs Maestro UI tests"
+  lane :run_maestro_ui_tests do
+    emulator_name = ENV["MAESTRO_EMULATOR_NAME"] || UI.input("Name of the emulator you want to use? Note that it will be wiped on every run.")
+    google_email = ENV["MAESTRO_GOOGLE_EMAIL"] || UI.input("Email of the google account to use for tests?")
+    google_password = ENV["MAESTRO_GOOGLE_PASSWORD"] || UI.input("Password of the google account to use for tests?")
+
+    UI.message("Make sure 'emulator', 'adb' and 'maestro' are in your PATH.")
+
+    UI.message("Initializing emulator")
+    initialize_emulator(emulator_name)
+
+    UI.message("Installing purchase-tester")
+    Dir.chdir(get_root_folder) do
+      # Install purchase-tester in emulator
+      sh("./gradlew examples:purchase-tester:installLatestDependenciesDebug")
+    end
+
+    UI.message("Running tests")
+    run_maestro_play_store_login_flow(google_email, google_password, retry_count: 2)
+
+    play_store_stabilization_wait_time_seconds = 30
+    UI.message("Waiting #{play_store_stabilization_wait_time_seconds} for Play Store to stabilize after login.")
+    sleep(play_store_stabilization_wait_time_seconds)
+
+    run_maestro_purchase_flow(retry_count: 2)
+  end
 end
 
 def is_snapshot_version?(version_name)
@@ -267,4 +294,37 @@ def check_no_git_tag_exists(version_number)
   if git_tag_exists(tag: version_number, remote: true, remote_name: 'origin')
     raise "git tag with version #{version_number} already exists!"
   end
+end
+
+def get_root_folder
+  File.expand_path('../../', __FILE__)
+end
+
+def initialize_emulator(emulator_name)
+  # Make sure `emulator` is in your path
+  # This should be further polished to run on CI machines.
+  sh("emulator -avd #{emulator_name} -wipe-data > /dev/null 2>&1 &")
+
+  # Make sure `adb` is in your path
+  sh("adb wait-for-device")
+end
+
+def run_maestro_play_store_login_flow(google_email, google_password, retry_count: 0)
+  sh("maestro -p=android test -e GOOGLE_EMAIL=#{google_email} -e GOOGLE_PASSWORD=#{google_password} ../examples/purchase-tester/maestro-tests/play_store_login.yaml",
+     error_callback: -> (_) {
+       UI.user_error!("Error logging in to Play Store") if retry_count == 0
+       sleep(5)
+       run_maestro_play_store_login_flow(google_email, google_password, retry_count: retry_count - 1)
+     }
+  )
+end
+
+def run_maestro_purchase_flow(retry_count: 0)
+  sh("maestro -p=android test ../examples/purchase-tester/maestro-tests/perform_purchase.yaml",
+     error_callback: -> (_) {
+       UI.user_error!("Error testing purchase flow") if retry_count == 0
+       sleep(5)
+       run_maestro_purchase_flow(retry_count: retry_count - 1)
+     }
+  )
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -125,9 +125,9 @@ platform :android do
 
     UI.verbose("Creating special version for Unity IAP with BillingClient 3 and Amazon 2 for version: #{version}")
     gradleProperties["PUBLISH_VARIANT"] = "unityIAPRelease"
-    
+
     UI.verbose("Adding -unityiap to artifact ids")
-    
+
 
     gradle(
       tasks: [
@@ -135,7 +135,7 @@ platform :android do
       ],
       properties: gradleProperties
     )
-    
+
     unless is_snapshot_version?(version)
       gradle(
         tasks: [
@@ -186,10 +186,10 @@ platform :android do
       project_dir = "examples/MagicWeather"
 
       tasks = [
-        "assembleAmazonDebug", 
-        "assembleAmazonRelease", 
-        "assembleGoogleDebug", 
-        "assembleGoogleRelease", 
+        "assembleAmazonDebug",
+        "assembleAmazonRelease",
+        "assembleGoogleDebug",
+        "assembleGoogleRelease",
       ]
       task = options[:task] || UI.select("Which task?", tasks)
 
@@ -274,7 +274,7 @@ platform :android do
     UI.message("Running tests")
     run_maestro_play_store_login_flow(google_email, google_password, retry_count: 2)
 
-    play_store_stabilization_wait_time_seconds = 30
+    play_store_stabilization_wait_time_seconds = 60
     UI.message("Waiting #{play_store_stabilization_wait_time_seconds} for Play Store to stabilize after login.")
     sleep(play_store_stabilization_wait_time_seconds)
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -45,7 +45,7 @@ Tag release version with latest if necessary
 [bundle exec] fastlane android automatic_bump
 ```
 
-Automatically bumps version, update swift header, edit changelog, and create pull request
+Automatically bumps version, replaces version numbers, updates changelog and creates PR
 
 ### android github_release
 
@@ -106,6 +106,14 @@ Builds a Magic Weather APK and prompts for:
 * Amazon pem path (optional)
 
 * New application id (optional)
+
+### android run_maestro_ui_tests
+
+```sh
+[bundle exec] fastlane android run_maestro_ui_tests
+```
+
+Runs Maestro UI tests
 
 ----
 


### PR DESCRIPTION
### Description
https://revenuecats.atlassian.net/browse/CSDK-145 (See the issue for a video with a working test case)

In this PR, we use Maestro (https://maestro.mobile.dev/) to add a simple UI test that makes a purchase in an emulator.
Currently, the process does the following:
- It starts the given emulator in a wiped state (make sure you don't need anything on the emulator)
- It installs `purchase-tester`
- It runs a Maestro UI test to login with a Google account 
- It runs a Maestro UI test to perform a purchase on the `purchase-tester` account.

This process runs from fastlane. For now, this is run locally on each dev's machine, not on CI yet.

In order to run it you need to:
- Have an emulator with the play store
- Have a google account added as a licensed tester and as a closed track tester
- Remember to set the API key in purchase-tester.
- Setup the new environment variables in your `fastlane/.env` file. (Remember the emulator you use will be wiped)
- Close the emulator if you have it running before each test, so it starts it up from scratch and wipes it.
- Run `bundle exec fastlane run_maestro_ui_tests`
