### PR TITLE
Add `Purchases.logLevel` and deprecate `Purchases.debugLogsEnabled`

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.BillingFeature;
 import com.revenuecat.purchases.CacheFetchPolicy;
 import com.revenuecat.purchases.CustomerInfo;
 import com.revenuecat.purchases.LogHandler;
+import com.revenuecat.purchases.LogLevel;
 import com.revenuecat.purchases.Offerings;
 import com.revenuecat.purchases.Package;
 import com.revenuecat.purchases.Purchases;
@@ -143,6 +144,9 @@ final class PurchasesAPI {
         Purchases.setDebugLogsEnabled(false);
         final boolean debugLogs = Purchases.getDebugLogsEnabled();
 
+        Purchases.setLogLevel(LogLevel.DEBUG);
+        final LogLevel logLevel = Purchases.getLogLevel();
+
         Purchases.setProxyURL(new URL(""));
         final URL proxyURL = Purchases.getProxyURL();
 
@@ -152,6 +156,7 @@ final class PurchasesAPI {
     static void checkLogHandler() {
         Purchases.setLogHandler(
                 new LogHandler() {
+                    @Override public void v(@NonNull String tag, @NonNull String msg) {}
                     @Override public void d(@NonNull String tag, @NonNull String msg) {}
                     @Override public void i(@NonNull String tag, @NonNull String msg) {}
                     @Override public void w(@NonNull String tag, @NonNull String msg) {}
@@ -161,4 +166,14 @@ final class PurchasesAPI {
         final LogHandler handler = Purchases.getLogHandler();
     }
 
+    static void checkLogLevel(final LogLevel level) {
+        switch (level) {
+            case VERBOSE:
+            case ERROR:
+            case WARN:
+            case INFO:
+            case DEBUG:
+                break;
+        }
+    }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.BillingFeature
 import com.revenuecat.purchases.CacheFetchPolicy
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.LogHandler
+import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.Purchases
@@ -216,6 +217,9 @@ private class PurchasesAPI {
         Purchases.debugLogsEnabled = false
         val debugLogs: Boolean = Purchases.debugLogsEnabled
 
+        Purchases.logLevel = LogLevel.INFO
+        val logLevel: LogLevel = Purchases.logLevel
+
         Purchases.proxyURL = URL("")
         val url: URL? = Purchases.proxyURL
 
@@ -224,11 +228,23 @@ private class PurchasesAPI {
 
     fun checkLogHandler() {
         Purchases.logHandler = object : LogHandler {
+            override fun v(tag: String, msg: String) {}
             override fun d(tag: String, msg: String) {}
             override fun i(tag: String, msg: String) {}
             override fun w(tag: String, msg: String) {}
             override fun e(tag: String, msg: String, throwable: Throwable?) {}
         }
         val handler = Purchases.logHandler
+    }
+
+    fun checkLogLevel(level: LogLevel) {
+        when (level) {
+            LogLevel.VERBOSE,
+            LogLevel.DEBUG,
+            LogLevel.INFO,
+            LogLevel.WARN,
+            LogLevel.ERROR
+            -> {}
+        }.exhaustive
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -1,8 +1,10 @@
 package com.revenuecat.purchases.common
 
+import com.revenuecat.purchases.LogLevel
+
 object Config {
 
-    var debugLogsEnabled = BuildConfig.DEBUG
+    var logLevel: LogLevel = LogLevel.debugLogsEnabled(BuildConfig.DEBUG)
 
     const val frameworkVersion = "5.7.0-SNAPSHOT"
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/Config.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Config.kt
@@ -3,8 +3,7 @@ package com.revenuecat.purchases.common
 import com.revenuecat.purchases.LogLevel
 
 object Config {
-
-    var logLevel: LogLevel = LogLevel.debugLogsEnabled(BuildConfig.DEBUG)
+    var logLevel = LogLevel.debugLogsEnabled(BuildConfig.DEBUG)
 
     const val frameworkVersion = "5.7.0-SNAPSHOT"
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/logUtils.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/logUtils.kt
@@ -1,25 +1,36 @@
 package com.revenuecat.purchases.common
 
+import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 
+fun verboseLog(message: String) {
+    logIfEnabled(LogLevel.VERBOSE, currentLogHandler::v, message)
+}
+
 fun debugLog(message: String) {
-    if (Config.debugLogsEnabled) {
-        currentLogHandler.d("[Purchases] - DEBUG", message)
-    }
+    logIfEnabled(LogLevel.DEBUG, currentLogHandler::d, message)
 }
 
 fun infoLog(message: String) {
-    currentLogHandler.i("[Purchases] - INFO", message)
+    logIfEnabled(LogLevel.INFO, currentLogHandler::i, message)
 }
 
 fun warnLog(message: String) {
-    currentLogHandler.w("[Purchases] - WARN", message)
+    logIfEnabled(LogLevel.WARN, currentLogHandler::w, message)
 }
 
 fun errorLog(message: String, throwable: Throwable? = null) {
-    currentLogHandler.e("[Purchases] - ERROR", message, throwable)
+    currentLogHandler.e("$PURCHASES_LOG_TAG - ${LogLevel.ERROR.name}", message, throwable)
 }
+
+private fun logIfEnabled(level: LogLevel, logger: (tag: String, message: String) -> Unit, message: String) {
+    if (Config.logLevel <= level) {
+        logger("$PURCHASES_LOG_TAG - ${level.name}", message)
+    }
+}
+
+private const val PURCHASES_LOG_TAG: String = "[Purchases]"
 
 fun errorLog(error: PurchasesError) {
     when (error.code) {

--- a/common/src/main/java/com/revenuecat/purchases/common/logUtils.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/logUtils.kt
@@ -4,6 +4,20 @@ import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 
+/**
+ * Whether debug logs are enabled
+ */
+val LogLevel.debugLogsEnabled: Boolean
+    get() = this <= LogLevel.DEBUG
+
+fun LogLevel.Companion.debugLogsEnabled(enabled: Boolean): LogLevel {
+    return if (enabled) {
+        LogLevel.DEBUG
+    } else {
+        LogLevel.INFO
+    }
+}
+
 fun verboseLog(message: String) {
     logIfEnabled(LogLevel.VERBOSE, currentLogHandler::v, message)
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/logWrapper.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/logWrapper.kt
@@ -7,6 +7,10 @@ import com.revenuecat.purchases.strings.Emojis
 var currentLogHandler: LogHandler = DefaultLogHandler()
 
 private class DefaultLogHandler : LogHandler {
+    override fun v(tag: String, msg: String) {
+        Log.v(tag, msg)
+    }
+
     override fun d(tag: String, msg: String) {
         Log.d(tag, msg)
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/LogHandlerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/LogHandlerTest.kt
@@ -2,7 +2,8 @@ package com.revenuecat.purchases.common
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.LogHandler
-import com.revenuecat.purchases.common.Config.debugLogsEnabled
+import com.revenuecat.purchases.LogLevel
+import com.revenuecat.purchases.common.Config.logLevel
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -14,11 +15,16 @@ import org.robolectric.annotation.Config
 @Config(manifest = Config.NONE)
 class LogHandlerTest {
     private class Handler : LogHandler {
+        var verboseMessage: String? = null
         var debugMessage: String? = null
         var infoMessage: String? = null
         var warningMessage: String? = null
         var errorMessage: String? = null
         var errorThrowable: Throwable? = null
+
+        override fun v(tag: String, msg: String) {
+            verboseMessage = msg
+        }
 
         override fun d(tag: String, msg: String) {
             debugMessage = msg
@@ -55,52 +61,118 @@ class LogHandlerTest {
     }
 
     @Test
-    fun debugWithDebugLogsDisabled() {
-        val enabled = debugLogsEnabled
-        debugLogsEnabled = false
-
-        debugLog(message)
-        assertThat(handler.debugMessage).isNull()
-
-        debugLogsEnabled = enabled
+    fun verboseWithDebugLogs() {
+        withChangedLevel(LogLevel.DEBUG) {
+            verboseLog(message)
+            assertThat(handler.verboseMessage).isNull()
+        }
     }
 
     @Test
-    fun debugWithLogsEnabled() {
-        val enabled = debugLogsEnabled
-        debugLogsEnabled = true
+    fun debugWithDebugLogsDisabled() {
+        withChangedLevel(LogLevel.INFO) {
+            debugLog(message)
+            assertThat(handler.debugMessage).isNull()
+        }
+    }
 
-        debugLog(message)
-        assertThat(handler.debugMessage).isEqualTo(message)
+    @Test
+    fun debugWithDebugLogsEnabled() {
+        withChangedLevel(LogLevel.DEBUG) {
+            debugLog(message)
+            assertThat(handler.debugMessage).isEqualTo(message)
+        }
+    }
 
-        debugLogsEnabled = enabled
+    @Test
+    fun debugWithVerboseLogs() {
+        withChangedLevel(LogLevel.VERBOSE) {
+            debugLog(message)
+            assertThat(handler.debugMessage).isEqualTo(message)
+        }
     }
 
     @Test
     fun info() {
-        infoLog(message)
-        assertThat(handler.infoMessage).isEqualTo(message)
+        withChangedLevel(LogLevel.INFO) {
+            infoLog(message)
+            assertThat(handler.infoMessage).isEqualTo(message)
+        }
     }
 
     @Test
     fun warning() {
-        warnLog(message)
-        assertThat(handler.warningMessage).isEqualTo(message)
+        withChangedLevel(LogLevel.WARN) {
+            warnLog(message)
+            assertThat(handler.warningMessage).isEqualTo(message)
+        }
     }
 
     @Test
     fun errorWithNoThrowable() {
-        errorLog(message)
-        assertThat(handler.errorMessage).isEqualTo(message)
-        assertThat(handler.errorThrowable).isNull()
+        withChangedLevel(LogLevel.ERROR) {
+            errorLog(message)
+            assertThat(handler.errorMessage).isEqualTo(message)
+            assertThat(handler.errorThrowable).isNull()
+        }
     }
 
     @Test
     fun errorWithThrowable() {
-        val throwable = ClassNotFoundException()
+        withChangedLevel(LogLevel.ERROR) {
+            val throwable = ClassNotFoundException()
 
-        errorLog(message, throwable)
-        assertThat(handler.errorMessage).isEqualTo(message)
-        assertThat(handler.errorThrowable).isSameAs(throwable)
+            errorLog(message, throwable)
+            assertThat(handler.errorMessage).isEqualTo(message)
+            assertThat(handler.errorThrowable).isSameAs(throwable)
+        }
+    }
+
+    @Test
+    fun errorWithDebugLogs() {
+        withChangedLevel(LogLevel.DEBUG) {
+            val throwable = ClassNotFoundException()
+
+            errorLog(message, throwable)
+            assertThat(handler.errorMessage).isEqualTo(message)
+            assertThat(handler.errorThrowable).isSameAs(throwable)
+        }
+    }
+
+    @Test
+    fun logLevelWithDebugLogsEnabled() {
+        assertThat(LogLevel.debugLogsEnabled(true)).isEqualTo(LogLevel.DEBUG)
+        assertThat(LogLevel.debugLogsEnabled(false)).isEqualTo(LogLevel.INFO)
+    }
+
+    @Test
+    fun logLevelDebugLogsEnabled() {
+        assertThat(LogLevel.VERBOSE.debugLogsEnabled).isEqualTo(true)
+        assertThat(LogLevel.DEBUG.debugLogsEnabled).isEqualTo(true)
+        assertThat(LogLevel.INFO.debugLogsEnabled).isEqualTo(false)
+        assertThat(LogLevel.WARN.debugLogsEnabled).isEqualTo(false)
+        assertThat(LogLevel.ERROR.debugLogsEnabled).isEqualTo(false)
+    }
+
+    @Test
+    fun testLogLevelComparable() {
+        assertThat(LogLevel.VERBOSE).isLessThan(LogLevel.DEBUG)
+        assertThat(LogLevel.DEBUG).isLessThan(LogLevel.INFO)
+        assertThat(LogLevel.INFO).isLessThan(LogLevel.WARN)
+        assertThat(LogLevel.WARN).isLessThan(LogLevel.ERROR)
+
+        assertThat(LogLevel.DEBUG).isGreaterThanOrEqualTo(LogLevel.VERBOSE)
+        assertThat(LogLevel.INFO).isGreaterThanOrEqualTo(LogLevel.DEBUG)
+        assertThat(LogLevel.WARN).isGreaterThanOrEqualTo(LogLevel.INFO)
+        assertThat(LogLevel.ERROR).isGreaterThanOrEqualTo(LogLevel.WARN)
+    }
+
+    private fun withChangedLevel(newLevel: LogLevel, test: () -> Unit) {
+        val level = logLevel
+        logLevel = newLevel
+
+        test.invoke()
+
+        logLevel = level
     }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/LogUtilsTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/LogUtilsTest.kt
@@ -1,0 +1,25 @@
+package com.revenuecat.purchases.common
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.LogLevel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LogUtilsTest {
+    @Test
+    fun logLevelWithDebugLogsEnabled() {
+        assertThat(LogLevel.debugLogsEnabled(true)).isEqualTo(LogLevel.DEBUG)
+        assertThat(LogLevel.debugLogsEnabled(false)).isEqualTo(LogLevel.INFO)
+    }
+
+    @Test
+    fun logLevelDebugLogsEnabled() {
+        assertThat(LogLevel.VERBOSE.debugLogsEnabled).isEqualTo(true)
+        assertThat(LogLevel.DEBUG.debugLogsEnabled).isEqualTo(true)
+        assertThat(LogLevel.INFO.debugLogsEnabled).isEqualTo(false)
+        assertThat(LogLevel.WARN.debugLogsEnabled).isEqualTo(false)
+        assertThat(LogLevel.ERROR.debugLogsEnabled).isEqualTo(false)
+    }
+}

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LogLevel.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LogLevel.kt
@@ -1,18 +1,13 @@
 package com.revenuecat.purchasetester
 
+import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases_sample.R
-
-enum class LogLevel {
-    DEBUG,
-    INFO,
-    WARNING,
-    ERROR
-}
 
 val LogLevel.colorResource: Int
     get() = when (this) {
+        LogLevel.VERBOSE -> R.color.white
         LogLevel.DEBUG -> R.color.white
         LogLevel.INFO -> R.color.blue
-        LogLevel.WARNING -> R.color.yellow
+        LogLevel.WARN -> R.color.yellow
         LogLevel.ERROR -> R.color.red
     }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LogMessage.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LogMessage.kt
@@ -1,3 +1,5 @@
 package com.revenuecat.purchasetester
 
+import com.revenuecat.purchases.LogLevel
+
 data class LogMessage(val logLevel: LogLevel, val message: String)

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/TesterLogHandler.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/TesterLogHandler.kt
@@ -6,6 +6,7 @@ import android.os.Looper
 import android.util.Log
 import android.widget.Toast
 import com.revenuecat.purchases.LogHandler
+import com.revenuecat.purchases.LogLevel
 
 class TesterLogHandler(
     private val applicationContext: Context,
@@ -16,6 +17,12 @@ class TesterLogHandler(
         get() = mutableStoredLogs
 
     private val mutableStoredLogs: MutableList<LogMessage> = mutableListOf()
+
+    @Synchronized
+    override fun v(tag: String, msg: String) {
+        Log.v(tag, msg)
+        mutableStoredLogs.add(LogMessage(LogLevel.VERBOSE, "$tag: $msg"))
+    }
 
     @Synchronized
     override fun d(tag: String, msg: String) {
@@ -32,7 +39,7 @@ class TesterLogHandler(
     @Synchronized
     override fun w(tag: String, msg: String) {
         Log.w(tag, msg)
-        mutableStoredLogs.add(LogMessage(LogLevel.WARNING, "$tag: $msg"))
+        mutableStoredLogs.add(LogMessage(LogLevel.WARN, "$tag: $msg"))
     }
 
     @Synchronized

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
@@ -330,6 +330,9 @@ class ProductDataHandlerTest {
         var receivedException: Throwable? = null
         var receivedLoggedException: Throwable? = null
         Purchases.logHandler = object : LogHandler {
+            override fun v(tag: String, msg: String) {
+            }
+
             override fun d(tag: String, msg: String) {
             }
 

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/PurchaseHandlerTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/PurchaseHandlerTest.kt
@@ -254,6 +254,9 @@ class PurchaseHandlerTest {
         var receivedException: Throwable? = null
         var receivedLoggedException: Throwable? = null
         Purchases.logHandler = object : LogHandler {
+            override fun v(tag: String, msg: String) {
+            }
+
             override fun d(tag: String, msg: String) {
             }
 

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/PurchaseUpdatesHandlerTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/PurchaseUpdatesHandlerTest.kt
@@ -21,8 +21,6 @@ import org.assertj.core.api.Assertions.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.Exception
-import java.lang.RuntimeException
 import java.util.Date
 
 @RunWith(AndroidJUnit4::class)
@@ -189,6 +187,9 @@ class PurchaseUpdatesHandlerTest {
         var receivedException: Throwable? = null
         var receivedLoggedException: Throwable? = null
         Purchases.logHandler = object : LogHandler {
+            override fun v(tag: String, msg: String) {
+            }
+
             override fun d(tag: String, msg: String) {
             }
 

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/UserDataHandlerTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/UserDataHandlerTest.kt
@@ -13,7 +13,6 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.amazon.helpers.PurchasingServiceProviderForTest
 import com.revenuecat.purchases.amazon.helpers.dummyUserData
 import com.revenuecat.purchases.utils.MockTimestampProvider
-import com.revenuecat.purchases.utils.TimestampProvider
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -22,8 +21,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.Exception
-import java.lang.RuntimeException
 
 @RunWith(AndroidJUnit4::class)
 class UserDataHandlerTest {
@@ -133,6 +130,9 @@ class UserDataHandlerTest {
         var receivedException: Throwable? = null
         var receivedLoggedException: Throwable? = null
         Purchases.logHandler = object : LogHandler {
+            override fun v(tag: String, msg: String) {
+            }
+
             override fun d(tag: String, msg: String) {
             }
 

--- a/public/src/main/java/com/revenuecat/purchases/LogHandler.kt
+++ b/public/src/main/java/com/revenuecat/purchases/LogHandler.kt
@@ -5,6 +5,7 @@ package com.revenuecat.purchases
  * See also [Purchases.logHandler]
  */
 interface LogHandler {
+    fun v(tag: String, msg: String)
     fun d(tag: String, msg: String)
     fun i(tag: String, msg: String)
     fun w(tag: String, msg: String)

--- a/public/src/main/java/com/revenuecat/purchases/LogLevel.kt
+++ b/public/src/main/java/com/revenuecat/purchases/LogLevel.kt
@@ -1,0 +1,28 @@
+package com.revenuecat.purchases
+
+enum class LogLevel {
+    VERBOSE,
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR;
+
+    /**
+     * Whether debug logs are enabled
+     */
+    val debugLogsEnabled: Boolean
+        get() = this <= DEBUG
+
+    companion object {
+        /**
+         * Creates a LogLevel from a Boolean.
+         */
+        fun debugLogsEnabled(enabled: Boolean): LogLevel {
+            return if (enabled) {
+                DEBUG
+            } else {
+                INFO
+            }
+        }
+    }
+}

--- a/public/src/main/java/com/revenuecat/purchases/LogLevel.kt
+++ b/public/src/main/java/com/revenuecat/purchases/LogLevel.kt
@@ -7,22 +7,5 @@ enum class LogLevel {
     WARN,
     ERROR;
 
-    /**
-     * Whether debug logs are enabled
-     */
-    val debugLogsEnabled: Boolean
-        get() = this <= DEBUG
-
-    companion object {
-        /**
-         * Creates a LogLevel from a Boolean.
-         */
-        fun debugLogsEnabled(enabled: Boolean): LogLevel {
-            return if (enabled) {
-                DEBUG
-            } else {
-                INFO
-            }
-        }
-    }
+    companion object
 }

--- a/public/src/test/java/com/revenuecat/purchases/LogLevelTest.kt
+++ b/public/src/test/java/com/revenuecat/purchases/LogLevelTest.kt
@@ -8,21 +8,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
  class LogLevelTest {
     @Test
-    fun logLevelWithDebugLogsEnabled() {
-        assertThat(LogLevel.debugLogsEnabled(true)).isEqualTo(LogLevel.DEBUG)
-        assertThat(LogLevel.debugLogsEnabled(false)).isEqualTo(LogLevel.INFO)
-    }
-
-    @Test
-    fun logLevelDebugLogsEnabled() {
-        assertThat(LogLevel.VERBOSE.debugLogsEnabled).isEqualTo(true)
-        assertThat(LogLevel.DEBUG.debugLogsEnabled).isEqualTo(true)
-        assertThat(LogLevel.INFO.debugLogsEnabled).isEqualTo(false)
-        assertThat(LogLevel.WARN.debugLogsEnabled).isEqualTo(false)
-        assertThat(LogLevel.ERROR.debugLogsEnabled).isEqualTo(false)
-    }
-
-    @Test
     fun testLogLevelComparable() {
         assertThat(LogLevel.VERBOSE).isLessThan(LogLevel.DEBUG)
         assertThat(LogLevel.DEBUG).isLessThan(LogLevel.INFO)

--- a/public/src/test/java/com/revenuecat/purchases/LogLevelTest.kt
+++ b/public/src/test/java/com/revenuecat/purchases/LogLevelTest.kt
@@ -1,0 +1,37 @@
+package com.revenuecat.purchases
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+ class LogLevelTest {
+    @Test
+    fun logLevelWithDebugLogsEnabled() {
+        assertThat(LogLevel.debugLogsEnabled(true)).isEqualTo(LogLevel.DEBUG)
+        assertThat(LogLevel.debugLogsEnabled(false)).isEqualTo(LogLevel.INFO)
+    }
+
+    @Test
+    fun logLevelDebugLogsEnabled() {
+        assertThat(LogLevel.VERBOSE.debugLogsEnabled).isEqualTo(true)
+        assertThat(LogLevel.DEBUG.debugLogsEnabled).isEqualTo(true)
+        assertThat(LogLevel.INFO.debugLogsEnabled).isEqualTo(false)
+        assertThat(LogLevel.WARN.debugLogsEnabled).isEqualTo(false)
+        assertThat(LogLevel.ERROR.debugLogsEnabled).isEqualTo(false)
+    }
+
+    @Test
+    fun testLogLevelComparable() {
+        assertThat(LogLevel.VERBOSE).isLessThan(LogLevel.DEBUG)
+        assertThat(LogLevel.DEBUG).isLessThan(LogLevel.INFO)
+        assertThat(LogLevel.INFO).isLessThan(LogLevel.WARN)
+        assertThat(LogLevel.WARN).isLessThan(LogLevel.ERROR)
+
+        assertThat(LogLevel.DEBUG).isGreaterThanOrEqualTo(LogLevel.VERBOSE)
+        assertThat(LogLevel.INFO).isGreaterThanOrEqualTo(LogLevel.DEBUG)
+        assertThat(LogLevel.WARN).isGreaterThanOrEqualTo(LogLevel.INFO)
+        assertThat(LogLevel.ERROR).isGreaterThanOrEqualTo(LogLevel.WARN)
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1959,11 +1959,19 @@ class Purchases internal constructor(
          * Enable debug logging. Useful for debugging issues with the lovely team @RevenueCat
          */
         @JvmStatic
+        @Deprecated(message = "Use logLevel instead")
         var debugLogsEnabled
-            get() = Config.debugLogsEnabled
-            set(value) {
-                Config.debugLogsEnabled = value
-            }
+            get() = logLevel.debugLogsEnabled
+            set(value) { logLevel = LogLevel.debugLogsEnabled(value) }
+
+        /**
+         * Configure log level. Useful for debugging issues with the lovely team @RevenueCat
+         * By default, LogLevel.DEBUG in debug builds, and LogLevel.INFO in release builds.
+         */
+        @JvmStatic
+        var logLevel: LogLevel
+            get() = Config.logLevel
+            set(value) { Config.logLevel = value }
 
         /**
          * Set a custom log handler for redirecting logs to your own logging system.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -30,6 +30,7 @@ import com.revenuecat.purchases.common.ReplaceSkuInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
 import com.revenuecat.purchases.common.currentLogHandler
+import com.revenuecat.purchases.common.debugLogsEnabled
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.sha1

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesLoggerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesLoggerTest.kt
@@ -12,7 +12,6 @@ import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.common.warnLog
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesLoggerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesLoggerTest.kt
@@ -1,9 +1,18 @@
-package com.revenuecat.purchases.common
+//  Purchases
+//
+//  Copyright © 2019 RevenueCat, Inc. All rights reserved.
+//
+
+package com.revenuecat.purchases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.revenuecat.purchases.LogHandler
-import com.revenuecat.purchases.LogLevel
-import com.revenuecat.purchases.common.Config.logLevel
+import com.revenuecat.purchases.common.currentLogHandler
+import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.infoLog
+import com.revenuecat.purchases.common.verboseLog
+import com.revenuecat.purchases.common.warnLog
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -13,7 +22,7 @@ import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
-class LogHandlerTest {
+class PurchasesLoggerTest {
     private class Handler : LogHandler {
         var verboseMessage: String? = null
         var debugMessage: String? = null
@@ -139,40 +148,12 @@ class LogHandlerTest {
         }
     }
 
-    @Test
-    fun logLevelWithDebugLogsEnabled() {
-        assertThat(LogLevel.debugLogsEnabled(true)).isEqualTo(LogLevel.DEBUG)
-        assertThat(LogLevel.debugLogsEnabled(false)).isEqualTo(LogLevel.INFO)
-    }
-
-    @Test
-    fun logLevelDebugLogsEnabled() {
-        assertThat(LogLevel.VERBOSE.debugLogsEnabled).isEqualTo(true)
-        assertThat(LogLevel.DEBUG.debugLogsEnabled).isEqualTo(true)
-        assertThat(LogLevel.INFO.debugLogsEnabled).isEqualTo(false)
-        assertThat(LogLevel.WARN.debugLogsEnabled).isEqualTo(false)
-        assertThat(LogLevel.ERROR.debugLogsEnabled).isEqualTo(false)
-    }
-
-    @Test
-    fun testLogLevelComparable() {
-        assertThat(LogLevel.VERBOSE).isLessThan(LogLevel.DEBUG)
-        assertThat(LogLevel.DEBUG).isLessThan(LogLevel.INFO)
-        assertThat(LogLevel.INFO).isLessThan(LogLevel.WARN)
-        assertThat(LogLevel.WARN).isLessThan(LogLevel.ERROR)
-
-        assertThat(LogLevel.DEBUG).isGreaterThanOrEqualTo(LogLevel.VERBOSE)
-        assertThat(LogLevel.INFO).isGreaterThanOrEqualTo(LogLevel.DEBUG)
-        assertThat(LogLevel.WARN).isGreaterThanOrEqualTo(LogLevel.INFO)
-        assertThat(LogLevel.ERROR).isGreaterThanOrEqualTo(LogLevel.WARN)
-    }
-
     private fun withChangedLevel(newLevel: LogLevel, test: () -> Unit) {
-        val level = logLevel
-        logLevel = newLevel
+        val level = Purchases.logLevel
+        Purchases.logLevel = newLevel
 
         test.invoke()
 
-        logLevel = level
+        Purchases.logLevel = level
     }
 }


### PR DESCRIPTION
Fixes [CSDK-549].


[CSDK-549]: https://revenuecats.atlassian.net/browse/CSDK-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ