### PR TITLE
Store purchase tester sdk configuration in DataStore

### DIFF
--- a/examples/purchase-tester/build.gradle
+++ b/examples/purchase-tester/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'com.google.android.material:material:1.6.0'
+    implementation "androidx.datastore:datastore-preferences:1.0.0"
 
     implementation "androidx.navigation:navigation-fragment-ktx:2.4.2"
     implementation "androidx.navigation:navigation-ui-ktx:2.4.2"

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/DataStoreUtils.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/DataStoreUtils.kt
@@ -1,0 +1,45 @@
+package com.revenuecat.purchasetester
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+val Context.configurationDataStore: DataStore<Preferences> by preferencesDataStore(name = "configuration")
+
+class DataStoreUtils(
+    private val dataStore: DataStore<Preferences>
+) {
+    private val apiKeyKey = stringPreferencesKey("last_sdk_api_key")
+    private val proxyUrlKey = stringPreferencesKey("last_proxy_url_key")
+    private val useAmazonKey = booleanPreferencesKey("last_use_amazon_key")
+
+    suspend fun saveSdkConfig(
+        sdkConfiguration: SdkConfiguration
+    ) {
+        dataStore.edit { preferences ->
+            preferences[apiKeyKey] = sdkConfiguration.apiKey
+            if (sdkConfiguration.proxyUrl == null) {
+                preferences.remove(proxyUrlKey)
+            } else {
+                preferences[proxyUrlKey] = sdkConfiguration.proxyUrl
+            }
+            preferences[useAmazonKey] = sdkConfiguration.useAmazon
+        }
+    }
+
+    fun getSdkConfig(): Flow<SdkConfiguration> {
+        return dataStore.data.map { preferences ->
+            SdkConfiguration(
+                apiKey = preferences[apiKeyKey] ?: "",
+                proxyUrl = preferences[proxyUrlKey],
+                useAmazon = preferences[useAmazonKey] ?: false
+            )
+        }
+    }
+}

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/SdkConfiguration.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/SdkConfiguration.kt
@@ -1,0 +1,7 @@
+package com.revenuecat.purchasetester
+
+data class SdkConfiguration(
+    val apiKey: String,
+    val proxyUrl: String?,
+    val useAmazon: Boolean
+)


### PR DESCRIPTION
### Description
https://revenuecats.atlassian.net/browse/CSDK-483

Followup to #632. In this PR we store the sdk configuration from the configuration screen in DataStore so it's prefilled next time the user opens the app. This PR uses coroutines and DataStore instead of using the old SharedPreferences system.
