### PR TITLE
Add configuration fragment to purchase tester

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -41,7 +41,7 @@ class ConfigureFragment : Fragment() {
         val proxyUrl = binding.proxyUrlInput.text?.toString()
         val useAmazonStore = binding.storeRadioGroup.checkedRadioButtonId == R.id.amazon_store_radio_id
 
-        val application = (activity?.application as? MainApplication) ?: return
+        val application = (requireActivity().application as MainApplication)
 
         if (proxyUrl?.isEmpty() == false) Purchases.proxyURL = URL(proxyUrl)
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -1,0 +1,96 @@
+package com.revenuecat.purchasetester
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.navigation.fragment.findNavController
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesConfiguration
+import com.revenuecat.purchases.amazon.AmazonConfiguration
+import com.revenuecat.purchases_sample.R
+import com.revenuecat.purchases_sample.databinding.FragmentConfigureBinding
+import java.net.MalformedURLException
+import java.net.URL
+
+class ConfigureFragment : Fragment() {
+
+    lateinit var binding: FragmentConfigureBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentConfigureBinding.inflate(inflater)
+
+        binding.continueButton.setOnClickListener {
+            if (!validateInputs()) return@setOnClickListener
+
+            configureSDK()
+            navigateToLoginFragment()
+        }
+
+        return binding.root
+    }
+
+    private fun configureSDK() {
+        val apiKey = binding.apiKeyInput.text.toString()
+        val proxyUrl = binding.proxyUrlInput.text?.toString()
+        val useAmazonStore = binding.storeRadioGroup.checkedRadioButtonId == R.id.amazon_store_radio_id
+
+        val application = (activity?.application as? MainApplication) ?: return
+
+        if (proxyUrl?.isEmpty() == false) Purchases.proxyURL = URL(proxyUrl)
+
+        val configurationBuilder =
+            if (useAmazonStore) AmazonConfiguration.Builder(application, apiKey)
+            else PurchasesConfiguration.Builder(application, apiKey)
+        val configuration = configurationBuilder.build()
+        Purchases.configure(configuration)
+
+        // set attributes to store additional, structured information for a user in RevenueCat.
+        // More info: https://docs.revenuecat.com/docs/user-attributes
+        Purchases.sharedInstance.setAttributes(mapOf("favorite_cat" to "garfield"))
+
+        Purchases.sharedInstance.updatedCustomerInfoListener = application
+    }
+
+    private fun navigateToLoginFragment() {
+        val directions = ConfigureFragmentDirections.actionConfigureFragmentToLoginFragment()
+        findNavController().navigate(directions)
+    }
+
+    private fun validateInputs(): Boolean {
+        return validateApiKey() && validateProxyURL()
+    }
+
+    private fun validateApiKey(): Boolean {
+        val errorMessages = mutableListOf<String>()
+        if (binding.apiKeyInput.text?.isNotEmpty() != true) errorMessages.add("API Key is empty")
+        if (errorMessages.isNotEmpty()) showError("API Key errors: $errorMessages")
+        return errorMessages.isEmpty()
+    }
+
+    private fun validateProxyURL(): Boolean {
+        val proxyURLString = binding.proxyUrlInput.text?.toString()
+        if (proxyURLString?.isEmpty() != false) return true
+        val errorMessages = mutableListOf<String>()
+        try {
+            URL(proxyURLString)
+        } catch (e: MalformedURLException) { errorMessages.add("Invalid proxy URL. Could not convert to URL.") }
+        if (errorMessages.isNotEmpty()) showError("Proxy URL errors: $errorMessages")
+        return errorMessages.isEmpty()
+    }
+
+    private fun showError(msg: String) {
+        context?.let {
+            MaterialAlertDialogBuilder(it)
+                .setMessage(msg)
+                .setPositiveButton("OK") { dialog, _ -> dialog.dismiss() }
+                .show()
+        }
+    }
+}

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
@@ -13,38 +13,28 @@ import androidx.core.content.ContextCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Purchases
-import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.PurchasesError
-import com.revenuecat.purchases.amazon.AmazonConfiguration
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
+import com.revenuecat.purchases_sample.BuildConfig
 
 class MainApplication : Application(), UpdatedCustomerInfoListener {
 
     override fun onCreate() {
         super.onCreate()
-        StrictMode.setVmPolicy(
-            VmPolicy.Builder()
-                .detectLeakedClosableObjects()
-                .penaltyLog()
-                .penaltyDeath()
-                .build()
-        )
+
+        if (BuildConfig.DEBUG) {
+            StrictMode.setVmPolicy(
+                VmPolicy.Builder()
+                    .detectLeakedClosableObjects()
+                    .penaltyLog()
+                    .penaltyDeath()
+                    .build()
+            )
+        }
+
         Purchases.debugLogsEnabled = true
 
-        val purchasesConfigurationBuilder =
-            when {
-                GOOGLE_API_KEY.isNotEmpty() -> PurchasesConfiguration.Builder(this, GOOGLE_API_KEY)
-                AMAZON_API_KEY.isNotEmpty() -> AmazonConfiguration.Builder(this, AMAZON_API_KEY)
-                else -> {
-                    throw IllegalArgumentException("Set at least one API key in Constants.")
-                }
-            }
-        Purchases.configure(purchasesConfigurationBuilder.build())
-        // set attributes to store additional, structured information for a user in RevenueCat.
-        // More info: https://docs.revenuecat.com/docs/user-attributes
-        Purchases.sharedInstance.setAttributes(mapOf("favorite_cat" to "garfield"))
-
-        Purchases.sharedInstance.updatedCustomerInfoListener = this
+        Purchases.logHandler = TesterLogHandler(this)
     }
 
     override fun onReceived(customerInfo: CustomerInfo) {

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/TesterLogHandler.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/TesterLogHandler.kt
@@ -1,0 +1,36 @@
+package com.revenuecat.purchasetester
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.widget.Toast
+import com.revenuecat.purchases.LogHandler
+
+class TesterLogHandler(
+    private val applicationContext: Context,
+    private val mainHandler: Handler = Handler(Looper.getMainLooper())
+) : LogHandler {
+    override fun d(tag: String, msg: String) {
+        Log.d(tag, msg)
+    }
+
+    override fun i(tag: String, msg: String) {
+        Log.i(tag, msg)
+    }
+
+    override fun w(tag: String, msg: String) {
+        Log.w(tag, msg)
+    }
+
+    override fun e(tag: String, msg: String, throwable: Throwable?) {
+        if (throwable != null) {
+            Log.e(tag, msg, throwable)
+        } else {
+            Log.e(tag, msg)
+        }
+        mainHandler.post {
+            Toast.makeText(applicationContext, "ERROR: $msg", Toast.LENGTH_LONG).show()
+        }
+    }
+}

--- a/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
@@ -50,7 +50,7 @@
                 app:layout_constraintTop_toTopOf="@id/api_key_label"
                 app:layout_constraintBottom_toBottomOf="@id/api_key_label"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintWidth_percent="0.6"
+                app:layout_constraintWidth_percent="0.55"
                 android:layout_marginLeft="20dp"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"/>
@@ -71,7 +71,7 @@
                 app:layout_constraintTop_toTopOf="@id/proxy_url_label"
                 app:layout_constraintBottom_toBottomOf="@id/proxy_url_label"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintWidth_percent="0.6"
+                app:layout_constraintWidth_percent="0.55"
                 android:layout_marginLeft="20dp"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"/>

--- a/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:bind="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools">
+        xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
@@ -18,7 +16,7 @@
                 android:id="@+id/configure_icon"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="😻"
+                android:text="@string/loving_cat"
                 android:textSize="100sp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -27,7 +25,7 @@
         <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/sdk_configuration_label"
                 style="@style/TextAppearance.AppCompat.Headline"
-                android:text="SDK Configuration"
+                android:text="@string/sdk_configuration"
                 android:layout_marginTop="20dp"
                 app:layout_constraintTop_toBottomOf="@id/configure_icon"
                 app:layout_constraintStart_toStartOf="parent"
@@ -36,7 +34,7 @@
 
         <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/api_key_label"
-                android:text="API Key"
+                android:text="@string/api_key"
                 android:textSize="15sp"
                 android:layout_marginTop="30dp"
                 app:layout_constraintTop_toBottomOf="@id/sdk_configuration_label"
@@ -51,13 +49,13 @@
                 app:layout_constraintBottom_toBottomOf="@id/api_key_label"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintWidth_percent="0.55"
-                android:layout_marginLeft="20dp"
+                android:layout_marginStart="20dp"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"/>
 
         <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/proxy_url_label"
-                android:text="Proxy URL (optional)"
+                android:text="@string/proxy_url_optional"
                 android:textSize="15sp"
                 android:layout_marginTop="20dp"
                 app:layout_constraintTop_toBottomOf="@id/api_key_label"
@@ -72,13 +70,13 @@
                 app:layout_constraintBottom_toBottomOf="@id/proxy_url_label"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintWidth_percent="0.55"
-                android:layout_marginLeft="20dp"
+                android:layout_marginStart="20dp"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"/>
 
         <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/store_label"
-                android:text="Store"
+                android:text="@string/store"
                 android:textSize="15sp"
                 android:layout_marginTop="20dp"
                 app:layout_constraintTop_toBottomOf="@id/proxy_url_input"
@@ -96,13 +94,13 @@
                 android:layout_height="wrap_content">
             <RadioButton
                     android:id="@+id/google_store_radio_id"
-                    android:text="Google"
+                    android:text="@string/google"
                     android:checked="true"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"/>
             <RadioButton
                     android:id="@+id/amazon_store_radio_id"
-                    android:text="Amazon"
+                    android:text="@string/amazon"
                     android:checked="false"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"/>
@@ -110,7 +108,7 @@
 
         <com.google.android.material.button.MaterialButton
                 android:id="@+id/continue_button"
-                android:text="Continue"
+                android:text="@string/continue_text"
                 android:layout_marginTop="30dp"
                 app:layout_constraintTop_toBottomOf="@id/store_label"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:bind="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/login_container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="@dimen/padding_large">
+
+        <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/configure_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="😻"
+                android:textSize="100sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/sdk_configuration_label"
+                style="@style/TextAppearance.AppCompat.Headline"
+                android:text="SDK Configuration"
+                android:layout_marginTop="20dp"
+                app:layout_constraintTop_toBottomOf="@id/configure_icon"
+                app:layout_constraintStart_toStartOf="parent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+
+        <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/api_key_label"
+                android:text="API Key"
+                android:textSize="15sp"
+                android:layout_marginTop="30dp"
+                app:layout_constraintTop_toBottomOf="@id/sdk_configuration_label"
+                app:layout_constraintStart_toStartOf="parent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+
+        <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/api_key_input"
+                android:background="@color/lightGrey"
+                app:layout_constraintTop_toTopOf="@id/api_key_label"
+                app:layout_constraintBottom_toBottomOf="@id/api_key_label"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintWidth_percent="0.6"
+                android:layout_marginLeft="20dp"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"/>
+
+        <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/proxy_url_label"
+                android:text="Proxy URL (optional)"
+                android:textSize="15sp"
+                android:layout_marginTop="20dp"
+                app:layout_constraintTop_toBottomOf="@id/api_key_label"
+                app:layout_constraintStart_toStartOf="parent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+
+        <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/proxy_url_input"
+                android:background="@color/lightGrey"
+                app:layout_constraintTop_toTopOf="@id/proxy_url_label"
+                app:layout_constraintBottom_toBottomOf="@id/proxy_url_label"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintWidth_percent="0.6"
+                android:layout_marginLeft="20dp"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"/>
+
+        <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/store_label"
+                android:text="Store"
+                android:textSize="15sp"
+                android:layout_marginTop="20dp"
+                app:layout_constraintTop_toBottomOf="@id/proxy_url_input"
+                app:layout_constraintStart_toStartOf="parent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+
+        <RadioGroup
+                android:id="@+id/store_radio_group"
+                app:layout_constraintTop_toTopOf="@id/store_label"
+                app:layout_constraintBottom_toBottomOf="@id/store_label"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:orientation="horizontal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
+            <RadioButton
+                    android:id="@+id/google_store_radio_id"
+                    android:text="Google"
+                    android:checked="true"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+            <RadioButton
+                    android:id="@+id/amazon_store_radio_id"
+                    android:text="Amazon"
+                    android:checked="false"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+        </RadioGroup>
+
+        <com.google.android.material.button.MaterialButton
+                android:id="@+id/continue_button"
+                android:text="Continue"
+                android:layout_marginTop="30dp"
+                app:layout_constraintTop_toBottomOf="@id/store_label"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:paddingHorizontal="30dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/examples/purchase-tester/src/main/res/navigation/nav_graph.xml
+++ b/examples/purchase-tester/src/main/res/navigation/nav_graph.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto" android:id="@+id/nav_graph.xml"
-        app:startDestination="@id/loginFragment">
+        app:startDestination="@id/configureFragment">
 
     <fragment
             android:id="@+id/loginFragment"
@@ -28,6 +28,15 @@
         <argument
                 android:name="offering"
                 app:argType="com.revenuecat.purchases.Offering" />
+    </fragment>
+    <fragment
+            android:id="@+id/configureFragment"
+            android:name="com.revenuecat.purchasetester.ConfigureFragment"
+            android:label="ConfigureFragment" >
+        <action
+                android:id="@+id/action_configureFragment_to_loginFragment"
+                app:destination="@id/loginFragment"
+                app:popUpTo="@id/nav_graph.xml" />
     </fragment>
 
 </navigation>

--- a/examples/purchase-tester/src/main/res/values/colors.xml
+++ b/examples/purchase-tester/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#30b296</color>
     <color name="colorPrimaryDark">#207663</color>
     <color name="colorAccent">#f2545b</color>
+    <color name="lightGrey">#dddddd</color>
 </resources>

--- a/examples/purchase-tester/src/main/res/values/strings.xml
+++ b/examples/purchase-tester/src/main/res/values/strings.xml
@@ -1,4 +1,12 @@
 <resources>
     <string name="app_name">Purchase Tester</string>
     <string name="offering_fragment_transition">OfferingFragmentTransition</string>
+    <string name="sdk_configuration">SDK Configuration</string>
+    <string name="api_key">API Key</string>
+    <string name="proxy_url_optional">Proxy URL (optional)</string>
+    <string name="store">Store</string>
+    <string name="google">Google</string>
+    <string name="amazon">Amazon</string>
+    <string name="continue_text">Continue</string>
+    <string name="loving_cat">😻</string>
 </resources>


### PR DESCRIPTION
### Description
First PR for https://revenuecats.atlassian.net/browse/CSDK-483

In this PR we are adding a new screen at the start of purchase tester where we can configure the SDK before it's initialized. This will allow us to not need to build the SDK to test with different API keys and proxy URLs. The app will always start on this screen and it will move to the login fragment once it's configured. The SDK won't be automatically initialized on app open anymore. Instead, it will be initialized after completing this screen.

Additionally, this PR also makes error logs show as Toasts. Since we intend to use this app from the play store test tracks, being able to see logs without a computer would be useful. However, i thought all logs would need a different system so for now I'm just showing error logs as Toasts.

<img src="https://user-images.githubusercontent.com/808417/194092670-58ffae7e-2f59-4157-a7f7-17131fc39cba.jpg" width="300">

For future PRs:
- [ ] Provide a way to go back to this screen from Login/Overview screens https://github.com/RevenueCat/purchases-android/pull/635
- [x] Store configuration in DataStore, so we don't need to introduce it on every app open https://github.com/RevenueCat/purchases-android/pull/633
