### PR TITLE
Refactor postReceipt helper method

### DIFF
--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -1004,11 +1004,10 @@ class BackendTest {
         backend.logIn(
             appUserID,
             newAppUserID,
-            onLoginSuccessHandler,
-            {
-                fail("Should have called success")
-            }
-        )
+            onLoginSuccessHandler
+        ) {
+            fail("Should have called success")
+        }
         verify(exactly = 1) {
             mockClient.performRequest(
                 "/subscribers/identify",
@@ -1123,11 +1122,10 @@ class BackendTest {
         backend.logIn(
             appUserID,
             newAppUserID,
-            onLoginSuccessHandler,
-            {
-                fail("Should have called success")
-            }
-        )
+            onLoginSuccessHandler
+        ) {
+            fail("Should have called success")
+        }
         assertThat(receivedCustomerInfoCreated).isFalse
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -70,7 +70,7 @@ class BackendTest {
         productIDs,
         offeringIdentifier = "offering_a"
     )
-
+    private val fetchToken = "fetch_token"
 
     private var receivedCustomerInfo: CustomerInfo? = null
     private var receivedCustomerInfoCreated: Boolean? = null
@@ -242,7 +242,7 @@ class BackendTest {
 
     @Test
     fun postReceiptCallsProperURL() {
-        val info = postReceipt(
+        val info = backend.postReceiptMockAndPost(
             responseCode = 200,
             isRestore = false,
             clientException = null,
@@ -258,7 +258,7 @@ class BackendTest {
 
     @Test
     fun postReceiptCallsFailsFor4XX() {
-        postReceipt(
+        backend.postReceiptMockAndPost(
             responseCode = 401,
             isRestore = false,
             clientException = null,
@@ -410,7 +410,7 @@ class BackendTest {
 
     @Test
     fun postReceiptObserverMode() {
-        val info = postReceipt(
+        val info = backend.postReceiptMockAndPost(
             responseCode = 200,
             isRestore = false,
             clientException = null,
@@ -426,7 +426,7 @@ class BackendTest {
 
     @Test
     fun `postReceipt passes price and currency`() {
-        val info = postReceipt(
+        val info = backend.postReceiptMockAndPost(
             responseCode = 200,
             isRestore = false,
             clientException = null,
@@ -738,7 +738,7 @@ class BackendTest {
 
     @Test
     fun `postReceipt passes durations`() {
-        val info = postReceipt(
+        val info = backend.postReceiptMockAndPost(
             responseCode = 200,
             isRestore = false,
             clientException = null,
@@ -819,7 +819,7 @@ class BackendTest {
 
     @Test
     fun `postReceipt calls fail for multiple product ids errors`() {
-        postReceipt(
+        backend.postReceiptMockAndPost(
             responseCode = 400,
             isRestore = false,
             clientException = null,
@@ -842,7 +842,7 @@ class BackendTest {
 
     @Test
     fun `postReceipt passes marketplace as header`() {
-        postReceipt(
+        backend.postReceiptMockAndPost(
             responseCode = 200,
             isRestore = false,
             clientException = null,
@@ -1320,7 +1320,7 @@ class BackendTest {
         return info
     }
 
-    private fun postReceipt(
+    private fun Backend.postReceiptMockAndPost(
         responseCode: Int,
         isRestore: Boolean,
         clientException: Exception?,
@@ -1340,7 +1340,7 @@ class BackendTest {
             storeAppUserID = storeAppUserID
         )
 
-        backend.postReceiptData(
+        this.postReceiptData(
             purchaseToken = fetchToken,
             appUserID = appUserID,
             isRestore = isRestore,
@@ -1377,8 +1377,6 @@ class BackendTest {
             "price" to receiptInfo.price,
             "currency" to receiptInfo.currency,
             "normal_duration" to receiptInfo.duration,
-            "intro_duration" to receiptInfo.introDuration,
-            "trial_duration" to receiptInfo.trialDuration,
             "store_user_id" to storeAppUserID
         ).mapNotNull { entry: Map.Entry<String, Any?> ->
             entry.value?.let { entry.key to it }

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -427,17 +427,6 @@ class BackendTest {
 
     @Test
     fun `given multiple post calls for same subscriber different price, both are triggered`() {
-        mockPostReceiptResponse(
-            isRestore = false,
-            responseCode = 200,
-            clientException = null,
-            resultBody = null,
-            delayed = true,
-            observerMode = false,
-            receiptInfo = basicReceiptInfo,
-            storeAppUserID = null
-        )
-
         val receiptInfo1 = ReceiptInfo(
             productIDs,
             offeringIdentifier = "offering_a",
@@ -552,16 +541,6 @@ class BackendTest {
 
     @Test
     fun `given multiple post calls for same subscriber different offering, both are triggered`() {
-        mockPostReceiptResponse(
-            isRestore = false,
-            responseCode = 200,
-            clientException = null,
-            resultBody = null,
-            delayed = true,
-            observerMode = false,
-            receiptInfo = basicReceiptInfo,
-            storeAppUserID = null
-        )
         val lock = CountDownLatch(2)
         mockPostReceiptResponseAndPost(
             asyncBackend,

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.utils.Responses
 import com.revenuecat.purchases.utils.getNullableString
+import com.revenuecat.purchases.utils.stubPurchaseOption
 import com.revenuecat.purchases.utils.stubStoreProduct
 import io.mockk.every
 import io.mockk.mockk
@@ -495,9 +496,16 @@ class BackendTest {
             storeProduct = storeProduct
         )
 
+        val originalPurchaseOption = storeProduct.purchaseOptions[0]
+        val originalDuration = originalPurchaseOption.pricingPhases[0].billingPeriod
         val storeProduct2 = stubStoreProduct(
             storeProduct.productId,
-            duration = storeProduct.subscriptionPeriod + "a"
+            listOf(
+                stubPurchaseOption(
+                    originalPurchaseOption.id,
+                    originalDuration + "a"
+                )
+            )
         )
 
         val receiptInfo2 = ReceiptInfo(

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -272,10 +272,9 @@ class BackendTest {
         assertThat(receivedError).`as`("Received error is not null").isNotNull
     }
 
-
     @Test
     fun `given multiple post calls for same subscriber, only one is triggered`() {
-        val (fetchToken, _) = mockPostReceiptResponse(
+        mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
@@ -342,7 +341,7 @@ class BackendTest {
             shouldMockCustomerInfo = false
         )
 
-        val (fetchToken, _) = mockPostReceiptResponse(
+        mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
@@ -445,7 +444,7 @@ class BackendTest {
 
     @Test
     fun `given multiple post calls for same subscriber different price, both are triggered`() {
-        val (fetchToken, _) = mockPostReceiptResponse(
+        mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
@@ -529,7 +528,7 @@ class BackendTest {
 
     @Test
     fun `given multiple post calls for same subscriber different durations, both are triggered`() {
-        val (fetchToken, _) = mockPostReceiptResponse(
+        mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
@@ -616,7 +615,7 @@ class BackendTest {
 
     @Test
     fun `given multiple post calls for same subscriber different offering, both are triggered`() {
-        val (fetchToken, _) = mockPostReceiptResponse(
+        mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
@@ -645,7 +644,7 @@ class BackendTest {
             basicReceiptInfo.productIDs,
             basicReceiptInfo.offeringIdentifier + "a"
         )
-        val (fetchToken1, _) = mockPostReceiptResponse(
+        mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
@@ -657,7 +656,7 @@ class BackendTest {
         )
 
         asyncBackend.postReceiptData(
-            purchaseToken = fetchToken1,
+            purchaseToken = fetchToken,
             appUserID = appUserID,
             isRestore = false,
             observerMode = false,
@@ -687,7 +686,7 @@ class BackendTest {
             offeringIdentifier = "offering_a",
             storeProduct = storeProduct
         )
-        val (fetchToken, _) = mockPostReceiptResponse(
+        mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
@@ -757,10 +756,9 @@ class BackendTest {
 
     @Test
     fun `given multiple post calls for same subscriber different store user ID, both are triggered`() {
-
         val lock = CountDownLatch(2)
         val receiptInfo = ReceiptInfo(productIDs)
-        val (fetchToken, _) = mockPostReceiptResponse(
+        mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
@@ -783,7 +781,7 @@ class BackendTest {
             },
             onError = postReceiptErrorCallback
         )
-        val (fetchToken1, _) = mockPostReceiptResponse(
+        mockPostReceiptResponse(
             isRestore = false,
             responseCode = 200,
             clientException = null,
@@ -794,7 +792,7 @@ class BackendTest {
             storeAppUserID = "store_app_user_id"
         )
         asyncBackend.postReceiptData(
-            purchaseToken = fetchToken1,
+            purchaseToken = fetchToken,
             appUserID = appUserID,
             isRestore = false,
             observerMode = false,
@@ -1321,6 +1319,7 @@ class BackendTest {
     }
 
     private fun Backend.postReceiptMockAndPost(
+        token: String = fetchToken,
         responseCode: Int,
         isRestore: Boolean,
         clientException: Exception?,
@@ -1328,12 +1327,13 @@ class BackendTest {
         observerMode: Boolean,
         receiptInfo: ReceiptInfo,
         storeAppUserID: String?,
-        marketplace: String? = null
+        marketplace: String? = null,
+
     ): CustomerInfo {
-        val (fetchToken, info) = mockPostReceiptResponse(
-            isRestore,
-            responseCode,
-            clientException,
+        val info = mockPostReceiptResponse(
+            isRestore = isRestore,
+            responseCode = responseCode,
+            clientException = clientException,
             resultBody = resultBody,
             observerMode = observerMode,
             receiptInfo = receiptInfo,
@@ -1357,6 +1357,7 @@ class BackendTest {
     }
 
     private fun mockPostReceiptResponse(
+        token: String = fetchToken,
         isRestore: Boolean,
         responseCode: Int,
         clientException: Exception?,
@@ -1365,10 +1366,9 @@ class BackendTest {
         observerMode: Boolean,
         receiptInfo: ReceiptInfo,
         storeAppUserID: String?
-    ): Pair<String, CustomerInfo> {
-        val fetchToken = "fetch_token"
+    ): CustomerInfo {
         val body = mapOf(
-            "fetch_token" to fetchToken,
+            "fetch_token" to token,
             "app_user_id" to appUserID,
             "product_ids" to receiptInfo.productIDs,
             "is_restore" to isRestore,
@@ -1390,7 +1390,7 @@ class BackendTest {
             resultBody,
             delayed
         )
-        return fetchToken to info
+        return info
     }
 
     private fun getCustomerInfo(

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -13,8 +13,7 @@ import com.revenuecat.purchases.models.toRecurrenceMode
 @SuppressWarnings("EmptyFunctionBlock")
 fun stubStoreProduct(
     productId: String,
-    duration: String = "P1M",
-    purchaseOptions: List<PurchaseOption> = listOf(stubPurchaseOption("monthly_base_plan", duration))
+    purchaseOptions: List<PurchaseOption> = listOf(stubPurchaseOption("monthly_base_plan", "P1M"))
 ): StoreProduct = object : StoreProduct {
     override val productId: String
         get() = productId
@@ -26,8 +25,8 @@ fun stubStoreProduct(
         get() = ""
     override val description: String
         get() = ""
-    override val subscriptionPeriod: String
-        get() = duration
+    override val subscriptionPeriod: String?
+        get() = purchaseOptions.firstOrNull { it.isBasePlan }?.pricingPhases?.get(0)?.billingPeriod
     override val purchaseOptions: List<PurchaseOption>
         get() = purchaseOptions
     override val sku: String
@@ -55,7 +54,7 @@ fun stubINAPPStoreProduct(
     override val subscriptionPeriod: String?
         get() = null
     override val purchaseOptions: List<PurchaseOption>
-        get() = listOf(stubPurchaseOption(productId, emptyList()))
+        get() = listOf(stubPurchaseOption(productId))
     override val sku: String
         get() = productId
 
@@ -67,7 +66,7 @@ fun stubINAPPStoreProduct(
 @SuppressWarnings("EmptyFunctionBlock")
 fun stubPurchaseOption(
     id: String,
-    duration: String,
+    duration: String = "P1M",
     pricingPhases: List<PricingPhase> = listOf(stubPricingPhase(billingPeriod = duration))
 ): PurchaseOption = object : PurchaseOption {
     override val id: String


### PR DESCRIPTION
We had a postReceipt() method called in `BackendTest` that I found a little confusing to work with. It calls both mockPostReceiptResponse and then posts to the backend. We had duplicate code mocking/posting for the tests using the asyncBackend.

This PR:
* renames postReceipt to make more clear that it is a test function
* update it to take a backend parameter so it can be reused for asyncBackend calls
* removes the fetchToken as a return value -- it was just hard-coded every time anyway
* update stubStoreProduct to not take in duration, since that's a pricingphase idea


tests for postReceipt will still be in a different PR, this was just some clean up to make those easier to add