### PR TITLE
Add queries (#788)

### DIFF
--- a/examples/purchase-tester/src/main/AndroidManifest.xml
+++ b/examples/purchase-tester/src/main/AndroidManifest.xml
@@ -20,4 +20,7 @@
             </intent-filter>
         </activity>
     </application>
+    <queries>
+        <package android:name="com.amazon.sdktestclient" />
+    </queries>
 </manifest>


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
This was needed to make the purchases_sample work with the AmazonAppTester on my Fire device

On fireOS 8 the application was throwing these error messages in the log:

```
02-10 16:46:53.898   665  1108 I AppsFilter: interaction: PackageSetting{9101216 com.revenuecat.purchases_sample/10202} -> PackageSetting{e147090 com.amazon.sdktestclient/10200} BLOCKED
```

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids
