### PR TITLE
[BC5] Fix DeviceCacheTest

### DIFF
--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -399,7 +399,9 @@ class DeviceCacheTest {
             "custom",
             PackageType.CUSTOM,
             storeProduct,
-            "offering_a"
+            "offering_a",
+            "P4M",
+            "onemonth_freetrial"
         )
         val offering = Offering(
             "offering_a",


### PR DESCRIPTION
Went through all the other tests and besides the ones that are broken due to `/receipt` needing some work, this was the one left. I was going to write some more tests but updating to BillingClient 5.1 will change some of the current code, so the tests will break again