### PR TITLE
[CF-997] Support upgrade/downgrade

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/UpgradeInfoAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/UpgradeInfoAPI.java
@@ -7,7 +7,6 @@ import com.revenuecat.purchases.UpgradeInfo;
 final class UpgradeInfoAPI {
     static void check(final UpgradeInfo upgradeInfo) {
         final String oldProductId = upgradeInfo.getOldProductId();
-        final String oldSku = upgradeInfo.getOldSku();
         @BillingFlowParams.ProrationMode final Integer prorationMode = upgradeInfo.getProrationMode();
 
         UpgradeInfo constructedUpgradeInfo = new UpgradeInfo(

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/UpgradeInfoAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/UpgradeInfoAPI.java
@@ -1,0 +1,31 @@
+package com.revenuecat.apitester.java;
+
+import com.android.billingclient.api.BillingFlowParams;
+import com.revenuecat.purchases.UpgradeInfo;
+
+@SuppressWarnings({"unused"})
+final class UpgradeInfoAPI {
+    static void check(final UpgradeInfo upgradeInfo) {
+        final String oldSku = upgradeInfo.getOldSku();
+        final String oldProductId = upgradeInfo.getOldProductId();
+        @BillingFlowParams.ProrationMode final Integer prorationMode = upgradeInfo.getProrationMode();
+
+        UpgradeInfo constructedUpgradeInfo = new UpgradeInfo(
+                upgradeInfo.getOldSku(),
+                upgradeInfo.getOldProductId(),
+                upgradeInfo.getProrationMode()
+        );
+
+        UpgradeInfo constructedUpgradeInfoNullProrationMode = new UpgradeInfo(
+                upgradeInfo.getOldProductId(),
+                upgradeInfo.getOldSku(),
+                null
+        );
+
+        UpgradeInfo constructedUpgradeInfoProductIdOnly = new UpgradeInfo(upgradeInfo.getOldProductId());
+        UpgradeInfo constructedUpgradeInfoProductIdAndOldSkuOnly = new UpgradeInfo(
+                upgradeInfo.getOldProductId(),
+                upgradeInfo.getOldSku()
+        );
+    }
+}

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/UpgradeInfoAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/UpgradeInfoAPI.java
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.UpgradeInfo;
 final class UpgradeInfoAPI {
     static void check(final UpgradeInfo upgradeInfo) {
         final String oldProductId = upgradeInfo.getOldProductId();
+        final String oldSku = upgradeInfo.getOldSku();
         @BillingFlowParams.ProrationMode final Integer prorationMode = upgradeInfo.getProrationMode();
 
         UpgradeInfo constructedUpgradeInfo = new UpgradeInfo(

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/UpgradeInfoAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/UpgradeInfoAPI.java
@@ -6,26 +6,22 @@ import com.revenuecat.purchases.UpgradeInfo;
 @SuppressWarnings({"unused"})
 final class UpgradeInfoAPI {
     static void check(final UpgradeInfo upgradeInfo) {
-        final String oldSku = upgradeInfo.getOldSku();
         final String oldProductId = upgradeInfo.getOldProductId();
         @BillingFlowParams.ProrationMode final Integer prorationMode = upgradeInfo.getProrationMode();
 
         UpgradeInfo constructedUpgradeInfo = new UpgradeInfo(
-                upgradeInfo.getOldSku(),
                 upgradeInfo.getOldProductId(),
                 upgradeInfo.getProrationMode()
         );
 
         UpgradeInfo constructedUpgradeInfoNullProrationMode = new UpgradeInfo(
                 upgradeInfo.getOldProductId(),
-                upgradeInfo.getOldSku(),
                 null
         );
 
         UpgradeInfo constructedUpgradeInfoProductIdOnly = new UpgradeInfo(upgradeInfo.getOldProductId());
         UpgradeInfo constructedUpgradeInfoProductIdAndOldSkuOnly = new UpgradeInfo(
-                upgradeInfo.getOldProductId(),
-                upgradeInfo.getOldSku()
+                upgradeInfo.getOldProductId()
         );
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
@@ -7,19 +7,17 @@ import com.revenuecat.purchases.UpgradeInfo
 private class UpgradeInfoAPI {
     fun check(upgradeInfo: UpgradeInfo) {
         with(upgradeInfo) {
-            val oldSku: String = oldSku
             val oldProductId: String = oldProductId
             @BillingFlowParams.ProrationMode val prorationMode: Int? = prorationMode
 
             val constructedUpgradeInfo =
                 UpgradeInfo(
-                    oldSku,
                     oldProductId,
                     prorationMode
                 )
 
             val constructedUpgradeInfoProductIdOnly = UpgradeInfo(oldProductId)
-            val constructedUpgradeInfoProductIdAndOldSkuOnly = UpgradeInfo(oldProductId, oldSku)
+            val constructedUpgradeInfoNullProrationMode = UpgradeInfo(oldProductId, null)
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
@@ -8,7 +8,6 @@ private class UpgradeInfoAPI {
     fun check(upgradeInfo: UpgradeInfo) {
         with(upgradeInfo) {
             val oldProductId: String = oldProductId
-            val oldSku: String = oldSku
             @BillingFlowParams.ProrationMode val prorationMode: Int? = prorationMode
 
             val constructedUpgradeInfo =
@@ -18,6 +17,7 @@ private class UpgradeInfoAPI {
                 )
 
             val constructedUpgradeInfoProductIdOnly = UpgradeInfo(oldProductId)
+            val constructedUpgradeInfoNullProrationMode = UpgradeInfo(oldProductId, null)
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
@@ -8,6 +8,7 @@ private class UpgradeInfoAPI {
     fun check(upgradeInfo: UpgradeInfo) {
         with(upgradeInfo) {
             val oldProductId: String = oldProductId
+            val oldSku: String = oldSku
             @BillingFlowParams.ProrationMode val prorationMode: Int? = prorationMode
 
             val constructedUpgradeInfo =
@@ -17,7 +18,6 @@ private class UpgradeInfoAPI {
                 )
 
             val constructedUpgradeInfoProductIdOnly = UpgradeInfo(oldProductId)
-            val constructedUpgradeInfoNullProrationMode = UpgradeInfo(oldProductId, null)
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
@@ -17,7 +17,6 @@ private class UpgradeInfoAPI {
                 )
 
             val constructedUpgradeInfoProductIdOnly = UpgradeInfo(oldProductId)
-            val constructedUpgradeInfoNullProrationMode = UpgradeInfo(oldProductId, null)
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
@@ -1,0 +1,25 @@
+package com.revenuecat.apitester.kotlin
+
+import com.android.billingclient.api.BillingFlowParams
+import com.revenuecat.purchases.UpgradeInfo
+
+@Suppress("unused", "UNUSED_VARIABLE", "RemoveExplicitTypeArguments")
+private class UpgradeInfoAPI {
+    fun check(upgradeInfo: UpgradeInfo) {
+        with(upgradeInfo) {
+            val oldSku: String = oldSku
+            val oldProductId: String = oldProductId
+            @BillingFlowParams.ProrationMode val prorationMode: Int? = prorationMode
+
+            val constructedUpgradeInfo =
+                UpgradeInfo(
+                    oldSku,
+                    oldProductId,
+                    prorationMode
+                )
+
+            val constructedUpgradeInfoProductIdOnly = UpgradeInfo(oldProductId)
+            val constructedUpgradeInfoProductIdAndOldSkuOnly = UpgradeInfo(oldProductId, oldSku)
+        }
+    }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -79,7 +79,7 @@ abstract class BillingAbstract {
         appUserID: String,
         storeProduct: StoreProduct,
         purchaseOption: PurchaseOption?,
-        replaceSkuInfo: ReplaceSkuInfo?,
+        replaceProductInfo: ReplaceProductInfo?,
         presentedOfferingIdentifier: String?
     )
 

--- a/common/src/main/java/com/revenuecat/purchases/common/ReplaceProductInfo.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/ReplaceProductInfo.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.common
 import com.android.billingclient.api.BillingFlowParams
 import com.revenuecat.purchases.models.StoreTransaction
 
-data class ReplaceSkuInfo(
+data class ReplaceProductInfo(
     val oldPurchase: StoreTransaction,
     @BillingFlowParams.ProrationMode val prorationMode: Int? = null
 )

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -26,7 +26,7 @@ import com.revenuecat.purchases.amazon.listener.UserDataResponseListener
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.LogIntent
-import com.revenuecat.purchases.common.ReplaceSkuInfo
+import com.revenuecat.purchases.common.ReplaceProductInfo
 import com.revenuecat.purchases.common.StoreProductsCallback
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.errorLog
@@ -224,12 +224,12 @@ internal class AmazonBilling constructor(
         appUserID: String,
         storeProduct: StoreProduct,
         purchaseOption: PurchaseOption?,
-        replaceSkuInfo: ReplaceSkuInfo?,
+        replaceProductInfo: ReplaceProductInfo?,
         presentedOfferingIdentifier: String?
     ) {
         if (checkObserverMode()) return
 
-        if (replaceSkuInfo != null) {
+        if (replaceProductInfo != null) {
             log(LogIntent.AMAZON_WARNING, AmazonStrings.PRODUCT_CHANGES_NOT_SUPPORTED)
             return
         }

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
@@ -7,6 +7,7 @@ fun BillingFlowParams.Builder.setUpgradeInfo(replaceProductInfo: ReplaceProductI
     val subscriptionUpdateParams = BillingFlowParams.SubscriptionUpdateParams.newBuilder().apply {
         setOldPurchaseToken(replaceProductInfo.oldPurchase.purchaseToken)
         replaceProductInfo.prorationMode?.let { prorationMode ->
+            // TODO BC5 handle new proration mode logic
             setReplaceProrationMode(prorationMode)
         }
     }

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
@@ -5,9 +5,9 @@ import com.revenuecat.purchases.common.ReplaceSkuInfo
 
 fun BillingFlowParams.Builder.setUpgradeInfo(replaceSkuInfo: ReplaceSkuInfo) {
     val subscriptionUpdateParams = BillingFlowParams.SubscriptionUpdateParams.newBuilder().apply {
-        setOldSkuPurchaseToken(replaceSkuInfo.oldPurchase.purchaseToken)
+        setOldPurchaseToken(replaceSkuInfo.oldPurchase.purchaseToken)
         replaceSkuInfo.prorationMode?.let { prorationMode ->
-            setReplaceSkusProrationMode(prorationMode)
+            setReplaceProrationMode(prorationMode)
         }
     }
     setSubscriptionUpdateParams(subscriptionUpdateParams.build())

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
@@ -1,12 +1,12 @@
 package com.revenuecat.purchases.google
 
 import com.android.billingclient.api.BillingFlowParams
-import com.revenuecat.purchases.common.ReplaceSkuInfo
+import com.revenuecat.purchases.common.ReplaceProductInfo
 
-fun BillingFlowParams.Builder.setUpgradeInfo(replaceSkuInfo: ReplaceSkuInfo) {
+fun BillingFlowParams.Builder.setUpgradeInfo(replaceProductInfo: ReplaceProductInfo) {
     val subscriptionUpdateParams = BillingFlowParams.SubscriptionUpdateParams.newBuilder().apply {
-        setOldPurchaseToken(replaceSkuInfo.oldPurchase.purchaseToken)
-        replaceSkuInfo.prorationMode?.let { prorationMode ->
+        setOldPurchaseToken(replaceProductInfo.oldPurchase.purchaseToken)
+        replaceProductInfo.prorationMode?.let { prorationMode ->
             setReplaceProrationMode(prorationMode)
         }
     }

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -29,7 +29,7 @@ import com.revenuecat.purchases.PurchasesErrorCallback
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.LogIntent
-import com.revenuecat.purchases.common.ReplaceSkuInfo
+import com.revenuecat.purchases.common.ReplaceProductInfo
 import com.revenuecat.purchases.common.StoreProductsCallback
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.errorLog
@@ -203,13 +203,13 @@ class BillingWrapper(
         appUserID: String,
         storeProduct: StoreProduct,
         purchaseOption: PurchaseOption?,
-        replaceSkuInfo: ReplaceSkuInfo?,
+        replaceProductInfo: ReplaceProductInfo?,
         presentedOfferingIdentifier: String?
     ) {
-        if (replaceSkuInfo != null) {
+        if (replaceProductInfo != null) {
             log(
                 LogIntent.PURCHASE, PurchaseStrings.UPGRADING_SKU
-                    .format(replaceSkuInfo.oldPurchase.productIds[0], storeProduct.productId)
+                    .format(replaceProductInfo.oldPurchase.productIds[0], storeProduct.productId)
             )
         } else {
             log(LogIntent.PURCHASE, PurchaseStrings.PURCHASING_PRODUCT.format(storeProduct.productId))
@@ -224,7 +224,7 @@ class BillingWrapper(
             val result = buildPurchaseParams(
                 storeProduct,
                 purchaseOption,
-                replaceSkuInfo,
+                replaceProductInfo,
                 appUserID
             )
             when (result) {
@@ -778,7 +778,7 @@ class BillingWrapper(
     private fun buildPurchaseParams(
         storeProduct: StoreProduct,
         purchaseOption: PurchaseOption?,
-        replaceSkuInfo: ReplaceSkuInfo?,
+        replaceProductInfo: ReplaceProductInfo?,
         appUserID: String
     ): Result<BillingFlowParams, PurchasesError> {
         val googleProduct = storeProduct.googleProduct
@@ -796,7 +796,7 @@ class BillingWrapper(
         }
 
         return if (googleProduct.type == ProductType.SUBS) {
-            buildSubscriptionPurchaseParams(googleProduct, purchaseOption, replaceSkuInfo, appUserID)
+            buildSubscriptionPurchaseParams(googleProduct, purchaseOption, replaceProductInfo, appUserID)
         } else {
             buildOneTimePurchaseParams(googleProduct, appUserID)
         }
@@ -821,7 +821,7 @@ class BillingWrapper(
     private fun buildSubscriptionPurchaseParams(
         googleProduct: GoogleStoreProduct,
         purchaseOption: PurchaseOption?,
-        replaceSkuInfo: ReplaceSkuInfo?,
+        replaceProductInfo: ReplaceProductInfo?,
         appUserID: String
     ): Result<BillingFlowParams, PurchasesError> {
         val googlePurchaseOption = purchaseOption as? GooglePurchaseOption
@@ -848,7 +848,7 @@ class BillingWrapper(
                 .apply {
                     // only setObfuscatedAccountId for non-upgrade/downgrades until google issue is fixed:
                     // https://issuetracker.google.com/issues/155005449
-                    replaceSkuInfo?.let {
+                    replaceProductInfo?.let {
                         setUpgradeInfo(it)
                     } ?: setObfuscatedAccountId(appUserID.sha256())
                 }

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -364,14 +364,14 @@ class BillingWrapperTest {
             BillingFlowParams.SubscriptionUpdateParams.newBuilder()
         } returns mockSubscriptionUpdateParamsBuilder
 
-        val oldSkuPurchaseTokenSlot = slot<String>()
+        val oldPurchaseTokenSlot = slot<String>()
         every {
-            mockSubscriptionUpdateParamsBuilder.setOldSkuPurchaseToken(capture(oldSkuPurchaseTokenSlot))
+            mockSubscriptionUpdateParamsBuilder.setOldPurchaseToken(capture(oldPurchaseTokenSlot))
         } returns mockSubscriptionUpdateParamsBuilder
 
         val prorationModeSlot = slot<Int>()
         every {
-            mockSubscriptionUpdateParamsBuilder.setReplaceSkusProrationMode(capture(prorationModeSlot))
+            mockSubscriptionUpdateParamsBuilder.setReplaceProrationMode(capture(prorationModeSlot))
         } returns mockSubscriptionUpdateParamsBuilder
 
         val productId = "product_a"
@@ -394,7 +394,7 @@ class BillingWrapperTest {
             assertThat(productId).isEqualTo(capturedProductDetailsParams[0].zza().productId)
             assertThat(subsGoogleProductType).isEqualTo(capturedProductDetailsParams[0].zza().productType)
 
-            assertThat(upgradeInfo.oldPurchase.purchaseToken).isEqualTo(oldSkuPurchaseTokenSlot.captured)
+            assertThat(upgradeInfo.oldPurchase.purchaseToken).isEqualTo(oldPurchaseTokenSlot.captured)
             assertThat(upgradeInfo.prorationMode).isEqualTo(prorationModeSlot.captured)
             billingClientOKResult
         }

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -27,7 +27,7 @@ import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.BillingAbstract
-import com.revenuecat.purchases.common.ReplaceSkuInfo
+import com.revenuecat.purchases.common.ReplaceProductInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.firstSku
 import com.revenuecat.purchases.common.sha1
@@ -2090,9 +2090,9 @@ class BillingWrapperTest {
         return oldPurchase.toStoreTransaction(type = ProductType.SUBS)
     }
 
-    private fun mockReplaceSkuInfo(): ReplaceSkuInfo {
+    private fun mockReplaceSkuInfo(): ReplaceProductInfo {
         val oldPurchase = mockPurchaseHistoryRecordWrapper()
-        return ReplaceSkuInfo(oldPurchase, BillingFlowParams.ProrationMode.DEFERRED)
+        return ReplaceProductInfo(oldPurchase, BillingFlowParams.ProrationMode.DEFERRED)
     }
 
     private fun getMockedPurchaseWrapper(

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -50,6 +50,14 @@ StoreProduct has been made an interface, which `GoogleStoreProduct` and `AmazonS
 |------------|------------|
 | skus       | productIds |
 
+### UpgradeInfo updates
+
+
+| Removed | New          |
+|---------|--------------|
+| oldSku  | oldProductId |
+
+
 ### New purchasing APIs
 
 | New              |

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -37,7 +37,7 @@ StoreProduct has been made an interface, which `GoogleStoreProduct` and `AmazonS
 |-----------------------------------|--|
 | product.originalPrice             | Accessible in basePlan's unique pricing phase `purchaseOptions.firstOrNull{ it.isBasePlan }?.pricingPhases?.first()?.formattedPrice` |
 | product.originalPriceAmountMicros | Accessible in basePlan's unique pricing phase `purchaseOptions.firstOrNull{ it.isBasePlan }?.pricingPhases?.first()?.priceAmountMicros` |
-| producct.iconUrl                  |  | 
+| product.iconUrl                  |  | 
 | product.originalJson              |(product as GoogleStoreProduct).productDetails |
 
 ### StoreTransaction updates

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1557,7 +1557,7 @@ class Purchases internal constructor(
     ) {
         billing.findPurchaseInPurchaseHistory(
             appUserID,
-            storeProduct.type,
+            ProductType.SUBS,
             upgradeInfo.oldProductId,
             onCompletion = { purchaseRecord ->
                 log(LogIntent.PURCHASE, PurchaseStrings.FOUND_EXISTING_PURCHASE.format(upgradeInfo.oldProductId))

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -379,11 +379,11 @@ class Purchases internal constructor(
     }
 
     /**
-     * Make a purchase upgrading from a previous sku. If purchasing a subscription,
+     * Make a purchase upgrading from a previous subscription. If purchasing a subscription,
      * it will choose the default [PurchaseOption].
      * @param [activity] Current activity
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
-     * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional
+     * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldProductId and the optional
      * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
      * @param [listener] The PurchaseCallback that will be called when purchase completes.
      */
@@ -423,7 +423,7 @@ class Purchases internal constructor(
      * @param [activity] Current activity
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
      * @param [purchaseOption] Your choice of purchase options available for the subscription StoreProduct
-     * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional
+     * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldProductId and the optional
      * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
      * @param [listener] The PurchaseCallback that will be called when purchase completes.
      */
@@ -462,11 +462,11 @@ class Purchases internal constructor(
     }
 
     /**
-     * Purchase a [Package] upgrading from a previous sku. If purchasing a subscription,
+     * Purchase a [Package] upgrading from a previous subscription. If purchasing a subscription,
      * it will choose the default [PurchaseOption].
      * @param [activity] Current activity
      * @param [packageToPurchase] The Package you wish to purchase
-     * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional
+     * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldProductId and the optional
      * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
      * @param [callback] The listener that will be called when purchase completes.
      */
@@ -1545,9 +1545,9 @@ class Purchases internal constructor(
         billing.findPurchaseInPurchaseHistory(
             appUserID,
             storeProduct.type,
-            upgradeInfo.oldSku,
+            upgradeInfo.oldProductId,
             onCompletion = { purchaseRecord ->
-                log(LogIntent.PURCHASE, PurchaseStrings.FOUND_EXISTING_PURCHASE.format(upgradeInfo.oldSku))
+                log(LogIntent.PURCHASE, PurchaseStrings.FOUND_EXISTING_PURCHASE.format(upgradeInfo.oldProductId))
 
                 billing.makePurchaseAsync(
                     activity,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -25,7 +25,7 @@ import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.ReceiptInfo
-import com.revenuecat.purchases.common.ReplaceSkuInfo
+import com.revenuecat.purchases.common.ReplaceProductInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
 import com.revenuecat.purchases.common.currentLogHandler
@@ -1554,7 +1554,7 @@ class Purchases internal constructor(
                     appUserID,
                     storeProduct,
                     purchaseOption,
-                    ReplaceSkuInfo(purchaseRecord, upgradeInfo.prorationMode),
+                    ReplaceProductInfo(purchaseRecord, upgradeInfo.prorationMode),
                     presentedOfferingIdentifier
                 )
             },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -379,8 +379,12 @@ class Purchases internal constructor(
     }
 
     /**
-     * Make a purchase upgrading from a previous subscription. If purchasing a subscription,
-     * it will choose the default [PurchaseOption].
+     * Purchases [storeProduct].
+     * If [storeProduct] represents a subscription, upgrades from the subscription specified by
+     * [upgradeInfo.oldProductId] and chooses [storeProduct]'s default [PurchaseOption].
+     *
+     * If [storeProduct] represents a non-subscription, [upgradeInfo] will be ignored.
+     *
      * @param [activity] Current activity
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
      * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldProductId and the optional
@@ -419,7 +423,12 @@ class Purchases internal constructor(
 
     // TODOBC5: remove storeProduct parameter
     /**
-     * Purchase a subscription [StoreProduct]'s [PurchaseOption] upgrading from a previous product.
+     * Purchases [storeProduct].
+     * If [storeProduct] represents a subscription, upgrades from the subscription specified by
+     * [upgradeInfo.oldProductId] and chooses [storeProduct]'s default [PurchaseOption].
+     *
+     * If [storeProduct] represents a non-subscription, [upgradeInfo] will be ignored.
+     *
      * @param [activity] Current activity
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
      * @param [purchaseOption] Your choice of purchase options available for the subscription StoreProduct
@@ -462,8 +471,12 @@ class Purchases internal constructor(
     }
 
     /**
-     * Purchase a [Package] upgrading from a previous subscription. If purchasing a subscription,
-     * it will choose the default [PurchaseOption].
+     * Purchases a [Package].
+     * If [packageToPurchase] represents a subscription, upgrades from the subscription specified by [upgradeInfo]'s
+     * [oldProductId]and chooses the default [PurchaseOption] from [packageToPurchase].
+     *
+     * If [packageToPurchase] represents a non-subscription, [upgradeInfo] will be ignored.
+     *
      * @param [activity] Current activity
      * @param [packageToPurchase] The Package you wish to purchase
      * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldProductId and the optional

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1556,8 +1556,13 @@ class Purchases internal constructor(
         listener: PurchaseErrorCallback
     ) {
         if (storeProduct.type != ProductType.SUBS) {
-            log(LogIntent.WARNING, PurchaseStrings.UPGRADING_INVALID_TYPE)
+            dispatch {
+                listener.onError(PurchasesError(PurchasesErrorCode.PurchaseNotAllowedError,
+                    PurchaseStrings.UPGRADING_INVALID_TYPE).also { errorLog(it) }, false)
+            }
+            return
         }
+
         billing.findPurchaseInPurchaseHistory(
             appUserID,
             ProductType.SUBS,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1555,6 +1555,9 @@ class Purchases internal constructor(
         presentedOfferingIdentifier: String?,
         listener: PurchaseErrorCallback
     ) {
+        if (storeProduct.type != ProductType.SUBS) {
+            log(LogIntent.WARNING, PurchaseStrings.UPGRADING_INVALID_TYPE)
+        }
         billing.findPurchaseInPurchaseHistory(
             appUserID,
             ProductType.SUBS,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeInfo.kt
@@ -10,4 +10,10 @@ import com.android.billingclient.api.BillingFlowParams
 data class UpgradeInfo @JvmOverloads constructor(
     val oldProductId: String,
     @BillingFlowParams.ProrationMode val prorationMode: Int? = null
-)
+) {
+    @Deprecated(
+        "Use oldProductId instead",
+        ReplaceWith("oldProductId")
+    )
+    val oldSku get() = oldProductId
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeInfo.kt
@@ -9,10 +9,5 @@ import com.android.billingclient.api.BillingFlowParams
  */
 data class UpgradeInfo @JvmOverloads constructor(
     val oldProductId: String,
-    @Deprecated(
-        "Replaced with oldProductId",
-        ReplaceWith("oldProductId")
-    )
-    val oldSku: String = oldProductId,
     @BillingFlowParams.ProrationMode val prorationMode: Int? = null
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeInfo.kt
@@ -10,10 +10,4 @@ import com.android.billingclient.api.BillingFlowParams
 data class UpgradeInfo @JvmOverloads constructor(
     val oldProductId: String,
     @BillingFlowParams.ProrationMode val prorationMode: Int? = null
-) {
-    @Deprecated(
-        "Use oldProductId instead",
-        ReplaceWith("oldProductId")
-    )
-    val oldSku get() = oldProductId
-}
+)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeInfo.kt
@@ -7,8 +7,12 @@ import com.android.billingclient.api.BillingFlowParams
  * @property oldProductId The old product ID to upgrade from.
  * @property prorationMode The [BillingFlowParams.ProrationMode] to use when upgrading the given oldSku.
  */
-data class UpgradeInfo(
-    // TODO deprecate oldSku
-    val oldSku: String, // TODOBC5 rename?
+data class UpgradeInfo @JvmOverloads constructor(
+    val oldProductId: String,
+    @Deprecated(
+        "Replaced with oldProductId",
+        ReplaceWith("oldProductId")
+    )
+    val oldSku: String = oldProductId,
     @BillingFlowParams.ProrationMode val prorationMode: Int? = null
 )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -25,7 +25,7 @@ import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.PostReceiptDataErrorCallback
 import com.revenuecat.purchases.common.PostReceiptDataSuccessCallback
 import com.revenuecat.purchases.common.ReceiptInfo
-import com.revenuecat.purchases.common.ReplaceSkuInfo
+import com.revenuecat.purchases.common.ReplaceProductInfo
 import com.revenuecat.purchases.common.buildCustomerInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
@@ -572,7 +572,7 @@ class PurchasesTest {
                 eq(appUserId),
                 storeProduct,
                 storeProduct.purchaseOptions[0],
-                ReplaceSkuInfo(oldPurchase),
+                ReplaceProductInfo(oldPurchase),
                 stubOfferingIdentifier
             )
         }
@@ -1091,7 +1091,7 @@ class PurchasesTest {
                 eq(appUserId),
                 storeProduct,
                 storeProduct.purchaseOptions[0],
-                ReplaceSkuInfo(oldPurchase),
+                ReplaceProductInfo(oldPurchase),
                 stubOfferingIdentifier
             )
         }
@@ -1148,7 +1148,7 @@ class PurchasesTest {
                 eq(appUserId),
                 storeProduct,
                 storeProduct.purchaseOptions[0],
-                ReplaceSkuInfo(oldPurchase),
+                ReplaceProductInfo(oldPurchase),
                 stubOfferingIdentifier
             )
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -470,6 +470,26 @@ class PurchasesTest {
     }
 
     @Test
+    fun `when attempting upgrade to OTP, error block is called`() {
+        val productId = "coins"
+
+        val receiptInfo = mockQueryingProductDetails(productId, ProductType.INAPP, null)
+
+        var errorCallCount = 0
+        purchases.purchaseProductWith(
+            mockActivity,
+            receiptInfo.storeProduct!!,
+            UpgradeInfo("oldSubID"),
+            onError = { _, _ ->
+                errorCallCount++
+            }, onSuccess = { _, _ ->
+                fail("should be error")
+            })
+
+        assertThat(errorCallCount).isEqualTo(1)
+    }
+
+    @Test
     fun canMakePurchase() {
         val storeProduct = stubStoreProduct("abc")
 

--- a/strings/src/main/java/com/revenuecat/purchases/strings/PurchaseStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/PurchaseStrings.kt
@@ -29,6 +29,8 @@ object PurchaseStrings {
         "It has already been posted"
     const val UPDATING_PENDING_PURCHASE_QUEUE = "Updating pending purchase queue"
     const val UPGRADING_SKU = "Moving from old SKU %s to sku %s"
+    const val UPGRADING_INVALID_TYPE = "UpgradeInfo passed to purchase for non-sub product type. No upgrade will " +
+        "occur. Consider using non-upgrade purchase flows for this product."
     const val UPGRADING_SKU_ERROR = "There was an error trying to upgrade. BillingResponseCode: %s"
     const val NOT_RECOGNIZED_PRODUCT_TYPE = "Type of product not recognized."
     const val SKIPPING_AUTOMATIC_SYNC = "Skipping automatic synchronization."


### PR DESCRIPTION
* Update the upgrade/downgrade purchase flow to use the new BC5 methods
* rename `ReplaceSkuInfo` -> `ReplaceProductInfo` (this is an internal class)
* deprecate `UpgradeInfo.oldSku` and replace with `UpgradeInfo.oldProductId`
* add `UpgradeInfo` purchase testers

Will open a different PR to merge some of my [POC](https://github.com/RevenueCat/purchases-android/pull/723/files) purchase tester code
