### PR TITLE
Revert "Update gems"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 92650e40d28b17899ca0cf80c8ba165931e4ab14
+  revision: 92553666e4619634ddc661eacfe1734d0716e909
+  branch: main
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,30 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 738f255ee8c6d4dbbb9ebdda79782ed90529e00a
+  revision: 92650e40d28b17899ca0cf80c8ba165931e4ab14
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.6)
+    CFPropertyList (3.0.5)
       rexml
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.701.0)
-    aws-sdk-core (3.170.0)
+    aws-partitions (1.643.0)
+    aws-sdk-core (3.158.1)
       aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.651.0)
-      aws-sigv4 (~> 1.5)
-      jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.62.0)
-      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.119.0)
-      aws-sdk-core (~> 3, >= 3.165.0)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.58.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.114.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.2)
@@ -41,18 +41,18 @@ GEM
       highline (~> 2.0.0)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (9.2.0)
+    danger (8.6.1)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
       cork (~> 0.1)
-      faraday (>= 0.9.0, < 3.0)
+      faraday (>= 0.9.0, < 2.0)
       faraday-http-cache (~> 2.0)
       git (~> 1.7)
       kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
-      octokit (~> 5.0)
+      octokit (~> 4.7)
       terminal-table (>= 1, < 4)
     declarative (0.0.20)
     digest-crc (0.6.4)
@@ -61,8 +61,8 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     emoji_regex (3.2.3)
-    excon (0.98.0)
-    faraday (1.10.3)
+    excon (0.93.0)
+    faraday (1.10.2)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -93,7 +93,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.2.6)
-    fastlane (2.211.0)
+    fastlane (2.210.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -134,12 +134,12 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-versioning_android (0.1.0)
     gh_inspector (1.1.3)
-    git (1.13.1)
+    git (1.12.0)
       addressable (~> 2.8)
       rchardet (~> 1.8)
-    google-apis-androidpublisher_v3 (0.33.0)
-      google-apis-core (>= 0.9.1, < 2.a)
-    google-apis-core (0.10.0)
+    google-apis-androidpublisher_v3 (0.29.0)
+      google-apis-core (>= 0.9.0, < 2.a)
+    google-apis-core (0.9.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -148,10 +148,10 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    google-apis-iamcredentials_v1 (0.16.0)
-      google-apis-core (>= 0.9.1, < 2.a)
-    google-apis-playcustomapp_v1 (0.12.0)
-      google-apis-core (>= 0.9.1, < 2.a)
+    google-apis-iamcredentials_v1 (0.15.0)
+      google-apis-core (>= 0.9.0, < 2.a)
+    google-apis-playcustomapp_v1 (0.11.0)
+      google-apis-core (>= 0.9.0, < 2.a)
     google-apis-storage_v1 (0.19.0)
       google-apis-core (>= 0.9.0, < 2.a)
     google-cloud-core (1.6.0)
@@ -160,7 +160,7 @@ GEM
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
     google-cloud-errors (1.3.0)
-    google-cloud-storage (1.44.0)
+    google-cloud-storage (1.43.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
@@ -168,7 +168,7 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
-    googleauth (1.3.0)
+    googleauth (1.2.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -179,15 +179,15 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    jmespath (1.6.2)
-    json (2.6.3)
-    jwt (2.6.0)
+    jmespath (1.6.1)
+    json (2.6.2)
+    jwt (2.5.0)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     memoist (0.16.2)
-    mini_magick (4.12.0)
+    mini_magick (4.11.0)
     mini_mime (1.1.2)
     multi_json (1.15.0)
     multipart-post (2.0.0)
@@ -195,14 +195,14 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     no_proxy_fix (0.1.2)
-    octokit (5.6.1)
+    octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     open4 (1.3.4)
     optparse (0.1.1)
     os (1.1.4)
     plist (3.6.0)
-    public_suffix (5.0.1)
+    public_suffix (5.0.0)
     rake (13.0.6)
     rchardet (1.8.0)
     representable (3.2.0)
@@ -223,7 +223,7 @@ GEM
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simctl (1.6.10)
+    simctl (1.6.8)
       CFPropertyList
       naturally
     terminal-notifier (2.0.0)
@@ -239,7 +239,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
-    webrick (1.8.1)
+    webrick (1.7.0)
     word_wrap (1.0.0)
     xcodeproj (1.22.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -254,7 +254,6 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
-  arm64-darwin
   ruby
 
 DEPENDENCIES
@@ -264,4 +263,4 @@ DEPENDENCIES
   fastlane-plugin-versioning_android
 
 BUNDLED WITH
-   2.4.6
+   2.3.14

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,4 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-versioning_android'
-gem "fastlane-plugin-revenuecat_internal", git: "https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal"
+gem "fastlane-plugin-revenuecat_internal", git: "https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal", branch: "main"


### PR DESCRIPTION
Reverts RevenueCat/purchases-android#765

Our CI (especially deploys) break because `octokit >= 5.x.x` requires Ruby >= 2.7 and we don't have that being used in our jobs

I tried adding them using CircleCi's Ruby Orb but it `rvm` fails to install newer Ruby versions due to `apt-get` issues 🤷‍♂️ 