### PR TITLE
Diagnostics: Diagnostics split manager into tracker and synchronizer

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -4,6 +4,10 @@ import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.verboseLog
 import java.io.IOException
 
+/**
+ * This class is the entry point for all diagnostics tracking. It contains all information for all events
+ * sent and their properties. Use this class if you want to send a a diagnostics entry.
+ */
 class DiagnosticsTracker(
     private val diagnosticsFileHelper: DiagnosticsFileHelper,
     private val diagnosticsAnonymizer: DiagnosticsAnonymizer,

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -1,0 +1,28 @@
+package com.revenuecat.purchases.common.diagnostics
+
+import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.verboseLog
+import java.io.IOException
+
+class DiagnosticsTracker(
+    private val diagnosticsFileHelper: DiagnosticsFileHelper,
+    private val diagnosticsAnonymizer: DiagnosticsAnonymizer,
+    private val diagnosticsDispatcher: Dispatcher
+) {
+
+    fun trackEvent(diagnosticsEvent: DiagnosticsEvent) {
+        diagnosticsDispatcher.enqueue(command = {
+            trackEventInCurrentThread(diagnosticsEvent)
+        })
+    }
+
+    internal fun trackEventInCurrentThread(diagnosticsEvent: DiagnosticsEvent) {
+        val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(diagnosticsEvent)
+        verboseLog("Tracking diagnostics event: $anonymizedEvent")
+        try {
+            diagnosticsFileHelper.appendEventToDiagnosticsFile(anonymizedEvent)
+        } catch (e: IOException) {
+            verboseLog("Error tracking diagnostics event: $e")
+        }
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
@@ -1,0 +1,65 @@
+package com.revenuecat.purchases.common.diagnostics
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.SyncDispatcher
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class DiagnosticsTrackerTest {
+
+    private val testDiagnosticsEvent = DiagnosticsEvent.Log(
+        name = DiagnosticsLogEventName.ENDPOINT_HIT,
+        properties = mapOf("test-key-1" to "test-value-1")
+    )
+
+    private val testAnonymizedEvent = DiagnosticsEvent.Log(
+        name = DiagnosticsLogEventName.ENDPOINT_HIT,
+        properties = mapOf("test-key-1" to "test-anonymized-value-1")
+    )
+
+    private lateinit var diagnosticsFileHelper: DiagnosticsFileHelper
+    private lateinit var diagnosticsAnonymizer: DiagnosticsAnonymizer
+    private lateinit var dispatcher: Dispatcher
+
+    private lateinit var diagnosticsTracker: DiagnosticsTracker
+
+    @Before
+    fun setup() {
+        diagnosticsFileHelper = mockk()
+        diagnosticsAnonymizer = mockk()
+        dispatcher = SyncDispatcher()
+
+        diagnosticsTracker = DiagnosticsTracker(
+            diagnosticsFileHelper,
+            diagnosticsAnonymizer,
+            dispatcher
+        )
+    }
+
+    @Test
+    fun `trackEvent performs correct calls`() {
+        every { diagnosticsFileHelper.appendEventToDiagnosticsFile(testAnonymizedEvent) } just Runs
+        every { diagnosticsAnonymizer.anonymizeEventIfNeeded(testDiagnosticsEvent) } returns testAnonymizedEvent
+        diagnosticsTracker.trackEvent(testDiagnosticsEvent)
+        verify(exactly = 1) { diagnosticsFileHelper.appendEventToDiagnosticsFile(testAnonymizedEvent) }
+        verify(exactly = 1) { diagnosticsAnonymizer.anonymizeEventIfNeeded(testDiagnosticsEvent) }
+    }
+
+    @Test
+    fun `trackEvent handles IOException`() {
+        every { diagnosticsAnonymizer.anonymizeEventIfNeeded(testDiagnosticsEvent) } returns testDiagnosticsEvent
+        every { diagnosticsFileHelper.appendEventToDiagnosticsFile(any()) } throws IOException()
+        diagnosticsTracker.trackEvent(testDiagnosticsEvent)
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
@@ -62,4 +62,12 @@ class DiagnosticsTrackerTest {
         every { diagnosticsFileHelper.appendEventToDiagnosticsFile(any()) } throws IOException()
         diagnosticsTracker.trackEvent(testDiagnosticsEvent)
     }
+
+    @Test
+    fun `trackEventInCurrentThread does not enqueue request`() {
+        dispatcher.close()
+        every { diagnosticsAnonymizer.anonymizeEventIfNeeded(testDiagnosticsEvent) } returns testDiagnosticsEvent
+        every { diagnosticsFileHelper.appendEventToDiagnosticsFile(any()) } throws IOException()
+        diagnosticsTracker.trackEventInCurrentThread(testDiagnosticsEvent)
+    }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -31,7 +31,7 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
 import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.common.debugLogsEnabled
-import com.revenuecat.purchases.common.diagnostics.DiagnosticsManager
+import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.sha1
@@ -104,7 +104,7 @@ class Purchases internal constructor(
     private val subscriberAttributesManager: SubscriberAttributesManager,
     @set:JvmSynthetic @get:JvmSynthetic internal var appConfig: AppConfig,
     private val customerInfoHelper: CustomerInfoHelper,
-    diagnosticsManager: DiagnosticsManager?,
+    diagnosticsSynchronizer: DiagnosticsSynchronizer?,
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper())
 ) : LifecycleDelegate {
@@ -176,7 +176,7 @@ class Purchases internal constructor(
             log(LogIntent.WARNING, AUTO_SYNC_PURCHASES_DISABLED)
         }
 
-        diagnosticsManager?.syncDiagnosticsFileIfNeeded()
+        diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
     }
 
     /** @suppress */

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -141,7 +141,7 @@ class PostingTransactionsTests {
                 store = Store.PLAY_STORE
             ),
             customerInfoHelper = customerInfoHelperMock,
-            diagnosticsManager = null
+            diagnosticsSynchronizer = null
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -29,7 +29,7 @@ import com.revenuecat.purchases.common.ReplaceSkuInfo
 import com.revenuecat.purchases.common.buildCustomerInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
-import com.revenuecat.purchases.common.diagnostics.DiagnosticsManager
+import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
 import com.revenuecat.purchases.google.toGoogleProductType
@@ -99,7 +99,7 @@ class PurchasesTest {
     private val mockIdentityManager = mockk<IdentityManager>()
     private val mockSubscriberAttributesManager = mockk<SubscriberAttributesManager>()
     private val mockCustomerInfoHelper = mockk<CustomerInfoHelper>()
-    private val mockDiagnosticsManager = mockk<DiagnosticsManager>()
+    private val mockDiagnosticsSynchronizer = mockk<DiagnosticsSynchronizer>()
 
     private var capturedPurchasesUpdatedListener = slot<BillingAbstract.PurchasesUpdatedListener>()
     private var capturedBillingWrapperStateListener = slot<BillingAbstract.StateListener>()
@@ -157,7 +157,7 @@ class PurchasesTest {
             mockIdentityManager.configure(any())
         } just Runs
         every {
-            mockDiagnosticsManager.syncDiagnosticsFileIfNeeded()
+            mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
         } just Runs
 
         anonymousSetup(false)
@@ -212,7 +212,7 @@ class PurchasesTest {
 
     @Test
     fun `diagnostics is synced if needed on constructor`() {
-        verify(exactly = 1) { mockDiagnosticsManager.syncDiagnosticsFileIfNeeded() }
+        verify(exactly = 1) { mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded() }
     }
 
     @Test
@@ -4146,7 +4146,7 @@ class PurchasesTest {
                 dangerousSettings = DangerousSettings(autoSyncPurchases = autoSync)
             ),
             customerInfoHelper = mockCustomerInfoHelper,
-            diagnosticsManager = mockDiagnosticsManager
+            diagnosticsSynchronizer = mockDiagnosticsSynchronizer
         )
         Purchases.sharedInstance = purchases
         purchases.state = purchases.state.copy(appInBackground = false)

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -149,7 +149,7 @@ class SubscriberAttributesPurchasesTests {
                 store = Store.PLAY_STORE
             ),
             customerInfoHelper = customerInfoHelperMock,
-            diagnosticsManager = null
+            diagnosticsSynchronizer = null
         )
     }
 


### PR DESCRIPTION
### Description
Based on #793 
This PR refactors previous code to split the `DiagnosticsManager` into `DiagnosticsTracker` and `DiagnosticsSynchronizer`. This is a prerequisite to avoid circular dependencies when tracking request data. 
- Before: `DiagnosticsManager`->`Backend`->`HttpClient`->`DiagnosticsManager`.
- After: `DiagnosticsSynchronizer`->`Backend` for syncing and `HttpClient`->`DiagnosticsTracker` for tracking requests 

I could have tried to extract this logic from the HttpClient, but that would be a bigger refactor. This was the simplest solution I thought for this problem. Also, sorry I didn't see that issue before. I didn't modify the #785 PR directly to try to avoid some conflicts that would happen if I did it there directly.