### PR TITLE
[CF1120] - Update SDK docs for default offer logic

### DIFF
--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -77,7 +77,7 @@ StoreProduct has been made an interface, which `GoogleStoreProduct` and `AmazonS
 The `purchasePackage()` and `purchaseProduct()` APIs have a new behavior for selecting which offer is used when
 purchasing a `Package` or `StoreProduct`. These functions use the following logic to choose
 a [SubscriptionOption] to purchase:
-*   - Filters out offers with "rc_ignore_default_offer" tag
+*   - Filters out offers with "rc-ignore-default-offer" tag
 *   - Uses longest free trial (if one exists)
 *   - Uses first phase with lowest price (if one exists)
 *   - Falls back to use base plan

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -74,6 +74,16 @@ StoreProduct has been made an interface, which `GoogleStoreProduct` and `AmazonS
 
 ### Purchasing APIs
 
+The `purchasePackage()` and `purchaseProduct()` APIs have a new behavior for selecting which offer is used when
+purchasing a `Package` or `StoreProduct`. These functions use the following logic to choose
+a [SubscriptionOption] to purchase:
+*   - Filters out offers with "rc_ignore_default_offer" tag
+*   - Uses longest free trial (if one exists)
+*   - Uses first phase with lowest price (if one exists)
+*   - Falls back to use base plan
+
+For more control, the `purchaseSubscriptionOption()` API can be used to manually choose which offer to purchase.
+
 | New                                                                                                      |
 |----------------------------------------------------------------------------------------------------------|
 | `purchaseSubscriptionOption(Activity, StoreProduct, SubscriptionOption, PurchaseCallback)`                   |

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -78,8 +78,7 @@ The `purchasePackage()` and `purchaseProduct()` APIs have a new behavior for sel
 purchasing a `Package` or `StoreProduct`. These functions use the following logic to choose
 a [SubscriptionOption] to purchase:
 *   - Filters out offers with "rc-ignore-default-offer" tag
-*   - Uses longest free trial (if one exists)
-*   - Uses first phase with lowest price (if one exists)
+*   - Uses [SubscriptionOption] WITH longest free trial or cheapest first phase
 *   - Falls back to use base plan
 
 For more control, the `purchaseSubscriptionOption()` API can be used to manually choose which offer to purchase.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -386,8 +386,7 @@ class Purchases internal constructor(
      *
      * The default [SubscriptionOption] logic:
      *   - Filters out offers with "rc-ignore-default-offer" tag
-     *   - Uses longest free trial (if one exists)
-     *   - Uses first phase with lowest price (if one exists)
+     *   - Uses [SubscriptionOption] WITH longest free trial or cheapest first phase
      *   - Falls back to use base plan
      *
      * If [storeProduct] represents a non-subscription, [upgradeInfo] will be ignored.
@@ -419,8 +418,7 @@ class Purchases internal constructor(
      *
      * The default [SubscriptionOption] logic:
      *   - Filters out offers with "rc-ignore-default-offer" tag
-     *   - Uses longest free trial (if one exists)
-     *   - Uses first phase with lowest price (if one exists)
+     *   - Uses [SubscriptionOption] WITH longest free trial or cheapest first phase
      *   - Falls back to use base plan
      *
      * @param [activity] Current activity
@@ -485,8 +483,7 @@ class Purchases internal constructor(
      *
      * The default [SubscriptionOption] logic:
      *   - Filters out offers with "rc-ignore-default-offer" tag
-     *   - Uses longest free trial (if one exists)
-     *   - Uses first phase with lowest price (if one exists)
+     *   - Uses [SubscriptionOption] WITH longest free trial or cheapest first phase
      *   - Falls back to use base plan
      *
      * If [packageToPurchase] represents a non-subscription, [upgradeInfo] will be ignored.
@@ -518,8 +515,7 @@ class Purchases internal constructor(
      *
      * The default [SubscriptionOption] logic:
      *   - Filters out offers with "rc-ignore-default-offer" tag
-     *   - Uses longest free trial (if one exists)
-     *   - Uses first phase with lowest price (if one exists)
+     *   - Uses [SubscriptionOption] WITH longest free trial or cheapest first phase
      *   - Falls back to use base plan
      *
      * @param [activity] Current activity

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -385,7 +385,7 @@ class Purchases internal constructor(
      * [upgradeInfo.oldProductId] and chooses [storeProduct]'s default [SubscriptionOption].
      *
      * The default [SubscriptionOption] logic:
-     *   - Filters out offers with "rc_ignore_default_offer" tag
+     *   - Filters out offers with "rc-ignore-default-offer" tag
      *   - Uses longest free trial (if one exists)
      *   - Uses first phase with lowest price (if one exists)
      *   - Falls back to use base plan
@@ -418,7 +418,7 @@ class Purchases internal constructor(
      * Purchases a [StoreProduct]. If purchasing a subscription, it will choose the default [SubscriptionOption].
      *
      * The default [SubscriptionOption] logic:
-     *   - Filters out offers with "rc_ignore_default_offer" tag
+     *   - Filters out offers with "rc-ignore-default-offer" tag
      *   - Uses longest free trial (if one exists)
      *   - Uses first phase with lowest price (if one exists)
      *   - Falls back to use base plan
@@ -484,7 +484,7 @@ class Purchases internal constructor(
      * [oldProductId]and chooses the default [SubscriptionOption] from [packageToPurchase].
      *
      * The default [SubscriptionOption] logic:
-     *   - Filters out offers with "rc_ignore_default_offer" tag
+     *   - Filters out offers with "rc-ignore-default-offer" tag
      *   - Uses longest free trial (if one exists)
      *   - Uses first phase with lowest price (if one exists)
      *   - Falls back to use base plan
@@ -517,7 +517,7 @@ class Purchases internal constructor(
      * Purchase a [Package]. If purchasing a subscription, it will choose the default [SubscriptionOption].
      *
      * The default [SubscriptionOption] logic:
-     *   - Filters out offers with "rc_ignore_default_offer" tag
+     *   - Filters out offers with "rc-ignore-default-offer" tag
      *   - Uses longest free trial (if one exists)
      *   - Uses first phase with lowest price (if one exists)
      *   - Falls back to use base plan

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -384,6 +384,12 @@ class Purchases internal constructor(
      * If [storeProduct] represents a subscription, upgrades from the subscription specified by
      * [upgradeInfo.oldProductId] and chooses [storeProduct]'s default [SubscriptionOption].
      *
+     * The default [SubscriptionOption] logic:
+     *   - Filters out offers with "rc_ignore_default_offer" tag
+     *   - Uses longest free trial (if one exists)
+     *   - Uses first phase with lowest price (if one exists)
+     *   - Falls back to use base plan
+     *
      * If [storeProduct] represents a non-subscription, [upgradeInfo] will be ignored.
      *
      * @param [activity] Current activity
@@ -410,6 +416,13 @@ class Purchases internal constructor(
 
     /**
      * Purchases a [StoreProduct]. If purchasing a subscription, it will choose the default [SubscriptionOption].
+     *
+     * The default [SubscriptionOption] logic:
+     *   - Filters out offers with "rc_ignore_default_offer" tag
+     *   - Uses longest free trial (if one exists)
+     *   - Uses first phase with lowest price (if one exists)
+     *   - Falls back to use base plan
+     *
      * @param [activity] Current activity
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
      * @param [callback] The PurchaseCallback that will be called when purchase completes.
@@ -470,6 +483,12 @@ class Purchases internal constructor(
      * If [packageToPurchase] represents a subscription, upgrades from the subscription specified by [upgradeInfo]'s
      * [oldProductId]and chooses the default [SubscriptionOption] from [packageToPurchase].
      *
+     * The default [SubscriptionOption] logic:
+     *   - Filters out offers with "rc_ignore_default_offer" tag
+     *   - Uses longest free trial (if one exists)
+     *   - Uses first phase with lowest price (if one exists)
+     *   - Falls back to use base plan
+     *
      * If [packageToPurchase] represents a non-subscription, [upgradeInfo] will be ignored.
      *
      * @param [activity] Current activity
@@ -496,6 +515,13 @@ class Purchases internal constructor(
 
     /**
      * Purchase a [Package]. If purchasing a subscription, it will choose the default [SubscriptionOption].
+     *
+     * The default [SubscriptionOption] logic:
+     *   - Filters out offers with "rc_ignore_default_offer" tag
+     *   - Uses longest free trial (if one exists)
+     *   - Uses first phase with lowest price (if one exists)
+     *   - Falls back to use base plan
+     *
      * @param [activity] Current activity
      * @param [packageToPurchase] The Package you wish to purchase
      * @param [listener] The listener that will be called when purchase completes.


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation

[CF-1120](https://revenuecats.atlassian.net/browse/CF-1120)

Adding some SDK doc about what default offer is

### Description

- Updated doc for the `purchasePackage` and `purchaseProduct` functions
- Updated V6 migration doc explaining new behavior


[CF-1120]: https://revenuecats.atlassian.net/browse/CF-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ