### PR TITLE
[BC5] Support PurchaseOptions in purchase tester app

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -15,6 +15,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.getCustomerInfoWith
+import com.revenuecat.purchases.models.PurchaseOption
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.purchasePackageOptionWith
 import com.revenuecat.purchases.purchaseProductOptionWith
@@ -57,14 +58,13 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         return binding.root
     }
 
-    override fun onPurchasePackageClicked(cardView: View, currentPackage: Package) {
+    override fun onPurchasePackageClicked(cardView: View, currentPackage: Package, purchaseOption: PurchaseOption?) {
         binding.purchaseProgress.visibility = View.VISIBLE
-        val basePlanOption = currentPackage.product.purchaseOptions.first { it.isBasePlan }
 
         Purchases.sharedInstance.purchasePackageOptionWith(
             requireActivity(),
             currentPackage,
-            basePlanOption,
+            purchaseOption!!, // TODOBC5: Fix API for OTP
             { error, userCancelled ->
                 if (!userCancelled) {
                     showUserError(requireActivity(), error)
@@ -75,14 +75,17 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
             })
     }
 
-    override fun onPurchaseProductClicked(cardView: View, currentProduct: StoreProduct) {
+    override fun onPurchaseProductClicked(
+        cardView: View,
+        currentProduct: StoreProduct,
+        purchaseOption: PurchaseOption?
+    ) {
         binding.purchaseProgress.visibility = View.VISIBLE
 
-        val basePlan = currentProduct.purchaseOptions.first { it.isBasePlan }
         Purchases.sharedInstance.purchaseProductOptionWith(
             requireActivity(),
             currentProduct,
-            basePlan,
+            purchaseOption!!, // TODOBC5: Fix API for OTP
             { error, userCancelled ->
                 if (!userCancelled) {
                     showUserError(requireActivity(), error)

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
@@ -1,12 +1,21 @@
 package com.revenuecat.purchasetester
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.RadioButton
+import androidx.core.view.children
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.models.GoogleStoreProduct
+import com.revenuecat.purchases.models.PurchaseOption
 import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.googleProduct
+import com.revenuecat.purchases_sample.R
 import com.revenuecat.purchases_sample.databinding.PackageCardBinding
 
 class PackageCardAdapter(
@@ -31,15 +40,35 @@ class PackageCardAdapter(
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(currentPackage: Package) {
+            val product = currentPackage.product
             binding.currentPackage = currentPackage
-            binding.isActive = activeSubscriptions.contains(currentPackage.product.productId)
+            binding.isSubscription = product.type == ProductType.SUBS
+            binding.isActive = activeSubscriptions.contains(product.productId)
 
             binding.packageBuyButton.setOnClickListener {
-                listener.onPurchasePackageClicked(binding.root, currentPackage)
+                val errorStartingPurchase = validateStartPurchase(product)
+                if (errorStartingPurchase == null) {
+                    listener.onPurchasePackageClicked(
+                        binding.root,
+                        currentPackage,
+                        getSelectedPurchaseOption()
+                    )
+                } else {
+                    showErrorMessage(errorStartingPurchase)
+                }
             }
 
             binding.productBuyButton.setOnClickListener {
-                listener.onPurchaseProductClicked(binding.root, currentPackage.product)
+                val errorStartingPurchase = validateStartPurchase(product)
+                if (errorStartingPurchase == null) {
+                    listener.onPurchaseProductClicked(
+                        binding.root,
+                        product,
+                        getSelectedPurchaseOption()
+                    )
+                } else {
+                    showErrorMessage(errorStartingPurchase)
+                }
             }
 
             binding.packageType.detail = if (currentPackage.packageType == PackageType.CUSTOM) {
@@ -48,8 +77,9 @@ class PackageCardAdapter(
                 currentPackage.packageType.toString()
             }
 
-            binding.packageDetailsJsonObject.detail = ""
-                // TODOBC5 currentPackage.product.originalJson.toString(JSON_FORMATTER_INDENT_SPACES)
+            binding.packageDetailsJsonObject.detail = product.googleProduct?.productDetails?.toString() ?: "TODO Amazon"
+
+            bindPurchaseOptions(product)
 
             binding.root.setOnClickListener {
                 with(binding.packageDetailsContainer) {
@@ -57,10 +87,46 @@ class PackageCardAdapter(
                 }
             }
         }
+
+        @SuppressLint("SetTextI18n")
+        private fun bindPurchaseOptions(product: StoreProduct) {
+            binding.packagePurchaseOptionGroup.removeAllViews()
+            val numberOfPurchaseOptions = product.purchaseOptions.size
+            product.purchaseOptions.forEach { purchaseOption ->
+                val radioButton = RadioButton(binding.root.context).apply {
+                    text = purchaseOption.toButtonString()
+                    tag = purchaseOption
+                    if (numberOfPurchaseOptions == 1) isChecked = true
+                }
+                binding.packagePurchaseOptionGroup.addView(radioButton)
+            }
+        }
+
+        private fun getSelectedPurchaseOption(): PurchaseOption? {
+            val selectedButtonId = binding.packagePurchaseOptionGroup.checkedRadioButtonId
+            return binding.packagePurchaseOptionGroup.children
+                .filter { it.id == selectedButtonId }
+                .firstOrNull()
+                ?.tag as? PurchaseOption
+        }
+
+        private fun validateStartPurchase(product: StoreProduct): String? {
+            if (product.type == ProductType.SUBS && binding.packagePurchaseOptionGroup.checkedRadioButtonId != -1) {
+                return "Please choose purchase option first"
+            }
+            return null
+        }
+
+        private fun showErrorMessage(errorMessage: String) {
+            MaterialAlertDialogBuilder(binding.root.context)
+                .setMessage(errorMessage)
+                .setPositiveButton("OK") { dialog, _ -> dialog.dismiss() }
+                .show()
+        }
     }
 
     interface PackageCardAdapterListener {
-        fun onPurchasePackageClicked(cardView: View, currentPackage: Package)
-        fun onPurchaseProductClicked(cardView: View, currentProduct: StoreProduct)
+        fun onPurchasePackageClicked(cardView: View, currentPackage: Package, purchaseOption: PurchaseOption?)
+        fun onPurchaseProductClicked(cardView: View, currentProduct: StoreProduct, purchaseOption: PurchaseOption?)
     }
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchasetester
 
-import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -11,11 +10,9 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.ProductType
-import com.revenuecat.purchases.models.GoogleStoreProduct
 import com.revenuecat.purchases.models.PurchaseOption
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.googleProduct
-import com.revenuecat.purchases_sample.R
 import com.revenuecat.purchases_sample.databinding.PackageCardBinding
 
 class PackageCardAdapter(
@@ -90,7 +87,6 @@ class PackageCardAdapter(
             }
         }
 
-        @SuppressLint("SetTextI18n")
         private fun bindPurchaseOptions(product: StoreProduct) {
             binding.packagePurchaseOptionGroup.removeAllViews()
             val numberOfPurchaseOptions = product.purchaseOptions.size
@@ -98,9 +94,9 @@ class PackageCardAdapter(
                 val radioButton = RadioButton(binding.root.context).apply {
                     text = purchaseOption.toButtonString()
                     tag = purchaseOption
-                    if (numberOfPurchaseOptions == 1) isChecked = true
                 }
                 binding.packagePurchaseOptionGroup.addView(radioButton)
+                if (numberOfPurchaseOptions == 1) binding.packagePurchaseOptionGroup.check(radioButton.id)
             }
         }
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
@@ -39,6 +39,8 @@ class PackageCardAdapter(
     inner class PackageViewHolder(private val binding: PackageCardBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
+        private val nothingCheckedIndex = -1
+
         fun bind(currentPackage: Package) {
             val product = currentPackage.product
             binding.currentPackage = currentPackage
@@ -111,7 +113,8 @@ class PackageCardAdapter(
         }
 
         private fun validateStartPurchase(product: StoreProduct): String? {
-            if (product.type == ProductType.SUBS && binding.packagePurchaseOptionGroup.checkedRadioButtonId != -1) {
+            if (product.type == ProductType.SUBS
+                && binding.packagePurchaseOptionGroup.checkedRadioButtonId == nothingCheckedIndex) {
                 return "Please choose purchase option first"
             }
             return null

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PurchaseOptionExtensions.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PurchaseOptionExtensions.kt
@@ -1,0 +1,10 @@
+package com.revenuecat.purchasetester
+
+import com.revenuecat.purchases.models.PurchaseOption
+
+fun PurchaseOption.toButtonString(): String {
+    val pricingPhasesString = pricingPhases.joinToString(separator = ",\n") { pricingPhase ->
+        "\t[${pricingPhase.formattedPrice}, ${pricingPhase.billingPeriod}, ${pricingPhase.billingCycleCount} cycles]"
+    }
+    return "PricingPhases = [\n$pricingPhasesString\n],\nTags = $tags"
+}

--- a/examples/purchase-tester/src/main/res/layout/package_card.xml
+++ b/examples/purchase-tester/src/main/res/layout/package_card.xml
@@ -5,13 +5,17 @@
         xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
+        <import type="android.view.View"/>
         <variable
                 name="currentPackage"
                 type="com.revenuecat.purchases.Package" />
 
         <variable
                 name="isActive"
+                type="Boolean" />
+
+        <variable
+                name="isSubscription"
                 type="Boolean" />
     </data>
 
@@ -83,17 +87,44 @@
                     tools:text="$rc_monthly" />
 
             <include
-                    android:id="@+id/package_price"
+                    android:id="@+id/package_one_time_price"
                     layout="@layout/row_view"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/padding_tiny"
                     android:layout_marginEnd="@dimen/padding_tiny"
+                    android:visibility="@{isSubscription ? View.GONE : View.VISIBLE}"
                     app:layout_constraintEnd_toStartOf="@+id/package_card_barrier"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/package_type"
-                    bind:header="@{`Price: TODOBC5`}"
+                    bind:header="@{`One Time Price:`}"
+                    bind:detail="@{currentPackage.product.oneTimeProductPrice.formattedPrice}"
                     tools:text="$1.99" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                    android:id="@+id/package_purchase_option_title"
+                    android:textStyle="bold"
+                    android:text="@string/purchase_options"
+                    android:paddingHorizontal="4dp"
+                    android:layout_marginHorizontal="@dimen/padding_tiny"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:visibility="@{isSubscription ? View.VISIBLE : View.GONE}"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/package_one_time_price" />
+
+            <RadioGroup
+                    android:id="@+id/package_purchase_option_group"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:divider="?android:attr/dividerHorizontal"
+                    android:showDividers="middle"
+                    android:visibility="@{isSubscription ? View.VISIBLE : View.GONE}"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/package_purchase_option_title">
+            </RadioGroup>
 
             <androidx.constraintlayout.widget.Barrier
                     android:id="@+id/package_card_barrier"
@@ -118,7 +149,7 @@
                     android:layout_height="wrap_content"
                     android:enabled="@{!isActive}"
                     android:text="Buy product"
-                    app:layout_constraintBottom_toTopOf="@+id/package_details_container"
+                    app:layout_constraintBottom_toTopOf="@+id/package_purchase_option_title"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/package_buy_button" />
 
@@ -131,7 +162,7 @@
                     android:visibility="gone"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/package_price"
+                    app:layout_constraintTop_toBottomOf="@+id/package_purchase_option_group"
                     app:layout_constraintVertical_bias="0">
 
                 <include

--- a/examples/purchase-tester/src/main/res/values/strings.xml
+++ b/examples/purchase-tester/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="logs">Logs</string>
     <string name="google_store_is_unavailable">Google Store is unavailable in this build. Download a version from the Play Store or build locally to enable it.</string>
     <string name="amazon_store_is_unavailable">Amazon Store is unavailable in this build. Download a version from LAT or build locally to enable it.</string>
+    <string name="purchase_options">Purchase Options:</string>
 </resources>


### PR DESCRIPTION
### Description
https://revenuecats.atlassian.net/browse/CF-971

Allows to visualize and choose different PurchaseOptions in purchase tester sample app.


https://user-images.githubusercontent.com/808417/200937963-38842dc1-78cc-479a-b168-eaee6248c1d1.mp4

