### PR TITLE
Added androidx.lifecycle.DefaultLifecycleObserver to consumer-rules.pro

### DIFF
--- a/purchases/consumer-rules.pro
+++ b/purchases/consumer-rules.pro
@@ -1,1 +1,2 @@
 -keep class com.revenuecat.** { *; }
+-keep class androidx.lifecycle.DefaultLifecycleObserver


### PR DESCRIPTION
Should prevent https://github.com/RevenueCat/purchases-flutter/pull/547 everywhere. Longer explanation in that other PR