### PR TITLE
Moves hold job after integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,4 @@
 aliases:
-  release-tags-and-branches: &release-tags-and-branches
-    filters:
-      tags:
-        ignore:
-          - /^.*-SNAPSHOT/
-          - latest
-      branches:
-        only: /^release\/.*/
-
   release-tags: &release-tags
     filters:
       tags:
@@ -400,12 +391,12 @@ workflows:
       - test
       - assemble-sample-app
 
-  integration-test:
+  deploy:
     when:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      - integration-tests-build: *release-tags-and-branches
+      - integration-tests-build: *release-branches
       - run-firebase-tests-latest-dependencies:
           requires:
             - integration-tests-build
@@ -415,14 +406,12 @@ workflows:
       - run-firebase-tests-bc5SupportDev:
           requires:
             - integration-tests-build
-
-  deploy:
-    when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-    jobs:
       - hold:
           type: approval
+          requires:
+            - run-firebase-tests-latest-dependencies
+            - run-firebase-tests-unityIAP
+            - run-firebase-tests-bc5SupportDev
           <<: *release-branches
       - revenuecat/tag-current-branch:
           requires:


### PR DESCRIPTION
To prevent deploying something that fails on integration tests, I think the deploy job should go after the integration tests are finished