### PR TITLE
Diagnostics: Increase jittering for diagnostics backend calls

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -152,7 +152,8 @@ class Backend(
             }
         }
         synchronized(this@Backend) {
-            callbacks.addCallback(call, dispatcher, cacheKey, onSuccess to onError, randomDelay = appInBackground)
+            val delay = if (appInBackground) Delay.DEFAULT else Delay.NONE
+            callbacks.addCallback(call, dispatcher, cacheKey, onSuccess to onError, delay)
         }
     }
 
@@ -292,7 +293,8 @@ class Backend(
             }
         }
         synchronized(this@Backend) {
-            offeringsCallbacks.addCallback(call, dispatcher, path, onSuccess to onError, randomDelay = appInBackground)
+            val delay = if (appInBackground) Delay.DEFAULT else Delay.NONE
+            offeringsCallbacks.addCallback(call, dispatcher, path, onSuccess to onError, delay)
         }
     }
 
@@ -398,7 +400,7 @@ class Backend(
                 diagnosticsDispatcher,
                 cacheKey,
                 onSuccessHandler to onErrorHandler,
-                randomDelay = true
+                Delay.LONG
             )
         }
     }
@@ -406,12 +408,12 @@ class Backend(
     private fun enqueue(
         call: Dispatcher.AsyncCall,
         dispatcher: Dispatcher,
-        randomDelay: Boolean = false
+        delay: Delay = Delay.NONE
     ) {
         if (dispatcher.isClosed()) {
             errorLog("Enqueuing operation in closed dispatcher.")
         } else {
-            dispatcher.enqueue(call, randomDelay)
+            dispatcher.enqueue(call, delay)
         }
     }
 
@@ -428,11 +430,11 @@ class Backend(
         dispatcher: Dispatcher,
         cacheKey: K,
         functions: Pair<S, E>,
-        randomDelay: Boolean = false
+        delay: Delay = Delay.NONE
     ) {
         if (!containsKey(cacheKey)) {
             this[cacheKey] = mutableListOf(functions)
-            enqueue(call, dispatcher, randomDelay)
+            enqueue(call, dispatcher, delay)
         } else {
             debugLog(String.format(NetworkStrings.SAME_CALL_ALREADY_IN_PROGRESS, cacheKey))
             this[cacheKey]!!.add(functions)

--- a/common/src/main/java/com/revenuecat/purchases/common/Dispatcher.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Dispatcher.kt
@@ -13,7 +13,14 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
-private const val JITTERING_DELAY_MILLISECONDS = 5000
+private const val JITTERING_DELAY_MILLISECONDS = 5000L
+private const val JITTERING_LONG_DELAY_MILLISECONDS = 10000L
+
+enum class Delay(val delayMillis: Long) {
+    NONE(0),
+    DEFAULT(JITTERING_DELAY_MILLISECONDS),
+    LONG(JITTERING_LONG_DELAY_MILLISECONDS)
+}
 
 open class Dispatcher(
     private val executorService: ExecutorService
@@ -42,13 +49,13 @@ open class Dispatcher(
 
     open fun enqueue(
         command: Runnable,
-        useRandomDelay: Boolean = false
+        delay: Delay = Delay.NONE
     ) {
         synchronized(this.executorService) {
             if (!executorService.isShutdown) {
-                val future = if (useRandomDelay && executorService is ScheduledExecutorService) {
-                    val delayToApply = (0..JITTERING_DELAY_MILLISECONDS).random()
-                    executorService.schedule(command, delayToApply.toLong(), TimeUnit.MILLISECONDS)
+                val future = if (delay != Delay.NONE && executorService is ScheduledExecutorService) {
+                    val delayToApply = (0..delay.delayMillis).random()
+                    executorService.schedule(command, delayToApply, TimeUnit.MILLISECONDS)
                 } else {
                     executorService.submit(command)
                 }

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -1005,7 +1005,7 @@ class BackendTest {
     @Test
     fun `offerings call is enqueued with delay if on background`() {
         mockResponse(Endpoint.GetOfferings(appUserID), null, 200, null, noOfferingsResponse)
-        dispatcher.calledWithRandomDelay = null
+        dispatcher.calledDelay = null
         backend.getOfferings(
             appUserID,
             appInBackground = true,
@@ -1013,20 +1013,20 @@ class BackendTest {
             onError = onReceiveOfferingsErrorHandler
         )
 
-        val calledWithRandomDelay: Boolean? = dispatcher.calledWithRandomDelay
-        assertThat(calledWithRandomDelay).isNotNull
-        assertThat(calledWithRandomDelay).isTrue
+        val calledDelay = dispatcher.calledDelay
+        assertThat(calledDelay).isNotNull
+        assertThat(calledDelay).isEqualTo(Delay.DEFAULT)
     }
 
     @Test
     fun `customer info call is enqueued with delay if on background`() {
-        dispatcher.calledWithRandomDelay = null
+        dispatcher.calledDelay = null
 
         getCustomerInfo(200, clientException = null, resultBody = null, appInBackground = true)
 
-        val calledWithRandomDelay: Boolean? = dispatcher.calledWithRandomDelay
-        assertThat(calledWithRandomDelay).isNotNull
-        assertThat(calledWithRandomDelay).isTrue
+        val calledDelay = dispatcher.calledDelay
+        assertThat(calledDelay).isNotNull
+        assertThat(calledDelay).isEqualTo(Delay.DEFAULT)
     }
 
     @Test
@@ -1671,16 +1671,16 @@ class BackendTest {
             resultBody = "{}",
             baseURL = mockDiagnosticsBaseURL
         )
-        dispatcher.calledWithRandomDelay = null
+        dispatcher.calledDelay = null
         backend.postDiagnostics(
             listOf(JSONObject("{\"test-key\":\"test-value\"}")),
             {},
             { _, _ -> fail("expected success") }
         )
 
-        val calledWithRandomDelay: Boolean? = dispatcher.calledWithRandomDelay
-        assertThat(calledWithRandomDelay).isNotNull
-        assertThat(calledWithRandomDelay).isTrue
+        val calledDelay = dispatcher.calledDelay
+        assertThat(calledDelay).isNotNull
+        assertThat(calledDelay).isEqualTo(Delay.LONG)
     }
 
 

--- a/common/src/test/java/com/revenuecat/purchases/common/SyncDispatcher.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/SyncDispatcher.kt
@@ -1,15 +1,16 @@
 package com.revenuecat.purchases.common
 
 import io.mockk.mockk
+import java.util.concurrent.Delayed
 import java.util.concurrent.RejectedExecutionException
 
 internal class SyncDispatcher : Dispatcher(mockk()) {
 
     private var closed = false
-    var calledWithRandomDelay: Boolean? = null
+    var calledDelay: Delay? = null
 
-    override fun enqueue(command: Runnable, useRandomDelay: Boolean) {
-        calledWithRandomDelay = useRandomDelay
+    override fun enqueue(command: Runnable, delay: Delay) {
+        calledDelay = delay
         if (closed) {
             throw RejectedExecutionException()
         }

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/SyncDispatcher.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/SyncDispatcher.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.utils
 
+import com.revenuecat.purchases.common.Delay
 import com.revenuecat.purchases.common.Dispatcher
 import io.mockk.mockk
 import java.util.concurrent.RejectedExecutionException
@@ -8,7 +9,7 @@ class SyncDispatcher : Dispatcher(mockk()) {
 
     private var closed = false
 
-    override fun enqueue(command: Runnable, useRandomDelay: Boolean) {
+    override fun enqueue(command: Runnable, delay: Delay) {
         if (closed) {
             throw RejectedExecutionException()
         }


### PR DESCRIPTION
### Description
Deals with [SDK-2865](https://linear.app/revenuecat/issue/SDK-2865/add-random-jitter-to-diagnostics-requests)

This increases the jittering we add for diagnostics calls to make sure they don't cause any interference with the main SDK calls.