### PR TITLE
Default ProrationMode to IMMEDIATE_WITHOUT_PRORATION

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/UpgradeInfoAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/UpgradeInfoAPI.java
@@ -14,14 +14,9 @@ final class UpgradeInfoAPI {
                 upgradeInfo.getProrationMode()
         );
 
-        UpgradeInfo constructedUpgradeInfoNullProrationMode = new UpgradeInfo(
-                upgradeInfo.getOldProductId(),
-                null
-        );
+        UpgradeInfo constructedUpgradeInfoNullProrationMode = new UpgradeInfo(upgradeInfo.getOldProductId());
 
         UpgradeInfo constructedUpgradeInfoProductIdOnly = new UpgradeInfo(upgradeInfo.getOldProductId());
-        UpgradeInfo constructedUpgradeInfoProductIdAndOldSkuOnly = new UpgradeInfo(
-                upgradeInfo.getOldProductId()
-        );
+        UpgradeInfo constructedUpgradeInfoProductIdAndOldSkuOnly = new UpgradeInfo(upgradeInfo.getOldProductId());
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
@@ -8,7 +8,7 @@ private class UpgradeInfoAPI {
     fun check(upgradeInfo: UpgradeInfo) {
         with(upgradeInfo) {
             val oldProductId: String = oldProductId
-            @BillingFlowParams.ProrationMode val prorationMode: Int? = prorationMode
+            @BillingFlowParams.ProrationMode val prorationMode: Int = prorationMode
 
             val constructedUpgradeInfo =
                 UpgradeInfo(

--- a/common/src/main/java/com/revenuecat/purchases/common/ReplaceProductInfo.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/ReplaceProductInfo.kt
@@ -5,5 +5,5 @@ import com.revenuecat.purchases.models.StoreTransaction
 
 data class ReplaceProductInfo(
     val oldPurchase: StoreTransaction,
-    @BillingFlowParams.ProrationMode val prorationMode: Int? = null
+    @BillingFlowParams.ProrationMode val prorationMode: Int
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeInfo.kt
@@ -5,9 +5,11 @@ import com.android.billingclient.api.BillingFlowParams
 /**
  * This object holds the information used when upgrading from another sku.
  * @property oldProductId The old product ID to upgrade from.
- * @property prorationMode The [BillingFlowParams.ProrationMode] to use when upgrading the given oldSku.
+ * @property prorationMode The [BillingFlowParams.ProrationMode] to use when upgrading the given oldSku. Defaults to
+ * [BillingFlowParams.ProrationMode.IMMEDIATE_WITHOUT_PRORATION].
  */
 data class UpgradeInfo @JvmOverloads constructor(
     val oldProductId: String,
-    @BillingFlowParams.ProrationMode val prorationMode: Int? = null
+    @BillingFlowParams.ProrationMode val prorationMode: Int? =
+        BillingFlowParams.ProrationMode.IMMEDIATE_WITHOUT_PRORATION
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/UpgradeInfo.kt
@@ -10,6 +10,6 @@ import com.android.billingclient.api.BillingFlowParams
  */
 data class UpgradeInfo @JvmOverloads constructor(
     val oldProductId: String,
-    @BillingFlowParams.ProrationMode val prorationMode: Int? =
+    @BillingFlowParams.ProrationMode val prorationMode: Int =
         BillingFlowParams.ProrationMode.IMMEDIATE_WITHOUT_PRORATION
 )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -541,7 +541,6 @@ class PurchasesTest {
                 any(),
                 expectedReplaceProductInfo,
                 any()
-
             )
         }
     }
@@ -649,7 +648,7 @@ class PurchasesTest {
                 eq(appUserId),
                 storeProduct,
                 storeProduct.purchaseOptions[0],
-                ReplaceProductInfo(oldPurchase),
+                ReplaceProductInfo(oldPurchase, ProrationMode.IMMEDIATE_WITHOUT_PRORATION),
                 stubOfferingIdentifier
             )
         }
@@ -1168,7 +1167,7 @@ class PurchasesTest {
                 eq(appUserId),
                 storeProduct,
                 storeProduct.purchaseOptions[0],
-                ReplaceProductInfo(oldPurchase),
+                ReplaceProductInfo(oldPurchase, ProrationMode.IMMEDIATE_WITHOUT_PRORATION),
                 stubOfferingIdentifier
             )
         }
@@ -1225,7 +1224,7 @@ class PurchasesTest {
                 eq(appUserId),
                 storeProduct,
                 storeProduct.purchaseOptions[0],
-                ReplaceProductInfo(oldPurchase),
+                ReplaceProductInfo(oldPurchase, ProrationMode.IMMEDIATE_WITHOUT_PRORATION),
                 stubOfferingIdentifier
             )
         }


### PR DESCRIPTION
BC4 used to default to `IMMEDIATE_WITH_TIME_PRORATION` when no `ProrationMode` was passed in, but BC5 will fail with no `ProrationMode`, so we now need a default.

Until we complete other ProrationMode logic, the best default is `IMMEDIATE_WITHOUT_PRORATION`. This will work for both base plan and sub switches.