### PR TITLE
Diagnostics Add diagnostics manager

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -350,6 +350,15 @@ class Backend(
         }
     }
 
+    @Suppress("UnusedPrivateMember") // WIP: Remove suppress
+    fun postDiagnostics(
+        diagnosticsList: List<JSONObject>,
+        onSuccessHandler: (JSONObject) -> Unit,
+        onErrorHandler: (PurchasesError, Boolean) -> Unit
+    ) {
+        // WIP: Perform request
+    }
+
     fun clearCaches() {
         httpClient.clearCaches()
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
@@ -1,0 +1,8 @@
+package com.revenuecat.purchases.common.diagnostics
+
+class DiagnosticsAnonymizer {
+    fun anonymizeEventIfNeeded(diagnosticsEvent: DiagnosticsEvent): DiagnosticsEvent {
+        // WIP: Anonymize
+        return diagnosticsEvent
+    }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManager.kt
@@ -1,0 +1,101 @@
+package com.revenuecat.purchases.common.diagnostics
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.verboseLog
+import java.io.IOException
+
+class DiagnosticsManager(
+    private val diagnosticsFileHelper: DiagnosticsFileHelper,
+    private val diagnosticsAnonymizer: DiagnosticsAnonymizer,
+    private val backend: Backend,
+    private val diagnosticsDispatcher: Dispatcher,
+    private val sharedPreferences: SharedPreferences
+) {
+    companion object {
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        const val CONSECUTIVE_FAILURES_COUNT_KEY = "consecutive_failures_count"
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        const val MAX_NUMBER_RETRIES = 3
+
+        fun initializeSharedPreferences(context: Context): SharedPreferences =
+            context.getSharedPreferences(
+                "com_revenuecat_purchases_${context.packageName}_preferences_diagnostics",
+                Context.MODE_PRIVATE
+            )
+    }
+
+    fun syncDiagnosticsFileIfNeeded() {
+        enqueue {
+            try {
+                val diagnosticsList = diagnosticsFileHelper.readDiagnosticsFile()
+                val diagnosticsCount = diagnosticsList.size
+                if (diagnosticsCount == 0) {
+                    verboseLog("No diagnostics to sync.")
+                    return@enqueue
+                }
+                backend.postDiagnostics(
+                    diagnosticsList = diagnosticsList,
+                    onSuccessHandler = {
+                        verboseLog("Synced diagnostics file successfully.")
+                        clearConsecutiveNumberOfErrors()
+                        diagnosticsFileHelper.cleanSentDiagnostics(diagnosticsCount)
+                    },
+                    onErrorHandler = { error, shouldRetry ->
+                        verboseLog("Error syncing diagnostics file: $error. Should retry: $shouldRetry")
+                        if (shouldRetry) {
+                            val currentRetryCount = increaseConsecutiveNumberOfErrors()
+                            if (currentRetryCount >= MAX_NUMBER_RETRIES) {
+                                resetDiagnosticsStatus()
+                            }
+                        } else {
+                            resetDiagnosticsStatus()
+                        }
+                    }
+                )
+            } catch (e: IOException) {
+                verboseLog("Error syncing diagnostics file: $e")
+                try {
+                    resetDiagnosticsStatus()
+                } catch (e: IOException) {
+                    verboseLog("Error deleting diagnostics file: $e")
+                }
+            }
+        }
+    }
+
+    fun trackEvent(diagnosticsEvent: DiagnosticsEvent) {
+        enqueue {
+            val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(diagnosticsEvent)
+            // WIP: Check that file size is not above certain limit. If it is, delete.
+            verboseLog("Tracking diagnostics event: $anonymizedEvent")
+            try {
+                diagnosticsFileHelper.appendEventToDiagnosticsFile(anonymizedEvent)
+            } catch (e: IOException) {
+                verboseLog("Error tracking diagnostics event: $e")
+            }
+        }
+    }
+
+    private fun enqueue(command: () -> Unit) {
+        diagnosticsDispatcher.enqueue(command = command)
+    }
+
+    private fun clearConsecutiveNumberOfErrors() {
+        sharedPreferences.edit().remove(CONSECUTIVE_FAILURES_COUNT_KEY).apply()
+    }
+
+    private fun increaseConsecutiveNumberOfErrors(): Int {
+        var count = sharedPreferences.getInt(CONSECUTIVE_FAILURES_COUNT_KEY, 0)
+        sharedPreferences.edit().putInt(CONSECUTIVE_FAILURES_COUNT_KEY, ++count).apply()
+        return count
+    }
+
+    private fun resetDiagnosticsStatus() {
+        clearConsecutiveNumberOfErrors()
+        diagnosticsFileHelper.deleteDiagnosticsFile()
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManagerTest.kt
@@ -132,7 +132,7 @@ class DiagnosticsManagerTest {
         mockBackendResponse(testDiagnosticsEventJSONs, errorReturn = errorCallbackResponse)
         every {
             sharedPreferences.getInt(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY, 0)
-        } returns DiagnosticsManager.MAX_NUMBER_RETRIES - 1
+        } returns DiagnosticsManager.MAX_NUMBER_POST_RETRIES - 1
 
         diagnosticsManager.syncDiagnosticsFileIfNeeded()
 
@@ -145,7 +145,7 @@ class DiagnosticsManagerTest {
         mockBackendResponse(testDiagnosticsEventJSONs, errorReturn = errorCallbackResponse)
         every {
             sharedPreferences.getInt(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY, 0)
-        } returns DiagnosticsManager.MAX_NUMBER_RETRIES - 1
+        } returns DiagnosticsManager.MAX_NUMBER_POST_RETRIES - 1
 
         diagnosticsManager.syncDiagnosticsFileIfNeeded()
 
@@ -184,6 +184,13 @@ class DiagnosticsManagerTest {
         every { diagnosticsFileHelper.readDiagnosticsFile() } throws IOException()
         diagnosticsManager.syncDiagnosticsFileIfNeeded()
         verify(exactly = 1) { sharedPreferencesEditor.remove(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY) }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded does not crash if IOException happens when deleting file`() {
+        every { diagnosticsFileHelper.readDiagnosticsFile() } throws IOException()
+        every { diagnosticsFileHelper.deleteDiagnosticsFile() } throws IOException()
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
     }
 
     // endregion

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManagerTest.kt
@@ -1,0 +1,253 @@
+package com.revenuecat.purchases.common.diagnostics
+
+import android.content.SharedPreferences
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.SyncDispatcher
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class DiagnosticsManagerTest {
+
+    private val testDiagnosticsEvent = DiagnosticsEvent.Log(
+        name = DiagnosticsLogEventName.ENDPOINT_HIT,
+        properties = emptyMap()
+    )
+
+    private val testDiagnosticsEventJSONs = listOf(
+        JSONObject(mapOf("test-key" to "test-value")),
+        JSONObject(mapOf("test-key-2" to "test-value-2"))
+    )
+
+    private lateinit var diagnosticsFileHelper: DiagnosticsFileHelper
+    private lateinit var diagnosticsAnonymizer: DiagnosticsAnonymizer
+    private lateinit var backend: Backend
+    private lateinit var dispatcher: Dispatcher
+    private lateinit var sharedPreferences: SharedPreferences
+    private lateinit var sharedPreferencesEditor: SharedPreferences.Editor
+
+    private lateinit var diagnosticsManager: DiagnosticsManager
+
+    @Before
+    fun setup() {
+        diagnosticsFileHelper = mockk()
+        diagnosticsAnonymizer = mockk()
+        backend = mockk()
+        dispatcher = SyncDispatcher()
+
+        mockSharedPreferences()
+        mockDiagnosticsFileHelper()
+
+        diagnosticsManager = DiagnosticsManager(
+            diagnosticsFileHelper,
+            diagnosticsAnonymizer,
+            backend,
+            dispatcher,
+            sharedPreferences
+        )
+    }
+
+    // region syncDiagnosticsFileIfNeeded
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded does not do anything if diagnostics file is empty`() {
+        every { diagnosticsFileHelper.readDiagnosticsFile() } returns emptyList()
+
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+
+        verify(exactly = 1) { diagnosticsFileHelper.readDiagnosticsFile() }
+        verify(exactly = 0) { backend.postDiagnostics(any(), any(), any()) }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded calls backend with correct parameters if file has contents`() {
+        mockBackendResponse(testDiagnosticsEventJSONs)
+
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+
+        verify(exactly = 1) { diagnosticsFileHelper.readDiagnosticsFile() }
+        verify(exactly = 1) { backend.postDiagnostics(testDiagnosticsEventJSONs, any(), any()) }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded cleans sent events if backend request successful`() {
+        mockBackendResponse(testDiagnosticsEventJSONs, successReturn = JSONObject())
+
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+
+        verify(exactly = 1) { diagnosticsFileHelper.cleanSentDiagnostics(testDiagnosticsEventJSONs.size) }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded removes consecutive failures count if request successful`() {
+        mockBackendResponse(testDiagnosticsEventJSONs, successReturn = JSONObject())
+
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+
+        verify(exactly = 1) { sharedPreferencesEditor.remove(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY) }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded increases consecutive errors count if backend request unsuccessful`() {
+        val errorCallbackResponse = Pair(PurchasesError(PurchasesErrorCode.ConfigurationError), true)
+        mockBackendResponse(testDiagnosticsEventJSONs, errorReturn = errorCallbackResponse)
+
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+
+        verify(exactly = 1) {
+            sharedPreferencesEditor.putInt(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY, 1)
+        }
+        verify(exactly = 0) { diagnosticsFileHelper.deleteDiagnosticsFile() }
+        verify(exactly = 0) { sharedPreferencesEditor.remove(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY) }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded does not delete file if backend request unsuccessful once`() {
+        val errorCallbackResponse = Pair(PurchasesError(PurchasesErrorCode.ConfigurationError), true)
+        mockBackendResponse(testDiagnosticsEventJSONs, errorReturn = errorCallbackResponse)
+
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+
+        verify(exactly = 0) { diagnosticsFileHelper.deleteDiagnosticsFile() }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded deletes file if backend request unsuccessful and last retry`() {
+        val errorCallbackResponse = Pair(PurchasesError(PurchasesErrorCode.ConfigurationError), true)
+        mockBackendResponse(testDiagnosticsEventJSONs, errorReturn = errorCallbackResponse)
+        every {
+            sharedPreferences.getInt(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY, 0)
+        } returns DiagnosticsManager.MAX_NUMBER_RETRIES - 1
+
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+
+        verify(exactly = 1) { diagnosticsFileHelper.deleteDiagnosticsFile() }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded removes consecutive failures count if request unsuccessful and last retry`() {
+        val errorCallbackResponse = Pair(PurchasesError(PurchasesErrorCode.ConfigurationError), true)
+        mockBackendResponse(testDiagnosticsEventJSONs, errorReturn = errorCallbackResponse)
+        every {
+            sharedPreferences.getInt(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY, 0)
+        } returns DiagnosticsManager.MAX_NUMBER_RETRIES - 1
+
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+
+        verify(exactly = 1) { sharedPreferencesEditor.remove(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY) }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded removes file if should not retry`() {
+        val errorCallbackResponse = Pair(PurchasesError(PurchasesErrorCode.ConfigurationError), false)
+        mockBackendResponse(testDiagnosticsEventJSONs, errorReturn = errorCallbackResponse)
+
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+
+        verify(exactly = 1) { diagnosticsFileHelper.deleteDiagnosticsFile() }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded removes consecutive failures count if should not retry`() {
+        val errorCallbackResponse = Pair(PurchasesError(PurchasesErrorCode.ConfigurationError), false)
+        mockBackendResponse(testDiagnosticsEventJSONs, errorReturn = errorCallbackResponse)
+
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+
+        verify(exactly = 1) { sharedPreferencesEditor.remove(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY) }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded deletes file if IOException happens`() {
+        every { diagnosticsFileHelper.readDiagnosticsFile() } throws IOException()
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+        verify(exactly = 1) { diagnosticsFileHelper.deleteDiagnosticsFile()  }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded removes consecutive failures count if IOException happens`() {
+        every { diagnosticsFileHelper.readDiagnosticsFile() } throws IOException()
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+        verify(exactly = 1) { sharedPreferencesEditor.remove(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY) }
+    }
+
+    // endregion
+
+    // region trackEvent
+
+    @Test
+    fun `trackEvent performs correct calls`() {
+        every { diagnosticsFileHelper.appendEventToDiagnosticsFile(testDiagnosticsEvent) } just Runs
+        every { diagnosticsAnonymizer.anonymizeEventIfNeeded(testDiagnosticsEvent) } returns testDiagnosticsEvent
+        diagnosticsManager.trackEvent(testDiagnosticsEvent)
+        verify(exactly = 1) { diagnosticsFileHelper.appendEventToDiagnosticsFile(testDiagnosticsEvent) }
+        verify(exactly = 1) { diagnosticsAnonymizer.anonymizeEventIfNeeded(testDiagnosticsEvent) }
+    }
+
+    @Test
+    fun `trackEvent handles IOException`() {
+        every { diagnosticsAnonymizer.anonymizeEventIfNeeded(testDiagnosticsEvent) } returns testDiagnosticsEvent
+        every { diagnosticsFileHelper.appendEventToDiagnosticsFile(any()) } throws IOException()
+        diagnosticsManager.trackEvent(testDiagnosticsEvent)
+    }
+
+    // endregion
+
+    private fun mockSharedPreferences() {
+        sharedPreferences = mockk()
+        sharedPreferencesEditor = mockk()
+        every { sharedPreferences.edit() } returns sharedPreferencesEditor
+        every { sharedPreferencesEditor.apply() } just Runs
+        every {
+            sharedPreferencesEditor.remove(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY)
+        } returns sharedPreferencesEditor
+        every {
+            sharedPreferencesEditor.putInt(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY, any())
+        } returns sharedPreferencesEditor
+        every {
+            sharedPreferences.getInt(DiagnosticsManager.CONSECUTIVE_FAILURES_COUNT_KEY, 0)
+        } returns 0
+    }
+
+    private fun mockDiagnosticsFileHelper() {
+        diagnosticsFileHelper = mockk()
+        every { diagnosticsFileHelper.readDiagnosticsFile() } returns testDiagnosticsEventJSONs
+        every { diagnosticsFileHelper.deleteDiagnosticsFile() } just Runs
+        every { diagnosticsFileHelper.cleanSentDiagnostics(testDiagnosticsEventJSONs.size) } just Runs
+    }
+
+    private fun mockBackendResponse(
+        diagnosticsEvents: List<JSONObject>,
+        successReturn: JSONObject? = null,
+        errorReturn: Pair<PurchasesError, Boolean>? = null
+    ) {
+        val successCallbackSlot = slot<(JSONObject) -> Unit>()
+        val errorCallbackSlot = slot<(PurchasesError, Boolean) -> Unit>()
+        every { backend.postDiagnostics(
+            diagnosticsEvents,
+            capture(successCallbackSlot),
+            capture(errorCallbackSlot)
+        ) } answers {
+            if (successReturn != null) {
+                successCallbackSlot.captured(successReturn)
+            } else if (errorReturn != null) {
+                errorCallbackSlot.captured(errorReturn.first, errorReturn.second)
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR is based on #784. Here we are adding the `DiagnosticsManager` which is in charge of coordinating the diagnostics logic like calling the backend and handling the jsonl files. There are some WIPs to be addressed in future PRs.