### PR TITLE
[BC5] Fix value of NON_RECURRING from 0 to 3

### DIFF
--- a/public/src/main/java/com/revenuecat/purchases/models/RecurrenceMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/RecurrenceMode.kt
@@ -5,16 +5,17 @@ package com.revenuecat.purchases.models
  */
 // TODO if google-only, rename and annotate identifier with @ProductDetails.RecurrenceMode
 // TODO add api testers
+@SuppressWarnings("MagicNumber")
 enum class RecurrenceMode(val identifier: Int?) {
-
-    // Pricing phase does not repeat
-    NON_RECURRING(0),
 
     // Pricing phase repeats infinitely until cancellation
     INFINITE_RECURRING(1),
 
     // Pricing phase repeats for a fixed number of billing periods
     FINITE_RECURRING(2),
+
+    // Pricing phase does not repeat
+    NON_RECURRING(3),
     UNKNOWN(null)
 }
 

--- a/public/src/test/java/com/revenuecat/purchases/RecurrenceModeTest.kt
+++ b/public/src/test/java/com/revenuecat/purchases/RecurrenceModeTest.kt
@@ -1,0 +1,26 @@
+package com.revenuecat.purchases
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.models.RecurrenceMode
+import com.revenuecat.purchases.models.toRecurrenceMode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+ class RecurrenceModeTest {
+    @Test
+    fun testToRecurrenceMode() {
+        val unknown0 = 0.toRecurrenceMode()
+        val infinite = 1.toRecurrenceMode()
+        val finite = 2.toRecurrenceMode()
+        val nonRecurring = 3.toRecurrenceMode()
+        val unknown4 = 4.toRecurrenceMode()
+
+        assertThat(unknown0).isEqualTo(RecurrenceMode.UNKNOWN)
+        assertThat(infinite).isEqualTo(RecurrenceMode.INFINITE_RECURRING)
+        assertThat(finite).isEqualTo(RecurrenceMode.FINITE_RECURRING)
+        assertThat(nonRecurring).isEqualTo(RecurrenceMode.NON_RECURRING)
+        assertThat(unknown4).isEqualTo(RecurrenceMode.UNKNOWN)
+    }
+}


### PR DESCRIPTION
## Motivation

Noticed that was testing the recurring mode of a prepaid plan (because curious) that the value was `3` and our `RecurrenceMode` enum only had values for 0, 1, and 2.

## Description

- `NON_RECURRING(0)` to `NON_RECURRING(3)`

### Docs

Docs here - https://developer.android.com/reference/com/android/billingclient/api/ProductDetails.RecurrenceMode
And screenshot incase this link or doc ever changes which would make this PR seem wrong 😝 

![Screen Shot 2023-02-15 at 5 42 30 AM](https://user-images.githubusercontent.com/401294/219024309-8c6b3226-b87f-49f3-9b28-96e72dbb9efb.png)

