### PR TITLE
Fix for calling getUnsyncedSubscriberAttributes callback twice

### DIFF
--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -214,7 +214,7 @@ class SubscriberAttributesManager(
         @Synchronized
         fun waitUntilIdle(completion: () -> Unit) {
             if (numberOfProcesses == 0) completion()
-            listeners.add { completion() }
+            else listeners.add { completion() }
         }
     }
 }


### PR DESCRIPTION
### Description
https://revenuecats.atlassian.net/browse/CSDK-520

This issue could happen in any situation in which we try to get unsynced subscriber attributes before getting device identifiers. For example, if we called `collectDeviceIdentifiers` or one of the set attribution ID methods after calling  `logIn`. In those cases, the completion blocks from getting unsynced subscriber attributes could be called twice. This could also cause us to send these attributes multiple times to the backend among other side effects. This issue was introduced in #604. 

