### PR TITLE
Add Amazon App tester package to purchase tester queries

### DIFF
--- a/examples/purchase-tester/src/main/AndroidManifest.xml
+++ b/examples/purchase-tester/src/main/AndroidManifest.xml
@@ -20,4 +20,7 @@
             </intent-filter>
         </activity>
     </application>
+    <queries>
+        <package android:name="com.amazon.sdktestclient" />
+    </queries>
 </manifest>


### PR DESCRIPTION
### Description
This cherry-picks the changes in #788 to main.

This change allows the app to communicate with the Amazon App tester app in android 11+

Thanks to @swehner for the fix!