### PR TITLE
Bc5 add new listener helper methods

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -29,7 +29,9 @@ import com.revenuecat.purchases.models.PurchaseOption
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.purchasePackageWith
+import com.revenuecat.purchases.purchasePackageWithOption
 import com.revenuecat.purchases.purchaseProductWith
+import com.revenuecat.purchases.purchaseProductWithOption
 import com.revenuecat.purchases.restorePurchasesWith
 import java.net.URL
 import java.util.concurrent.ExecutorService
@@ -124,6 +126,7 @@ private class PurchasesAPI {
         activity: Activity,
         packageToPurchase: Package,
         storeProduct: StoreProduct,
+        purchaseOption: PurchaseOption,
         upgradeInfo: UpgradeInfo
     ) {
         purchases.getOfferingsWith(
@@ -153,6 +156,36 @@ private class PurchasesAPI {
         purchases.purchasePackageWith(
             activity,
             packageToPurchase,
+            onError = { _: PurchasesError, _: Boolean -> },
+            onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
+        )
+        purchases.purchaseProductWithOption(
+            activity,
+            storeProduct,
+            purchaseOption,
+            onError = { _: PurchasesError, _: Boolean -> },
+            onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
+        )
+        purchases.purchaseProductWithOption(
+            activity,
+            storeProduct,
+            purchaseOption,
+            upgradeInfo,
+            onError = { _: PurchasesError, _: Boolean -> },
+            onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
+        )
+        purchases.purchasePackageWithOption(
+            activity,
+            packageToPurchase,
+            purchaseOption,
+            upgradeInfo,
+            onError = { _: PurchasesError, _: Boolean -> },
+            onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
+        )
+        purchases.purchasePackageWithOption(
+            activity,
+            packageToPurchase,
+            purchaseOption,
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
         )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -378,7 +378,7 @@ class Purchases internal constructor(
      */
     @Deprecated(
         "Replaced with purchaseProductWithOption",
-        ReplaceWith("purchaseProductWithOption")
+        ReplaceWith("purchaseProductWithOption(activity, storeProduct, purchaseOption, upgradeInfo, listener)")
     )
     fun purchaseProduct(
         activity: Activity,
@@ -410,7 +410,7 @@ class Purchases internal constructor(
      */
     @Deprecated(
         "Replaced with purchaseProductWithOption",
-        ReplaceWith("purchaseProductWithOption")
+        ReplaceWith("purchaseProductWithOption(activity, storeProduct, purchaseOption, callback)")
     )
     fun purchaseProduct(
         activity: Activity,
@@ -478,7 +478,7 @@ class Purchases internal constructor(
      */
     @Deprecated(
         "Replaced with purchasePackageWithOption",
-        ReplaceWith("purchasePackageWithOption")
+        ReplaceWith("purchasePackageWithOption(activity, packageToPurchase, purchaseOption, upgradeInfo, callback)")
     )
     fun purchasePackage(
         activity: Activity,
@@ -510,7 +510,7 @@ class Purchases internal constructor(
      */
     @Deprecated(
         "Replaced with purchasePackageWithOption",
-        ReplaceWith("purchasePackageWithOption")
+        ReplaceWith("purchasePackageWithOption(activity, packageToPurchase, purchaseOption, listener)")
     )
     fun purchasePackage(
         activity: Activity,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.interfaces.ProductChangeCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
+import com.revenuecat.purchases.models.PurchaseOption
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 
@@ -117,6 +118,10 @@ fun Purchases.getOfferingsWith(
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
+@Deprecated(
+    "Replaced with purchaseProductWithOption",
+    ReplaceWith("purchaseProductWithOption")
+)
 fun Purchases.purchaseProductWith(
     activity: Activity,
     storeProduct: StoreProduct,
@@ -124,6 +129,29 @@ fun Purchases.purchaseProductWith(
     onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
 ) {
     purchaseProduct(activity, storeProduct, purchaseCompletedCallback(onSuccess, onError))
+}
+
+/**
+ * Purchase product.
+ * @param [activity] Current activity
+ * @param [storeProduct] The storeProduct of the product you wish to purchase
+ * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [onSuccess] Will be called after the purchase has completed
+ * @param [onError] Will be called after the purchase has completed with error
+ */
+fun Purchases.purchaseProductWithOption(
+    activity: Activity,
+    storeProduct: StoreProduct,
+    purchaseOption: PurchaseOption,
+    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
+    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
+) {
+    purchaseProductWithOption(
+        activity,
+        storeProduct,
+        purchaseOption,
+        purchaseCompletedCallback(onSuccess, onError)
+    )
 }
 
 /**
@@ -135,6 +163,10 @@ fun Purchases.purchaseProductWith(
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
+@Deprecated(
+    "Replaced with purchaseProductWithOption",
+    ReplaceWith("purchaseProductWithOption")
+)
 fun Purchases.purchaseProductWith(
     activity: Activity,
     storeProduct: StoreProduct,
@@ -148,12 +180,43 @@ fun Purchases.purchaseProductWith(
 /**
  * Make a purchase upgrading from a previous sku.
  * @param [activity] Current activity
+ * @param [storeProduct] The storeProduct of the product you wish to purchase
+ * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
+ * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
+ * @param [onSuccess] Will be called after the purchase has completed
+ * @param [onError] Will be called after the purchase has completed with error
+ */
+fun Purchases.purchaseProductWithOption(
+    activity: Activity,
+    storeProduct: StoreProduct,
+    purchaseOption: PurchaseOption,
+    upgradeInfo: UpgradeInfo,
+    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
+    onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
+) {
+    purchaseProductWithOption(
+        activity,
+        storeProduct,
+        purchaseOption,
+        upgradeInfo,
+        productChangeCompletedListener(onSuccess, onError)
+    )
+}
+
+/**
+ * Make a purchase upgrading from a previous sku.
+ * @param [activity] Current activity
  * @param [packageToPurchase] The Package you wish to purchase
  * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
+@Deprecated(
+    "Replaced with purchasePackageWithOption",
+    ReplaceWith("purchasePackageWithOption")
+)
 fun Purchases.purchasePackageWith(
     activity: Activity,
     packageToPurchase: Package,
@@ -165,12 +228,44 @@ fun Purchases.purchasePackageWith(
 }
 
 /**
+ * Make a purchase upgrading from a previous sku.
+ * @param [activity] Current activity
+ * @param [packageToPurchase] The Package you wish to purchase
+ * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
+ * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
+ * @param [onSuccess] Will be called after the purchase has completed
+ * @param [onError] Will be called after the purchase has completed with error
+ */
+@SuppressWarnings("LongParameterList")
+fun Purchases.purchasePackageWithOption(
+    activity: Activity,
+    packageToPurchase: Package,
+    purchaseOption: PurchaseOption,
+    upgradeInfo: UpgradeInfo,
+    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
+    onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
+) {
+    purchasePackageWithOption(
+        activity,
+        packageToPurchase,
+        purchaseOption,
+        upgradeInfo,
+        productChangeCompletedListener(onSuccess, onError)
+    )
+}
+
+/**
  * Make a purchase.
  * @param [activity] Current activity
  * @param [packageToPurchase] The Package you wish to purchase
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
+@Deprecated(
+    "Replaced with purchasePackageWithOption",
+    ReplaceWith("purchasePackageWithOption")
+)
 fun Purchases.purchasePackageWith(
     activity: Activity,
     packageToPurchase: Package,
@@ -178,6 +273,29 @@ fun Purchases.purchasePackageWith(
     onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
 ) {
     purchasePackage(activity, packageToPurchase, purchaseCompletedCallback(onSuccess, onError))
+}
+
+/**
+ * Make a purchase.
+ * @param [activity] Current activity
+ * @param [packageToPurchase] The Package you wish to purchase
+ * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [onSuccess] Will be called after the purchase has completed
+ * @param [onError] Will be called after the purchase has completed with error
+ */
+fun Purchases.purchasePackageWithOption(
+    activity: Activity,
+    packageToPurchase: Package,
+    purchaseOption: PurchaseOption,
+    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
+    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
+) {
+    purchasePackageWithOption(
+        activity,
+        packageToPurchase,
+        purchaseOption,
+        purchaseCompletedCallback(onSuccess, onError)
+    )
 }
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -120,7 +120,7 @@ fun Purchases.getOfferingsWith(
  */
 @Deprecated(
     "Replaced with purchaseProductWithOption",
-    ReplaceWith("purchaseProductWithOption")
+    ReplaceWith("purchaseProductWithOption(activity, storeProduct, purchaseOption, onError, onSuccess)")
 )
 fun Purchases.purchaseProductWith(
     activity: Activity,
@@ -165,7 +165,7 @@ fun Purchases.purchaseProductWithOption(
  */
 @Deprecated(
     "Replaced with purchaseProductWithOption",
-    ReplaceWith("purchaseProductWithOption")
+    ReplaceWith("purchaseProductWithOption(activity, storeProduct, upgradeInfo, purchaseOption, onError, onSuccess)")
 )
 fun Purchases.purchaseProductWith(
     activity: Activity,
@@ -215,7 +215,9 @@ fun Purchases.purchaseProductWithOption(
  */
 @Deprecated(
     "Replaced with purchasePackageWithOption",
-    ReplaceWith("purchasePackageWithOption")
+    ReplaceWith(
+        "purchasePackageWithOption(activity, packageToPurchase, upgradeInfo, purchaseOption, onError, onSuccess)"
+    )
 )
 fun Purchases.purchasePackageWith(
     activity: Activity,
@@ -264,7 +266,7 @@ fun Purchases.purchasePackageWithOption(
  */
 @Deprecated(
     "Replaced with purchasePackageWithOption",
-    ReplaceWith("purchasePackageWithOption")
+    ReplaceWith("purchasePackageWithOption(activity, packageToPurchase, purchaseOption, onError, onSuccess)")
 )
 fun Purchases.purchasePackageWith(
     activity: Activity,

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -271,6 +271,27 @@ class PurchasesTest {
     }
 
     @Test
+    fun canMakePurchaseWithoutProvidingOption() {
+        val storeProduct = createStoreProductWithoutOffers()
+
+        purchases.purchaseProductWith(
+            mockActivity,
+            storeProduct
+        ) { _, _ -> }
+
+        verify {
+            mockBillingAbstract.makePurchaseAsync(
+                eq(mockActivity),
+                eq(appUserId),
+                storeProduct,
+                storeProduct.purchaseOptions[0],
+                null,
+                null
+            )
+        }
+    }
+
+    @Test
     fun canMakePurchaseOfAPackage() {
         val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
 
@@ -278,6 +299,27 @@ class PurchasesTest {
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
             storeProduct.purchaseOptions[0],
+        ) { _, _ -> }
+
+        verify {
+            mockBillingAbstract.makePurchaseAsync(
+                eq(mockActivity),
+                eq(appUserId),
+                storeProduct,
+                storeProduct.purchaseOptions[0],
+                null,
+                stubOfferingIdentifier
+            )
+        }
+    }
+
+    @Test
+    fun canMakePurchaseOfAPackageWithoutProvidingOption() {
+        val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
+
+        purchases.purchasePackageWith(
+            mockActivity,
+            offerings[stubOfferingIdentifier]!!.monthly!!
         ) { _, _ -> }
 
         verify {
@@ -302,6 +344,30 @@ class PurchasesTest {
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
             storeProduct.purchaseOptions[0],
+            UpgradeInfo(oldPurchase.skus[0])
+        ) { _, _ -> }
+
+        verify {
+            mockBillingAbstract.makePurchaseAsync(
+                eq(mockActivity),
+                eq(appUserId),
+                storeProduct,
+                storeProduct.purchaseOptions[0],
+                ReplaceSkuInfo(oldPurchase),
+                stubOfferingIdentifier
+            )
+        }
+    }
+
+    @Test
+    fun canMakePurchaseUpgradeOfAPackageWithoutProvidingOption() {
+        val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
+
+        val oldPurchase = mockPurchaseFound()
+
+        purchases.purchasePackageWith(
+            mockActivity,
+            offerings[stubOfferingIdentifier]!!.monthly!!,
             UpgradeInfo(oldPurchase.skus[0])
         ) { _, _ -> }
 


### PR DESCRIPTION
### Description
This PR follows up on #662 to add the new API to the listener helper methods in Kotlin. This also moves the tests currently using those helper methods to use the new ones, though we have still added some to keep coverage on the deprecated methods.