### PR TITLE
fix build errors and add postReceipt PostingTransactionsTests

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -193,8 +193,6 @@ class Backend(
             "pricing_phases" to receiptInfo.pricingPhases?.map { it.toMap() }
         ).filterValues { value -> value != null }
 
-        // TODO BC5 we used to only pass this if storeProduct.price was non-null,
-        // is it okay to update the logic to pass it when it is non-null?
         val extraHeaders = marketplace?.let {
             mapOf("marketplace" to it)
         } ?: emptyMap()

--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.strings.NetworkStrings
+import com.revenuecat.purchases.utils.filterNotNullValues
 import org.json.JSONException
 import org.json.JSONObject
 

--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -191,7 +191,7 @@ class Backend(
             "normal_duration" to receiptInfo.duration,
             "store_user_id" to storeAppUserID,
             "pricing_phases" to receiptInfo.pricingPhases?.map { it.toMap() }
-        ).filterValues { value -> value != null }
+        ).filterNotNullValues()
 
         val extraHeaders = marketplace?.let {
             mapOf("marketplace" to it)

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -259,6 +259,25 @@ class BackendTest {
     }
 
     @Test
+    fun `postReceipt calls backend once`() {
+        mockPostReceiptResponseAndPost(
+            backend,
+            isRestore = false,
+            observerMode = false,
+            receiptInfo = basicReceiptInfo,
+            storeAppUserID = null
+        )
+
+        verify(exactly = 1) {
+            mockClient.performRequest(
+                "/receipts",
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
     fun postReceiptCallsFailsFor4XX() {
         mockPostReceiptResponseAndPost(
             backend,

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -259,31 +259,6 @@ class BackendTest {
     }
 
     @Test
-    fun `postReceipt passes pricing phases as header`() {
-        val purchaseOption = storeProduct.purchaseOptions[0]
-        val receiptInfo = ReceiptInfo(
-            productIDs = productIDs,
-            storeProduct = storeProduct,
-            purchaseOptionId = purchaseOption.id
-        )
-
-        mockPostReceiptResponseAndPost(
-            backend,
-            responseCode = 200,
-            isRestore = false,
-            clientException = null,
-            resultBody = null,
-            observerMode = true,
-            receiptInfo = receiptInfo,
-            storeAppUserID = null,
-        )
-
-        assertThat(headersSlot.isCaptured).isTrue
-        assertThat(headersSlot.captured.keys).contains("pricing_phases")
-        assertThat(headersSlot.captured["pricing_phases"]).isEqualTo(purchaseOption.pricingPhases)
-    }
-
-    @Test
     fun postReceiptCallsFailsFor4XX() {
         mockPostReceiptResponseAndPost(
             backend,

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -267,7 +267,8 @@ class BackendTest {
             purchaseOptionId = purchaseOption.id
         )
 
-        backend.postReceiptMockAndPost(
+        mockPostReceiptResponseAndPost(
+            backend,
             responseCode = 200,
             isRestore = false,
             clientException = null,

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -259,6 +259,30 @@ class BackendTest {
     }
 
     @Test
+    fun `postReceipt passes pricing phases as header`() {
+        val purchaseOption = storeProduct.purchaseOptions[0]
+        val receiptInfo = ReceiptInfo(
+            productIDs = productIDs,
+            storeProduct = storeProduct,
+            purchaseOptionId = purchaseOption.id
+        )
+
+        backend.postReceiptMockAndPost(
+            responseCode = 200,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            observerMode = true,
+            receiptInfo = receiptInfo,
+            storeAppUserID = null,
+        )
+
+        assertThat(headersSlot.isCaptured).isTrue
+        assertThat(headersSlot.captured.keys).contains("pricing_phases")
+        assertThat(headersSlot.captured["pricing_phases"]).isEqualTo(purchaseOption.pricingPhases)
+    }
+
+    @Test
     fun postReceiptCallsFailsFor4XX() {
         mockPostReceiptResponseAndPost(
             backend,

--- a/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
@@ -375,7 +375,7 @@ class OfferingsTest {
             billingPeriod = duration,
             recurrenceMode = ProductDetails.RecurrenceMode.INFINITE_RECURRING
         )
-        val basePlanPurchaseOption = stubPurchaseOption(basePlanId, listOf(basePlanPricingPhase))
+        val basePlanPurchaseOption = stubPurchaseOption(basePlanId, "P1M", listOf(basePlanPricingPhase))
 
         val offerPricingPhases = listOf(
             stubPricingPhase(
@@ -385,7 +385,7 @@ class OfferingsTest {
             ),
             basePlanPricingPhase
         )
-        val offerPurchaseOption = stubPurchaseOption(basePlanId, offerPricingPhases)
+        val offerPurchaseOption = stubPurchaseOption(basePlanId, "P1M", offerPricingPhases)
         return stubStoreProduct(productId, duration, listOf(basePlanPurchaseOption, offerPurchaseOption))
     }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
@@ -375,7 +375,7 @@ class OfferingsTest {
             billingPeriod = duration,
             recurrenceMode = ProductDetails.RecurrenceMode.INFINITE_RECURRING
         )
-        val basePlanPurchaseOption = stubPurchaseOption(basePlanId, "P1M", listOf(basePlanPricingPhase))
+        val basePlanPurchaseOption = stubPurchaseOption(basePlanId, duration, listOf(basePlanPricingPhase))
 
         val offerPricingPhases = listOf(
             stubPricingPhase(
@@ -385,7 +385,7 @@ class OfferingsTest {
             ),
             basePlanPricingPhase
         )
-        val offerPurchaseOption = stubPurchaseOption(basePlanId, "P1M", offerPricingPhases)
-        return stubStoreProduct(productId, duration, listOf(basePlanPurchaseOption, offerPurchaseOption))
+        val offerPurchaseOption = stubPurchaseOption(basePlanId, duration, offerPricingPhases)
+        return stubStoreProduct(productId, listOf(basePlanPurchaseOption, offerPurchaseOption))
     }
 }

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -379,7 +379,7 @@ class BillingWrapperTest {
         val upgradeInfo = mockReplaceSkuInfo()
         val productDetails = mockProductDetails(productId = productId, type = subsGoogleProductType)
         val storeProduct = productDetails.toStoreProduct(
-            productDetails.subscriptionOfferDetails!![0],
+            productDetails.subscriptionOfferDetails!![0].subscriptionBillingPeriod,
             productDetails.subscriptionOfferDetails!!
         )
 
@@ -435,7 +435,7 @@ class BillingWrapperTest {
         val upgradeInfo = mockReplaceSkuInfo()
         val productDetails = mockProductDetails(productId = productId, type = subsGoogleProductType)
         val storeProduct = productDetails.toStoreProduct(
-            productDetails.subscriptionOfferDetails!![0],
+            productDetails.subscriptionOfferDetails!![0].subscriptionBillingPeriod,
             productDetails.subscriptionOfferDetails!!
         )
 
@@ -632,6 +632,7 @@ class BillingWrapperTest {
             description = "",
             subscriptionPeriod = null,
             purchaseOptions = listOf(GooglePurchaseOption(
+                id = "purchaseOption",
                 pricingPhases = listOf(PricingPhase(
                     billingPeriod = "",
                     priceCurrencyCode = "",
@@ -653,6 +654,8 @@ class BillingWrapperTest {
         } just Runs
 
         val nonGooglePurchaseOption = object : PurchaseOption {
+            override val id: String
+                get() = "purchaseOption"
             override val pricingPhases: List<PricingPhase>
                 get() = listOf(PricingPhase(
                     billingPeriod = "",
@@ -703,7 +706,9 @@ class BillingWrapperTest {
             override val subscriptionPeriod: String?
                 get() = null
             override val purchaseOptions: List<PurchaseOption>
-                get() = listOf(GooglePurchaseOption(emptyList(), emptyList(), "fake-token"))
+                get() = listOf(GooglePurchaseOption("purchaseOption", emptyList(), emptyList(), "fake-token"))
+            override val sku: String
+                get() = productId
 
             override fun describeContents(): Int = 0
 
@@ -1128,7 +1133,7 @@ class BillingWrapperTest {
 
         val productDetails = mockProductDetails(productId = "product_a")
         val storeProduct = productDetails.toStoreProduct(
-            productDetails.subscriptionOfferDetails!![0],
+            productDetails.subscriptionOfferDetails!![0].subscriptionBillingPeriod,
             productDetails.subscriptionOfferDetails!!
         )
 
@@ -2142,7 +2147,7 @@ class BillingWrapperTest {
     private fun createStoreProductWithoutOffers(): StoreProduct {
         val productDetails = createMockProductDetailsNoOffers()
         return productDetails.toStoreProduct(
-            productDetails.subscriptionOfferDetails!![0],
+            productDetails.subscriptionOfferDetails!![0].subscriptionBillingPeriod,
             productDetails.subscriptionOfferDetails!!
         )
     }

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -632,7 +632,7 @@ class BillingWrapperTest {
             description = "",
             subscriptionPeriod = null,
             purchaseOptions = listOf(GooglePurchaseOption(
-                id = "purchaseOption",
+                id = "purchaseOptionId",
                 pricingPhases = listOf(PricingPhase(
                     billingPeriod = "",
                     priceCurrencyCode = "",

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.SubscriberAttributeError
 import com.revenuecat.purchases.common.buildCustomerInfo
 import com.revenuecat.purchases.google.BillingWrapper
+import com.revenuecat.purchases.google.subscriptionBillingPeriod
 import com.revenuecat.purchases.google.toStoreProduct
 import com.revenuecat.purchases.google.toStoreTransaction
 import com.revenuecat.purchases.models.StoreProduct
@@ -21,6 +22,7 @@ import com.revenuecat.purchases.utils.Responses
 import com.revenuecat.purchases.utils.SyncDispatcher
 import com.revenuecat.purchases.utils.mockProductDetails
 import com.revenuecat.purchases.utils.stubGooglePurchase
+import com.revenuecat.purchases.utils.stubStoreProduct
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.just
@@ -158,9 +160,7 @@ class PostingTransactionsTests {
         postReceiptSuccess = PostReceiptCompletionContainer()
 
         val expectedSubscriptionPeriod = "P1M"
-        val expectedIntroPricePeriod = "P2M"
-        val expectedFreeTrialPeriod = "P3M"
-        val mockStoreProduct = createStoreProductWithoutOffers("product_id")
+        val mockStoreProduct = stubStoreProduct("product_id")
         underTest.postToBackend(
             purchase = mockk(relaxed = true),
             storeProduct = mockStoreProduct,
@@ -172,8 +172,6 @@ class PostingTransactionsTests {
         )
         assertThat(postedProductInfoSlot.isCaptured).isTrue
         assertThat(postedProductInfoSlot.captured.duration).isEqualTo(expectedSubscriptionPeriod)
-        assertThat(postedProductInfoSlot.captured.introDuration).isEqualTo(expectedIntroPricePeriod)
-        assertThat(postedProductInfoSlot.captured.trialDuration).isEqualTo(expectedFreeTrialPeriod)
         verify(exactly = 1) {
             backendMock.postReceiptData(
                 purchaseToken = any(),
@@ -194,7 +192,7 @@ class PostingTransactionsTests {
     fun `inapps send null durations when posting to backend`() {
         postReceiptSuccess = PostReceiptCompletionContainer()
 
-        val mockStoreProduct = createStoreProductWithoutOffers("product_id")
+        val mockStoreProduct = stubStoreProduct("product_id")
         underTest.postToBackend(
             purchase = mockk(relaxed = true),
             storeProduct = mockStoreProduct,
@@ -206,8 +204,6 @@ class PostingTransactionsTests {
         )
         assertThat(postedProductInfoSlot.isCaptured).isTrue
         assertThat(postedProductInfoSlot.captured.duration).isNull()
-        assertThat(postedProductInfoSlot.captured.introDuration).isNull()
-        assertThat(postedProductInfoSlot.captured.trialDuration).isNull()
         verify(exactly = 1) {
             backendMock.postReceiptData(
                 purchaseToken = any(),
@@ -228,7 +224,7 @@ class PostingTransactionsTests {
     fun `store user id is sent when posting to backend`() {
         postReceiptSuccess = PostReceiptCompletionContainer()
 
-        val mockStoreProduct = createStoreProductWithoutOffers("product_id")
+        val mockStoreProduct = stubStoreProduct("product_id")
         val purchase: StoreTransaction = mockk(relaxed = true)
         val expectedStoreUserID = "a_store_user_id"
         every {
@@ -246,8 +242,6 @@ class PostingTransactionsTests {
         )
         assertThat(postedProductInfoSlot.isCaptured).isTrue
         assertThat(postedProductInfoSlot.captured.duration).isNull()
-        assertThat(postedProductInfoSlot.captured.introDuration).isNull()
-        assertThat(postedProductInfoSlot.captured.trialDuration).isNull()
         verify(exactly = 1) {
             backendMock.postReceiptData(
                 purchaseToken = any(),
@@ -270,7 +264,7 @@ class PostingTransactionsTests {
         val productIds = listOf("uno", "dos")
         val purchase =
             stubGooglePurchase(productIds = productIds).toStoreTransaction(ProductType.SUBS, null)
-        val mockStoreProduct = createStoreProductWithoutOffers("uno")
+        val mockStoreProduct = stubStoreProduct("uno")
 
         underTest.postToBackend(
             purchase = purchase,
@@ -304,7 +298,7 @@ class PostingTransactionsTests {
         val productIds = listOf("uno", "dos")
         val purchase =
             stubGooglePurchase(productIds = productIds).toStoreTransaction(ProductType.SUBS, null)
-        val mockStoreProduct = createStoreProductWithoutOffers("uno")
+        val mockStoreProduct = stubStoreProduct("uno")
 
         underTest.postToBackend(
             purchase = purchase,
@@ -324,11 +318,4 @@ class PostingTransactionsTests {
         }
     }
 
-    private fun createStoreProductWithoutOffers(productId: String = "sample_product_id"): StoreProduct {
-        val productDetails = mockProductDetails(productId = productId)
-        return productDetails.toStoreProduct(
-            productDetails.subscriptionOfferDetails!![0],
-            productDetails.subscriptionOfferDetails!!
-        )
-    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -53,9 +53,9 @@ import com.revenuecat.purchases.utils.Responses
 import com.revenuecat.purchases.utils.SyncDispatcher
 import com.revenuecat.purchases.utils.createMockOneTimeProductDetails
 import com.revenuecat.purchases.utils.createMockProductDetailsFreeTrial
-import com.revenuecat.purchases.utils.mockProductDetails
 import com.revenuecat.purchases.utils.stubGooglePurchase
 import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
+import com.revenuecat.purchases.utils.stubStoreProduct
 import io.mockk.Call
 import io.mockk.CapturingSlot
 import io.mockk.MockKAnswerScope
@@ -195,7 +195,7 @@ class PurchasesTest {
     }
 
     private fun stubOfferings(productId: String): Pair<StoreProduct, Offerings> {
-        val storeProduct = createStoreProductWithoutOffers(productId)
+        val storeProduct = stubStoreProduct(productId)
         val jsonObject = JSONObject(oneOfferingsResponse)
         val packageObject = Package(
             "\$rc_monthly",
@@ -330,7 +330,7 @@ class PurchasesTest {
 
     @Test
     fun canMakePurchase() {
-        val storeProduct = createStoreProductWithoutOffers()
+        val storeProduct = stubStoreProduct("abc")
 
         purchases.purchaseProductOptionWith(
             mockActivity,
@@ -352,7 +352,7 @@ class PurchasesTest {
 
     @Test
     fun canMakePurchaseWithoutProvidingOption() {
-        val storeProduct = createStoreProductWithoutOffers()
+        val storeProduct = stubStoreProduct("productId")
 
         purchases.purchaseProductWith(
             mockActivity,
@@ -572,7 +572,7 @@ class PurchasesTest {
     @Test
     fun passesUpErrors() {
         var errorCalled = false
-        val storeProduct = createStoreProductWithoutOffers()
+        val storeProduct = stubStoreProduct("productId")
         purchases.purchaseProductOptionWith(
             mockk(),
             storeProduct,
@@ -1569,7 +1569,7 @@ class PurchasesTest {
     fun `when making another purchase for a product for a pending product, error is issued`() {
         purchases.updatedCustomerInfoListener = updatedCustomerInfoListener
 
-        val storeProduct = createStoreProductWithoutOffers()
+        val storeProduct = stubStoreProduct("productId")
         purchases.purchaseProductOptionWith(
             mockk(),
             storeProduct,
@@ -1599,7 +1599,7 @@ class PurchasesTest {
 
         mockQueryingProductDetails(productId, ProductType.SUBS, null)
 
-        val storeProduct = createStoreProductWithoutOffers(productId)
+        val storeProduct = stubStoreProduct(productId)
 
         var callCount = 0
         purchases.purchaseProductOptionWith(
@@ -1627,7 +1627,7 @@ class PurchasesTest {
         val purchaseToken1 = "crazy_purchase_token_1"
         var callCount = 0
         mockQueryingProductDetails(productId1, ProductType.SUBS, null)
-        val storeProduct = createStoreProductWithoutOffers(productId)
+        val storeProduct = stubStoreProduct(productId)
         purchases.purchaseProductOptionWith(
             mockActivity,
             storeProduct,
@@ -1645,7 +1645,7 @@ class PurchasesTest {
 
     @Test
     fun `when multiple make purchase callbacks, a failure doesn't throw ConcurrentModificationException`() {
-        val storeProduct = createStoreProductWithoutOffers("productId")
+        val storeProduct = stubStoreProduct("productId")
         purchases.purchaseProductOptionWith(
             mockActivity,
             storeProduct,
@@ -4079,7 +4079,7 @@ class PurchasesTest {
         type: ProductType
     ): List<StoreProduct> {
         val storeProducts = productIdsSuccessfullyFetched.map { productId ->
-            if (type == ProductType.SUBS) createStoreProductWithoutOffers(productId)
+            if (type == ProductType.SUBS) stubStoreProduct(productId)
             else createMockOneTimeProductDetails(productId).toStoreProduct()
         }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -53,6 +53,7 @@ import com.revenuecat.purchases.utils.Responses
 import com.revenuecat.purchases.utils.SyncDispatcher
 import com.revenuecat.purchases.utils.createMockOneTimeProductDetails
 import com.revenuecat.purchases.utils.createMockProductDetailsFreeTrial
+import com.revenuecat.purchases.utils.mockProductDetails
 import com.revenuecat.purchases.utils.stubGooglePurchase
 import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
 import com.revenuecat.purchases.utils.stubStoreProduct


### PR DESCRIPTION
* fix a couple build errors in unit tests
* updates `PostingTransactionTests` to use new stubStoreProduct method
* adds a couple missing tests to `PostingTransactionsTests`, including one for pricing phases being sent
* uses `stubStoreProduct` in a few leftover PurchasesTests