### PR TITLE
Diagnostics: Adapt to latest backend changes

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/FileHelper.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/FileHelper.kt
@@ -45,7 +45,7 @@ class FileHelper(
             errorLog("Trying to remove $numberOfLinesToRemove from file with ${readLines.size} lines.")
             ""
         } else {
-            readLines.subList(numberOfLinesToRemove, readLines.size).joinToString(separator = "")
+            readLines.subList(numberOfLinesToRemove, readLines.size).joinToString(separator = "\n", postfix = "\n")
         }
         appendToFile(filePath, textToAppend)
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
@@ -9,6 +9,7 @@ class DiagnosticsAnonymizer(
         return when (diagnosticsEntry) {
             is DiagnosticsEntry.Event -> anonymizeEvent(diagnosticsEntry)
             is DiagnosticsEntry.Counter -> diagnosticsEntry
+            is DiagnosticsEntry.Histogram -> diagnosticsEntry
         }
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
@@ -8,7 +8,7 @@ class DiagnosticsAnonymizer(
     fun anonymizeEntryIfNeeded(diagnosticsEntry: DiagnosticsEntry): DiagnosticsEntry {
         return when (diagnosticsEntry) {
             is DiagnosticsEntry.Event -> anonymizeEvent(diagnosticsEntry)
-            is DiagnosticsEntry.Metric -> diagnosticsEntry
+            is DiagnosticsEntry.Counter -> diagnosticsEntry
         }
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
@@ -5,23 +5,16 @@ import com.revenuecat.purchases.common.Anonymizer
 class DiagnosticsAnonymizer(
     private val anonymizer: Anonymizer
 ) {
-    fun anonymizeEventIfNeeded(diagnosticsEvent: DiagnosticsEvent): DiagnosticsEvent {
-        return when (diagnosticsEvent) {
-            is DiagnosticsEvent.Log -> anonymizeLog(diagnosticsEvent)
-            is DiagnosticsEvent.Exception -> anonymizeException(diagnosticsEvent)
-            is DiagnosticsEvent.Metric -> diagnosticsEvent
+    fun anonymizeEntryIfNeeded(diagnosticsEntry: DiagnosticsEntry): DiagnosticsEntry {
+        return when (diagnosticsEntry) {
+            is DiagnosticsEntry.Event -> anonymizeEvent(diagnosticsEntry)
+            is DiagnosticsEntry.Metric -> diagnosticsEntry
         }
     }
 
-    private fun anonymizeLog(diagnosticsLog: DiagnosticsEvent.Log): DiagnosticsEvent {
-        return diagnosticsLog.copy(
-            properties = anonymizer.anonymizedMap(diagnosticsLog.properties)
-        )
-    }
-
-    private fun anonymizeException(diagnosticsException: DiagnosticsEvent.Exception): DiagnosticsEvent {
-        return diagnosticsException.copy(
-            message = anonymizer.anonymizedString(diagnosticsException.message)
+    private fun anonymizeEvent(diagnosticsEvent: DiagnosticsEntry.Event): DiagnosticsEntry {
+        return diagnosticsEvent.copy(
+            properties = anonymizer.anonymizedMap(diagnosticsEvent.properties)
         )
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
@@ -38,11 +38,11 @@ sealed class DiagnosticsEntry(val diagnosticType: String) {
         }
     }
 
-    data class Metric(
+    data class Counter(
         val name: String,
         val tags: Map<String, String>,
         val value: Int
-    ) : DiagnosticsEntry("metric") {
+    ) : DiagnosticsEntry("counter") {
         private companion object {
             const val NAME_KEY = "name"
             const val TAGS_KEY = "tags"

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.common.diagnostics
 
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
+import org.json.JSONArray
 import org.json.JSONObject
 import java.util.Date
 
@@ -59,6 +60,30 @@ sealed class DiagnosticsEntry(val diagnosticType: String) {
             put(NAME_KEY, name.lowercase())
             put(TAGS_KEY, JSONObject(tags))
             put(VALUE_KEY, value)
+        }
+    }
+
+    data class Histogram(
+        val name: String,
+        val tags: Map<String, String>,
+        val values: List<Double>
+    ) : DiagnosticsEntry("histogram") {
+        private companion object {
+            const val NAME_KEY = "name"
+            const val TAGS_KEY = "tags"
+            const val VALUES_KEY = "values"
+        }
+
+        override fun toString(): String {
+            return toJSONObject().toString()
+        }
+
+        private fun toJSONObject() = JSONObject().apply {
+            put(VERSION_KEY, VERSION)
+            put(TYPE_KEY, diagnosticType)
+            put(NAME_KEY, name.lowercase())
+            put(TAGS_KEY, JSONObject(tags))
+            put(VALUES_KEY, JSONArray(values))
         }
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
@@ -6,7 +6,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.util.Date
 
-sealed class DiagnosticsEvent(val diagnosticType: String) {
+sealed class DiagnosticsEntry(val diagnosticType: String) {
     companion object {
         private const val VERSION_KEY = "version"
         private const val TYPE_KEY = "type"
@@ -14,12 +14,12 @@ sealed class DiagnosticsEvent(val diagnosticType: String) {
         private const val VERSION = 1
     }
 
-    data class Log(
-        val name: DiagnosticsLogEventName,
+    data class Event(
+        val name: DiagnosticsEventName,
         val properties: Map<String, Any>,
         val dateProvider: DateProvider = DefaultDateProvider(),
         val dateTime: Date = dateProvider.now
-    ) : DiagnosticsEvent("log") {
+    ) : DiagnosticsEntry("event") {
         private companion object {
             const val NAME_KEY = "name"
             const val PROPERTIES_KEY = "properties"
@@ -43,7 +43,7 @@ sealed class DiagnosticsEvent(val diagnosticType: String) {
         val name: String,
         val tags: List<String>,
         val value: Int
-    ) : DiagnosticsEvent("metric") {
+    ) : DiagnosticsEntry("metric") {
         private companion object {
             const val NAME_KEY = "name"
             const val TAGS_KEY = "tags"
@@ -60,34 +60,6 @@ sealed class DiagnosticsEvent(val diagnosticType: String) {
             put(NAME_KEY, name.lowercase())
             put(TAGS_KEY, JSONArray(tags))
             put(VALUE_KEY, value)
-        }
-    }
-
-    data class Exception(
-        val exceptionClass: String,
-        val message: String,
-        val location: String,
-        val dateProvider: DateProvider = DefaultDateProvider(),
-        val dateTime: Date = dateProvider.now
-    ) : DiagnosticsEvent("exception") {
-        private companion object {
-            const val EXCEPTION_CLASS_KEY = "exc_class"
-            const val MESSAGE_KEY = "message"
-            const val LOCATION_KEY = "location"
-            const val TIMESTAMP_KEY = "timestamp"
-        }
-
-        override fun toString(): String {
-            return toJSONObject().toString()
-        }
-
-        private fun toJSONObject() = JSONObject().apply {
-            put(VERSION_KEY, VERSION)
-            put(TYPE_KEY, diagnosticType)
-            put(EXCEPTION_CLASS_KEY, exceptionClass)
-            put(MESSAGE_KEY, message)
-            put(LOCATION_KEY, location)
-            put(TIMESTAMP_KEY, dateTime.time)
         }
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
@@ -41,7 +41,7 @@ sealed class DiagnosticsEntry(val diagnosticType: String) {
 
     data class Metric(
         val name: String,
-        val tags: List<String>,
+        val tags: Map<String, String>,
         val value: Int
     ) : DiagnosticsEntry("metric") {
         private companion object {
@@ -58,7 +58,7 @@ sealed class DiagnosticsEntry(val diagnosticType: String) {
             put(VERSION_KEY, VERSION)
             put(TYPE_KEY, diagnosticType)
             put(NAME_KEY, name.lowercase())
-            put(TAGS_KEY, JSONArray(tags))
+            put(TAGS_KEY, JSONObject(tags))
             put(VALUE_KEY, value)
         }
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases.common.diagnostics
 
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
-import org.json.JSONArray
 import org.json.JSONObject
 import java.util.Date
 

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEventName.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEventName.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.common.diagnostics
 
-enum class DiagnosticsLogEventName {
+enum class DiagnosticsEventName {
     HTTP_REQUEST_PERFORMED,
     MAX_EVENTS_STORED_LIMIT_REACHED
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
@@ -11,12 +11,12 @@ class DiagnosticsFileHelper(
     private val fileHelper: FileHelper
 ) {
     companion object {
-        const val DIAGNOSTICS_FILE_PATH = "RevenueCat/diagnostics/diagnostic_events.jsonl"
+        const val DIAGNOSTICS_FILE_PATH = "RevenueCat/diagnostics/diagnostic_entries.jsonl"
     }
 
     @Synchronized
-    fun appendEventToDiagnosticsFile(diagnosticsEvent: DiagnosticsEvent) {
-        fileHelper.appendToFile(DIAGNOSTICS_FILE_PATH, diagnosticsEvent.toString() + "\n")
+    fun appendEntryToDiagnosticsFile(diagnosticsEntry: DiagnosticsEntry) {
+        fileHelper.appendToFile(DIAGNOSTICS_FILE_PATH, diagnosticsEntry.toString() + "\n")
     }
 
     @Synchronized

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -25,8 +25,8 @@ class DiagnosticsTracker(
         resultOrigin: HTTPResult.Origin?
     ) {
         trackEvent(
-            DiagnosticsEvent.Log(
-                name = DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED,
+            DiagnosticsEntry.Event(
+                name = DiagnosticsEventName.HTTP_REQUEST_PERFORMED,
                 properties = mapOf(
                     "endpoint_name" to endpoint.name,
                     "response_time_millis" to responseTime.inWholeMilliseconds,
@@ -39,8 +39,8 @@ class DiagnosticsTracker(
     }
 
     fun trackMaxEventsStoredLimitReached(totalEventsStored: Int, eventsRemoved: Int, useCurrentThread: Boolean = true) {
-        val event = DiagnosticsEvent.Log(
-            name = DiagnosticsLogEventName.MAX_EVENTS_STORED_LIMIT_REACHED,
+        val event = DiagnosticsEntry.Event(
+            name = DiagnosticsEventName.MAX_EVENTS_STORED_LIMIT_REACHED,
             properties = mapOf(
                 "total_number_events_stored" to totalEventsStored,
                 "events_removed" to eventsRemoved
@@ -53,17 +53,17 @@ class DiagnosticsTracker(
         }
     }
 
-    fun trackEvent(diagnosticsEvent: DiagnosticsEvent) {
+    fun trackEvent(diagnosticsEntry: DiagnosticsEntry) {
         diagnosticsDispatcher.enqueue(command = {
-            trackEventInCurrentThread(diagnosticsEvent)
+            trackEventInCurrentThread(diagnosticsEntry)
         })
     }
 
-    internal fun trackEventInCurrentThread(diagnosticsEvent: DiagnosticsEvent) {
-        val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(diagnosticsEvent)
+    internal fun trackEventInCurrentThread(diagnosticsEntry: DiagnosticsEntry) {
+        val anonymizedEvent = diagnosticsAnonymizer.anonymizeEntryIfNeeded(diagnosticsEntry)
         verboseLog("Tracking diagnostics event: $anonymizedEvent")
         try {
-            diagnosticsFileHelper.appendEventToDiagnosticsFile(anonymizedEvent)
+            diagnosticsFileHelper.appendEntryToDiagnosticsFile(anonymizedEvent)
         } catch (e: IOException) {
             verboseLog("Error tracking diagnostics event: $e")
         }

--- a/common/src/test/java/com/revenuecat/purchases/common/FileHelperTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/FileHelperTest.kt
@@ -66,10 +66,17 @@ class FileHelperTest {
     }
 
     @Test
-    fun `removeFirstLinesFromFile leaves content after first lines`() {
-        createTestFileWithContents("first line\nsecond line\nthird line\nfourth line")
+    fun `removeFirstLinesFromFile leaves multiple lines after first lines`() {
+        createTestFileWithContents("first line\nsecond line\nthird line\nfourth line\nfifth line\n")
         fileHelper.removeFirstLinesFromFile(testFilePath, 3)
-        verifyFileExistsWithContents("fourth line")
+        verifyFileExistsWithContents("fourth line\nfifth line\n")
+    }
+
+    @Test
+    fun `removeFirstLinesFromFile leaves content after first lines`() {
+        createTestFileWithContents("first line\nsecond line\nthird line\nfourth line\n")
+        fileHelper.removeFirstLinesFromFile(testFilePath, 3)
+        verifyFileExistsWithContents("fourth line\n")
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
@@ -59,13 +59,13 @@ class DiagnosticsAnonymizerTest {
     }
 
     @Test
-    fun `anonymizeEntryIfNeeded does not anonymize metric`() {
-        val metricToAnonymize = DiagnosticsEntry.Metric(
+    fun `anonymizeEntryIfNeeded does not anonymize counter`() {
+        val counterToAnonymize = DiagnosticsEntry.Counter(
             name = "metric-name",
             tags = emptyMap(),
             value = 123
         )
-        val anonymizedMetric = diagnosticsAnonymizer.anonymizeEntryIfNeeded(metricToAnonymize)
-        assertThat(anonymizedMetric).isEqualTo(metricToAnonymize)
+        val anonymizedMetric = diagnosticsAnonymizer.anonymizeEntryIfNeeded(counterToAnonymize)
+        assertThat(anonymizedMetric).isEqualTo(counterToAnonymize)
     }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
@@ -62,7 +62,7 @@ class DiagnosticsAnonymizerTest {
     fun `anonymizeEntryIfNeeded does not anonymize metric`() {
         val metricToAnonymize = DiagnosticsEntry.Metric(
             name = "metric-name",
-            tags = listOf("tag-1", "tag-2"),
+            tags = emptyMap(),
             value = 123
         )
         val anonymizedMetric = diagnosticsAnonymizer.anonymizeEntryIfNeeded(metricToAnonymize)

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
@@ -65,7 +65,18 @@ class DiagnosticsAnonymizerTest {
             tags = emptyMap(),
             value = 123
         )
-        val anonymizedMetric = diagnosticsAnonymizer.anonymizeEntryIfNeeded(counterToAnonymize)
-        assertThat(anonymizedMetric).isEqualTo(counterToAnonymize)
+        val anonymizedCounter = diagnosticsAnonymizer.anonymizeEntryIfNeeded(counterToAnonymize)
+        assertThat(anonymizedCounter).isEqualTo(counterToAnonymize)
+    }
+
+    @Test
+    fun `anonymizeEntryIfNeeded does not anonymize histogram`() {
+        val histogramToAnonymize = DiagnosticsEntry.Histogram(
+            name = "metric-name",
+            tags = emptyMap(),
+            values = listOf(1.1)
+        )
+        val anonymizedHistogram = diagnosticsAnonymizer.anonymizeEntryIfNeeded(histogramToAnonymize)
+        assertThat(anonymizedHistogram).isEqualTo(histogramToAnonymize)
     }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
@@ -37,16 +37,16 @@ class DiagnosticsAnonymizerTest {
     }
 
     @Test
-    fun `anonymizeEventIfNeeded anonymizes log properties`() {
+    fun `anonymizeEntryIfNeeded anonymizes event properties`() {
         val originalPropertiesMap = mapOf("key-1" to "value-1")
         val expectedPropertiesMap = mapOf("key-1" to "anonymized-value-1")
-        val eventToAnonymize = DiagnosticsEvent.Log(
-            name = DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED,
+        val eventToAnonymize = DiagnosticsEntry.Event(
+            name = DiagnosticsEventName.HTTP_REQUEST_PERFORMED,
             properties = originalPropertiesMap,
             dateProvider = testDateProvider
         )
-        val expectedEvent = DiagnosticsEvent.Log(
-            name = DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED,
+        val expectedEvent = DiagnosticsEntry.Event(
+            name = DiagnosticsEventName.HTTP_REQUEST_PERFORMED,
             properties = expectedPropertiesMap,
             dateProvider = testDateProvider,
             dateTime = testDate
@@ -54,40 +54,18 @@ class DiagnosticsAnonymizerTest {
         every {
             anonymizer.anonymizedMap(originalPropertiesMap)
         } returns expectedPropertiesMap
-        val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(eventToAnonymize)
+        val anonymizedEvent = diagnosticsAnonymizer.anonymizeEntryIfNeeded(eventToAnonymize)
         assertThat(anonymizedEvent).isEqualTo(expectedEvent)
     }
 
     @Test
-    fun `anonymizeEventIfNeeded anonymizes exception message`() {
-        val eventToAnonymize = DiagnosticsEvent.Exception(
-            exceptionClass = "TestClass",
-            message = "Some message with possible PII",
-            location = "TestClass:131",
-            dateProvider = testDateProvider
-        )
-        val expectedEvent = DiagnosticsEvent.Exception(
-            exceptionClass = "TestClass",
-            message = "Some message without PII",
-            location = "TestClass:131",
-            dateProvider = testDateProvider,
-            dateTime = testDate
-        )
-        every {
-            anonymizer.anonymizedString("Some message with possible PII")
-        } returns "Some message without PII"
-        val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(eventToAnonymize)
-        assertThat(anonymizedEvent).isEqualTo(expectedEvent)
-    }
-
-    @Test
-    fun `anonymizeEventIfNeeded does not anonymize metric`() {
-        val eventToAnonymize = DiagnosticsEvent.Metric(
+    fun `anonymizeEntryIfNeeded does not anonymize metric`() {
+        val metricToAnonymize = DiagnosticsEntry.Metric(
             name = "metric-name",
             tags = listOf("tag-1", "tag-2"),
             value = 123
         )
-        val anonymizedEvent = diagnosticsAnonymizer.anonymizeEventIfNeeded(eventToAnonymize)
-        assertThat(anonymizedEvent).isEqualTo(eventToAnonymize)
+        val anonymizedMetric = diagnosticsAnonymizer.anonymizeEntryIfNeeded(metricToAnonymize)
+        assertThat(anonymizedMetric).isEqualTo(metricToAnonymize)
     }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
@@ -11,7 +11,7 @@ import java.util.Date
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
-class DiagnosticsEventTest {
+class DiagnosticsEntryTest {
 
     private val testDate = Date(1675954145L) // Thursday, February 9, 2023 2:49:05 PM GMT
 
@@ -26,9 +26,9 @@ class DiagnosticsEventTest {
     }
 
     @Test
-    fun `toString transforms log event to correct JSON`() {
-        val event = DiagnosticsEvent.Log(
-            name = DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED,
+    fun `toString transforms event to correct JSON`() {
+        val event = DiagnosticsEntry.Event(
+            name = DiagnosticsEventName.HTTP_REQUEST_PERFORMED,
             properties = mapOf("test-key-1" to "test-value-1", "test-key-2" to 123, "test-key-3" to true),
             dateProvider = testDateProvider
         )
@@ -44,8 +44,8 @@ class DiagnosticsEventTest {
     }
 
     @Test
-    fun `toString transforms metrics event to correct JSON`() {
-        val event = DiagnosticsEvent.Metric(
+    fun `toString transforms metrics to correct JSON`() {
+        val event = DiagnosticsEntry.Metric(
             name = "test_metric_name",
             tags = listOf("test-1", "test-2"),
             value = 2
@@ -57,26 +57,6 @@ class DiagnosticsEventTest {
             "\"name\":\"test_metric_name\"," +
             "\"tags\":[\"test-1\",\"test-2\"]," +
             "\"value\":2" +
-            "}"
-        assertThat(eventAsString).isEqualTo(expectedString)
-    }
-
-    @Test
-    fun `toString transforms exception event to correct JSON`() {
-        val event = DiagnosticsEvent.Exception(
-            exceptionClass = "TestClass.kt",
-            message = "test message",
-            location = "DiagnosticsEvent:121",
-            dateProvider = testDateProvider
-        )
-        val eventAsString = event.toString()
-        val expectedString = "{" +
-            "\"version\":1," +
-            "\"type\":\"exception\"," +
-            "\"exc_class\":\"TestClass.kt\"," +
-            "\"message\":\"test message\"," +
-            "\"location\":\"DiagnosticsEvent:121\"," +
-            "\"timestamp\":1675954145" +
             "}"
         assertThat(eventAsString).isEqualTo(expectedString)
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
@@ -60,4 +60,22 @@ class DiagnosticsEntryTest {
             "}"
         assertThat(eventAsString).isEqualTo(expectedString)
     }
+
+    @Test
+    fun `toString transforms histogram to correct JSON`() {
+        val event = DiagnosticsEntry.Histogram(
+            name = "test_histogram_name",
+            tags = mapOf("test-key-1" to "test-value-1", "test-key-2" to "test-value-2"),
+            values = listOf(2.1, 3.4)
+        )
+        val eventAsString = event.toString()
+        val expectedString = "{" +
+            "\"version\":1," +
+            "\"type\":\"histogram\"," +
+            "\"name\":\"test_histogram_name\"," +
+            "\"tags\":{\"test-key-1\":\"test-value-1\",\"test-key-2\":\"test-value-2\"}," +
+            "\"values\":[2.1,3.4]" +
+            "}"
+        assertThat(eventAsString).isEqualTo(expectedString)
+    }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
@@ -35,7 +35,7 @@ class DiagnosticsEntryTest {
         val eventAsString = event.toString()
         val expectedString = "{" +
             "\"version\":1," +
-            "\"type\":\"log\"," +
+            "\"type\":\"event\"," +
             "\"name\":\"http_request_performed\"," +
             "\"properties\":{\"test-key-1\":\"test-value-1\",\"test-key-2\":123,\"test-key-3\":true}," +
             "\"timestamp\":1675954145" +

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
@@ -47,7 +47,7 @@ class DiagnosticsEntryTest {
     fun `toString transforms metrics to correct JSON`() {
         val event = DiagnosticsEntry.Metric(
             name = "test_metric_name",
-            tags = listOf("test-1", "test-2"),
+            tags = mapOf("test-key-1" to "test-value-1", "test-key-2" to "test-value-2"),
             value = 2
         )
         val eventAsString = event.toString()
@@ -55,7 +55,7 @@ class DiagnosticsEntryTest {
             "\"version\":1," +
             "\"type\":\"metric\"," +
             "\"name\":\"test_metric_name\"," +
-            "\"tags\":[\"test-1\",\"test-2\"]," +
+            "\"tags\":{\"test-key-1\":\"test-value-1\",\"test-key-2\":\"test-value-2\"}," +
             "\"value\":2" +
             "}"
         assertThat(eventAsString).isEqualTo(expectedString)

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
@@ -44,8 +44,8 @@ class DiagnosticsEntryTest {
     }
 
     @Test
-    fun `toString transforms metrics to correct JSON`() {
-        val event = DiagnosticsEntry.Metric(
+    fun `toString transforms counter to correct JSON`() {
+        val event = DiagnosticsEntry.Counter(
             name = "test_metric_name",
             tags = mapOf("test-key-1" to "test-value-1", "test-key-2" to "test-value-2"),
             value = 2
@@ -53,7 +53,7 @@ class DiagnosticsEntryTest {
         val eventAsString = event.toString()
         val expectedString = "{" +
             "\"version\":1," +
-            "\"type\":\"metric\"," +
+            "\"type\":\"counter\"," +
             "\"name\":\"test_metric_name\"," +
             "\"tags\":{\"test-key-1\":\"test-value-1\",\"test-key-2\":\"test-value-2\"}," +
             "\"value\":2" +

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
@@ -18,8 +18,8 @@ import org.robolectric.annotation.Config
 @Config(manifest = Config.NONE)
 class DiagnosticsFileHelperTest {
 
-    private val testDiagnosticsEvent = DiagnosticsEvent.Log(
-        name = DiagnosticsLogEventName.HTTP_REQUEST_PERFORMED,
+    private val testDiagnosticsEntry = DiagnosticsEntry.Event(
+        name = DiagnosticsEventName.HTTP_REQUEST_PERFORMED,
         properties = emptyMap()
     )
     private val diagnosticsFilePath = DiagnosticsFileHelper.DIAGNOSTICS_FILE_PATH
@@ -35,10 +35,10 @@ class DiagnosticsFileHelperTest {
     }
 
     @Test
-    fun `appendEventToDiagnosticsFile calls are correct`() {
-        val contentToAppend = "$testDiagnosticsEvent\n"
+    fun `appendEntryToDiagnosticsFile calls are correct`() {
+        val contentToAppend = "$testDiagnosticsEntry\n"
         every { fileHelper.appendToFile(diagnosticsFilePath, contentToAppend) } just Runs
-        diagnosticsFileHelper.appendEventToDiagnosticsFile(testDiagnosticsEvent)
+        diagnosticsFileHelper.appendEntryToDiagnosticsFile(testDiagnosticsEntry)
         verify(exactly = 1) { fileHelper.appendToFile(diagnosticsFilePath, contentToAppend) }
     }
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -9,6 +9,7 @@ import androidx.core.view.get
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.amazon.AmazonConfiguration
@@ -74,10 +75,15 @@ class ConfigureFragment : Fragment() {
 
         if (proxyUrl.isNotEmpty()) Purchases.proxyURL = URL(proxyUrl)
 
+        Purchases.logLevel = LogLevel.VERBOSE
+
         val configurationBuilder =
             if (useAmazonStore) AmazonConfiguration.Builder(application, apiKey)
             else PurchasesConfiguration.Builder(application, apiKey)
-        val configuration = configurationBuilder.build()
+
+        val configuration = configurationBuilder
+            .diagnosticsEnabled(true)
+            .build()
         Purchases.configure(configuration)
 
         // set attributes to store additional, structured information for a user in RevenueCat.


### PR DESCRIPTION
### Description
This PR we are adapting the code to the latest changes in the backend. 

### Changes
- We've removed `exceptions` as a type of diagnostic, those can be sent as a Log/Event
- We've renamed `DiagnosticsEvent` to `DiagnosticsEntry`
- We've renamed `DiagnosticsEvent.Log` to `DiagnosticsEntry.Event`
- Renamed "type" of `DiagnosticsEntry.Event` to `event`
- Enabled diagnostics and verbose logs in purchase tester.
