### PR TITLE
Fix crash when cleaning old attribution data if SharedPreferences has a null key

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -162,7 +162,7 @@ open class DeviceCache(
     fun cleanupOldAttributionData() {
         val editor = preferences.edit()
         for (key in preferences.all.keys) {
-            if (key.startsWith(attributionCacheKey)) {
+            if (key != null && key.startsWith(attributionCacheKey)) {
                 editor.remove(key)
             }
         }

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -468,7 +468,7 @@ class DeviceCacheTest {
     }
 
     @Test
-    fun `cleanupOldAttributionData works with null keys`() {
+    fun `cleanupOldAttributionData doesn't crash if a null key is stored in SharedPreferences`() {
         val stubPreferences = mapOf(
             null to "random-value",
             "${cache.attributionCacheKey}.cesar.tenjin" to "tenjinid",

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -467,6 +467,26 @@ class DeviceCacheTest {
         verify (exactly = 1) { mockEditor.apply() }
     }
 
+    @Test
+    fun `cleanupOldAttributionData works with null keys`() {
+        val stubPreferences = mapOf(
+            null to "random-value",
+            "${cache.attributionCacheKey}.cesar.tenjin" to "tenjinid",
+            "${cache.attributionCacheKey}.pedro.mixpanel" to "mixpanelid",
+        )
+        every {
+            mockPrefs.all
+        } returns stubPreferences
+
+        cache.cleanupOldAttributionData()
+
+        verify (exactly = 1) { mockEditor.remove("${cache.attributionCacheKey}.cesar.tenjin") }
+        verify (exactly = 1) { mockEditor.remove("${cache.attributionCacheKey}.pedro.mixpanel") }
+        verify (exactly = 2) { mockEditor.remove(any()) }
+
+        verify (exactly = 1) { mockEditor.apply() }
+    }
+
     private fun mockString(key: String, value: String?) {
         every {
             mockPrefs.getString(eq(key), isNull())


### PR DESCRIPTION
### Description
Deals with #737 

If devs store something in SharedPreferences with a null key, it can cause a crash the next time the SDK is configured. This PR just ignores that key when cleaning up SDK values from SharedPreferences.
