### PR TITLE
Store debug builds of purchase tester on each commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,8 @@ jobs:
             -PreleaseKeyPassword=$RELEASE_KEY_PASSWORD
       - store_artifacts:
           path: examples/purchase-tester/build/outputs/apk/latestDependencies/release/purchase-tester-latestDependencies-release.apk
+      - store_artifacts:
+          path: examples/purchase-tester/build/outputs/apk/latestDependencies/debug/purchase-tester-latestDependencies-debug.apk
       - android-wordpress-orb/save-gradle-cache
       - android/save-build-cache
 


### PR DESCRIPTION
### Description
The `assemble-sample-app` job didn't work very well until it was fixed in https://github.com/RevenueCat/purchases-android/pull/639. This job builds the purchase tester app on every commit. Before this PR, we were only storing the latestDependencies release build as an artifact. This adds the debug version of latestDependencies since it can be useful while developing bc5. 

Note that this will increase our space usage a lot, since this happens on every commit to every branch. I thought about limiting it to run only on main (or at least, only store artifacts on main), but I thought I would leave it until it becomes a problem, and we can reevaluate then.
