### PR TITLE
Diagnostics: Sync diagnostics when configuring SDK if needed

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -134,6 +134,7 @@ final class PurchasesAPI {
                 .observerMode(true)
                 .observerMode(false)
                 .service(executorService)
+                .diagnosticsEnabled(true)
                 .build();
 
         Purchases.configure(build);

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -207,6 +207,7 @@ private class PurchasesAPI {
             .observerMode(true)
             .observerMode(false)
             .service(executorService)
+            .diagnosticsEnabled(true)
             .build()
 
         Purchases.configure(build)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -31,6 +31,7 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
 import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.common.debugLogsEnabled
+import com.revenuecat.purchases.common.diagnostics.DiagnosticsManager
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.sha1
@@ -103,6 +104,7 @@ class Purchases internal constructor(
     private val subscriberAttributesManager: SubscriberAttributesManager,
     @set:JvmSynthetic @get:JvmSynthetic internal var appConfig: AppConfig,
     private val customerInfoHelper: CustomerInfoHelper,
+    diagnosticsManager: DiagnosticsManager?,
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper())
 ) : LifecycleDelegate {
@@ -173,6 +175,8 @@ class Purchases internal constructor(
         if (!appConfig.dangerousSettings.autoSyncPurchases) {
             log(LogIntent.WARNING, AUTO_SYNC_PURCHASES_DISABLED)
         }
+
+        diagnosticsManager?.syncDiagnosticsFileIfNeeded()
     }
 
     /** @suppress */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -11,6 +11,7 @@ open class PurchasesConfiguration(builder: Builder) {
     val observerMode: Boolean
     val service: ExecutorService?
     val store: Store
+    val diagnosticsEnabled: Boolean
     val dangerousSettings: DangerousSettings
 
     init {
@@ -20,6 +21,7 @@ open class PurchasesConfiguration(builder: Builder) {
         this.observerMode = builder.observerMode
         this.service = builder.service
         this.store = builder.store
+        this.diagnosticsEnabled = builder.diagnosticsEnabled
         this.dangerousSettings = builder.dangerousSettings
     }
 
@@ -32,6 +34,7 @@ open class PurchasesConfiguration(builder: Builder) {
         @set:JvmSynthetic @get:JvmSynthetic internal var observerMode: Boolean = false
         @set:JvmSynthetic @get:JvmSynthetic internal var service: ExecutorService? = null
         @set:JvmSynthetic @get:JvmSynthetic internal var store: Store = Store.PLAY_STORE
+        @set:JvmSynthetic @get:JvmSynthetic internal var diagnosticsEnabled: Boolean = false
         @set:JvmSynthetic @get:JvmSynthetic internal var dangerousSettings: DangerousSettings = DangerousSettings()
 
         fun appUserID(appUserID: String?) = apply {
@@ -48,6 +51,10 @@ open class PurchasesConfiguration(builder: Builder) {
 
         fun store(store: Store) = apply {
             this.store = store
+        }
+
+        fun diagnosticsEnabled(diagnosticsEnabled: Boolean) = apply {
+            this.diagnosticsEnabled = diagnosticsEnabled
         }
 
         /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.preference.PreferenceManager
 import androidx.annotation.VisibleForTesting
+import com.revenuecat.purchases.common.Anonymizer
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BillingAbstract
@@ -148,7 +149,7 @@ internal class PurchasesFactory(
         return if (diagnosticsEnabled) {
             DiagnosticsManager(
                 DiagnosticsFileHelper(FileHelper(context)),
-                DiagnosticsAnonymizer(),
+                DiagnosticsAnonymizer(Anonymizer()),
                 backend,
                 dispatcher,
                 DiagnosticsManager.initializeSharedPreferences(context)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -10,9 +10,13 @@ import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.FileHelper
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.diagnostics.DiagnosticsAnonymizer
+import com.revenuecat.purchases.common.diagnostics.DiagnosticsFileHelper
+import com.revenuecat.purchases.common.diagnostics.DiagnosticsManager
 import com.revenuecat.purchases.common.networking.ETagManager
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
@@ -91,6 +95,13 @@ internal class PurchasesFactory(
 
             val customerInfoHelper = CustomerInfoHelper(cache, backend, identityManager)
 
+            val diagnosticsManager = createDiagnosticsManagerIfNeeded(
+                context,
+                backend,
+                diagnosticsDispatcher,
+                diagnosticsEnabled
+            )
+
             return Purchases(
                 application,
                 appUserID,
@@ -101,7 +112,8 @@ internal class PurchasesFactory(
                 identityManager,
                 subscriberAttributesManager,
                 appConfig,
-                customerInfoHelper
+                customerInfoHelper,
+                diagnosticsManager
             )
         }
     }
@@ -125,6 +137,25 @@ internal class PurchasesFactory(
 
     private fun Context.hasPermission(permission: String): Boolean {
         return checkCallingOrSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun createDiagnosticsManagerIfNeeded(
+        context: Context,
+        backend: Backend,
+        dispatcher: Dispatcher,
+        diagnosticsEnabled: Boolean
+    ): DiagnosticsManager? {
+        return if (diagnosticsEnabled) {
+            DiagnosticsManager(
+                DiagnosticsFileHelper(FileHelper(context)),
+                DiagnosticsAnonymizer(),
+                backend,
+                dispatcher,
+                DiagnosticsManager.initializeSharedPreferences(context)
+            )
+        } else {
+            null
+        }
     }
 
     private fun createDefaultExecutor(): ExecutorService {

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -140,7 +140,8 @@ class PostingTransactionsTests {
                 proxyURL = null,
                 store = Store.PLAY_STORE
             ),
-            customerInfoHelper = customerInfoHelperMock
+            customerInfoHelper = customerInfoHelperMock,
+            diagnosticsManager = null
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -1,0 +1,79 @@
+package com.revenuecat.purchases
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.ExecutorService
+
+@RunWith(AndroidJUnit4::class)
+class PurchasesConfigurationTest {
+
+    private val apiKey = "test-api-key"
+
+    private lateinit var context: Context
+
+    private lateinit var builder: PurchasesConfiguration.Builder
+
+    @Before
+    fun setup() {
+        context = mockk()
+
+        builder = PurchasesConfiguration.Builder(context, apiKey)
+    }
+
+    @Test
+    fun `PurchasesConfiguration has expected default parameters`() {
+        val purchasesConfiguration = builder.build()
+        assertThat(purchasesConfiguration.apiKey).isEqualTo(apiKey)
+        assertThat(purchasesConfiguration.context).isEqualTo(context)
+        assertThat(purchasesConfiguration.appUserID).isNull()
+        assertThat(purchasesConfiguration.observerMode).isFalse
+        assertThat(purchasesConfiguration.service).isNull()
+        assertThat(purchasesConfiguration.store).isEqualTo(Store.PLAY_STORE)
+        assertThat(purchasesConfiguration.diagnosticsEnabled).isFalse
+        assertThat(purchasesConfiguration.dangerousSettings).isEqualTo(DangerousSettings(autoSyncPurchases = true))
+    }
+
+    @Test
+    fun `PurchasesConfiguration sets appUserId correctly`() {
+        val testUserId = "test-user-id"
+        val purchasesConfiguration = builder.appUserID(testUserId).build()
+        assertThat(purchasesConfiguration.appUserID).isEqualTo(testUserId)
+    }
+
+    @Test
+    fun `PurchasesConfiguration sets observerMode correctly`() {
+        val purchasesConfiguration = builder.observerMode(true).build()
+        assertThat(purchasesConfiguration.observerMode).isTrue
+    }
+
+    @Test
+    fun `PurchasesConfiguration sets service correctly`() {
+        val serviceMock: ExecutorService = mockk()
+        val purchasesConfiguration = builder.service(serviceMock).build()
+        assertThat(purchasesConfiguration.service).isEqualTo(serviceMock)
+    }
+
+    @Test
+    fun `PurchasesConfiguration sets store correctly`() {
+        val purchasesConfiguration = builder.store(Store.AMAZON).build()
+        assertThat(purchasesConfiguration.store).isEqualTo(Store.AMAZON)
+    }
+
+    @Test
+    fun `PurchasesConfiguration sets diagnosticsEnabled correctly`() {
+        val purchasesConfiguration = builder.diagnosticsEnabled(true).build()
+        assertThat(purchasesConfiguration.diagnosticsEnabled).isTrue
+    }
+
+    @Test
+    fun `PurchasesConfiguration sets dangerous settings correctly`() {
+        val dangerousSettings = DangerousSettings(autoSyncPurchases = false)
+        val purchasesConfiguration = builder.dangerousSettings(dangerousSettings).build()
+        assertThat(purchasesConfiguration.dangerousSettings).isEqualTo(dangerousSettings)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -29,6 +29,7 @@ import com.revenuecat.purchases.common.ReplaceSkuInfo
 import com.revenuecat.purchases.common.buildCustomerInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
+import com.revenuecat.purchases.common.diagnostics.DiagnosticsManager
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
 import com.revenuecat.purchases.google.toGoogleProductType
@@ -98,6 +99,7 @@ class PurchasesTest {
     private val mockIdentityManager = mockk<IdentityManager>()
     private val mockSubscriberAttributesManager = mockk<SubscriberAttributesManager>()
     private val mockCustomerInfoHelper = mockk<CustomerInfoHelper>()
+    private val mockDiagnosticsManager = mockk<DiagnosticsManager>()
 
     private var capturedPurchasesUpdatedListener = slot<BillingAbstract.PurchasesUpdatedListener>()
     private var capturedBillingWrapperStateListener = slot<BillingAbstract.StateListener>()
@@ -154,6 +156,9 @@ class PurchasesTest {
         every {
             mockIdentityManager.configure(any())
         } just Runs
+        every {
+            mockDiagnosticsManager.syncDiagnosticsFileIfNeeded()
+        } just Runs
 
         anonymousSetup(false)
     }
@@ -203,6 +208,11 @@ class PurchasesTest {
     @Test
     fun canBeCreated() {
         assertThat(purchases).isNotNull
+    }
+
+    @Test
+    fun `diagnostics is synced if needed on constructor`() {
+        verify(exactly = 1) { mockDiagnosticsManager.syncDiagnosticsFileIfNeeded() }
     }
 
     @Test
@@ -4135,7 +4145,8 @@ class PurchasesTest {
                 store = Store.PLAY_STORE,
                 dangerousSettings = DangerousSettings(autoSyncPurchases = autoSync)
             ),
-            customerInfoHelper = mockCustomerInfoHelper
+            customerInfoHelper = mockCustomerInfoHelper,
+            diagnosticsManager = mockDiagnosticsManager
         )
         Purchases.sharedInstance = purchases
         purchases.state = purchases.state.copy(appInBackground = false)

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -148,7 +148,8 @@ class SubscriberAttributesPurchasesTests {
                 proxyURL = null,
                 store = Store.PLAY_STORE
             ),
-            customerInfoHelper = customerInfoHelperMock
+            customerInfoHelper = customerInfoHelperMock,
+            diagnosticsManager = null
         )
     }
 


### PR DESCRIPTION
### Description
Based on #787 

This PR adds support to enable/disable diagnostics (disabled by default) and adds all the plumbing to sync diagnostics when configuring the SDK.