### PR TITLE
[WIP] setIsPersonalizedPrice

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -80,7 +80,15 @@ final class PurchasesAPI {
         purchases.purchasePackage(activity, packageToPurchase, upgradeInfo, purchaseChangeListener);
         purchases.purchasePackage(activity, packageToPurchase, makePurchaseListener);
         purchases.purchaseSubscriptionOption(activity, subscriptionOption, upgradeInfo, purchaseChangeListener);
+        purchases.purchaseSubscriptionOption(
+                activity,
+                subscriptionOption,
+                upgradeInfo,
+                purchaseChangeListener,
+                true
+        );
         purchases.purchaseSubscriptionOption(activity, subscriptionOption, makePurchaseListener);
+        purchases.purchaseSubscriptionOption(activity, subscriptionOption, makePurchaseListener, false);
         purchases.restorePurchases(receiveCustomerInfoListener);
 
         purchases.logIn("", logInCallback);

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -150,11 +150,23 @@ private class PurchasesAPI {
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
         )
+        purchases.purchaseProductWith(
+            activity,
+            storeProduct,
+            upgradeInfo,
+            onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
+        )
         purchases.purchasePackageWith(
             activity,
             packageToPurchase,
             upgradeInfo,
             onError = { _: PurchasesError, _: Boolean -> },
+            onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
+        )
+        purchases.purchasePackageWith(
+            activity,
+            packageToPurchase,
+            upgradeInfo,
             onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
         )
         purchases.purchasePackageWith(
@@ -168,6 +180,17 @@ private class PurchasesAPI {
             subscriptionOption,
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
+        )
+        purchases.purchaseSubscriptionOptionWith(
+            activity,
+            subscriptionOption,
+            onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
+        )
+        purchases.purchaseSubscriptionOptionWith(
+            activity,
+            subscriptionOption,
+            upgradeInfo,
+            onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
         )
         purchases.purchaseSubscriptionOptionWith(
             activity,

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -38,7 +38,7 @@ import java.util.concurrent.ExecutorService
 
 @Suppress("unused", "UNUSED_VARIABLE", "EmptyFunctionBlock", "RemoveExplicitTypeArguments", "RedundantLambdaArrow")
 private class PurchasesAPI {
-    @SuppressWarnings("LongParameterList")
+    @SuppressWarnings("LongParameterList", "LongMethod")
     fun check(
         purchases: Purchases,
         activity: Activity,
@@ -78,10 +78,20 @@ private class PurchasesAPI {
         purchases.getProducts(productIds, productsResponseCallback)
 
         // we need these for hybrids... these all fall back on some "best offer" or just purchase the base plan
+        purchases.purchaseProduct(activity, storeProduct, upgradeInfo, purchaseChangeCallback, false)
         purchases.purchaseProduct(activity, storeProduct, upgradeInfo, purchaseChangeCallback)
+        purchases.purchaseProduct(activity, storeProduct, purchaseCallback, false)
         purchases.purchaseProduct(activity, storeProduct, purchaseCallback)
         purchases.purchasePackage(activity, packageToPurchase, upgradeInfo, purchaseChangeCallback)
+        purchases.purchasePackage(
+            activity,
+            packageToPurchase,
+            upgradeInfo,
+            purchaseChangeCallback,
+            true
+        )
         purchases.purchasePackage(activity, packageToPurchase, purchaseCallback)
+        purchases.purchasePackage(activity, packageToPurchase, purchaseCallback, true)
 
         purchases.purchaseSubscriptionOption(
             activity,

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -187,12 +187,14 @@ private class PurchasesAPI {
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
         )
+
         purchases.purchaseSubscriptionOptionWith(
             activity,
             subscriptionOption,
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
         )
+
         purchases.purchaseSubscriptionOptionWith(
             activity,
             subscriptionOption,

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -156,6 +156,12 @@ private class PurchasesAPI {
             upgradeInfo,
             onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
         )
+
+        purchases.purchaseProductWith(
+            activity,
+            storeProduct,
+            upgradeInfo) { _: StoreTransaction?, _: CustomerInfo -> }
+
         purchases.purchasePackageWith(
             activity,
             packageToPurchase,
@@ -169,6 +175,12 @@ private class PurchasesAPI {
             upgradeInfo,
             onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
         )
+
+        purchases.purchasePackageWith(
+            activity,
+            packageToPurchase,
+            upgradeInfo) { _: StoreTransaction?, _: CustomerInfo -> }
+
         purchases.purchasePackageWith(
             activity,
             packageToPurchase,
@@ -186,12 +198,23 @@ private class PurchasesAPI {
             subscriptionOption,
             onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
         )
+
+        purchases.purchaseSubscriptionOptionWith(
+            activity,
+            subscriptionOption) { _: StoreTransaction, _: CustomerInfo -> }
+
         purchases.purchaseSubscriptionOptionWith(
             activity,
             subscriptionOption,
             upgradeInfo,
             onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
         )
+
+        purchases.purchaseSubscriptionOptionWith(
+            activity,
+            subscriptionOption,
+            upgradeInfo) { _: StoreTransaction?, _: CustomerInfo -> }
+
         purchases.purchaseSubscriptionOptionWith(
             activity,
             subscriptionOption,

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -89,7 +89,17 @@ private class PurchasesAPI {
             upgradeInfo,
             purchaseChangeCallback
         )
+
+        purchases.purchaseSubscriptionOption(
+            activity,
+            subscriptionOption,
+            upgradeInfo,
+            purchaseChangeCallback,
+            false
+        )
+
         purchases.purchaseSubscriptionOption(activity, subscriptionOption, purchaseCallback)
+        purchases.purchaseSubscriptionOption(activity, subscriptionOption, purchaseCallback, false)
 
         purchases.restorePurchases(receiveCustomerInfoCallback)
         purchases.logIn("", logInCallback)

--- a/common/src/main/java/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -79,7 +79,8 @@ abstract class BillingAbstract {
         appUserID: String,
         purchasingData: PurchasingData,
         replaceProductInfo: ReplaceProductInfo?,
-        presentedOfferingIdentifier: String?
+        presentedOfferingIdentifier: String?,
+        isPersonalizedPrice: Boolean = false
     )
 
     abstract fun isConnected(): Boolean

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -225,7 +225,8 @@ internal class AmazonBilling constructor(
         appUserID: String,
         purchasingData: PurchasingData,
         replaceProductInfo: ReplaceProductInfo?,
-        presentedOfferingIdentifier: String?
+        presentedOfferingIdentifier: String?,
+        isPersonalizedPrice: Boolean
     ) {
         val amazonPurchaseInfo = purchasingData as? AmazonPurchasingData.Product
         if (amazonPurchaseInfo == null) {

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -200,7 +200,8 @@ class BillingWrapper(
         appUserID: String,
         purchasingData: PurchasingData,
         replaceProductInfo: ReplaceProductInfo?,
-        presentedOfferingIdentifier: String?
+        presentedOfferingIdentifier: String?,
+        isPersonalizedPrice: Boolean
     ) {
         val googlePurchasingData = purchasingData as? GooglePurchasingData
         if (googlePurchasingData == null) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -410,7 +410,8 @@ class Purchases internal constructor(
             storeProduct.defaultOption?.purchasingData ?: storeProduct.purchasingData,
             null,
             upgradeInfo,
-            listener
+            listener,
+            false // TODO bc5 think about personalized price for products
         )
     }
 
@@ -447,19 +448,25 @@ class Purchases internal constructor(
      * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldProductId and the optional
      * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
      * @param [listener] The PurchaseCallback that will be called when purchase completes.
+     * @param [isPersonalizedPrice] Set this parameter to true if the [SubscriptionOption] is a developer-determined
+     * offer available for purchase in the EU. Default is false.
+     * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
+
      */
     fun purchaseSubscriptionOption(
         activity: Activity,
         subscriptionOption: SubscriptionOption,
         upgradeInfo: UpgradeInfo,
-        listener: ProductChangeCallback
+        listener: ProductChangeCallback,
+        isPersonalizedPrice: Boolean = false
     ) {
         startProductChange(
             activity,
             subscriptionOption.purchasingData,
             null,
             upgradeInfo,
-            listener
+            listener,
+            isPersonalizedPrice
         )
     }
 
@@ -507,7 +514,8 @@ class Purchases internal constructor(
             packageToPurchase.product.defaultOption?.purchasingData ?: packageToPurchase.product.purchasingData,
             packageToPurchase.offering,
             upgradeInfo,
-            callback
+            callback,
+            false // TODO BC5 think about personalized price for packages
         )
     }
 
@@ -1527,7 +1535,8 @@ class Purchases internal constructor(
         purchasingData: PurchasingData,
         offeringIdentifier: String?,
         upgradeInfo: UpgradeInfo,
-        listener: ProductChangeCallback
+        listener: ProductChangeCallback,
+        isPersonalizedPrice: Boolean
     ) {
         log(
             LogIntent.PURCHASE, PurchaseStrings.PRODUCT_CHANGE_STARTED.format(
@@ -1556,7 +1565,8 @@ class Purchases internal constructor(
                 activity,
                 appUserID,
                 offeringIdentifier,
-                listener
+                listener,
+                isPersonalizedPrice
             )
         } ?: listener.dispatch(PurchasesError(PurchasesErrorCode.OperationAlreadyInProgressError).also { errorLog(it) })
     }
@@ -1567,7 +1577,8 @@ class Purchases internal constructor(
         activity: Activity,
         appUserID: String,
         presentedOfferingIdentifier: String?,
-        listener: PurchaseErrorCallback
+        listener: PurchaseErrorCallback,
+        isPersonalizedPrice: Boolean
     ) {
         if (purchasingData.productType != ProductType.SUBS) {
             dispatch {
@@ -1589,7 +1600,8 @@ class Purchases internal constructor(
                     appUserID,
                     purchasingData,
                     ReplaceProductInfo(purchaseRecord, upgradeInfo.googleProrationMode.playBillingClientMode),
-                    presentedOfferingIdentifier
+                    presentedOfferingIdentifier,
+                    isPersonalizedPrice
                 )
             },
             onError = { error ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -430,14 +430,16 @@ class Purchases internal constructor(
     fun purchaseProduct(
         activity: Activity,
         storeProduct: StoreProduct,
-        callback: PurchaseCallback
+        callback: PurchaseCallback,
+        isPersonalizedPrice: Boolean = false
     ) {
         startPurchase(
             activity,
             // TODOBC5 Move this logic to StoreProduct
             storeProduct.defaultOption?.purchasingData ?: storeProduct.purchasingData,
             null,
-            callback
+            callback,
+            isPersonalizedPrice
         )
     }
 
@@ -448,11 +450,11 @@ class Purchases internal constructor(
      * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldProductId and the optional
      * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
      * @param [listener] The PurchaseCallback that will be called when purchase completes.
-     * @param [isPersonalizedPrice] Set this parameter to true if the [SubscriptionOption] is a developer-determined
-     * offer available for purchase in the EU. Default is false.
+     * @param [isPersonalizedPrice] Set this parameter to true if the [SubscriptionOption] is a Google
+     * developer-determined offer available for purchase in the EU. Default is false. Ignored for Amazon.
      * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
-
      */
+    @JvmOverloads
     fun purchaseSubscriptionOption(
         activity: Activity,
         subscriptionOption: SubscriptionOption,
@@ -475,13 +477,23 @@ class Purchases internal constructor(
      * @param [activity] Current activity
      * @param [subscriptionOption] Your choice of [SubscriptionOption]s available for a subscription StoreProduct
      * @param [callback] The PurchaseCallback that will be called when purchase completes
+     * @param [isPersonalizedPrice] Set this parameter to true if the [SubscriptionOption] is a Google
+     * developer-determined offer available for purchase in the EU. Default is false. Ignored for Amazon.
+     * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
      */
+    @JvmOverloads
     fun purchaseSubscriptionOption(
         activity: Activity,
         subscriptionOption: SubscriptionOption,
-        callback: PurchaseCallback
+        callback: PurchaseCallback,
+        isPersonalizedPrice: Boolean = false
     ) {
-        startPurchase(activity, subscriptionOption.purchasingData, null, callback)
+        startPurchase(activity,
+            subscriptionOption.purchasingData,
+            null,
+            callback,
+            isPersonalizedPrice
+        )
     }
 
     /**
@@ -541,7 +553,8 @@ class Purchases internal constructor(
             // TODOBC5 Move this logic to StoreProduct
             packageToPurchase.product.defaultOption?.purchasingData ?: packageToPurchase.product.purchasingData,
             packageToPurchase.offering,
-            listener
+            listener,
+            false // TODOC5 figure out isPersonalizedPrice with package
         )
     }
 
@@ -1494,7 +1507,8 @@ class Purchases internal constructor(
         activity: Activity,
         purchasingData: PurchasingData,
         presentedOfferingIdentifier: String?,
-        listener: PurchaseCallback
+        listener: PurchaseCallback,
+        isPersonalizedPrice: Boolean
     ) {
         log(
             LogIntent.PURCHASE, PurchaseStrings.PURCHASE_STARTED.format(
@@ -1525,7 +1539,8 @@ class Purchases internal constructor(
                 appUserID,
                 purchasingData,
                 null,
-                presentedOfferingIdentifier
+                presentedOfferingIdentifier,
+                isPersonalizedPrice
             )
         } ?: listener.dispatch(PurchasesError(PurchasesErrorCode.OperationAlreadyInProgressError).also { errorLog(it) })
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -440,7 +440,7 @@ class Purchases internal constructor(
         activity: Activity,
         storeProduct: StoreProduct,
         callback: PurchaseCallback,
-        isPersonalizedPrice: Boolean = false,
+        isPersonalizedPrice: Boolean = false
     ) {
         startPurchase(
             activity,
@@ -527,6 +527,7 @@ class Purchases internal constructor(
      * developer-determined offer available for purchase in the EU. Default is false. Ignored for Amazon.
      * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
      */
+    @JvmOverloads
     fun purchasePackage(
         activity: Activity,
         packageToPurchase: Package,
@@ -557,6 +558,7 @@ class Purchases internal constructor(
      * @param [packageToPurchase] The Package you wish to purchase
      * @param [listener] The listener that will be called when purchase completes.
      */
+    @JvmOverloads
     fun purchasePackage(
         activity: Activity,
         packageToPurchase: Package,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -397,12 +397,17 @@ class Purchases internal constructor(
      * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldProductId and the optional
      * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
      * @param [listener] The PurchaseCallback that will be called when purchase completes.
+     * @param [isPersonalizedPrice] Set this parameter to true if the [SubscriptionOption] is a Google
+     * developer-determined offer available for purchase in the EU. Default is false. Ignored for Amazon.
+     * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
      */
+    @JvmOverloads
     fun purchaseProduct(
         activity: Activity,
         storeProduct: StoreProduct,
         upgradeInfo: UpgradeInfo,
-        listener: ProductChangeCallback
+        listener: ProductChangeCallback,
+        isPersonalizedPrice: Boolean = false
     ) {
         startProductChange(
             activity,
@@ -410,8 +415,8 @@ class Purchases internal constructor(
             storeProduct.defaultOption?.purchasingData ?: storeProduct.purchasingData,
             null,
             upgradeInfo,
-            listener,
-            false // TODO bc5 think about personalized price for products
+            isPersonalizedPrice, // TODOBC5 think about personalized price for products
+            listener
         )
     }
 
@@ -426,20 +431,24 @@ class Purchases internal constructor(
      * @param [activity] Current activity
      * @param [storeProduct] The StoreProduct of the product you wish to purchase
      * @param [callback] The PurchaseCallback that will be called when purchase completes.
+     * @param [isPersonalizedPrice] Set this parameter to true if the [SubscriptionOption] is a Google
+     * developer-determined offer available for purchase in the EU. Default is false. Ignored for Amazon.
+     * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
      */
+    @JvmOverloads
     fun purchaseProduct(
         activity: Activity,
         storeProduct: StoreProduct,
         callback: PurchaseCallback,
-        isPersonalizedPrice: Boolean = false
+        isPersonalizedPrice: Boolean = false,
     ) {
         startPurchase(
             activity,
             // TODOBC5 Move this logic to StoreProduct
             storeProduct.defaultOption?.purchasingData ?: storeProduct.purchasingData,
             null,
-            callback,
-            isPersonalizedPrice
+            isPersonalizedPrice,
+            callback
         )
     }
 
@@ -467,8 +476,8 @@ class Purchases internal constructor(
             subscriptionOption.purchasingData,
             null,
             upgradeInfo,
-            listener,
-            isPersonalizedPrice
+            isPersonalizedPrice,
+            listener
         )
     }
 
@@ -488,11 +497,12 @@ class Purchases internal constructor(
         callback: PurchaseCallback,
         isPersonalizedPrice: Boolean = false
     ) {
-        startPurchase(activity,
+        startPurchase(
+            activity,
             subscriptionOption.purchasingData,
             null,
-            callback,
-            isPersonalizedPrice
+            isPersonalizedPrice,
+            callback
         )
     }
 
@@ -513,12 +523,16 @@ class Purchases internal constructor(
      * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldProductId and the optional
      * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
      * @param [callback] The listener that will be called when purchase completes.
+     * @param [isPersonalizedPrice] Set this parameter to true if the [SubscriptionOption] is a Google
+     * developer-determined offer available for purchase in the EU. Default is false. Ignored for Amazon.
+     * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
      */
     fun purchasePackage(
         activity: Activity,
         packageToPurchase: Package,
         upgradeInfo: UpgradeInfo,
-        callback: ProductChangeCallback
+        callback: ProductChangeCallback,
+        isPersonalizedPrice: Boolean = false
     ) {
         startProductChange(
             activity,
@@ -526,8 +540,8 @@ class Purchases internal constructor(
             packageToPurchase.product.defaultOption?.purchasingData ?: packageToPurchase.product.purchasingData,
             packageToPurchase.offering,
             upgradeInfo,
-            callback,
-            false // TODO BC5 think about personalized price for packages
+            isPersonalizedPrice, // TODO BC5 think about personalized price for packages
+            callback
         )
     }
 
@@ -546,15 +560,16 @@ class Purchases internal constructor(
     fun purchasePackage(
         activity: Activity,
         packageToPurchase: Package,
-        listener: PurchaseCallback
+        listener: PurchaseCallback,
+        isPersonalizedPrice: Boolean = false
     ) {
         startPurchase(
             activity,
             // TODOBC5 Move this logic to StoreProduct
             packageToPurchase.product.defaultOption?.purchasingData ?: packageToPurchase.product.purchasingData,
             packageToPurchase.offering,
-            listener,
-            false // TODOC5 figure out isPersonalizedPrice with package
+            isPersonalizedPrice, // TODOC5 figure out isPersonalizedPrice with package
+            listener
         )
     }
 
@@ -1507,8 +1522,8 @@ class Purchases internal constructor(
         activity: Activity,
         purchasingData: PurchasingData,
         presentedOfferingIdentifier: String?,
-        listener: PurchaseCallback,
-        isPersonalizedPrice: Boolean
+        isPersonalizedPrice: Boolean,
+        listener: PurchaseCallback
     ) {
         log(
             LogIntent.PURCHASE, PurchaseStrings.PURCHASE_STARTED.format(
@@ -1550,8 +1565,8 @@ class Purchases internal constructor(
         purchasingData: PurchasingData,
         offeringIdentifier: String?,
         upgradeInfo: UpgradeInfo,
-        listener: ProductChangeCallback,
-        isPersonalizedPrice: Boolean
+        isPersonalizedPrice: Boolean,
+        listener: ProductChangeCallback
     ) {
         log(
             LogIntent.PURCHASE, PurchaseStrings.PRODUCT_CHANGE_STARTED.format(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -1,3 +1,4 @@
+@file:SuppressWarnings("LongParameterList")
 package com.revenuecat.purchases
 
 import android.app.Activity
@@ -117,14 +118,18 @@ fun Purchases.getOfferingsWith(
  * @param [storeProduct] The storeProduct of the product you wish to purchase
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called if there was an error with the purchase
+ * @param [isPersonalizedPrice] Set this parameter to true if the [SubscriptionOption] is a Google
+ * developer-determined offer available for purchase in the EU. Default is false. Ignored for Amazon.
+ * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
  */
 fun Purchases.purchaseProductWith(
     activity: Activity,
     storeProduct: StoreProduct,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
-    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
+    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit,
+    isPersonalizedPrice: Boolean = false
 ) {
-    purchaseProduct(activity, storeProduct, purchaseCompletedCallback(onSuccess, onError))
+    purchaseProduct(activity, storeProduct, purchaseCompletedCallback(onSuccess, onError), isPersonalizedPrice)
 }
 
 /**
@@ -136,15 +141,25 @@ fun Purchases.purchaseProductWith(
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called if there was an error with the purchase
+ * @param [isPersonalizedPrice] Set this parameter to true if the [SubscriptionOption] is a Google
+ * developer-determined offer available for purchase in the EU. Default is false. Ignored for Amazon.
+ * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
  */
 fun Purchases.purchaseProductWith(
     activity: Activity,
     storeProduct: StoreProduct,
     upgradeInfo: UpgradeInfo,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
-    onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
+    onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit,
+    isPersonalizedPrice: Boolean = false
 ) {
-    purchaseProduct(activity, storeProduct, upgradeInfo, productChangeCompletedListener(onSuccess, onError))
+    purchaseProduct(
+        activity,
+        storeProduct,
+        upgradeInfo,
+        productChangeCompletedListener(onSuccess, onError),
+        isPersonalizedPrice
+    )
 }
 
 /**
@@ -153,17 +168,22 @@ fun Purchases.purchaseProductWith(
  * @param [subscriptionOption] Your choice of [SubscriptionOption]s available for a subscription StoreProduct
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called if there was an error with the purchase
+ * @param [isPersonalizedPrice] Set this parameter to true if the [SubscriptionOption] is a Google
+ * developer-determined offer available for purchase in the EU. Default is false. Ignored for Amazon.
+ * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
  */
 fun Purchases.purchaseSubscriptionOptionWith(
     activity: Activity,
     subscriptionOption: SubscriptionOption,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
-    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
+    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit,
+    isPersonalizedPrice: Boolean = false
 ) {
     purchaseSubscriptionOption(
         activity,
         subscriptionOption,
-        purchaseCompletedCallback(onSuccess, onError)
+        purchaseCompletedCallback(onSuccess, onError),
+        isPersonalizedPrice
     )
 }
 
@@ -175,6 +195,9 @@ fun Purchases.purchaseSubscriptionOptionWith(
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called if there was an error with the purchase
+ * @param [isPersonalizedPrice] Set this parameter to true if the [SubscriptionOption] is a Google
+ * developer-determined offer available for purchase in the EU. Default is false. Ignored for Amazon.
+ * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
  */
 @Suppress("LongParameterList")
 fun Purchases.purchaseSubscriptionOptionWith(
@@ -182,13 +205,15 @@ fun Purchases.purchaseSubscriptionOptionWith(
     subscriptionOption: SubscriptionOption,
     upgradeInfo: UpgradeInfo,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
-    onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
+    onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit,
+    isPersonalizedPrice: Boolean = false,
 ) {
     purchaseSubscriptionOption(
         activity,
         subscriptionOption,
         upgradeInfo,
-        productChangeCompletedListener(onSuccess, onError)
+        productChangeCompletedListener(onSuccess, onError),
+        isPersonalizedPrice
     )
 }
 
@@ -201,15 +226,25 @@ fun Purchases.purchaseSubscriptionOptionWith(
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called if there was an error with the purchase
+ * @param [isPersonalizedPrice] Set this parameter to true if the [SubscriptionOption] is a Google
+ * developer-determined offer available for purchase in the EU. Default is false. Ignored for Amazon.
+ * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
  */
 fun Purchases.purchasePackageWith(
     activity: Activity,
     packageToPurchase: Package,
     upgradeInfo: UpgradeInfo,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
-    onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
+    onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit,
+    isPersonalizedPrice: Boolean = false
 ) {
-    purchasePackage(activity, packageToPurchase, upgradeInfo, productChangeCompletedListener(onSuccess, onError))
+    purchasePackage(
+        activity,
+        packageToPurchase,
+        upgradeInfo,
+        productChangeCompletedListener(onSuccess, onError),
+        isPersonalizedPrice
+    )
 }
 
 /**
@@ -218,14 +253,18 @@ fun Purchases.purchasePackageWith(
  * @param [packageToPurchase] The Package you wish to purchase
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called if there was an error with the purchase
+ * @param [isPersonalizedPrice] Set this parameter to true if the [SubscriptionOption] is a Google
+ * developer-determined offer available for purchase in the EU. Default is false. Ignored for Amazon.
+ * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
  */
 fun Purchases.purchasePackageWith(
     activity: Activity,
     packageToPurchase: Package,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
-    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
+    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit,
+    isPersonalizedPrice: Boolean = false
 ) {
-    purchasePackage(activity, packageToPurchase, purchaseCompletedCallback(onSuccess, onError))
+    purchasePackage(activity, packageToPurchase, purchaseCompletedCallback(onSuccess, onError), isPersonalizedPrice)
 }
 
 /**

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -450,6 +450,16 @@ class PurchasesTest {
     // region purchasing
 
     @Test
+    fun `isPersonalizedPrice value is passed through to purchase`() {
+        // TODO
+    }
+
+    @Test
+    fun `isPersonazlizedPrice defaults to false`() {
+        // TODO
+    }
+
+    @Test
     fun `when making purchase with upgrade info, completion block is called`() {
         val productId = "onemonth_freetrial"
         val purchaseToken = "crazy_purchase_token"

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -40,6 +40,7 @@ import com.revenuecat.purchases.google.toStoreTransaction
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
+import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.BillingFeature
@@ -451,12 +452,54 @@ class PurchasesTest {
 
     @Test
     fun `isPersonalizedPrice value is passed through to purchase`() {
-        // TODO
+        val storeProduct = stubStoreProduct("abc")
+        val expectedPersonalizedPrice = true
+
+        purchases.purchaseSubscriptionOption(
+            mockActivity,
+            storeProduct.subscriptionOptions[0],
+            object: PurchaseCallback {
+                override fun onCompleted(storeTransaction: StoreTransaction, customerInfo: CustomerInfo) {}
+                override fun onError(error: PurchasesError, userCancelled: Boolean) {}
+            },
+            expectedPersonalizedPrice
+        )
+
+        verify {
+            mockBillingAbstract.makePurchaseAsync(
+                eq(mockActivity),
+                eq(appUserId),
+                storeProduct.subscriptionOptions[0].purchasingData,
+                null,
+                null,
+                expectedPersonalizedPrice
+            )
+        }
     }
 
     @Test
-    fun `isPersonazlizedPrice defaults to false`() {
-        // TODO
+    fun `isPersonalizedPrice defaults to false`() {
+        val storeProduct = stubStoreProduct("abc")
+
+        purchases.purchaseSubscriptionOption(
+            mockActivity,
+            storeProduct.subscriptionOptions[0],
+            object: PurchaseCallback {
+                override fun onCompleted(storeTransaction: StoreTransaction, customerInfo: CustomerInfo) {}
+                override fun onError(error: PurchasesError, userCancelled: Boolean) {}
+            }
+        )
+
+        verify {
+            mockBillingAbstract.makePurchaseAsync(
+                eq(mockActivity),
+                eq(appUserId),
+                storeProduct.subscriptionOptions[0].purchasingData,
+                null,
+                null,
+                false
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
There is a new EU directive requiring developers to disclose whether a price is personalized. Google does not provide guidance as to what makes a price personalized. It's possible that this is for developer-determined offers, or for any offers via the console with eligibility criteria set.

BC5 provides a parameter on the `BillingFlowParams` accepting a boolean, and, when set to true, will display a "This price has been customized for you" line in the purchase dialog.