### PR TITLE
Diagnostics: limit events sent

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
@@ -20,8 +20,8 @@ class DiagnosticsFileHelper(
     }
 
     @Synchronized
-    fun cleanSentDiagnostics(diagnosticsSentCount: Int) {
-        fileHelper.removeFirstLinesFromFile(DIAGNOSTICS_FILE_PATH, diagnosticsSentCount)
+    fun deleteOlderDiagnostics(eventsToDeleteCount: Int) {
+        fileHelper.removeFirstLinesFromFile(DIAGNOSTICS_FILE_PATH, eventsToDeleteCount)
     }
 
     @Synchronized

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsLogEventName.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsLogEventName.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.common.diagnostics
 
 enum class DiagnosticsLogEventName {
-    ENDPOINT_HIT
+    ENDPOINT_HIT,
+    MAX_EVENTS_STORED_LIMIT_REACHED
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManager.kt
@@ -89,26 +89,26 @@ class DiagnosticsManager(
 
     private fun getEventsToSync(): List<JSONObject> {
         val diagnosticsList = diagnosticsFileHelper.readDiagnosticsFile()
-        return deleteOlderEventsIfNeeded(diagnosticsList)
-    }
-
-    private fun deleteOlderEventsIfNeeded(diagnosticsList: List<JSONObject>): List<JSONObject> {
         val diagnosticsInFileCount = diagnosticsList.size
         if (diagnosticsInFileCount > MAX_NUMBER_EVENTS) {
             val eventsToRemoveCount = diagnosticsInFileCount - MAX_NUMBER_EVENTS + 1
             diagnosticsFileHelper.deleteOlderDiagnostics(eventsToRemoveCount)
-            trackEventInCurrentThread(
-                DiagnosticsEvent.Log(
-                    name = DiagnosticsLogEventName.MAX_EVENTS_STORED_LIMIT_REACHED,
-                    properties = mapOf(
-                        "total_number_events_stored" to diagnosticsInFileCount,
-                        "events_removed" to eventsToRemoveCount
-                    )
-                )
-            )
+            trackMaxEventsStoredLimitReached(diagnosticsInFileCount, eventsToRemoveCount)
             return diagnosticsFileHelper.readDiagnosticsFile()
         }
         return diagnosticsList
+    }
+
+    private fun trackMaxEventsStoredLimitReached(totalEventsStored: Int, eventsRemoved: Int) {
+        trackEventInCurrentThread(
+            DiagnosticsEvent.Log(
+                name = DiagnosticsLogEventName.MAX_EVENTS_STORED_LIMIT_REACHED,
+                properties = mapOf(
+                    "total_number_events_stored" to totalEventsStored,
+                    "events_removed" to eventsRemoved
+                )
+            )
+        )
     }
 
     private fun trackEventInCurrentThread(diagnosticsEvent: DiagnosticsEvent) {

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManager.kt
@@ -11,7 +11,7 @@ import java.io.IOException
 
 /**
  * This class is the entry point to perform all diagnostics related operations. All operations will be executed
- * in a background thread.
+ * in a single background thread. Multithreading is not currently supported for these operations.
  *
  * If syncing diagnostics fails multiple times, we will delete any stored diagnostics data and start again.
  */

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManager.kt
@@ -113,7 +113,6 @@ class DiagnosticsManager(
 
     private fun trackEventInCurrentThread(diagnosticsEvent: DiagnosticsEvent) {
         val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(diagnosticsEvent)
-        // WIP: Check that file size is not above certain limit. If it is, delete.
         verboseLog("Tracking diagnostics event: $anonymizedEvent")
         try {
             diagnosticsFileHelper.appendEventToDiagnosticsFile(anonymizedEvent)

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManager.kt
@@ -6,6 +6,7 @@ import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.verboseLog
+import org.json.JSONObject
 import java.io.IOException
 
 /**
@@ -26,6 +27,8 @@ class DiagnosticsManager(
         const val CONSECUTIVE_FAILURES_COUNT_KEY = "consecutive_failures_count"
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         const val MAX_NUMBER_POST_RETRIES = 3
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        const val MAX_NUMBER_EVENTS = 1000
 
         fun initializeSharedPreferences(context: Context): SharedPreferences =
             context.getSharedPreferences(
@@ -37,7 +40,7 @@ class DiagnosticsManager(
     fun syncDiagnosticsFileIfNeeded() {
         enqueue {
             try {
-                val diagnosticsList = diagnosticsFileHelper.readDiagnosticsFile()
+                val diagnosticsList = getEventsToSync()
                 val diagnosticsCount = diagnosticsList.size
                 if (diagnosticsCount == 0) {
                     verboseLog("No diagnostics to sync.")
@@ -48,7 +51,7 @@ class DiagnosticsManager(
                     onSuccessHandler = {
                         verboseLog("Synced diagnostics file successfully.")
                         clearConsecutiveNumberOfErrors()
-                        diagnosticsFileHelper.cleanSentDiagnostics(diagnosticsCount)
+                        diagnosticsFileHelper.deleteOlderDiagnostics(diagnosticsCount)
                     },
                     onErrorHandler = { error, shouldRetry ->
                         if (shouldRetry) {
@@ -80,14 +83,42 @@ class DiagnosticsManager(
 
     fun trackEvent(diagnosticsEvent: DiagnosticsEvent) {
         enqueue {
-            val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(diagnosticsEvent)
-            // WIP: Check that file size is not above certain limit. If it is, delete.
-            verboseLog("Tracking diagnostics event: $anonymizedEvent")
-            try {
-                diagnosticsFileHelper.appendEventToDiagnosticsFile(anonymizedEvent)
-            } catch (e: IOException) {
-                verboseLog("Error tracking diagnostics event: $e")
-            }
+            trackEventInCurrentThread(diagnosticsEvent)
+        }
+    }
+
+    private fun getEventsToSync(): List<JSONObject> {
+        val diagnosticsList = diagnosticsFileHelper.readDiagnosticsFile()
+        return deleteOlderEventsIfNeeded(diagnosticsList)
+    }
+
+    private fun deleteOlderEventsIfNeeded(diagnosticsList: List<JSONObject>): List<JSONObject> {
+        val diagnosticsInFileCount = diagnosticsList.size
+        if (diagnosticsInFileCount > MAX_NUMBER_EVENTS) {
+            val eventsToRemoveCount = diagnosticsInFileCount - MAX_NUMBER_EVENTS + 1
+            diagnosticsFileHelper.deleteOlderDiagnostics(eventsToRemoveCount)
+            trackEventInCurrentThread(
+                DiagnosticsEvent.Log(
+                    name = DiagnosticsLogEventName.MAX_EVENTS_STORED_LIMIT_REACHED,
+                    properties = mapOf(
+                        "total_number_events_stored" to diagnosticsInFileCount,
+                        "events_removed" to eventsToRemoveCount
+                    )
+                )
+            )
+            return diagnosticsFileHelper.readDiagnosticsFile()
+        }
+        return diagnosticsList
+    }
+
+    private fun trackEventInCurrentThread(diagnosticsEvent: DiagnosticsEvent) {
+        val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(diagnosticsEvent)
+        // WIP: Check that file size is not above certain limit. If it is, delete.
+        verboseLog("Tracking diagnostics event: $anonymizedEvent")
+        try {
+            diagnosticsFileHelper.appendEventToDiagnosticsFile(anonymizedEvent)
+        } catch (e: IOException) {
+            verboseLog("Error tracking diagnostics event: $e")
         }
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
@@ -43,9 +43,9 @@ class DiagnosticsFileHelperTest {
     }
 
     @Test
-    fun `cleanSentDiagnostics calls are correct`() {
+    fun `deleteOlderDiagnostics calls are correct`() {
         every { fileHelper.removeFirstLinesFromFile(diagnosticsFilePath, 2) } just Runs
-        diagnosticsFileHelper.cleanSentDiagnostics(2)
+        diagnosticsFileHelper.deleteOlderDiagnostics(2)
         verify(exactly = 1) { fileHelper.removeFirstLinesFromFile(diagnosticsFilePath, 2) }
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManagerTest.kt
@@ -90,7 +90,7 @@ class DiagnosticsManagerTest {
 
         diagnosticsManager.syncDiagnosticsFileIfNeeded()
 
-        verify(exactly = 1) { diagnosticsFileHelper.cleanSentDiagnostics(testDiagnosticsEventJSONs.size) }
+        verify(exactly = 1) { diagnosticsFileHelper.deleteOlderDiagnostics(testDiagnosticsEventJSONs.size) }
     }
 
     @Test
@@ -235,7 +235,7 @@ class DiagnosticsManagerTest {
         diagnosticsFileHelper = mockk()
         every { diagnosticsFileHelper.readDiagnosticsFile() } returns testDiagnosticsEventJSONs
         every { diagnosticsFileHelper.deleteDiagnosticsFile() } just Runs
-        every { diagnosticsFileHelper.cleanSentDiagnostics(testDiagnosticsEventJSONs.size) } just Runs
+        every { diagnosticsFileHelper.deleteOlderDiagnostics(testDiagnosticsEventJSONs.size) } just Runs
     }
 
     private fun mockBackendResponse(

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsManagerTest.kt
@@ -193,6 +193,50 @@ class DiagnosticsManagerTest {
         diagnosticsManager.syncDiagnosticsFileIfNeeded()
     }
 
+    @Test
+    fun `syncDiagnosticsFileIfNeeded removes old events if exceeding limit`() {
+        val eventsOverLimit = 10
+        val eventsToRemove = eventsOverLimit + 1 // Leaves space for tracking event
+        val eventsInFile = (0 until DiagnosticsManager.MAX_NUMBER_EVENTS + eventsOverLimit).map {
+            JSONObject(mapOf("test-key-$it" to "value-$it"))
+        }
+        val eventsAfterRemovingOlder = eventsInFile.subList(eventsOverLimit, eventsInFile.size)
+        every { diagnosticsFileHelper.readDiagnosticsFile() } returnsMany listOf(eventsInFile, eventsAfterRemovingOlder)
+        every { diagnosticsFileHelper.deleteOlderDiagnostics(eventsToRemove) } just Runs
+        every { diagnosticsAnonymizer.anonymizeEventIfNeeded(any()) } answers { firstArg() }
+        every { diagnosticsFileHelper.appendEventToDiagnosticsFile(any()) } just Runs
+        mockBackendResponse(eventsAfterRemovingOlder)
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+        verify(exactly = 1) { diagnosticsFileHelper.deleteOlderDiagnostics(eventsToRemove) }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded tracks max elements stored reached if syncing more than limit`() {
+        val eventsOverLimit = 10
+        val eventsToRemove = eventsOverLimit + 1 // Leaves space for tracking event
+        val totalNumberOfEventsInFile = DiagnosticsManager.MAX_NUMBER_EVENTS + eventsOverLimit
+        val eventsInFile = (0 until totalNumberOfEventsInFile).map {
+            JSONObject(mapOf("test-key-$it" to "value-$it"))
+        }
+        val eventsAfterRemovingOlder = eventsInFile.subList(eventsOverLimit, eventsInFile.size)
+        every { diagnosticsFileHelper.readDiagnosticsFile() } returnsMany listOf(eventsInFile, eventsAfterRemovingOlder)
+        every { diagnosticsFileHelper.deleteOlderDiagnostics(eventsToRemove) } just Runs
+        every { diagnosticsAnonymizer.anonymizeEventIfNeeded(any()) } answers { firstArg() }
+        every { diagnosticsFileHelper.appendEventToDiagnosticsFile(any()) } just Runs
+        mockBackendResponse(eventsAfterRemovingOlder)
+        diagnosticsManager.syncDiagnosticsFileIfNeeded()
+        verify(exactly = 1) {
+            diagnosticsFileHelper.appendEventToDiagnosticsFile(match { event ->
+                (event is DiagnosticsEvent.Log)
+                    && event.name == DiagnosticsLogEventName.MAX_EVENTS_STORED_LIMIT_REACHED
+                    && event.properties == mapOf(
+                        "total_number_events_stored" to totalNumberOfEventsInFile,
+                        "events_removed" to eventsToRemove
+                    )
+            })
+        }
+    }
+
     // endregion
 
     // region trackEvent


### PR DESCRIPTION
### Description
Based on #785 
Deals with [CSDK-648](https://revenuecats.atlassian.net/browse/CSDK-648)

In this PR we add a limit to the number of events that can be sent to the backend and we add a diagnostics event tracking when this happens.

[CSDK-648]: https://revenuecats.atlassian.net/browse/CSDK-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ