### PR TITLE
Use toString in errorLog so that underlying message gets logged too

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/logUtils.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/logUtils.kt
@@ -35,7 +35,7 @@ fun errorLog(error: PurchasesError) {
         PurchasesErrorCode.UnsupportedError,
         PurchasesErrorCode.EmptySubscriberAttributesError,
         PurchasesErrorCode.CustomerInfoError,
-        PurchasesErrorCode.InvalidSubscriberAttributesError -> log(LogIntent.RC_ERROR, error.message)
+        PurchasesErrorCode.InvalidSubscriberAttributesError -> log(LogIntent.RC_ERROR, error.toString())
         PurchasesErrorCode.PurchaseCancelledError,
         PurchasesErrorCode.StoreProblemError,
         PurchasesErrorCode.PurchaseNotAllowedError,
@@ -48,6 +48,6 @@ fun errorLog(error: PurchasesError) {
         PurchasesErrorCode.IneligibleError,
         PurchasesErrorCode.InsufficientPermissionsError,
         PurchasesErrorCode.PaymentPendingError,
-        PurchasesErrorCode.InvalidCredentialsError -> log(LogIntent.GOOGLE_ERROR, error.message)
+        PurchasesErrorCode.InvalidCredentialsError -> log(LogIntent.GOOGLE_ERROR, error.toString())
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
@@ -126,7 +126,7 @@ internal class CustomerInfoHelper(
                 dispatch { callback?.onReceived(info) }
             },
             { error ->
-                Log.e("Purchases", "Error fetching customer data: ${error.message}")
+                Log.e("Purchases", "Error fetching customer data: $error")
                 deviceCache.clearCustomerInfoCacheTimestamp(appUserID)
                 dispatch { callback?.onError(error) }
             })

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1559,7 +1559,7 @@ class Purchases internal constructor(
                 )
             },
             onError = { error ->
-                log(LogIntent.GOOGLE_ERROR, error.message)
+                log(LogIntent.GOOGLE_ERROR, error.toString())
                 dispatch {
                     listener.onError(error, false)
                 }
@@ -1594,7 +1594,7 @@ class Purchases internal constructor(
                             )
                         },
                         onError = { error ->
-                            log(LogIntent.GOOGLE_ERROR, error.message)
+                            log(LogIntent.GOOGLE_ERROR, error.toString())
                         })
                 }
             })


### PR DESCRIPTION
I've run into a number of situations now while testing where the `PurchasesError` `message (code.description)` is a little too vague, and we weren't printing the `underlyingErrorMessage` associated with the error.

I suggest updating the `errorLog` method to use `PurchasesError.toString()`, which prints both the `code.description` and `underlyingErrorMessage` for more detail while debugging. This only affects debug logs -- users can still switch on the higher-level code if they wish.

I then searched for where else we only print the message, and updated those usages to print the full error.

If people like this change, I'll get it into `main` as well.