### PR TITLE
BC5 Continue fixing purchase tests and add missing BillingWrapper tests

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -36,6 +36,7 @@ import java.util.concurrent.ExecutorService
 
 @Suppress("unused", "UNUSED_VARIABLE", "EmptyFunctionBlock", "RemoveExplicitTypeArguments", "RedundantLambdaArrow")
 private class PurchasesAPI {
+    @SuppressWarnings("LongParameterList")
     fun check(
         purchases: Purchases,
         activity: Activity,
@@ -85,7 +86,13 @@ private class PurchasesAPI {
 
         purchases.purchaseProductWithOption(activity, storeProduct, purchaseOption, upgradeInfo, purchaseChangeCallback)
         purchases.purchaseProductWithOption(activity, storeProduct, purchaseOption, purchaseCallback)
-        purchases.purchasePackageWithOption(activity, packageToPurchase, purchaseOption, upgradeInfo, purchaseChangeCallback)
+        purchases.purchasePackageWithOption(
+            activity,
+            packageToPurchase,
+            purchaseOption,
+            upgradeInfo,
+            purchaseChangeCallback
+        )
         purchases.purchasePackageWithOption(activity, packageToPurchase, purchaseOption, purchaseCallback)
 
         purchases.restorePurchases(receiveCustomerInfoCallback)

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -29,7 +29,9 @@ import com.revenuecat.purchases.models.PurchaseOption
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.purchasePackageWith
+import com.revenuecat.purchases.purchasePackageWithOption
 import com.revenuecat.purchases.purchaseProductWith
+import com.revenuecat.purchases.purchaseProductWithOption
 import com.revenuecat.purchases.restorePurchasesWith
 import java.net.URL
 import java.util.concurrent.ExecutorService
@@ -124,6 +126,7 @@ private class PurchasesAPI {
         activity: Activity,
         packageToPurchase: Package,
         storeProduct: StoreProduct,
+        purchaseOption: PurchaseOption,
         upgradeInfo: UpgradeInfo
     ) {
         purchases.getOfferingsWith(
@@ -153,6 +156,36 @@ private class PurchasesAPI {
         purchases.purchasePackageWith(
             activity,
             packageToPurchase,
+            onError = { _: PurchasesError, _: Boolean -> },
+            onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
+        )
+        purchases.purchaseProductWithOption(
+            activity,
+            storeProduct,
+            purchaseOption,
+            onError = { _: PurchasesError, _: Boolean -> },
+            onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
+        )
+        purchases.purchaseProductWithOption(
+            activity,
+            storeProduct,
+            purchaseOption,
+            upgradeInfo,
+            onError = { _: PurchasesError, _: Boolean -> },
+            onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
+        )
+        purchases.purchasePackageWithOption(
+            activity,
+            packageToPurchase,
+            purchaseOption,
+            upgradeInfo,
+            onError = { _: PurchasesError, _: Boolean -> },
+            onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
+        )
+        purchases.purchasePackageWithOption(
+            activity,
+            packageToPurchase,
+            purchaseOption,
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
         )

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -776,10 +776,12 @@ class BillingWrapper(
         val googleProduct = storeProduct.googleProduct
         if (token == null) {
             errorLog("PurchaseOption must have a token with BC5.") // TODOBC5: Improve and move error message
+            purchasesUpdatedListener?.onPurchasesFailedToUpdate(PurchasesError(PurchasesErrorCode.UnknownError))
             return null
         }
         if (googleProduct == null) {
             errorLog("Product must be a Google Product.") // TODOBC5: Improve and move error message
+            purchasesUpdatedListener?.onPurchasesFailedToUpdate(PurchasesError(PurchasesErrorCode.UnknownError))
             return null
         }
         val productDetailsParamsList = BillingFlowParams.ProductDetailsParams.newBuilder().apply {

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -765,6 +765,7 @@ class BillingWrapper(
         }
     }
 
+    @SuppressWarnings("ReturnCount")
     private fun createPurchaseParams(
         storeProduct: StoreProduct,
         purchaseOption: PurchaseOption,

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -39,6 +39,7 @@ import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.sha256
 import com.revenuecat.purchases.common.toHumanReadableDescription
+import com.revenuecat.purchases.models.GoogleStoreProduct
 import com.revenuecat.purchases.models.PurchaseOption
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.StoreProduct
@@ -203,6 +204,15 @@ class BillingWrapper(
         replaceSkuInfo: ReplaceSkuInfo?,
         presentedOfferingIdentifier: String?
     ) {
+        val googleProduct = storeProduct.googleProduct
+        if (googleProduct == null) {
+            val errorMessage = "Product must be a Google Product."
+            errorLog(errorMessage)
+            purchasesUpdatedListener?.onPurchasesFailedToUpdate(
+                PurchasesError(PurchasesErrorCode.UnknownError, errorMessage)
+            )
+            return
+        }
         if (replaceSkuInfo != null) {
             log(
                 LogIntent.PURCHASE, PurchaseStrings.UPGRADING_SKU
@@ -217,20 +227,13 @@ class BillingWrapper(
             presentedOfferingsByProductIdentifier[storeProduct.sku] = presentedOfferingIdentifier
         }
         executeRequestOnUIThread {
-            try {
-                val params = createPurchaseParams(
-                    storeProduct,
-                    purchaseOption,
-                    replaceSkuInfo,
-                    appUserID
-                )
-                launchBillingFlow(activity, params)
-            } catch (exception: InvalidProductException) {
-                errorLog("Error creating purchase params to purchase", exception)
-                purchasesUpdatedListener?.onPurchasesFailedToUpdate(
-                    PurchasesError(PurchasesErrorCode.UnknownError, exception.message)
-                )
-            }
+            val params = createPurchaseParams(
+                googleProduct,
+                purchaseOption,
+                replaceSkuInfo,
+                appUserID
+            )
+            launchBillingFlow(activity, params)
         }
     }
 
@@ -772,19 +775,15 @@ class BillingWrapper(
         }
     }
 
-    @SuppressWarnings("ReturnCount")
     private fun createPurchaseParams(
-        storeProduct: StoreProduct,
+        storeProduct: GoogleStoreProduct,
         purchaseOption: PurchaseOption,
         replaceSkuInfo: ReplaceSkuInfo?,
         appUserID: String
     ): BillingFlowParams {
-        val token = purchaseOption.token ?: throw InvalidProductException("PurchaseOption must have a token with BC5.")
-        val googleProduct = storeProduct.googleProduct
-            ?: throw InvalidProductException("Product must be a Google Product.")
         val productDetailsParamsList = BillingFlowParams.ProductDetailsParams.newBuilder().apply {
-            setOfferToken(token)
-            setProductDetails(googleProduct.productDetails)
+            setOfferToken(purchaseOption.token!!)
+            setProductDetails(storeProduct.productDetails)
         }.build()
 
         return BillingFlowParams.newBuilder()
@@ -798,6 +797,4 @@ class BillingWrapper(
             }
             .build()
     }
-
-    private class InvalidProductException(override val message: String) : Exception(message)
 }

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -458,7 +458,7 @@ class BillingWrapperTest {
         assertThat(tokenSlot.isCaptured).isTrue
         assertThat(tokenSlot.captured).isEqualTo("mock-subscription-offer-token")
         assertThat(productDetailsSlot.isCaptured).isTrue
-        assertThat(productDetailsSlot.captured == productDetails)
+        assertThat(productDetailsSlot.captured).isEqualTo(productDetails)
     }
 
     @Test

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -378,7 +378,7 @@ class Purchases internal constructor(
      */
     @Deprecated(
         "Replaced with purchaseProductWithOption",
-        ReplaceWith("purchaseProductWithOption")
+        ReplaceWith("purchaseProductWithOption(activity, storeProduct, purchaseOption, upgradeInfo, listener)")
     )
     fun purchaseProduct(
         activity: Activity,
@@ -410,7 +410,7 @@ class Purchases internal constructor(
      */
     @Deprecated(
         "Replaced with purchaseProductWithOption",
-        ReplaceWith("purchaseProductWithOption")
+        ReplaceWith("purchaseProductWithOption(activity, storeProduct, purchaseOption, callback)")
     )
     fun purchaseProduct(
         activity: Activity,
@@ -478,7 +478,7 @@ class Purchases internal constructor(
      */
     @Deprecated(
         "Replaced with purchasePackageWithOption",
-        ReplaceWith("purchasePackageWithOption")
+        ReplaceWith("purchasePackageWithOption(activity, packageToPurchase, purchaseOption, upgradeInfo, callback)")
     )
     fun purchasePackage(
         activity: Activity,
@@ -510,7 +510,7 @@ class Purchases internal constructor(
      */
     @Deprecated(
         "Replaced with purchasePackageWithOption",
-        ReplaceWith("purchasePackageWithOption")
+        ReplaceWith("purchasePackageWithOption(activity, packageToPurchase, purchaseOption, listener)")
     )
     fun purchasePackage(
         activity: Activity,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.interfaces.ProductChangeCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
+import com.revenuecat.purchases.models.PurchaseOption
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 
@@ -117,6 +118,10 @@ fun Purchases.getOfferingsWith(
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
+@Deprecated(
+    "Replaced with purchaseProductWithOption",
+    ReplaceWith("purchaseProductWithOption(activity, storeProduct, purchaseOption, onError, onSuccess)")
+)
 fun Purchases.purchaseProductWith(
     activity: Activity,
     storeProduct: StoreProduct,
@@ -124,6 +129,29 @@ fun Purchases.purchaseProductWith(
     onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
 ) {
     purchaseProduct(activity, storeProduct, purchaseCompletedCallback(onSuccess, onError))
+}
+
+/**
+ * Purchase product.
+ * @param [activity] Current activity
+ * @param [storeProduct] The storeProduct of the product you wish to purchase
+ * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [onSuccess] Will be called after the purchase has completed
+ * @param [onError] Will be called after the purchase has completed with error
+ */
+fun Purchases.purchaseProductWithOption(
+    activity: Activity,
+    storeProduct: StoreProduct,
+    purchaseOption: PurchaseOption,
+    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
+    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
+) {
+    purchaseProductWithOption(
+        activity,
+        storeProduct,
+        purchaseOption,
+        purchaseCompletedCallback(onSuccess, onError)
+    )
 }
 
 /**
@@ -135,6 +163,10 @@ fun Purchases.purchaseProductWith(
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
+@Deprecated(
+    "Replaced with purchaseProductWithOption",
+    ReplaceWith("purchaseProductWithOption(activity, storeProduct, upgradeInfo, purchaseOption, onError, onSuccess)")
+)
 fun Purchases.purchaseProductWith(
     activity: Activity,
     storeProduct: StoreProduct,
@@ -148,12 +180,45 @@ fun Purchases.purchaseProductWith(
 /**
  * Make a purchase upgrading from a previous sku.
  * @param [activity] Current activity
+ * @param [storeProduct] The storeProduct of the product you wish to purchase
+ * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
+ * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
+ * @param [onSuccess] Will be called after the purchase has completed
+ * @param [onError] Will be called after the purchase has completed with error
+ */
+fun Purchases.purchaseProductWithOption(
+    activity: Activity,
+    storeProduct: StoreProduct,
+    purchaseOption: PurchaseOption,
+    upgradeInfo: UpgradeInfo,
+    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
+    onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
+) {
+    purchaseProductWithOption(
+        activity,
+        storeProduct,
+        purchaseOption,
+        upgradeInfo,
+        productChangeCompletedListener(onSuccess, onError)
+    )
+}
+
+/**
+ * Make a purchase upgrading from a previous sku.
+ * @param [activity] Current activity
  * @param [packageToPurchase] The Package you wish to purchase
  * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
+@Deprecated(
+    "Replaced with purchasePackageWithOption",
+    ReplaceWith(
+        "purchasePackageWithOption(activity, packageToPurchase, upgradeInfo, purchaseOption, onError, onSuccess)"
+    )
+)
 fun Purchases.purchasePackageWith(
     activity: Activity,
     packageToPurchase: Package,
@@ -165,12 +230,44 @@ fun Purchases.purchasePackageWith(
 }
 
 /**
+ * Make a purchase upgrading from a previous sku.
+ * @param [activity] Current activity
+ * @param [packageToPurchase] The Package you wish to purchase
+ * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
+ * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
+ * @param [onSuccess] Will be called after the purchase has completed
+ * @param [onError] Will be called after the purchase has completed with error
+ */
+@SuppressWarnings("LongParameterList")
+fun Purchases.purchasePackageWithOption(
+    activity: Activity,
+    packageToPurchase: Package,
+    purchaseOption: PurchaseOption,
+    upgradeInfo: UpgradeInfo,
+    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
+    onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
+) {
+    purchasePackageWithOption(
+        activity,
+        packageToPurchase,
+        purchaseOption,
+        upgradeInfo,
+        productChangeCompletedListener(onSuccess, onError)
+    )
+}
+
+/**
  * Make a purchase.
  * @param [activity] Current activity
  * @param [packageToPurchase] The Package you wish to purchase
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
+@Deprecated(
+    "Replaced with purchasePackageWithOption",
+    ReplaceWith("purchasePackageWithOption(activity, packageToPurchase, purchaseOption, onError, onSuccess)")
+)
 fun Purchases.purchasePackageWith(
     activity: Activity,
     packageToPurchase: Package,
@@ -178,6 +275,29 @@ fun Purchases.purchasePackageWith(
     onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
 ) {
     purchasePackage(activity, packageToPurchase, purchaseCompletedCallback(onSuccess, onError))
+}
+
+/**
+ * Make a purchase.
+ * @param [activity] Current activity
+ * @param [packageToPurchase] The Package you wish to purchase
+ * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [onSuccess] Will be called after the purchase has completed
+ * @param [onError] Will be called after the purchase has completed with error
+ */
+fun Purchases.purchasePackageWithOption(
+    activity: Activity,
+    packageToPurchase: Package,
+    purchaseOption: PurchaseOption,
+    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
+    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
+) {
+    purchasePackageWithOption(
+        activity,
+        packageToPurchase,
+        purchaseOption,
+        purchaseCompletedCallback(onSuccess, onError)
+    )
 }
 
 /**

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.SubscriberAttributeError
 import com.revenuecat.purchases.common.buildCustomerInfo
 import com.revenuecat.purchases.google.BillingWrapper
+import com.revenuecat.purchases.google.toStoreProduct
 import com.revenuecat.purchases.google.toStoreTransaction
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
@@ -18,6 +19,7 @@ import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.toBackendMap
 import com.revenuecat.purchases.utils.Responses
 import com.revenuecat.purchases.utils.SyncDispatcher
+import com.revenuecat.purchases.utils.mockProductDetails
 import com.revenuecat.purchases.utils.stubGooglePurchase
 import io.mockk.clearMocks
 import io.mockk.every
@@ -158,14 +160,7 @@ class PostingTransactionsTests {
         val expectedSubscriptionPeriod = "P1M"
         val expectedIntroPricePeriod = "P2M"
         val expectedFreeTrialPeriod = "P3M"
-        val mockStoreProduct = mockk<StoreProduct>().also {
-            every { it.sku } returns "product_id"
-            every { it.priceAmountMicros } returns 2000000
-            every { it.priceCurrencyCode } returns "USD"
-            every { it.subscriptionPeriod } returns expectedSubscriptionPeriod
-            every { it.introductoryPricePeriod } returns expectedIntroPricePeriod
-            every { it.freeTrialPeriod } returns expectedFreeTrialPeriod
-        }
+        val mockStoreProduct = createStoreProductWithoutOffers("product_id")
         underTest.postToBackend(
             purchase = mockk(relaxed = true),
             storeProduct = mockStoreProduct,
@@ -175,7 +170,7 @@ class PostingTransactionsTests {
             onSuccess = { _, _ -> },
             onError = { _, _ -> }
         )
-        assertThat(postedProductInfoSlot.isCaptured).isTrue()
+        assertThat(postedProductInfoSlot.isCaptured).isTrue
         assertThat(postedProductInfoSlot.captured.duration).isEqualTo(expectedSubscriptionPeriod)
         assertThat(postedProductInfoSlot.captured.introDuration).isEqualTo(expectedIntroPricePeriod)
         assertThat(postedProductInfoSlot.captured.trialDuration).isEqualTo(expectedFreeTrialPeriod)
@@ -199,14 +194,7 @@ class PostingTransactionsTests {
     fun `inapps send null durations when posting to backend`() {
         postReceiptSuccess = PostReceiptCompletionContainer()
 
-        val mockStoreProduct = mockk<StoreProduct>().also {
-            every { it.sku } returns "product_id"
-            every { it.priceAmountMicros } returns 2000000
-            every { it.priceCurrencyCode } returns "USD"
-            every { it.subscriptionPeriod } returns ""
-            every { it.introductoryPricePeriod } returns ""
-            every { it.freeTrialPeriod } returns ""
-        }
+        val mockStoreProduct = createStoreProductWithoutOffers("product_id")
         underTest.postToBackend(
             purchase = mockk(relaxed = true),
             storeProduct = mockStoreProduct,
@@ -216,7 +204,7 @@ class PostingTransactionsTests {
             onSuccess = { _, _ -> },
             onError = { _, _ -> }
         )
-        assertThat(postedProductInfoSlot.isCaptured).isTrue()
+        assertThat(postedProductInfoSlot.isCaptured).isTrue
         assertThat(postedProductInfoSlot.captured.duration).isNull()
         assertThat(postedProductInfoSlot.captured.introDuration).isNull()
         assertThat(postedProductInfoSlot.captured.trialDuration).isNull()
@@ -240,14 +228,7 @@ class PostingTransactionsTests {
     fun `store user id is sent when posting to backend`() {
         postReceiptSuccess = PostReceiptCompletionContainer()
 
-        val mockStoreProduct = mockk<StoreProduct>().also {
-            every { it.sku } returns "product_id"
-            every { it.priceAmountMicros } returns 2000000
-            every { it.priceCurrencyCode } returns "USD"
-            every { it.subscriptionPeriod } returns ""
-            every { it.introductoryPricePeriod } returns ""
-            every { it.freeTrialPeriod } returns ""
-        }
+        val mockStoreProduct = createStoreProductWithoutOffers("product_id")
         val purchase: StoreTransaction = mockk(relaxed = true)
         val expectedStoreUserID = "a_store_user_id"
         every {
@@ -263,7 +244,7 @@ class PostingTransactionsTests {
             onSuccess = { _, _ -> },
             onError = { _, _ -> }
         )
-        assertThat(postedProductInfoSlot.isCaptured).isTrue()
+        assertThat(postedProductInfoSlot.isCaptured).isTrue
         assertThat(postedProductInfoSlot.captured.duration).isNull()
         assertThat(postedProductInfoSlot.captured.introDuration).isNull()
         assertThat(postedProductInfoSlot.captured.trialDuration).isNull()
@@ -289,14 +270,7 @@ class PostingTransactionsTests {
         val productIds = listOf("uno", "dos")
         val purchase =
             stubGooglePurchase(productIds = productIds).toStoreTransaction(ProductType.SUBS, null)
-        val mockStoreProduct = mockk<StoreProduct>().also {
-            every { it.sku } returns "uno"
-            every { it.priceAmountMicros } returns 2000000
-            every { it.priceCurrencyCode } returns "USD"
-            every { it.subscriptionPeriod } returns ""
-            every { it.introductoryPricePeriod } returns ""
-            every { it.freeTrialPeriod } returns ""
-        }
+        val mockStoreProduct = createStoreProductWithoutOffers("uno")
 
         underTest.postToBackend(
             purchase = purchase,
@@ -307,7 +281,7 @@ class PostingTransactionsTests {
             onSuccess = { _, _ -> },
             onError = { _, _ -> }
         )
-        assertThat(postedProductInfoSlot.isCaptured).isTrue()
+        assertThat(postedProductInfoSlot.isCaptured).isTrue
         assertThat(postedProductInfoSlot.captured.productIDs).isEqualTo(productIds)
         verify(exactly = 1) {
             backendMock.postReceiptData(
@@ -330,14 +304,7 @@ class PostingTransactionsTests {
         val productIds = listOf("uno", "dos")
         val purchase =
             stubGooglePurchase(productIds = productIds).toStoreTransaction(ProductType.SUBS, null)
-        val mockStoreProduct = mockk<StoreProduct>().also {
-            every { it.sku } returns "uno"
-            every { it.priceAmountMicros } returns 2000000
-            every { it.priceCurrencyCode } returns "USD"
-            every { it.subscriptionPeriod } returns ""
-            every { it.introductoryPricePeriod } returns ""
-            every { it.freeTrialPeriod } returns ""
-        }
+        val mockStoreProduct = createStoreProductWithoutOffers("uno")
 
         underTest.postToBackend(
             purchase = purchase,
@@ -355,5 +322,13 @@ class PostingTransactionsTests {
         verify(exactly = 1) {
             customerInfoHelperMock.sendUpdatedCustomerInfoToDelegateIfChanged(any())
         }
+    }
+
+    private fun createStoreProductWithoutOffers(productId: String = "sample_product_id"): StoreProduct {
+        val productDetails = mockProductDetails(productId = productId)
+        return productDetails.toStoreProduct(
+            productDetails.subscriptionOfferDetails!![0],
+            productDetails.subscriptionOfferDetails!!
+        )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -52,7 +52,6 @@ import com.revenuecat.purchases.utils.Responses
 import com.revenuecat.purchases.utils.SyncDispatcher
 import com.revenuecat.purchases.utils.createMockOneTimeProductDetails
 import com.revenuecat.purchases.utils.createMockProductDetailsFreeTrial
-import com.revenuecat.purchases.utils.mockOneTimePurchaseOfferDetails
 import com.revenuecat.purchases.utils.mockProductDetails
 import com.revenuecat.purchases.utils.stubGooglePurchase
 import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
@@ -254,6 +253,28 @@ class PurchasesTest {
     fun canMakePurchase() {
         val storeProduct = createStoreProductWithoutOffers()
 
+        purchases.purchaseProductWithOption(
+            mockActivity,
+            storeProduct,
+            storeProduct.purchaseOptions[0]
+        ) { _, _ -> }
+
+        verify {
+            mockBillingAbstract.makePurchaseAsync(
+                eq(mockActivity),
+                eq(appUserId),
+                storeProduct,
+                storeProduct.purchaseOptions[0],
+                null,
+                null
+            )
+        }
+    }
+
+    @Test
+    fun canMakePurchaseWithoutProvidingOption() {
+        val storeProduct = createStoreProductWithoutOffers()
+
         purchases.purchaseProductWith(
             mockActivity,
             storeProduct
@@ -275,6 +296,28 @@ class PurchasesTest {
     fun canMakePurchaseOfAPackage() {
         val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
 
+        purchases.purchasePackageWithOption(
+            mockActivity,
+            offerings[stubOfferingIdentifier]!!.monthly!!,
+            storeProduct.purchaseOptions[0],
+        ) { _, _ -> }
+
+        verify {
+            mockBillingAbstract.makePurchaseAsync(
+                eq(mockActivity),
+                eq(appUserId),
+                storeProduct,
+                storeProduct.purchaseOptions[0],
+                null,
+                stubOfferingIdentifier
+            )
+        }
+    }
+
+    @Test
+    fun canMakePurchaseOfAPackageWithoutProvidingOption() {
+        val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
+
         purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!
@@ -294,6 +337,31 @@ class PurchasesTest {
 
     @Test
     fun canMakePurchaseUpgradeOfAPackage() {
+        val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
+
+        val oldPurchase = mockPurchaseFound()
+
+        purchases.purchasePackageWithOption(
+            mockActivity,
+            offerings[stubOfferingIdentifier]!!.monthly!!,
+            storeProduct.purchaseOptions[0],
+            UpgradeInfo(oldPurchase.skus[0])
+        ) { _, _ -> }
+
+        verify {
+            mockBillingAbstract.makePurchaseAsync(
+                eq(mockActivity),
+                eq(appUserId),
+                storeProduct,
+                storeProduct.purchaseOptions[0],
+                ReplaceSkuInfo(oldPurchase),
+                stubOfferingIdentifier
+            )
+        }
+    }
+
+    @Test
+    fun canMakePurchaseUpgradeOfAPackageWithoutProvidingOption() {
         val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
 
         val oldPurchase = mockPurchaseFound()
@@ -436,9 +504,10 @@ class PurchasesTest {
     fun passesUpErrors() {
         var errorCalled = false
         val storeProduct = createStoreProductWithoutOffers()
-        purchases.purchaseProductWith(
+        purchases.purchaseProductWithOption(
             mockk(),
             storeProduct,
+            storeProduct.purchaseOptions[0],
             onError = { error, _ ->
                 errorCalled = true
                 assertThat(error.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
@@ -1457,17 +1526,19 @@ class PurchasesTest {
         purchases.updatedCustomerInfoListener = updatedCustomerInfoListener
 
         val storeProduct = createStoreProductWithoutOffers()
-        purchases.purchaseProductWith(
+        purchases.purchaseProductWithOption(
             mockk(),
             storeProduct,
+            storeProduct.purchaseOptions[0],
             onError = { _, _ -> fail("Should be success") }) { _, _ ->
             // First one works
         }
 
         var errorCalled: PurchasesError? = null
-        purchases.purchaseProductWith(
+        purchases.purchaseProductWithOption(
             mockk(),
             storeProduct,
+            storeProduct.purchaseOptions[0],
             onError = { error, _ ->
                 errorCalled = error
             }) { _, _ ->
@@ -1487,9 +1558,10 @@ class PurchasesTest {
         val storeProduct = createStoreProductWithoutOffers(productId)
 
         var callCount = 0
-        purchases.purchaseProductWith(
+        purchases.purchaseProductWithOption(
             mockActivity,
             storeProduct,
+            storeProduct.purchaseOptions[0],
             onSuccess = { _, _ ->
                 callCount++
             }, onError = { _, _ -> fail("should be successful") })
@@ -1511,9 +1583,11 @@ class PurchasesTest {
         val purchaseToken1 = "crazy_purchase_token_1"
         var callCount = 0
         mockQueryingSkuDetails(productId1, ProductType.SUBS, null)
-        purchases.purchaseProductWith(
+        val storeProduct = createStoreProductWithoutOffers(productId)
+        purchases.purchaseProductWithOption(
             mockActivity,
-            createStoreProductWithoutOffers(productId),
+            storeProduct,
+            storeProduct.purchaseOptions[0],
             onSuccess = { _, _ ->
                 callCount++
             }, onError = { _, _ -> fail("should be successful") })
@@ -1527,14 +1601,17 @@ class PurchasesTest {
 
     @Test
     fun `when multiple make purchase callbacks, a failure doesn't throw ConcurrentModificationException`() {
-        purchases.purchaseProductWith(
+        val storeProduct = createStoreProductWithoutOffers("productId")
+        purchases.purchaseProductWithOption(
             mockActivity,
-            createStoreProductWithoutOffers("productId")
+            storeProduct,
+            storeProduct.purchaseOptions[0]
         ) { _, _ -> }
 
-        purchases.purchaseProductWith(
+        purchases.purchaseProductWithOption(
             mockActivity,
-            createStoreProductWithoutOffers("productId")
+            storeProduct,
+            storeProduct.purchaseOptions[0]
         ) { _, _ -> }
 
         try {
@@ -3383,9 +3460,10 @@ class PurchasesTest {
 
         var receivedError: PurchasesError? = null
         var receivedUserCancelled: Boolean? = null
-        purchases.purchasePackageWith(
+        purchases.purchasePackageWithOption(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
+            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.skus[0]),
             onError = { error, userCancelled ->
                 receivedError = error
@@ -3439,9 +3517,10 @@ class PurchasesTest {
 
         var receivedError: PurchasesError? = null
         var receivedUserCancelled: Boolean? = null
-        purchases.purchasePackageWith(
+        purchases.purchasePackageWithOption(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
+            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.skus[0]),
             onError = { error, userCancelled ->
                 receivedError = error
@@ -3467,7 +3546,7 @@ class PurchasesTest {
 
     @Test
     fun `Deferred downgrade`() {
-        val (_, offerings) = stubOfferings("onemonth_freetrial")
+        val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
 
         val oldPurchase = mockk<StoreTransaction>()
         every { oldPurchase.skus[0] } returns "oldSku"
@@ -3485,9 +3564,10 @@ class PurchasesTest {
             lambda<(StoreTransaction) -> Unit>().captured.invoke(oldPurchase)
         }
 
-        purchases.purchasePackageWith(
+        purchases.purchasePackageWithOption(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
+            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.skus[0])
         ) { _, _ -> }
 
@@ -3658,9 +3738,10 @@ class PurchasesTest {
 
         var callCount = 0
 
-        purchases.purchaseProductWith(
+        purchases.purchaseProductWithOption(
             mockActivity,
             receiptInfo.storeProduct!!,
+            receiptInfo.storeProduct!!.purchaseOptions[0],
             UpgradeInfo(oldPurchase.skus[0]),
             onError = { _, _ ->
                 fail("should be successful")
@@ -3683,9 +3764,10 @@ class PurchasesTest {
         val oldPurchase = mockPurchaseFound()
 
         var callCount = 0
-        purchases.purchaseProductWith(
+        purchases.purchaseProductWithOption(
             mockActivity,
             receiptInfo.storeProduct!!,
+            receiptInfo.storeProduct!!.purchaseOptions[0],
             UpgradeInfo(oldPurchase.skus[0]),
             onError = { _, _ ->
                 fail("should be success")
@@ -3716,9 +3798,10 @@ class PurchasesTest {
         var receivedError: PurchasesError? = null
         var receivedUserCancelled: Boolean? = null
 
-        purchases.purchaseProductWith(
+        purchases.purchaseProductWithOption(
             mockActivity,
             receiptInfo.storeProduct!!,
+            receiptInfo.storeProduct!!.purchaseOptions[0],
             UpgradeInfo(oldPurchase.skus[0]),
             onError = { purchaseError, userCancelled ->
                 receivedError = purchaseError
@@ -3743,9 +3826,10 @@ class PurchasesTest {
         var receivedError: PurchasesError? = null
         var receivedUserCancelled: Boolean? = null
 
-        purchases.purchaseProductWith(
+        purchases.purchaseProductWithOption(
             mockActivity,
             receiptInfo.storeProduct!!,
+            receiptInfo.storeProduct!!.purchaseOptions[0],
             UpgradeInfo(oldPurchase.skus[0]),
             onError = { error, userCancelled ->
                 receivedError = error
@@ -3767,7 +3851,7 @@ class PurchasesTest {
     fun `when purchasing a package with upgrade info, completion block is called`() {
         val sku = "onemonth_freetrial"
 
-        val (_, offerings) = stubOfferings(sku)
+        val (storeProduct, offerings) = stubOfferings(sku)
         mockQueryingSkuDetails(sku, ProductType.SUBS, null)
 
         val purchaseToken = "crazy_purchase_token"
@@ -3776,9 +3860,10 @@ class PurchasesTest {
 
         var callCount = 0
 
-        purchases.purchasePackageWith(
+        purchases.purchasePackageWithOption(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
+            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.skus[0]),
             onError = { _, _ ->
                 fail("should be successful")
@@ -3799,15 +3884,16 @@ class PurchasesTest {
     @Test
     fun `when purchasing a package with upgrade info, completion is called with null purchase if product change is deferred`() {
         val sku = "onemonth_freetrial"
-        val (_, offerings) = stubOfferings(sku)
+        val (storeProduct, offerings) = stubOfferings(sku)
 
         val oldPurchase = mockPurchaseFound()
 
         var callCount = 0
 
-        purchases.purchasePackageWith(
+        purchases.purchasePackageWithOption(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
+            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.skus[0]),
             onError = { _, _ ->
                 fail("should be success")
@@ -3823,7 +3909,7 @@ class PurchasesTest {
     @Test
     fun `when purchasing a package with upgrade info, error is forwarded`() {
         val sku = "onemonth_freetrial"
-        val (_, offerings) = stubOfferings(sku)
+        val (storeProduct, offerings) = stubOfferings(sku)
 
         mockQueryingSkuDetails(sku, ProductType.SUBS, null)
 
@@ -3838,9 +3924,10 @@ class PurchasesTest {
 
         var receivedError: PurchasesError? = null
         var receivedUserCancelled: Boolean? = null
-        purchases.purchasePackageWith(
+        purchases.purchasePackageWithOption(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
+            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.skus[0]),
             onError = { error, userCancelled ->
                 receivedError = error
@@ -3857,15 +3944,16 @@ class PurchasesTest {
     @Test
     fun `when purchasing a package with upgrade info, failures purchasing are forwarded`() {
         val sku = "onemonth_freetrial"
-        val (_, offerings) = stubOfferings(sku)
+        val (storeProduct, offerings) = stubOfferings(sku)
 
         val oldPurchase = mockPurchaseFound()
 
         var receivedError: PurchasesError? = null
         var receivedUserCancelled: Boolean? = null
-        purchases.purchasePackageWith(
+        purchases.purchasePackageWithOption(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
+            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.skus[0]),
             onError = { error, userCancelled ->
                 receivedError = error

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -31,6 +31,7 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
+import com.revenuecat.purchases.google.isBasePlan
 import com.revenuecat.purchases.google.toGoogleProductType
 import com.revenuecat.purchases.google.toStoreProduct
 import com.revenuecat.purchases.google.toStoreTransaction
@@ -123,7 +124,7 @@ class PurchasesTest {
         "'description': 'This is the base offering', " +
         "'packages': [" +
         "{'identifier': '\$rc_monthly','platform_product_identifier': '$stubProductIdentifier'," +
-        "'platform_product_group_identifier': '$stubProductGroupIdentifier'}]}]," +
+        "'platform_product_group_identifier': '$stubProductGroupIdentifier','product_duration': 'P1M'}]}]," +
         "'current_offering_id': '$stubOfferingIdentifier'}"
     private val oneOfferingWithNoProductsResponse = "{'offerings': [" +
         "{'identifier': '$stubOfferingIdentifier', " +
@@ -4190,7 +4191,7 @@ class PurchasesTest {
             else createMockOneTimeProductDetails(sku, 2.00)
 
         val storeProduct = if (type == ProductType.SUBS) productDetails.toStoreProduct(
-            productDetails.subscriptionOfferDetails!![1],
+            productDetails.subscriptionOfferDetails!!.first { it.isBasePlan },
             productDetails.subscriptionOfferDetails!!
         ) else productDetails.toStoreProduct()
 

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/billingClientStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/billingClientStubs.kt
@@ -1,3 +1,4 @@
+@file:Suppress("TooManyFunctions")
 package com.revenuecat.purchases.utils
 
 import com.android.billingclient.api.BillingClient
@@ -115,6 +116,13 @@ fun createMockProductDetailsFreeTrial(
                 )
             )
         )
+    )
+)
+fun createMockOneTimeProductDetails(productId: String, price: Double = 4.99): ProductDetails = mockProductDetails(
+    productId = productId,
+    type = BillingClient.ProductType.INAPP,
+    oneTimePurchaseOfferDetails = mockOneTimePurchaseOfferDetails(
+        price = price
     )
 )
 

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/billingClientStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/billingClientStubs.kt
@@ -28,7 +28,7 @@ fun mockProductDetails(
     productId: String = "sample_product_id",
     @BillingClient.ProductType type: String = BillingClient.ProductType.SUBS,
     oneTimePurchaseOfferDetails: OneTimePurchaseOfferDetails? = null,
-    subscriptionOfferDetails: List<SubscriptionOfferDetails> = listOf(mockSubscriptionOfferDetails()),
+    subscriptionOfferDetails: List<SubscriptionOfferDetails>? = listOf(mockSubscriptionOfferDetails()),
     name: String = "subscription_mock_name",
     description: String = "subscription_mock_description",
     title: String = "subscription_mock_title"
@@ -123,7 +123,8 @@ fun createMockOneTimeProductDetails(productId: String, price: Double = 4.99): Pr
     type = BillingClient.ProductType.INAPP,
     oneTimePurchaseOfferDetails = mockOneTimePurchaseOfferDetails(
         price = price
-    )
+    ),
+    subscriptionOfferDetails = null
 )
 
 @SuppressWarnings("LongParameterList", "MagicNumber")


### PR DESCRIPTION
### Description
In this PR we:
- Fix issue where we weren't calling the listener if we had errors when launching the billing flow.
- Fix tests in `PurchaseTests` related to the changes in #662 .
- Fix a couple of detekt issues.
- Add some new tests to `BillingWrapperTests`

