### PR TITLE
Upgrade/downgrade purchase tester improvements

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -257,6 +257,10 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
                 toggleLoadingIndicator(false)
                 callback(null)
             }
+            .setOnDismissListener {
+                toggleLoadingIndicator(false)
+                callback(null)
+            }
             .show()
     }
 
@@ -282,6 +286,10 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
             }
             .setNegativeButton("Cancel purchase") { dialog, _ ->
                 dialog.dismiss()
+                toggleLoadingIndicator(false)
+                callback(null)
+            }
+            .setOnDismissListener {
                 toggleLoadingIndicator(false)
                 callback(null)
             }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -131,7 +131,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
                     prorationMode?.let {
                         val upgradeInfo = UpgradeInfo(
                             subId,
-                            prorationMode
+                            if (prorationMode == 0) null else prorationMode
                         )
                         callback(upgradeInfo)
                     } ?: callback(null)

--- a/examples/purchase-tester/src/main/res/layout/package_card.xml
+++ b/examples/purchase-tester/src/main/res/layout/package_card.xml
@@ -144,11 +144,11 @@
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintBottom_toTopOf="@+id/package_buy_button"/>
 
+            <!-- TODO BC5 enable based on whether current base plan is active -->
             <com.google.android.material.button.MaterialButton
                     android:id="@+id/package_buy_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:enabled="@{!isActive}"
                     android:text="Buy package"
                     app:layout_constraintBottom_toTopOf="@+id/product_buy_button"
                     app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
* undo disabling the purchase button if the subscription is active... this would disable upgrade/downgrade between base plans. we can update to check whether a specific base plan is active once the entitlementinfo/customerinfo are updated to include the base plan
* cancel purchase flow if you click outside of the upgradeinfo prompts
* bug fix: pass null instead of 0 if "none" is selected as prorationmode