### PR TITLE
Remove bc5DevSupport flavor from main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,10 +286,8 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - integration-tests/build/outputs/apk/bc5SupportDev/release/integration-tests-bc5SupportDev-release.apk
             - integration-tests/build/outputs/apk/latestDependencies/release/integration-tests-latestDependencies-release.apk
             - integration-tests/build/outputs/apk/unityIAP/release/integration-tests-unityIAP-release.apk
-            - integration-tests/build/outputs/apk/androidTest/bc5SupportDev/release/integration-tests-bc5SupportDev-release-androidTest.apk
             - integration-tests/build/outputs/apk/androidTest/latestDependencies/release/integration-tests-latestDependencies-release-androidTest.apk
             - integration-tests/build/outputs/apk/androidTest/unityIAP/release/integration-tests-unityIAP-release-androidTest.apk
 
@@ -353,36 +351,6 @@ jobs:
       - store_test_results:
           path: ~/gsutil/
 
-  run-firebase-tests-bc5SupportDev:
-    description: "Run integration tests for Android in Firebase. Variant bc5SupportDev"
-    executor: gcp-cli/google
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - gcp-cli/initialize:
-          gcloud-service-key: GCLOUD_SERVICE_KEY
-          google-compute-zone: GOOGLE_COMPUTE_ZONE
-          google-project-id: GOOGLE_PROJECT_ID
-      - run:
-          name: Test with Firebase Test Lab
-          command: >
-            gcloud firebase test android run --type instrumentation \
-              --app integration-tests/build/outputs/apk/bc5SupportDev/release/integration-tests-bc5SupportDev-release.apk \
-              --test integration-tests/build/outputs/apk/androidTest/bc5SupportDev/release/integration-tests-bc5SupportDev-release-androidTest.apk \
-              --timeout 2m \
-              --results-bucket cloud-test-${GOOGLE_PROJECT_ID}
-      - run:
-          name: Copy test results data
-          command: |
-            mkdir -p ~/gsutil/
-            gsutil -m cp -r -U `gsutil ls gs://cloud-test-$GOOGLE_PROJECT_ID | tail -1` ~/gsutil/ | true
-          when: always
-      - store_artifacts:
-          path: ~/gsutil/
-      - store_test_results:
-          path: ~/gsutil/
-
 workflows:
   version: 2
   danger:
@@ -410,9 +378,6 @@ workflows:
           requires:
             - integration-tests-build
       - run-firebase-tests-unityIAP:
-          requires:
-            - integration-tests-build
-      - run-firebase-tests-bc5SupportDev:
           requires:
             - integration-tests-build
 

--- a/base-application.gradle
+++ b/base-application.gradle
@@ -29,9 +29,6 @@ android {
         latestDependencies {
             dimension "dependencyVersions"
         }
-        bc5SupportDev {
-            dimension "dependencyVersions"
-        }
     }
 
     // TODO remove after BC5 is merged

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     implementation project(":strings")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
-    bc5SupportDevImplementation "com.android.billingclient:billing:$billing5Version"
     latestDependenciesImplementation "com.android.billingclient:billing:$billing4Version"
     unityIAPCompileOnly "com.android.billingclient:billing:$billing4Version"
     testImplementation project(":test-utils")

--- a/feature/amazon/build.gradle
+++ b/feature/amazon/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.annotation:annotation:$annotationVersion"
 
-    bc5SupportDevImplementation "com.amazon.device:amazon-appstore-sdk:$amazonVersion"
     latestDependenciesImplementation "com.amazon.device:amazon-appstore-sdk:$amazonVersion"
     unityIAPCompileOnly files("libs/in-app-purchasing-${amazon2Version}.jar")
 
@@ -80,6 +79,4 @@ afterEvaluate {
     preUnityIAPReleaseBuild.dependsOn getAmazonLibrary
     preLatestDependenciesDebugBuild.dependsOn cleanAmazonLibrary
     preLatestDependenciesReleaseBuild.dependsOn cleanAmazonLibrary
-    preBc5SupportDevDebugBuild.dependsOn cleanAmazonLibrary
-    preBc5SupportDevReleaseBuild.dependsOn cleanAmazonLibrary
 }

--- a/feature/google/build.gradle
+++ b/feature/google/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     implementation 'com.google.android.gms:play-services-ads-identifier:17.0.1'
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    bc5SupportDevImplementation "com.android.billingclient:billing:$billing5Version"
     latestDependenciesImplementation "com.android.billingclient:billing:$billing4Version"
     unityIAPCompileOnly "com.android.billingclient:billing:$billing4Version"
 

--- a/library.gradle
+++ b/library.gradle
@@ -13,9 +13,6 @@ android {
         latestDependencies {
             dimension "dependencyVersions"
         }
-        bc5SupportDev {
-            dimension "dependencyVersions"
-        }
     }
     defaultConfig {
         minSdkVersion minVersion

--- a/public/build.gradle
+++ b/public/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     implementation project(":strings")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
-    bc5SupportDevImplementation "com.android.billingclient:billing:$billing5Version"
     latestDependenciesImplementation "com.android.billingclient:billing:$billing4Version"
     unityIAPCompileOnly "com.android.billingclient:billing:$billing4Version"
     testImplementation project(":test-utils")

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -18,7 +18,6 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.annotation:annotation:$annotationVersion"
-    bc5SupportDevApi "com.android.billingclient:billing:$billing5Version"
     latestDependenciesApi "com.android.billingclient:billing:$billing4Version"
     unityIAPCompileOnly "com.android.billingclient:billing:$billing4Version"
     implementation "androidx.lifecycle:lifecycle-runtime:$lifecycleVersion"
@@ -33,7 +32,6 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "io.mockk:mockk:$mockkVersion"
     testImplementation "org.assertj:assertj-core:$assertJVersion"
-    testBc5SupportDevImplementation "com.android.billingclient:billing:$billing5Version"
     testLatestDependenciesImplementation "com.android.billingclient:billing:$billing4Version"
     testUnityIAPImplementation "com.android.billingclient:billing:$billing4Version"
 }

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     implementation project(":feature:google")
     implementation project(":utils")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    bc5SupportDevImplementation "com.android.billingclient:billing:$billing5Version"
     latestDependenciesImplementation "com.android.billingclient:billing:$billing4Version"
     unityIAPCompileOnly "com.android.billingclient:billing:$billing4Version"
     implementation "org.assertj:assertj-core:$assertJVersion"


### PR DESCRIPTION
Part of https://revenuecats.atlassian.net/browse/CF-969

Removing `bc5DevSupport` flavor from `main`. The flavor will be moved to `latestDependencies` in a new branch

I didn't remove any code in this PR on purpose, those files will be moved to the `main` folder in the `bc5-support` branch. They have already been reviewed so I didn't want to remove them