### PR TITLE
Diagnostics: Track endpoint hit

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -28,6 +28,8 @@ import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
 import java.net.MalformedURLException
 import java.net.URL
+import java.util.Date
+import kotlin.time.Duration
 
 class HTTPClient(
     private val appConfig: AppConfig,
@@ -105,7 +107,7 @@ class HTTPClient(
         refreshETag: Boolean = false
     ): HTTPResult {
         var callSuccessful = false
-        val requestStartTime = dateProvider.now.time
+        val requestStartTime = dateProvider.now
         var callResult: HTTPResult? = null
         try {
             callResult = performCall(baseURL, endpoint, body, requestHeaders, refreshETag)
@@ -171,12 +173,12 @@ class HTTPClient(
 
     private fun trackHttpRequestPerformedIfNeeded(
         endpoint: Endpoint,
-        requestStartTime: Long,
+        requestStartTime: Date,
         callSuccessful: Boolean,
         callResult: HTTPResult?
     ) {
         diagnosticsTracker?.let { tracker ->
-            val responseTime = dateProvider.now.time - requestStartTime
+            val responseTime = Duration.between(requestStartTime, dateProvider.now)
             val responseCode = if (callSuccessful) {
                 // When the result given by ETagManager is null, is because we are asking to refresh the etag
                 // since we could not find the response in the cache.

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -34,6 +34,9 @@ class HTTPClient(
     private val diagnosticsTracker: DiagnosticsTracker?,
     private val dateProvider: DateProvider = DefaultDateProvider()
 ) {
+    internal companion object {
+        const val NO_STATUS_CODE = -1
+    }
 
     private fun buffer(inputStream: InputStream): BufferedReader {
         return BufferedReader(InputStreamReader(inputStream))
@@ -176,7 +179,7 @@ class HTTPClient(
                 // since we could not find the response in the cache.
                 callResult?.responseCode ?: RCHTTPStatusCodes.NOT_MODIFIED
             } else {
-                -1
+                NO_STATUS_CODE
             }
             val origin = callResult?.origin
             val requestWasError = callSuccessful && RCHTTPStatusCodes.isSuccessful(responseCode)

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -37,6 +37,7 @@ class HTTPClient(
 ) {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal companion object {
+        // This will be used when we could not reach the server due to connectivity or any other issues.
         const val NO_STATUS_CODE = -1
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -6,6 +6,7 @@
 package com.revenuecat.purchases.common
 
 import android.os.Build
+import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.ETagManager
@@ -34,6 +35,7 @@ class HTTPClient(
     private val diagnosticsTracker: DiagnosticsTracker?,
     private val dateProvider: DateProvider = DefaultDateProvider()
 ) {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal companion object {
         const val NO_STATUS_CODE = -1
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.common.networking.ETagManager
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPRequest
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.strings.NetworkStrings
 import com.revenuecat.purchases.utils.filterNotNullValues
 import org.json.JSONException
@@ -144,7 +145,7 @@ class HTTPClient(
                 urlPathWithVersion,
                 refreshETag
             )
-            requestSuccessful = true
+            requestSuccessful = RCHTTPStatusCodes.isSuccessful(responseCode)
         } finally {
             diagnosticsTracker?.let { tracker ->
                 val responseTime = dateProvider.now.time - requestStartTime

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -111,7 +111,7 @@ class HTTPClient(
             callResult = performCall(baseURL, endpoint, body, requestHeaders, refreshETag)
             callSuccessful = true
         } finally {
-            trackEndpointHitIfNeeded(endpoint, requestStartTime, callSuccessful, callResult)
+            trackHttpRequestPerformedIfNeeded(endpoint, requestStartTime, callSuccessful, callResult)
         }
         if (callResult == null) {
             log(LogIntent.WARNING, NetworkStrings.ETAG_RETRYING_CALL)
@@ -169,7 +169,7 @@ class HTTPClient(
         )
     }
 
-    private fun trackEndpointHitIfNeeded(
+    private fun trackHttpRequestPerformedIfNeeded(
         endpoint: Endpoint,
         requestStartTime: Long,
         callSuccessful: Boolean,
@@ -186,7 +186,7 @@ class HTTPClient(
             }
             val origin = callResult?.origin
             val requestWasError = callSuccessful && RCHTTPStatusCodes.isSuccessful(responseCode)
-            tracker.trackEndpointHit(endpoint, responseTime, requestWasError, responseCode, origin)
+            tracker.trackHttpRequestPerformed(endpoint, responseTime, requestWasError, responseCode, origin)
         }
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEvent.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEvent.kt
@@ -16,7 +16,7 @@ sealed class DiagnosticsEvent(val diagnosticType: String) {
 
     data class Log(
         val name: DiagnosticsLogEventName,
-        val properties: Map<String, Any>,
+        val properties: Map<String, Any?>,
         val dateProvider: DateProvider = DefaultDateProvider(),
         val dateTime: Date = dateProvider.now
     ) : DiagnosticsEvent("log") {

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEvent.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEvent.kt
@@ -16,7 +16,7 @@ sealed class DiagnosticsEvent(val diagnosticType: String) {
 
     data class Log(
         val name: DiagnosticsLogEventName,
-        val properties: Map<String, Any?>,
+        val properties: Map<String, Any>,
         val dateProvider: DateProvider = DefaultDateProvider(),
         val dateTime: Date = dateProvider.now
     ) : DiagnosticsEvent("log") {

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsLogEventName.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsLogEventName.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.common.diagnostics
 
 enum class DiagnosticsLogEventName {
-    ENDPOINT_HIT,
+    HTTP_REQUEST_PERFORMED,
     MAX_EVENTS_STORED_LIMIT_REACHED
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
@@ -24,7 +24,7 @@ class DiagnosticsSynchronizer(
     private val sharedPreferences: SharedPreferences
 ) {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal companion object {
+    companion object {
         const val CONSECUTIVE_FAILURES_COUNT_KEY = "consecutive_failures_count"
         const val MAX_NUMBER_POST_RETRIES = 3
         const val MAX_NUMBER_EVENTS = 1000

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
@@ -23,12 +23,10 @@ class DiagnosticsSynchronizer(
     private val diagnosticsDispatcher: Dispatcher,
     private val sharedPreferences: SharedPreferences
 ) {
-    companion object {
-        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal companion object {
         const val CONSECUTIVE_FAILURES_COUNT_KEY = "consecutive_failures_count"
-        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         const val MAX_NUMBER_POST_RETRIES = 3
-        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         const val MAX_NUMBER_EVENTS = 1000
 
         fun initializeSharedPreferences(context: Context): SharedPreferences =

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
@@ -88,22 +88,10 @@ class DiagnosticsSynchronizer(
         if (diagnosticsInFileCount > MAX_NUMBER_EVENTS) {
             val eventsToRemoveCount = diagnosticsInFileCount - MAX_NUMBER_EVENTS + 1
             diagnosticsFileHelper.deleteOlderDiagnostics(eventsToRemoveCount)
-            trackMaxEventsStoredLimitReached(diagnosticsInFileCount, eventsToRemoveCount)
+            diagnosticsTracker.trackMaxEventsStoredLimitReached(diagnosticsInFileCount, eventsToRemoveCount)
             return diagnosticsFileHelper.readDiagnosticsFile()
         }
         return diagnosticsList
-    }
-
-    private fun trackMaxEventsStoredLimitReached(totalEventsStored: Int, eventsRemoved: Int) {
-        diagnosticsTracker.trackEventInCurrentThread(
-            DiagnosticsEvent.Log(
-                name = DiagnosticsLogEventName.MAX_EVENTS_STORED_LIMIT_REACHED,
-                properties = mapOf(
-                    "total_number_events_stored" to totalEventsStored,
-                    "events_removed" to eventsRemoved
-                )
-            )
-        )
     }
 
     private fun enqueue(command: () -> Unit) {

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
@@ -23,10 +23,12 @@ class DiagnosticsSynchronizer(
     private val diagnosticsDispatcher: Dispatcher,
     private val sharedPreferences: SharedPreferences
 ) {
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     companion object {
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         const val CONSECUTIVE_FAILURES_COUNT_KEY = "consecutive_failures_count"
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         const val MAX_NUMBER_POST_RETRIES = 3
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         const val MAX_NUMBER_EVENTS = 1000
 
         fun initializeSharedPreferences(context: Context): SharedPreferences =

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -37,6 +37,21 @@ class DiagnosticsTracker(
         )
     }
 
+    fun trackMaxEventsStoredLimitReached(totalEventsStored: Int, eventsRemoved: Int, useCurrentThread: Boolean = true) {
+        val event = DiagnosticsEvent.Log(
+            name = DiagnosticsLogEventName.MAX_EVENTS_STORED_LIMIT_REACHED,
+            properties = mapOf(
+                "total_number_events_stored" to totalEventsStored,
+                "events_removed" to eventsRemoved
+            )
+        )
+        if (useCurrentThread) {
+            trackEventInCurrentThread(event)
+        } else {
+            trackEvent(event)
+        }
+    }
+
     fun trackEvent(diagnosticsEvent: DiagnosticsEvent) {
         diagnosticsDispatcher.enqueue(command = {
             trackEventInCurrentThread(diagnosticsEvent)

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common.diagnostics
 
 import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.ResultOrigin
 import com.revenuecat.purchases.common.verboseLog
 import java.io.IOException
@@ -16,8 +17,8 @@ class DiagnosticsTracker(
 ) {
 
     fun trackEndpointHit(
-        path: String,
-        responseTime: Long?,
+        endpoint: Endpoint,
+        responseTime: Long,
         wasSuccessful: Boolean,
         responseCode: Int,
         resultOrigin: ResultOrigin?
@@ -26,7 +27,7 @@ class DiagnosticsTracker(
             DiagnosticsEvent.Log(
                 name = DiagnosticsLogEventName.ENDPOINT_HIT,
                 properties = mapOf(
-                    "endpoint_path" to path, // WIP: Need to anonymize this better
+                    "endpoint_name" to endpoint.name,
                     "response_time_millis" to responseTime,
                     "successful" to wasSuccessful,
                     "response_code" to responseCode,

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common.diagnostics
 
 import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.networking.ResultOrigin
 import com.revenuecat.purchases.common.verboseLog
 import java.io.IOException
 
@@ -13,6 +14,27 @@ class DiagnosticsTracker(
     private val diagnosticsAnonymizer: DiagnosticsAnonymizer,
     private val diagnosticsDispatcher: Dispatcher
 ) {
+
+    fun trackEndpointHit(
+        path: String,
+        responseTime: Long?,
+        wasSuccessful: Boolean,
+        responseCode: Int,
+        resultOrigin: ResultOrigin?
+    ) {
+        trackEvent(
+            DiagnosticsEvent.Log(
+                name = DiagnosticsLogEventName.ENDPOINT_HIT,
+                properties = mapOf(
+                    "endpoint_path" to path, // WIP: Need to anonymize this better
+                    "response_time_millis" to responseTime,
+                    "successful" to wasSuccessful,
+                    "response_code" to responseCode,
+                    "etag_hit" to (resultOrigin == ResultOrigin.CACHE)
+                )
+            )
+        )
+    }
 
     fun trackEvent(diagnosticsEvent: DiagnosticsEvent) {
         diagnosticsDispatcher.enqueue(command = {

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -2,7 +2,7 @@ package com.revenuecat.purchases.common.diagnostics
 
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.networking.Endpoint
-import com.revenuecat.purchases.common.networking.ResultOrigin
+import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.verboseLog
 import java.io.IOException
 
@@ -21,7 +21,7 @@ class DiagnosticsTracker(
         responseTime: Long,
         wasSuccessful: Boolean,
         responseCode: Int,
-        resultOrigin: ResultOrigin?
+        resultOrigin: HTTPResult.Origin?
     ) {
         trackEvent(
             DiagnosticsEvent.Log(
@@ -31,7 +31,7 @@ class DiagnosticsTracker(
                     "response_time_millis" to responseTime,
                     "successful" to wasSuccessful,
                     "response_code" to responseCode,
-                    "etag_hit" to (resultOrigin == ResultOrigin.CACHE)
+                    "etag_hit" to (resultOrigin == HTTPResult.Origin.CACHE)
                 )
             )
         )

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.verboseLog
 import java.io.IOException
+import kotlin.time.Duration
 
 /**
  * This class is the entry point for all diagnostics tracking. It contains all information for all events
@@ -18,7 +19,7 @@ class DiagnosticsTracker(
 
     fun trackHttpRequestPerformed(
         endpoint: Endpoint,
-        responseTime: Long,
+        responseTime: Duration,
         wasSuccessful: Boolean,
         responseCode: Int,
         resultOrigin: HTTPResult.Origin?
@@ -28,7 +29,7 @@ class DiagnosticsTracker(
                 name = DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED,
                 properties = mapOf(
                     "endpoint_name" to endpoint.name,
-                    "response_time_millis" to responseTime,
+                    "response_time_millis" to responseTime.inWholeMilliseconds,
                     "successful" to wasSuccessful,
                     "response_code" to responseCode,
                     "etag_hit" to (resultOrigin == HTTPResult.Origin.CACHE)

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -16,7 +16,7 @@ class DiagnosticsTracker(
     private val diagnosticsDispatcher: Dispatcher
 ) {
 
-    fun trackEndpointHit(
+    fun trackHttpRequestPerformed(
         endpoint: Endpoint,
         responseTime: Long,
         wasSuccessful: Boolean,
@@ -25,7 +25,7 @@ class DiagnosticsTracker(
     ) {
         trackEvent(
             DiagnosticsEvent.Log(
-                name = DiagnosticsLogEventName.ENDPOINT_HIT,
+                name = DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED,
                 properties = mapOf(
                     "endpoint_name" to endpoint.name,
                     "response_time_millis" to responseTime,

--- a/common/src/main/java/com/revenuecat/purchases/common/durationExtensions.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/durationExtensions.kt
@@ -1,0 +1,8 @@
+package com.revenuecat.purchases.common
+
+import java.util.Date
+import kotlin.time.Duration
+
+fun Duration.Companion.between(startTime: Date, endTime: Date): Duration {
+    return (endTime.time - startTime.time).milliseconds
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -53,7 +53,7 @@ class ETagManager(
         urlPathWithVersion: String,
         refreshETag: Boolean
     ): HTTPResult? {
-        val resultFromBackend = HTTPResult(responseCode, payload)
+        val resultFromBackend = HTTPResult(responseCode, payload, ResultOrigin.BACKEND)
         connection.getETagHeader()?.let { eTagInResponse ->
             if (shouldUseCachedVersion(responseCode)) {
                 val storedResult = getStoredResult(urlPathWithVersion)
@@ -100,7 +100,8 @@ class ETagManager(
         result: HTTPResult,
         eTag: String
     ) {
-        val httpResultWithETag = HTTPResultWithETag(eTag, result)
+        val cacheResult = result.copy(origin = ResultOrigin.CACHE)
+        val httpResultWithETag = HTTPResultWithETag(eTag, cacheResult)
         prefs.edit().putString(path, httpResultWithETag.serialize()).apply()
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -53,7 +53,7 @@ class ETagManager(
         urlPathWithVersion: String,
         refreshETag: Boolean
     ): HTTPResult? {
-        val resultFromBackend = HTTPResult(responseCode, payload, ResultOrigin.BACKEND)
+        val resultFromBackend = HTTPResult(responseCode, payload, HTTPResult.Origin.BACKEND)
         connection.getETagHeader()?.let { eTagInResponse ->
             if (shouldUseCachedVersion(responseCode)) {
                 val storedResult = getStoredResult(urlPathWithVersion)
@@ -100,7 +100,7 @@ class ETagManager(
         result: HTTPResult,
         eTag: String
     ) {
-        val cacheResult = result.copy(origin = ResultOrigin.CACHE)
+        val cacheResult = result.copy(origin = HTTPResult.Origin.CACHE)
         val httpResultWithETag = HTTPResultWithETag(eTag, cacheResult)
         prefs.edit().putString(path, httpResultWithETag.serialize()).apply()
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -1,0 +1,31 @@
+package com.revenuecat.purchases.common.networking
+
+import android.net.Uri
+
+sealed class Endpoint(val pathTemplate: String, val name: String) {
+    abstract fun getPath(): String
+    data class GetCustomerInfo(val userId: String) : Endpoint("/subscribers/%s", "get_customer") {
+        override fun getPath() = pathTemplate.format(Uri.encode(userId))
+    }
+    object PostReceipt : Endpoint("/receipt", "post_receipt") {
+        override fun getPath() = pathTemplate
+    }
+    data class GetOfferings(val userId: String) : Endpoint("/subscribers/%s/offerings", "get_offerings") {
+        override fun getPath() = pathTemplate.format(Uri.encode(userId))
+    }
+    object LogIn : Endpoint("/subscribers/identify", "log_in") {
+        override fun getPath() = pathTemplate
+    }
+    object PostDiagnostics : Endpoint("/diagnostics", "post_diagnostics") {
+        override fun getPath() = pathTemplate
+    }
+    data class PostAttributes(val userId: String) : Endpoint("/subscribers/%s/attributes", "post_attributes") {
+        override fun getPath() = pathTemplate.format(Uri.encode(userId))
+    }
+    data class GetAmazonReceipt(
+        val userId: String,
+        val receiptId: String
+        ) : Endpoint("/receipts/amazon/%s/%s", "get_amazon_receipt") {
+        override fun getPath() = pathTemplate.format(Uri.encode(userId), receiptId)
+    }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPResult.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPResult.kt
@@ -4,10 +4,16 @@ import org.json.JSONObject
 
 private const val SERIALIZATION_NAME_RESPONSE_CODE = "responseCode"
 private const val SERIALIZATION_NAME_PAYLOAD = "payload"
+private const val SERIALIZATION_NAME_ORIGIN = "origin"
+
+enum class ResultOrigin {
+    BACKEND, CACHE
+}
 
 data class HTTPResult(
     val responseCode: Int,
-    val payload: String
+    val payload: String,
+    val origin: ResultOrigin
 ) {
     val body: JSONObject = payload.takeIf { it.isNotBlank() }?.let { JSONObject(it) } ?: JSONObject()
 
@@ -15,6 +21,7 @@ data class HTTPResult(
         val jsonObject = JSONObject().apply {
             put(SERIALIZATION_NAME_RESPONSE_CODE, responseCode)
             put(SERIALIZATION_NAME_PAYLOAD, payload)
+            put(SERIALIZATION_NAME_ORIGIN, origin.name)
         }
         return jsonObject.toString()
     }
@@ -24,7 +31,12 @@ data class HTTPResult(
             val jsonObject = JSONObject(serialized)
             val responseCode = jsonObject.getInt(SERIALIZATION_NAME_RESPONSE_CODE)
             val payload = jsonObject.getString(SERIALIZATION_NAME_PAYLOAD)
-            return HTTPResult(responseCode, payload)
+            val origin: ResultOrigin = if (jsonObject.has(SERIALIZATION_NAME_ORIGIN)) {
+                ResultOrigin.valueOf(jsonObject.getString(SERIALIZATION_NAME_ORIGIN))
+            } else {
+                ResultOrigin.CACHE
+            }
+            return HTTPResult(responseCode, payload, origin)
         }
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPResult.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPResult.kt
@@ -6,15 +6,15 @@ private const val SERIALIZATION_NAME_RESPONSE_CODE = "responseCode"
 private const val SERIALIZATION_NAME_PAYLOAD = "payload"
 private const val SERIALIZATION_NAME_ORIGIN = "origin"
 
-enum class ResultOrigin {
-    BACKEND, CACHE
-}
-
 data class HTTPResult(
     val responseCode: Int,
     val payload: String,
-    val origin: ResultOrigin
+    val origin: Origin
 ) {
+    enum class Origin {
+        BACKEND, CACHE
+    }
+
     val body: JSONObject = payload.takeIf { it.isNotBlank() }?.let { JSONObject(it) } ?: JSONObject()
 
     fun serialize(): String {
@@ -31,10 +31,10 @@ data class HTTPResult(
             val jsonObject = JSONObject(serialized)
             val responseCode = jsonObject.getInt(SERIALIZATION_NAME_RESPONSE_CODE)
             val payload = jsonObject.getString(SERIALIZATION_NAME_PAYLOAD)
-            val origin: ResultOrigin = if (jsonObject.has(SERIALIZATION_NAME_ORIGIN)) {
-                ResultOrigin.valueOf(jsonObject.getString(SERIALIZATION_NAME_ORIGIN))
+            val origin: Origin = if (jsonObject.has(SERIALIZATION_NAME_ORIGIN)) {
+                Origin.valueOf(jsonObject.getString(SERIALIZATION_NAME_ORIGIN))
             } else {
-                ResultOrigin.CACHE
+                Origin.CACHE
             }
             return HTTPResult(responseCode, payload, origin)
         }

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/RCHTTPStatusCodes.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/RCHTTPStatusCodes.kt
@@ -5,9 +5,9 @@ object RCHTTPStatusCodes {
     const val CREATED = 201
     const val UNSUCCESSFUL = 300
     const val NOT_MODIFIED = 304
-    const val REQUEST_ERROR = 400
+    const val BAD_REQUEST = 400
     const val NOT_FOUND = 404
     const val ERROR = 500
 
-    fun isSuccessful(statusCode: Int) = statusCode < REQUEST_ERROR
+    fun isSuccessful(statusCode: Int) = statusCode < BAD_REQUEST
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/RCHTTPStatusCodes.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/RCHTTPStatusCodes.kt
@@ -5,6 +5,9 @@ object RCHTTPStatusCodes {
     const val CREATED = 201
     const val UNSUCCESSFUL = 300
     const val NOT_MODIFIED = 304
+    const val REQUEST_ERROR = 400
     const val NOT_FOUND = 404
     const val ERROR = 500
+
+    fun isSuccessful(statusCode: Int) = statusCode < REQUEST_ERROR
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -11,7 +11,6 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
-import com.revenuecat.purchases.common.networking.ResultOrigin
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.utils.Responses
 import com.revenuecat.purchases.utils.getNullableString
@@ -151,7 +150,7 @@ class BackendTest {
     ): CustomerInfo {
         val info: CustomerInfo = mockk()
 
-        val result = HTTPResult(responseCode, resultBody ?: "{}", ResultOrigin.BACKEND)
+        val result = HTTPResult(responseCode, resultBody ?: "{}", HTTPResult.Origin.BACKEND)
 
         if (shouldMockCustomerInfo) {
             every {

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -5,12 +5,13 @@
 
 package com.revenuecat.purchases.common
 
-import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.ResultOrigin
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.utils.Responses
 import com.revenuecat.purchases.utils.getNullableString
@@ -50,7 +51,7 @@ class BackendTest {
     private var mockClient: HTTPClient = mockk(relaxed = true)
     private val mockBaseURL = URL("http://mock-api-test.revenuecat.com/")
     private val mockDiagnosticsBaseURL = URL("https://mock-api-diagnostics.revenuecat.com/")
-    private val diagnosticsEndpoint = "/telemetry"
+    private val diagnosticsEndpoint = Endpoint.PostDiagnostics
     private val mockAppConfig: AppConfig = mockk<AppConfig>().apply {
         every { baseURL } returns mockBaseURL
         every { diagnosticsURL } returns mockDiagnosticsBaseURL
@@ -139,7 +140,7 @@ class BackendTest {
     }
 
     private fun mockResponse(
-        path: String,
+        endpoint: Endpoint,
         body: Map<String, Any?>?,
         responseCode: Int,
         clientException: Exception?,
@@ -150,7 +151,7 @@ class BackendTest {
     ): CustomerInfo {
         val info: CustomerInfo = mockk()
 
-        val result = HTTPResult(responseCode, resultBody ?: "{}")
+        val result = HTTPResult(responseCode, resultBody ?: "{}", ResultOrigin.BACKEND)
 
         if (shouldMockCustomerInfo) {
             every {
@@ -160,7 +161,7 @@ class BackendTest {
         val everyMockedCall = every {
             mockClient.performRequest(
                 eq(baseURL),
-                eq(path),
+                eq(endpoint),
                 (if (body == null) any() else eq(body)),
                 capture(headersSlot)
             )
@@ -245,7 +246,7 @@ class BackendTest {
         }.toMap()
 
         val info = mockResponse(
-            "/receipts",
+            Endpoint.PostReceipt,
             body,
             responseCode,
             clientException,
@@ -262,7 +263,7 @@ class BackendTest {
         appInBackground: Boolean = false
     ): CustomerInfo {
         val info =
-            mockResponse("/subscribers/$appUserID", null, responseCode, clientException, resultBody)
+            mockResponse(Endpoint.GetCustomerInfo(appUserID), null, responseCode, clientException, resultBody)
 
         backend.getCustomerInfo(
             appUserID,
@@ -306,7 +307,7 @@ class BackendTest {
         getCustomerInfo(404, null, "{'code': 7225, 'message': 'Dude not found'}")
 
         assertThat(receivedError).`as`("Received error is not null").isNotNull
-        assertThat(receivedError!!.underlyingErrorMessage).`as`("Received underlying message is not null").isNotNull()
+        assertThat(receivedError!!.underlyingErrorMessage).`as`("Received underlying message is not null").isNotNull
         assertThat(receivedError!!.underlyingErrorMessage!!).contains("Dude not found")
     }
 
@@ -352,7 +353,7 @@ class BackendTest {
     @Test
     fun `given a no offerings response`() {
 
-        mockResponse("/subscribers/$appUserID/offerings", null, 200, null, noOfferingsResponse)
+        mockResponse(Endpoint.GetOfferings(appUserID), null, 200, null, noOfferingsResponse)
 
         backend.getOfferings(
             appUserID,
@@ -362,35 +363,8 @@ class BackendTest {
         )
 
         assertThat(receivedOfferingsJSON).`as`("Received offerings response is not null").isNotNull
-        assertThat(receivedOfferingsJSON!!.getJSONArray("offerings").length()).isZero()
+        assertThat(receivedOfferingsJSON!!.getJSONArray("offerings").length()).isZero
         assertThat(receivedOfferingsJSON!!.getNullableString("current_offering_id")).isNull()
-    }
-
-    @Test
-    fun encodesAppUserId() {
-        val encodeableUserID = "userid with spaces"
-
-        val encodedUserID = "userid%20with%20spaces"
-        val path = "/subscribers/$encodedUserID/offerings"
-
-        val `object` = JSONObject()
-        `object`.put("string", "value")
-
-        backend.getOfferings(
-            encodeableUserID,
-            appInBackground = false,
-            onSuccess = {},
-            onError = {}
-        )
-
-        verify {
-            mockClient.performRequest(
-                mockBaseURL,
-                eq(path),
-                any(),
-                any()
-            )
-        }
     }
 
     @Test
@@ -415,7 +389,7 @@ class BackendTest {
     @Test
     fun `given multiple get calls for same subscriber, only one is triggered`() {
         mockResponse(
-            "/subscribers/$appUserID",
+            Endpoint.GetCustomerInfo(appUserID),
             null,
             200,
             null,
@@ -434,7 +408,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/subscribers/" + Uri.encode(appUserID),
+                Endpoint.GetCustomerInfo(appUserID),
                 null,
                 any()
             )
@@ -497,7 +471,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/receipts",
+                Endpoint.PostReceipt,
                 any(),
                 any()
             )
@@ -512,7 +486,7 @@ class BackendTest {
         assertThat(initialInfo).isEqualTo(initialInfo.rawData.buildCustomerInfo())
 
         mockResponse(
-            "/subscribers/$appUserID",
+            Endpoint.GetCustomerInfo(appUserID),
             null,
             200,
             null,
@@ -552,7 +526,7 @@ class BackendTest {
             storeAppUserID = null,
             onSuccess = { _, _ ->
                 mockResponse(
-                    "/subscribers/$appUserID",
+                    Endpoint.GetCustomerInfo(appUserID),
                     null,
                     200,
                     null,
@@ -577,7 +551,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/receipts",
+                Endpoint.PostReceipt,
                 any(),
                 any()
             )
@@ -585,7 +559,7 @@ class BackendTest {
         verify(exactly = 2) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/subscribers/$appUserID",
+                Endpoint.GetCustomerInfo(appUserID),
                 null,
                 any()
             )
@@ -595,7 +569,7 @@ class BackendTest {
     @Test
     fun `given multiple get offerings calls for same user, only one is triggered`() {
         mockResponse(
-            "/subscribers/$appUserID/offerings",
+            Endpoint.GetOfferings(appUserID),
             null,
             200,
             null,
@@ -614,7 +588,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/subscribers/$appUserID/offerings",
+                Endpoint.GetOfferings(appUserID),
                 null,
                 any()
             )
@@ -624,7 +598,7 @@ class BackendTest {
     @Test
     fun `given multiple offerings get calls for different user, both are triggered`() {
         mockResponse(
-            "/subscribers/$appUserID/offerings",
+            Endpoint.GetOfferings(appUserID),
             null,
             200,
             null,
@@ -643,7 +617,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/subscribers/$appUserID/offerings",
+                Endpoint.GetOfferings(appUserID),
                 null,
                 any()
             )
@@ -651,7 +625,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/subscribers/anotherUser/offerings",
+                Endpoint.GetOfferings("anotherUser"),
                 null,
                 any()
             )
@@ -726,7 +700,7 @@ class BackendTest {
         verify(exactly = 2) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/receipts",
+                Endpoint.PostReceipt,
                 any(),
                 any()
             )
@@ -850,7 +824,7 @@ class BackendTest {
         verify(exactly = 2) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/receipts",
+                Endpoint.PostReceipt,
                 any() as Map<String, Any?>,
                 any()
             )
@@ -938,7 +912,7 @@ class BackendTest {
         verify(exactly = 2) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/receipts",
+                Endpoint.PostReceipt,
                 any() as Map<String, Any?>,
                 any()
             )
@@ -997,7 +971,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/receipts",
+                Endpoint.PostReceipt,
                 any() as Map<String, Any?>,
                 any()
             )
@@ -1031,7 +1005,7 @@ class BackendTest {
 
     @Test
     fun `offerings call is enqueued with delay if on background`() {
-        mockResponse("/subscribers/$appUserID/offerings", null, 200, null, noOfferingsResponse)
+        mockResponse(Endpoint.GetOfferings(appUserID), null, 200, null, noOfferingsResponse)
         dispatcher.calledWithRandomDelay = null
         backend.getOfferings(
             appUserID,
@@ -1041,8 +1015,8 @@ class BackendTest {
         )
 
         val calledWithRandomDelay: Boolean? = dispatcher.calledWithRandomDelay
-        assertThat(calledWithRandomDelay).isNotNull()
-        assertThat(calledWithRandomDelay).isTrue()
+        assertThat(calledWithRandomDelay).isNotNull
+        assertThat(calledWithRandomDelay).isTrue
     }
 
     @Test
@@ -1052,8 +1026,8 @@ class BackendTest {
         getCustomerInfo(200, clientException = null, resultBody = null, appInBackground = true)
 
         val calledWithRandomDelay: Boolean? = dispatcher.calledWithRandomDelay
-        assertThat(calledWithRandomDelay).isNotNull()
-        assertThat(calledWithRandomDelay).isTrue()
+        assertThat(calledWithRandomDelay).isNotNull
+        assertThat(calledWithRandomDelay).isTrue
     }
 
     @Test
@@ -1064,7 +1038,7 @@ class BackendTest {
             "app_user_id" to appUserID
         )
         mockResponse(
-            "/subscribers/identify",
+            Endpoint.LogIn,
             body,
             201,
             null,
@@ -1082,7 +1056,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/subscribers/identify",
+                Endpoint.LogIn,
                 body,
                 any()
             )
@@ -1098,7 +1072,7 @@ class BackendTest {
         )
         val resultBody = Responses.validFullPurchaserResponse
         mockResponse(
-            "/subscribers/identify",
+            Endpoint.LogIn,
             requestBody,
             responseCode = 201,
             clientException = null,
@@ -1128,7 +1102,7 @@ class BackendTest {
         )
         val resultBody = "{}"
         mockResponse(
-            "/subscribers/$appUserID/identify",
+            Endpoint.LogIn,
             requestBody,
             responseCode = 201,
             clientException = null,
@@ -1158,7 +1132,7 @@ class BackendTest {
         )
         val resultBody = Responses.validFullPurchaserResponse
         mockResponse(
-            "/subscribers/identify",
+            Endpoint.LogIn,
             requestBody,
             responseCode = 201,
             clientException = null,
@@ -1173,7 +1147,7 @@ class BackendTest {
                 fail("Should have called success")
             }
         )
-        assertThat(receivedCreated).isTrue()
+        assertThat(receivedCreated).isTrue
     }
 
     @Test
@@ -1185,7 +1159,7 @@ class BackendTest {
         )
         val resultBody = Responses.validFullPurchaserResponse
         mockResponse(
-            "/subscribers/identify",
+            Endpoint.LogIn,
             requestBody,
             responseCode = 200,
             clientException = null,
@@ -1212,7 +1186,7 @@ class BackendTest {
         )
         val resultBody = Responses.validFullPurchaserResponse
         mockResponse(
-            "/subscribers/identify",
+            Endpoint.LogIn,
             requestBody,
             responseCode = 200,
             clientException = null,
@@ -1246,7 +1220,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/subscribers/identify",
+                Endpoint.LogIn,
                 requestBody,
                 any()
             )
@@ -1262,7 +1236,7 @@ class BackendTest {
         )
         val resultBody = "{}"
         mockResponse(
-            "/subscribers/identify",
+            Endpoint.LogIn,
             requestBody,
             responseCode = 200,
             clientException = null,
@@ -1296,7 +1270,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/subscribers/identify",
+                Endpoint.LogIn,
                 requestBody,
                 any()
             )
@@ -1312,7 +1286,7 @@ class BackendTest {
         )
         val resultBody = "{}"
         mockResponse(
-            "/subscribers/identify",
+            Endpoint.LogIn,
             requestBody,
             responseCode = 500,
             clientException = null,
@@ -1346,7 +1320,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/subscribers/identify",
+                Endpoint.LogIn,
                 requestBody,
                 any()
             )
@@ -1409,7 +1383,7 @@ class BackendTest {
         verify(exactly = 2) {
             mockClient.performRequest(
                 mockBaseURL,
-                "/receipts",
+                Endpoint.PostReceipt,
                 any(),
                 any()
             )
@@ -1445,7 +1419,7 @@ class BackendTest {
         assertThat(receivedError!!.code)
             .`as`("Received error code is the right one")
             .isEqualTo(PurchasesErrorCode.UnsupportedError)
-        assertThat(receivedShouldConsumePurchase).`as`("Purchase shouldn't be consumed").isFalse()
+        assertThat(receivedShouldConsumePurchase).`as`("Purchase shouldn't be consumed").isFalse
     }
 
     @Test
@@ -1503,7 +1477,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 baseURL = mockDiagnosticsBaseURL,
-                path = diagnosticsEndpoint,
+                endpoint = diagnosticsEndpoint,
                 body = mapOf("entries" to JSONArray(diagnosticsList)),
                 requestHeaders = mapOf("Authorization" to "Bearer TEST_API_KEY")
             )
@@ -1514,7 +1488,7 @@ class BackendTest {
     fun `postDiagnostics only executes once same request if one in progress`() {
         val diagnosticsList = listOf(JSONObject("{\"test-key\":\"test-value\"}"))
         mockResponse(
-            path = diagnosticsEndpoint,
+            endpoint = diagnosticsEndpoint,
             body = null,
             responseCode = 200,
             clientException = null,
@@ -1531,7 +1505,7 @@ class BackendTest {
         verify(exactly = 1) {
             mockClient.performRequest(
                 baseURL = mockDiagnosticsBaseURL,
-                path = diagnosticsEndpoint,
+                endpoint = diagnosticsEndpoint,
                 body = mapOf("entries" to JSONArray(diagnosticsList)),
                 requestHeaders = mapOf("Authorization" to "Bearer TEST_API_KEY")
             )
@@ -1542,7 +1516,7 @@ class BackendTest {
     fun `postDiagnostics executes same request if done after first one finishes`() {
         val diagnosticsList = listOf(JSONObject("{\"test-key\":\"test-value\"}"))
         mockResponse(
-            path = diagnosticsEndpoint,
+            endpoint = diagnosticsEndpoint,
             body = null,
             responseCode = 200,
             clientException = null,
@@ -1561,7 +1535,7 @@ class BackendTest {
         verify(exactly = 2) {
             mockClient.performRequest(
                 baseURL = mockDiagnosticsBaseURL,
-                path = diagnosticsEndpoint,
+                endpoint = diagnosticsEndpoint,
                 body = mapOf("entries" to JSONArray(diagnosticsList)),
                 requestHeaders = mapOf("Authorization" to "Bearer TEST_API_KEY")
             )
@@ -1572,7 +1546,7 @@ class BackendTest {
     fun `postDiagnostics calls error handler without retry when InsufficientPermissionsError`() {
         val diagnosticsList = listOf(JSONObject("{\"test-key\":\"test-value\"}"))
         mockResponse(
-            path = diagnosticsEndpoint,
+            endpoint = diagnosticsEndpoint,
             body = null,
             responseCode = 200,
             clientException = SecurityException(),
@@ -1596,7 +1570,7 @@ class BackendTest {
     fun `postDiagnostics calls error handler with retry when Network error`() {
         val diagnosticsList = listOf(JSONObject("{\"test-key\":\"test-value\"}"))
         mockResponse(
-            path = diagnosticsEndpoint,
+            endpoint = diagnosticsEndpoint,
             body = null,
             responseCode = 200,
             clientException = IOException(),
@@ -1620,7 +1594,7 @@ class BackendTest {
     fun `postDiagnostics calls error handler with retry if status code is 500`() {
         val diagnosticsList = listOf(JSONObject("{\"test-key\":\"test-value\"}"))
         mockResponse(
-            path = diagnosticsEndpoint,
+            endpoint = diagnosticsEndpoint,
             body = null,
             responseCode = 500,
             clientException = null,
@@ -1644,7 +1618,7 @@ class BackendTest {
     fun `postDiagnostics calls error handler without retry if status code is 400`() {
         val diagnosticsList = listOf(JSONObject("{\"test-key\":\"test-value\"}"))
         mockResponse(
-            path = diagnosticsEndpoint,
+            endpoint = diagnosticsEndpoint,
             body = null,
             responseCode = 400,
             clientException = null,
@@ -1669,7 +1643,7 @@ class BackendTest {
         val diagnosticsList = listOf(JSONObject("{\"test-key\":\"test-value\"}"))
         val resultBody = "{\"test-response-key\":1234}"
         mockResponse(
-            path = diagnosticsEndpoint,
+            endpoint = diagnosticsEndpoint,
             body = null,
             responseCode = 200,
             clientException = null,
@@ -1691,7 +1665,7 @@ class BackendTest {
     @Test
     fun `postDiagnostics call is enqueued with delay`() {
         mockResponse(
-            path = diagnosticsEndpoint,
+            endpoint = diagnosticsEndpoint,
             body = null,
             responseCode = 200,
             clientException = null,

--- a/common/src/test/java/com/revenuecat/purchases/common/DispatcherTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DispatcherTest.kt
@@ -9,7 +9,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.networking.HTTPResult
-import com.revenuecat.purchases.common.networking.ResultOrigin
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -55,7 +54,7 @@ class DispatcherTest {
 
     @Test
     fun executesInExecutor() {
-        val result = HTTPResult(200, "{}", ResultOrigin.BACKEND)
+        val result = HTTPResult(200, "{}", HTTPResult.Origin.BACKEND)
 
         every {
             mockExecutorService.isShutdown
@@ -95,7 +94,7 @@ class DispatcherTest {
 
     @Test
     fun asyncCallHandlesSuccess() {
-        val result = HTTPResult(200, "{}", ResultOrigin.BACKEND)
+        val result = HTTPResult(200, "{}", HTTPResult.Origin.BACKEND)
         val call = object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {
                 return result

--- a/common/src/test/java/com/revenuecat/purchases/common/DispatcherTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DispatcherTest.kt
@@ -9,13 +9,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.ResultOrigin
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.json.JSONException
-import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -43,7 +43,7 @@ class DispatcherTest {
 
 
     @Before
-    fun `setup`() {
+    fun setup() {
         currentThreadExecutorService = CurrentThreadExecutorService()
         dispatcher = Dispatcher(currentThreadExecutorService)
     }
@@ -55,7 +55,7 @@ class DispatcherTest {
 
     @Test
     fun executesInExecutor() {
-        val result = HTTPResult(200, "{}")
+        val result = HTTPResult(200, "{}", ResultOrigin.BACKEND)
 
         every {
             mockExecutorService.isShutdown
@@ -90,12 +90,12 @@ class DispatcherTest {
 
         call.run()
 
-        assertThat(this.errorCalled!!).isTrue()
+        assertThat(this.errorCalled!!).isTrue
     }
 
     @Test
     fun asyncCallHandlesSuccess() {
-        val result = HTTPResult(200, "{}")
+        val result = HTTPResult(200, "{}", ResultOrigin.BACKEND)
         val call = object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {
                 return result

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -401,7 +401,7 @@ class HTTPClientTest {
 
         every {
             mockETagManager.getHTTPResultFromCacheOrBackend(
-                responseCode,
+                400,
                 "not uh json",
                 connection = any(),
                 "/v1${endpoint.getPath()}",
@@ -415,7 +415,7 @@ class HTTPClientTest {
             client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
         } catch (e: JSONException) {
             verify(exactly = 1) {
-                diagnosticsTracker.trackEndpointHit(endpoint, any(), false, responseCode, null)
+                diagnosticsTracker.trackEndpointHit(endpoint, any(), false, -1, null)
             }
             return
         }

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -32,6 +32,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import java.net.URL
 import java.util.Date
+import kotlin.time.Duration.Companion.milliseconds
 import org.robolectric.annotation.Config as AnnotationConfig
 
 @RunWith(AndroidJUnit4::class)
@@ -353,7 +354,7 @@ class HTTPClientTest {
         val responseCode = 200
         val requestStartTime = 1676379370000L // Tuesday, February 14, 2023 12:56:10:000 PM GMT
         val requestEndTime = 1676379370123L // Tuesday, February 14, 2023 12:56:10:123 PM GMT
-        val responseTime = requestEndTime - requestStartTime
+        val responseTime = (requestEndTime - requestStartTime).milliseconds
 
         enqueue(
             endpoint,
@@ -376,7 +377,7 @@ class HTTPClientTest {
         val responseCode = 400
         val requestStartTime = 1676379370000L // Tuesday, February 14, 2023 12:56:10:000 PM GMT
         val requestEndTime = 1676379370123L // Tuesday, February 14, 2023 12:56:10:123 PM GMT
-        val responseTime = requestEndTime - requestStartTime
+        val responseTime = (requestEndTime - requestStartTime).milliseconds
 
         enqueue(
             endpoint,

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -415,7 +415,7 @@ class HTTPClientTest {
             client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
         } catch (e: JSONException) {
             verify(exactly = 1) {
-                diagnosticsTracker.trackEndpointHit(endpoint, any(), false, -1, null)
+                diagnosticsTracker.trackEndpointHit(endpoint, any(), false, HTTPClient.NO_STATUS_CODE, null)
             }
             return
         }

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -26,16 +26,13 @@ import io.mockk.verify
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
 import org.json.JSONException
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.io.IOException
 import java.net.URL
 import java.util.Date
-import java.util.HashMap
 import org.robolectric.annotation.Config as AnnotationConfig
 
 @RunWith(AndroidJUnit4::class)
@@ -364,7 +361,7 @@ class HTTPClientTest {
             expectedResult = HTTPResult(responseCode, "{}", ResultOrigin.BACKEND)
         )
 
-        every { dateProvider.now } returnsMany listOf(Date(requestStartTime), Date(requestEndTime),)
+        every { dateProvider.now } returnsMany listOf(Date(requestStartTime), Date(requestEndTime))
 
         client.performRequest(baseURL, Endpoint.LogIn, null, mapOf("" to ""))
         server.takeRequest()
@@ -387,7 +384,7 @@ class HTTPClientTest {
             expectedResult = HTTPResult(responseCode, "{}", ResultOrigin.BACKEND)
         )
 
-        every { dateProvider.now } returnsMany listOf(Date(requestStartTime), Date(requestEndTime),)
+        every { dateProvider.now } returnsMany listOf(Date(requestStartTime), Date(requestEndTime))
 
         client.performRequest(baseURL, Endpoint.LogIn, null, mapOf("" to ""))
         server.takeRequest()

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -15,7 +15,6 @@ import com.revenuecat.purchases.common.networking.ETagManager
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
-import com.revenuecat.purchases.common.networking.ResultOrigin
 import com.revenuecat.purchases.utils.Responses
 import io.mockk.Runs
 import io.mockk.every
@@ -95,7 +94,7 @@ class HTTPClientTest {
     fun canPerformASimpleGet() {
         enqueue(
             Endpoint.LogIn,
-            expectedResult = HTTPResult(200, "{}", ResultOrigin.BACKEND)
+            expectedResult = HTTPResult(200, "{}", HTTPResult.Origin.BACKEND)
         )
 
         client.performRequest(baseURL, Endpoint.LogIn, null, mapOf("" to ""))
@@ -110,7 +109,7 @@ class HTTPClientTest {
         val endpoint = Endpoint.LogIn
         enqueue(
             endpoint,
-            expectedResult = HTTPResult(223, "{}", ResultOrigin.BACKEND)
+            expectedResult = HTTPResult(223, "{}", HTTPResult.Origin.BACKEND)
         )
 
         val result = client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
@@ -125,7 +124,7 @@ class HTTPClientTest {
         val endpoint = Endpoint.LogIn
         enqueue(
             endpoint,
-            expectedResult = HTTPResult(223, "{'response': 'OK'}", ResultOrigin.BACKEND)
+            expectedResult = HTTPResult(223, "{'response': 'OK'}", HTTPResult.Origin.BACKEND)
         )
 
         val result = client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
@@ -142,7 +141,7 @@ class HTTPClientTest {
         val endpoint = Endpoint.LogIn
         enqueue(
             endpoint,
-            expectedResult = HTTPResult(200, "not uh jason", ResultOrigin.BACKEND)
+            expectedResult = HTTPResult(200, "not uh jason", HTTPResult.Origin.BACKEND)
         )
 
         try {
@@ -155,7 +154,7 @@ class HTTPClientTest {
     // Headers
     @Test
     fun addsHeadersToRequest() {
-        val expectedResult = HTTPResult(200, "{}", ResultOrigin.BACKEND)
+        val expectedResult = HTTPResult(200, "{}", HTTPResult.Origin.BACKEND)
         val endpoint = Endpoint.LogIn
         enqueue(
             endpoint,
@@ -174,7 +173,7 @@ class HTTPClientTest {
 
     @Test
     fun addsDefaultHeadersToRequest() {
-        val expectedResult = HTTPResult(200, "{}", ResultOrigin.BACKEND)
+        val expectedResult = HTTPResult(200, "{}", HTTPResult.Origin.BACKEND)
         val endpoint = Endpoint.LogIn
         enqueue(
             endpoint,
@@ -207,7 +206,7 @@ class HTTPClientTest {
             store = Store.PLAY_STORE
         )
 
-        val expectedResult = HTTPResult(200, "{}", ResultOrigin.BACKEND)
+        val expectedResult = HTTPResult(200, "{}", HTTPResult.Origin.BACKEND)
         val endpoint = Endpoint.LogIn
         enqueue(
             endpoint,
@@ -224,7 +223,7 @@ class HTTPClientTest {
 
     @Test
     fun addsPostBody() {
-        val expectedResult = HTTPResult(200, "{}", ResultOrigin.BACKEND)
+        val expectedResult = HTTPResult(200, "{}", HTTPResult.Origin.BACKEND)
         val endpoint = Endpoint.LogIn
         enqueue(
             endpoint,
@@ -246,7 +245,7 @@ class HTTPClientTest {
     fun `given observer mode is enabled, observer mode header is sent`() {
         appConfig.finishTransactions = false
 
-        val expectedResult = HTTPResult(200, "{}", ResultOrigin.BACKEND)
+        val expectedResult = HTTPResult(200, "{}", HTTPResult.Origin.BACKEND)
         val endpoint = Endpoint.LogIn
         enqueue(
             endpoint,
@@ -298,7 +297,7 @@ class HTTPClientTest {
                 .setResponseCode(RCHTTPStatusCodes.NOT_MODIFIED)
 
         val expectedResult = HTTPResult(
-            RCHTTPStatusCodes.SUCCESS, Responses.validEmptyPurchaserResponse, ResultOrigin.BACKEND
+            RCHTTPStatusCodes.SUCCESS, Responses.validEmptyPurchaserResponse, HTTPResult.Origin.BACKEND
         )
         val secondResponse =
             MockResponse()
@@ -358,7 +357,7 @@ class HTTPClientTest {
 
         enqueue(
             endpoint,
-            expectedResult = HTTPResult(responseCode, "{}", ResultOrigin.BACKEND)
+            expectedResult = HTTPResult(responseCode, "{}", HTTPResult.Origin.BACKEND)
         )
 
         every { dateProvider.now } returnsMany listOf(Date(requestStartTime), Date(requestEndTime))
@@ -367,7 +366,7 @@ class HTTPClientTest {
         server.takeRequest()
 
         verify(exactly = 1) {
-            diagnosticsTracker.trackEndpointHit(endpoint, responseTime, true, responseCode, ResultOrigin.BACKEND)
+            diagnosticsTracker.trackEndpointHit(endpoint, responseTime, true, responseCode, HTTPResult.Origin.BACKEND)
         }
     }
 
@@ -381,7 +380,7 @@ class HTTPClientTest {
 
         enqueue(
             endpoint,
-            expectedResult = HTTPResult(responseCode, "{}", ResultOrigin.BACKEND)
+            expectedResult = HTTPResult(responseCode, "{}", HTTPResult.Origin.BACKEND)
         )
 
         every { dateProvider.now } returnsMany listOf(Date(requestStartTime), Date(requestEndTime))
@@ -390,7 +389,7 @@ class HTTPClientTest {
         server.takeRequest()
 
         verify(exactly = 1) {
-            diagnosticsTracker.trackEndpointHit(endpoint, responseTime, false, responseCode, ResultOrigin.BACKEND)
+            diagnosticsTracker.trackEndpointHit(endpoint, responseTime, false, responseCode, HTTPResult.Origin.BACKEND)
         }
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -83,7 +83,7 @@ class HTTPClientTest {
             store = Store.PLAY_STORE
         )
         diagnosticsTracker = mockk()
-        every { diagnosticsTracker.trackEndpointHit(any(), any(), any(), any(), any()) } just Runs
+        every { diagnosticsTracker.trackHttpRequestPerformed(any(), any(), any(), any(), any()) } just Runs
 
         dateProvider = mockk()
         every { dateProvider.now } returns Date(1676379370000) // Tuesday, February 14, 2023 12:56:10 PM GMT
@@ -345,10 +345,10 @@ class HTTPClientTest {
         assertThat(result.responseCode).isEqualTo(expectedResult.responseCode)
     }
 
-    // region trackEndpointHit
+    // region trackHttpRequestPerformed
 
     @Test
-    fun `performRequest tracks endpoint hit diagnostic event if request successful`() {
+    fun `performRequest tracks http request performed diagnostic event if request successful`() {
         val endpoint = Endpoint.LogIn
         val responseCode = 200
         val requestStartTime = 1676379370000L // Tuesday, February 14, 2023 12:56:10:000 PM GMT
@@ -366,12 +366,12 @@ class HTTPClientTest {
         server.takeRequest()
 
         verify(exactly = 1) {
-            diagnosticsTracker.trackEndpointHit(endpoint, responseTime, true, responseCode, HTTPResult.Origin.BACKEND)
+            diagnosticsTracker.trackHttpRequestPerformed(endpoint, responseTime, true, responseCode, HTTPResult.Origin.BACKEND)
         }
     }
 
     @Test
-    fun `performRequest tracks endpoint hit diagnostic event if request fails`() {
+    fun `performRequest tracks http request performed diagnostic event if request fails`() {
         val endpoint = Endpoint.LogIn
         val responseCode = 400
         val requestStartTime = 1676379370000L // Tuesday, February 14, 2023 12:56:10:000 PM GMT
@@ -389,12 +389,12 @@ class HTTPClientTest {
         server.takeRequest()
 
         verify(exactly = 1) {
-            diagnosticsTracker.trackEndpointHit(endpoint, responseTime, false, responseCode, HTTPResult.Origin.BACKEND)
+            diagnosticsTracker.trackHttpRequestPerformed(endpoint, responseTime, false, responseCode, HTTPResult.Origin.BACKEND)
         }
     }
 
     @Test
-    fun `performRequest tracks endpoint hit diagnostic event if request throws Exception`() {
+    fun `performRequest tracks http request performed diagnostic event if request throws Exception`() {
         val endpoint = Endpoint.LogIn
         val responseCode = 400
 
@@ -414,7 +414,7 @@ class HTTPClientTest {
             client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
         } catch (e: JSONException) {
             verify(exactly = 1) {
-                diagnosticsTracker.trackEndpointHit(endpoint, any(), false, HTTPClient.NO_STATUS_CODE, null)
+                diagnosticsTracker.trackHttpRequestPerformed(endpoint, any(), false, HTTPClient.NO_STATUS_CODE, null)
             }
             return
         }

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
@@ -41,12 +41,12 @@ class DiagnosticsAnonymizerTest {
         val originalPropertiesMap = mapOf("key-1" to "value-1")
         val expectedPropertiesMap = mapOf("key-1" to "anonymized-value-1")
         val eventToAnonymize = DiagnosticsEvent.Log(
-            name = DiagnosticsLogEventName.ENDPOINT_HIT,
+            name = DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED,
             properties = originalPropertiesMap,
             dateProvider = testDateProvider
         )
         val expectedEvent = DiagnosticsEvent.Log(
-            name = DiagnosticsLogEventName.ENDPOINT_HIT,
+            name = DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED,
             properties = expectedPropertiesMap,
             dateProvider = testDateProvider,
             dateTime = testDate

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEventTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEventTest.kt
@@ -36,7 +36,7 @@ class DiagnosticsEventTest {
         val expectedString = "{" +
             "\"version\":1," +
             "\"type\":\"log\"," +
-            "\"name\":\"endpoint_hit\"," +
+            "\"name\":\"http_request_performed\"," +
             "\"properties\":{\"test-key-1\":\"test-value-1\",\"test-key-2\":123,\"test-key-3\":true}," +
             "\"timestamp\":1675954145" +
             "}"

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEventTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEventTest.kt
@@ -28,7 +28,7 @@ class DiagnosticsEventTest {
     @Test
     fun `toString transforms log event to correct JSON`() {
         val event = DiagnosticsEvent.Log(
-            name = DiagnosticsLogEventName.ENDPOINT_HIT,
+            name = DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED,
             properties = mapOf("test-key-1" to "test-value-1", "test-key-2" to 123, "test-key-3" to true),
             dateProvider = testDateProvider
         )

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
@@ -19,7 +19,7 @@ import org.robolectric.annotation.Config
 class DiagnosticsFileHelperTest {
 
     private val testDiagnosticsEvent = DiagnosticsEvent.Log(
-        name = DiagnosticsLogEventName.ENDPOINT_HIT,
+        name = DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED,
         properties = emptyMap()
     )
     private val diagnosticsFilePath = DiagnosticsFileHelper.DIAGNOSTICS_FILE_PATH

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
@@ -21,12 +21,12 @@ import java.io.IOException
 class DiagnosticsTrackerTest {
 
     private val testDiagnosticsEvent = DiagnosticsEvent.Log(
-        name = DiagnosticsLogEventName.ENDPOINT_HIT,
+        name = DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED,
         properties = mapOf("test-key-1" to "test-value-1")
     )
 
     private val testAnonymizedEvent = DiagnosticsEvent.Log(
-        name = DiagnosticsLogEventName.ENDPOINT_HIT,
+        name = DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED,
         properties = mapOf("test-key-1" to "test-anonymized-value-1")
     )
 
@@ -76,7 +76,7 @@ class DiagnosticsTrackerTest {
     }
 
     @Test
-    fun `trackEndpointHit tracks correct event when coming from cache`() {
+    fun `trackHttpRequestPerformed tracks correct event when coming from cache`() {
         val expectedProperties = mapOf(
             "endpoint_name" to "post_receipt",
             "response_time_millis" to 1234L,
@@ -85,18 +85,18 @@ class DiagnosticsTrackerTest {
             "etag_hit" to true
         )
         every { diagnosticsFileHelper.appendEventToDiagnosticsFile(any()) } just Runs
-        diagnosticsTracker.trackEndpointHit(Endpoint.PostReceipt, 1234, true, 200, HTTPResult.Origin.CACHE)
+        diagnosticsTracker.trackHttpRequestPerformed(Endpoint.PostReceipt, 1234, true, 200, HTTPResult.Origin.CACHE)
         verify(exactly = 1) {
             diagnosticsFileHelper.appendEventToDiagnosticsFile(match { event ->
                 event is DiagnosticsEvent.Log &&
-                    event.name == DiagnosticsLogEventName.ENDPOINT_HIT &&
+                    event.name == DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED &&
                     event.properties == expectedProperties
             })
         }
     }
 
     @Test
-    fun `trackEndpointHit tracks correct event when coming from backend`() {
+    fun `trackHttpRequestPerformed tracks correct event when coming from backend`() {
         val expectedProperties = mapOf(
             "endpoint_name" to "get_offerings",
             "response_time_millis" to 1234L,
@@ -105,11 +105,11 @@ class DiagnosticsTrackerTest {
             "etag_hit" to false
         )
         every { diagnosticsFileHelper.appendEventToDiagnosticsFile(any()) } just Runs
-        diagnosticsTracker.trackEndpointHit(Endpoint.GetOfferings("test id"), 1234, true, 200, HTTPResult.Origin.BACKEND)
+        diagnosticsTracker.trackHttpRequestPerformed(Endpoint.GetOfferings("test id"), 1234, true, 200, HTTPResult.Origin.BACKEND)
         verify(exactly = 1) {
             diagnosticsFileHelper.appendEventToDiagnosticsFile(match { event ->
                 event is DiagnosticsEvent.Log &&
-                    event.name == DiagnosticsLogEventName.ENDPOINT_HIT &&
+                    event.name == DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED &&
                     event.properties == expectedProperties
             })
         }

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
@@ -114,4 +114,21 @@ class DiagnosticsTrackerTest {
             })
         }
     }
+
+    @Test
+    fun `trackMaxEventsStoredLimitReached tracks correct event`() {
+        val expectedProperties = mapOf(
+            "total_number_events_stored" to 1234,
+            "events_removed" to 234
+        )
+        every { diagnosticsFileHelper.appendEventToDiagnosticsFile(any()) } just Runs
+        diagnosticsTracker.trackMaxEventsStoredLimitReached(totalEventsStored = 1234, eventsRemoved = 234)
+        verify(exactly = 1) {
+            diagnosticsFileHelper.appendEventToDiagnosticsFile(match { event ->
+                event is DiagnosticsEvent.Log &&
+                    event.name == DiagnosticsLogEventName.MAX_EVENTS_STORED_LIMIT_REACHED &&
+                    event.properties == expectedProperties
+            })
+        }
+    }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
@@ -4,7 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.SyncDispatcher
 import com.revenuecat.purchases.common.networking.Endpoint
-import com.revenuecat.purchases.common.networking.ResultOrigin
+import com.revenuecat.purchases.common.networking.HTTPResult
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -85,7 +85,7 @@ class DiagnosticsTrackerTest {
             "etag_hit" to true
         )
         every { diagnosticsFileHelper.appendEventToDiagnosticsFile(any()) } just Runs
-        diagnosticsTracker.trackEndpointHit(Endpoint.PostReceipt, 1234, true, 200, ResultOrigin.CACHE)
+        diagnosticsTracker.trackEndpointHit(Endpoint.PostReceipt, 1234, true, 200, HTTPResult.Origin.CACHE)
         verify(exactly = 1) {
             diagnosticsFileHelper.appendEventToDiagnosticsFile(match { event ->
                 event is DiagnosticsEvent.Log &&
@@ -105,7 +105,7 @@ class DiagnosticsTrackerTest {
             "etag_hit" to false
         )
         every { diagnosticsFileHelper.appendEventToDiagnosticsFile(any()) } just Runs
-        diagnosticsTracker.trackEndpointHit(Endpoint.GetOfferings("test id"), 1234, true, 200, ResultOrigin.BACKEND)
+        diagnosticsTracker.trackEndpointHit(Endpoint.GetOfferings("test id"), 1234, true, 200, HTTPResult.Origin.BACKEND)
         verify(exactly = 1) {
             diagnosticsFileHelper.appendEventToDiagnosticsFile(match { event ->
                 event is DiagnosticsEvent.Log &&

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
@@ -15,6 +15,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.IOException
+import kotlin.time.Duration.Companion.milliseconds
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -85,7 +86,7 @@ class DiagnosticsTrackerTest {
             "etag_hit" to true
         )
         every { diagnosticsFileHelper.appendEventToDiagnosticsFile(any()) } just Runs
-        diagnosticsTracker.trackHttpRequestPerformed(Endpoint.PostReceipt, 1234, true, 200, HTTPResult.Origin.CACHE)
+        diagnosticsTracker.trackHttpRequestPerformed(Endpoint.PostReceipt, 1234L.milliseconds, true, 200, HTTPResult.Origin.CACHE)
         verify(exactly = 1) {
             diagnosticsFileHelper.appendEventToDiagnosticsFile(match { event ->
                 event is DiagnosticsEvent.Log &&
@@ -105,7 +106,7 @@ class DiagnosticsTrackerTest {
             "etag_hit" to false
         )
         every { diagnosticsFileHelper.appendEventToDiagnosticsFile(any()) } just Runs
-        diagnosticsTracker.trackHttpRequestPerformed(Endpoint.GetOfferings("test id"), 1234, true, 200, HTTPResult.Origin.BACKEND)
+        diagnosticsTracker.trackHttpRequestPerformed(Endpoint.GetOfferings("test id"), 1234L.milliseconds, true, 200, HTTPResult.Origin.BACKEND)
         verify(exactly = 1) {
             diagnosticsFileHelper.appendEventToDiagnosticsFile(match { event ->
                 event is DiagnosticsEvent.Log &&

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -3,7 +3,6 @@ package com.revenuecat.purchases.common.networking
 import android.content.SharedPreferences
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.utils.Responses
-import com.revenuecat.purchases.utils.filterNotNullValues
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -16,7 +15,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.net.HttpURLConnection
-import java.net.URL
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -111,7 +109,7 @@ class ETagManagerTest {
         val path = "/v1/subscribers/appUserID"
         val eTag = "eTag"
 
-        val resultFromBackend = HTTPResult(RCHTTPStatusCodes.NOT_MODIFIED, "", ResultOrigin.BACKEND)
+        val resultFromBackend = HTTPResult(RCHTTPStatusCodes.NOT_MODIFIED, "", HTTPResult.Origin.BACKEND)
 
         underTest.storeBackendResultIfNoError(path, resultFromBackend, eTag)
 
@@ -125,10 +123,10 @@ class ETagManagerTest {
         val eTag = "eTag"
 
         val resultFromBackend = HTTPResult(
-            RCHTTPStatusCodes.SUCCESS, Responses.validEmptyPurchaserResponse, ResultOrigin.BACKEND
+            RCHTTPStatusCodes.SUCCESS, Responses.validEmptyPurchaserResponse, HTTPResult.Origin.BACKEND
         )
         val resultStored = resultFromBackend.copy(
-            origin = ResultOrigin.CACHE
+            origin = HTTPResult.Origin.CACHE
         )
         val resultStoredWithETag = HTTPResultWithETag(eTag, resultStored)
 
@@ -146,7 +144,7 @@ class ETagManagerTest {
         val path = "/v1/subscribers/appUserID"
         val eTag = "eTag"
 
-        val resultFromBackend = HTTPResult(500, "{}", ResultOrigin.BACKEND)
+        val resultFromBackend = HTTPResult(500, "{}", HTTPResult.Origin.BACKEND)
 
         underTest.storeBackendResultIfNoError(path, resultFromBackend, eTag)
 
@@ -256,7 +254,7 @@ class ETagManagerTest {
         assertThat(result).isNotNull
         assertThat(result!!.responseCode).isEqualTo(RCHTTPStatusCodes.NOT_MODIFIED)
         assertThat(result.payload).isEqualTo(responsePayload)
-        assertThat(result.origin).isEqualTo(ResultOrigin.BACKEND)
+        assertThat(result.origin).isEqualTo(HTTPResult.Origin.BACKEND)
         assertThat(slotPutStringSharedPreferencesKey.isCaptured).isFalse()
         assertThat(slotPutSharedPreferencesValue.isCaptured).isFalse()
     }
@@ -278,7 +276,7 @@ class ETagManagerTest {
         assertThat(result).isNotNull
         assertThat(result!!.responseCode).isEqualTo(RCHTTPStatusCodes.SUCCESS)
         assertThat(result.payload).isEqualTo(responsePayload)
-        assertThat(result.origin).isEqualTo(ResultOrigin.BACKEND)
+        assertThat(result.origin).isEqualTo(HTTPResult.Origin.BACKEND)
 
         assertStoredResponse(path, eTagInResponse, responsePayload)
     }
@@ -300,7 +298,7 @@ class ETagManagerTest {
         assertThat(result).isNotNull
         assertThat(result!!.responseCode).isEqualTo(RCHTTPStatusCodes.SUCCESS)
         assertThat(result.payload).isEqualTo(responsePayload)
-        assertThat(result.origin).isEqualTo(ResultOrigin.BACKEND)
+        assertThat(result.origin).isEqualTo(HTTPResult.Origin.BACKEND)
 
         assertStoredResponse(path, eTagInResponse, responsePayload)
     }
@@ -316,7 +314,7 @@ class ETagManagerTest {
         path: String
     ): HTTPResultWithETag? {
         val cachedResult = expectedETag?.let {
-            HTTPResultWithETag(expectedETag, HTTPResult(RCHTTPStatusCodes.SUCCESS, "{}", ResultOrigin.CACHE))
+            HTTPResultWithETag(expectedETag, HTTPResult(RCHTTPStatusCodes.SUCCESS, "{}", HTTPResult.Origin.CACHE))
         }
         every {
             mockedPrefs.getString(path, null)

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -125,9 +125,12 @@ class ETagManagerTest {
         val eTag = "eTag"
 
         val resultFromBackend = HTTPResult(
-            RCHTTPStatusCodes.SUCCESS, Responses.validEmptyPurchaserResponse, ResultOrigin.CACHE
+            RCHTTPStatusCodes.SUCCESS, Responses.validEmptyPurchaserResponse, ResultOrigin.BACKEND
         )
-        val resultFromBackendWithETag = HTTPResultWithETag(eTag, resultFromBackend)
+        val resultStored = resultFromBackend.copy(
+            origin = ResultOrigin.CACHE
+        )
+        val resultStoredWithETag = HTTPResultWithETag(eTag, resultStored)
 
         underTest.storeBackendResultIfNoError(path, resultFromBackend, eTag)
 
@@ -135,7 +138,7 @@ class ETagManagerTest {
         assertThat(slotPutSharedPreferencesValue.isCaptured).isTrue()
 
         assertThat(slotPutStringSharedPreferencesKey.captured).isEqualTo(path)
-        assertThat(slotPutSharedPreferencesValue.captured).isEqualTo(resultFromBackendWithETag.serialize())
+        assertThat(slotPutSharedPreferencesValue.captured).isEqualTo(resultStoredWithETag.serialize())
     }
 
     @Test
@@ -253,6 +256,7 @@ class ETagManagerTest {
         assertThat(result).isNotNull
         assertThat(result!!.responseCode).isEqualTo(RCHTTPStatusCodes.NOT_MODIFIED)
         assertThat(result.payload).isEqualTo(responsePayload)
+        assertThat(result.origin).isEqualTo(ResultOrigin.BACKEND)
         assertThat(slotPutStringSharedPreferencesKey.isCaptured).isFalse()
         assertThat(slotPutSharedPreferencesValue.isCaptured).isFalse()
     }
@@ -274,6 +278,7 @@ class ETagManagerTest {
         assertThat(result).isNotNull
         assertThat(result!!.responseCode).isEqualTo(RCHTTPStatusCodes.SUCCESS)
         assertThat(result.payload).isEqualTo(responsePayload)
+        assertThat(result.origin).isEqualTo(ResultOrigin.BACKEND)
 
         assertStoredResponse(path, eTagInResponse, responsePayload)
     }
@@ -295,6 +300,7 @@ class ETagManagerTest {
         assertThat(result).isNotNull
         assertThat(result!!.responseCode).isEqualTo(RCHTTPStatusCodes.SUCCESS)
         assertThat(result.payload).isEqualTo(responsePayload)
+        assertThat(result.origin).isEqualTo(ResultOrigin.BACKEND)
 
         assertStoredResponse(path, eTagInResponse, responsePayload)
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -111,7 +111,7 @@ class ETagManagerTest {
         val path = "/v1/subscribers/appUserID"
         val eTag = "eTag"
 
-        val resultFromBackend = HTTPResult(RCHTTPStatusCodes.NOT_MODIFIED, "")
+        val resultFromBackend = HTTPResult(RCHTTPStatusCodes.NOT_MODIFIED, "", ResultOrigin.BACKEND)
 
         underTest.storeBackendResultIfNoError(path, resultFromBackend, eTag)
 
@@ -124,7 +124,9 @@ class ETagManagerTest {
         val path = "/v1/subscribers/appUserID"
         val eTag = "eTag"
 
-        val resultFromBackend = HTTPResult(RCHTTPStatusCodes.SUCCESS, Responses.validEmptyPurchaserResponse)
+        val resultFromBackend = HTTPResult(
+            RCHTTPStatusCodes.SUCCESS, Responses.validEmptyPurchaserResponse, ResultOrigin.CACHE
+        )
         val resultFromBackendWithETag = HTTPResultWithETag(eTag, resultFromBackend)
 
         underTest.storeBackendResultIfNoError(path, resultFromBackend, eTag)
@@ -141,7 +143,7 @@ class ETagManagerTest {
         val path = "/v1/subscribers/appUserID"
         val eTag = "eTag"
 
-        val resultFromBackend = HTTPResult(500, "{}")
+        val resultFromBackend = HTTPResult(500, "{}", ResultOrigin.BACKEND)
 
         underTest.storeBackendResultIfNoError(path, resultFromBackend, eTag)
 
@@ -308,29 +310,12 @@ class ETagManagerTest {
         path: String
     ): HTTPResultWithETag? {
         val cachedResult = expectedETag?.let {
-            HTTPResultWithETag(expectedETag, HTTPResult(RCHTTPStatusCodes.SUCCESS, "{}"))
+            HTTPResultWithETag(expectedETag, HTTPResult(RCHTTPStatusCodes.SUCCESS, "{}", ResultOrigin.CACHE))
         }
         every {
             mockedPrefs.getString(path, null)
         } returns cachedResult?.serialize()
         return cachedResult
-    }
-
-    private fun getHTTPRequest(eTag: String?): HTTPRequest {
-        val fullURL = URL("https://api.revenuecat.com/v1/subscribers/appUserID")
-        val headers = mapOf(
-            "Content-Type" to "application/json",
-            "X-Platform" to "android",
-            "X-Platform-Flavor" to "native",
-            "X-Platform-Version" to "29",
-            "X-Version" to "4.1.0",
-            "X-Client-Locale" to "en-US",
-            "X-Client-Version" to "1.0",
-            "X-Observer-Mode-Enabled" to "false",
-            "Authorization" to "Bearer apiKey",
-            ETAG_HEADER_NAME to eTag
-        ).filterNotNullValues()
-        return HTTPRequest(fullURL, headers, body = null)
     }
 
     private fun assertStoredResponse(

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -1,0 +1,61 @@
+package com.revenuecat.purchases.common.networking
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class EndpointTest {
+
+    @Test
+    fun `GetCustomerInfo has correct path`() {
+        val endpoint = Endpoint.GetCustomerInfo("test user-id")
+        val expectedPath = "/subscribers/test%20user-id"
+        assertThat(endpoint.getPath()).isEqualTo(expectedPath)
+    }
+
+    @Test
+    fun `PostReceipt has correct path`() {
+        val endpoint = Endpoint.PostReceipt
+        val expectedPath = "/receipt"
+        assertThat(endpoint.getPath()).isEqualTo(expectedPath)
+    }
+
+    @Test
+    fun `GetOfferings has correct path`() {
+        val endpoint = Endpoint.GetOfferings("test user-id")
+        val expectedPath = "/subscribers/test%20user-id/offerings"
+        assertThat(endpoint.getPath()).isEqualTo(expectedPath)
+    }
+
+    @Test
+    fun `LogIn has correct path`() {
+        val endpoint = Endpoint.LogIn
+        val expectedPath = "/subscribers/identify"
+        assertThat(endpoint.getPath()).isEqualTo(expectedPath)
+    }
+
+    @Test
+    fun `Diagnostics has correct path`() {
+        val endpoint = Endpoint.PostDiagnostics
+        val expectedPath = "/diagnostics"
+        assertThat(endpoint.getPath()).isEqualTo(expectedPath)
+    }
+
+    @Test
+    fun `PostAttributes has correct path`() {
+        val endpoint = Endpoint.PostAttributes("test user-id")
+        val expectedPath = "/subscribers/test%20user-id/attributes"
+        assertThat(endpoint.getPath()).isEqualTo(expectedPath)
+    }
+
+    @Test
+    fun `GetAmazonReceipt has correct path`() {
+        val endpoint = Endpoint.GetAmazonReceipt("test user-id", "test-receipt-id")
+        val expectedPath = "/receipts/amazon/test%20user-id/test-receipt-id"
+        assertThat(endpoint.getPath()).isEqualTo(expectedPath)
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
@@ -1,0 +1,41 @@
+package com.revenuecat.purchases.common.networking
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class HTTPResultTest {
+
+    @Test
+    fun `result is serialized correctly`() {
+        val result = HTTPResult(200, "{\"test-key\":\"test-value\"}", ResultOrigin.BACKEND)
+        assertThat(result.serialize()).isEqualTo("{" +
+            "\"responseCode\":200," +
+            "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"," +
+            "\"origin\":\"BACKEND\"}"
+        )
+    }
+
+    @Test
+    fun `result is deserialized correctly`() {
+        val expectedResult = HTTPResult(200, "{\"test-key\":\"test-value\"}", ResultOrigin.BACKEND)
+        val result = HTTPResult.deserialize("{" +
+            "\"responseCode\":200," +
+            "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"," +
+            "\"origin\":\"BACKEND\"}")
+        assertThat(result).isEqualTo(expectedResult)
+    }
+
+    @Test
+    fun `result is defaults to CACHE origin if not part of serialized string`() {
+        val expectedResult = HTTPResult(200, "{\"test-key\":\"test-value\"}", ResultOrigin.CACHE)
+        val result = HTTPResult.deserialize("{" +
+            "\"responseCode\":200," +
+            "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"}")
+        assertThat(result).isEqualTo(expectedResult)
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
@@ -12,7 +12,7 @@ class HTTPResultTest {
 
     @Test
     fun `result is serialized correctly`() {
-        val result = HTTPResult(200, "{\"test-key\":\"test-value\"}", ResultOrigin.BACKEND)
+        val result = HTTPResult(200, "{\"test-key\":\"test-value\"}", HTTPResult.Origin.BACKEND)
         assertThat(result.serialize()).isEqualTo("{" +
             "\"responseCode\":200," +
             "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"," +
@@ -22,7 +22,7 @@ class HTTPResultTest {
 
     @Test
     fun `result is deserialized correctly`() {
-        val expectedResult = HTTPResult(200, "{\"test-key\":\"test-value\"}", ResultOrigin.BACKEND)
+        val expectedResult = HTTPResult(200, "{\"test-key\":\"test-value\"}", HTTPResult.Origin.BACKEND)
         val result = HTTPResult.deserialize("{" +
             "\"responseCode\":200," +
             "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"," +
@@ -32,7 +32,7 @@ class HTTPResultTest {
 
     @Test
     fun `result is defaults to CACHE origin if not part of serialized string`() {
-        val expectedResult = HTTPResult(200, "{\"test-key\":\"test-value\"}", ResultOrigin.CACHE)
+        val expectedResult = HTTPResult(200, "{\"test-key\":\"test-value\"}", HTTPResult.Origin.CACHE)
         val result = HTTPResult.deserialize("{" +
             "\"responseCode\":200," +
             "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"}")

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBackend.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBackend.kt
@@ -1,8 +1,8 @@
 package com.revenuecat.purchases.amazon
 
-import android.net.Uri
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.networking.Endpoint
 import org.json.JSONObject
 
 /** @suppress */
@@ -30,7 +30,7 @@ class AmazonBackend(
 
         val call = {
             backend.performRequest(
-                "/receipts/amazon/${Uri.encode(storeUserID)}/$receiptId",
+                Endpoint.GetAmazonReceipt(storeUserID, receiptId),
                 null,
                 { error ->
                     synchronized(this@AmazonBackend) {

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
@@ -7,7 +7,9 @@ import com.revenuecat.purchases.amazon.helpers.successfulRVSResponse
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.HTTPClient
+import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.ResultOrigin
 import com.revenuecat.purchases.utils.SyncDispatcher
 import io.mockk.every
 import io.mockk.mockk
@@ -62,7 +64,8 @@ class AmazonBackendTest {
 
     private var successfulResult = HTTPResult(
         responseCode = 200,
-        payload = successfulRVSResponse()
+        payload = successfulRVSResponse(),
+        origin = ResultOrigin.BACKEND
     )
     private var unsuccessfulResult = HTTPResult(
         responseCode = 401,
@@ -71,7 +74,8 @@ class AmazonBackendTest {
                     "code":7225,"message":
                     "Invalid API Key."
                 }
-            """.trimIndent()
+            """.trimIndent(),
+        origin = ResultOrigin.BACKEND
     )
 
     @Test
@@ -79,7 +83,7 @@ class AmazonBackendTest {
         every {
             mockClient.performRequest(
                 baseURL = mockBaseURL,
-                path = "/receipts/amazon/store_user_id/receipt_id",
+                endpoint = Endpoint.GetAmazonReceipt("store_user_id", "receipt_id"),
                 body = null,
                 requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
             )
@@ -100,7 +104,7 @@ class AmazonBackendTest {
         every {
             mockClient.performRequest(
                 baseURL = mockBaseURL,
-                path = "/receipts/amazon/store_user_id/receipt_id",
+                endpoint = Endpoint.GetAmazonReceipt("store_user_id", "receipt_id"),
                 body = null,
                 requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
             )
@@ -122,7 +126,7 @@ class AmazonBackendTest {
         every {
             mockClient.performRequest(
                 baseURL = mockBaseURL,
-                path = "/receipts/amazon/store_user_id/receipt_id",
+                endpoint = Endpoint.GetAmazonReceipt("store_user_id", "receipt_id"),
                 body = null,
                 requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
             )

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
@@ -9,7 +9,6 @@ import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
-import com.revenuecat.purchases.common.networking.ResultOrigin
 import com.revenuecat.purchases.utils.SyncDispatcher
 import io.mockk.every
 import io.mockk.mockk
@@ -65,7 +64,7 @@ class AmazonBackendTest {
     private var successfulResult = HTTPResult(
         responseCode = 200,
         payload = successfulRVSResponse(),
-        origin = ResultOrigin.BACKEND
+        origin = HTTPResult.Origin.BACKEND
     )
     private var unsuccessfulResult = HTTPResult(
         responseCode = 401,
@@ -75,7 +74,7 @@ class AmazonBackendTest {
                     "Invalid API Key."
                 }
             """.trimIndent(),
-        origin = ResultOrigin.BACKEND
+        origin = HTTPResult.Origin.BACKEND
     )
 
     @Test

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesPoster.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesPoster.kt
@@ -1,10 +1,10 @@
 package com.revenuecat.purchases.subscriberattributes
 
-import android.net.Uri
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.SubscriberAttributeError
+import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 
 class SubscriberAttributesPoster(
@@ -22,7 +22,7 @@ class SubscriberAttributesPoster(
         ) -> Unit
     ) {
         backend.performRequest(
-            "/subscribers/" + Uri.encode(appUserID) + "/attributes",
+            Endpoint.PostAttributes(appUserID),
             mapOf("attributes" to attributes),
             { error ->
                 onErrorHandler(error, false, emptyList())

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -12,7 +12,6 @@ import com.revenuecat.purchases.common.SubscriberAttributeError
 import com.revenuecat.purchases.common.buildCustomerInfo
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
-import com.revenuecat.purchases.common.networking.ResultOrigin
 import com.revenuecat.purchases.utils.Responses
 import com.revenuecat.purchases.utils.SyncDispatcher
 import io.mockk.every
@@ -400,7 +399,7 @@ class SubscriberAttributesPosterTests {
 
         if (clientException == null) {
             everyMockedCall answers {
-                HTTPResult(responseCode, expectedResultBody ?: "{}", ResultOrigin.BACKEND)
+                HTTPResult(responseCode, expectedResultBody ?: "{}", HTTPResult.Origin.BACKEND)
             }
         } else {
             everyMockedCall throws clientException
@@ -420,7 +419,7 @@ class SubscriberAttributesPosterTests {
                 mapOf("Authorization" to "Bearer $API_KEY")
             )
         } answers {
-            HTTPResult(responseCode, responseBody, ResultOrigin.BACKEND).also {
+            HTTPResult(responseCode, responseBody, HTTPResult.Origin.BACKEND).also {
                 every {
                     it.body.buildCustomerInfo()
                 } returns mockk()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -71,14 +71,12 @@ internal class PurchasesFactory(
                 )
             }
 
-            val httpClient = HTTPClient(appConfig, eTagManager, diagnosticsTracker)
-
             val backend = Backend(
                 apiKey,
                 appConfig,
                 dispatcher,
                 diagnosticsDispatcher,
-                httpClient
+                HTTPClient(appConfig, eTagManager, diagnosticsTracker)
             )
             val subscriberAttributesPoster = SubscriberAttributesPoster(backend)
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -60,6 +60,7 @@ internal class PurchasesFactory(
             val dispatcher = Dispatcher(service ?: createDefaultExecutor())
             val diagnosticsDispatcher = Dispatcher(createDiagnosticsExecutor())
 
+
             var diagnosticsFileHelper: DiagnosticsFileHelper? = null
             var diagnosticsTracker: DiagnosticsTracker? = null
             if (diagnosticsEnabled) {
@@ -71,12 +72,14 @@ internal class PurchasesFactory(
                 )
             }
 
+            val httpClient = HTTPClient(appConfig, eTagManager, diagnosticsTracker)
+
             val backend = Backend(
                 apiKey,
                 appConfig,
                 dispatcher,
                 diagnosticsDispatcher,
-                HTTPClient(appConfig, eTagManager)
+                httpClient
             )
             val subscriberAttributesPoster = SubscriberAttributesPoster(backend)
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -60,7 +60,6 @@ internal class PurchasesFactory(
             val dispatcher = Dispatcher(service ?: createDefaultExecutor())
             val diagnosticsDispatcher = Dispatcher(createDiagnosticsExecutor())
 
-
             var diagnosticsFileHelper: DiagnosticsFileHelper? = null
             var diagnosticsTracker: DiagnosticsTracker? = null
             if (diagnosticsEnabled) {


### PR DESCRIPTION
### Description
Based on #795 
Deals with [CSDK-655](https://revenuecats.atlassian.net/browse/CSDK-655)

### Changes
- Adds functionality to send an `endpoint_hit` event to the diagnostics endpoint on every request
- Adds the `Endpoint` class with the enpoints we support, instead of hardcoding the path on each method.
- Adds functionality to detect whether a response comes from the backend or the cache.

[CSDK-655]: https://revenuecats.atlassian.net/browse/CSDK-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ