### PR TITLE
Disable unsupported features for first BC5 beta

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/FeatureLockUtils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/FeatureLockUtils.kt
@@ -1,0 +1,11 @@
+package com.revenuecat.purchases
+
+@Suppress("MaxLineLength")
+internal enum class LockedFeature(val isLocked: Boolean, val lockedMessage: String) {
+    ObserverMode(true, "Observer mode is not supported in this version. Please disable it or use the latest stable version to use this."),
+    AmazonStore(true, "Amazon store is not supported in this version. Please use the Google store or use the latest stable version to use this."),
+    SyncPurchases(true, "Syncing purchases is not supported in this version. Please use the latest stable version to use this."),
+    InappPurchasing(true, "Purchasing inapp products is not supported in this version. Please use the latest stable version to use this.")
+}
+
+internal class FeatureNotSupportedException(lockedFeature: LockedFeature) : Exception(lockedFeature.lockedMessage)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/FeatureLockUtils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/FeatureLockUtils.kt
@@ -5,7 +5,7 @@ internal enum class LockedFeature(val isLocked: Boolean, val lockedMessage: Stri
     ObserverMode(true, "Observer mode is not supported in this version. Please disable it or use the latest stable version to use this."),
     AmazonStore(true, "Amazon store is not supported in this version. Please use the Google store or use the latest stable version to use this."),
     SyncPurchases(true, "Syncing purchases is not supported in this version. Please use the latest stable version to use this."),
-    InappPurchasing(true, "Purchasing inapp products is not supported in this version. Please use the latest stable version to use this.")
+    InAppPurchasing(true, "Purchasing INAPP products is not supported in this version. Please use the latest stable version to use this.")
 }
 
 internal class FeatureNotSupportedException(lockedFeature: LockedFeature) : Exception(lockedFeature.lockedMessage)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1527,8 +1527,8 @@ class Purchases internal constructor(
         presentedOfferingIdentifier: String?,
         listener: PurchaseCallback
     ) {
-        if (storeProduct.type == ProductType.INAPP && LockedFeature.InappPurchasing.isLocked) {
-            throw FeatureNotSupportedException(LockedFeature.InappPurchasing)
+        if (storeProduct.type == ProductType.INAPP && LockedFeature.InAppPurchasing.isLocked) {
+            throw FeatureNotSupportedException(LockedFeature.InAppPurchasing)
         }
         log(
             LogIntent.PURCHASE, PurchaseStrings.PURCHASE_STARTED.format(
@@ -1571,8 +1571,8 @@ class Purchases internal constructor(
         upgradeInfo: UpgradeInfo,
         listener: ProductChangeCallback
     ) {
-        if (storeProduct.type == ProductType.INAPP && LockedFeature.InappPurchasing.isLocked) {
-            throw FeatureNotSupportedException(LockedFeature.InappPurchasing)
+        if (storeProduct.type == ProductType.INAPP && LockedFeature.InAppPurchasing.isLocked) {
+            throw FeatureNotSupportedException(LockedFeature.InAppPurchasing)
         }
         log(
             LogIntent.PURCHASE, PurchaseStrings.PRODUCT_CHANGE_STARTED.format(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -204,6 +204,9 @@ class Purchases internal constructor(
      * @warning This function should only be called if you're migrating to RevenueCat or in observer mode.
      */
     fun syncPurchases() {
+        if (LockedFeature.SyncPurchases.isLocked) {
+            throw FeatureNotSupportedException(LockedFeature.SyncPurchases)
+        }
         log(LogIntent.DEBUG, PurchaseStrings.SYNCING_PURCHASES)
 
         val appUserID = identityManager.currentAppUserID
@@ -258,6 +261,12 @@ class Purchases internal constructor(
         isoCurrencyCode: String?,
         price: Double?
     ) {
+        if (LockedFeature.AmazonStore.isLocked) {
+            throw FeatureNotSupportedException(LockedFeature.AmazonStore)
+        }
+        if (LockedFeature.ObserverMode.isLocked) {
+            throw FeatureNotSupportedException(LockedFeature.ObserverMode)
+        }
         log(LogIntent.DEBUG, PurchaseStrings.SYNCING_PURCHASE_STORE_USER_ID.format(receiptID, amazonUserID))
 
         deviceCache.getPreviouslySentHashedTokens().takeIf { it.contains(receiptID.sha1()) }?.apply {
@@ -1518,6 +1527,9 @@ class Purchases internal constructor(
         presentedOfferingIdentifier: String?,
         listener: PurchaseCallback
     ) {
+        if (storeProduct.type == ProductType.INAPP && LockedFeature.InappPurchasing.isLocked) {
+            throw FeatureNotSupportedException(LockedFeature.InappPurchasing)
+        }
         log(
             LogIntent.PURCHASE, PurchaseStrings.PURCHASE_STARTED.format(
                 " $storeProduct ${
@@ -1559,6 +1571,9 @@ class Purchases internal constructor(
         upgradeInfo: UpgradeInfo,
         listener: ProductChangeCallback
     ) {
+        if (storeProduct.type == ProductType.INAPP && LockedFeature.InappPurchasing.isLocked) {
+            throw FeatureNotSupportedException(LockedFeature.InappPurchasing)
+        }
         log(
             LogIntent.PURCHASE, PurchaseStrings.PRODUCT_CHANGE_STARTED.format(
                 " $storeProduct ${
@@ -1819,6 +1834,12 @@ class Purchases internal constructor(
         fun configure(
             configuration: PurchasesConfiguration
         ): Purchases {
+            if (configuration.store == Store.AMAZON && LockedFeature.AmazonStore.isLocked) {
+                throw FeatureNotSupportedException(LockedFeature.AmazonStore)
+            }
+            if (configuration.observerMode && LockedFeature.ObserverMode.isLocked) {
+                throw FeatureNotSupportedException(LockedFeature.ObserverMode)
+            }
             return PurchasesFactory().createPurchases(
                 configuration,
                 platformInfo,

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -149,8 +149,8 @@ class PurchasesTest {
         every { LockedFeature.ObserverMode.isLocked } returns false
         mockkObject(LockedFeature.AmazonStore)
         every { LockedFeature.AmazonStore.isLocked } returns false
-        mockkObject(LockedFeature.InappPurchasing)
-        every { LockedFeature.InappPurchasing.isLocked } returns false
+        mockkObject(LockedFeature.InAppPurchasing)
+        every { LockedFeature.InAppPurchasing.isLocked } returns false
 
         mockkStatic("com.revenuecat.purchases.common.CustomerInfoFactoriesKt")
         mockkStatic("com.revenuecat.purchases.common.OfferingFactoriesKt")

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.CacheFetchPolicy
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.CustomerInfoHelper
+import com.revenuecat.purchases.LockedFeature
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -32,6 +33,7 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
@@ -77,6 +79,9 @@ class SubscriberAttributesPurchasesTests {
 
     @Before
     fun setup() {
+        mockkObject(LockedFeature.SyncPurchases)
+        every { LockedFeature.SyncPurchases.isLocked } returns false
+
         every {
             billingWrapperMock.queryAllPurchases(appUserId, captureLambda(), any())
         } answers {

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/billingClientStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/billingClientStubs.kt
@@ -56,10 +56,14 @@ fun mockOneTimePurchaseOfferDetails(
 fun mockSubscriptionOfferDetails(
     tags: List<String> = emptyList(),
     token: String = "mock-subscription-offer-token",
+    offerId: String = "mock-offer-id",
+    basePlanId: String = "mock-base-plan-id",
     pricingPhases: List<PricingPhase> = listOf(mockPricingPhase())
 ): SubscriptionOfferDetails = mockk<SubscriptionOfferDetails>().apply {
     every { offerTags } returns tags
     every { offerToken } returns token
+    every { getOfferId() } returns offerId
+    every { getBasePlanId() } returns basePlanId
     every { getPricingPhases() } returns mockk<ProductDetails.PricingPhases>().apply {
         every { pricingPhaseList } returns pricingPhases
     }


### PR DESCRIPTION
### Description
https://revenuecats.atlassian.net/browse/CF-989

For the first BC5 beta, not all features will be available. We will document this for our beta users but additionally, it's good to try to fail early if beta users try to use unsupported features. This PR adds some checks so we fail as early as possible when using any of these unsupported features.
