### PR TITLE
[BC5] Fix a few tests that were not compiling on passing after BC5 changes

### DIFF
--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -1367,6 +1367,7 @@ class BackendTest {
         storeAppUserID: String?
     ): Pair<String, CustomerInfo> {
         val fetchToken = "fetch_token"
+        // TODO BC5 Check if we need to add new fields to response
         val body = mapOf(
             "fetch_token" to fetchToken,
             "app_user_id" to appUserID,
@@ -1377,8 +1378,6 @@ class BackendTest {
             "price" to receiptInfo.price,
             "currency" to receiptInfo.currency,
             "normal_duration" to receiptInfo.duration,
-            "intro_duration" to receiptInfo.introDuration,
-            "trial_duration" to receiptInfo.trialDuration,
             "store_user_id" to storeAppUserID
         ).mapNotNull { entry: Map.Entry<String, Any?> ->
             entry.value?.let { entry.key to it }

--- a/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
@@ -375,7 +375,7 @@ class OfferingsTest {
             billingPeriod = duration,
             recurrenceMode = ProductDetails.RecurrenceMode.INFINITE_RECURRING
         )
-        val basePlanPurchaseOption = stubPurchaseOption(basePlanId, listOf(basePlanPricingPhase))
+        val basePlanPurchaseOption = stubPurchaseOption(basePlanId, duration, listOf(basePlanPricingPhase))
 
         val offerPricingPhases = listOf(
             stubPricingPhase(
@@ -385,7 +385,7 @@ class OfferingsTest {
             ),
             basePlanPricingPhase
         )
-        val offerPurchaseOption = stubPurchaseOption(basePlanId, offerPricingPhases)
+        val offerPurchaseOption = stubPurchaseOption(basePlanId, duration, offerPricingPhases)
         return stubStoreProduct(productId, duration, listOf(basePlanPurchaseOption, offerPurchaseOption))
     }
 }

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -55,7 +55,7 @@ fun stubINAPPStoreProduct(
     override val subscriptionPeriod: String?
         get() = null
     override val purchaseOptions: List<PurchaseOption>
-        get() = listOf(stubPurchaseOption(productId, emptyList()))
+        get() = listOf(stubPurchaseOption(productId, "P1M", emptyList()))
     override val sku: String
         get() = productId
 


### PR DESCRIPTION
### Description
I was trying to run the tests and was running into a few issues with compilation and failing tests. This PR fixes the issues related to the current changes, but Amazon's tests are still failing to compile. Will leave those until we fix Amazon to the new models.