### PR TITLE
Add test coverage using Kover

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,12 @@ jobs:
       - run:
           name: Detekt
           command: ./gradlew detektAll
+      - run:
+          name: Kover HTML
+          command: ./gradlew koverMergedHtmlReport
+      - run:
+          name: Kover XML
+          command: ./gradlew koverMergedXmlReport
       - android/save-build-cache
       - store_artifacts:
           path: build/reports

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:7.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.21"
+        classpath "org.jetbrains.kotlinx:kover:0.6.1"
     }
 }
 
@@ -86,4 +87,16 @@ apply plugin: 'org.jetbrains.dokka'
 tasks.dokkaHtmlMultiModule.configure {
     outputDirectory.set(file("docs/" + project.property("VERSION_NAME")))
     includes.from("README.md")
+}
+
+apply plugin: 'kover'
+
+koverMerged {
+    enable()
+    filters {
+        projects {
+            // Specifies the projects excluded from the merged tasks
+            excludes.addAll(":api-tester", ":integration-tests", ":examples:purchase-tester")
+        }
+    }
 }

--- a/library.gradle
+++ b/library.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
+apply plugin: 'kover'
 
 android {
     compileSdkVersion compileVersion


### PR DESCRIPTION
Added test coverage for the project using Kover (https://kotlin.github.io/kotlinx-kover/)

We need to decide a report tool. We used coveralls in the past and it wasn't very good. I think we should try [Codecov](https://about.codecov.io/), which is pretty popular and free for open source projects.

For now I am just saving the reports in HTML and XML in CircleCI