### PR TITLE
Remove unnecessary appcompat dependency

### DIFF
--- a/feature/identity/build.gradle
+++ b/feature/identity/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     implementation project(":feature:subscriber-attributes")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
-    implementation 'androidx.appcompat:appcompat:1.2.0'
     testImplementation "androidx.test:core:$testLibrariesVersion"
     testImplementation "androidx.test:runner:$testLibrariesVersion"
     testImplementation "androidx.test:rules:$testLibrariesVersion"

--- a/feature/subscriber-attributes/build.gradle
+++ b/feature/subscriber-attributes/build.gradle
@@ -12,7 +12,6 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
-    implementation "androidx.appcompat:appcompat:1.2.0"
 
     testImplementation project(":test-utils")
     testImplementation "androidx.test:core:$testLibrariesVersion"


### PR DESCRIPTION
### Description
Remove unnecessary appcompat dependency from feature modules. This isn't needed there and only used in the apps (purchase-tester, MagicWeather and integration tests) which already include the dependency.

