### PR TITLE
[BC5] Change purchasing API with latest changes

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -79,10 +79,8 @@ final class PurchasesAPI {
         purchases.purchaseProduct(activity, storeProduct, makePurchaseListener);
         purchases.purchasePackage(activity, packageToPurchase, upgradeInfo, purchaseChangeListener);
         purchases.purchasePackage(activity, packageToPurchase, makePurchaseListener);
-        purchases.purchaseProductOption(activity, storeProduct, purchaseOption, upgradeInfo, purchaseChangeListener);
-        purchases.purchaseProductOption(activity, storeProduct, purchaseOption, makePurchaseListener);
-        purchases.purchasePackageOption(activity, packageToPurchase, purchaseOption, upgradeInfo, purchaseChangeListener);
-        purchases.purchasePackageOption(activity, packageToPurchase, purchaseOption, makePurchaseListener);
+        purchases.purchaseSubscriptionOption(activity, storeProduct, purchaseOption, upgradeInfo, purchaseChangeListener);
+        purchases.purchaseSubscriptionOption(activity, storeProduct, purchaseOption, makePurchaseListener);
         purchases.restorePurchases(receiveCustomerInfoListener);
 
         purchases.logIn("", logInCallback);

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -29,9 +29,8 @@ import com.revenuecat.purchases.models.PurchaseOption
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.purchasePackageWith
-import com.revenuecat.purchases.purchasePackageOptionWith
 import com.revenuecat.purchases.purchaseProductWith
-import com.revenuecat.purchases.purchaseProductOptionWith
+import com.revenuecat.purchases.purchaseSubscriptionOptionWith
 import com.revenuecat.purchases.restorePurchasesWith
 import java.net.URL
 import java.util.concurrent.ExecutorService
@@ -86,16 +85,14 @@ private class PurchasesAPI {
         purchases.purchasePackage(activity, packageToPurchase, upgradeInfo, purchaseChangeCallback)
         purchases.purchasePackage(activity, packageToPurchase, purchaseCallback)
 
-        purchases.purchaseProductOption(activity, storeProduct, purchaseOption, upgradeInfo, purchaseChangeCallback)
-        purchases.purchaseProductOption(activity, storeProduct, purchaseOption, purchaseCallback)
-        purchases.purchasePackageOption(
+        purchases.purchaseSubscriptionOption(
             activity,
-            packageToPurchase,
+            storeProduct,
             purchaseOption,
             upgradeInfo,
             purchaseChangeCallback
         )
-        purchases.purchasePackageOption(activity, packageToPurchase, purchaseOption, purchaseCallback)
+        purchases.purchaseSubscriptionOption(activity, storeProduct, purchaseOption, purchaseCallback)
 
         purchases.restorePurchases(receiveCustomerInfoCallback)
         purchases.logIn("", logInCallback)
@@ -159,35 +156,20 @@ private class PurchasesAPI {
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
         )
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             activity,
             storeProduct,
             purchaseOption,
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
         )
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             activity,
             storeProduct,
             purchaseOption,
             upgradeInfo,
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
-        )
-        purchases.purchasePackageOptionWith(
-            activity,
-            packageToPurchase,
-            purchaseOption,
-            upgradeInfo,
-            onError = { _: PurchasesError, _: Boolean -> },
-            onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
-        )
-        purchases.purchasePackageOptionWith(
-            activity,
-            packageToPurchase,
-            purchaseOption,
-            onError = { _: PurchasesError, _: Boolean -> },
-            onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
         )
         purchases.restorePurchasesWith(
             onError = { _: PurchasesError -> },

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -89,7 +89,6 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
                     handleSuccessfulPurchase(storeTransaction.orderId)
                 })
         }
-
     }
 
     override fun onPurchaseProductClicked(
@@ -126,8 +125,6 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
                     handleSuccessfulPurchase(storeTransaction.orderId)
                 })
         }
-
-
     }
 
     private fun handleSuccessfulPurchase(orderId: String?) {

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -17,8 +17,9 @@ import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.getCustomerInfoWith
 import com.revenuecat.purchases.models.PurchaseOption
 import com.revenuecat.purchases.models.StoreProduct
-import com.revenuecat.purchases.purchasePackageOptionWith
-import com.revenuecat.purchases.purchaseProductOptionWith
+import com.revenuecat.purchases.purchasePackageWith
+import com.revenuecat.purchases.purchaseProductWith
+import com.revenuecat.purchases.purchaseSubscriptionOptionWith
 import com.revenuecat.purchases_sample.R
 import com.revenuecat.purchases_sample.databinding.FragmentOfferingBinding
 
@@ -39,7 +40,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         }
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         Purchases.sharedInstance.getCustomerInfoWith {
             activeSubscriptions = it.activeSubscriptions
         }
@@ -61,18 +62,34 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
     override fun onPurchasePackageClicked(cardView: View, currentPackage: Package, purchaseOption: PurchaseOption?) {
         binding.purchaseProgress.visibility = View.VISIBLE
 
-        Purchases.sharedInstance.purchasePackageOptionWith(
-            requireActivity(),
-            currentPackage,
-            purchaseOption!!, // TODOBC5: Fix API for OTP
-            { error, userCancelled ->
-                if (!userCancelled) {
-                    showUserError(requireActivity(), error)
+        if (purchaseOption == null) {
+            Purchases.sharedInstance.purchasePackageWith(
+                requireActivity(),
+                currentPackage,
+                { error, userCancelled ->
+                    if (!userCancelled) {
+                        showUserError(requireActivity(), error)
+                    }
+                },
+                { storeTransaction, _ ->
+                    handleSuccessfulPurchase(storeTransaction.orderId)
                 }
-            },
-            { storeTransaction, _ ->
-                handleSuccessfulPurchase(storeTransaction.orderId)
-            })
+            )
+        } else {
+            Purchases.sharedInstance.purchaseSubscriptionOptionWith(
+                requireActivity(),
+                currentPackage.product,
+                purchaseOption,
+                { error, userCancelled ->
+                    if (!userCancelled) {
+                        showUserError(requireActivity(), error)
+                    }
+                },
+                { storeTransaction, _ ->
+                    handleSuccessfulPurchase(storeTransaction.orderId)
+                })
+        }
+
     }
 
     override fun onPurchaseProductClicked(
@@ -82,18 +99,35 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
     ) {
         binding.purchaseProgress.visibility = View.VISIBLE
 
-        Purchases.sharedInstance.purchaseProductOptionWith(
-            requireActivity(),
-            currentProduct,
-            purchaseOption!!, // TODOBC5: Fix API for OTP
-            { error, userCancelled ->
-                if (!userCancelled) {
-                    showUserError(requireActivity(), error)
+        if (purchaseOption == null) {
+            Purchases.sharedInstance.purchaseProductWith(
+                requireActivity(),
+                currentProduct,
+                { error, userCancelled ->
+                    if (!userCancelled) {
+                        showUserError(requireActivity(), error)
+                    }
+                },
+                { storeTransaction, _ ->
+                    handleSuccessfulPurchase(storeTransaction.orderId)
                 }
-            },
-            { storeTransaction, _ ->
-                handleSuccessfulPurchase(storeTransaction.orderId)
-            })
+            )
+        } else {
+            Purchases.sharedInstance.purchaseSubscriptionOptionWith(
+                requireActivity(),
+                currentProduct,
+                purchaseOption,
+                { error, userCancelled ->
+                    if (!userCancelled) {
+                        showUserError(requireActivity(), error)
+                    }
+                },
+                { storeTransaction, _ ->
+                    handleSuccessfulPurchase(storeTransaction.orderId)
+                })
+        }
+
+
     }
 
     private fun handleSuccessfulPurchase(orderId: String?) {

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -50,27 +50,19 @@ StoreProduct has been made an interface, which `GoogleStoreProduct` and `AmazonS
 |------------|------------|
 | skus       | productIds |
 
-### Deprecated + New APIs
-
-| Deprecated                                                                    | New                                                                                                 |
-|-------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
-| `purchaseProduct(Activity, StoreProduct, UpgradeInfo, ProductChangeCallback)` | `purchaseSubscriptionOption(Activity, StoreProduct, PurchaseOption, UpgradeInfo, ProductChangeCallback)` |
-| `purchasePackage(Activity, Package, UpgradeInfo, ProductChangeCallback)`      | `purchaseSubscriptionOption(Activity, StoreProduct, PurchaseOption, UpgradeInfo, ProductChangeCallback)` |
+### New purchasing APIs
 
 | New              |
 |------------------|
 | `purchaseSubscriptionOption(Activity, StoreProduct, PurchaseOption, PurchaseCallback)` |
+| `purchaseSubscriptionOption(Activity, StoreProduct, PurchaseOption, UpgradeInfo, ProductChangeCallback)` |
 
 ### Kotlin Helpers Changes
-
-| Deprecated                                                                                                                              | New                                                                                                                                                           |
-|-----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `purchaseProductWith(Activity, StoreProduct, UpgradeInfo, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)` | `purchaseSubscriptionOptionWith(Activity, StoreProduct, UpgradeInfo, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)` |
-| `purchasePackageWith(Activity, Package, UpgradeInfo, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)`      | `purchaseSubscriptionOptionWith(Activity, Package, UpgradeInfo, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)`      |
 
 | New              |
 |------------------|
 | `purchaseSubscriptionOptionWith(Activity, StoreProduct, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)` |
+| `purchaseSubscriptionOptionWith(Activity, StoreProduct, UpgradeInfo, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)` |
 
 | Removed |
 |----------------------------------------------------------------------------------------------------------------------|

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -54,22 +54,25 @@ StoreProduct has been made an interface, which `GoogleStoreProduct` and `AmazonS
 
 | Deprecated                                                                    | New                                                                                                 |
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
-| `purchaseProduct(Activity, StoreProduct, PurchaseCallback)`                   | `purchaseProductOption(Activity, StoreProduct, PurchaseOption, PurchaseCallback)`                   |
-| `purchaseProduct(Activity, StoreProduct, UpgradeInfo, ProductChangeCallback)` | `purchaseProductOption(Activity, StoreProduct, PurchaseOption, UpgradeInfo, ProductChangeCallback)` |
-| `purchasePackage(Activity, Package, PurchaseCallback)`                        | `purchasePackageOption(Activity, Package, PurchaseOption, PurchaseCallback)`                        |
-| `purchasePackage(Activity, Package, UpgradeInfo, ProductChangeCallback)`      | `purchasePackage(Activity, Package, PurchaseOption, UpgradeInfo, ProductChangeCallback)`            |
+| `purchaseProduct(Activity, StoreProduct, UpgradeInfo, ProductChangeCallback)` | `purchaseSubscriptionOption(Activity, StoreProduct, PurchaseOption, UpgradeInfo, ProductChangeCallback)` |
+| `purchasePackage(Activity, Package, UpgradeInfo, ProductChangeCallback)`      | `purchaseSubscriptionOption(Activity, StoreProduct, PurchaseOption, UpgradeInfo, ProductChangeCallback)` |
 
+| New              |
+|------------------|
+| `purchaseSubscriptionOption(Activity, StoreProduct, PurchaseOption, PurchaseCallback)` |
 
 ### Kotlin Helpers Changes
 
-| Old signature                                                                                                                           | New signature                                                                                                                                                 |
+| Deprecated                                                                                                                              | New                                                                                                                                                           |
 |-----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `purchaseProductWith(Activity, StoreProduct, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)`              | `purchaseProductOptionWith(Activity, StoreProduct, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)`              |
-| `purchaseProductWith(Activity, StoreProduct, UpgradeInfo, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)` | `purchaseProductOptionWith(Activity, StoreProduct, UpgradeInfo, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)` |
-| `purchasePackageWith(Activity, Package, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)`                   | `purchasePackageOptionWith(Activity, Package, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)`                   |
-| `purchasePackageWith(Activity, Package, UpgradeInfo, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)`      | `purchasePackageOptionWith(Activity, Package, UpgradeInfo, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)`      |
+| `purchaseProductWith(Activity, StoreProduct, UpgradeInfo, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)` | `purchaseSubscriptionOptionWith(Activity, StoreProduct, UpgradeInfo, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)` |
+| `purchasePackageWith(Activity, Package, UpgradeInfo, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)`      | `purchaseSubscriptionOptionWith(Activity, Package, UpgradeInfo, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)`      |
 
-| Removed|  
+| New              |
+|------------------|
+| `purchaseSubscriptionOptionWith(Activity, StoreProduct, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)` |
+
+| Removed |
 |----------------------------------------------------------------------------------------------------------------------|
 | `getPurchaserInfoWith((PurchasesError) -> Unit, (PurchaserInfo) -> Unit)`                                            |
 | `purchasePackageWith(Activity, Package, (PurchasesError) -> Unit, (Purchase, PurchaserInfo) -> Unit)`                |

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -379,7 +379,8 @@ class Purchases internal constructor(
     }
 
     /**
-     * Make a purchase upgrading from a previous sku.
+     * Make a purchase upgrading from a previous sku. If purchasing a subscription,
+     * it will choose the default [PurchaseOption].
      * @param [activity] Current activity
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
      * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional
@@ -413,7 +414,7 @@ class Purchases internal constructor(
     }
 
     /**
-     * Make a purchase.
+     * Purchases a [StoreProduct]. If purchasing a subscription, it will choose the default [PurchaseOption].
      * @param [activity] Current activity
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
      * @param [callback] The PurchaseCallback that will be called when purchase completes.
@@ -477,7 +478,8 @@ class Purchases internal constructor(
     }
 
     /**
-     * Make a purchase upgrading from a previous sku.
+     * Purchase a [Package] upgrading from a previous sku. If purchasing a subscription,
+     * it will choose the default [PurchaseOption].
      * @param [activity] Current activity
      * @param [packageToPurchase] The Package you wish to purchase
      * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional
@@ -511,7 +513,7 @@ class Purchases internal constructor(
     }
 
     /**
-     * Make a purchase.
+     * Purchase a [Package]. If purchasing a subscription, it will choose the default [PurchaseOption].
      * @param [activity] Current activity
      * @param [packageToPurchase] The Package you wish to purchase
      * @param [listener] The listener that will be called when purchase completes.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -387,10 +387,6 @@ class Purchases internal constructor(
      * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
      * @param [listener] The PurchaseCallback that will be called when purchase completes.
      */
-    @Deprecated(
-        "Replaced with purchaseSubscriptionOption",
-        ReplaceWith("purchaseSubscriptionOption(activity, storeProduct, purchaseOption, upgradeInfo, listener)")
-    )
     fun purchaseProduct(
         activity: Activity,
         storeProduct: StoreProduct,
@@ -486,10 +482,6 @@ class Purchases internal constructor(
      * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
      * @param [callback] The listener that will be called when purchase completes.
      */
-    @Deprecated(
-        "Replaced with purchaseSubscriptionOption",
-        ReplaceWith("purchaseSubscriptionOption(activity, storeProduct, purchaseOption, upgradeInfo, callback)")
-    )
     fun purchasePackage(
         activity: Activity,
         packageToPurchase: Package,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -431,10 +431,10 @@ class Purchases internal constructor(
 
     // TODOBC5: remove storeProduct parameter
     /**
-     * Purchase a [StoreProduct]'s [PurchaseOption] upgrading from a previous product.
+     * Purchase a subscription [StoreProduct]'s [PurchaseOption] upgrading from a previous product.
      * @param [activity] Current activity
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
-     * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+     * @param [purchaseOption] Your choice of purchase options available for the subscription StoreProduct
      * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional
      * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
      * @param [listener] The PurchaseCallback that will be called when purchase completes.
@@ -458,10 +458,10 @@ class Purchases internal constructor(
 
     // TODOBC5: Remove storeProduct parameter
     /**
-     * Purchase a [StoreProduct]'s [PurchaseOption].
+     * Purchase a subscription [StoreProduct]'s [PurchaseOption].
      * @param [activity] Current activity
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
-     * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+     * @param [purchaseOption] Your choice of purchase options available for the subscription StoreProduct
      * @param [callback] The PurchaseCallback that will be called when purchase completes
      */
     fun purchaseSubscriptionOption(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -387,8 +387,8 @@ class Purchases internal constructor(
      * @param [listener] The PurchaseCallback that will be called when purchase completes.
      */
     @Deprecated(
-        "Replaced with purchaseProductOption",
-        ReplaceWith("purchaseProductOption(activity, storeProduct, purchaseOption, upgradeInfo, listener)")
+        "Replaced with purchaseSubscriptionOption",
+        ReplaceWith("purchaseSubscriptionOption(activity, storeProduct, purchaseOption, upgradeInfo, listener)")
     )
     fun purchaseProduct(
         activity: Activity,
@@ -418,10 +418,6 @@ class Purchases internal constructor(
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
      * @param [callback] The PurchaseCallback that will be called when purchase completes.
      */
-    @Deprecated(
-        "Replaced with purchaseProductOption",
-        ReplaceWith("purchaseProductOption(activity, storeProduct, purchaseOption, callback)")
-    )
     fun purchaseProduct(
         activity: Activity,
         storeProduct: StoreProduct,
@@ -436,6 +432,7 @@ class Purchases internal constructor(
         startPurchase(activity, storeProduct, purchaseOption, null, callback)
     }
 
+    // TODOBC5: remove storeProduct parameter
     /**
      * Purchase a [StoreProduct]'s [PurchaseOption] upgrading from a previous product.
      * @param [activity] Current activity
@@ -445,7 +442,7 @@ class Purchases internal constructor(
      * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
      * @param [listener] The PurchaseCallback that will be called when purchase completes.
      */
-    fun purchaseProductOption(
+    fun purchaseSubscriptionOption(
         activity: Activity,
         storeProduct: StoreProduct,
         purchaseOption: PurchaseOption,
@@ -462,6 +459,7 @@ class Purchases internal constructor(
         )
     }
 
+    // TODOBC5: Remove storeProduct parameter
     /**
      * Purchase a [StoreProduct]'s [PurchaseOption].
      * @param [activity] Current activity
@@ -469,7 +467,7 @@ class Purchases internal constructor(
      * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
      * @param [callback] The PurchaseCallback that will be called when purchase completes
      */
-    fun purchaseProductOption(
+    fun purchaseSubscriptionOption(
         activity: Activity,
         storeProduct: StoreProduct,
         purchaseOption: PurchaseOption,
@@ -487,8 +485,8 @@ class Purchases internal constructor(
      * @param [callback] The listener that will be called when purchase completes.
      */
     @Deprecated(
-        "Replaced with purchasePackageOption",
-        ReplaceWith("purchasePackageOption(activity, packageToPurchase, purchaseOption, upgradeInfo, callback)")
+        "Replaced with purchaseSubscriptionOption",
+        ReplaceWith("purchaseSubscriptionOption(activity, storeProduct, purchaseOption, upgradeInfo, callback)")
     )
     fun purchasePackage(
         activity: Activity,
@@ -518,10 +516,6 @@ class Purchases internal constructor(
      * @param [packageToPurchase] The Package you wish to purchase
      * @param [listener] The listener that will be called when purchase completes.
      */
-    @Deprecated(
-        "Replaced with purchasePackageOption",
-        ReplaceWith("purchasePackageOption(activity, packageToPurchase, purchaseOption, listener)")
-    )
     fun purchasePackage(
         activity: Activity,
         packageToPurchase: Package,
@@ -533,54 +527,6 @@ class Purchases internal constructor(
             errorLog("PurchasePackage: Product does not have any purchase option")
             return
         }
-        startPurchase(
-            activity,
-            packageToPurchase.product,
-            purchaseOption,
-            packageToPurchase.offering,
-            listener
-        )
-    }
-
-    /**
-     * Purchase a [Package]'s [PurchaseOption], switching from an old product.
-     * @param [activity] Current activity
-     * @param [packageToPurchase] The Package you wish to purchase
-     * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
-     * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional
-     * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
-     * @param [callback] The listener that will be called when purchase completes.
-     */
-    fun purchasePackageOption(
-        activity: Activity,
-        packageToPurchase: Package,
-        purchaseOption: PurchaseOption,
-        upgradeInfo: UpgradeInfo,
-        callback: ProductChangeCallback
-    ) {
-        startProductChange(
-            activity,
-            packageToPurchase.product,
-            purchaseOption,
-            packageToPurchase.offering,
-            upgradeInfo,
-            callback
-        )
-    }
-
-    /**
-     * Make a purchase.
-     * @param [activity] Current activity
-     * @param [packageToPurchase] The Package you wish to purchase
-     * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
-     * @param [listener] The listener that will be called when purchase completes.
-     */
-    fun purchasePackageOption(
-        activity: Activity,
-        packageToPurchase: Package,
-        purchaseOption: PurchaseOption,
-        listener: PurchaseCallback
-    ) {
         startPurchase(
             activity,
             packageToPurchase.product,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -136,10 +136,6 @@ fun Purchases.purchaseProductWith(
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
-@Deprecated(
-    "Replaced with purchaseSubscriptionOptionWith",
-    ReplaceWith("purchaseSubscriptionOptionWith(activity, storeProduct, upgradeInfo, purchaseOption, onError, onSuccess)")
-)
 fun Purchases.purchaseProductWith(
     activity: Activity,
     storeProduct: StoreProduct,
@@ -212,12 +208,6 @@ fun Purchases.purchaseSubscriptionOptionWith(
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
-@Deprecated(
-    "Replaced with purchaseSubscriptionOptionWith",
-    ReplaceWith(
-        "purchaseSubscriptionOptionWith(activity, storeProduct, upgradeInfo, purchaseOption, onError, onSuccess)"
-    )
-)
 fun Purchases.purchasePackageWith(
     activity: Activity,
     packageToPurchase: Package,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -112,7 +112,7 @@ fun Purchases.getOfferingsWith(
 }
 
 /**
- * Purchase product.
+ * Purchase product. If purchasing a subscription, it will choose the default [PurchaseOption].
  * @param [activity] Current activity
  * @param [storeProduct] The storeProduct of the product you wish to purchase
  * @param [onSuccess] Will be called after the purchase has completed
@@ -128,7 +128,8 @@ fun Purchases.purchaseProductWith(
 }
 
 /**
- * Make a purchase upgrading from a previous sku.
+ * Make a purchase upgrading from a previous sku. If purchasing a subscription, it will choose the
+ * default [PurchaseOption].
  * @param [activity] Current activity
  * @param [storeProduct] The storeProduct of the product you wish to purchase
  * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
@@ -200,7 +201,8 @@ fun Purchases.purchaseSubscriptionOptionWith(
 }
 
 /**
- * Make a purchase upgrading from a previous sku.
+ * Make a purchase upgrading from a previous sku. If purchasing a subscription, it will choose the
+ * default [PurchaseOption].
  * @param [activity] Current activity
  * @param [packageToPurchase] The Package you wish to purchase
  * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
@@ -219,7 +221,7 @@ fun Purchases.purchasePackageWith(
 }
 
 /**
- * Make a purchase.
+ * Make a purchase. If purchasing a subscription, it will choose the default [PurchaseOption].
  * @param [activity] Current activity
  * @param [packageToPurchase] The Package you wish to purchase
  * @param [onSuccess] Will be called after the purchase has completed

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -118,10 +118,6 @@ fun Purchases.getOfferingsWith(
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
-@Deprecated(
-    "Replaced with purchaseProductOptionWith",
-    ReplaceWith("purchaseProductOptionWith(activity, storeProduct, purchaseOption, onError, onSuccess)")
-)
 fun Purchases.purchaseProductWith(
     activity: Activity,
     storeProduct: StoreProduct,
@@ -129,29 +125,6 @@ fun Purchases.purchaseProductWith(
     onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
 ) {
     purchaseProduct(activity, storeProduct, purchaseCompletedCallback(onSuccess, onError))
-}
-
-/**
- * Purchase a [Product]'s [PurchaseOption].
- * @param [activity] Current activity
- * @param [storeProduct] The storeProduct of the product you wish to purchase
- * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
- * @param [onSuccess] Will be called after the purchase has completed
- * @param [onError] Will be called after the purchase has completed with error
- */
-fun Purchases.purchaseProductOptionWith(
-    activity: Activity,
-    storeProduct: StoreProduct,
-    purchaseOption: PurchaseOption,
-    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
-    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
-) {
-    purchaseProductOption(
-        activity,
-        storeProduct,
-        purchaseOption,
-        purchaseCompletedCallback(onSuccess, onError)
-    )
 }
 
 /**
@@ -164,8 +137,8 @@ fun Purchases.purchaseProductOptionWith(
  * @param [onError] Will be called after the purchase has completed with error
  */
 @Deprecated(
-    "Replaced with purchaseProductOptionWith",
-    ReplaceWith("purchaseProductOptionWith(activity, storeProduct, upgradeInfo, purchaseOption, onError, onSuccess)")
+    "Replaced with purchaseSubscriptionOptionWith",
+    ReplaceWith("purchaseSubscriptionOptionWith(activity, storeProduct, upgradeInfo, purchaseOption, onError, onSuccess)")
 )
 fun Purchases.purchaseProductWith(
     activity: Activity,
@@ -177,8 +150,33 @@ fun Purchases.purchaseProductWith(
     purchaseProduct(activity, storeProduct, upgradeInfo, productChangeCompletedListener(onSuccess, onError))
 }
 
+// TODOBC5: Remove storeProduct parameter
 /**
- * Purchase a [Product]'s [PurchaseOption], upgrading from an old product.
+ * Purchase a [StoreProduct]'s [PurchaseOption].
+ * @param [activity] Current activity
+ * @param [storeProduct] The storeProduct of the product you wish to purchase
+ * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [onSuccess] Will be called after the purchase has completed
+ * @param [onError] Will be called after the purchase has completed with error
+ */
+fun Purchases.purchaseSubscriptionOptionWith(
+    activity: Activity,
+    storeProduct: StoreProduct,
+    purchaseOption: PurchaseOption,
+    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
+    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
+) {
+    purchaseSubscriptionOption(
+        activity,
+        storeProduct,
+        purchaseOption,
+        purchaseCompletedCallback(onSuccess, onError)
+    )
+}
+
+// TODOBC5: Remove storeProduct parameter
+/**
+ * Purchase a [StoreProduct]'s [PurchaseOption], upgrading from an old product.
  * @param [activity] Current activity
  * @param [storeProduct] The storeProduct of the product you wish to purchase
  * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
@@ -188,7 +186,7 @@ fun Purchases.purchaseProductWith(
  * @param [onError] Will be called after the purchase has completed with error
  */
 @Suppress("LongParameterList")
-fun Purchases.purchaseProductOptionWith(
+fun Purchases.purchaseSubscriptionOptionWith(
     activity: Activity,
     storeProduct: StoreProduct,
     purchaseOption: PurchaseOption,
@@ -196,7 +194,7 @@ fun Purchases.purchaseProductOptionWith(
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
     onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
 ) {
-    purchaseProductOption(
+    purchaseSubscriptionOption(
         activity,
         storeProduct,
         purchaseOption,
@@ -215,9 +213,9 @@ fun Purchases.purchaseProductOptionWith(
  * @param [onError] Will be called after the purchase has completed with error
  */
 @Deprecated(
-    "Replaced with purchasePackageOptionWith",
+    "Replaced with purchaseSubscriptionOptionWith",
     ReplaceWith(
-        "purchasePackageOptionWith(activity, packageToPurchase, upgradeInfo, purchaseOption, onError, onSuccess)"
+        "purchaseSubscriptionOptionWith(activity, storeProduct, upgradeInfo, purchaseOption, onError, onSuccess)"
     )
 )
 fun Purchases.purchasePackageWith(
@@ -231,44 +229,12 @@ fun Purchases.purchasePackageWith(
 }
 
 /**
- * Purchase a [Package]'s [PurchaseOption], upgrading from an old product
- * @param [activity] Current activity
- * @param [packageToPurchase] The Package you wish to purchase
- * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
- * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode
- * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases
- * @param [onSuccess] Will be called after the purchase has completed
- * @param [onError] Will be called after the purchase has completed with error
- */
-@SuppressWarnings("LongParameterList")
-fun Purchases.purchasePackageOptionWith(
-    activity: Activity,
-    packageToPurchase: Package,
-    purchaseOption: PurchaseOption,
-    upgradeInfo: UpgradeInfo,
-    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
-    onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
-) {
-    purchasePackageOption(
-        activity,
-        packageToPurchase,
-        purchaseOption,
-        upgradeInfo,
-        productChangeCompletedListener(onSuccess, onError)
-    )
-}
-
-/**
  * Make a purchase.
  * @param [activity] Current activity
  * @param [packageToPurchase] The Package you wish to purchase
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
-@Deprecated(
-    "Replaced with purchasePackageWithOption",
-    ReplaceWith("purchasePackageWithOption(activity, packageToPurchase, purchaseOption, onError, onSuccess)")
-)
 fun Purchases.purchasePackageWith(
     activity: Activity,
     packageToPurchase: Package,
@@ -276,29 +242,6 @@ fun Purchases.purchasePackageWith(
     onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
 ) {
     purchasePackage(activity, packageToPurchase, purchaseCompletedCallback(onSuccess, onError))
-}
-
-/**
- * Purchase a [Package]'s [PurchaseOption]
- * @param [activity] Current activity
- * @param [packageToPurchase] The Package you wish to purchase
- * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
- * @param [onSuccess] Will be called after the purchase has completed
- * @param [onError] Will be called after the purchase has completed with error
- */
-fun Purchases.purchasePackageOptionWith(
-    activity: Activity,
-    packageToPurchase: Package,
-    purchaseOption: PurchaseOption,
-    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
-    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
-) {
-    purchasePackageOption(
-        activity,
-        packageToPurchase,
-        purchaseOption,
-        purchaseCompletedCallback(onSuccess, onError)
-    )
 }
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -148,10 +148,10 @@ fun Purchases.purchaseProductWith(
 
 // TODOBC5: Remove storeProduct parameter
 /**
- * Purchase a [StoreProduct]'s [PurchaseOption].
+ * Purchase a subscription [StoreProduct]'s [PurchaseOption].
  * @param [activity] Current activity
  * @param [storeProduct] The storeProduct of the product you wish to purchase
- * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [purchaseOption] Your choice of purchase options available for the subscription StoreProduct
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called after the purchase has completed with error
  */
@@ -172,10 +172,10 @@ fun Purchases.purchaseSubscriptionOptionWith(
 
 // TODOBC5: Remove storeProduct parameter
 /**
- * Purchase a [StoreProduct]'s [PurchaseOption], upgrading from an old product.
+ * Purchase a subscription [StoreProduct]'s [PurchaseOption], upgrading from an old product.
  * @param [activity] Current activity
  * @param [storeProduct] The storeProduct of the product you wish to purchase
- * @param [purchaseOption] Your choice of purchase options available for the StoreProduct
+ * @param [purchaseOption] Your choice of purchase options available for the subscription StoreProduct
  * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
  * @param [onSuccess] Will be called after the purchase has completed

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -53,7 +53,6 @@ import com.revenuecat.purchases.utils.Responses
 import com.revenuecat.purchases.utils.SyncDispatcher
 import com.revenuecat.purchases.utils.createMockOneTimeProductDetails
 import com.revenuecat.purchases.utils.createMockProductDetailsFreeTrial
-import com.revenuecat.purchases.utils.mockProductDetails
 import com.revenuecat.purchases.utils.stubGooglePurchase
 import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
 import com.revenuecat.purchases.utils.stubPurchaseOption
@@ -428,7 +427,7 @@ class PurchasesTest {
 
         var callCount = 0
 
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             receiptInfo.storeProduct!!,
             receiptInfo.storeProduct!!.purchaseOptions[0],
@@ -454,7 +453,7 @@ class PurchasesTest {
         val oldPurchase = mockPurchaseFound()
 
         var callCount = 0
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             receiptInfo.storeProduct!!,
             receiptInfo.storeProduct!!.purchaseOptions[0],
@@ -474,7 +473,7 @@ class PurchasesTest {
     fun canMakePurchase() {
         val storeProduct = stubStoreProduct("abc")
 
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             storeProduct,
             storeProduct.purchaseOptions[0]
@@ -517,10 +516,9 @@ class PurchasesTest {
     fun canMakePurchaseOfAPackage() {
         val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
 
-        purchases.purchasePackageOptionWith(
+        purchases.purchasePackageWith(
             mockActivity,
-            offerings[stubOfferingIdentifier]!!.monthly!!,
-            storeProduct.purchaseOptions[0],
+            offerings[stubOfferingIdentifier]!!.monthly!!
         ) { _, _ -> }
 
         verify {
@@ -558,31 +556,6 @@ class PurchasesTest {
 
     @Test
     fun canMakePurchaseUpgradeOfAPackage() {
-        val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
-
-        val oldPurchase = mockPurchaseFound()
-
-        purchases.purchasePackageOptionWith(
-            mockActivity,
-            offerings[stubOfferingIdentifier]!!.monthly!!,
-            storeProduct.purchaseOptions[0],
-            UpgradeInfo(oldPurchase.productIds[0])
-        ) { _, _ -> }
-
-        verify {
-            mockBillingAbstract.makePurchaseAsync(
-                eq(mockActivity),
-                eq(appUserId),
-                storeProduct,
-                storeProduct.purchaseOptions[0],
-                ReplaceSkuInfo(oldPurchase),
-                stubOfferingIdentifier
-            )
-        }
-    }
-
-    @Test
-    fun canMakePurchaseUpgradeOfAPackageWithoutProvidingOption() {
         val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
 
         val oldPurchase = mockPurchaseFound()
@@ -715,7 +688,7 @@ class PurchasesTest {
     fun passesUpErrors() {
         var errorCalled = false
         val storeProduct = stubStoreProduct("productId")
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             mockk(),
             storeProduct,
             storeProduct.purchaseOptions[0],
@@ -734,7 +707,7 @@ class PurchasesTest {
         purchases.updatedCustomerInfoListener = updatedCustomerInfoListener
 
         val storeProduct = stubStoreProduct("productId")
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             mockk(),
             storeProduct,
             storeProduct.purchaseOptions[0],
@@ -743,7 +716,7 @@ class PurchasesTest {
         }
 
         var errorCalled: PurchasesError? = null
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             mockk(),
             storeProduct,
             storeProduct.purchaseOptions[0],
@@ -766,7 +739,7 @@ class PurchasesTest {
         val storeProduct = stubStoreProduct(productId)
 
         var callCount = 0
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             storeProduct,
             storeProduct.purchaseOptions[0],
@@ -792,7 +765,7 @@ class PurchasesTest {
         var callCount = 0
         mockQueryingProductDetails(productId1, ProductType.SUBS, null)
         val storeProduct = stubStoreProduct(productId)
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             storeProduct,
             storeProduct.purchaseOptions[0],
@@ -810,13 +783,13 @@ class PurchasesTest {
     @Test
     fun `when multiple make purchase callbacks, a failure doesn't throw ConcurrentModificationException`() {
         val storeProduct = stubStoreProduct("productId")
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             storeProduct,
             storeProduct.purchaseOptions[0]
         ) { _, _ -> }
 
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             storeProduct,
             storeProduct.purchaseOptions[0]
@@ -848,7 +821,7 @@ class PurchasesTest {
         var receivedError: PurchasesError? = null
         var receivedUserCancelled: Boolean? = null
 
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             receiptInfo.storeProduct!!,
             receiptInfo.storeProduct!!.purchaseOptions[0],
@@ -876,7 +849,7 @@ class PurchasesTest {
         var receivedError: PurchasesError? = null
         var receivedUserCancelled: Boolean? = null
 
-        purchases.purchaseProductOptionWith(
+        purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             receiptInfo.storeProduct!!,
             receiptInfo.storeProduct!!.purchaseOptions[0],
@@ -901,7 +874,7 @@ class PurchasesTest {
     fun `when purchasing a package with upgrade info, completion block is called`() {
         val productId = "onemonth_freetrial"
 
-        val (storeProduct, offerings) = stubOfferings(productId)
+        val (_, offerings) = stubOfferings(productId)
         mockQueryingProductDetails(productId, ProductType.SUBS, null)
 
         val purchaseToken = "crazy_purchase_token"
@@ -910,10 +883,9 @@ class PurchasesTest {
 
         var callCount = 0
 
-        purchases.purchasePackageOptionWith(
+        purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.productIds[0]),
             onError = { _, _ ->
                 fail("should be successful")
@@ -934,16 +906,15 @@ class PurchasesTest {
     @Test
     fun `when purchasing a package with upgrade info, completion is called with null purchase if product change is deferred`() {
         val productId = "onemonth_freetrial"
-        val (storeProduct, offerings) = stubOfferings(productId)
+        val (_, offerings) = stubOfferings(productId)
 
         val oldPurchase = mockPurchaseFound()
 
         var callCount = 0
 
-        purchases.purchasePackageOptionWith(
+        purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.productIds[0]),
             onError = { _, _ ->
                 fail("should be success")
@@ -959,7 +930,7 @@ class PurchasesTest {
     @Test
     fun `when purchasing a package with upgrade info, error is forwarded`() {
         val productId = "onemonth_freetrial"
-        val (storeProduct, offerings) = stubOfferings(productId)
+        val (_, offerings) = stubOfferings(productId)
 
         mockQueryingProductDetails(productId, ProductType.SUBS, null)
 
@@ -974,10 +945,9 @@ class PurchasesTest {
 
         var receivedError: PurchasesError? = null
         var receivedUserCancelled: Boolean? = null
-        purchases.purchasePackageOptionWith(
+        purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.productIds[0]),
             onError = { error, userCancelled ->
                 receivedError = error
@@ -994,16 +964,15 @@ class PurchasesTest {
     @Test
     fun `when purchasing a package with upgrade info, failures purchasing are forwarded`() {
         val productId = "onemonth_freetrial"
-        val (storeProduct, offerings) = stubOfferings(productId)
+        val (_, offerings) = stubOfferings(productId)
 
         val oldPurchase = mockPurchaseFound()
 
         var receivedError: PurchasesError? = null
         var receivedUserCancelled: Boolean? = null
-        purchases.purchasePackageOptionWith(
+        purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.productIds[0]),
             onError = { error, userCancelled ->
                 receivedError = error
@@ -1032,10 +1001,9 @@ class PurchasesTest {
 
         var receivedError: PurchasesError? = null
         var receivedUserCancelled: Boolean? = null
-        purchases.purchasePackageOptionWith(
+        purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.productIds[0]),
             onError = { error, userCancelled ->
                 receivedError = error
@@ -1090,10 +1058,9 @@ class PurchasesTest {
 
         var receivedError: PurchasesError? = null
         var receivedUserCancelled: Boolean? = null
-        purchases.purchasePackageOptionWith(
+        purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.productIds[0]),
             onError = { error, userCancelled ->
                 receivedError = error
@@ -1119,7 +1086,7 @@ class PurchasesTest {
 
     @Test
     fun `Deferred downgrade`() {
-        val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
+        val (_, offerings) = stubOfferings("onemonth_freetrial")
         val oldProductId = "oldProductId"
 
         val oldPurchase = mockk<StoreTransaction>()
@@ -1138,10 +1105,9 @@ class PurchasesTest {
             lambda<(StoreTransaction) -> Unit>().captured.invoke(oldPurchase)
         }
 
-        purchases.purchasePackageOptionWith(
+        purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            storeProduct.purchaseOptions[0],
             UpgradeInfo(oldPurchase.productIds[0])
         ) { _, _ -> }
 


### PR DESCRIPTION
### Description
This PR is a first step towards the latest API we talked about in the last meeting.
- Undeprecate `purchaseProduct` and `purchasePackage` which meant to be used with INAPP products, and when used with subscriptions, it will choose a default `purchaseOption` (logic on this TBD).
- Removed old `purchaseProductOption` and `purchasePackageOption` in favor of `purchaseSubscriptionOption`. This is meant only for subscriptions so devs can choose their own subscription option. Currently it requires a `StoreProduct` + `PurchaseOption` but the intention is to remove the `StoreProduct` parameter which deserves it's own big PR.

