### PR TITLE
Remove `tag_release_with_latest_if_needed` fastlane lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,37 +49,6 @@ platform :android do
     )
   end
 
-  desc "Tag release version with latest if necessary"
-  lane :tag_release_with_latest_if_needed do |options|
-    release_version = options[:release_version]
-    puts "Release version is #{release_version}"
-
-    sh("git", "checkout", "tags/latest")
-    latest_version = current_version_number
-    puts "Latest version is #{latest_version}"
-
-    # We assume there's already a tag for the version we are tagging as latest
-    sh("git", "checkout", release_version)
-
-    unless Gem::Version.new(release_version) > Gem::Version.new(latest_version)
-      puts "There's a more recent version. Skipping tagging."
-      next
-    end
-    latest_version_commit = sh("git", "rev-list", "--tags=#{release_version}*", "--max-count=1").chomp
-    puts "Tagging #{release_version}, with commit #{latest_version_commit} with latest"
-
-    add_git_tag(
-      tag: "latest",
-      force: true,
-      grouping: "releases",
-      commit: latest_version_commit
-    )
-    push_git_tags(
-      tag: "latest",
-      force: true
-    )
-  end
-
   desc "Automatically bumps version, replaces version numbers, updates changelog and creates PR"
   lane :automatic_bump do |options|
     next_version, type_of_bump = determine_next_version_using_labels(
@@ -99,7 +68,7 @@ platform :android do
     bump(options)
   end
 
-  desc "Creates github release and updates the latest tag"
+  desc "Creates github release"
   lane :github_release do |options|
     release_version = options[:version]
     create_github_release(
@@ -108,7 +77,6 @@ platform :android do
       github_api_token: ENV["GITHUB_TOKEN"],
       changelog_latest_path: changelog_latest_path
     )
-    tag_release_with_latest_if_needed(release_version: release_version)
   end
 
   desc "Upload and close a release"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -31,14 +31,6 @@ Runs all the tests
 
 Replaces version numbers, updates changelog and creates PR
 
-### android tag_release_with_latest_if_needed
-
-```sh
-[bundle exec] fastlane android tag_release_with_latest_if_needed
-```
-
-Tag release version with latest if necessary
-
 ### android automatic_bump
 
 ```sh
@@ -53,7 +45,7 @@ Automatically bumps version, replaces version numbers, updates changelog and cre
 [bundle exec] fastlane android github_release
 ```
 
-Creates github release and updates the latest tag
+Creates github release
 
 ### android deploy
 


### PR DESCRIPTION
I believe we are not using the `latest` tag for anything. We were using it to point to the latest version from the docs