### PR TITLE
Add timeout to Amazon's getProducts and getUserData requests

### DIFF
--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -59,7 +59,7 @@ internal class AmazonBilling constructor(
     private val purchaseUpdatesHandler: PurchaseUpdatesResponseListener = PurchaseUpdatesHandler(
         purchasingServiceProvider
     ),
-    private val userDataHandler: UserDataResponseListener = UserDataHandler(purchasingServiceProvider)
+    private val userDataHandler: UserDataResponseListener = UserDataHandler(purchasingServiceProvider, mainHandler)
 ) : BillingAbstract(),
     ProductDataResponseListener by productDataHandler,
     PurchaseResponseListener by purchaseHandler,

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -52,7 +52,8 @@ internal class AmazonBilling constructor(
     private val observerMode: Boolean,
     private val mainHandler: Handler,
     private val purchasingServiceProvider: PurchasingServiceProvider = DefaultPurchasingServiceProvider(),
-    private val productDataHandler: ProductDataResponseListener = ProductDataHandler(purchasingServiceProvider),
+    private val productDataHandler: ProductDataResponseListener =
+        ProductDataHandler(purchasingServiceProvider, mainHandler),
     private val purchaseHandler: PurchaseResponseListener =
         PurchaseHandler(purchasingServiceProvider, applicationContext),
     private val purchaseUpdatesHandler: PurchaseUpdatesResponseListener = PurchaseUpdatesHandler(

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
@@ -41,4 +41,6 @@ object AmazonStrings {
     const val WARNING_AMAZON_OBSERVER_MODE =
         "Attempting to interact with Amazon App Store with an Amazon Purchases configuration in observer mode " +
             "won't do anything. Please use syncObserverModeAmazonPurchase to send purchases to RevenueCat instead."
+    const val ERROR_TIMEOUT_GETTING_PRODUCT_DATA =
+        "Timeout error trying to get Amazon product data for SKUs: %s. Please check that the SKUs are correct."
 }

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStrings.kt
@@ -43,4 +43,6 @@ object AmazonStrings {
             "won't do anything. Please use syncObserverModeAmazonPurchase to send purchases to RevenueCat instead."
     const val ERROR_TIMEOUT_GETTING_PRODUCT_DATA =
         "Timeout error trying to get Amazon product data for SKUs: %s. Please check that the SKUs are correct."
+    const val ERROR_TIMEOUT_GETTING_USER_DATA =
+        "Timeout error trying to get Amazon user data."
 }

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/ProductDataHandler.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/ProductDataHandler.kt
@@ -23,7 +23,7 @@ class ProductDataHandler(
 ) : ProductDataResponseListener {
 
     companion object {
-        private const val GET_PRODUCT_DATA_TIMEOUT_MILLIS = 10000L
+        private const val GET_PRODUCT_DATA_TIMEOUT_MILLIS = 10_000L
     }
 
     private data class Request(

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/ProductDataHandler.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/ProductDataHandler.kt
@@ -26,7 +26,7 @@ class ProductDataHandler(
         private const val GET_PRODUCT_DATA_TIMEOUT_MILLIS = 10000L
     }
 
-    data class Request(
+    private data class Request(
         val skuList: List<String>,
         val marketplace: String,
         val onReceive: StoreProductsCallback,

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/ProductDataHandler.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/ProductDataHandler.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.amazon.handler
 
+import android.os.Handler
 import com.amazon.device.iap.model.Product
 import com.amazon.device.iap.model.ProductDataResponse
 import com.amazon.device.iap.model.RequestId
@@ -17,8 +18,13 @@ import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.models.StoreProduct
 
 class ProductDataHandler(
-    private val purchasingServiceProvider: PurchasingServiceProvider
+    private val purchasingServiceProvider: PurchasingServiceProvider,
+    private val mainHandler: Handler
 ) : ProductDataResponseListener {
+
+    companion object {
+        private const val GET_PRODUCT_DATA_TIMEOUT_MILLIS = 10000L
+    }
 
     data class Request(
         val skuList: List<String>,
@@ -47,8 +53,10 @@ class ProductDataHandler(
                 handleSuccessfulProductDataResponse(cachedProducts, marketplace, onReceive)
             } else {
                 val productDataRequestId = purchasingServiceProvider.getProductData(skus)
+                val request = Request(skus.toList(), marketplace, onReceive, onError)
                 synchronized(this) {
-                    productDataRequests[productDataRequestId] = Request(skus.toList(), marketplace, onReceive, onError)
+                    productDataRequests[productDataRequestId] = request
+                    addTimeoutToProductDataRequest(productDataRequestId)
                 }
             }
         }
@@ -64,19 +72,17 @@ class ProductDataHandler(
             }
 
             val requestId = response.requestId
-            val request = synchronized(this) { productDataRequests.remove(requestId) }
+            val request = getRequest(requestId) ?: return
 
-            if (request != null) {
-                val responseIsSuccessful = response.requestStatus == ProductDataResponse.RequestStatus.SUCCESSFUL
+            val responseIsSuccessful = response.requestStatus == ProductDataResponse.RequestStatus.SUCCESSFUL
 
-                if (responseIsSuccessful) {
-                    synchronized(this) {
-                        productDataCache.putAll(response.productData)
-                    }
-                    handleSuccessfulProductDataResponse(response.productData, request.marketplace, request.onReceive)
-                } else {
-                    handleUnsuccessfulProductDataResponse(response, request.onError)
+            if (responseIsSuccessful) {
+                synchronized(this) {
+                    productDataCache.putAll(response.productData)
                 }
+                handleSuccessfulProductDataResponse(response.productData, request.marketplace, request.onReceive)
+            } else {
+                handleUnsuccessfulProductDataResponse(response, request.onError)
             }
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             errorLog("Exception in onProductDataResponse", e)
@@ -113,5 +119,24 @@ class ProductDataHandler(
         val purchasesError = PurchasesError(PurchasesErrorCode.StoreProblemError, underlyingErrorMessage)
 
         onError(purchasesError)
+    }
+
+    private fun addTimeoutToProductDataRequest(requestId: RequestId) {
+        mainHandler.postDelayed(
+            {
+                val request = getRequest(requestId) ?: return@postDelayed
+                val error = PurchasesError(
+                    PurchasesErrorCode.UnknownError,
+                    AmazonStrings.ERROR_TIMEOUT_GETTING_PRODUCT_DATA.format(request.skuList.toString())
+                )
+                request.onError(error)
+            },
+            GET_PRODUCT_DATA_TIMEOUT_MILLIS
+        )
+    }
+
+    @Synchronized
+    private fun getRequest(requestId: RequestId): Request? {
+        return productDataRequests.remove(requestId)
     }
 }

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/UserDataHandler.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/UserDataHandler.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.amazon.handler
 
+import android.os.Handler
 import com.amazon.device.iap.model.RequestId
 import com.amazon.device.iap.model.UserData
 import com.amazon.device.iap.model.UserDataResponse
@@ -13,30 +14,36 @@ import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 
-typealias UserDataCallbacks = Pair<(UserData) -> Unit, PurchasesErrorCallback>
-
 class UserDataHandler(
-    private val purchasingServiceProvider: PurchasingServiceProvider
+    private val purchasingServiceProvider: PurchasingServiceProvider,
+    private val mainHandler: Handler
 ) : UserDataResponseListener {
 
-    private val requests = mutableMapOf<RequestId, UserDataCallbacks>()
+    companion object {
+        private const val GET_USER_DATA_TIMEOUT_MILLIS = 10000L
+    }
+
+    private data class Request(
+        val onReceive: (UserData) -> Unit,
+        val onError: PurchasesErrorCallback
+    )
+
+    private val requests = mutableMapOf<RequestId, Request>()
 
     override fun onUserDataResponse(response: UserDataResponse) {
         // Amazon is catching all exceptions and swallowing them so we have to catch ourselves and log
         try {
             log(LogIntent.DEBUG, AmazonStrings.USER_DATA_REQUEST_FINISHED.format(response.requestStatus.name))
 
-            val callbacks = synchronized(this) { requests.remove(response.requestId) }
+            val request = getRequest(response.requestId) ?: return
 
-            callbacks?.let { (onSuccess, onError) ->
-                when (response.requestStatus) {
-                    UserDataResponse.RequestStatus.SUCCESSFUL -> onSuccess(response.userData)
-                    UserDataResponse.RequestStatus.FAILED ->
-                        onError.invokeWithStoreProblem(AmazonStrings.ERROR_FAILED_USER_DATA)
-                    UserDataResponse.RequestStatus.NOT_SUPPORTED ->
-                        onError.invokeWithStoreProblem(AmazonStrings.ERROR_UNSUPPORTED_USER_DATA)
-                    else -> onError.invokeWithStoreProblem(AmazonStrings.ERROR_USER_DATA_STORE_PROBLEM)
-                }
+            when (response.requestStatus) {
+                UserDataResponse.RequestStatus.SUCCESSFUL -> request.onReceive(response.userData)
+                UserDataResponse.RequestStatus.FAILED ->
+                    request.onError.invokeWithStoreProblem(AmazonStrings.ERROR_FAILED_USER_DATA)
+                UserDataResponse.RequestStatus.NOT_SUPPORTED ->
+                    request.onError.invokeWithStoreProblem(AmazonStrings.ERROR_UNSUPPORTED_USER_DATA)
+                else -> request.onError.invokeWithStoreProblem(AmazonStrings.ERROR_USER_DATA_STORE_PROBLEM)
             }
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             errorLog("Exception in onUserDataResponse", e)
@@ -50,10 +57,33 @@ class UserDataHandler(
         onError: PurchasesErrorCallback
     ) {
         val userDataRequestId = purchasingServiceProvider.getUserData()
-        requests[userDataRequestId] = onSuccess to onError
+        val request = Request(onSuccess, onError)
+        synchronized(this) {
+            requests[userDataRequestId] = request
+            addTimeoutToUserDataRequest(userDataRequestId)
+        }
     }
 
     private fun PurchasesErrorCallback.invokeWithStoreProblem(message: String) {
         this(PurchasesError(PurchasesErrorCode.StoreProblemError, message))
+    }
+
+    private fun addTimeoutToUserDataRequest(requestId: RequestId) {
+        mainHandler.postDelayed(
+            {
+                val request = getRequest(requestId) ?: return@postDelayed
+                val error = PurchasesError(
+                    PurchasesErrorCode.UnknownError,
+                    AmazonStrings.ERROR_TIMEOUT_GETTING_USER_DATA
+                )
+                request.onError(error)
+            },
+            GET_USER_DATA_TIMEOUT_MILLIS
+        )
+    }
+
+    @Synchronized
+    private fun getRequest(requestId: RequestId): Request? {
+        return requests.remove(requestId)
     }
 }

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/UserDataHandler.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/UserDataHandler.kt
@@ -20,7 +20,7 @@ class UserDataHandler(
 ) : UserDataResponseListener {
 
     companion object {
-        private const val GET_USER_DATA_TIMEOUT_MILLIS = 10000L
+        private const val GET_USER_DATA_TIMEOUT_MILLIS = 10_000L
     }
 
     private data class Request(

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
@@ -382,7 +382,7 @@ class ProductDataHandlerTest {
             unexpectedOnError
         )
 
-        verify(exactly = 1) { mainHandler.postDelayed(any(), 10000L) }
+        verify(exactly = 1) { mainHandler.postDelayed(any(), 10_000L) }
         assertThat(mainHandlerCallbacks.size).isEqualTo(1)
     }
 

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
@@ -45,6 +45,7 @@ class ProductDataHandlerTest {
     @Before
     fun setup() {
         cache = MockDeviceCache(mockk(), apiKey)
+        mainHandlerCallbacks.clear()
         setupMainHandler()
         purchasingServiceProvider = PurchasingServiceProviderForTest()
         underTest = ProductDataHandler(purchasingServiceProvider, mainHandler)

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
@@ -1,28 +1,27 @@
 package com.revenuecat.purchases.amazon.handler
 
+import android.os.Handler
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.amazon.device.iap.internal.model.ProductDataResponseBuilder
 import com.amazon.device.iap.model.Product
 import com.amazon.device.iap.model.ProductDataResponse
-import com.amazon.device.iap.model.Receipt
 import com.amazon.device.iap.model.RequestId
-import com.amazon.device.iap.model.UserData
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.amazon.helpers.MockDeviceCache
 import com.revenuecat.purchases.amazon.helpers.PurchasingServiceProviderForTest
 import com.revenuecat.purchases.amazon.helpers.dummyAmazonProduct
 import com.revenuecat.purchases.models.StoreProduct
+import io.mockk.every
 import io.mockk.mockk
-import org.assertj.core.api.Assertions
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.Exception
-import java.lang.RuntimeException
 
 @RunWith(AndroidJUnit4::class)
 class ProductDataHandlerTest {
@@ -30,6 +29,7 @@ class ProductDataHandlerTest {
     private lateinit var underTest: ProductDataHandler
     private val apiKey = "api_key"
     private lateinit var cache: MockDeviceCache
+    private lateinit var mainHandler: Handler
     private lateinit var purchasingServiceProvider: PurchasingServiceProviderForTest
 
     private var unexpectedOnSuccess: (List<StoreProduct>) -> Unit = {
@@ -40,11 +40,14 @@ class ProductDataHandlerTest {
         fail("should be success")
     }
 
+    private val mainHandlerCallbacks: MutableList<Runnable> = ArrayList()
+
     @Before
     fun setup() {
         cache = MockDeviceCache(mockk(), apiKey)
+        setupMainHandler()
         purchasingServiceProvider = PurchasingServiceProviderForTest()
-        underTest = ProductDataHandler(purchasingServiceProvider)
+        underTest = ProductDataHandler(purchasingServiceProvider, mainHandler)
     }
 
     @Test
@@ -73,7 +76,7 @@ class ProductDataHandlerTest {
         val receivedSkus = receivedStoreProducts!!.map { it.sku }
         assertThat(receivedSkus).hasSameElementsAs(expectedSkus)
 
-        assertThat(purchasingServiceProvider.getProductDataCalledTimes).isZero()
+        assertThat(purchasingServiceProvider.getProductDataCalledTimes).isZero
     }
 
     @Test
@@ -113,7 +116,7 @@ class ProductDataHandlerTest {
         val receivedSkus = receivedStoreProducts!!.map { it.sku }
         assertThat(receivedSkus).hasSameElementsAs(expectedSkus)
 
-        assertThat(purchasingServiceProvider.getProductDataCalledTimes).isOne()
+        assertThat(purchasingServiceProvider.getProductDataCalledTimes).isOne
     }
 
     @Test
@@ -360,10 +363,124 @@ class ProductDataHandlerTest {
             receivedException = e
         }
 
-        assertThat(receivedException).isNotNull()
-        assertThat(receivedLoggedException).isNotNull()
+        assertThat(receivedException).isNotNull
+        assertThat(receivedLoggedException).isNotNull
         assertThat(expectedException).isEqualTo(receivedException)
         assertThat(expectedException).isEqualTo(receivedLoggedException)
+    }
+
+    @Test
+    fun `timeout millis when getting products is correct`() {
+        val dummyRequestId = "a_request_id"
+        purchasingServiceProvider.getProductDataRequestId = dummyRequestId
+
+        underTest.getProductData(
+            setOf("sku_a", "sku_b"),
+            "US",
+            unexpectedOnSuccess,
+            unexpectedOnError
+        )
+
+        verify(exactly = 1) { mainHandler.postDelayed(any(), 10000L) }
+        assertThat(mainHandlerCallbacks.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `request fails with timeout if did not receive response`() {
+        val expectedProductData = mapOf(
+            "sku_a" to dummyAmazonProduct(sku = "sku_a")
+        )
+
+        val dummyRequestId = "a_request_id"
+        purchasingServiceProvider.getProductDataRequestId = dummyRequestId
+
+        var resultError: PurchasesError? = null
+        underTest.getProductData(
+            expectedProductData.keys,
+            "US",
+            unexpectedOnSuccess
+        ) { resultError = it }
+
+        assertThat(resultError).isNull()
+
+        assertThat(mainHandlerCallbacks.size).isEqualTo(1)
+        mainHandlerCallbacks[0].run()
+
+        assertThat(resultError).isNotNull
+        assertThat(resultError?.code).isEqualTo(PurchasesErrorCode.UnknownError)
+        assertThat(resultError?.underlyingErrorMessage).isEqualTo(
+            "Timeout error trying to get Amazon product data for SKUs: [sku_a]. Please check that the SKUs are correct."
+        )
+    }
+
+    @Test
+    fun `request does not succeed if received response after timeout`() {
+        val expectedProductData = mapOf(
+            "sku_a" to dummyAmazonProduct(sku = "sku_a")
+        )
+
+        val dummyRequestId = "a_request_id"
+        purchasingServiceProvider.getProductDataRequestId = dummyRequestId
+
+        var resultError: PurchasesError? = null
+        underTest.getProductData(
+            expectedProductData.keys,
+            "US",
+            unexpectedOnSuccess
+        ) { resultError = it }
+
+        assertThat(mainHandlerCallbacks.size).isEqualTo(1)
+        mainHandlerCallbacks[0].run()
+
+        val response = getDummyProductDataResponse(
+            requestId = dummyRequestId,
+            productData = expectedProductData
+        )
+
+        underTest.onProductDataResponse(response)
+
+        assertThat(resultError).isNotNull
+    }
+
+    @Test
+    fun `request succeeds if received response before timeout`() {
+        val expectedProductData = mapOf(
+            "sku_a" to dummyAmazonProduct(sku = "sku_a")
+        )
+
+        val dummyRequestId = "a_request_id"
+        purchasingServiceProvider.getProductDataRequestId = dummyRequestId
+
+        var resultProducts: List<StoreProduct>? = null
+        underTest.getProductData(
+            expectedProductData.keys,
+            "US",
+            { resultProducts = it },
+            unexpectedOnError
+        )
+
+        assertThat(mainHandlerCallbacks.size).isEqualTo(1)
+
+        val response = getDummyProductDataResponse(
+            requestId = dummyRequestId,
+            productData = expectedProductData
+        )
+
+        underTest.onProductDataResponse(response)
+
+        mainHandlerCallbacks[0].run()
+
+        assertThat(resultProducts).isNotNull
+        assertThat(resultProducts?.size).isEqualTo(1)
+    }
+
+    private fun setupMainHandler() {
+        mainHandler = mockk()
+        every {
+            mainHandler.postDelayed(any(), any())
+        } answers {
+            mainHandlerCallbacks.add(firstArg())
+        }
     }
 }
 

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/UserDataHandlerTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/UserDataHandlerTest.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases.amazon.handler
 
+import android.os.Handler
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.amazon.device.iap.internal.model.UserDataBuilder
 import com.amazon.device.iap.internal.model.UserDataResponseBuilder
 import com.amazon.device.iap.model.RequestId
 import com.amazon.device.iap.model.UserData
@@ -12,6 +12,9 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.amazon.helpers.PurchasingServiceProviderForTest
 import com.revenuecat.purchases.amazon.helpers.dummyUserData
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -24,6 +27,7 @@ import java.lang.RuntimeException
 class UserDataHandlerTest {
 
     private lateinit var underTest: UserDataHandler
+    private lateinit var mainHandler: Handler
     private lateinit var purchasingServiceProvider: PurchasingServiceProviderForTest
 
     private var receivedUserData: UserData? = null
@@ -44,10 +48,14 @@ class UserDataHandlerTest {
         Assertions.fail("should be success")
     }
 
+    private val mainHandlerCallbacks: MutableList<Runnable> = ArrayList()
+
     @Before
     fun setup() {
         purchasingServiceProvider = PurchasingServiceProviderForTest()
-        underTest = UserDataHandler(purchasingServiceProvider)
+        mainHandlerCallbacks.clear()
+        setupMainHandler()
+        underTest = UserDataHandler(purchasingServiceProvider, mainHandler)
     }
 
     @Test
@@ -82,7 +90,7 @@ class UserDataHandlerTest {
     }
 
     @Test
-    fun `Getting user data is not supperted, and sends appropriate error`() {
+    fun `Getting user data is not supported, and sends appropriate error`() {
         val dummyRequestId = "a_request_id"
         purchasingServiceProvider.getUserDataRequestId = dummyRequestId
 
@@ -148,10 +156,90 @@ class UserDataHandlerTest {
             receivedException = e
         }
 
-        assertThat(receivedException).isNotNull()
-        assertThat(receivedLoggedException).isNotNull()
+        assertThat(receivedException).isNotNull
+        assertThat(receivedLoggedException).isNotNull
         assertThat(expectedException).isEqualTo(receivedException)
         assertThat(expectedException).isEqualTo(receivedLoggedException)
+    }
+
+    @Test
+    fun `timeout millis when getting user data is correct`() {
+        val dummyRequestId = "a_request_id"
+        purchasingServiceProvider.getUserDataRequestId = dummyRequestId
+
+        underTest.getUserData(
+            unexpectedOnSuccess,
+            unexpectedOnError
+        )
+
+        verify(exactly = 1) { mainHandler.postDelayed(any(), 10000L) }
+        assertThat(mainHandlerCallbacks.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `request fails with timeout if did not receive response`() {
+        val dummyRequestId = "a_request_id"
+        purchasingServiceProvider.getUserDataRequestId = dummyRequestId
+
+        var resultError: PurchasesError? = null
+        underTest.getUserData(
+            unexpectedOnSuccess
+        ) { resultError = it }
+
+        assertThat(resultError).isNull()
+
+        assertThat(mainHandlerCallbacks.size).isEqualTo(1)
+        mainHandlerCallbacks[0].run()
+
+        assertThat(resultError).isNotNull
+        assertThat(resultError?.code).isEqualTo(PurchasesErrorCode.UnknownError)
+        assertThat(resultError?.underlyingErrorMessage).isEqualTo(
+            "Timeout error trying to get Amazon user data."
+        )
+    }
+
+    @Test
+    fun `request does not succeed if received response after timeout`() {
+        val dummyRequestId = "a_request_id"
+        purchasingServiceProvider.getUserDataRequestId = dummyRequestId
+
+        var resultError: PurchasesError? = null
+        underTest.getUserData(
+            unexpectedOnSuccess
+        ) { resultError = it }
+
+        assertThat(mainHandlerCallbacks.size).isEqualTo(1)
+        mainHandlerCallbacks[0].run()
+
+        val response = getDummyUserDataResponse(
+            expectedRequestId = dummyRequestId,
+        )
+
+        underTest.onUserDataResponse(response)
+
+        assertThat(resultError).isNotNull
+    }
+
+    @Test
+    fun `request succeeds if received response before timeout`() {
+        val dummyRequestId = "a_request_id"
+        purchasingServiceProvider.getUserDataRequestId = dummyRequestId
+
+        var userData: UserData? = null
+        underTest.getUserData(
+            { userData = it },
+            unexpectedOnError
+        )
+
+        assertThat(mainHandlerCallbacks.size).isEqualTo(1)
+
+        val response = getDummyUserDataResponse(expectedRequestId = dummyRequestId)
+
+        underTest.onUserDataResponse(response)
+
+        mainHandlerCallbacks[0].run()
+
+        assertThat(userData).isNotNull
     }
 
     private fun getDummyUserDataResponse(
@@ -168,4 +256,12 @@ class UserDataHandlerTest {
         return UserDataResponse(builder)
     }
 
+    private fun setupMainHandler() {
+        mainHandler = mockk()
+        every {
+            mainHandler.postDelayed(any(), any())
+        } answers {
+            mainHandlerCallbacks.add(firstArg())
+        }
+    }
 }

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/UserDataHandlerTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/UserDataHandlerTest.kt
@@ -172,7 +172,7 @@ class UserDataHandlerTest {
             unexpectedOnError
         )
 
-        verify(exactly = 1) { mainHandler.postDelayed(any(), 10000L) }
+        verify(exactly = 1) { mainHandler.postDelayed(any(), 10_000L) }
         assertThat(mainHandlerCallbacks.size).isEqualTo(1)
     }
 


### PR DESCRIPTION
### Description
https://revenuecats.atlassian.net/browse/CSDK-452

In certain situations, Amazon fails silently and doesn't return anything for the requests. For example, when enabling [sandbox mode ](https://developer.amazon.com/docs/in-app-purchasing/iap-app-tester-user-guide.html#installtester) and using the version from Live App testing. In those situations, we want to add a timeout to the requests so it doesn't get stuck and we show a meaningful error log. I added it to both the `getUserData` and `getProducts` requests.
