### PR TITLE
Diagnostics: Backend integration

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.utils.filterNotNullValues
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import java.net.URL
 
 const val ATTRIBUTES_ERROR_RESPONSE_KEY = "attributes_error_response"
 const val ATTRIBUTE_ERRORS_KEY = "attribute_errors"
@@ -40,6 +41,7 @@ typealias TelemetryCallback = Pair<(JSONObject) -> Unit, (PurchasesError) -> Uni
 
 class Backend(
     private val apiKey: String,
+    private val appConfig: AppConfig,
     private val dispatcher: Dispatcher,
     private val diagnosticsDispatcher: Dispatcher,
     private val httpClient: HTTPClient
@@ -75,6 +77,7 @@ class Backend(
         enqueue(object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {
                 return httpClient.performRequest(
+                    appConfig.baseURL,
                     path,
                     body,
                     authenticationHeaders
@@ -118,6 +121,7 @@ class Backend(
 
             override fun call(): HTTPResult {
                 return httpClient.performRequest(
+                    appConfig.baseURL,
                     path,
                     null,
                     authenticationHeaders
@@ -200,6 +204,7 @@ class Backend(
 
             override fun call(): HTTPResult {
                 return httpClient.performRequest(
+                    appConfig.baseURL,
                     "/receipts",
                     body,
                     authenticationHeaders + extraHeaders
@@ -255,6 +260,7 @@ class Backend(
         val call = object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {
                 return httpClient.performRequest(
+                    appConfig.baseURL,
                     path,
                     null,
                     authenticationHeaders
@@ -307,6 +313,7 @@ class Backend(
         val call = object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {
                 return httpClient.performRequest(
+                    appConfig.baseURL,
                     "/subscribers/identify",
                     mapOf(
                         "new_app_user_id" to newAppUserID,
@@ -359,6 +366,7 @@ class Backend(
         val call = object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {
                 return httpClient.performRequest(
+                    URL("https://api-telemetry.revenuecat.com/"),
                     "/telemetry",
                     body,
                     authenticationHeaders,

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -85,8 +85,10 @@ class HTTPClient(
      * @throws JSONException Thrown for any JSON errors, not thrown for returned HTTP error codes
      * @throws IOException Thrown for any unexpected errors, not thrown for returned HTTP error codes
      */
+    @SuppressWarnings("LongParameterList")
     @Throws(JSONException::class, IOException::class)
     fun performRequest(
+        baseURL: URL,
         path: String,
         body: Map<String, Any?>?,
         requestHeaders: Map<String, String>,
@@ -100,7 +102,7 @@ class HTTPClient(
         val httpRequest: HTTPRequest
         val urlPathWithVersion = "/v1$path"
         try {
-            fullURL = URL(appConfig.baseURL, urlPathWithVersion)
+            fullURL = URL(baseURL, urlPathWithVersion)
 
             val headers = getHeaders(requestHeaders, urlPathWithVersion, refreshETag, gzipRequest)
             httpRequest = HTTPRequest(fullURL, headers, jsonBody, gzipRequest)
@@ -137,7 +139,7 @@ class HTTPClient(
         )
         if (callResult == null) {
             log(LogIntent.WARNING, NetworkStrings.ETAG_RETRYING_CALL)
-            return performRequest(path, body, requestHeaders, refreshETag = true)
+            return performRequest(baseURL, path, body, requestHeaders, refreshETag = true)
         }
         return callResult
     }
@@ -152,10 +154,9 @@ class HTTPClient(
         refreshETag: Boolean,
         gzipRequest: Boolean
     ): Map<String, String> {
-        val contentEncoding = if (gzipRequest) "gzip" else null
         return mapOf(
             "Content-Type" to "application/json",
-            "Content-Encoding" to contentEncoding,
+            "Content-Encoding" to if (gzipRequest) "gzip" else null,
             "X-Platform" to getXPlatformHeader(),
             "X-Platform-Flavor" to appConfig.platformInfo.flavor,
             "X-Platform-Flavor-Version" to appConfig.platformInfo.version,

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
@@ -32,12 +32,11 @@ class DiagnosticsFileHelper(
     }
 
     @Synchronized
-    fun diagnosticsFileIsEmpty(): Boolean {
-        return fileHelper.fileIsEmpty(DIAGNOSTICS_FILE_PATH)
-    }
-
-    @Synchronized
     fun readDiagnosticsFile(): List<JSONObject> {
-        return fileHelper.readFilePerLines(DIAGNOSTICS_FILE_PATH).map { JSONObject(it) }
+        return if (fileHelper.fileIsEmpty(DIAGNOSTICS_FILE_PATH)) {
+            emptyList()
+        } else {
+            fileHelper.readFilePerLines(DIAGNOSTICS_FILE_PATH).map { JSONObject(it) }
+        }
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPRequest.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPRequest.kt
@@ -6,5 +6,6 @@ import java.net.URL
 internal data class HTTPRequest(
     val fullURL: URL,
     val headers: Map<String, String>,
-    val body: JSONObject?
+    val body: JSONObject?,
+    val gzipRequest: Boolean
 )

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.IOException
 import java.lang.Thread.sleep
+import java.net.URL
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadLocalRandom
@@ -40,19 +41,22 @@ private const val API_KEY = "TEST_API_KEY"
 @Config(manifest = Config.NONE)
 class BackendTest {
 
-    @Before
-    fun setup() = mockkStatic("com.revenuecat.purchases.common.CustomerInfoFactoriesKt")
-
     private var mockClient: HTTPClient = mockk(relaxed = true)
     private val dispatcher = SyncDispatcher()
+    private val mockBaseURL = URL("http://mock-api-test.revenuecat.com/")
+    private val mockAppConfig: AppConfig = mockk<AppConfig>().apply {
+        every { baseURL } returns mockBaseURL
+    }
     private var backend: Backend = Backend(
         API_KEY,
+        mockAppConfig,
         dispatcher,
         dispatcher,
         mockClient
     )
     private var asyncBackend: Backend = Backend(
         API_KEY,
+        mockAppConfig,
         Dispatcher(
             ThreadPoolExecutor(
                 1,
@@ -119,6 +123,12 @@ class BackendTest {
         this@BackendTest.receivedError = it
     }
 
+    @Before
+    fun setup() {
+        mockkStatic("com.revenuecat.purchases.common.CustomerInfoFactoriesKt")
+
+    }
+
     @Test
     fun canBeCreated() {
         assertThat(backend).isNotNull
@@ -144,6 +154,7 @@ class BackendTest {
         }
         val everyMockedCall = every {
             mockClient.performRequest(
+                mockBaseURL,
                 eq(path),
                 (if (body == null) any() else eq(body)),
                 capture(headersSlot)
@@ -369,6 +380,7 @@ class BackendTest {
 
         verify {
             mockClient.performRequest(
+                mockBaseURL,
                 eq(path),
                 any(),
                 any()
@@ -416,6 +428,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/subscribers/" + Uri.encode(appUserID),
                 null,
                 any()
@@ -478,6 +491,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/receipts",
                 any(),
                 any()
@@ -557,6 +571,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/receipts",
                 any(),
                 any()
@@ -564,6 +579,7 @@ class BackendTest {
         }
         verify(exactly = 2) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/subscribers/$appUserID",
                 null,
                 any()
@@ -592,6 +608,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/subscribers/$appUserID/offerings",
                 null,
                 any()
@@ -620,6 +637,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/subscribers/$appUserID/offerings",
                 null,
                 any()
@@ -627,6 +645,7 @@ class BackendTest {
         }
         verify(exactly = 1) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/subscribers/anotherUser/offerings",
                 null,
                 any()
@@ -701,6 +720,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 2) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/receipts",
                 any(),
                 any()
@@ -824,6 +844,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 2) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/receipts",
                 any() as Map<String, Any?>,
                 any()
@@ -911,6 +932,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 2) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/receipts",
                 any() as Map<String, Any?>,
                 any()
@@ -969,6 +991,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/receipts",
                 any() as Map<String, Any?>,
                 any()
@@ -1053,6 +1076,7 @@ class BackendTest {
         )
         verify(exactly = 1) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/subscribers/identify",
                 body,
                 any()
@@ -1216,6 +1240,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/subscribers/identify",
                 requestBody,
                 any()
@@ -1265,6 +1290,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/subscribers/identify",
                 requestBody,
                 any()
@@ -1314,6 +1340,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/subscribers/identify",
                 requestBody,
                 any()
@@ -1376,6 +1403,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 2) {
             mockClient.performRequest(
+                mockBaseURL,
                 "/receipts",
                 any(),
                 any()

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -91,7 +91,7 @@ class HTTPClientTest {
             expectedResult = HTTPResult(200, "{}")
         )
 
-        client.performRequest(path, null, mapOf("" to ""))
+        client.performRequest(baseURL, path, null, mapOf("" to ""))
 
         val request = server.takeRequest()
         assertThat(request.method).`as`("method request is GET").isEqualTo("GET")
@@ -106,7 +106,7 @@ class HTTPClientTest {
             expectedResult = HTTPResult(223, "{}")
         )
 
-        val result = client.performRequest(path, null, mapOf("" to ""))
+        val result = client.performRequest(baseURL, path, null, mapOf("" to ""))
 
         server.takeRequest()
 
@@ -121,7 +121,7 @@ class HTTPClientTest {
             expectedResult = HTTPResult(223, "{'response': 'OK'}")
         )
 
-        val result = client.performRequest(path, null, mapOf("" to ""))
+        val result = client.performRequest(baseURL, path, null, mapOf("" to ""))
 
         server.takeRequest()
 
@@ -139,7 +139,7 @@ class HTTPClientTest {
         )
 
         try {
-            client.performRequest(path, null, mapOf("" to ""))
+            client.performRequest(baseURL, path, null, mapOf("" to ""))
         } finally {
             server.takeRequest()
         }
@@ -158,7 +158,7 @@ class HTTPClientTest {
         val headers = HashMap<String, String>()
         headers["Authentication"] = "Bearer todd"
 
-        client.performRequest(path, null, headers)
+        client.performRequest(baseURL, path, null, headers)
 
         val request = server.takeRequest()
 
@@ -174,7 +174,7 @@ class HTTPClientTest {
             expectedResult
         )
 
-        client.performRequest(path, null, mapOf("" to ""))
+        client.performRequest(baseURL, path, null, mapOf("" to ""))
 
         val request = server.takeRequest()
 
@@ -208,7 +208,7 @@ class HTTPClientTest {
         )
 
         client = HTTPClient(appConfig, mockETagManager)
-        client.performRequest(path, null, mapOf("" to ""))
+        client.performRequest(baseURL, path, null, mapOf("" to ""))
 
         val request = server.takeRequest()
 
@@ -227,7 +227,7 @@ class HTTPClientTest {
         val body = HashMap<String, String>()
         body["user_id"] = "jerry"
 
-        client.performRequest(path, body, mapOf("" to ""))
+        client.performRequest(baseURL, path, body, mapOf("" to ""))
 
         val request = server.takeRequest()
         assertThat(request.method).`as`("method is POST").isEqualTo("POST")
@@ -246,7 +246,7 @@ class HTTPClientTest {
             expectedResult
         )
 
-        client.performRequest(path, null, mapOf("" to ""))
+        client.performRequest(baseURL, path, null, mapOf("" to ""))
 
         val request = server.takeRequest()
 
@@ -322,7 +322,7 @@ class HTTPClientTest {
             )
         } returns expectedResult
 
-        val result = client.performRequest(path, null, mapOf("" to ""))
+        val result = client.performRequest(baseURL, path, null, mapOf("" to ""))
 
         server.takeRequest()
         server.takeRequest()

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
@@ -8,6 +8,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -58,14 +59,16 @@ class DiagnosticsFileHelperTest {
     }
 
     @Test
-    fun `diagnosticsFileIsEmpty calls are correct`() {
+    fun `readDiagnosticsFile returns empty list if file is empty`() {
         every { fileHelper.fileIsEmpty(diagnosticsFilePath) } returns true
-        assertTrue(diagnosticsFileHelper.diagnosticsFileIsEmpty())
+        assertThat(diagnosticsFileHelper.readDiagnosticsFile()).isEqualTo(emptyList<JSONObject>())
         verify(exactly = 1) { fileHelper.fileIsEmpty(diagnosticsFilePath) }
+        verify(exactly = 0) { fileHelper.readFilePerLines(diagnosticsFilePath) }
     }
 
     @Test
     fun `readDiagnosticsFile reads content as json`() {
+        every { fileHelper.fileIsEmpty(diagnosticsFilePath) } returns false
         every { fileHelper.readFilePerLines(diagnosticsFilePath) } returns listOf(
             "{}", "{\"test_key\": \"test_value\"}"
         )

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -330,7 +330,7 @@ class ETagManagerTest {
             "Authorization" to "Bearer apiKey",
             ETAG_HEADER_NAME to eTag
         ).filterNotNullValues()
-        return HTTPRequest(fullURL, headers, body = null)
+        return HTTPRequest(fullURL, headers, body = null, false)
     }
 
     private fun assertStoredResponse(

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.amazon.helpers.successfulRVSResponse
+import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.networking.HTTPResult
@@ -16,6 +17,7 @@ import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
+import java.net.URL
 
 private const val API_KEY = "TEST_API_KEY"
 
@@ -23,11 +25,16 @@ private const val API_KEY = "TEST_API_KEY"
 class AmazonBackendTest {
 
     private var mockClient = mockk<HTTPClient>()
+    private val mockBaseURL = URL("http://mock-api-test.revenuecat.com/")
+    private val mockAppConfig = mockk<AppConfig>().apply {
+        every { baseURL } returns mockBaseURL
+    }
 
     private val syncDispatcher = SyncDispatcher()
 
     private var backend: Backend = Backend(
         API_KEY,
+        mockAppConfig,
         syncDispatcher,
         syncDispatcher,
         mockClient
@@ -72,6 +79,7 @@ class AmazonBackendTest {
     fun `When getting Amazon receipt data is successful, onSuccess is called`() {
         every {
             mockClient.performRequest(
+                baseURL = mockBaseURL,
                 path = "/receipts/amazon/store_user_id/receipt_id",
                 body = null,
                 requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
@@ -92,6 +100,7 @@ class AmazonBackendTest {
     fun `when Amazon receipt data call returns an error, errors are passed along`() {
         every {
             mockClient.performRequest(
+                baseURL = mockBaseURL,
                 path = "/receipts/amazon/store_user_id/receipt_id",
                 body = null,
                 requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
@@ -113,6 +122,7 @@ class AmazonBackendTest {
     fun `when Amazon receipt data call fails, errors are passed along`() {
         every {
             mockClient.performRequest(
+                baseURL = mockBaseURL,
                 path = "/receipts/amazon/store_user_id/receipt_id",
                 body = null,
                 requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.ReceiptInfo
@@ -23,16 +24,23 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
+import java.net.URL
 
 private const val API_KEY = "TEST_API_KEY"
 
 @RunWith(AndroidJUnit4::class)
 class SubscriberAttributesPosterTests {
     private var mockClient: HTTPClient = mockk(relaxed = true)
+    private val mockBaseURL = URL("http://mock-api-test.revenuecat.com/")
+    private val mockAppConfig = mockk<AppConfig>().apply {
+        every { baseURL } returns mockBaseURL
+    }
     private val appUserID = "jerry"
     private val syncDispatcher = SyncDispatcher()
+
     private var backend: Backend = Backend(
         API_KEY,
+        mockAppConfig,
         syncDispatcher,
         syncDispatcher,
         mockClient,
@@ -386,6 +394,7 @@ class SubscriberAttributesPosterTests {
     ) {
         val everyMockedCall = every {
             mockClient.performRequest(
+                mockBaseURL,
                 path,
                 (expectedBody ?: any()),
                 mapOf("Authorization" to "Bearer $API_KEY")
@@ -408,6 +417,7 @@ class SubscriberAttributesPosterTests {
     ) {
         every {
             mockClient.performRequest(
+                mockBaseURL,
                 "/receipts",
                 capture(actualPostReceiptBodySlot),
                 mapOf("Authorization" to "Bearer $API_KEY")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -145,11 +145,13 @@ internal class PurchasesFactory(
         backend: Backend,
         dispatcher: Dispatcher
     ): DiagnosticsManager {
+        val sharedPreferences = DiagnosticsManager.initializeSharedPreferences(context)
         return DiagnosticsManager(
             DiagnosticsFileHelper(FileHelper(context)),
             DiagnosticsAnonymizer(),
             backend,
-            dispatcher
+            dispatcher,
+            sharedPreferences
         )
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -61,6 +61,7 @@ internal class PurchasesFactory(
             val dispatcher = Dispatcher(service ?: createDefaultExecutor())
             val backend = Backend(
                 apiKey,
+                appConfig,
                 dispatcher,
                 diagnosticsDispatcher,
                 HTTPClient(appConfig, eTagManager)


### PR DESCRIPTION
### Description
Based off https://github.com/RevenueCat/purchases-android/pull/766.
Deals with [CSDK-647](https://revenuecats.atlassian.net/browse/CSDK-647) and [CSDK-648](https://revenuecats.atlassian.net/browse/CSDK-648)

This PR adds support for the backend request of the telemetry feature. We will gzip compress the request to save data usage.

This PR still hasn't been tested against the backend currently.

[CSDK-647]: https://revenuecats.atlassian.net/browse/CSDK-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CSDK-648]: https://revenuecats.atlassian.net/browse/CSDK-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ