### PR TITLE
Fix existing BillingWrapper unit tests related to purchasing

### DIFF
--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -37,6 +37,7 @@ import com.revenuecat.purchases.common.firstSku
 import com.revenuecat.purchases.common.listOfSkus
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.sha1
+import com.revenuecat.purchases.common.sha256
 import com.revenuecat.purchases.common.toHumanReadableDescription
 import com.revenuecat.purchases.models.PurchaseOption
 import com.revenuecat.purchases.models.PurchaseState
@@ -216,8 +217,12 @@ class BillingWrapper(
             presentedOfferingsByProductIdentifier[storeProduct.sku] = presentedOfferingIdentifier
         }
         executeRequestOnUIThread {
-            val params = createPurchaseParams(storeProduct, purchaseOption) ?: return@executeRequestOnUIThread
-
+            val params = createPurchaseParams(
+                storeProduct,
+                purchaseOption,
+                replaceSkuInfo,
+                appUserID
+            ) ?: return@executeRequestOnUIThread
             launchBillingFlow(activity, params)
         }
     }
@@ -762,7 +767,9 @@ class BillingWrapper(
 
     private fun createPurchaseParams(
         storeProduct: StoreProduct,
-        purchaseOption: PurchaseOption
+        purchaseOption: PurchaseOption,
+        replaceSkuInfo: ReplaceSkuInfo?,
+        appUserID: String
     ): BillingFlowParams? {
         val token = purchaseOption.token
         val googleProduct = storeProduct.googleProduct
@@ -781,6 +788,11 @@ class BillingWrapper(
 
         return BillingFlowParams.newBuilder()
             .setProductDetailsParamsList(listOf(productDetailsParamsList))
+            .apply {
+                replaceSkuInfo?.let {
+                    setUpgradeInfo(it)
+                } ?: setObfuscatedAccountId(appUserID.sha256())
+            }
             .build()
     }
 }

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -789,6 +789,8 @@ class BillingWrapper(
         return BillingFlowParams.newBuilder()
             .setProductDetailsParamsList(listOf(productDetailsParamsList))
             .apply {
+                // only setObfuscatedAccountId for non-upgrade/downgrades until google issue is fixed:
+                // https://issuetracker.google.com/issues/155005449
                 replaceSkuInfo?.let {
                     setUpgradeInfo(it)
                 } ?: setObfuscatedAccountId(appUserID.sha256())

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/billingClientStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/billingClientStubs.kt
@@ -81,19 +81,36 @@ fun mockPricingPhase(
 }
 
 fun createMockProductDetailsNoOffers(): ProductDetails = mockProductDetails()
-fun createMockProductDetailsFreeTrial(): ProductDetails = mockProductDetails(
-    productId = "product_id_with_trial",
+fun createMockProductDetailsFreeTrial(
+    productId: String = "mock-free-trial-subscription",
+    priceAfterFreeTrial: Double = 4.99,
+    freeTrialPeriod: String = "P7D",
+    subscriptionPeriod: String = "P1M"
+): ProductDetails = mockProductDetails(
+    productId = productId,
     subscriptionOfferDetails = listOf(
         mockSubscriptionOfferDetails(
-            token = "free_trial_offer_phase",
+            token = "free_trial_offer",
             pricingPhases = listOf(
                 mockPricingPhase(
                     price = 0.0,
                     billingCycleCount = 1,
+                    billingPeriod = freeTrialPeriod,
                     recurrenceMode = RecurrenceMode.FINITE_RECURRING
                 ),
                 mockPricingPhase(
-                    price = 4.99,
+                    price = priceAfterFreeTrial,
+                    billingPeriod = subscriptionPeriod,
+                    recurrenceMode = RecurrenceMode.INFINITE_RECURRING
+                )
+            )
+        ),
+        mockSubscriptionOfferDetails(
+            token = "base_plan_offer",
+            pricingPhases = listOf(
+                mockPricingPhase(
+                    price = priceAfterFreeTrial,
+                    billingPeriod = subscriptionPeriod,
                     recurrenceMode = RecurrenceMode.INFINITE_RECURRING
                 )
             )


### PR DESCRIPTION
### Description
This fixes part of the existing tests that were broken in #662 , specifically those in `BillingWrapperTests`. I still need to fix tests in `PurchasesTests` and add the new tests, but I thought I would do this in several PRs so it doesn't end up with a huge PR
