### PR TITLE
[CF-1069] [CSDK-484] Replace getSubscriptionSkus and getNonSubscriptionSkus with getProducts

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -44,7 +44,7 @@ final class PurchasesAPI {
                       final Package packageToPurchase,
                       final PurchaseOption purchaseOption,
                       final UpgradeInfo upgradeInfo) {
-        final ArrayList<String> skus = new ArrayList<>();
+        final ArrayList<String> productIds = new ArrayList<>();
 
         final ReceiveOfferingsCallback receiveOfferingsListener = new ReceiveOfferingsCallback() {
             @Override public void onReceived(@NonNull Offerings offerings) {}
@@ -73,8 +73,8 @@ final class PurchasesAPI {
 
         purchases.syncPurchases();
         purchases.getOfferings(receiveOfferingsListener);
-        purchases.getSubscriptionSkus(skus, skusResponseListener);
-        purchases.getNonSubscriptionSkus(skus, skusResponseListener);
+        purchases.getSubscriptionProducts(productIds, skusResponseListener);
+        purchases.getNonSubscriptionProducts(productIds, skusResponseListener);
         purchases.purchaseProduct(activity, storeProduct, upgradeInfo, purchaseChangeListener);
         purchases.purchaseProduct(activity, storeProduct, makePurchaseListener);
         purchases.purchasePackage(activity, packageToPurchase, upgradeInfo, purchaseChangeListener);

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -50,7 +50,7 @@ final class PurchasesAPI {
             @Override public void onReceived(@NonNull Offerings offerings) {}
             @Override public void onError(@NonNull PurchasesError error) {}
         };
-        final GetStoreProductsCallback skusResponseListener = new GetStoreProductsCallback() {
+        final GetStoreProductsCallback productResponseListener = new GetStoreProductsCallback() {
             @Override public void onReceived(@NonNull List<StoreProduct> storeProducts) { }
             @Override public void onError(@NonNull PurchasesError error) {}
         };
@@ -73,8 +73,7 @@ final class PurchasesAPI {
 
         purchases.syncPurchases();
         purchases.getOfferings(receiveOfferingsListener);
-        purchases.getSubscriptionProducts(productIds, skusResponseListener);
-        purchases.getNonSubscriptionProducts(productIds, skusResponseListener);
+        purchases.getProducts(productIds, productResponseListener);
         purchases.purchaseProduct(activity, storeProduct, upgradeInfo, purchaseChangeListener);
         purchases.purchaseProduct(activity, storeProduct, makePurchaseListener);
         purchases.purchasePackage(activity, packageToPurchase, upgradeInfo, purchaseChangeListener);

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreTransactionAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreTransactionAPI.java
@@ -13,6 +13,7 @@ import java.util.List;
 final class StoreTransactionAPI {
     static void check(final StoreTransaction transaction) {
         final String orderId = transaction.getOrderId();
+        final List<String> skus = transaction.getSkus();
         final List<String> productIds = transaction.getProductIds();
         final ProductType type = transaction.getType();
         final long purchaseTime = transaction.getPurchaseTime();

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreTransactionAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreTransactionAPI.java
@@ -13,7 +13,6 @@ import java.util.List;
 final class StoreTransactionAPI {
     static void check(final StoreTransaction transaction) {
         final String orderId = transaction.getOrderId();
-        final List<String> skus = transaction.getProductIds();
         final List<String> productIds = transaction.getProductIds();
         final ProductType type = transaction.getType();
         final long purchaseTime = transaction.getPurchaseTime();

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreTransactionAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreTransactionAPI.java
@@ -13,7 +13,7 @@ import java.util.List;
 final class StoreTransactionAPI {
     static void check(final StoreTransaction transaction) {
         final String orderId = transaction.getOrderId();
-        final List<String> skus = transaction.getSkus();
+        final List<String> skus = transaction.getProductIds();
         final List<String> productIds = transaction.getProductIds();
         final ProductType type = transaction.getType();
         final long purchaseTime = transaction.getPurchaseTime();

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -46,7 +46,7 @@ private class PurchasesAPI {
         purchaseOption: PurchaseOption,
         upgradeInfo: UpgradeInfo
     ) {
-        val skus = ArrayList<String>()
+        val productIds = ArrayList<String>()
         val receiveOfferingsCallback = object : ReceiveOfferingsCallback {
             override fun onReceived(offerings: Offerings) {}
             override fun onError(error: PurchasesError) {}
@@ -75,8 +75,8 @@ private class PurchasesAPI {
         purchases.getOfferings(receiveOfferingsCallback)
 
         // TODO deprecate, replaced with getProducts
-        purchases.getSubscriptionSkus(skus, productsResponseCallback)
-        purchases.getNonSubscriptionSkus(skus, productsResponseCallback)
+        purchases.getSubscriptionProducts(productIds, productsResponseCallback)
+        purchases.getNonSubscriptionProducts(productIds, productsResponseCallback)
 //        purchases.getProducts(productIds, productsResponseCallback)
 
         // we need these for hybrids... these all fall back on some "best offer" or just purchase the base plan

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -74,10 +74,7 @@ private class PurchasesAPI {
         purchases.syncPurchases()
         purchases.getOfferings(receiveOfferingsCallback)
 
-        // TODO deprecate, replaced with getProducts
-        purchases.getSubscriptionProducts(productIds, productsResponseCallback)
-        purchases.getNonSubscriptionProducts(productIds, productsResponseCallback)
-//        purchases.getProducts(productIds, productsResponseCallback)
+        purchases.getProducts(productIds, productsResponseCallback)
 
         // we need these for hybrids... these all fall back on some "best offer" or just purchase the base plan
         purchases.purchaseProduct(activity, storeProduct, upgradeInfo, purchaseChangeCallback)

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -1,8 +1,8 @@
-## v6 API changes
+## V6 API Changes
 
-### New
+### Classes
 
-| Name                   |
+| New                    |
 |------------------------|
 | `PurchaseOption`       |
 | `GooglePurchaseOption` |
@@ -12,7 +12,11 @@
 | `PricingPhase`         |
 | `RecurrenceMode`       |
 
-### StoreProduct updates
+| Old Location                            | New Location                                   |
+|-----------------------------------------|------------------------------------------------|
+| com.revenuecat.purchases.BillingFeature | com.revenuecat.purchases.models.BillingFeature |
+
+### StoreProduct
 
 StoreProduct has been made an interface, which `GoogleStoreProduct` and `AmazonStoreProduct` implement.
 
@@ -40,7 +44,7 @@ StoreProduct has been made an interface, which `GoogleStoreProduct` and `AmazonS
 | producct.iconUrl                  |  | 
 | product.originalJson              |(product as GoogleStoreProduct).productDetails |
 
-### StoreTransaction updates
+### StoreTransaction
 
 | New              |
 |------------------|
@@ -50,33 +54,29 @@ StoreProduct has been made an interface, which `GoogleStoreProduct` and `AmazonS
 |------------|------------|
 | skus       | productIds |
 
-### New purchasing APIs
+### Purchasing APIs
 
-| New              |
-|------------------|
-| `purchaseSubscriptionOption(Activity, StoreProduct, PurchaseOption, PurchaseCallback)` |
+| New                                                                                                      |
+|----------------------------------------------------------------------------------------------------------|
+| `purchaseSubscriptionOption(Activity, StoreProduct, PurchaseOption, PurchaseCallback)`                   |
 | `purchaseSubscriptionOption(Activity, StoreProduct, PurchaseOption, UpgradeInfo, ProductChangeCallback)` |
 
-### Kotlin Helpers Changes
+| Deprecated                                                       | New                                                   |
+|------------------------------------------------------------------|-------------------------------------------------------|
+| `getSubscriptionSkus(List<String>, GetStoreProductsCallback)`    | `getProducts(List<String>, GetStoreProductsCallback)` |
+| `getNonSubscriptionSkus(List<String>, GetStoreProductsCallback)` | `getProducts(List<String>, GetStoreProductsCallback)` |
 
-| New              |
-|------------------|
-| `purchaseSubscriptionOptionWith(Activity, StoreProduct, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)` |
+### Kotlin Helpers
+
+| New                                                                                                                                                                |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `purchaseSubscriptionOptionWith(Activity, StoreProduct, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)`              |
 | `purchaseSubscriptionOptionWith(Activity, StoreProduct, UpgradeInfo, PurchaseOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)` |
 
-| Removed |
-|----------------------------------------------------------------------------------------------------------------------|
-| `getPurchaserInfoWith((PurchasesError) -> Unit, (PurchaserInfo) -> Unit)`                                            |
-| `purchasePackageWith(Activity, Package, (PurchasesError) -> Unit, (Purchase, PurchaserInfo) -> Unit)`                |
-| `purchasePackageWith(Activity, Package, UpgradeInfo, (PurchasesError) -> Unit, (Purchase, PurchaserInfo) -> Unit)`   |
-| `purchaseProductWith(Activity, SkuDetails, (PurchasesError) -> Unit, (Purchase, PurchaserInfo) -> Unit)`             |
-| `purchaseProductWith(Activity, SkuDetails, UpgradeInfo, (PurchasesError) -> Unit, (Purchase, PurchaserInfo) -> Unit)` |
-
-### Moved
-
-| Old location                            | New location                                   |
-|-----------------------------------------|------------------------------------------------|
-| com.revenuecat.purchases.BillingFeature | com.revenuecat.purchases.models.BillingFeature |
+| Deprecated                                                                                         | New                                                                                     |
+|----------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| `getSubscriptionSkusWith(List<String>, (PurchasesError) -> Unit, (List<StoreProduct>) -> Unit)`    | `getProductsWith(List<String>, (PurchasesError) -> Unit, (List<StoreProduct>) -> Unit)` |
+| `getNonSubscriptionSkusWith(List<String>, (PurchasesError) -> Unit, (List<StoreProduct>) -> Unit)` | `getProductsWith(List<String>, (PurchasesError) -> Unit, (List<StoreProduct>) -> Unit)` |
 
 ### Removed APIs
 
@@ -101,6 +101,8 @@ StoreProduct has been made an interface, which `GoogleStoreProduct` and `AmazonS
 | `removeUpdatedPurchaserInfoListener()`                                                                                |
 | `setUpdatedPurchaserInfoListener(UpdatedPurchaserInfoListener)`                                                       |
 | `getPurchaserInfoWith((PurchasesError) -> Unit, (PurchaserInfo) -> Unit)`                                             |
+| `purchasePackageWith(Activity, Package, (PurchasesError) -> Unit, (Purchase, PurchaserInfo) -> Unit)`                 |
+| `purchasePackageWith(Activity, Package, UpgradeInfo, (PurchasesError) -> Unit, (Purchase, PurchaserInfo) -> Unit)`    |
 | `purchaseProductWith(Activity, SkuDetails, (PurchasesError) -> Unit, (Purchase, PurchaserInfo) -> Unit)`              |
 | `purchaseProductWith(Activity, SkuDetails, UpgradeInfo, (PurchasesError) -> Unit, (Purchase, PurchaserInfo) -> Unit)` |
 

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -1,4 +1,4 @@
-## V6 API Changes
+## v6 API Changes
 
 ### Classes
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -353,7 +353,7 @@ class Purchases internal constructor(
     }
 
     /**
-     * Gets the StoreProduct for the given list of subscription and non-subscription productIds.
+     * Gets the StoreProduct(s) for the given list of product ids.
      * @param [productIds] List of productIds
      * @param [callback] Response callback
      */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1689,7 +1689,7 @@ class Purchases internal constructor(
     }
 
     /**
-     * Gets the SKUDetails for the given list of non-subscription products.
+     * Gets the StoreProduct for the given list of non-subscription products.
      * @param [productIds] List of productIds
      * @param [callback] Response callback
      */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -353,29 +353,29 @@ class Purchases internal constructor(
     }
 
     /**
-     * Gets the StoreProduct for the given list of subscription skus.
-     * @param [skus] List of skus
+     * Gets the StoreProduct for the given list of subscription products.
+     * @param [productIds] List of productIds
      * @param [callback] Response callback
      */
     // TODO deprecate, replaced with getProducts
-    fun getSubscriptionSkus(
-        skus: List<String>,
+    fun getSubscriptionProducts(
+        productIds: List<String>,
         callback: GetStoreProductsCallback
     ) {
-        getSkus(skus.toSet(), ProductType.SUBS, callback)
+        getProducts(productIds.toSet(), ProductType.SUBS, callback)
     }
 
     /**
-     * Gets the SKUDetails for the given list of non-subscription skus.
-     * @param [skus] List of skus
+     * Gets the SKUDetails for the given list of non-subscription products.
+     * @param [productIds] List of productIds
      * @param [callback] Response callback
      */
     // TODO deprecate, replaced with getProducts
-    fun getNonSubscriptionSkus(
-        skus: List<String>,
+    fun getNonSubscriptionProducts(
+        productIds: List<String>,
         callback: GetStoreProductsCallback
     ) {
-        getSkus(skus.toSet(), ProductType.INAPP, callback)
+        getProducts(productIds.toSet(), ProductType.INAPP, callback)
     }
 
     /**
@@ -1158,14 +1158,14 @@ class Purchases internal constructor(
             )
         }
 
-    private fun getSkus(
-        skus: Set<String>,
+    private fun getProducts(
+        productIds: Set<String>,
         productType: ProductType,
         callback: GetStoreProductsCallback
     ) {
         billing.queryProductDetailsAsync(
             productType,
-            skus,
+            productIds,
             { storeProducts ->
                 dispatch {
                     callback.onReceived(storeProducts)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -353,29 +353,29 @@ class Purchases internal constructor(
     }
 
     /**
-     * Gets the StoreProduct for the given list of subscription products.
+     * Gets the StoreProduct for the given list of subscription and non-subscription productIds.
      * @param [productIds] List of productIds
      * @param [callback] Response callback
      */
-    // TODO deprecate, replaced with getProducts
-    fun getSubscriptionProducts(
+    fun getProducts(
         productIds: List<String>,
         callback: GetStoreProductsCallback
     ) {
-        getProducts(productIds.toSet(), ProductType.SUBS, callback)
-    }
-
-    /**
-     * Gets the SKUDetails for the given list of non-subscription products.
-     * @param [productIds] List of productIds
-     * @param [callback] Response callback
-     */
-    // TODO deprecate, replaced with getProducts
-    fun getNonSubscriptionProducts(
-        productIds: List<String>,
-        callback: GetStoreProductsCallback
-    ) {
-        getProducts(productIds.toSet(), ProductType.INAPP, callback)
+        getProducts(productIds.toSet(), ProductType.SUBS, object : GetStoreProductsCallback {
+            override fun onReceived(subStoreProducts: List<StoreProduct>) {
+                getProducts(productIds.toSet(), ProductType.INAPP, object : GetStoreProductsCallback {
+                    override fun onReceived(inappStoreProducts: List<StoreProduct>) {
+                        callback.onReceived(subStoreProducts + inappStoreProducts)
+                    }
+                    override fun onError(error: PurchasesError) {
+                        callback.onError(error)
+                    }
+                })
+            }
+            override fun onError(error: PurchasesError) {
+                callback.onError(error)
+            }
+        })
     }
 
     /**
@@ -1671,6 +1671,38 @@ class Purchases internal constructor(
         @Synchronized set(value) {
             state = state.copy(allowSharingPlayStoreAccount = value)
         }
+
+    /**
+     * Gets the StoreProduct for the given list of subscription products.
+     * @param [productIds] List of productIds
+     * @param [callback] Response callback
+     */
+    @Deprecated(
+        "Replaced with getProducts() which returns both subscriptions and non-subscriptions",
+        ReplaceWith("getProducts()")
+    )
+    fun getSubscriptionSkus(
+        productIds: List<String>,
+        callback: GetStoreProductsCallback
+    ) {
+        getProducts(productIds.toSet(), ProductType.SUBS, callback)
+    }
+
+    /**
+     * Gets the SKUDetails for the given list of non-subscription products.
+     * @param [productIds] List of productIds
+     * @param [callback] Response callback
+     */
+    @Deprecated(
+        "Replaced with getProducts() which returns both subscriptions and non-subscriptions",
+        ReplaceWith("getProducts()")
+    )
+    fun getNonSubscriptionSkus(
+        productIds: List<String>,
+        callback: GetStoreProductsCallback
+    ) {
+        getProducts(productIds.toSet(), ProductType.INAPP, callback)
+    }
 
     // endregion
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -319,6 +319,7 @@ fun Purchases.getCustomerInfoWith(
 /**
  * Gets the StoreProduct for the given list of subscription and non-subscription productIds.
  * @param [productIds] List of productIds
+ * @param [onError] Will be called after the purchase has completed with error
  * @param [onGetStoreProducts] Will be called after fetching StoreProducts
  */
 @Suppress("unused")
@@ -335,6 +336,7 @@ fun Purchases.getProductsWith(
 /**
  * Gets the SKUDetails for the given list of subscription skus.
  * @param [skus] List of skus
+ * @param [onError] Will be called after the purchase has completed with error
  * @param [onReceiveSkus] Will be called after fetching subscriptions
  */
 @Deprecated(
@@ -352,6 +354,7 @@ fun Purchases.getSubscriptionSkusWith(
 /**
  * Gets the StoreProduct for the given list of non-subscription skus.
  * @param [skus] List of skus
+ * @param [onError] Will be called after the purchase has completed with error
  * @param [onReceiveSkus] Will be called after fetching StoreProduct
  */
 @Deprecated(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -350,9 +350,9 @@ fun Purchases.getSubscriptionSkusWith(
 }
 
 /**
- * Gets the SKUDetails for the given list of non-subscription skus.
+ * Gets the StoreProduct for the given list of non-subscription skus.
  * @param [skus] List of skus
- * @param [onReceiveSkus] Will be called after fetching SkuDetails
+ * @param [onReceiveSkus] Will be called after fetching StoreProduct
  */
 @Deprecated(
     "Replaced with getProductsWith() which returns both subscriptions and non-subscriptions",

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -327,7 +327,7 @@ fun Purchases.getSubscriptionSkusWith(
     onError: (error: PurchasesError) -> Unit = ON_ERROR_STUB,
     onReceiveSkus: (storeProducts: List<StoreProduct>) -> Unit
 ) {
-    getSubscriptionSkus(skus, getStoreProductsCallback(onReceiveSkus, onError))
+    getSubscriptionProducts(skus, getStoreProductsCallback(onReceiveSkus, onError))
 }
 
 /**
@@ -341,5 +341,5 @@ fun Purchases.getNonSubscriptionSkusWith(
     onError: (error: PurchasesError) -> Unit,
     onReceiveSkus: (storeProducts: List<StoreProduct>) -> Unit
 ) {
-    getNonSubscriptionSkus(skus, getStoreProductsCallback(onReceiveSkus, onError))
+    getNonSubscriptionProducts(skus, getStoreProductsCallback(onReceiveSkus, onError))
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -116,7 +116,7 @@ fun Purchases.getOfferingsWith(
  * @param [activity] Current activity
  * @param [storeProduct] The storeProduct of the product you wish to purchase
  * @param [onSuccess] Will be called after the purchase has completed
- * @param [onError] Will be called after the purchase has completed with error
+ * @param [onError] Will be called if there was an error with the purchase
  */
 fun Purchases.purchaseProductWith(
     activity: Activity,
@@ -135,7 +135,7 @@ fun Purchases.purchaseProductWith(
  * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
  * @param [onSuccess] Will be called after the purchase has completed
- * @param [onError] Will be called after the purchase has completed with error
+ * @param [onError] Will be called if there was an error with the purchase
  */
 fun Purchases.purchaseProductWith(
     activity: Activity,
@@ -154,7 +154,7 @@ fun Purchases.purchaseProductWith(
  * @param [storeProduct] The storeProduct of the product you wish to purchase
  * @param [purchaseOption] Your choice of purchase options available for the subscription StoreProduct
  * @param [onSuccess] Will be called after the purchase has completed
- * @param [onError] Will be called after the purchase has completed with error
+ * @param [onError] Will be called if there was an error with the purchase
  */
 fun Purchases.purchaseSubscriptionOptionWith(
     activity: Activity,
@@ -180,7 +180,7 @@ fun Purchases.purchaseSubscriptionOptionWith(
  * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
  * @param [onSuccess] Will be called after the purchase has completed
- * @param [onError] Will be called after the purchase has completed with error
+ * @param [onError] Will be called if there was an error with the purchase
  */
 @Suppress("LongParameterList")
 fun Purchases.purchaseSubscriptionOptionWith(
@@ -208,7 +208,7 @@ fun Purchases.purchaseSubscriptionOptionWith(
  * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
  * @param [onSuccess] Will be called after the purchase has completed
- * @param [onError] Will be called after the purchase has completed with error
+ * @param [onError] Will be called if there was an error with the purchase
  */
 fun Purchases.purchasePackageWith(
     activity: Activity,
@@ -225,7 +225,7 @@ fun Purchases.purchasePackageWith(
  * @param [activity] Current activity
  * @param [packageToPurchase] The Package you wish to purchase
  * @param [onSuccess] Will be called after the purchase has completed
- * @param [onError] Will be called after the purchase has completed with error
+ * @param [onError] Will be called if there was an error with the purchase
  */
 fun Purchases.purchasePackageWith(
     activity: Activity,
@@ -276,7 +276,7 @@ fun Purchases.logInWith(
  * Logs out the Purchases client clearing the save appUserID. This will generate a random user
  * id and save it in the cache.
  * @param [onSuccess] Will be called after the call has completed.
- * @param [onError] Will be called after the call has completed with an error.
+ * @param [onError] Will be called if there was an error with the purchase.
  */
 @Suppress("unused")
 fun Purchases.logOutWith(
@@ -290,7 +290,7 @@ fun Purchases.logOutWith(
  * Get latest available customer info.
  * @param onSuccess Called when customer info is available and not stale. Called immediately if
  * customer info is cached.
- * @param onError Will be called after the call has completed with an error.
+ * @param onError Will be called if there was an error with the purchase.
  */
 @Suppress("unused")
 fun Purchases.getCustomerInfoWith(
@@ -305,7 +305,7 @@ fun Purchases.getCustomerInfoWith(
  * @param fetchPolicy Specifies cache behavior for customer info retrieval
  * @param onSuccess Called when customer info is available depending on the fetchPolicy parameter, this can be called
  * immediately or after a fetch has happened.
- * @param onError Will be called after the call has completed with an error.
+ * @param onError Will be called if there was an error with the purchase.
  */
 @Suppress("unused")
 fun Purchases.getCustomerInfoWith(
@@ -319,7 +319,7 @@ fun Purchases.getCustomerInfoWith(
 /**
  * Gets the StoreProduct for the given list of subscription and non-subscription productIds.
  * @param [productIds] List of productIds
- * @param [onError] Will be called after the purchase has completed with error
+ * @param [onError] Will be called if there was an error with the purchase
  * @param [onGetStoreProducts] Will be called after fetching StoreProducts
  */
 @Suppress("unused")
@@ -336,7 +336,7 @@ fun Purchases.getProductsWith(
 /**
  * Gets the SKUDetails for the given list of subscription skus.
  * @param [skus] List of skus
- * @param [onError] Will be called after the purchase has completed with error
+ * @param [onError] Will be called if there was an error with the purchase
  * @param [onReceiveSkus] Will be called after fetching subscriptions
  */
 @Deprecated(
@@ -354,7 +354,7 @@ fun Purchases.getSubscriptionSkusWith(
 /**
  * Gets the StoreProduct for the given list of non-subscription skus.
  * @param [skus] List of skus
- * @param [onError] Will be called after the purchase has completed with error
+ * @param [onError] Will be called if there was an error with the purchase
  * @param [onReceiveSkus] Will be called after fetching StoreProduct
  */
 @Deprecated(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -317,17 +317,36 @@ fun Purchases.getCustomerInfoWith(
 }
 
 /**
+ * Gets the StoreProduct for the given list of subscription and non-subscription productIds.
+ * @param [productIds] List of productIds
+ * @param [onGetStoreProducts] Will be called after fetching StoreProducts
+ */
+@Suppress("unused")
+fun Purchases.getProductsWith(
+    productIds: List<String>,
+    onError: (error: PurchasesError) -> Unit = ON_ERROR_STUB,
+    onGetStoreProducts: (storeProducts: List<StoreProduct>) -> Unit
+) {
+    getProducts(productIds, getStoreProductsCallback(onGetStoreProducts, onError))
+}
+
+// region Deprecated
+
+/**
  * Gets the SKUDetails for the given list of subscription skus.
  * @param [skus] List of skus
  * @param [onReceiveSkus] Will be called after fetching subscriptions
  */
-@Suppress("unused")
+@Deprecated(
+    "Replaced with getProductsWith() which returns both subscriptions and non-subscriptions",
+    ReplaceWith("getProductsWith()")
+)
 fun Purchases.getSubscriptionSkusWith(
     skus: List<String>,
     onError: (error: PurchasesError) -> Unit = ON_ERROR_STUB,
     onReceiveSkus: (storeProducts: List<StoreProduct>) -> Unit
 ) {
-    getSubscriptionProducts(skus, getStoreProductsCallback(onReceiveSkus, onError))
+    getProducts(skus, getStoreProductsCallback(onReceiveSkus, onError))
 }
 
 /**
@@ -335,11 +354,16 @@ fun Purchases.getSubscriptionSkusWith(
  * @param [skus] List of skus
  * @param [onReceiveSkus] Will be called after fetching SkuDetails
  */
-@Suppress("unused")
+@Deprecated(
+    "Replaced with getProductsWith() which returns both subscriptions and non-subscriptions",
+    ReplaceWith("getProductsWith()")
+)
 fun Purchases.getNonSubscriptionSkusWith(
     skus: List<String>,
     onError: (error: PurchasesError) -> Unit,
     onReceiveSkus: (storeProducts: List<StoreProduct>) -> Unit
 ) {
-    getNonSubscriptionProducts(skus, getStoreProductsCallback(onReceiveSkus, onError))
+    getProducts(skus, getStoreProductsCallback(onReceiveSkus, onError))
 }
+
+// endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -373,32 +373,16 @@ class PurchasesTest {
     // region get products
 
     @Test
-    fun getsSubscriptionProducts() {
-        val productIds = listOf("onemonth_freetrial")
+    fun getsAllProducts() {
+        val subProductIds = listOf("onemonth_freetrial")
+        val inappProductIds = listOf("normal_purchase")
+        val productIds = subProductIds + inappProductIds
 
-        val productDetails = mockStoreProduct(productIds, listOf(), ProductType.SUBS)
+        val subStoreProducts = mockStoreProduct(productIds, subProductIds, ProductType.SUBS)
+        val inappStoreProducts = mockStoreProduct(productIds, inappProductIds, ProductType.INAPP)
+        val storeProducts = subStoreProducts + inappStoreProducts
 
-        purchases.getSubscriptionProducts(productIds,
-            object : GetStoreProductsCallback {
-                override fun onReceived(storeProducts: List<StoreProduct>) {
-                    receivedProducts = storeProducts
-                }
-
-                override fun onError(error: PurchasesError) {
-                    fail("shouldn't be error")
-                }
-            })
-
-        assertThat(receivedProducts).isEqualTo(productDetails)
-    }
-
-    @Test
-    fun getsNonSubscriptionProducts() {
-        val productIds = listOf("normal_purchase")
-
-        val storeProducts = mockStoreProduct(productIds, listOf(), ProductType.INAPP)
-
-        purchases.getNonSubscriptionProducts(productIds,
+        purchases.getProducts(productIds,
             object : GetStoreProductsCallback {
                 override fun onReceived(storeProducts: List<StoreProduct>) {
                     receivedProducts = storeProducts
@@ -410,6 +394,53 @@ class PurchasesTest {
             })
 
         assertThat(receivedProducts).isEqualTo(storeProducts)
+        assertThat(receivedProducts?.size).isEqualTo(productIds.size)
+    }
+
+    @Test
+    fun getsSubscriptionProducts() {
+        val productIds = listOf("onemonth_freetrial")
+
+        val subStoreProducts = mockStoreProduct(productIds, productIds, ProductType.SUBS)
+        val inappStoreProducts = mockStoreProduct(productIds, listOf(), ProductType.INAPP)
+        val storeProducts = subStoreProducts + inappStoreProducts
+
+        purchases.getProducts(productIds,
+            object : GetStoreProductsCallback {
+                override fun onReceived(storeProducts: List<StoreProduct>) {
+                    receivedProducts = storeProducts
+                }
+
+                override fun onError(error: PurchasesError) {
+                    fail("shouldn't be error")
+                }
+            })
+
+        assertThat(receivedProducts).isEqualTo(storeProducts)
+        assertThat(receivedProducts?.size).isEqualTo(productIds.size)
+    }
+
+    @Test
+    fun getsNonSubscriptionProducts() {
+        val productIds = listOf("normal_purchase")
+
+        val subStoreProducts = mockStoreProduct(productIds, listOf(), ProductType.SUBS)
+        val inappStoreProducts = mockStoreProduct(productIds, productIds, ProductType.INAPP)
+        val storeProducts = subStoreProducts + inappStoreProducts
+
+        purchases.getProducts(productIds,
+            object : GetStoreProductsCallback {
+                override fun onReceived(storeProducts: List<StoreProduct>) {
+                    receivedProducts = storeProducts
+                }
+
+                override fun onError(error: PurchasesError) {
+                    fail("shouldn't be error")
+                }
+            })
+
+        assertThat(receivedProducts).isEqualTo(storeProducts)
+        assertThat(receivedProducts?.size).isEqualTo(productIds.size)
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -378,7 +378,7 @@ class PurchasesTest {
 
         val productDetails = mockStoreProduct(productIds, listOf(), ProductType.SUBS)
 
-        purchases.getSubscriptionSkus(productIds,
+        purchases.getSubscriptionProducts(productIds,
             object : GetStoreProductsCallback {
                 override fun onReceived(storeProducts: List<StoreProduct>) {
                     receivedProducts = storeProducts
@@ -398,7 +398,7 @@ class PurchasesTest {
 
         val storeProducts = mockStoreProduct(productIds, listOf(), ProductType.INAPP)
 
-        purchases.getNonSubscriptionSkus(productIds,
+        purchases.getNonSubscriptionProducts(productIds,
             object : GetStoreProductsCallback {
                 override fun onReceived(storeProducts: List<StoreProduct>) {
                     receivedProducts = storeProducts


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation

[CF-1069](https://revenuecats.atlassian.net/browse/CF-1069)
[CSDK-484](https://revenuecats.atlassian.net/browse/CSDK-484)

This task was to verify that `getSubscriptionSkus` and `getNonSubscriptionSkus` still worked but realized this naming is using BC4/V5 style so renamed all things talking about SKUs to Products

### Description

- Added:
  - `getProducts`
  - `getProductsWith`
- Deprecated:
  - `getSubscriptionSkus`
  - `getNonSubscriptionSkus`
  - `getSubscriptionSkusWith`
  - `getNonSubscriptionSkusWith`

Also updated and cleaned up `v6-MIGRATION.md`


[CF-1069]: https://revenuecats.atlassian.net/browse/CF-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CSDK-484]: https://revenuecats.atlassian.net/browse/CSDK-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ