### PR TITLE
Diagnostics: Add diagnostics event types

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEvent.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEvent.kt
@@ -1,7 +1,10 @@
 package com.revenuecat.purchases.common.diagnostics
 
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.DefaultDateProvider
 import org.json.JSONArray
 import org.json.JSONObject
+import java.util.Date
 
 sealed class DiagnosticsEvent(val diagnosticType: String) {
     companion object {
@@ -14,7 +17,8 @@ sealed class DiagnosticsEvent(val diagnosticType: String) {
     data class Log(
         val name: DiagnosticsLogEventName,
         val properties: Map<String, Any>,
-        val timestamp: String
+        val dateProvider: DateProvider = DefaultDateProvider(),
+        val time: Date = dateProvider.now
     ) : DiagnosticsEvent("log") {
         private companion object {
             const val NAME_KEY = "name"
@@ -31,7 +35,7 @@ sealed class DiagnosticsEvent(val diagnosticType: String) {
             put(TYPE_KEY, diagnosticType)
             put(NAME_KEY, name.name.lowercase())
             put(PROPERTIES_KEY, JSONObject(properties))
-            put(TIMESTAMP_KEY, timestamp)
+            put(TIMESTAMP_KEY, time.time)
         }
     }
 
@@ -63,7 +67,8 @@ sealed class DiagnosticsEvent(val diagnosticType: String) {
         val exceptionClass: String,
         val message: String,
         val location: String,
-        val timestamp: String
+        val dateProvider: DateProvider = DefaultDateProvider(),
+        val time: Date = dateProvider.now
     ) : DiagnosticsEvent("exception") {
         private companion object {
             const val EXCEPTION_CLASS_KEY = "exc_class"
@@ -82,7 +87,7 @@ sealed class DiagnosticsEvent(val diagnosticType: String) {
             put(EXCEPTION_CLASS_KEY, exceptionClass)
             put(MESSAGE_KEY, message)
             put(LOCATION_KEY, location)
-            put(TIMESTAMP_KEY, timestamp)
+            put(TIMESTAMP_KEY, time.time)
         }
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEvent.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEvent.kt
@@ -18,7 +18,7 @@ sealed class DiagnosticsEvent(val diagnosticType: String) {
         val name: DiagnosticsLogEventName,
         val properties: Map<String, Any>,
         val dateProvider: DateProvider = DefaultDateProvider(),
-        val time: Date = dateProvider.now
+        val dateTime: Date = dateProvider.now
     ) : DiagnosticsEvent("log") {
         private companion object {
             const val NAME_KEY = "name"
@@ -35,7 +35,7 @@ sealed class DiagnosticsEvent(val diagnosticType: String) {
             put(TYPE_KEY, diagnosticType)
             put(NAME_KEY, name.name.lowercase())
             put(PROPERTIES_KEY, JSONObject(properties))
-            put(TIMESTAMP_KEY, time.time)
+            put(TIMESTAMP_KEY, dateTime.time)
         }
     }
 
@@ -68,7 +68,7 @@ sealed class DiagnosticsEvent(val diagnosticType: String) {
         val message: String,
         val location: String,
         val dateProvider: DateProvider = DefaultDateProvider(),
-        val time: Date = dateProvider.now
+        val dateTime: Date = dateProvider.now
     ) : DiagnosticsEvent("exception") {
         private companion object {
             const val EXCEPTION_CLASS_KEY = "exc_class"
@@ -87,7 +87,7 @@ sealed class DiagnosticsEvent(val diagnosticType: String) {
             put(EXCEPTION_CLASS_KEY, exceptionClass)
             put(MESSAGE_KEY, message)
             put(LOCATION_KEY, location)
-            put(TIMESTAMP_KEY, time.time)
+            put(TIMESTAMP_KEY, dateTime.time)
         }
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEvent.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEvent.kt
@@ -1,0 +1,88 @@
+package com.revenuecat.purchases.common.diagnostics
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+sealed class DiagnosticsEvent(val diagnosticType: String) {
+    companion object {
+        private const val VERSION_KEY = "version"
+        private const val TYPE_KEY = "type"
+
+        private const val VERSION = 1
+    }
+
+    data class Log(
+        val name: DiagnosticsLogEventName,
+        val properties: Map<String, Any>,
+        val timestamp: String
+    ) : DiagnosticsEvent("log") {
+        private companion object {
+            const val NAME_KEY = "name"
+            const val PROPERTIES_KEY = "properties"
+            const val TIMESTAMP_KEY = "timestamp"
+        }
+
+        override fun toString(): String {
+            return toJSONObject().toString()
+        }
+
+        private fun toJSONObject() = JSONObject().apply {
+            put(VERSION_KEY, VERSION)
+            put(TYPE_KEY, diagnosticType)
+            put(NAME_KEY, name.name.lowercase())
+            put(PROPERTIES_KEY, JSONObject(properties))
+            put(TIMESTAMP_KEY, timestamp)
+        }
+    }
+
+    data class Metric(
+        val name: String,
+        val tags: List<String>,
+        val value: Int
+    ) : DiagnosticsEvent("metric") {
+        private companion object {
+            const val NAME_KEY = "name"
+            const val TAGS_KEY = "tags"
+            const val VALUE_KEY = "value"
+        }
+
+        override fun toString(): String {
+            return toJSONObject().toString()
+        }
+
+        private fun toJSONObject() = JSONObject().apply {
+            put(VERSION_KEY, VERSION)
+            put(TYPE_KEY, diagnosticType)
+            put(NAME_KEY, name.lowercase())
+            put(TAGS_KEY, JSONArray(tags))
+            put(VALUE_KEY, value)
+        }
+    }
+
+    data class Exception(
+        val exceptionClass: String,
+        val message: String,
+        val location: String,
+        val timestamp: String
+    ) : DiagnosticsEvent("exception") {
+        private companion object {
+            const val EXCEPTION_CLASS_KEY = "exc_class"
+            const val MESSAGE_KEY = "message"
+            const val LOCATION_KEY = "location"
+            const val TIMESTAMP_KEY = "timestamp"
+        }
+
+        override fun toString(): String {
+            return toJSONObject().toString()
+        }
+
+        private fun toJSONObject() = JSONObject().apply {
+            put(VERSION_KEY, VERSION)
+            put(TYPE_KEY, diagnosticType)
+            put(EXCEPTION_CLASS_KEY, exceptionClass)
+            put(MESSAGE_KEY, message)
+            put(LOCATION_KEY, location)
+            put(TIMESTAMP_KEY, timestamp)
+        }
+    }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsLogEventName.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsLogEventName.kt
@@ -1,0 +1,5 @@
+package com.revenuecat.purchases.common.diagnostics
+
+enum class DiagnosticsLogEventName {
+    ENDPOINT_HIT
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEventTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEventTest.kt
@@ -1,21 +1,36 @@
 package com.revenuecat.purchases.common.diagnostics
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.DateProvider
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.util.Date
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 class DiagnosticsEventTest {
+
+    private val testDate = Date(1675954145L) // Thursday, February 9, 2023 2:49:05 PM GMT
+
+    private lateinit var testDateProvider: DateProvider
+
+    @Before
+    fun setup() {
+        testDateProvider = object : DateProvider {
+            override val now: Date
+                get() = testDate
+        }
+    }
 
     @Test
     fun `toString transforms log event to correct JSON`() {
         val event = DiagnosticsEvent.Log(
             name = DiagnosticsLogEventName.ENDPOINT_HIT,
             properties = mapOf("test-key-1" to "test-value-1", "test-key-2" to 123, "test-key-3" to true),
-            timestamp = "timestamp"
+            dateProvider = testDateProvider
         )
         val eventAsString = event.toString()
         val expectedString = "{" +
@@ -23,7 +38,7 @@ class DiagnosticsEventTest {
             "\"type\":\"log\"," +
             "\"name\":\"endpoint_hit\"," +
             "\"properties\":{\"test-key-1\":\"test-value-1\",\"test-key-2\":123,\"test-key-3\":true}," +
-            "\"timestamp\":\"timestamp\"" +
+            "\"timestamp\":1675954145" +
             "}"
         assertThat(eventAsString).isEqualTo(expectedString)
     }
@@ -52,7 +67,7 @@ class DiagnosticsEventTest {
             exceptionClass = "TestClass.kt",
             message = "test message",
             location = "DiagnosticsEvent:121",
-            timestamp = "timestamp"
+            dateProvider = testDateProvider
         )
         val eventAsString = event.toString()
         val expectedString = "{" +
@@ -61,7 +76,7 @@ class DiagnosticsEventTest {
             "\"exc_class\":\"TestClass.kt\"," +
             "\"message\":\"test message\"," +
             "\"location\":\"DiagnosticsEvent:121\"," +
-            "\"timestamp\":\"timestamp\"" +
+            "\"timestamp\":1675954145" +
             "}"
         assertThat(eventAsString).isEqualTo(expectedString)
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEventTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEventTest.kt
@@ -1,0 +1,68 @@
+package com.revenuecat.purchases.common.diagnostics
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class DiagnosticsEventTest {
+
+    @Test
+    fun `toString transforms log event to correct JSON`() {
+        val event = DiagnosticsEvent.Log(
+            name = DiagnosticsLogEventName.ENDPOINT_HIT,
+            properties = mapOf("test-key-1" to "test-value-1", "test-key-2" to 123, "test-key-3" to true),
+            timestamp = "timestamp"
+        )
+        val eventAsString = event.toString()
+        val expectedString = "{" +
+            "\"version\":1," +
+            "\"type\":\"log\"," +
+            "\"name\":\"endpoint_hit\"," +
+            "\"properties\":{\"test-key-1\":\"test-value-1\",\"test-key-2\":123,\"test-key-3\":true}," +
+            "\"timestamp\":\"timestamp\"" +
+            "}"
+        assertThat(eventAsString).isEqualTo(expectedString)
+    }
+
+    @Test
+    fun `toString transforms metrics event to correct JSON`() {
+        val event = DiagnosticsEvent.Metric(
+            name = "test_metric_name",
+            tags = listOf("test-1", "test-2"),
+            value = 2
+        )
+        val eventAsString = event.toString()
+        val expectedString = "{" +
+            "\"version\":1," +
+            "\"type\":\"metric\"," +
+            "\"name\":\"test_metric_name\"," +
+            "\"tags\":[\"test-1\",\"test-2\"]," +
+            "\"value\":2" +
+            "}"
+        assertThat(eventAsString).isEqualTo(expectedString)
+    }
+
+    @Test
+    fun `toString transforms exception event to correct JSON`() {
+        val event = DiagnosticsEvent.Exception(
+            exceptionClass = "TestClass.kt",
+            message = "test message",
+            location = "DiagnosticsEvent:121",
+            timestamp = "timestamp"
+        )
+        val eventAsString = event.toString()
+        val expectedString = "{" +
+            "\"version\":1," +
+            "\"type\":\"exception\"," +
+            "\"exc_class\":\"TestClass.kt\"," +
+            "\"message\":\"test message\"," +
+            "\"location\":\"DiagnosticsEvent:121\"," +
+            "\"timestamp\":\"timestamp\"" +
+            "}"
+        assertThat(eventAsString).isEqualTo(expectedString)
+    }
+}


### PR DESCRIPTION
### Description
 This is the first PR in a series of PRs to support sending diagnostic data from our SDKs to our backend. In this PR, we are just adding the models that we can potentially send to the backend.

This work is based on #766 but I'm splitting it up to make it easier to review. It's pointing to the `diagnostics` branch so we don't merge to main until everything is ready.
