### PR TITLE
Diagnostics: Anonymize events

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Anonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Anonymizer.kt
@@ -5,18 +5,28 @@ class Anonymizer {
         const val EMAIL_REGEX = "[a-zA-Z0-9_!#\$%&'*+/=?`{|}~^.]+@[a-zA-Z0-9]+\\.[a-zA-Z]+" // Based on RFC5322
         const val UUID_REGEX = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
         const val IP_REGEX = "((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}"
+
+        const val REDACTED = "*****"
     }
 
     private val anonymizeRegex = Regex("$EMAIL_REGEX|$UUID_REGEX|$IP_REGEX")
 
-    fun anonymizeString(textToAnonymize: String): String {
-        return textToAnonymize.replace(anonymizeRegex, "*****")
+    fun anonymizedString(textToAnonymize: String): String {
+        return textToAnonymize.replace(anonymizeRegex, REDACTED)
     }
 
-    fun anonymizeMap(mapToAnonymize: Map<String, Any>): Map<String, Any> {
-        return mapToAnonymize.mapValues { (_, value) ->
-            if (value is String) anonymizeString(value)
-            else value
+    fun anonymizedMap(mapToAnonymize: Map<String, Any>): Map<String, Any> {
+        return mapToAnonymize.mapValues { (_, value) -> anonymizedAny(value) }
+    }
+
+    private fun anonymizedAny(valueToAnonymize: Any): Any {
+        return when(valueToAnonymize) {
+            is String -> anonymizedString(valueToAnonymize)
+            is List<*> -> valueToAnonymize.map { if (it == null) null else anonymizedAny(it) }
+            is Map<*, *> -> valueToAnonymize.mapValues { (_, value) ->
+                if (value == null) null else anonymizedAny(value)
+            }
+            else -> valueToAnonymize
         }
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/Anonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Anonymizer.kt
@@ -12,4 +12,11 @@ class Anonymizer {
     fun anonymizeString(textToAnonymize: String): String {
         return textToAnonymize.replace(anonymizeRegex, "*****")
     }
+
+    fun anonymizeMap(mapToAnonymize: Map<String, Any>): Map<String, Any> {
+        return mapToAnonymize.mapValues { (_, value) ->
+            if (value is String) anonymizeString(value)
+            else value
+        }
+    }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/Anonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Anonymizer.kt
@@ -20,7 +20,7 @@ class Anonymizer {
     }
 
     private fun anonymizedAny(valueToAnonymize: Any): Any {
-        return when(valueToAnonymize) {
+        return when (valueToAnonymize) {
             is String -> anonymizedString(valueToAnonymize)
             is List<*> -> valueToAnonymize.map { if (it == null) null else anonymizedAny(it) }
             is Map<*, *> -> valueToAnonymize.mapValues { (_, value) ->

--- a/common/src/main/java/com/revenuecat/purchases/common/Anonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Anonymizer.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.purchases.common
+
+class Anonymizer {
+    private companion object {
+        const val EMAIL_REGEX = "[a-zA-Z0-9_!#\$%&'*+/=?`{|}~^.]+@[a-zA-Z0-9]+\\.[a-zA-Z]+" // Based on RFC5322
+        const val UUID_REGEX = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+        const val IP_REGEX = "((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}"
+    }
+
+    private val anonymizeRegex = Regex("$EMAIL_REGEX|$UUID_REGEX|$IP_REGEX")
+
+    fun anonymizeString(textToAnonymize: String): String {
+        return textToAnonymize.replace(anonymizeRegex, "*****")
+    }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
@@ -15,13 +15,13 @@ class DiagnosticsAnonymizer(
 
     private fun anonymizeLog(diagnosticsLog: DiagnosticsEvent.Log): DiagnosticsEvent {
         return diagnosticsLog.copy(
-            properties = anonymizer.anonymizeMap(diagnosticsLog.properties)
+            properties = anonymizer.anonymizedMap(diagnosticsLog.properties)
         )
     }
 
     private fun anonymizeException(diagnosticsException: DiagnosticsEvent.Exception): DiagnosticsEvent {
         return diagnosticsException.copy(
-            message = anonymizer.anonymizeString(diagnosticsException.message)
+            message = anonymizer.anonymizedString(diagnosticsException.message)
         )
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
@@ -15,24 +15,13 @@ class DiagnosticsAnonymizer(
 
     private fun anonymizeLog(diagnosticsLog: DiagnosticsEvent.Log): DiagnosticsEvent {
         return diagnosticsLog.copy(
-            properties = anonymizeMap(diagnosticsLog.properties)
+            properties = anonymizer.anonymizeMap(diagnosticsLog.properties)
         )
     }
 
     private fun anonymizeException(diagnosticsException: DiagnosticsEvent.Exception): DiagnosticsEvent {
         return diagnosticsException.copy(
-            message = anonymizeString(diagnosticsException.message)
+            message = anonymizer.anonymizeString(diagnosticsException.message)
         )
-    }
-
-    private fun anonymizeMap(mapToAnonymize: Map<String, Any>): Map<String, Any> {
-        return mapToAnonymize.mapValues { (_, value) ->
-            if (value is String) anonymizeString(value)
-            else value
-        }
-    }
-
-    private fun anonymizeString(textToAnonymize: String): String {
-        return anonymizer.anonymizeString(textToAnonymize)
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
@@ -6,7 +6,7 @@ class DiagnosticsAnonymizer(
     private val anonymizer: Anonymizer
 ) {
     fun anonymizeEventIfNeeded(diagnosticsEvent: DiagnosticsEvent): DiagnosticsEvent {
-        return when(diagnosticsEvent) {
+        return when (diagnosticsEvent) {
             is DiagnosticsEvent.Log -> anonymizeLog(diagnosticsEvent)
             is DiagnosticsEvent.Exception -> anonymizeException(diagnosticsEvent)
             is DiagnosticsEvent.Metric -> diagnosticsEvent

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
@@ -1,8 +1,38 @@
 package com.revenuecat.purchases.common.diagnostics
 
-class DiagnosticsAnonymizer {
+import com.revenuecat.purchases.common.Anonymizer
+
+class DiagnosticsAnonymizer(
+    private val anonymizer: Anonymizer
+) {
     fun anonymizeEventIfNeeded(diagnosticsEvent: DiagnosticsEvent): DiagnosticsEvent {
-        // WIP: Anonymize
-        return diagnosticsEvent
+        return when(diagnosticsEvent) {
+            is DiagnosticsEvent.Log -> anonymizeLog(diagnosticsEvent)
+            is DiagnosticsEvent.Exception -> anonymizeException(diagnosticsEvent)
+            is DiagnosticsEvent.Metric -> diagnosticsEvent
+        }
+    }
+
+    private fun anonymizeLog(diagnosticsLog: DiagnosticsEvent.Log): DiagnosticsEvent {
+        return diagnosticsLog.copy(
+            properties = anonymizeMap(diagnosticsLog.properties)
+        )
+    }
+
+    private fun anonymizeException(diagnosticsException: DiagnosticsEvent.Exception): DiagnosticsEvent {
+        return diagnosticsException.copy(
+            message = anonymizeString(diagnosticsException.message)
+        )
+    }
+
+    private fun anonymizeMap(mapToAnonymize: Map<String, Any>): Map<String, Any> {
+        return mapToAnonymize.mapValues { (_, value) ->
+            if (value is String) anonymizeString(value)
+            else value
+        }
+    }
+
+    private fun anonymizeString(textToAnonymize: String): String {
+        return anonymizer.anonymizeString(textToAnonymize)
     }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/AnonymizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/AnonymizerTest.kt
@@ -17,6 +17,8 @@ class AnonymizerTest {
         anonymizer = Anonymizer()
     }
 
+    // region anonymizeString
+
     @Test
     fun `anonymizeString removes emails`() {
         val originalString = "Some random text with an sample.123+34@revenuecat.com and test.1@gmail.com email."
@@ -45,4 +47,29 @@ class AnonymizerTest {
         val expectedString = "Some random text with a ***** uuid and a ***** email and a random ***** ip"
         assertThat(anonymizer.anonymizeString(originalString)).isEqualTo(expectedString)
     }
+
+    // endregion
+
+    // region anonymizeMap
+
+    @Test
+    fun `anonymizeMap anonymizes all string fields if needed`() {
+        val originalMap = mapOf(
+            "key-1" to 1234,
+            "key-2" to "string with some.pii@revenuecat.com and 192.168.1.1.",
+            "key-3" to true,
+            "key-4" to "string without pii",
+            "key-5" to "string with other.pii@revenuecat.com"
+        )
+        val expectedMap = mapOf(
+            "key-1" to 1234,
+            "key-2" to "string with ***** and *****.",
+            "key-3" to true,
+            "key-4" to "string without pii",
+            "key-5" to "string with *****"
+        )
+        assertThat(anonymizer.anonymizeMap(originalMap)).isEqualTo(expectedMap)
+    }
+
+    // endregion
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/AnonymizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/AnonymizerTest.kt
@@ -23,21 +23,21 @@ class AnonymizerTest {
     fun `anonymizeString removes emails`() {
         val originalString = "Some random text with an sample.123+34@revenuecat.com and test.1@gmail.com email."
         val expectedString = "Some random text with an ***** and ***** email."
-        assertThat(anonymizer.anonymizeString(originalString)).isEqualTo(expectedString)
+        assertThat(anonymizer.anonymizedString(originalString)).isEqualTo(expectedString)
     }
 
     @Test
     fun `anonymizeString removes UUIDs`() {
         val originalString = "Some random text with a 2c5e8760-a864-11ed-afa1-0242ac120002 uuid."
         val expectedString = "Some random text with a ***** uuid."
-        assertThat(anonymizer.anonymizeString(originalString)).isEqualTo(expectedString)
+        assertThat(anonymizer.anonymizedString(originalString)).isEqualTo(expectedString)
     }
 
     @Test
     fun `anonymizeString removes IPs`() {
         val originalString = "Some random text with a 192.168.1.1 ip."
         val expectedString = "Some random text with a ***** ip."
-        assertThat(anonymizer.anonymizeString(originalString)).isEqualTo(expectedString)
+        assertThat(anonymizer.anonymizedString(originalString)).isEqualTo(expectedString)
     }
 
     @Test
@@ -45,7 +45,7 @@ class AnonymizerTest {
         val originalString = "Some random text with a 685a5091-7e0b-44c0-a948-61ce324477c4 uuid and a " +
             "random.test@revenuecat.com email and a random 1.1.1.1 ip"
         val expectedString = "Some random text with a ***** uuid and a ***** email and a random ***** ip"
-        assertThat(anonymizer.anonymizeString(originalString)).isEqualTo(expectedString)
+        assertThat(anonymizer.anonymizedString(originalString)).isEqualTo(expectedString)
     }
 
     // endregion
@@ -68,7 +68,53 @@ class AnonymizerTest {
             "key-4" to "string without pii",
             "key-5" to "string with *****"
         )
-        assertThat(anonymizer.anonymizeMap(originalMap)).isEqualTo(expectedMap)
+        assertThat(anonymizer.anonymizedMap(originalMap)).isEqualTo(expectedMap)
+    }
+
+    @Test
+    fun `anonymizeMap anonymizes lists`() {
+        val originalMap = mapOf(
+            "key-1" to 1234,
+            "key-2" to "string with some.pii@revenuecat.com and 192.168.1.1.",
+            "key-3" to listOf("some string with some.pii@revenuecat.com", "and some without", 1234),
+            "key-4" to "string without pii",
+            "key-5" to "string with other.pii@revenuecat.com"
+        )
+        val expectedMap = mapOf(
+            "key-1" to 1234,
+            "key-2" to "string with ***** and *****.",
+            "key-3" to listOf("some string with *****", "and some without", 1234),
+            "key-4" to "string without pii",
+            "key-5" to "string with *****"
+        )
+        assertThat(anonymizer.anonymizedMap(originalMap)).isEqualTo(expectedMap)
+    }
+
+    @Test
+    fun `anonymizeMap anonymizes nested maps`() {
+        val originalMap = mapOf(
+            "key-1" to 1234,
+            "key-2" to "string with some.pii@revenuecat.com and 192.168.1.1.",
+            "key-3" to mapOf(
+                "nested-key-1" to "some random.email@revenuecat.com",
+                "nested-key-2" to 4321,
+                "nested-key-3" to "string without PII"
+            ),
+            "key-4" to "string without pii",
+            "key-5" to "string with other.pii@revenuecat.com"
+        )
+        val expectedMap = mapOf(
+            "key-1" to 1234,
+            "key-2" to "string with ***** and *****.",
+            "key-3" to mapOf(
+                "nested-key-1" to "some *****",
+                "nested-key-2" to 4321,
+                "nested-key-3" to "string without PII"
+            ),
+            "key-4" to "string without pii",
+            "key-5" to "string with *****"
+        )
+        assertThat(anonymizer.anonymizedMap(originalMap)).isEqualTo(expectedMap)
     }
 
     // endregion

--- a/common/src/test/java/com/revenuecat/purchases/common/AnonymizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/AnonymizerTest.kt
@@ -1,0 +1,48 @@
+package com.revenuecat.purchases.common
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class AnonymizerTest {
+    private lateinit var anonymizer: Anonymizer
+
+    @Before
+    fun setup() {
+        anonymizer = Anonymizer()
+    }
+
+    @Test
+    fun `anonymizeString removes emails`() {
+        val originalString = "Some random text with an sample.123+34@revenuecat.com and test.1@gmail.com email."
+        val expectedString = "Some random text with an ***** and ***** email."
+        assertThat(anonymizer.anonymizeString(originalString)).isEqualTo(expectedString)
+    }
+
+    @Test
+    fun `anonymizeString removes UUIDs`() {
+        val originalString = "Some random text with a 2c5e8760-a864-11ed-afa1-0242ac120002 uuid."
+        val expectedString = "Some random text with a ***** uuid."
+        assertThat(anonymizer.anonymizeString(originalString)).isEqualTo(expectedString)
+    }
+
+    @Test
+    fun `anonymizeString removes IPs`() {
+        val originalString = "Some random text with a 192.168.1.1 ip."
+        val expectedString = "Some random text with a ***** ip."
+        assertThat(anonymizer.anonymizeString(originalString)).isEqualTo(expectedString)
+    }
+
+    @Test
+    fun `anonymizeString removes multiple pieces of PII`() {
+        val originalString = "Some random text with a 685a5091-7e0b-44c0-a948-61ce324477c4 uuid and a " +
+            "random.test@revenuecat.com email and a random 1.1.1.1 ip"
+        val expectedString = "Some random text with a ***** uuid and a ***** email and a random ***** ip"
+        assertThat(anonymizer.anonymizeString(originalString)).isEqualTo(expectedString)
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
@@ -52,7 +52,7 @@ class DiagnosticsAnonymizerTest {
             dateTime = testDate
         )
         every {
-            anonymizer.anonymizeMap(originalPropertiesMap)
+            anonymizer.anonymizedMap(originalPropertiesMap)
         } returns expectedPropertiesMap
         val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(eventToAnonymize)
         assertThat(anonymizedEvent).isEqualTo(expectedEvent)
@@ -74,7 +74,7 @@ class DiagnosticsAnonymizerTest {
             dateTime = testDate
         )
         every {
-            anonymizer.anonymizeString("Some message with possible PII")
+            anonymizer.anonymizedString("Some message with possible PII")
         } returns "Some message without PII"
         val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(eventToAnonymize)
         assertThat(anonymizedEvent).isEqualTo(expectedEvent)

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
@@ -1,0 +1,94 @@
+package com.revenuecat.purchases.common.diagnostics
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.Anonymizer
+import com.revenuecat.purchases.common.DateProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class DiagnosticsAnonymizerTest {
+
+    private val testDate = Date(1675954145L) // Thursday, February 9, 2023 2:49:05 PM GMT
+
+    private lateinit var anonymizer: Anonymizer
+
+    private lateinit var diagnosticsAnonymizer: DiagnosticsAnonymizer
+
+    private lateinit var testDateProvider: DateProvider
+
+    @Before
+    fun setup() {
+        testDateProvider = object : DateProvider {
+            override val now: Date
+                get() = testDate
+        }
+
+        anonymizer = mockk()
+
+        diagnosticsAnonymizer = DiagnosticsAnonymizer(anonymizer)
+    }
+
+    @Test
+    fun `anonymizeEventIfNeeded anonymizes log properties`() {
+        val eventToAnonymize = DiagnosticsEvent.Log(
+            name = DiagnosticsLogEventName.ENDPOINT_HIT,
+            properties = mapOf("key-1" to "value-1", "key-2" to 123, "key-3" to true, "key-4" to "value-4"),
+            dateProvider = testDateProvider
+        )
+        val expectedEvent = DiagnosticsEvent.Log(
+            name = DiagnosticsLogEventName.ENDPOINT_HIT,
+            properties = mapOf("key-1" to "anon-value-1", "key-2" to 123, "key-3" to true, "key-4" to "anon-value-4"),
+            dateProvider = testDateProvider,
+            time = testDate
+        )
+        every {
+            anonymizer.anonymizeString("value-1")
+        } returns "anon-value-1"
+        every {
+            anonymizer.anonymizeString("value-4")
+        } returns "anon-value-4"
+        val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(eventToAnonymize)
+        assertThat(anonymizedEvent).isEqualTo(expectedEvent)
+    }
+
+    @Test
+    fun `anonymizeEventIfNeeded anonymizes exception message`() {
+        val eventToAnonymize = DiagnosticsEvent.Exception(
+            exceptionClass = "TestClass",
+            message = "Some message with possible PII",
+            location = "TestClass:131",
+            dateProvider = testDateProvider
+        )
+        val expectedEvent = DiagnosticsEvent.Exception(
+            exceptionClass = "TestClass",
+            message = "Some message without PII",
+            location = "TestClass:131",
+            dateProvider = testDateProvider,
+            time = testDate
+        )
+        every {
+            anonymizer.anonymizeString("Some message with possible PII")
+        } returns "Some message without PII"
+        val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(eventToAnonymize)
+        assertThat(anonymizedEvent).isEqualTo(expectedEvent)
+    }
+
+    @Test
+    fun `anonymizeEventIfNeeded does not anonymize metric`() {
+        val eventToAnonymize = DiagnosticsEvent.Metric(
+            name = "metric-name",
+            tags = listOf("tag-1", "tag-2"),
+            value = 123
+        )
+        val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(eventToAnonymize)
+        assertThat(anonymizedEvent).isEqualTo(eventToAnonymize)
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
@@ -38,23 +38,22 @@ class DiagnosticsAnonymizerTest {
 
     @Test
     fun `anonymizeEventIfNeeded anonymizes log properties`() {
+        val originalPropertiesMap = mapOf("key-1" to "value-1")
+        val expectedPropertiesMap = mapOf("key-1" to "anonymized-value-1")
         val eventToAnonymize = DiagnosticsEvent.Log(
             name = DiagnosticsLogEventName.ENDPOINT_HIT,
-            properties = mapOf("key-1" to "value-1", "key-2" to 123, "key-3" to true, "key-4" to "value-4"),
+            properties = originalPropertiesMap,
             dateProvider = testDateProvider
         )
         val expectedEvent = DiagnosticsEvent.Log(
             name = DiagnosticsLogEventName.ENDPOINT_HIT,
-            properties = mapOf("key-1" to "anon-value-1", "key-2" to 123, "key-3" to true, "key-4" to "anon-value-4"),
+            properties = expectedPropertiesMap,
             dateProvider = testDateProvider,
-            time = testDate
+            dateTime = testDate
         )
         every {
-            anonymizer.anonymizeString("value-1")
-        } returns "anon-value-1"
-        every {
-            anonymizer.anonymizeString("value-4")
-        } returns "anon-value-4"
+            anonymizer.anonymizeMap(originalPropertiesMap)
+        } returns expectedPropertiesMap
         val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(eventToAnonymize)
         assertThat(anonymizedEvent).isEqualTo(expectedEvent)
     }
@@ -72,7 +71,7 @@ class DiagnosticsAnonymizerTest {
             message = "Some message without PII",
             location = "TestClass:131",
             dateProvider = testDateProvider,
-            time = testDate
+            dateTime = testDate
         )
         every {
             anonymizer.anonymizeString("Some message with possible PII")


### PR DESCRIPTION
### Description
Based on #785 
Deals with [CSDK-652](https://revenuecats.atlassian.net/browse/CSDK-652)

This PR introduces some basic anonymization guardrails for diagnostics events. Currently we remove emails, uuids and ips from exception error messages, the only arbitrary piece of data.


[CSDK-652]: https://revenuecats.atlassian.net/browse/CSDK-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ