### PR TITLE
Adds `Purchases.verboseLogHandler` and `Purchases.verboseLogs`

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.common
 object Config {
 
     var debugLogsEnabled = BuildConfig.DEBUG
+    var verboseLogs = false
 
     const val frameworkVersion = "5.7.0-SNAPSHOT"
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/logUtils.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/logUtils.kt
@@ -2,24 +2,31 @@ package com.revenuecat.purchases.common
 
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.logging.LogLevel
 
-fun debugLog(message: String) {
+fun debugLog(message: String, elements: Array<StackTraceElement>? = null) {
     if (Config.debugLogsEnabled) {
-        currentLogHandler.d("[Purchases] - DEBUG", message)
+        currentVerboseLogHandler.log(LogLevel.DEBUG, LogLevel.DEBUG.createTag(), message, null, elements)
     }
 }
 
-fun infoLog(message: String) {
-    currentLogHandler.i("[Purchases] - INFO", message)
+fun infoLog(message: String, elements: Array<StackTraceElement>? = null) {
+    currentVerboseLogHandler.log(LogLevel.INFO, LogLevel.INFO.createTag(), message, null, elements)
 }
 
-fun warnLog(message: String) {
-    currentLogHandler.w("[Purchases] - WARN", message)
+fun warnLog(message: String, elements: Array<StackTraceElement>? = null) {
+    currentVerboseLogHandler.log(LogLevel.WARN, LogLevel.WARN.createTag(), message, null, elements)
 }
 
-fun errorLog(message: String, throwable: Throwable? = null) {
-    currentLogHandler.e("[Purchases] - ERROR", message, throwable)
+fun errorLog(message: String, throwable: Throwable? = null, elements: Array<StackTraceElement>? = null) {
+    currentVerboseLogHandler.log(LogLevel.ERROR, LogLevel.ERROR.createTag(), message, throwable, elements)
 }
+
+fun verboseLog(message: String, throwable: Throwable? = null, elements: Array<StackTraceElement>? = null) {
+    currentVerboseLogHandler.log(LogLevel.VERBOSE, LogLevel.VERBOSE.createTag(), message, throwable, elements)
+}
+
+fun LogLevel.createTag() = "[Purchases] - ${this.name}"
 
 fun errorLog(error: PurchasesError) {
     when (error.code) {

--- a/common/src/main/java/com/revenuecat/purchases/common/logWrapper.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/logWrapper.kt
@@ -2,29 +2,81 @@ package com.revenuecat.purchases.common
 
 import android.util.Log
 import com.revenuecat.purchases.LogHandler
+import com.revenuecat.purchases.logging.LogLevel
+import com.revenuecat.purchases.logging.VerboseLogHandler
 import com.revenuecat.purchases.strings.Emojis
 
 var currentLogHandler: LogHandler = DefaultLogHandler()
+var currentVerboseLogHandler: VerboseLogHandler = DefaultVerboseLogHandler()
 
 private class DefaultLogHandler : LogHandler {
     override fun d(tag: String, msg: String) {
-        Log.d(tag, msg)
+        debugLog(msg, null)
     }
 
     override fun i(tag: String, msg: String) {
-        Log.i(tag, msg)
+        infoLog(msg, null)
     }
 
     override fun w(tag: String, msg: String) {
-        Log.w(tag, msg)
+        warnLog(msg, null)
     }
 
     override fun e(tag: String, msg: String, throwable: Throwable?) {
-        if (throwable != null) {
-            Log.e(tag, msg, throwable)
-        } else {
-            Log.e(tag, msg)
+        errorLog(msg, throwable)
+    }
+}
+
+fun verboseLogHandlerToLogHandler(value: LogHandler) = object : VerboseLogHandler {
+    override fun log(
+        level: LogLevel,
+        tag: String,
+        message: String,
+        throwable: Throwable?,
+        elements: Array<StackTraceElement>?
+    ) {
+        when (level) {
+            LogLevel.DEBUG -> value.d(tag, message)
+            LogLevel.INFO -> value.i(tag, message)
+            LogLevel.WARN -> value.w(tag, message)
+            LogLevel.ERROR -> value.e(tag, message, throwable)
+            LogLevel.VERBOSE -> return // LogHandler doesn't handle verbose
         }
+    }
+}
+
+private class DefaultVerboseLogHandler : VerboseLogHandler {
+    override fun log(
+        level: LogLevel,
+        tag: String,
+        message: String,
+        throwable: Throwable?,
+        elements: Array<StackTraceElement>?
+    ) {
+        val messageWithStacktraceIfNeeded = message + if (Config.verboseLogs) { stacktraceString(elements) } else ""
+
+        when (level) {
+            LogLevel.DEBUG -> Log.d(tag, messageWithStacktraceIfNeeded)
+            LogLevel.INFO -> Log.i(tag, messageWithStacktraceIfNeeded)
+            LogLevel.WARN -> Log.w(tag, messageWithStacktraceIfNeeded)
+            LogLevel.ERROR -> throwable?.let {
+                Log.e(tag, messageWithStacktraceIfNeeded, it)
+            } ?: Log.e(tag, messageWithStacktraceIfNeeded)
+            LogLevel.VERBOSE -> throwable?.let {
+                Log.v(tag, messageWithStacktraceIfNeeded, it)
+            } ?: Log.v(tag, messageWithStacktraceIfNeeded)
+        }
+    }
+
+    private fun stacktraceString(elements: Array<StackTraceElement>?) = if (elements != null) {
+        "\n${elements.joinToString("\n")}"
+    } else {
+        // Getting the stacktrace by creating a Throwable is faster and gives the correct item (this function)
+        // for the first item of the stacktrace. It prints "java.lang.Throwable\n" in the first line,
+        // so we remove that. Using currentThread().stacktrace will print this at the beginning of the stack:
+        //      dalvik.system.VMStack.getThreadStackTrace(Native Method)
+        //      java.lang.Thread.getStackTrace(Thread.java:1841)
+        "\n${Throwable().stackTraceToString().replaceFirst("java.lang.Throwable\n", "")}"
     }
 }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/LogHandlerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/LogHandlerTest.kt
@@ -45,13 +45,13 @@ class LogHandlerTest {
 
     @Before
     fun setUp() {
-        previousHandler = currentLogHandler
-        currentLogHandler = handler
+        previousHandler = currentVerboseLogHandler
+        currentVerboseLogHandler = handler
     }
 
     @After
     fun tearDown() {
-        currentLogHandler = previousHandler
+        currentVerboseLogHandler = previousHandler
     }
 
     @Test

--- a/public/src/main/java/com/revenuecat/purchases/logging/LogLevel.kt
+++ b/public/src/main/java/com/revenuecat/purchases/logging/LogLevel.kt
@@ -1,0 +1,9 @@
+package com.revenuecat.purchases.logging
+
+enum class LogLevel {
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR,
+    VERBOSE
+}

--- a/public/src/main/java/com/revenuecat/purchases/logging/VerboseLogHandler.kt
+++ b/public/src/main/java/com/revenuecat/purchases/logging/VerboseLogHandler.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.purchases.logging
+
+/**
+ * Interface that allows handling logs manually.
+ * See also [Purchases.logHandler]
+ */
+interface VerboseLogHandler {
+    fun log(
+        level: LogLevel,
+        tag: String,
+        message: String,
+        throwable: Throwable?,
+        elements: Array<StackTraceElement>?
+    )
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -30,10 +30,12 @@ import com.revenuecat.purchases.common.ReplaceSkuInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
 import com.revenuecat.purchases.common.currentLogHandler
+import com.revenuecat.purchases.common.currentVerboseLogHandler
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
+import com.revenuecat.purchases.common.verboseLogHandlerToLogHandler
 import com.revenuecat.purchases.google.isSuccessful
 import com.revenuecat.purchases.google.toRevenueCatProductType
 import com.revenuecat.purchases.google.toStoreProduct
@@ -52,6 +54,7 @@ import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsListener
 import com.revenuecat.purchases.interfaces.ReceivePurchaserInfoListener
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
+import com.revenuecat.purchases.logging.VerboseLogHandler
 import com.revenuecat.purchases.interfaces.UpdatedPurchaserInfoListener
 import com.revenuecat.purchases.interfaces.toGetStoreProductsCallback
 import com.revenuecat.purchases.interfaces.toProductChangeCallback
@@ -1966,6 +1969,17 @@ class Purchases internal constructor(
             }
 
         /**
+         * Setting this to `true` adds additional information to the default log handler: Filename, line, and method
+         * data. You can also access that information for your own logging system by using [verboseLogHandler].
+         */
+        @JvmStatic
+        var verboseLogs
+            get() = Config.verboseLogs
+            set(value) {
+                Config.verboseLogs = value
+            }
+
+        /**
          * Set a custom log handler for redirecting logs to your own logging system.
          * Defaults to [android.util.Log].
          *
@@ -1976,7 +1990,22 @@ class Purchases internal constructor(
         var logHandler: LogHandler
             @Synchronized get() = currentLogHandler
             @Synchronized set(value) {
+                verboseLogHandler = verboseLogHandlerToLogHandler(value)
                 currentLogHandler = value
+            }
+
+        /**
+         * Set a custom log handler for redirecting logs to your own logging system.
+         * Defaults to [android.util.Log].
+         *
+         * By default, this sends info, warning, and error messages.
+         * If you wish to receive Debug level messages, see [debugLogsEnabled].
+         */
+        @JvmStatic
+        var verboseLogHandler: VerboseLogHandler
+            @Synchronized get() = currentVerboseLogHandler
+            @Synchronized set(value) {
+                currentVerboseLogHandler = value
             }
 
         @JvmSynthetic


### PR DESCRIPTION
[CSDK-550] and [CSDK-551]

For parity with iOS, added `verboseLogs` boolean and `verboseLogsHandler`.

I thought about adding a `verbose` function to the current `LogHandler` we already have, but that would break the API, so I had to create a new `VerboseLogHandler`, which I made it as a functional interface with a function that accepts a `LogLevel`, in case we want to add more log levels in the future, so we don't have to break the API.

This is still missing tests, but I would love some feedback on it 

[CSDK-550]: https://revenuecats.atlassian.net/browse/CSDK-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CSDK-551]: https://revenuecats.atlassian.net/browse/CSDK-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ