### PR TITLE
[BC5] Fix offerings

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1182,18 +1182,18 @@ class Purchases internal constructor(
 
     private fun extractProductGroupIdentifiers(offeringsJSON: JSONObject): Set<String> {
         val jsonOfferingsArray = offeringsJSON.getJSONArray("offerings")
-        val productGroupIds = mutableSetOf<String>()
+        val productIds = mutableSetOf<String>()
         for (i in 0 until jsonOfferingsArray.length()) {
             val jsonPackagesArray =
                 jsonOfferingsArray.getJSONObject(i).getJSONArray("packages")
             for (j in 0 until jsonPackagesArray.length()) {
                 jsonPackagesArray.getJSONObject(j)
-                    .optString("platform_product_group_identifier").takeIf { it.isNotBlank() }?.let {
-                        productGroupIds.add(it)
+                    .optString("platform_product_identifier").takeIf { it.isNotBlank() }?.let {
+                        productIds.add(it)
                     }
             }
         }
-        return productGroupIds
+        return productIds
     }
 
     private fun handleErrorFetchingOfferings(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1130,8 +1130,8 @@ class Purchases internal constructor(
             appInBackground,
             { offeringsJSON ->
                 try {
-                    val productGroupIdentifiers = extractProductGroupIdentifiers(offeringsJSON)
-                    if (productGroupIdentifiers.isEmpty()) {
+                    val productIdentifiers = extractProductIdentifiers(offeringsJSON)
+                    if (productIdentifiers.isEmpty()) {
                         handleErrorFetchingOfferings(
                             PurchasesError(
                                 PurchasesErrorCode.ConfigurationError,
@@ -1140,7 +1140,7 @@ class Purchases internal constructor(
                             completion
                         )
                     } else {
-                        getStoreProductsById(productGroupIdentifiers, { productsById ->
+                        getStoreProductsById(productIdentifiers, { productsById ->
                             val offerings = offeringsJSON.createOfferings(productsById)
 
                             logMissingProducts(offerings, productsById)
@@ -1180,7 +1180,7 @@ class Purchases internal constructor(
             })
     }
 
-    private fun extractProductGroupIdentifiers(offeringsJSON: JSONObject): Set<String> {
+    private fun extractProductIdentifiers(offeringsJSON: JSONObject): Set<String> {
         val jsonOfferingsArray = offeringsJSON.getJSONArray("offerings")
         val productIds = mutableSetOf<String>()
         for (i in 0 until jsonOfferingsArray.length()) {

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -117,13 +117,12 @@ class PurchasesTest {
 
     private val stubOfferingIdentifier = "offering_a"
     private val stubProductIdentifier = "monthly_freetrial"
-    private val stubProductGroupIdentifier = "monthly_freetrial"
     private val oneOfferingsResponse = "{'offerings': [" +
         "{'identifier': '$stubOfferingIdentifier', " +
         "'description': 'This is the base offering', " +
         "'packages': [" +
         "{'identifier': '\$rc_monthly','platform_product_identifier': '$stubProductIdentifier'," +
-        "'platform_product_group_identifier': '$stubProductGroupIdentifier','product_duration': 'P1M'}]}]," +
+        "'platform_product_plan_identifier': 'p1m'}]}]," +
         "'current_offering_id': '$stubOfferingIdentifier'}"
     private val oneOfferingWithNoProductsResponse = "{'offerings': [" +
         "{'identifier': '$stubOfferingIdentifier', " +
@@ -185,9 +184,7 @@ class PurchasesTest {
             "\$rc_monthly",
             PackageType.MONTHLY,
             storeProduct,
-            stubOfferingIdentifier,
-            null,
-            productId
+            stubOfferingIdentifier
         )
         val offering = Offering(
             stubOfferingIdentifier,


### PR DESCRIPTION
We were still using the old `platform_product_group_identifier` when getting offerings