### PR TITLE
BackendTests and BillingWrapperTests for postReceipt

### DIFF
--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -296,13 +296,13 @@ class BackendTest {
         )
 
         val expectedPricingPhases = receiptInfo.pricingPhases
-        val expectedPricingPhasesMap = expectedPricingPhases?.map { it.toMap() }
+        val mappedExpectedPricingPhases = expectedPricingPhases?.map { it.toMap() }
         assertThat(requestBodySlot.isCaptured).isTrue
         assertThat(requestBodySlot.captured.keys).contains("pricing_phases")
-        assertThat(requestBodySlot.captured["pricing_phases"]).isEqualTo(expectedPricingPhasesMap)
+        assertThat(requestBodySlot.captured["pricing_phases"]).isEqualTo(mappedExpectedPricingPhases)
 
         expectedPricingPhases?.forEachIndexed { index, pricingPhase ->
-            val mappedPricingPhase = expectedPricingPhasesMap?.get(index)
+            val mappedPricingPhase = mappedExpectedPricingPhases?.get(index)
             assertThat(mappedPricingPhase).isNotNull.withFailMessage(
                 "there should be a mapped version for every pricingPhase"
             )

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1175,8 +1175,8 @@ class BillingWrapperTest {
 
         val productDetails = mockProductDetails(productId = "product_a")
         val storeProduct = productDetails.toStoreProduct(
-            productDetails.subscriptionOfferDetails!![0].subscriptionBillingPeriod,
-            productDetails.subscriptionOfferDetails!!
+            productDetails.subscriptionOfferDetails!!,
+            productDetails.subscriptionOfferDetails!![0]
         )
 
         billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1168,6 +1168,42 @@ class BillingWrapperTest {
     }
 
     @Test
+    fun `purchaseOptionId is properly forwarded`() {
+        every {
+            mockClient.launchBillingFlow(any(), any())
+        } returns billingClientOKResult
+
+        val productDetails = mockProductDetails(productId = "product_a")
+        val storeProduct = productDetails.toStoreProduct(
+            productDetails.subscriptionOfferDetails!![0].subscriptionBillingPeriod,
+            productDetails.subscriptionOfferDetails!!
+        )
+
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
+        val purchaseOption = storeProduct.purchaseOptions[0]
+        wrapper.makePurchaseAsync(
+            mockActivity,
+            appUserId,
+            storeProduct,
+            purchaseOption,
+            null,
+            "offering_a"
+        )
+
+        val purchases = listOf(stubGooglePurchase(productIds = listOf("product_a")))
+
+        val slot = slot<List<StoreTransaction>>()
+        every {
+            mockPurchasesListener.onPurchasesUpdated(capture(slot))
+        } just Runs
+
+        purchasesUpdatedListener!!.onPurchasesUpdated(billingClientOKResult, purchases)
+
+        assertThat(slot.captured.size).isOne
+        assertThat(slot.captured[0].purchaseOptionId).isEqualTo(purchaseOption.id)
+    }
+
+    @Test
     fun `When building the BillingClient enabledPendingPurchases is called`() {
         val context = mockk<Context>()
         mockkStatic(BillingClient::class)


### PR DESCRIPTION
Adds a few tests to cover the postReceipt updates

I think we could use better testing around the `cacheKey` calculation, but that is an existing issue for all calls and feels bigger than this PR