### PR TITLE
Avoid syncing attributes for users with blank user ids

### DIFF
--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -3,6 +3,8 @@ package com.revenuecat.purchases.subscriberattributes
 import android.app.Application
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.SubscriberAttributeError
+import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.subscriberattributes.DeviceIdentifiersFetcher
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
@@ -71,6 +73,13 @@ class SubscriberAttributesManager(
             var currentSyncedAttributeCount = 0
 
             unsyncedStoredAttributesForAllUsers.forEach { (syncingAppUserID, unsyncedAttributesForUser) ->
+                if (syncingAppUserID.isBlank()) {
+                    infoLog(AttributionStrings.SKIP_ATTRIBUTES_SYNC.format(syncingAppUserID))
+                    if (completion != null) {
+                        completion()
+                    }
+                    return@forEach
+                }
                 backend.postSubscriberAttributes(
                     unsyncedAttributesForUser.toBackendMap(),
                     syncingAppUserID,

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -74,9 +74,7 @@ class SubscriberAttributesManager(
             unsyncedStoredAttributesForAllUsers.forEach { (syncingAppUserID, unsyncedAttributesForUser) ->
                 if (syncingAppUserID.isBlank()) {
                     infoLog(AttributionStrings.SKIP_ATTRIBUTES_SYNC.format(syncingAppUserID))
-                    if (completion != null) {
-                        completion()
-                    }
+                    currentSyncedAttributeCount++
                     return@forEach
                 }
                 backend.postSubscriberAttributes(

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -3,7 +3,6 @@ package com.revenuecat.purchases.subscriberattributes
 import android.app.Application
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.SubscriberAttributeError
-import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.subscriberattributes.DeviceIdentifiersFetcher
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
@@ -59,7 +58,7 @@ class SubscriberAttributesManager(
     ) {
         obtainingDeviceIdentifiersObservable.waitUntilIdle {
             val unsyncedStoredAttributesForAllUsers =
-                deviceCache.getUnsyncedSubscriberAttributes()
+                deviceCache.getUnsyncedSubscriberAttributes().filterKeys { it.isNotBlank() }
             if (unsyncedStoredAttributesForAllUsers.isEmpty()) {
                 log(LogIntent.DEBUG, AttributionStrings.NO_SUBSCRIBER_ATTRIBUTES_TO_SYNCHRONIZE)
                 if (completion != null) {
@@ -72,11 +71,6 @@ class SubscriberAttributesManager(
             var currentSyncedAttributeCount = 0
 
             unsyncedStoredAttributesForAllUsers.forEach { (syncingAppUserID, unsyncedAttributesForUser) ->
-                if (syncingAppUserID.isBlank()) {
-                    infoLog(AttributionStrings.SKIP_ATTRIBUTES_SYNC.format(syncingAppUserID))
-                    currentSyncedAttributeCount++
-                    return@forEach
-                }
                 backend.postSubscriberAttributes(
                     unsyncedAttributesForUser.toBackendMap(),
                     syncingAppUserID,

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -57,8 +57,9 @@ class SubscriberAttributesManager(
         completion: (() -> Unit)? = null
     ) {
         obtainingDeviceIdentifiersObservable.waitUntilIdle {
-            // We are filtering out blank user IDs to guard against old users that could potentially have
-            // stored attributes as a blank user ID. See https://github.com/RevenueCat/purchases-android/pull/755
+            // We are filtering out blank user IDs to skip requests for attributes that might have been stored
+            // as blank user IDs on older versions of the SDK.
+            // See https://github.com/RevenueCat/purchases-android/pull/755
             val unsyncedStoredAttributesForAllUsers =
                 deviceCache.getUnsyncedSubscriberAttributes().filterKeys { it.isNotBlank() }
             if (unsyncedStoredAttributesForAllUsers.isEmpty()) {

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -57,6 +57,8 @@ class SubscriberAttributesManager(
         completion: (() -> Unit)? = null
     ) {
         obtainingDeviceIdentifiersObservable.waitUntilIdle {
+            // We are filtering out blank user IDs to guard against old users that could potentially have
+            // stored attributes as a blank user ID. See https://github.com/RevenueCat/purchases-android/pull/755
             val unsyncedStoredAttributesForAllUsers =
                 deviceCache.getUnsyncedSubscriberAttributes().filterKeys { it.isNotBlank() }
             if (unsyncedStoredAttributesForAllUsers.isEmpty()) {

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -3,7 +3,6 @@ package com.revenuecat.purchases.subscriberattributes
 import android.app.Application
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.SubscriberAttributeError
-import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.subscriberattributes.DeviceIdentifiersFetcher

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManagerTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManagerTests.kt
@@ -594,6 +594,58 @@ class SubscriberAttributesManagerTests {
     }
 
     @Test
+    fun `When syncing all users attributes, does not sync attributes for empty user IDs`() {
+        every {
+            mockBackend.postSubscriberAttributes(any(), any(), any(), any())
+        } just Runs
+
+        val attributes = mapOf(
+            "tshirtsize" to SubscriberAttribute("tshirtsize", "L"),
+            "removeThis" to SubscriberAttribute("tshirtsize", null)
+        )
+        every {
+            mockDeviceCache.getUnsyncedSubscriberAttributes()
+        } returns mapOf(
+            appUserID to attributes,
+            "" to attributes
+        )
+        underTest.synchronizeSubscriberAttributesForAllUsers(appUserID)
+        verify(exactly = 1) {
+            mockBackend.postSubscriberAttributes(attributes.toBackendMap(), appUserID, any(), any())
+        }
+        verify(exactly = 0) {
+            mockBackend.postSubscriberAttributes(any(), "", any(), any())
+        }
+    }
+
+    @Test
+    fun `When syncing all users attributes, does not sync attributes for whitespaces user IDs`() {
+        every {
+            mockBackend.postSubscriberAttributes(any(), any(), any(), any())
+        } just Runs
+
+        val whitespacesUserId = "   "
+
+        val attributes = mapOf(
+            "tshirtsize" to SubscriberAttribute("tshirtsize", "L"),
+            "removeThis" to SubscriberAttribute("tshirtsize", null)
+        )
+        every {
+            mockDeviceCache.getUnsyncedSubscriberAttributes()
+        } returns mapOf(
+            appUserID to attributes,
+            whitespacesUserId to attributes
+        )
+        underTest.synchronizeSubscriberAttributesForAllUsers(appUserID)
+        verify(exactly = 1) {
+            mockBackend.postSubscriberAttributes(attributes.toBackendMap(), appUserID, any(), any())
+        }
+        verify(exactly = 0) {
+            mockBackend.postSubscriberAttributes(any(), eq(whitespacesUserId), any(), any())
+        }
+    }
+
+    @Test
     fun `When syncing another user attributes, clear them when posted`() {
         val subscriberAttribute = SubscriberAttribute("key", null, isSynced = false)
         val subscriberAttribute2 = SubscriberAttribute("key2", "value2", isSynced = true)

--- a/strings/src/main/java/com/revenuecat/purchases/strings/AttributionStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/AttributionStrings.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases.strings
 
 object AttributionStrings {
     const val ATTRIBUTES_SYNC_ERROR = "Error when syncing subscriber attributes. App User ID: %s, Error: %s"
-    const val SKIP_ATTRIBUTES_SYNC = "Skipping attributes sync for user id: \"%s\". Empty User IDs are not allowed."
     const val ATTRIBUTES_SYNC_SUCCESS = "Subscriber attributes synced successfully for App User ID: %s"
     const val DELETING_ATTRIBUTES = "Deleting subscriber attributes for %s from cache"
     const val DELETING_ATTRIBUTES_OTHER_USERS = "Deleting old synced subscriber attributes that don't belong to %s"

--- a/strings/src/main/java/com/revenuecat/purchases/strings/AttributionStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/AttributionStrings.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.strings
 
 object AttributionStrings {
     const val ATTRIBUTES_SYNC_ERROR = "Error when syncing subscriber attributes. App User ID: %s, Error: %s"
+    const val SKIP_ATTRIBUTES_SYNC = "Skipping attributes sync for user id: \"%s\". Empty User IDs are not allowed."
     const val ATTRIBUTES_SYNC_SUCCESS = "Subscriber attributes synced successfully for App User ID: %s"
     const val DELETING_ATTRIBUTES = "Deleting subscriber attributes for %s from cache"
     const val DELETING_ATTRIBUTES_OTHER_USERS = "Deleting old synced subscriber attributes that don't belong to %s"


### PR DESCRIPTION
### Description
Attempt at dealing with [CSDK-531](https://revenuecats.atlassian.net/browse/CSDK-531)

Back in https://github.com/RevenueCat/purchases-android/pull/384, we added checks to make sure we don't allow blank user ids. However, before that was added, user ids could be empty and could have subscriber attributes. Those could remain in SharedPreferences unless users uninstall which could cause some issues when syncing user attributes.

This is an attempt of solving that issue by just ignoring those old user ids when syncing subscriber attributes.


[CSDK-531]: https://revenuecats.atlassian.net/browse/CSDK-531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ