### PR TITLE
Update README.md to include minimum Kotlin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Or view our Android sample app:
 
 ## Requirements
 - Java 8+
+- Kotlin 1.5.0+
 - Minimum target: Android 4.0+ (API level 14+)
 
 ## SDK Reference


### PR DESCRIPTION
I tested a project using Kotlin gradle plugin 1.4.31 and I had issues when adding purchases-android. I tested and 1.5.0 was the minimum version that let me compile the app