### PR TITLE
[BC5] Change API to support one time purchases

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -44,7 +44,7 @@ private class PurchasesAPI {
         activity: Activity,
         storeProduct: StoreProduct,
         packageToPurchase: Package,
-        purchaseOption: PurchaseOption,
+        purchaseOption: PurchaseOption?,
         upgradeInfo: UpgradeInfo
     ) {
         val skus = ArrayList<String>()
@@ -126,7 +126,7 @@ private class PurchasesAPI {
         activity: Activity,
         packageToPurchase: Package,
         storeProduct: StoreProduct,
-        purchaseOption: PurchaseOption,
+        purchaseOption: PurchaseOption?,
         upgradeInfo: UpgradeInfo
     ) {
         purchases.getOfferingsWith(

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -64,7 +64,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         Purchases.sharedInstance.purchasePackageOptionWith(
             requireActivity(),
             currentPackage,
-            purchaseOption!!, // TODOBC5: Fix API for OTP
+            purchaseOption,
             { error, userCancelled ->
                 if (!userCancelled) {
                     showUserError(requireActivity(), error)
@@ -85,7 +85,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         Purchases.sharedInstance.purchaseProductOptionWith(
             requireActivity(),
             currentProduct,
-            purchaseOption!!, // TODOBC5: Fix API for OTP
+            purchaseOption,
             { error, userCancelled ->
                 if (!userCancelled) {
                     showUserError(requireActivity(), error)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -430,7 +430,7 @@ class Purchases internal constructor(
      * Purchase a [StoreProduct]'s [PurchaseOption] upgrading from a previous product.
      * @param [activity] Current activity
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
-     * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+     * @param [purchaseOption] For subscriptions only. Your choice of purchase options available for the StoreProduct
      * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional
      * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
      * @param [listener] The PurchaseCallback that will be called when purchase completes.
@@ -438,7 +438,7 @@ class Purchases internal constructor(
     fun purchaseProductOption(
         activity: Activity,
         storeProduct: StoreProduct,
-        purchaseOption: PurchaseOption,
+        purchaseOption: PurchaseOption?,
         upgradeInfo: UpgradeInfo,
         listener: ProductChangeCallback
     ) {
@@ -456,13 +456,13 @@ class Purchases internal constructor(
      * Purchase a [StoreProduct]'s [PurchaseOption].
      * @param [activity] Current activity
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
-     * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+     * @param [purchaseOption] For subscriptions only. Your choice of purchase options available for the StoreProduct
      * @param [callback] The PurchaseCallback that will be called when purchase completes
      */
     fun purchaseProductOption(
         activity: Activity,
         storeProduct: StoreProduct,
-        purchaseOption: PurchaseOption,
+        purchaseOption: PurchaseOption?,
         callback: PurchaseCallback
     ) {
         startPurchase(activity, storeProduct, purchaseOption, null, callback)
@@ -536,7 +536,7 @@ class Purchases internal constructor(
      * Purchase a [Package]'s [PurchaseOption], switching from an old product.
      * @param [activity] Current activity
      * @param [packageToPurchase] The Package you wish to purchase
-     * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+     * @param [purchaseOption] For subscriptions only. Your choice of purchase options available for the StoreProduct
      * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional
      * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
      * @param [callback] The listener that will be called when purchase completes.
@@ -544,7 +544,7 @@ class Purchases internal constructor(
     fun purchasePackageOption(
         activity: Activity,
         packageToPurchase: Package,
-        purchaseOption: PurchaseOption,
+        purchaseOption: PurchaseOption?,
         upgradeInfo: UpgradeInfo,
         callback: ProductChangeCallback
     ) {
@@ -562,13 +562,13 @@ class Purchases internal constructor(
      * Make a purchase.
      * @param [activity] Current activity
      * @param [packageToPurchase] The Package you wish to purchase
-     * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+     * @param [purchaseOption] For subscriptions only. Your choice of purchase options available for the StoreProduct
      * @param [listener] The listener that will be called when purchase completes.
      */
     fun purchasePackageOption(
         activity: Activity,
         packageToPurchase: Package,
-        purchaseOption: PurchaseOption,
+        purchaseOption: PurchaseOption?,
         listener: PurchaseCallback
     ) {
         startPurchase(
@@ -1514,7 +1514,7 @@ class Purchases internal constructor(
     private fun startPurchase(
         activity: Activity,
         storeProduct: StoreProduct,
-        purchaseOption: PurchaseOption,
+        purchaseOption: PurchaseOption?,
         presentedOfferingIdentifier: String?,
         listener: PurchaseCallback
     ) {
@@ -1554,7 +1554,7 @@ class Purchases internal constructor(
     private fun startProductChange(
         activity: Activity,
         storeProduct: StoreProduct,
-        purchaseOption: PurchaseOption,
+        purchaseOption: PurchaseOption?,
         offeringIdentifier: String?,
         upgradeInfo: UpgradeInfo,
         listener: ProductChangeCallback
@@ -1594,7 +1594,7 @@ class Purchases internal constructor(
 
     private fun replaceOldPurchaseWithNewProduct(
         storeProduct: StoreProduct,
-        purchaseOption: PurchaseOption,
+        purchaseOption: PurchaseOption?,
         upgradeInfo: UpgradeInfo,
         activity: Activity,
         appUserID: String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -135,14 +135,14 @@ fun Purchases.purchaseProductWith(
  * Purchase a [Product]'s [PurchaseOption].
  * @param [activity] Current activity
  * @param [storeProduct] The storeProduct of the product you wish to purchase
- * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [purchaseOption] For subscriptions only. Your choice of purchase options available for the StoreProduct
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
 fun Purchases.purchaseProductOptionWith(
     activity: Activity,
     storeProduct: StoreProduct,
-    purchaseOption: PurchaseOption,
+    purchaseOption: PurchaseOption?,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
     onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
 ) {
@@ -181,7 +181,7 @@ fun Purchases.purchaseProductWith(
  * Purchase a [Product]'s [PurchaseOption], upgrading from an old product.
  * @param [activity] Current activity
  * @param [storeProduct] The storeProduct of the product you wish to purchase
- * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [purchaseOption] For subscriptions only. Your choice of purchase options available for the StoreProduct
  * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
  * @param [onSuccess] Will be called after the purchase has completed
@@ -190,7 +190,7 @@ fun Purchases.purchaseProductWith(
 fun Purchases.purchaseProductOptionWith(
     activity: Activity,
     storeProduct: StoreProduct,
-    purchaseOption: PurchaseOption,
+    purchaseOption: PurchaseOption?,
     upgradeInfo: UpgradeInfo,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
     onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
@@ -233,7 +233,7 @@ fun Purchases.purchasePackageWith(
  * Purchase a [Package]'s [PurchaseOption], upgrading from an old product
  * @param [activity] Current activity
  * @param [packageToPurchase] The Package you wish to purchase
- * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [purchaseOption] For subscriptions only. Your choice of purchase options available for the StoreProduct
  * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases
  * @param [onSuccess] Will be called after the purchase has completed
@@ -243,7 +243,7 @@ fun Purchases.purchasePackageWith(
 fun Purchases.purchasePackageOptionWith(
     activity: Activity,
     packageToPurchase: Package,
-    purchaseOption: PurchaseOption,
+    purchaseOption: PurchaseOption?,
     upgradeInfo: UpgradeInfo,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
     onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
@@ -280,7 +280,7 @@ fun Purchases.purchasePackageWith(
 /**
  * Purchase a [Package]'s [PurchaseOption]
  * @param [activity] Current activity
- * @param [packageToPurchase] The Package you wish to purchase
+ * @param [packageToPurchase] For subscriptions only. The Package you wish to purchase
  * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
@@ -288,7 +288,7 @@ fun Purchases.purchasePackageWith(
 fun Purchases.purchasePackageOptionWith(
     activity: Activity,
     packageToPurchase: Package,
-    purchaseOption: PurchaseOption,
+    purchaseOption: PurchaseOption?,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
     onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
 ) {


### PR DESCRIPTION
### Description
Makes the `purchaseOption` parameter nullable in the purchase API methods. This is to support one time purchases that don't have any purchase option.
