### PR TITLE
Fix GitHub releases not being created 

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -141,6 +141,8 @@ platform :android do
       ],
       properties: gradleProperties
     )
+
+    github_release(version: version) unless is_snapshot_version?(version)
   end
 
   desc "Upload a snapshot release"


### PR DESCRIPTION
I accidentally broke creating the GitHub release during a deploy in https://github.com/RevenueCat/purchases-android/commit/1b1f647bf0e924bd24fa79f5311d5ccb8cd08b60#diff-dff4b99d4e651ab9d7597876ec8dbe92aa934e42c0fb55f4aadd6c106fc96688L152