### PR TITLE
Diagnostics: Add jsonl file management for diagnostics

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/FileHelper.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/FileHelper.kt
@@ -1,0 +1,65 @@
+package com.revenuecat.purchases.common
+
+import android.content.Context
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.InputStreamReader
+
+class FileHelper(
+    private val applicationContext: Context,
+) {
+    fun appendToFile(filePath: String, contentToAppend: String) {
+        val file = getFileInFilesDir(filePath)
+        file.parentFile?.mkdirs()
+        val shouldAppend = true
+        val outputStream = FileOutputStream(file, shouldAppend)
+        outputStream.use {
+            outputStream.write(contentToAppend.toByteArray())
+        }
+    }
+
+    fun deleteFile(filePath: String): Boolean {
+        val file = getFileInFilesDir(filePath)
+        return file.delete()
+    }
+
+    fun readFilePerLines(filePath: String): List<String> {
+        val readLines = mutableListOf<String>()
+        val file = getFileInFilesDir(filePath)
+        FileInputStream(file).use { fileInputStream ->
+            InputStreamReader(fileInputStream).use { inputStreamReader ->
+                BufferedReader(inputStreamReader).use { bufferedReader ->
+                    readLines.addAll(bufferedReader.readLines())
+                }
+            }
+        }
+        return readLines
+    }
+
+    fun removeFirstLinesFromFile(filePath: String, numberOfLinesToRemove: Int) {
+        val readLines = readFilePerLines(filePath)
+        deleteFile(filePath)
+        val textToAppend = if (readLines.isEmpty() || numberOfLinesToRemove >= readLines.size) {
+            errorLog("Trying to remove $numberOfLinesToRemove from file with ${readLines.size} lines.")
+            ""
+        } else {
+            readLines.subList(numberOfLinesToRemove, readLines.size).joinToString(separator = "")
+        }
+        appendToFile(filePath, textToAppend)
+    }
+
+    fun fileIsEmpty(filePath: String): Boolean {
+        val file = getFileInFilesDir(filePath)
+        return !file.exists() || file.length() == 0L
+    }
+
+    private fun getFileInFilesDir(filePath: String): File {
+        return File(getFilesDir(), filePath)
+    }
+
+    private fun getFilesDir(): File {
+        return applicationContext.filesDir
+    }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
@@ -1,0 +1,42 @@
+package com.revenuecat.purchases.common.diagnostics
+
+import com.revenuecat.purchases.common.FileHelper
+import com.revenuecat.purchases.common.verboseLog
+import org.json.JSONObject
+
+/**
+ * All methods in this file should be executed within the diagnostics thread to ensure there are no threading issues.
+ */
+class DiagnosticsFileHelper(
+    private val fileHelper: FileHelper
+) {
+    companion object {
+        const val DIAGNOSTICS_FILE_PATH = "RevenueCat/diagnostics/diagnostic_events.jsonl"
+    }
+
+    @Synchronized
+    fun appendEventToDiagnosticsFile(diagnosticsEvent: DiagnosticsEvent) {
+        fileHelper.appendToFile(DIAGNOSTICS_FILE_PATH, diagnosticsEvent.toString() + "\n")
+    }
+
+    @Synchronized
+    fun cleanSentDiagnostics(diagnosticsSentCount: Int) {
+        fileHelper.removeFirstLinesFromFile(DIAGNOSTICS_FILE_PATH, diagnosticsSentCount)
+    }
+
+    @Synchronized
+    fun deleteDiagnosticsFile() {
+        if (!fileHelper.deleteFile(DIAGNOSTICS_FILE_PATH)) {
+            verboseLog("Failed to delete diagnostics file.")
+        }
+    }
+
+    @Synchronized
+    fun readDiagnosticsFile(): List<JSONObject> {
+        return if (fileHelper.fileIsEmpty(DIAGNOSTICS_FILE_PATH)) {
+            emptyList()
+        } else {
+            fileHelper.readFilePerLines(DIAGNOSTICS_FILE_PATH).map { JSONObject(it) }
+        }
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/FileHelperTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/FileHelperTest.kt
@@ -1,0 +1,139 @@
+package com.revenuecat.purchases.common
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Fail.fail
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class FileHelperTest {
+
+    private val testFolder = "temp_test_folder"
+    private val testFilePath = "RevenueCat/test_file.txt"
+
+    private lateinit var applicationContext: Context
+
+    private lateinit var fileHelper: FileHelper
+
+    @Before
+    fun setup() {
+        val tempTestFolder = File(testFolder)
+        if (tempTestFolder.exists()) {
+            error("Temp test folder should not exist before starting tests")
+        }
+        tempTestFolder.mkdirs()
+
+        applicationContext = mockk()
+        every { applicationContext.filesDir } returns tempTestFolder
+
+        fileHelper = FileHelper(applicationContext)
+    }
+
+    @After
+    fun tearDown() {
+        val tempTestFolder = File(testFolder)
+        tempTestFolder.deleteRecursively()
+    }
+
+    @Test
+    fun `appendToFile creates file if it does not exist`() {
+        verifyFileDoesNotExist()
+        fileHelper.appendToFile(testFilePath, "test string")
+        verifyFileExistsWithContents("test string")
+    }
+
+    @Test
+    fun `appendToFile appends to file if it exists with content`() {
+        createTestFileWithContents("test string 1")
+        fileHelper.appendToFile(testFilePath, "\ntest string 2")
+        verifyFileExistsWithContents("test string 1\ntest string 2")
+    }
+
+    @Test
+    fun `deleteFile calls appropriate methods`() {
+        createTestFileWithContents("")
+        fileHelper.deleteFile(testFilePath)
+        verifyFileDoesNotExist()
+    }
+
+    @Test
+    fun `removeFirstLinesFromFile leaves content after first lines`() {
+        createTestFileWithContents("first line\nsecond line\nthird line\nfourth line")
+        fileHelper.removeFirstLinesFromFile(testFilePath, 3)
+        verifyFileExistsWithContents("fourth line")
+    }
+
+    @Test
+    fun `removeFirstLinesFromFile leaves empty file if exact lines removed`() {
+        createTestFileWithContents("first line\nsecond line\nthird line")
+        fileHelper.removeFirstLinesFromFile(testFilePath, 3)
+        verifyFileExistsWithContents("")
+    }
+
+    @Test
+    fun `removeFirstLinesFromFile leaves empty file if fewer removed`() {
+        createTestFileWithContents("first line\nsecond line")
+        fileHelper.removeFirstLinesFromFile(testFilePath, 3)
+        verifyFileExistsWithContents("")
+    }
+
+    @Test
+    fun `fileIsEmpty returns true if file exists and is empty`() {
+        createTestFileWithContents("")
+        val fileIsEmpty = fileHelper.fileIsEmpty(testFilePath)
+        assertThat(fileIsEmpty).isTrue
+    }
+
+    @Test
+    fun `fileIsEmpty returns false if file exists and has text`() {
+        createTestFileWithContents("a")
+        val fileIsEmpty = fileHelper.fileIsEmpty(testFilePath)
+        assertThat(fileIsEmpty).isFalse
+    }
+
+    @Test
+    fun `fileIsEmpty returns true if file does not exist`() {
+        verifyFileDoesNotExist()
+        val fileIsEmpty = fileHelper.fileIsEmpty(testFilePath)
+        assertThat(fileIsEmpty).isTrue
+    }
+
+    @Test
+    fun `readFilePerLines returns correct content`() {
+        createTestFileWithContents("first line\nsecond line\nthird line\nfourth line")
+        val filePerLines = fileHelper.readFilePerLines(testFilePath)
+        assertThat(filePerLines).isEqualTo(listOf("first line", "second line", "third line", "fourth line"))
+    }
+
+    private fun verifyFileDoesNotExist() {
+        val file = File(testFolder, testFilePath)
+        if (file.exists()) {
+            fail<Unit>("File $file should not exist")
+        }
+    }
+
+    private fun verifyFileExistsWithContents(expectedContents: String) {
+        val file = File(testFolder, testFilePath)
+        if (!file.exists()) {
+            fail<Unit>("File $file should exist")
+        }
+        val contents = file.readText()
+        assertThat(contents).isEqualTo(expectedContents)
+    }
+
+    private fun createTestFileWithContents(contents: String) {
+        val file = File(testFolder, testFilePath)
+        file.parentFile?.mkdirs()
+        file.createNewFile()
+        file.writeText(contents)
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
@@ -1,0 +1,79 @@
+package com.revenuecat.purchases.common.diagnostics
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.FileHelper
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class DiagnosticsFileHelperTest {
+
+    private val testDiagnosticsEvent = DiagnosticsEvent.Log(
+        name = DiagnosticsLogEventName.ENDPOINT_HIT,
+        properties = emptyMap()
+    )
+    private val diagnosticsFilePath = DiagnosticsFileHelper.DIAGNOSTICS_FILE_PATH
+
+    private lateinit var fileHelper: FileHelper
+
+    private lateinit var diagnosticsFileHelper: DiagnosticsFileHelper
+
+    @Before
+    fun setup() {
+        fileHelper = mockk()
+        diagnosticsFileHelper = DiagnosticsFileHelper(fileHelper)
+    }
+
+    @Test
+    fun `appendEventToDiagnosticsFile calls are correct`() {
+        val contentToAppend = "$testDiagnosticsEvent\n"
+        every { fileHelper.appendToFile(diagnosticsFilePath, contentToAppend) } just Runs
+        diagnosticsFileHelper.appendEventToDiagnosticsFile(testDiagnosticsEvent)
+        verify(exactly = 1) { fileHelper.appendToFile(diagnosticsFilePath, contentToAppend) }
+    }
+
+    @Test
+    fun `cleanSentDiagnostics calls are correct`() {
+        every { fileHelper.removeFirstLinesFromFile(diagnosticsFilePath, 2) } just Runs
+        diagnosticsFileHelper.cleanSentDiagnostics(2)
+        verify(exactly = 1) { fileHelper.removeFirstLinesFromFile(diagnosticsFilePath, 2) }
+    }
+
+    @Test
+    fun `deleteDiagnosticsFile calls are correct`() {
+        every { fileHelper.deleteFile(diagnosticsFilePath) } returns true
+        diagnosticsFileHelper.deleteDiagnosticsFile()
+        verify(exactly = 1) { fileHelper.deleteFile(diagnosticsFilePath) }
+    }
+
+    @Test
+    fun `readDiagnosticsFile returns empty list if file is empty`() {
+        every { fileHelper.fileIsEmpty(diagnosticsFilePath) } returns true
+        assertThat(diagnosticsFileHelper.readDiagnosticsFile()).isEqualTo(emptyList<JSONObject>())
+        verify(exactly = 1) { fileHelper.fileIsEmpty(diagnosticsFilePath) }
+        verify(exactly = 0) { fileHelper.readFilePerLines(diagnosticsFilePath) }
+    }
+
+    @Test
+    fun `readDiagnosticsFile reads content as json`() {
+        every { fileHelper.fileIsEmpty(diagnosticsFilePath) } returns false
+        every { fileHelper.readFilePerLines(diagnosticsFilePath) } returns listOf(
+            "{}", "{\"test_key\": \"test_value\"}"
+        )
+        val result = diagnosticsFileHelper.readDiagnosticsFile()
+        assertThat(result.size).isEqualTo(2)
+        assertThat(result[0].length()).isEqualTo(0)
+        assertThat(result[1]["test_key"]).isEqualTo("test_value")
+        verify(exactly = 1) { fileHelper.readFilePerLines(diagnosticsFilePath) }
+    }
+}


### PR DESCRIPTION
### Description
Based on #783, this PR adds the logic to store and read JSONL files with the events we want to send to the backend.

This has been extracted from #766 and #771 