### PR TITLE
[CF-1121] Update Magic Weather for BC5 / SDK V6

### DIFF
--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/data/Constants.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/data/Constants.kt
@@ -7,7 +7,7 @@ object Constants {
 
      Modify this property to reflect your Google Play app's API key.
     */
-    const val GOOGLE_API_KEY = "goog_GncthBrhtStvgWspGnllfHgPeQP"
+    const val GOOGLE_API_KEY = "googl_api_key"
 
     /*
     The API key for your Amazon App Store app. This can be found in via Project Settings >

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/data/Constants.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/data/Constants.kt
@@ -7,7 +7,7 @@ object Constants {
 
      Modify this property to reflect your Google Play app's API key.
     */
-    const val GOOGLE_API_KEY = "goog_uqEyfYMTjEKAipqQizyhInffjwP"
+    const val GOOGLE_API_KEY = "goog_GncthBrhtStvgWspGnllfHgPeQP"
 
     /*
     The API key for your Amazon App Store app. This can be found in via Project Settings >

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/data/Constants.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/data/Constants.kt
@@ -7,7 +7,7 @@ object Constants {
 
      Modify this property to reflect your Google Play app's API key.
     */
-    const val GOOGLE_API_KEY = "googl_api_key"
+    const val GOOGLE_API_KEY = "goog_uqEyfYMTjEKAipqQizyhInffjwP"
 
     /*
     The API key for your Amazon App Store app. This can be found in via Project Settings >

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallAdapter.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallAdapter.kt
@@ -4,21 +4,24 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.sample.R
 
 class PaywallAdapter(
     var offering: Offering?,
-    var didChoosePackage: (Package) -> Unit
+    var didChoosePaywallItem: (PaywallItem) -> Unit
 ) : RecyclerView.Adapter<PaywallAdapter.PackageViewHolder>() {
 
     class PackageViewHolder(
         val view: View,
-        val didChoosePackage: (Package) -> Unit
+        val didChoosePaywallItem: (PaywallItem) -> Unit
     ) : RecyclerView.ViewHolder(view), View.OnClickListener {
-        var item: Package? = null
+        var item: PaywallItem? = null
 
         init {
             view.setOnClickListener(this)
@@ -26,7 +29,7 @@ class PaywallAdapter(
 
         override fun onClick(v: View) {
             item?.let {
-                didChoosePackage(it)
+                didChoosePaywallItem(it)
             }
         }
     }
@@ -35,21 +38,90 @@ class PaywallAdapter(
         val view = LayoutInflater.from(viewGroup.context)
             .inflate(R.layout.paywall_item, viewGroup, false)
 
-        return PackageViewHolder(view, didChoosePackage)
+        return PackageViewHolder(view, didChoosePaywallItem)
     }
 
     override fun onBindViewHolder(viewHolder: PackageViewHolder, position: Int) {
-        offering?.availablePackages?.get(position)?.let {
+        theItems[position].let {
             val item = it
             viewHolder.item = item
 
-            val price = item.product.defaultOption?.pricingPhases?.lastOrNull()?.formattedPrice ?: item.product.oneTimeProductPrice?.formattedPrice ?: "???"
+            when (it) {
+                is PaywallItem.Title -> {
+                    viewHolder.view.findViewById<TextView>(R.id.paywall_item_options_title).visibility = View.VISIBLE
+                    viewHolder.view.findViewById<TextView>(R.id.paywall_item_options_title).text = it.title
+                    viewHolder.view.findViewById<ConstraintLayout>(R.id.purchasableLayout).visibility = View.GONE
+                }
+                is PaywallItem.Product -> {
+                    viewHolder.view.findViewById<TextView>(R.id.paywall_item_options_title).visibility = View.GONE
+                    viewHolder.view.findViewById<ConstraintLayout>(R.id.purchasableLayout).visibility = View.VISIBLE
 
-            viewHolder.view.findViewById<TextView>(R.id.paywall_item_title).text = item.product.title
-            viewHolder.view.findViewById<TextView>(R.id.paywall_item_description).text = item.product.productId
-            viewHolder.view.findViewById<TextView>(R.id.paywall_item_price).text = price
+                    val product = it.storeProduct
+                    val price = product.oneTimeProductPrice?.formattedPrice ?: "???"
+
+                    viewHolder.view.findViewById<TextView>(R.id.paywall_item_price).text = price
+                    viewHolder.view.findViewById<TextView>(R.id.paywall_item_best_offer).visibility = View.GONE
+                }
+                is PaywallItem.Option -> {
+                    viewHolder.view.findViewById<TextView>(R.id.paywall_item_options_title).visibility = View.GONE
+                    viewHolder.view.findViewById<ConstraintLayout>(R.id.purchasableLayout).visibility = View.VISIBLE
+
+                    val option = it.subscriptionOption
+                    val price = option.pricingPhases.map { phase ->
+                        "${phase.formattedPrice} for ${phase.billingPeriod}"
+                    }.joinToString(separator = " -> ")
+
+                    viewHolder.view.findViewById<TextView>(R.id.paywall_item_price).text = price
+                    viewHolder.view.findViewById<TextView>(R.id.paywall_item_best_offer).visibility =  if (it.defaultOffer) View.VISIBLE else View.GONE
+                }
+            }
         }
     }
 
-    override fun getItemCount() = offering?.availablePackages?.size ?: 0
+    override fun getItemCount() = theItems.size ?: 0
+
+    private val theItems: List<PaywallItem>
+        get() = offering?.availablePackages?.flatMap {
+
+            if (it.product.subscriptionOptions.isEmpty()) {
+                listOf(
+                    PaywallItem.Title(it.product.title),
+                    PaywallItem.Product(it.product)
+                )
+            } else {
+                val product = it.product
+                val title = product.defaultOption?.pricingPhases?.lastOrNull()?.billingPeriod?.let { period ->
+                    when (period) {
+                        "P1W" -> "Weekly"
+                        "P4W" -> "Every 4  Weeks"
+                        "P1M" -> "Monthly"
+                        "P3M" -> "Every 3 Months"
+                        "P6M" -> "Every 6 Months"
+                        "P1Y" -> "Yearly"
+                        else -> {
+                            null
+                        }
+                    }
+                } ?: product.title
+
+                mutableListOf(PaywallItem.Title(title)) + it.product.subscriptionOptions.map { option ->
+                    PaywallItem.Option(option, option == it.product.defaultOption)
+                }.sortedBy { option -> !option.defaultOffer }
+            }
+        } ?: emptyList()
+}
+
+sealed class PaywallItem {
+    data class Title(
+        val title: String
+    ) : PaywallItem()
+
+    data class Product(
+        val storeProduct: StoreProduct
+    ) : PaywallItem()
+
+    data class Option(
+        val subscriptionOption: SubscriptionOption,
+        val defaultOffer: Boolean
+    ) : PaywallItem()
 }

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallAdapter.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallAdapter.kt
@@ -46,7 +46,7 @@ class PaywallAdapter(
             val price = item.product.defaultOption?.pricingPhases?.lastOrNull()?.formattedPrice ?: item.product.oneTimeProductPrice?.formattedPrice ?: "???"
 
             viewHolder.view.findViewById<TextView>(R.id.paywall_item_title).text = item.product.title
-            viewHolder.view.findViewById<TextView>(R.id.paywall_item_description).text = item.product.description
+            viewHolder.view.findViewById<TextView>(R.id.paywall_item_description).text = item.product.productId
             viewHolder.view.findViewById<TextView>(R.id.paywall_item_price).text = price
         }
     }

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallAdapter.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallAdapter.kt
@@ -43,9 +43,11 @@ class PaywallAdapter(
             val item = it
             viewHolder.item = item
 
+            val price = item.product.defaultOption?.pricingPhases?.lastOrNull()?.formattedPrice ?: item.product.oneTimeProductPrice?.formattedPrice ?: "???"
+
             viewHolder.view.findViewById<TextView>(R.id.paywall_item_title).text = item.product.title
             viewHolder.view.findViewById<TextView>(R.id.paywall_item_description).text = item.product.description
-            viewHolder.view.findViewById<TextView>(R.id.paywall_item_price).text = item.product.originalPrice
+            viewHolder.view.findViewById<TextView>(R.id.paywall_item_price).text = price
         }
     }
 

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallFragment.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallFragment.kt
@@ -4,10 +4,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.revenuecat.purchases.*
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.sample.R
 import com.revenuecat.sample.extensions.buildError
 
@@ -31,8 +34,15 @@ class PaywallFragment : Fragment() {
         linearLayoutManager.orientation = LinearLayoutManager.VERTICAL
         recyclerView.layoutManager = linearLayoutManager
 
-        adapter = PaywallAdapter(null, didChoosePackage = { item: Package ->
-            purchasePackage(item)
+        adapter = PaywallAdapter(null, didChoosePaywallItem = { item: PaywallItem ->
+            when (item) {
+                is PaywallItem.Product -> {
+                    purchaseProduct(item.storeProduct)
+                }
+                is PaywallItem.Option -> {
+                    purchaseOption(item.subscriptionOption)
+                }
+            }
         })
 
         recyclerView.adapter = adapter
@@ -52,15 +62,27 @@ class PaywallFragment : Fragment() {
         }
     }
 
-    private fun purchasePackage(item: Package) {
-        Purchases.sharedInstance.purchasePackageWith(requireActivity(), item,
-                onError = { error, userCancelled ->
-                    if (!userCancelled) {
-                        buildError(context, error.message)
-                    }
-                },
-                onSuccess = { _, _ ->
-                    activity?.finish()
-                })
+    private fun purchaseProduct(item: StoreProduct) {
+        Purchases.sharedInstance.purchaseProductWith(requireActivity(), item,
+            onError = { error, userCancelled ->
+                if (!userCancelled) {
+                    buildError(context, error.message)
+                }
+            },
+            onSuccess = { _, _ ->
+                activity?.finish()
+            })
+    }
+
+    private fun purchaseOption(item: SubscriptionOption) {
+        Purchases.sharedInstance.purchaseSubscriptionOptionWith(requireActivity(), item,
+            onError = { error, userCancelled ->
+                if (!userCancelled) {
+                    buildError(context, error.message)
+                }
+            },
+            onSuccess = { _, _ ->
+                activity?.finish()
+            })
     }
 }

--- a/examples/MagicWeather/app/src/main/res/layout/paywall_item.xml
+++ b/examples/MagicWeather/app/src/main/res/layout/paywall_item.xml
@@ -6,69 +6,65 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <androidx.cardview.widget.CardView
-        android:id="@+id/card_view"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginBottom="8dp"
-        app:cardBackgroundColor="#292929"
-        app:cardCornerRadius="4dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="match_parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
 
-            <LinearLayout
+            <TextView
+                android:id="@+id/paywall_item_options_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginBottom="8dp"
+                android:textColor="#B6B6B6"
+                android:textSize="20sp"
+                tools:text="Description" />
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/card_view"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="horizontal">
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginBottom="8dp"
+                app:cardBackgroundColor="#292929"
+                app:cardCornerRadius="4dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/constraintLayout"
+                    android:id="@+id/purchasableLayout"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    >
 
                     <TextView
-                        android:id="@+id/paywall_item_description"
+                        android:id="@+id/paywall_item_best_offer"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="16dp"
-                        android:layout_marginBottom="8dp"
-                        android:textColor="#B6B6B6"
-                        android:textSize="12sp"
-                        app:layout_constraintBottom_toTopOf="@+id/paywall_item_price"
-                        app:layout_constraintStart_toStartOf="parent"
-                        tools:text="Description" />
-
-                    <TextView
-                        android:id="@+id/paywall_item_title"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="16dp"
-                        android:layout_marginTop="12dp"
                         android:layout_marginBottom="8dp"
                         android:textColor="#FFFFFF"
                         android:textSize="18sp"
                         android:textStyle="bold"
-                        app:layout_constraintBottom_toTopOf="@+id/paywall_item_description"
+                        app:layout_constraintBottom_toTopOf="@+id/paywall_item_price"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent"
-                        tools:text="6 Month" />
+                        android:text="Best Offer" />
 
                     <TextView
                         android:id="@+id/paywall_item_price"
                         android:layout_width="wrap_content"
                         android:layout_height="19dp"
-                        android:layout_marginStart="16dp"
-                        android:layout_marginBottom="16dp"
                         android:textAlignment="textEnd"
                         android:textColor="#FFFFFF"
                         android:textStyle="bold"
@@ -77,10 +73,10 @@
                         tools:text="$4.99" />
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
-            </LinearLayout>
+            </androidx.cardview.widget.CardView>
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        </LinearLayout>
 
-    </androidx.cardview.widget.CardView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/MagicWeather/build.gradle
+++ b/examples/MagicWeather/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext.compileVersion = 31
     ext.kotlinVersion = "1.6.21"
-    ext.purchasesVersion = "6.0.0-alpha.1"
+    ext.purchasesVersion = "6.0.0-alpha.2"
     ext.lifecycleVersion = "2.5.0"
     ext.androidxCoreVersion = "1.8.0"
     repositories {

--- a/examples/MagicWeather/build.gradle
+++ b/examples/MagicWeather/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext.compileVersion = 31
     ext.kotlinVersion = "1.6.21"
-    ext.purchasesVersion = "5.0.0"
+    ext.purchasesVersion = "6.0.0-alpha.1"
     ext.lifecycleVersion = "2.5.0"
     ext.androidxCoreVersion = "1.8.0"
     repositories {


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation

[CF-1121](https://revenuecats.atlassian.net/browse/CF-1121)

### Description

- Migrated from SDK `5.0.0` to `6.0.0-alpha.2`
- Changes to `PaywallAdapter` to make paywall show more useful information to user
  - Duration (gross code)
  - Multiple offers (and "best offer" first)
  - Pricing phases (gross looking now but will improve later)
- Works for both subscriptions and one-time purchases

#### Step 1

The initial migration (with only necessary code changes to compile) made for a very confusing paywall 👇 

- The subscriptions relied on the product title (which is the same for each base plan)
- Did not include the duration so user had no idea what they were buying
  -  This is because these were previously in the individual subscription titles for BC4
- It did use the default/best offer which was nice but didn't explain any offer info

<img width="473" alt="Screen Shot 2023-01-30 at 8 23 51 AM (1)" src="https://user-images.githubusercontent.com/401294/216314716-eb584d1c-d943-4dd1-9c03-2dd6436bb3e4.png">

#### Step 2

Big rework to programmatically show as much info as we could (even though it is kind of ugly UI right now) 👇 

- Shows all the options for each subscription with "best offer" on top
  - This might be overkill because why not just choose the best offer but wanted to show this as example 🤷‍♂️ 
- Shows the pricing phases that come with each option
- Needed very different logic for subscriptions vs one-time purchases
  - This is because one-time purchases contain all the data in the `StoreProduct`
  - Where subscriptions contain all needed data in `SubscriptionOption` and `PricingPhase`s

https://user-images.githubusercontent.com/401294/216314819-54f24dfa-48c4-4bd9-9d75-b89754015f92.mov




[CF-1121]: https://revenuecats.atlassian.net/browse/CF-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ