### PR TITLE
Fix PostingTransactionsTests

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -152,6 +152,7 @@ class PostingTransactionsTests {
     fun tearDown() {
         postReceiptError = null
         postReceiptSuccess = null
+        postedStoreUserIdSlot.clear()
         clearMocks(customerInfoHelperMock)
     }
 
@@ -361,7 +362,7 @@ class PostingTransactionsTests {
     }
 
     @Test
-    fun `!consumeAllTransactions is sent as observerMode when posting to backend`() {
+    fun `observerMode parameter is sent as false when transactions are consumed`() {
         postReceiptSuccess = PostReceiptCompletionContainer()
 
         val expectedConsumeAllTransactions = true

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -53,7 +53,7 @@ class PostingTransactionsTests {
     private val attributesToMarkAsSyncSlot = slot<Map<String, SubscriberAttribute>>()
     private val attributesErrorsSlot = slot<List<SubscriberAttributeError>>()
     private val postedReceiptInfoSlot = slot<ReceiptInfo>()
-    private val postedStoreUserIdSlot = slot<String>()
+    private val postedStoreUserIdSlot = mutableListOf<String?>()
 
     private val mockStoreProduct = stubStoreProduct("productId")
 
@@ -87,7 +87,7 @@ class PostingTransactionsTests {
                 observerMode = any(),
                 subscriberAttributes = any(),
                 receiptInfo = capture(postedReceiptInfoSlot),
-                storeAppUserID = capture(postedStoreUserIdSlot),
+                storeAppUserID = captureNullable(postedStoreUserIdSlot),
                 marketplace = any(),
                 onSuccess = capture(successSlot),
                 onError = capture(errorSlot)
@@ -246,7 +246,7 @@ class PostingTransactionsTests {
             onSuccess = { _, _ -> },
             onError = { _, _ -> }
         )
-        assertThat(postedStoreUserIdSlot.captured).isEqualTo(expectedStoreUserID)
+        assertThat(postedStoreUserIdSlot.first()).isEqualTo(expectedStoreUserID)
 
         verify(exactly = 1) {
             backendMock.postReceiptData(

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -55,7 +55,16 @@ class PostingTransactionsTests {
     private val postedReceiptInfoSlot = slot<ReceiptInfo>()
     private val postedStoreUserIdSlot = mutableListOf<String?>()
 
+    private val purchaseOptionId = "purchaseOptionId"
     private val mockStoreProduct = stubStoreProduct("productId")
+    private val mockGooglePurchase = stubGooglePurchase(
+        productIds = listOf("uno", "dos")
+    )
+    private val mockStoreTransaction = mockGooglePurchase.toStoreTransaction(
+        ProductType.SUBS,
+        null,
+        purchaseOptionId
+    )
 
     internal data class PostReceiptErrorContainer(
         val error: PurchasesError,
@@ -82,7 +91,7 @@ class PostingTransactionsTests {
         every {
             backendMock.postReceiptData(
                 purchaseToken = any(),
-                appUserID = any(),
+                appUserID = appUserId,
                 isRestore = any(),
                 observerMode = any(),
                 subscriberAttributes = any(),
@@ -161,7 +170,7 @@ class PostingTransactionsTests {
         postReceiptSuccess = PostReceiptCompletionContainer()
 
         underTest.postToBackend(
-            purchase = mockk(relaxed = true),
+            purchase = mockStoreTransaction,
             storeProduct = mockStoreProduct,
             allowSharingPlayStoreAccount = true,
             consumeAllTransactions = true,
@@ -177,14 +186,8 @@ class PostingTransactionsTests {
     fun `purchaseOptionId is sent when posting to backend`() {
         postReceiptSuccess = PostReceiptCompletionContainer()
 
-        val purchase: StoreTransaction = mockk(relaxed = true)
-        val expectedPurchaseOptionId = "purchase_option_a"
-        every {
-            purchase.purchaseOptionId
-        } returns expectedPurchaseOptionId
-
         underTest.postToBackend(
-            purchase = purchase,
+            purchase = mockStoreTransaction,
             storeProduct = mockStoreProduct,
             allowSharingPlayStoreAccount = true,
             consumeAllTransactions = true,
@@ -193,7 +196,7 @@ class PostingTransactionsTests {
             onError = { _, _ -> }
         )
         assertThat(postedReceiptInfoSlot.isCaptured).isTrue
-        assertThat(postedReceiptInfoSlot.captured.purchaseOptionId).isEqualTo(expectedPurchaseOptionId)
+        assertThat(postedReceiptInfoSlot.captured.purchaseOptionId).isEqualTo(purchaseOptionId)
     }
 
     @Test
@@ -202,7 +205,7 @@ class PostingTransactionsTests {
 
         val mockInAppProduct = stubINAPPStoreProduct("productId")
         underTest.postToBackend(
-            purchase = mockk(relaxed = true),
+            purchase = mockStoreTransaction,
             storeProduct = mockInAppProduct,
             allowSharingPlayStoreAccount = true,
             consumeAllTransactions = true,
@@ -232,14 +235,13 @@ class PostingTransactionsTests {
     fun `store user id is sent when posting to backend`() {
         postReceiptSuccess = PostReceiptCompletionContainer()
 
-        val purchase: StoreTransaction = mockk(relaxed = true)
         val expectedStoreUserID = "a_store_user_id"
         every {
-            purchase.storeUserID
+            mockStoreTransaction.storeUserID
         } returns expectedStoreUserID
 
         underTest.postToBackend(
-            purchase = purchase,
+            purchase = mockStoreTransaction,
             storeProduct = mockStoreProduct,
             allowSharingPlayStoreAccount = true,
             consumeAllTransactions = true,
@@ -268,16 +270,9 @@ class PostingTransactionsTests {
     @Test
     fun `productIds are sent when posting to backend`() {
         postReceiptSuccess = PostReceiptCompletionContainer()
-        val productIds = listOf("uno", "dos")
-        val purchase = stubGooglePurchase(
-            productIds = productIds
-        ).toStoreTransaction(
-            ProductType.SUBS,
-            null
-        )
 
         underTest.postToBackend(
-            purchase = purchase,
+            purchase = mockStoreTransaction,
             storeProduct = mockStoreProduct,
             allowSharingPlayStoreAccount = true,
             consumeAllTransactions = true,
@@ -286,7 +281,7 @@ class PostingTransactionsTests {
             onError = { _, _ -> }
         )
         assertThat(postedReceiptInfoSlot.isCaptured).isTrue
-        assertThat(postedReceiptInfoSlot.captured.productIDs).isEqualTo(productIds)
+        assertThat(postedReceiptInfoSlot.captured.productIDs).isEqualTo(mockStoreTransaction.productIds)
     }
 
     @Test
@@ -294,9 +289,7 @@ class PostingTransactionsTests {
         postReceiptSuccess = PostReceiptCompletionContainer()
 
         val expectedPresentedOfferingIdentifier = "offering_a"
-        val purchase = stubGooglePurchase(
-            productIds = listOf("abc")
-        ).toStoreTransaction(
+        val purchase = mockGooglePurchase.toStoreTransaction(
             ProductType.SUBS,
             expectedPresentedOfferingIdentifier
         )
@@ -319,7 +312,7 @@ class PostingTransactionsTests {
         postReceiptSuccess = PostReceiptCompletionContainer()
 
         underTest.postToBackend(
-            purchase = mockk(relaxed = true),
+            purchase = mockStoreTransaction,
             storeProduct = mockStoreProduct,
             allowSharingPlayStoreAccount = true,
             consumeAllTransactions = true,
@@ -337,7 +330,7 @@ class PostingTransactionsTests {
 
         val expectedAllowSharingPlayStoreAccount = true
         underTest.postToBackend(
-            purchase = mockk(relaxed = true),
+            purchase = mockStoreTransaction,
             storeProduct = mockStoreProduct,
             allowSharingPlayStoreAccount = expectedAllowSharingPlayStoreAccount,
             consumeAllTransactions = true,
@@ -367,7 +360,7 @@ class PostingTransactionsTests {
 
         val expectedConsumeAllTransactions = true
         underTest.postToBackend(
-            purchase = mockk(relaxed = true),
+            purchase = mockStoreTransaction,
             storeProduct = mockStoreProduct,
             allowSharingPlayStoreAccount = true,
             consumeAllTransactions = expectedConsumeAllTransactions,
@@ -397,7 +390,7 @@ class PostingTransactionsTests {
         postReceiptSuccess = PostReceiptCompletionContainer()
 
         underTest.postToBackend(
-            purchase = mockk(relaxed = true),
+            purchase = mockStoreTransaction,
             storeProduct = mockStoreProduct,
             allowSharingPlayStoreAccount = true,
             consumeAllTransactions = true,

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -53,7 +53,6 @@ class PostingTransactionsTests {
     private val attributesToMarkAsSyncSlot = slot<Map<String, SubscriberAttribute>>()
     private val attributesErrorsSlot = slot<List<SubscriberAttributeError>>()
     private val postedReceiptInfoSlot = slot<ReceiptInfo>()
-    private val postedStoreUserIdSlot = mutableListOf<String?>()
 
     private val purchaseOptionId = "purchaseOptionId"
     private val mockStoreProduct = stubStoreProduct("productId")
@@ -96,7 +95,7 @@ class PostingTransactionsTests {
                 observerMode = any(),
                 subscriberAttributes = any(),
                 receiptInfo = capture(postedReceiptInfoSlot),
-                storeAppUserID = captureNullable(postedStoreUserIdSlot),
+                storeAppUserID = any(),
                 marketplace = any(),
                 onSuccess = capture(successSlot),
                 onError = capture(errorSlot)
@@ -161,7 +160,6 @@ class PostingTransactionsTests {
     fun tearDown() {
         postReceiptError = null
         postReceiptSuccess = null
-        postedStoreUserIdSlot.clear()
         clearMocks(customerInfoHelperMock)
     }
 
@@ -224,42 +222,6 @@ class PostingTransactionsTests {
                 subscriberAttributes = expectedAttributes.toBackendMap(),
                 receiptInfo = any(),
                 storeAppUserID = any(),
-                marketplace = any(),
-                onSuccess = any(),
-                onError = any()
-            )
-        }
-    }
-
-    @Test
-    fun `store user id is sent when posting to backend`() {
-        postReceiptSuccess = PostReceiptCompletionContainer()
-
-        val expectedStoreUserID = "a_store_user_id"
-        every {
-            mockStoreTransaction.storeUserID
-        } returns expectedStoreUserID
-
-        underTest.postToBackend(
-            purchase = mockStoreTransaction,
-            storeProduct = mockStoreProduct,
-            allowSharingPlayStoreAccount = true,
-            consumeAllTransactions = true,
-            appUserID = appUserId,
-            onSuccess = { _, _ -> },
-            onError = { _, _ -> }
-        )
-        assertThat(postedStoreUserIdSlot.first()).isEqualTo(expectedStoreUserID)
-
-        verify(exactly = 1) {
-            backendMock.postReceiptData(
-                purchaseToken = any(),
-                appUserID = appUserId,
-                isRestore = any(),
-                observerMode = any(),
-                subscriberAttributes = expectedAttributes.toBackendMap(),
-                receiptInfo = any(),
-                storeAppUserID = expectedStoreUserID,
                 marketplace = any(),
                 onSuccess = any(),
                 onError = any()


### PR DESCRIPTION
Fixes failing tests in `PostingTransactionsTests`

One interesting find -- you cannot `capture` a nullable type. This was leading to some of the failures... 

we had
```
val postedStoreUserIdSlot = slot<String>()
every {
            backendMock.postReceiptData(
                ...
                storeAppUserID = capture(postedStoreUserIdSlot),
                ...
            )
} answers { ... }
```

and when the storeUserId was null, it wasn't matching the calls. you can't make a `slot<String?>`, so the [recommendation](https://github.com/mockk/mockk/issues/293) for nullables is apparently to use a list, like i did here. idk if that's a well-known thing, but it definitely caught me.. 