### PR TITLE
[CF-1145] Upgrade/downgrade support in purchase tester

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
@@ -42,7 +42,7 @@ class MainApplication : Application(), UpdatedCustomerInfoListener {
         val message = "CustomerInfoListener received update at ${customerInfo.requestDate}"
         Toast.makeText(this,
             message,
-            Toast.LENGTH_LONG
+            Toast.LENGTH_SHORT
         ).show()
         Log.d("CustomerInfoListener", "$message: $customerInfo")
     }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -147,33 +147,33 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
     ) {
         when {
             upgradeInfo == null && purchaseOption == null -> Purchases.sharedInstance.purchaseProductWith(
-                    requireActivity(),
-                    currentProduct,
-                    purchaseErrorCallback,
-                    successfulPurchaseCallback
-                )
+                requireActivity(),
+                currentProduct,
+                purchaseErrorCallback,
+                successfulPurchaseCallback
+            )
             upgradeInfo == null && purchaseOption != null -> Purchases.sharedInstance.purchaseSubscriptionOptionWith(
-                    requireActivity(),
-                    currentProduct,
-                    purchaseOption,
-                    purchaseErrorCallback,
-                    successfulPurchaseCallback
-                )
+                requireActivity(),
+                currentProduct,
+                purchaseOption,
+                purchaseErrorCallback,
+                successfulPurchaseCallback
+            )
             upgradeInfo != null && purchaseOption == null -> Purchases.sharedInstance.purchaseProductWith(
-                    requireActivity(),
-                    currentProduct,
-                    upgradeInfo,
-                    purchaseErrorCallback,
-                    successfulUpgradeCallback
-                )
+                requireActivity(),
+                currentProduct,
+                upgradeInfo,
+                purchaseErrorCallback,
+                successfulUpgradeCallback
+            )
             upgradeInfo != null && purchaseOption != null -> Purchases.sharedInstance.purchaseSubscriptionOptionWith(
-                    requireActivity(),
-                    currentProduct,
-                    purchaseOption,
-                    upgradeInfo,
-                    purchaseErrorCallback,
-                    successfulUpgradeCallback
-                )
+                requireActivity(),
+                currentProduct,
+                purchaseOption,
+                upgradeInfo,
+                purchaseErrorCallback,
+                successfulUpgradeCallback
+            )
         }
     }
 
@@ -195,33 +195,33 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
     ) {
         when {
             upgradeInfo == null && purchaseOption == null -> Purchases.sharedInstance.purchasePackageWith(
-                    requireActivity(),
-                    currentPackage,
-                    purchaseErrorCallback,
-                    successfulPurchaseCallback
-                )
+                requireActivity(),
+                currentPackage,
+                purchaseErrorCallback,
+                successfulPurchaseCallback
+            )
             upgradeInfo == null && purchaseOption != null -> Purchases.sharedInstance.purchaseSubscriptionOptionWith(
-                    requireActivity(),
-                    currentPackage.product,
-                    purchaseOption,
-                    purchaseErrorCallback,
-                    successfulPurchaseCallback
-                )
+                requireActivity(),
+                currentPackage.product,
+                purchaseOption,
+                purchaseErrorCallback,
+                successfulPurchaseCallback
+            )
             upgradeInfo != null && purchaseOption == null -> Purchases.sharedInstance.purchasePackageWith(
-                    requireActivity(),
-                    currentPackage,
-                    upgradeInfo,
-                    purchaseErrorCallback,
-                    successfulUpgradeCallback
-                )
+                requireActivity(),
+                currentPackage,
+                upgradeInfo,
+                purchaseErrorCallback,
+                successfulUpgradeCallback
+            )
             upgradeInfo != null && purchaseOption != null -> Purchases.sharedInstance.purchaseSubscriptionOptionWith(
-                    requireActivity(),
-                    currentPackage.product,
-                    purchaseOption,
-                    upgradeInfo,
-                    purchaseErrorCallback,
-                    successfulUpgradeCallback
-                )
+                requireActivity(),
+                currentPackage.product,
+                purchaseOption,
+                upgradeInfo,
+                purchaseErrorCallback,
+                successfulUpgradeCallback
+            )
         }
     }
 
@@ -263,11 +263,12 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
     private fun showProrationModePicker(callback: (Int?) -> Unit) {
         val prorationModeOptions = mapOf(
             0 to "None",
-            ProrationMode.IMMEDIATE_WITH_TIME_PRORATION to "IMMEDIATE_WITH_TIME_PRORATION",
-            ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE to "IMMEDIATE_AND_CHARGE_PRORATED_PRICE",
-            ProrationMode.IMMEDIATE_WITHOUT_PRORATION to "IMMEDIATE_WITHOUT_PRORATION",
-            ProrationMode.DEFERRED to "DEFERRED",
-            ProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE to "IMMEDIATE_AND_CHARGE_FULL_PRICE"
+            ProrationMode.IMMEDIATE_WITH_TIME_PRORATION to ProrationMode::IMMEDIATE_WITH_TIME_PRORATION.name,
+            ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE to
+                ProrationMode::IMMEDIATE_AND_CHARGE_PRORATED_PRICE.name,
+            ProrationMode.IMMEDIATE_WITHOUT_PRORATION to ProrationMode::IMMEDIATE_WITHOUT_PRORATION.name,
+            ProrationMode.DEFERRED to ProrationMode::DEFERRED.name,
+            ProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE to ProrationMode::IMMEDIATE_AND_CHARGE_FULL_PRICE.name
         )
         @ProrationMode var selectedProrationMode = 0
         MaterialAlertDialogBuilder(requireContext())

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -71,10 +71,9 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         purchaseOption: PurchaseOption?,
         isUpgrade: Boolean
     ) {
-        binding.purchaseProgress.visibility = View.VISIBLE
+        toggleLoadingIndicator(true)
 
         if (isUpgrade) {
-            // TODO fix infinite spinner
             showOldSubIdPicker()
         } else {
             if (purchaseOption == null) {
@@ -115,6 +114,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
                 "Cannot ugprade without an existing active subscription.",
                 Toast.LENGTH_LONG
             ).show()
+            toggleLoadingIndicator(false)
             return
         }
         MaterialAlertDialogBuilder(requireContext())
@@ -122,12 +122,12 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
             .setSingleChoiceItems(activeSubIds.toTypedArray(), 0) { dialog_, which ->
                 selectedUpgradeSubId = activeSubIds[which]
             }
-            .setPositiveButton("Ok") { dialog, _ ->
+            .setPositiveButton("Continue") { dialog, _ ->
                 Log.e("maddietest", "upgrading from $selectedUpgradeSubId ")
                 dialog.dismiss()
                 showProrationModePicker()
             }
-            .setNegativeButton("Cancel") { dialog, _ ->
+            .setNegativeButton("Cancel purchase") { dialog, _ ->
                 dialog.dismiss()
             }
             .show()
@@ -144,15 +144,15 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         )
 
         MaterialAlertDialogBuilder(requireContext())
-            .setTitle("Switch from which currently active subscription?")
+            .setTitle("Switch with which ProrationMode?")
             .setSingleChoiceItems(prorationModeOptions.values.toTypedArray(), 0) { _, selectedIndex ->
                 selectedProrationMode = prorationModeOptions.keys.elementAt(selectedIndex)
             }
-            .setPositiveButton("Ok") { dialog, _ ->
+            .setPositiveButton("Start purchase") { dialog, _ ->
                 Log.e("maddietest", "upgrading with proration mode $selectedProrationMode")
                 // todo start purchase
             }
-            .setNegativeButton("Cancel") { dialog, _ ->
+            .setNegativeButton("Cancel purchase") { dialog, _ ->
                 dialog.dismiss()
             }
             .show()
@@ -164,13 +164,14 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         purchaseOption: PurchaseOption?,
         isUpgrade: Boolean
     ) {
-        binding.purchaseProgress.visibility = View.VISIBLE
+        toggleLoadingIndicator(true)
 
         if (purchaseOption == null) {
             Purchases.sharedInstance.purchaseProductWith(
                 requireActivity(),
                 currentProduct,
                 { error, userCancelled ->
+                    toggleLoadingIndicator(false)
                     if (!userCancelled) {
                         showUserError(requireActivity(), error)
                     }
@@ -185,6 +186,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
                 currentProduct,
                 purchaseOption,
                 { error, userCancelled ->
+                    toggleLoadingIndicator(false)
                     if (!userCancelled) {
                         showUserError(requireActivity(), error)
                     }
@@ -196,7 +198,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
     }
 
     private fun handleSuccessfulPurchase(orderId: String?) {
-        binding.purchaseProgress.visibility = View.GONE
+        toggleLoadingIndicator(false)
         context?.let {
             Toast.makeText(
                 it,
@@ -205,5 +207,9 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
             ).show()
             findNavController().navigateUp()
         }
+    }
+
+    private fun toggleLoadingIndicator(isLoading: Boolean) {
+        binding.purchaseProgress.visibility = if (isLoading) View.VISIBLE else View.GONE
     }
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -106,58 +106,6 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         }
     }
 
-    private fun showOldSubIdPicker() {
-        val activeSubIds = activeSubscriptions.map { it.split(":").first() } // TODOBC5 remove sub Id parsing
-        if (activeSubIds.isEmpty()) {
-            Toast.makeText(
-                requireContext(),
-                "Cannot ugprade without an existing active subscription.",
-                Toast.LENGTH_LONG
-            ).show()
-            toggleLoadingIndicator(false)
-            return
-        }
-        MaterialAlertDialogBuilder(requireContext())
-            .setTitle("Switch from which currently active subscription?")
-            .setSingleChoiceItems(activeSubIds.toTypedArray(), 0) { dialog_, which ->
-                selectedUpgradeSubId = activeSubIds[which]
-            }
-            .setPositiveButton("Continue") { dialog, _ ->
-                Log.e("maddietest", "upgrading from $selectedUpgradeSubId ")
-                dialog.dismiss()
-                showProrationModePicker()
-            }
-            .setNegativeButton("Cancel purchase") { dialog, _ ->
-                dialog.dismiss()
-            }
-            .show()
-    }
-
-    private fun showProrationModePicker() {
-        val prorationModeOptions = mapOf(
-            0 to "None",
-            ProrationMode.IMMEDIATE_WITH_TIME_PRORATION to "IMMEDIATE_WITH_TIME_PRORATION",
-            ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE to "IMMEDIATE_AND_CHARGE_PRORATED_PRICE",
-            ProrationMode.IMMEDIATE_WITHOUT_PRORATION to "IMMEDIATE_WITHOUT_PRORATION",
-            ProrationMode.DEFERRED to "DEFERRED",
-            ProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE to "IMMEDIATE_AND_CHARGE_FULL_PRICE"
-        )
-
-        MaterialAlertDialogBuilder(requireContext())
-            .setTitle("Switch with which ProrationMode?")
-            .setSingleChoiceItems(prorationModeOptions.values.toTypedArray(), 0) { _, selectedIndex ->
-                selectedProrationMode = prorationModeOptions.keys.elementAt(selectedIndex)
-            }
-            .setPositiveButton("Start purchase") { dialog, _ ->
-                Log.e("maddietest", "upgrading with proration mode $selectedProrationMode")
-                // todo start purchase
-            }
-            .setNegativeButton("Cancel purchase") { dialog, _ ->
-                dialog.dismiss()
-            }
-            .show()
-    }
-
     override fun onPurchaseProductClicked(
         cardView: View,
         currentProduct: StoreProduct,
@@ -211,5 +159,57 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
 
     private fun toggleLoadingIndicator(isLoading: Boolean) {
         binding.purchaseProgress.visibility = if (isLoading) View.VISIBLE else View.GONE
+    }
+
+    private fun showOldSubIdPicker() {
+        val activeSubIds = activeSubscriptions.map { it.split(":").first() } // TODOBC5 remove sub Id parsing
+        if (activeSubIds.isEmpty()) {
+            Toast.makeText(
+                requireContext(),
+                "Cannot ugprade without an existing active subscription.",
+                Toast.LENGTH_LONG
+            ).show()
+            toggleLoadingIndicator(false)
+            return
+        }
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle("Switch from which currently active subscription?")
+            .setSingleChoiceItems(activeSubIds.toTypedArray(), 0) { dialog_, which ->
+                selectedUpgradeSubId = activeSubIds[which]
+            }
+            .setPositiveButton("Continue") { dialog, _ ->
+                Log.e("maddietest", "upgrading from $selectedUpgradeSubId ")
+                dialog.dismiss()
+                showProrationModePicker()
+            }
+            .setNegativeButton("Cancel purchase") { dialog, _ ->
+                dialog.dismiss()
+            }
+            .show()
+    }
+
+    private fun showProrationModePicker() {
+        val prorationModeOptions = mapOf(
+            0 to "None",
+            ProrationMode.IMMEDIATE_WITH_TIME_PRORATION to "IMMEDIATE_WITH_TIME_PRORATION",
+            ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE to "IMMEDIATE_AND_CHARGE_PRORATED_PRICE",
+            ProrationMode.IMMEDIATE_WITHOUT_PRORATION to "IMMEDIATE_WITHOUT_PRORATION",
+            ProrationMode.DEFERRED to "DEFERRED",
+            ProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE to "IMMEDIATE_AND_CHARGE_FULL_PRICE"
+        )
+
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle("Switch with which ProrationMode?")
+            .setSingleChoiceItems(prorationModeOptions.values.toTypedArray(), 0) { _, selectedIndex ->
+                selectedProrationMode = prorationModeOptions.keys.elementAt(selectedIndex)
+            }
+            .setPositiveButton("Start purchase") { dialog, _ ->
+                Log.e("maddietest", "upgrading with proration mode $selectedProrationMode")
+                // todo start purchase
+            }
+            .setNegativeButton("Cancel purchase") { dialog, _ ->
+                dialog.dismiss()
+            }
+            .show()
     }
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -145,34 +145,28 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         currentProduct: StoreProduct,
         upgradeInfo: UpgradeInfo?
     ) {
-        if (upgradeInfo == null) {
-            if (purchaseOption == null) {
-                Purchases.sharedInstance.purchaseProductWith(
+        when {
+            upgradeInfo == null && purchaseOption == null -> Purchases.sharedInstance.purchaseProductWith(
                     requireActivity(),
                     currentProduct,
                     purchaseErrorCallback,
                     successfulPurchaseCallback
                 )
-            } else {
-                Purchases.sharedInstance.purchaseSubscriptionOptionWith(
+            upgradeInfo == null && purchaseOption != null -> Purchases.sharedInstance.purchaseSubscriptionOptionWith(
                     requireActivity(),
                     currentProduct,
                     purchaseOption,
                     purchaseErrorCallback,
                     successfulPurchaseCallback
                 )
-            }
-        } else {
-            if (purchaseOption == null) {
-                Purchases.sharedInstance.purchaseProductWith(
+            upgradeInfo != null && purchaseOption == null -> Purchases.sharedInstance.purchaseProductWith(
                     requireActivity(),
                     currentProduct,
                     upgradeInfo,
                     purchaseErrorCallback,
                     successfulUpgradeCallback
                 )
-            } else {
-                Purchases.sharedInstance.purchaseSubscriptionOptionWith(
+            upgradeInfo != null && purchaseOption != null -> Purchases.sharedInstance.purchaseSubscriptionOptionWith(
                     requireActivity(),
                     currentProduct,
                     purchaseOption,
@@ -180,7 +174,6 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
                     purchaseErrorCallback,
                     successfulUpgradeCallback
                 )
-            }
         }
     }
 
@@ -200,34 +193,28 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         currentPackage: Package,
         upgradeInfo: UpgradeInfo?
     ) {
-        if (upgradeInfo == null) {
-            if (purchaseOption == null) {
-                Purchases.sharedInstance.purchasePackageWith(
+        when {
+            upgradeInfo == null && purchaseOption == null -> Purchases.sharedInstance.purchasePackageWith(
                     requireActivity(),
                     currentPackage,
                     purchaseErrorCallback,
                     successfulPurchaseCallback
                 )
-            } else {
-                Purchases.sharedInstance.purchaseSubscriptionOptionWith(
+            upgradeInfo == null && purchaseOption != null -> Purchases.sharedInstance.purchaseSubscriptionOptionWith(
                     requireActivity(),
                     currentPackage.product,
                     purchaseOption,
                     purchaseErrorCallback,
                     successfulPurchaseCallback
                 )
-            }
-        } else {
-            if (purchaseOption == null) {
-                Purchases.sharedInstance.purchasePackageWith(
+            upgradeInfo != null && purchaseOption == null -> Purchases.sharedInstance.purchasePackageWith(
                     requireActivity(),
                     currentPackage,
                     upgradeInfo,
                     purchaseErrorCallback,
                     successfulUpgradeCallback
                 )
-            } else {
-                Purchases.sharedInstance.purchaseSubscriptionOptionWith(
+            upgradeInfo != null && purchaseOption != null -> Purchases.sharedInstance.purchaseSubscriptionOptionWith(
                     requireActivity(),
                     currentPackage.product,
                     purchaseOption,
@@ -235,7 +222,6 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
                     purchaseErrorCallback,
                     successfulUpgradeCallback
                 )
-            }
         }
     }
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -34,7 +34,8 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
     private val offering: Offering by lazy { args.offering }
     private var activeSubscriptions: Set<String> = setOf()
     private var selectedUpgradeSubId: String? = null
-    @ProrationMode private var selectedProrationMode: Int? = null
+    @ProrationMode
+    private var selectedProrationMode: Int? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -73,7 +74,6 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         binding.purchaseProgress.visibility = View.VISIBLE
 
         if (isUpgrade) {
-            // TODO if no active subs, fail
             // TODO fix infinite spinner
             showOldSubIdPicker()
         } else {
@@ -109,6 +109,14 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
 
     private fun showOldSubIdPicker() {
         val activeSubIds = activeSubscriptions.map { it.split(":").first() } // TODOBC5 remove sub Id parsing
+        if (activeSubIds.isEmpty()) {
+            Toast.makeText(
+                requireContext(),
+                "Cannot ugprade without an existing active subscription.",
+                Toast.LENGTH_LONG
+            ).show()
+            return
+        }
         MaterialAlertDialogBuilder(requireContext())
             .setTitle("Switch from which currently active subscription?")
             .setSingleChoiceItems(activeSubIds.toTypedArray(), 0) { dialog_, which ->
@@ -142,6 +150,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
             }
             .setPositiveButton("Ok") { dialog, _ ->
                 Log.e("maddietest", "upgrading with proration mode $selectedProrationMode")
+                // todo start purchase
             }
             .setNegativeButton("Cancel") { dialog, _ ->
                 dialog.dismiss()

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
@@ -50,7 +50,8 @@ class PackageCardAdapter(
                     listener.onPurchasePackageClicked(
                         binding.root,
                         currentPackage,
-                        getSelectedPurchaseOption()
+                        getSelectedPurchaseOption(),
+                        binding.isUpgradeCheckbox.isChecked
                     )
                 } else {
                     showErrorMessage(errorStartingPurchase)
@@ -63,7 +64,8 @@ class PackageCardAdapter(
                     listener.onPurchaseProductClicked(
                         binding.root,
                         product,
-                        getSelectedPurchaseOption()
+                        getSelectedPurchaseOption(),
+                        binding.isUpgradeCheckbox.isChecked
                     )
                 } else {
                     showErrorMessage(errorStartingPurchase)
@@ -125,7 +127,17 @@ class PackageCardAdapter(
     }
 
     interface PackageCardAdapterListener {
-        fun onPurchasePackageClicked(cardView: View, currentPackage: Package, purchaseOption: PurchaseOption?)
-        fun onPurchaseProductClicked(cardView: View, currentProduct: StoreProduct, purchaseOption: PurchaseOption?)
+        fun onPurchasePackageClicked(
+            cardView: View,
+            currentPackage: Package,
+            purchaseOption: PurchaseOption?,
+            isUpgrade: Boolean
+        )
+        fun onPurchaseProductClicked(
+            cardView: View,
+            currentProduct: StoreProduct,
+            purchaseOption: PurchaseOption?,
+            isUpgrade: Boolean
+        )
     }
 }

--- a/examples/purchase-tester/src/main/res/layout/package_card.xml
+++ b/examples/purchase-tester/src/main/res/layout/package_card.xml
@@ -136,10 +136,11 @@
 
             <com.google.android.material.checkbox.MaterialCheckBox
                     android:id="@+id/is_upgrade_checkbox"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:text="Is upgrade?"
-                    app:layout_constraintEnd_toEndOf="parent"
+                    android:text="Is product change?"
+                    app:layout_constraintStart_toStartOf="@+id/package_buy_button"
+                    app:layout_constraintEnd_toEndOf="@id/package_buy_button"
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintBottom_toTopOf="@+id/package_buy_button"/>
 

--- a/examples/purchase-tester/src/main/res/layout/package_card.xml
+++ b/examples/purchase-tester/src/main/res/layout/package_card.xml
@@ -5,7 +5,9 @@
         xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-        <import type="android.view.View"/>
+
+        <import type="android.view.View" />
+
         <variable
                 name="currentPackage"
                 type="com.revenuecat.purchases.Package" />
@@ -97,21 +99,21 @@
                     app:layout_constraintEnd_toStartOf="@+id/package_card_barrier"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/package_type"
-                    bind:header="@{`One Time Price:`}"
                     bind:detail="@{currentPackage.product.oneTimeProductPrice.formattedPrice}"
+                    bind:header="@{`One Time Price:`}"
                     tools:text="$1.99" />
 
             <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/package_purchase_option_title"
-                    android:textStyle="bold"
-                    android:text="@string/purchase_options"
-                    android:paddingHorizontal="4dp"
-                    android:layout_marginHorizontal="@dimen/padding_tiny"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/padding_tiny"
+                    android:paddingHorizontal="4dp"
+                    android:text="@string/purchase_options"
+                    android:textStyle="bold"
                     android:visibility="@{isSubscription ? View.VISIBLE : View.GONE}"
-                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/package_one_time_price" />
 
             <RadioGroup
@@ -121,10 +123,9 @@
                     android:divider="?android:attr/dividerHorizontal"
                     android:showDividers="middle"
                     android:visibility="@{isSubscription ? View.VISIBLE : View.GONE}"
-                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/package_purchase_option_title">
-            </RadioGroup>
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/package_purchase_option_title"></RadioGroup>
 
             <androidx.constraintlayout.widget.Barrier
                     android:id="@+id/package_card_barrier"
@@ -132,6 +133,15 @@
                     android:layout_height="wrap_content"
                     app:barrierDirection="start"
                     app:constraint_referenced_ids="package_buy_button, product_buy_button" />
+
+            <com.google.android.material.checkbox.MaterialCheckBox
+                    android:id="@+id/is_upgrade_checkbox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Is upgrade?"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toTopOf="@+id/package_buy_button"/>
 
             <com.google.android.material.button.MaterialButton
                     android:id="@+id/package_buy_button"
@@ -141,7 +151,7 @@
                     android:text="Buy package"
                     app:layout_constraintBottom_toTopOf="@+id/product_buy_button"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    app:layout_constraintTop_toBottomOf="@+id/is_upgrade_checkbox" />
 
             <com.google.android.material.button.MaterialButton
                     android:id="@+id/product_buy_button"
@@ -173,7 +183,7 @@
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent"
-                        bind:header="@{`Product JSON`}"/>
+                        bind:header="@{`Product JSON`}" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
Adds product change functionality to the purchase tester. See attached video for example.

When the `Is product change?` box is selected:
* prompts user for oldSubId (selecting from any current subs) -- debated having this be a text box so we could test invalid scenarios, open to thoughts there
* prompts user for proration mode
* creates `UpgradeInfo` with that data and passes to purchase flow

Other changes:
* make some interfering toasts short
* pull purchase callbacks out as members
* fix infinite loading indicator happening in some cases
* 
https://user-images.githubusercontent.com/2272924/211677644-bb279250-d671-47ed-bdd6-63d1264ac15b.mp4