### PR TITLE
[BC5] Map packages to SubscriptionOfferDetails using basePlanId instead of duration

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/OfferingFactories.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/OfferingFactories.kt
@@ -54,15 +54,16 @@ fun JSONObject.createPackage(
     offeringIdentifier: String
 ): Package? {
     val packageIdentifier = getString("identifier")
-    val productGroupIdentifier = optString("platform_product_group_identifier")
     // TODO handle INAPP products
     val productIdentifier = getString("platform_product_identifier")
-    val productDuration = optString("product_duration")
-    val subProducts = productsById[productGroupIdentifier]
-    val matchingProduct = subProducts?.firstOrNull { it.subscriptionPeriod == productDuration }
+    val planIdentifier = getString("platform_product_plan_identifier")
+    val storeProducts: List<StoreProduct>? = productsById[productIdentifier]
+    val matchingProduct = storeProducts?.firstOrNull { storeProduct ->
+        storeProduct.purchaseOptions.firstOrNull { it.isBasePlan }?.id == planIdentifier
+    }
     return matchingProduct?.let { product ->
         val packageType = packageIdentifier.toPackageType()
-        return Package(packageIdentifier, packageType, product, offeringIdentifier, productDuration, productGroupIdentifier)
+        return Package(packageIdentifier, packageType, product, offeringIdentifier)
     }
 }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
@@ -267,9 +267,11 @@ class OfferingsTest {
             """
                 {
                     'identifier': '$packageIdentifier',
-                    'platform_product_group_identifier': '$productGroupIdentifier',
                     'platform_product_identifier': '$productIdentifier',
-                    'product_duration': '$duration'
+                    'store_identifier': {
+                        'subscription': '$productIdentifier',
+                        'base_plan': 'bp1'
+                    }
                 }
             """.trimIndent()
         )

--- a/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
@@ -62,11 +62,6 @@ class OfferingsTest {
     }
 
     @Test
-    fun `Package is created for migrated products with same product identifier and group`() {
-        // TODO BC5: not sure how migrated products will look like
-    }
-
-    @Test
     fun `Offering is not created if there are no valid packages`() {
         val productId = "com.myproduct.bad"
         val storeProductAnnual = getStoreProduct(productId, annualDuration, annualBasePlan)

--- a/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
@@ -23,13 +23,19 @@ import org.robolectric.annotation.Config
 @Config(manifest = Config.NONE)
 class OfferingsTest {
 
-    private val monthlyProductGroupIdentifier = "com.myproduct"
-    private val monthlyProductIdentifier = "com.myproduct.monthly"
+    private val productIdentifier = "com.myproduct"
+    private val monthlyBasePlan = "monthly_base_plan"
+    private val annualBasePlan = "annual_base_plan"
+    private val monthlyDuration = "P1M"
+    private val annualDuration = "P1Y"
 
     @Test
     fun `Package is not created if there are no valid products`() {
+        val storeProductAnnual = getStoreProduct(productIdentifier, annualDuration, annualBasePlan)
+        val products = mapOf(productIdentifier to listOf(storeProductAnnual))
+
         val packageToTest = getPackageJSON().createPackage(
-            getProductsByGroupId("com.myproduct.annual" to "P1Y"),
+            products,
             "offering"
         )
         assertThat(packageToTest).isNull()
@@ -37,38 +43,35 @@ class OfferingsTest {
 
     @Test
     fun `Package is created if there are valid products`() {
-        val products: Map<String, List<StoreProduct>> = getProductsByGroupId()
-        val packageJSON = getPackageJSON(
+        val storeProductMonthly = getStoreProduct(productIdentifier, monthlyDuration, monthlyBasePlan)
+        val storeProductAnnual = getStoreProduct(productIdentifier, annualDuration, annualBasePlan)
+
+        val products = mapOf(productIdentifier to listOf(storeProductMonthly, storeProductAnnual))
+
+        val monthlyPackageJSON = getPackageJSON(
             packageIdentifier = PackageType.MONTHLY.identifier!!,
-            productIdentifier = monthlyProductIdentifier,
-            productGroupIdentifier = monthlyProductGroupIdentifier
+            productIdentifier = productIdentifier,
+            basePlanId = monthlyBasePlan
         )
-        val packageToTest = packageJSON.createPackage(products, "offering")
+
+        val packageToTest = monthlyPackageJSON.createPackage(products, "offering")
         assertThat(packageToTest).isNotNull
-        assertThat(packageToTest!!.product).isEqualTo(products[monthlyProductGroupIdentifier]?.get(0))
+        assertThat(packageToTest!!.product).isEqualTo(products[productIdentifier]?.get(0))
         assertThat(packageToTest.identifier).isEqualTo(PackageType.MONTHLY.identifier)
         assertThat(packageToTest.packageType).isEqualTo(PackageType.MONTHLY)
     }
 
     @Test
     fun `Package is created for migrated products with same product identifier and group`() {
-        val productIdPreBC5 = "onemonth_freetrial"
-        val products: Map<String, List<StoreProduct>> = getProductsByGroupId(productIdPreBC5 to "P1M")
-        val packageJSON = getPackageJSON(
-            packageIdentifier = PackageType.MONTHLY.identifier!!,
-            productIdentifier = productIdPreBC5,
-            productGroupIdentifier = productIdPreBC5
-        )
-        val packageToTest = packageJSON.createPackage(products, "offering")
-        assertThat(packageToTest).isNotNull
-        assertThat(packageToTest!!.product).isEqualTo(products[productIdPreBC5]?.get(0))
-        assertThat(packageToTest.identifier).isEqualTo(PackageType.MONTHLY.identifier)
-        assertThat(packageToTest.packageType).isEqualTo(PackageType.MONTHLY)
+        // TODO BC5: not sure how migrated products will look like
     }
 
     @Test
     fun `Offering is not created if there are no valid packages`() {
-        val products = getProductsByGroupId("com.myproduct.bad" to "P1M")
+        val productId = "com.myproduct.bad"
+        val storeProductAnnual = getStoreProduct(productId, annualDuration, annualBasePlan)
+        val products = mapOf(productId to listOf(storeProductAnnual))
+
         val offeringJSON = getOfferingJSON()
         val offering = offeringJSON.createOffering(products)
         assertThat(offering).isNull()
@@ -76,14 +79,36 @@ class OfferingsTest {
 
     @Test
     fun `Offering is created if there are valid packages`() {
-        val products = getProductsByGroupId()
-        val offering = getOfferingJSON().createOffering(products)
+        val storeProductMonthly = getStoreProduct(productIdentifier, monthlyDuration, monthlyBasePlan)
+        val storeProductAnnual = getStoreProduct(productIdentifier, annualDuration, annualBasePlan)
+
+        val products = mapOf(productIdentifier to listOf(storeProductMonthly, storeProductAnnual))
+
+        val monthlyPackageJSON = getPackageJSON(
+            PackageType.MONTHLY.identifier!!,
+            productIdentifier,
+            monthlyBasePlan
+        )
+        val annualPackageJSON = getPackageJSON(
+            PackageType.ANNUAL.identifier!!,
+            productIdentifier,
+            annualBasePlan
+        )
+        val offeringJSON = getOfferingJSON(
+            offeringIdentifier = "offering_a",
+            packagesJSON = listOf(monthlyPackageJSON, annualPackageJSON)
+        )
+
+        val offering = offeringJSON.createOffering(products)
         assertThat(offering).isNotNull
     }
 
     @Test
     fun `List of offerings is empty if there are no valid offerings`() {
-        val products = getProductsByGroupId("com.myproduct.bad" to "P1M")
+        val productId = "com.myproduct.bad"
+        val storeProductAnnual = getStoreProduct(productId, annualDuration, annualBasePlan)
+        val products = mapOf(productId to listOf(storeProductAnnual))
+
         val offerings = getOfferingsJSON().createOfferings(products)
         assertThat(offerings).isNotNull
         assertThat(offerings.current).isNull()
@@ -93,7 +118,11 @@ class OfferingsTest {
 
     @Test
     fun `Offerings can be created`() {
-        val products = getProductsByGroupId("com.myproduct" to "P6M", "com.myproduct" to "P1M")
+        val storeProductMonthly = getStoreProduct(productIdentifier, monthlyDuration, monthlyBasePlan)
+        val storeProductAnnual = getStoreProduct(productIdentifier, annualDuration, annualBasePlan)
+
+        val products = mapOf(productIdentifier to listOf(storeProductMonthly, storeProductAnnual))
+
         val offerings = getOfferingsJSON().createOfferings(products)
         assertThat(offerings).isNotNull
         assertThat(offerings.current!!.identifier).isEqualTo("offering_a")
@@ -179,22 +208,20 @@ class OfferingsTest {
                 "custom"
             }
         }
-        val productGroupIdentifier = "com.revenuecat.premium"
-        val productIdentifier = "com.revenuecat.premium.monthly"
-        val duration = "P1M"
-        val products = getProductsByGroupId(productGroupIdentifier to duration)
+        val storeProductMonthly = getStoreProduct()
+        val products = mapOf(productIdentifier to listOf(storeProductMonthly))
         val offeringJSON = getOfferingJSON(
             offeringIdentifier = "offering_a",
-            packageIdentifier = identifier,
-            productIdentifier = productIdentifier,
-            productGroupIdentifier = productGroupIdentifier
+            listOf(
+                getPackageJSON(packageIdentifier = identifier)
+            )
         )
         val offerings = JSONObject(
             """
                 {
                   'offerings': [
                     $offeringJSON
-                  ], 
+                  ],
                   'current_offering_id': 'offering_a'
                }""".trimIndent()
         ).createOfferings(products)
@@ -227,69 +254,77 @@ class OfferingsTest {
     private fun getOfferingsJSON() =
         JSONObject(
             "{'offerings': [" +
-                "${getOfferingJSON(
-                    offeringIdentifier = "offering_a",
-                    packageIdentifier = PackageType.SIX_MONTH.identifier!!,
-                    productIdentifier = "com.myproduct.sixMonth",
-                    productGroupIdentifier = "com.myproduct"
-                )}, " +
-                "${getOfferingJSON(
-                    offeringIdentifier = "offering_b",
-                    packageIdentifier = PackageType.MONTHLY.identifier!!,
-                    productIdentifier = "com.myproduct.monthly",
-                    productGroupIdentifier = "com.myproduct"
-                )}]" +
+                "${
+                    getOfferingJSON(
+                        offeringIdentifier = "offering_a",
+                        packagesJSON = listOf(getPackageJSON(
+                            PackageType.ANNUAL.identifier!!,
+                            productIdentifier,
+                            annualBasePlan
+                        ))
+                    )
+                }, " +
+                "${
+                    getOfferingJSON(offeringIdentifier = "offering_b")
+                }]" +
                 ", 'current_offering_id': 'offering_a'}"
         )
 
     private fun getOfferingJSON(
         offeringIdentifier: String = "offering_a",
-        packageIdentifier: String = PackageType.MONTHLY.identifier!!,
-        productIdentifier: String = monthlyProductIdentifier,
-        productGroupIdentifier: String = monthlyProductGroupIdentifier
+        packagesJSON: List<JSONObject> = listOf(
+            getPackageJSON(
+                PackageType.MONTHLY.identifier!!,
+                this.productIdentifier,
+                monthlyBasePlan
+            )
+        )
     ) = JSONObject(
         """
             {
                 'description': 'This is the base offering',
                 'identifier': '$offeringIdentifier',
-                'packages':[${getPackageJSON(packageIdentifier, productIdentifier, productGroupIdentifier)}]
+                'packages': ${packagesJSON}
             }
         """.trimIndent()
     )
 
     private fun getPackageJSON(
         packageIdentifier: String = PackageType.MONTHLY.identifier!!,
-        productIdentifier: String = monthlyProductIdentifier,
-        productGroupIdentifier: String = monthlyProductGroupIdentifier,
-        duration: String = "P1M"
+        productIdentifier: String = this.productIdentifier,
+        basePlanId: String = monthlyBasePlan,
     ) =
         JSONObject(
             """
                 {
                     'identifier': '$packageIdentifier',
                     'platform_product_identifier': '$productIdentifier',
-                    'store_identifier': {
-                        'subscription': '$productIdentifier',
-                        'base_plan': 'bp1'
-                    }
+                    'platform_product_plan_identifier': '$basePlanId'
                 }
             """.trimIndent()
         )
 
-    private fun getProductsByGroupId(
-        vararg productGroupsAndDurations: Pair<String, String> = arrayOf(monthlyProductGroupIdentifier to "P1M")
-    ): Map<String, List<StoreProduct>> =
-        productGroupsAndDurations.associate { (productGroupIdentifier, duration) ->
-            val pricingPhases = listOf(
-                stubPricingPhase(
-                    price = 1.99,
-                    billingPeriod = duration,
-                    recurrenceMode = ProductDetails.RecurrenceMode.INFINITE_RECURRING
-                )
-            )
-            val purchaseOption = stubPurchaseOption(pricingPhases, listOf("tag"))
-            val storeProduct = stubStoreProduct(productId = productGroupIdentifier, duration, listOf(purchaseOption))
-            productGroupIdentifier to listOf(storeProduct)
-        }
+    private fun getStoreProduct(
+        productId: String = productIdentifier,
+        duration: String = monthlyDuration,
+        basePlanId: String = monthlyBasePlan,
+    ): StoreProduct {
+        val basePlanPricingPhase = stubPricingPhase(
+            price = 1.99,
+            billingPeriod = duration,
+            recurrenceMode = ProductDetails.RecurrenceMode.INFINITE_RECURRING
+        )
+        val basePlanPurchaseOption = stubPurchaseOption(basePlanId, listOf(basePlanPricingPhase))
 
+        val offerPricingPhases = listOf(
+            stubPricingPhase(
+                price = 0.0,
+                billingPeriod = duration,
+                recurrenceMode = ProductDetails.RecurrenceMode.NON_RECURRING
+            ),
+            basePlanPricingPhase
+        )
+        val offerPurchaseOption = stubPurchaseOption(basePlanId, offerPricingPhases)
+        return stubStoreProduct(productId, duration, listOf(basePlanPurchaseOption, offerPurchaseOption))
+    }
 }

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/purchaseOptionConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/purchaseOptionConversions.kt
@@ -5,5 +5,7 @@ import com.revenuecat.purchases.models.GooglePurchaseOption
 
 fun ProductDetails.SubscriptionOfferDetails.toPurchaseOption(): GooglePurchaseOption {
     val pricingPhases = pricingPhases.pricingPhaseList.map { it.toRevenueCatPricingPhase() }
-    return GooglePurchaseOption(offerId ?: basePlanId, pricingPhases, offerTags, offerToken)
+    return GooglePurchaseOption(determinePurchaseOptionId(), pricingPhases, offerTags, offerToken)
 }
+
+private fun ProductDetails.SubscriptionOfferDetails.determinePurchaseOptionId() = offerId ?: basePlanId

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/purchaseOptionConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/purchaseOptionConversions.kt
@@ -5,5 +5,5 @@ import com.revenuecat.purchases.models.GooglePurchaseOption
 
 fun ProductDetails.SubscriptionOfferDetails.toPurchaseOption(): GooglePurchaseOption {
     val pricingPhases = pricingPhases.pricingPhaseList.map { it.toRevenueCatPricingPhase() }
-    return GooglePurchaseOption(pricingPhases, offerTags, offerToken)
+    return GooglePurchaseOption(offerId ?: basePlanId, pricingPhases, offerTags, offerToken)
 }

--- a/public/src/main/java/com/revenuecat/purchases/Package.kt
+++ b/public/src/main/java/com/revenuecat/purchases/Package.kt
@@ -19,11 +19,7 @@ data class Package(
     val identifier: String,
     val packageType: PackageType,
     val product: StoreProduct,
-    val offering: String, // TODOBC5 change type?
-
-    // TODO both of these are only used to create StoreProduct, maybe we don't need to store them in this class
-    private val subscriptionPeriod: String?,
-    private val storeProductIdentifier: String
+    val offering: String // TODOBC5 change type?
 ) : Parcelable
 
 /**

--- a/public/src/main/java/com/revenuecat/purchases/models/GooglePurchaseOption.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GooglePurchaseOption.kt
@@ -8,11 +8,12 @@ import kotlinx.parcelize.Parcelize
  */
 @Parcelize
 data class GooglePurchaseOption(
+    override val id: String,
     override val pricingPhases: List<PricingPhase>,
     override val tags: List<String>,
 
     /**
      * Token used to purchase
      */
-    val token: String,
+    val token: String
 ) : PurchaseOption, Parcelable

--- a/public/src/main/java/com/revenuecat/purchases/models/PurchaseOption.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/PurchaseOption.kt
@@ -7,6 +7,13 @@ import android.os.Parcelable
  */
 interface PurchaseOption : Parcelable {
     /**
+     * If this PurchaseOption represents a Google subscription base plan, this will be the base plan ID.
+     * If it represents an offer, it will be the offer ID.
+     * Not applicable for Amazon subscriptions.
+     */
+    val id: String
+
+    /**
      * Pricing phases defining a user's payment plan for the product over time.
      */
     val pricingPhases: List<PricingPhase>

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -12,7 +12,7 @@ import com.revenuecat.purchases.models.toRecurrenceMode
 fun stubStoreProduct(
     productId: String,
     duration: String = "P1M",
-    purchaseOptions: List<PurchaseOption> = listOf(stubPurchaseOption())
+    purchaseOptions: List<PurchaseOption> = listOf(stubPurchaseOption("monthly_base_plan"))
 ): StoreProduct = object : StoreProduct {
     override val productId: String
         get() = productId
@@ -37,13 +37,15 @@ fun stubStoreProduct(
 }
 
 fun stubPurchaseOption(
-    pricingPhases: List<PricingPhase> = listOf(stubPricingPhase()),
-    tags: List<String> = listOf("tag"),
+    id: String,
+    pricingPhases: List<PricingPhase> = listOf(stubPricingPhase())
 ): PurchaseOption = object : PurchaseOption {
+    override val id: String
+        get() = id
     override val pricingPhases: List<PricingPhase>
         get() = pricingPhases
     override val tags: List<String>
-        get() = tags
+        get() = listOf("tag")
 
     override fun describeContents(): Int = 0
     override fun writeToParcel(dest: Parcel?, flags: Int) {}


### PR DESCRIPTION
[CF-1020]

Use basePlanId and subscriptionId from the package definition to map subscriptionOfferDetails objects to a package instead of subscriptionId and duration

[CF-1020]: https://revenuecats.atlassian.net/browse/CF-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ