### PR TITLE
[CF-1065] Fix and add tests for listing of INAPP StoreProducts

### DIFF
--- a/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -46,6 +46,8 @@ fun List<ProductDetails>.toStoreProducts(): List<StoreProduct> {
             it.subscriptionBillingPeriod
         } ?: emptyMap()
 
+        // Maps basePlans to StoreProducts, if any
+        // Otherwise, maps productDetail to StoreProduct
         basePlans.takeUnless { it.isEmpty() }?.forEach { basePlan ->
             val basePlanBillingPeriod = basePlan.subscriptionBillingPeriod
             val offerDetailsForBasePlan = offerDetailsBySubPeriod[basePlanBillingPeriod] ?: emptyList()

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -40,7 +40,7 @@ private fun ProductDetails.createOneTimeProductPrice(): Price? {
 fun List<ProductDetails>.toStoreProducts(): List<StoreProduct> {
     val storeProducts = mutableListOf<StoreProduct>()
     forEach { productDetails ->
-        val basePlans = productDetails.subscriptionOfferDetails?.filter { it.isBasePlan } ?: return emptyList()
+        val basePlans = productDetails.subscriptionOfferDetails?.filter { it.isBasePlan } ?: emptyList()
 
         val offerDetailsBySubPeriod = productDetails.subscriptionOfferDetails?.groupBy {
             it.subscriptionBillingPeriod

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductConversionsTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductConversionsTest.kt
@@ -1,0 +1,60 @@
+package com.revenuecat.purchases.google
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.billingclient.api.BillingClient
+import com.revenuecat.purchases.utils.mockProductDetails
+import com.revenuecat.purchases.utils.mockSubscriptionOfferDetails
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StoreProductConversionsTest {
+    @Test
+    fun `list of INAPP ProductDetails maps to StoreProducts`() {
+        val productDetail1 = mockProductDetails(productId = "iap_1", type = BillingClient.ProductType.INAPP, subscriptionOfferDetails = null)
+        val productDetails = listOf(productDetail1)
+
+        val storeProducts = productDetails.toStoreProducts()
+        assertThat(storeProducts.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `list of SUBS ProductDetails maps to StoreProducts`() {
+        val productDetail1 = mockProductDetails(productId = "sub_1", type = BillingClient.ProductType.SUBS)
+        val productDetails = listOf(productDetail1)
+
+        val storeProducts = productDetails.toStoreProducts()
+        assertThat(storeProducts.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `list of INAPP and SUBS ProductDetails maps to StoreProducts`() {
+        val productDetail1 = mockProductDetails(
+            productId = "iap_1",
+            type = BillingClient.ProductType.INAPP,
+            subscriptionOfferDetails = null)
+        val productDetail2 = mockProductDetails(
+            productId = "sub_1",
+            type = BillingClient.ProductType.SUBS)
+        val productDetails = listOf(productDetail1, productDetail2)
+
+        val storeProducts = productDetails.toStoreProducts()
+        assertThat(storeProducts.size).isEqualTo(2)
+    }
+
+    @Test
+    fun `list of SUBS ProductDetails with multiple subscription offers maps to multiple StoreProducts`() {
+        val monthlyBasePlan = mockSubscriptionOfferDetails(offerId = "monthly-offer", basePlanId = "monthly")
+        val yearlyBasePlan = mockSubscriptionOfferDetails(offerId = "yearly-offer", basePlanId = "yearly")
+
+        val productDetail1 = mockProductDetails(
+            productId = "sub_1",
+            type = BillingClient.ProductType.SUBS,
+            subscriptionOfferDetails = listOf(monthlyBasePlan, yearlyBasePlan))
+        val productDetails = listOf(productDetail1)
+
+        val storeProducts = productDetails.toStoreProducts()
+        assertThat(storeProducts.size).isEqualTo(2)
+    }
+}

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.google
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.BillingClient
 import com.revenuecat.purchases.utils.mockProductDetails
+import com.revenuecat.purchases.utils.mockSubscriptionOfferDetails
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,5 +26,35 @@ class StoreProductTest {
 
         val storeProducts = productDetails.toStoreProducts()
         assertThat(storeProducts.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `list of INAPP and SUBS ProductDetails maps to StoreProducts`() {
+        val productDetail1 = mockProductDetails(
+            productId = "iap_1",
+            type = BillingClient.ProductType.INAPP,
+            subscriptionOfferDetails = null)
+        val productDetail2 = mockProductDetails(
+            productId = "sub_1",
+            type = BillingClient.ProductType.SUBS)
+        val productDetails = listOf(productDetail1, productDetail2)
+
+        val storeProducts = productDetails.toStoreProducts()
+        assertThat(storeProducts.size).isEqualTo(2)
+    }
+
+    @Test
+    fun `list of SUBS ProductDetails with multiple subscription offers maps to multiple StoreProducts`() {
+        val monthlyBasePlan = mockSubscriptionOfferDetails(offerId = "monthly-offer", basePlanId = "monthly")
+        val yearlyBasePlan = mockSubscriptionOfferDetails(offerId = "yearly-offer", basePlanId = "yearly")
+
+        val productDetail1 = mockProductDetails(
+            productId = "sub_1",
+            type = BillingClient.ProductType.SUBS,
+            subscriptionOfferDetails = listOf(monthlyBasePlan, yearlyBasePlan))
+        val productDetails = listOf(productDetail1)
+
+        val storeProducts = productDetails.toStoreProducts()
+        assertThat(storeProducts.size).isEqualTo(2)
     }
 }

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -1,94 +1,152 @@
 package com.revenuecat.purchases.google
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.models.GooglePurchaseOption
+import com.revenuecat.purchases.models.GoogleStoreProduct
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.PricingPhase
+import com.revenuecat.purchases.models.RecurrenceMode
+import com.revenuecat.purchases.utils.mockProductDetails
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.Test
 import org.junit.runner.RunWith
 
-//    TODOBC5: After using mocks for ProductDetails, these tests don't make much sense. Leaving for now.
-//@RunWith(AndroidJUnit4::class)
-//class StoreProductTest {
-//    @Test
-//    fun `Two StoreProducts with the same properties are equal`() {
-//        val storeProduct1 = GoogleStoreProduct(
-//            sku = "sku",
-//            type = ProductType.INAPP,
-//            price = "$2",
-//            priceAmountMicros = 2 * 1_000_000,
-//            priceCurrencyCode = "USD",
-//            originalPrice = "$2",
-//            originalPriceAmountMicros = 2 * 1_000_000,
-//            title = "TITLE",
-//            description = "DESCRIPTION",
-//            subscriptionPeriod = "P1M",
-//            freeTrialPeriod = "P1M",
-//            introductoryPrice = "$0",
-//            introductoryPriceAmountMicros = 0 * 1_000_000,
-//            introductoryPricePeriod = "P1W",
-//            introductoryPriceCycles = 1,
-//            iconUrl = "http://",
-//            originalJson = JSONObject("{}")
-//        )
-//        val storeProduct2 = GoogleStoreProduct(
-//            sku = "sku",
-//            type = ProductType.INAPP,
-//            price = "$2",
-//            priceAmountMicros = 2 * 1_000_000,
-//            priceCurrencyCode = "USD",
-//            originalPrice = "$2",
-//            originalPriceAmountMicros = 2 * 1_000_000,
-//            title = "TITLE",
-//            description = "DESCRIPTION",
-//            subscriptionPeriod = "P1M",
-//            freeTrialPeriod = "P1M",
-//            introductoryPrice = "$0",
-//            introductoryPriceAmountMicros = 0 * 1_000_000,
-//            introductoryPricePeriod = "P1W",
-//            introductoryPriceCycles = 1,
-//            iconUrl = "http://",
-//            originalJson = JSONObject("{}")
-//        )
-//        Assertions.assertThat(storeProduct1).isEqualTo(storeProduct2)
-//    }
-//
-//    @Test
-//    fun `Two StoreProducts with the same properties have the same hashcode`() {
-//        val storeProduct1 = GoogleStoreProduct(
-//            sku = "sku",
-//            type = ProductType.INAPP,
-//            price = "$2",
-//            priceAmountMicros = 2 * 1_000_000,
-//            priceCurrencyCode = "USD",
-//            originalPrice = "$2",
-//            originalPriceAmountMicros = 2 * 1_000_000,
-//            title = "TITLE",
-//            description = "DESCRIPTION",
-//            subscriptionPeriod = "P1M",
-//            freeTrialPeriod = "P1M",
-//            introductoryPrice = "$0",
-//            introductoryPriceAmountMicros = 0 * 1_000_000,
-//            introductoryPricePeriod = "P1W",
-//            introductoryPriceCycles = 1,
-//            iconUrl = "http://",
-//            originalJson = JSONObject("{}")
-//        )
-//        val storeProduct2 = GoogleStoreProduct(
-//            sku = "sku",
-//            type = ProductType.INAPP,
-//            price = "$2",
-//            priceAmountMicros = 2 * 1_000_000,
-//            priceCurrencyCode = "USD",
-//            originalPrice = "$2",
-//            originalPriceAmountMicros = 2 * 1_000_000,
-//            title = "TITLE",
-//            description = "DESCRIPTION",
-//            subscriptionPeriod = "P1M",
-//            freeTrialPeriod = "P1M",
-//            introductoryPrice = "$0",
-//            introductoryPriceAmountMicros = 0 * 1_000_000,
-//            introductoryPricePeriod = "P1W",
-//            introductoryPriceCycles = 1,
-//            iconUrl = "http://",
-//            originalJson = JSONObject("{}")
-//        )
-//        Assertions.assertThat(storeProduct1.hashCode()).isEqualTo(storeProduct2.hashCode())
-//    }
-//}
+@RunWith(AndroidJUnit4::class)
+class StoreProductTest {
+    @Test
+    fun `Two StoreProducts with the same properties are equal`() {
+        val productDetails = mockProductDetails()
+        val price1 = Price(
+            formattedPrice = "$1.00",
+            priceAmountMicros = 100,
+            currencyCode = "USD"
+        )
+        val price2 = Price(
+            formattedPrice = "$1.00",
+            priceAmountMicros = 100,
+            currencyCode = "USD"
+        )
+
+        val purchaseOption1 = GooglePurchaseOption(
+            id = "purchaseOptionId",
+            pricingPhases = listOf(PricingPhase(
+                billingPeriod = "",
+                priceCurrencyCode = "",
+                formattedPrice = "",
+                priceAmountMicros = 0L,
+                recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                billingCycleCount = 0
+            )),
+            tags = emptyList(),
+            token = "mock-token"
+        )
+        val purchaseOption2 = GooglePurchaseOption(
+            id = "purchaseOptionId",
+            pricingPhases = listOf(PricingPhase(
+                billingPeriod = "",
+                priceCurrencyCode = "",
+                formattedPrice = "",
+                priceAmountMicros = 0L,
+                recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                billingCycleCount = 0
+            )),
+            tags = emptyList(),
+            token = "mock-token"
+        )
+
+        val storeProduct1 = GoogleStoreProduct(
+            productId = "product_id",
+            type = ProductType.INAPP,
+            oneTimeProductPrice = price1,
+            title = "TITLE",
+            description = "DESCRIPTION",
+            subscriptionPeriod = "P1M",
+            purchaseOptions = listOf(purchaseOption1),
+            defaultOption = null,
+            productDetails = productDetails
+        )
+
+        val storeProduct2 = GoogleStoreProduct(
+            productId = "product_id",
+            type = ProductType.INAPP,
+            oneTimeProductPrice = price2,
+            title = "TITLE",
+            description = "DESCRIPTION",
+            subscriptionPeriod = "P1M",
+            purchaseOptions = listOf(purchaseOption2),
+            defaultOption = null,
+            productDetails = productDetails
+        )
+
+        assertThat(storeProduct1).isEqualTo(storeProduct2)
+    }
+
+    @Test
+    fun `Two StoreProducts with the same properties have the same hashcode`() {
+        val productDetails = mockProductDetails()
+        val price1 = Price(
+            formattedPrice = "$1.00",
+            priceAmountMicros = 100,
+            currencyCode = "USD"
+        )
+        val price2 = Price(
+            formattedPrice = "$1.00",
+            priceAmountMicros = 100,
+            currencyCode = "USD"
+        )
+
+        val purchaseOption1 = GooglePurchaseOption(
+            id = "purchaseOptionId",
+            pricingPhases = listOf(PricingPhase(
+                billingPeriod = "",
+                priceCurrencyCode = "",
+                formattedPrice = "",
+                priceAmountMicros = 0L,
+                recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                billingCycleCount = 0
+            )),
+            tags = emptyList(),
+            token = "mock-token"
+        )
+        val purchaseOption2 = GooglePurchaseOption(
+            id = "purchaseOptionId",
+            pricingPhases = listOf(PricingPhase(
+                billingPeriod = "",
+                priceCurrencyCode = "",
+                formattedPrice = "",
+                priceAmountMicros = 0L,
+                recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                billingCycleCount = 0
+            )),
+            tags = emptyList(),
+            token = "mock-token"
+        )
+
+        val storeProduct1 = GoogleStoreProduct(
+            productId = "product_id",
+            type = ProductType.INAPP,
+            oneTimeProductPrice = price1,
+            title = "TITLE",
+            description = "DESCRIPTION",
+            subscriptionPeriod = "P1M",
+            purchaseOptions = listOf(purchaseOption1),
+            defaultOption = null,
+            productDetails = productDetails
+        )
+
+        val storeProduct2 = GoogleStoreProduct(
+            productId = "product_id",
+            type = ProductType.INAPP,
+            oneTimeProductPrice = price2,
+            title = "TITLE",
+            description = "DESCRIPTION",
+            subscriptionPeriod = "P1M",
+            purchaseOptions = listOf(purchaseOption2),
+            defaultOption = null,
+            productDetails = productDetails
+        )
+
+        assertThat(storeProduct1.hashCode()).isEqualTo(storeProduct2.hashCode())
+    }
+}

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -1,94 +1,29 @@
 package com.revenuecat.purchases.google
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.billingclient.api.BillingClient
+import com.revenuecat.purchases.utils.mockProductDetails
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.Test
 import org.junit.runner.RunWith
 
-//    TODOBC5: After using mocks for ProductDetails, these tests don't make much sense. Leaving for now.
-//@RunWith(AndroidJUnit4::class)
-//class StoreProductTest {
-//    @Test
-//    fun `Two StoreProducts with the same properties are equal`() {
-//        val storeProduct1 = GoogleStoreProduct(
-//            sku = "sku",
-//            type = ProductType.INAPP,
-//            price = "$2",
-//            priceAmountMicros = 2 * 1_000_000,
-//            priceCurrencyCode = "USD",
-//            originalPrice = "$2",
-//            originalPriceAmountMicros = 2 * 1_000_000,
-//            title = "TITLE",
-//            description = "DESCRIPTION",
-//            subscriptionPeriod = "P1M",
-//            freeTrialPeriod = "P1M",
-//            introductoryPrice = "$0",
-//            introductoryPriceAmountMicros = 0 * 1_000_000,
-//            introductoryPricePeriod = "P1W",
-//            introductoryPriceCycles = 1,
-//            iconUrl = "http://",
-//            originalJson = JSONObject("{}")
-//        )
-//        val storeProduct2 = GoogleStoreProduct(
-//            sku = "sku",
-//            type = ProductType.INAPP,
-//            price = "$2",
-//            priceAmountMicros = 2 * 1_000_000,
-//            priceCurrencyCode = "USD",
-//            originalPrice = "$2",
-//            originalPriceAmountMicros = 2 * 1_000_000,
-//            title = "TITLE",
-//            description = "DESCRIPTION",
-//            subscriptionPeriod = "P1M",
-//            freeTrialPeriod = "P1M",
-//            introductoryPrice = "$0",
-//            introductoryPriceAmountMicros = 0 * 1_000_000,
-//            introductoryPricePeriod = "P1W",
-//            introductoryPriceCycles = 1,
-//            iconUrl = "http://",
-//            originalJson = JSONObject("{}")
-//        )
-//        Assertions.assertThat(storeProduct1).isEqualTo(storeProduct2)
-//    }
-//
-//    @Test
-//    fun `Two StoreProducts with the same properties have the same hashcode`() {
-//        val storeProduct1 = GoogleStoreProduct(
-//            sku = "sku",
-//            type = ProductType.INAPP,
-//            price = "$2",
-//            priceAmountMicros = 2 * 1_000_000,
-//            priceCurrencyCode = "USD",
-//            originalPrice = "$2",
-//            originalPriceAmountMicros = 2 * 1_000_000,
-//            title = "TITLE",
-//            description = "DESCRIPTION",
-//            subscriptionPeriod = "P1M",
-//            freeTrialPeriod = "P1M",
-//            introductoryPrice = "$0",
-//            introductoryPriceAmountMicros = 0 * 1_000_000,
-//            introductoryPricePeriod = "P1W",
-//            introductoryPriceCycles = 1,
-//            iconUrl = "http://",
-//            originalJson = JSONObject("{}")
-//        )
-//        val storeProduct2 = GoogleStoreProduct(
-//            sku = "sku",
-//            type = ProductType.INAPP,
-//            price = "$2",
-//            priceAmountMicros = 2 * 1_000_000,
-//            priceCurrencyCode = "USD",
-//            originalPrice = "$2",
-//            originalPriceAmountMicros = 2 * 1_000_000,
-//            title = "TITLE",
-//            description = "DESCRIPTION",
-//            subscriptionPeriod = "P1M",
-//            freeTrialPeriod = "P1M",
-//            introductoryPrice = "$0",
-//            introductoryPriceAmountMicros = 0 * 1_000_000,
-//            introductoryPricePeriod = "P1W",
-//            introductoryPriceCycles = 1,
-//            iconUrl = "http://",
-//            originalJson = JSONObject("{}")
-//        )
-//        Assertions.assertThat(storeProduct1.hashCode()).isEqualTo(storeProduct2.hashCode())
-//    }
-//}
+@RunWith(AndroidJUnit4::class)
+class StoreProductTest {
+    @Test
+    fun `list of INAPP ProductDetails maps to StoreProducts`() {
+        val productDetail1 = mockProductDetails(productId = "iap_1", type = BillingClient.ProductType.INAPP, subscriptionOfferDetails = null)
+        val productDetails = listOf(productDetail1)
+
+        val storeProducts = productDetails.toStoreProducts()
+        assertThat(storeProducts.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `list of SUBS ProductDetails maps to StoreProducts`() {
+        val productDetail1 = mockProductDetails(productId = "sub_1", type = BillingClient.ProductType.SUBS)
+        val productDetails = listOf(productDetail1)
+
+        val storeProducts = productDetails.toStoreProducts()
+        assertThat(storeProducts.size).isEqualTo(1)
+    }
+}

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -1,60 +1,94 @@
 package com.revenuecat.purchases.google
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.billingclient.api.BillingClient
-import com.revenuecat.purchases.utils.mockProductDetails
-import com.revenuecat.purchases.utils.mockSubscriptionOfferDetails
-import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
-import org.junit.Test
 import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
-class StoreProductTest {
-    @Test
-    fun `list of INAPP ProductDetails maps to StoreProducts`() {
-        val productDetail1 = mockProductDetails(productId = "iap_1", type = BillingClient.ProductType.INAPP, subscriptionOfferDetails = null)
-        val productDetails = listOf(productDetail1)
-
-        val storeProducts = productDetails.toStoreProducts()
-        assertThat(storeProducts.size).isEqualTo(1)
-    }
-
-    @Test
-    fun `list of SUBS ProductDetails maps to StoreProducts`() {
-        val productDetail1 = mockProductDetails(productId = "sub_1", type = BillingClient.ProductType.SUBS)
-        val productDetails = listOf(productDetail1)
-
-        val storeProducts = productDetails.toStoreProducts()
-        assertThat(storeProducts.size).isEqualTo(1)
-    }
-
-    @Test
-    fun `list of INAPP and SUBS ProductDetails maps to StoreProducts`() {
-        val productDetail1 = mockProductDetails(
-            productId = "iap_1",
-            type = BillingClient.ProductType.INAPP,
-            subscriptionOfferDetails = null)
-        val productDetail2 = mockProductDetails(
-            productId = "sub_1",
-            type = BillingClient.ProductType.SUBS)
-        val productDetails = listOf(productDetail1, productDetail2)
-
-        val storeProducts = productDetails.toStoreProducts()
-        assertThat(storeProducts.size).isEqualTo(2)
-    }
-
-    @Test
-    fun `list of SUBS ProductDetails with multiple subscription offers maps to multiple StoreProducts`() {
-        val monthlyBasePlan = mockSubscriptionOfferDetails(offerId = "monthly-offer", basePlanId = "monthly")
-        val yearlyBasePlan = mockSubscriptionOfferDetails(offerId = "yearly-offer", basePlanId = "yearly")
-
-        val productDetail1 = mockProductDetails(
-            productId = "sub_1",
-            type = BillingClient.ProductType.SUBS,
-            subscriptionOfferDetails = listOf(monthlyBasePlan, yearlyBasePlan))
-        val productDetails = listOf(productDetail1)
-
-        val storeProducts = productDetails.toStoreProducts()
-        assertThat(storeProducts.size).isEqualTo(2)
-    }
-}
+//    TODOBC5: After using mocks for ProductDetails, these tests don't make much sense. Leaving for now.
+//@RunWith(AndroidJUnit4::class)
+//class StoreProductTest {
+//    @Test
+//    fun `Two StoreProducts with the same properties are equal`() {
+//        val storeProduct1 = GoogleStoreProduct(
+//            sku = "sku",
+//            type = ProductType.INAPP,
+//            price = "$2",
+//            priceAmountMicros = 2 * 1_000_000,
+//            priceCurrencyCode = "USD",
+//            originalPrice = "$2",
+//            originalPriceAmountMicros = 2 * 1_000_000,
+//            title = "TITLE",
+//            description = "DESCRIPTION",
+//            subscriptionPeriod = "P1M",
+//            freeTrialPeriod = "P1M",
+//            introductoryPrice = "$0",
+//            introductoryPriceAmountMicros = 0 * 1_000_000,
+//            introductoryPricePeriod = "P1W",
+//            introductoryPriceCycles = 1,
+//            iconUrl = "http://",
+//            originalJson = JSONObject("{}")
+//        )
+//        val storeProduct2 = GoogleStoreProduct(
+//            sku = "sku",
+//            type = ProductType.INAPP,
+//            price = "$2",
+//            priceAmountMicros = 2 * 1_000_000,
+//            priceCurrencyCode = "USD",
+//            originalPrice = "$2",
+//            originalPriceAmountMicros = 2 * 1_000_000,
+//            title = "TITLE",
+//            description = "DESCRIPTION",
+//            subscriptionPeriod = "P1M",
+//            freeTrialPeriod = "P1M",
+//            introductoryPrice = "$0",
+//            introductoryPriceAmountMicros = 0 * 1_000_000,
+//            introductoryPricePeriod = "P1W",
+//            introductoryPriceCycles = 1,
+//            iconUrl = "http://",
+//            originalJson = JSONObject("{}")
+//        )
+//        Assertions.assertThat(storeProduct1).isEqualTo(storeProduct2)
+//    }
+//
+//    @Test
+//    fun `Two StoreProducts with the same properties have the same hashcode`() {
+//        val storeProduct1 = GoogleStoreProduct(
+//            sku = "sku",
+//            type = ProductType.INAPP,
+//            price = "$2",
+//            priceAmountMicros = 2 * 1_000_000,
+//            priceCurrencyCode = "USD",
+//            originalPrice = "$2",
+//            originalPriceAmountMicros = 2 * 1_000_000,
+//            title = "TITLE",
+//            description = "DESCRIPTION",
+//            subscriptionPeriod = "P1M",
+//            freeTrialPeriod = "P1M",
+//            introductoryPrice = "$0",
+//            introductoryPriceAmountMicros = 0 * 1_000_000,
+//            introductoryPricePeriod = "P1W",
+//            introductoryPriceCycles = 1,
+//            iconUrl = "http://",
+//            originalJson = JSONObject("{}")
+//        )
+//        val storeProduct2 = GoogleStoreProduct(
+//            sku = "sku",
+//            type = ProductType.INAPP,
+//            price = "$2",
+//            priceAmountMicros = 2 * 1_000_000,
+//            priceCurrencyCode = "USD",
+//            originalPrice = "$2",
+//            originalPriceAmountMicros = 2 * 1_000_000,
+//            title = "TITLE",
+//            description = "DESCRIPTION",
+//            subscriptionPeriod = "P1M",
+//            freeTrialPeriod = "P1M",
+//            introductoryPrice = "$0",
+//            introductoryPriceAmountMicros = 0 * 1_000_000,
+//            introductoryPricePeriod = "P1W",
+//            introductoryPriceCycles = 1,
+//            iconUrl = "http://",
+//            originalJson = JSONObject("{}")
+//        )
+//        Assertions.assertThat(storeProduct1.hashCode()).isEqualTo(storeProduct2.hashCode())
+//    }
+//}


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation

[CF-1065](https://revenuecats.atlassian.net/browse/CF-1065)
Part of [CF-1000](https://revenuecats.atlassian.net/browse/CF-1000) _(I think)_

Non-subscription products were mysteriously not showing in offerings and no tests were failing/catching this

### Description

- `List<ProductDetails>.toStoreProducts()` no longer early returns when no base plan is found
- Added tests for `List<ProductDetails>.toStoreProducts()`

#### Purchase Tester screenshot of non-subscription showing as an option

![Screen Shot 2022-12-19 at 10 08 38 AM](https://user-images.githubusercontent.com/401294/208469394-34ace2aa-4488-48c0-9c5c-e0d28d6f37ea.png)
