### PR TITLE
[BC5] New Period and Unit classes to represent ISO8601 period strings

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=11.0.13-librca
+java=11.0.17-librca

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PeriodAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PeriodAPI.java
@@ -1,0 +1,20 @@
+package com.revenuecat.apitester.java;
+
+import com.revenuecat.purchases.models.Period;
+
+@SuppressWarnings({"unused", "SpellCheckingInspection"})
+final class PeriodAPI {
+    static void check(final Period period) {
+        int val = period.getValue();
+        Period.Unit unit = period.getUnit();
+        String iso8601 = period.getIso8601();
+
+        switch (unit) {
+            case DAY:
+            case WEEK:
+            case MONTH:
+            case YEAR:
+            case UNKNOWN:
+        }
+    }
+}

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.models.GoogleStoreProductKt;
 import com.revenuecat.purchases.models.Price;
 import com.revenuecat.purchases.models.SubscriptionOption;
 import com.revenuecat.purchases.models.StoreProduct;
+import com.revenuecat.purchases.models.Period;
 
 import java.util.List;
 
@@ -20,7 +21,7 @@ final class StoreProductAPI {
         final Price price = product.getPrice();
         final String title = product.getTitle();
         final String description = product.getDescription();
-        final String subscriptionPeriod = product.getSubscriptionPeriod();
+        final Period period = product.getPeriod();
         List<SubscriptionOption> subscriptionOptions = product.getSubscriptionOptions();
         SubscriptionOption defaultOption = product.getDefaultOption();
 
@@ -47,7 +48,7 @@ final class StoreProductAPI {
                 googleStoreProduct.getPrice(),
                 googleStoreProduct.getTitle(),
                 googleStoreProduct.getDescription(),
-                googleStoreProduct.getSubscriptionPeriod(),
+                googleStoreProduct.getPeriod(),
                 googleStoreProduct.getSubscriptionOptions(),
                 googleStoreProduct.getDefaultOption(),
                 googleStoreProduct.getProductDetails()

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
@@ -15,7 +15,7 @@ import java.util.List;
 @SuppressWarnings({"unused"})
 final class StoreProductAPI {
     static void check(final StoreProduct product) {
-        final String productId = product.getProductId();
+        final String productId = product.getId();
         final String sku = product.getSku();
         final ProductType type = product.getType();
         final Price price = product.getPrice();
@@ -43,7 +43,8 @@ final class StoreProductAPI {
         List<GoogleSubscriptionOption> subscriptionOptions = googleStoreProduct.getSubscriptionOptions();
         GoogleSubscriptionOption defaultOption = googleStoreProduct.getDefaultOption();
         GoogleStoreProduct constructedGoogleStoreProduct = new GoogleStoreProduct(
-                googleStoreProduct.getProductId(),
+                googleStoreProduct.getId(),
+                null,
                 googleStoreProduct.getType(),
                 googleStoreProduct.getPrice(),
                 googleStoreProduct.getTitle(),
@@ -53,5 +54,8 @@ final class StoreProductAPI {
                 googleStoreProduct.getDefaultOption(),
                 googleStoreProduct.getProductDetails()
         );
+
+        String productId = constructedGoogleStoreProduct.getProductId();
+        String basePlanId = constructedGoogleStoreProduct.getBasePlanId();
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PeriodAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PeriodAPI.kt
@@ -1,0 +1,24 @@
+package com.revenuecat.apitester.kotlin
+
+import com.revenuecat.purchases.models.Period
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class PeriodAPI {
+    fun check(period: Period) {
+        with(period) {
+            val value: Int = value
+            val unit: Period.Unit = unit
+            val iso8601: String = iso8601
+
+            when (unit) {
+                Period.Unit.DAY,
+                Period.Unit.WEEK,
+                Period.Unit.MONTH,
+                Period.Unit.YEAR,
+                Period.Unit.UNKNOWN,
+                -> {
+                }
+            }.exhaustive
+        }
+    }
+}

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.models.GoogleStoreProduct
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.googleProduct
 
 @Suppress("unused", "UNUSED_VARIABLE")
@@ -19,7 +20,7 @@ private class StoreProductAPI {
             val price: Price? = price
             val title: String = title
             val description: String = description
-            val subscriptionPeriod: String? = subscriptionPeriod
+            val period: Period? = period
             val subscriptionOptions: List<SubscriptionOption> = subscriptionOptions
             val defaultOption: SubscriptionOption? = defaultOption
             val underlyingProduct: GoogleStoreProduct? = googleProduct
@@ -46,7 +47,7 @@ private class StoreProductAPI {
             googleStoreProduct.price,
             googleStoreProduct.title,
             googleStoreProduct.description,
-            googleStoreProduct.subscriptionPeriod,
+            googleStoreProduct.period,
             googleStoreProduct.subscriptionOptions,
             googleStoreProduct.defaultOption,
             googleStoreProduct.productDetails

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
@@ -14,7 +14,7 @@ import com.revenuecat.purchases.models.googleProduct
 private class StoreProductAPI {
     fun check(product: StoreProduct) {
         with(product) {
-            val storeProductId: String = productId
+            val storeProductId: String = id
             val sku: String = sku
             val type: ProductType = type
             val price: Price? = price
@@ -42,7 +42,8 @@ private class StoreProductAPI {
         val subscriptionOptions: List<GoogleSubscriptionOption> = googleStoreProduct.subscriptionOptions
         val defaultOption: GoogleSubscriptionOption? = googleStoreProduct.defaultOption
         val constructedGoogleStoreProduct = GoogleStoreProduct(
-            googleStoreProduct.productId,
+            googleStoreProduct.id,
+            null,
             googleStoreProduct.type,
             googleStoreProduct.price,
             googleStoreProduct.title,
@@ -52,5 +53,8 @@ private class StoreProductAPI {
             googleStoreProduct.defaultOption,
             googleStoreProduct.productDetails
         )
+
+        val productId = constructedGoogleStoreProduct.productId
+        val basePlanId = constructedGoogleStoreProduct.basePlanId
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/ReceiptInfo.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/ReceiptInfo.kt
@@ -13,7 +13,7 @@ class ReceiptInfo(
     val currency: String? = storeProduct?.price?.currencyCode
 ) {
 
-    val duration: String? = storeProduct?.subscriptionPeriod?.takeUnless { it.isEmpty() }
+    val duration: String? = storeProduct?.period?.iso8601?.takeUnless { it.isEmpty() }
     val pricingPhases: List<PricingPhase>? =
         storeProduct?.subscriptionOptions?.firstOrNull { it.id == subscriptionOptionId }?.pricingPhases
 

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -595,7 +595,7 @@ class BackendTest {
         val originalDuration = originalSubscriptionOption.pricingPhases[0].billingPeriod.iso8601
         val subscriptionOption = stubSubscriptionOption(originalSubscriptionOption.id, originalDuration + "a")
         val storeProduct2 = stubStoreProduct(
-            storeProduct.productId,
+            storeProduct.id,
             subscriptionOption
         )
 

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -592,7 +592,7 @@ class BackendTest {
         )
 
         val originalSubscriptionOption = storeProduct.subscriptionOptions[0]
-        val originalDuration = originalSubscriptionOption.pricingPhases[0].billingPeriod
+        val originalDuration = originalSubscriptionOption.pricingPhases[0].billingPeriod.iso8601
         val subscriptionOption = stubSubscriptionOption(originalSubscriptionOption.id, originalDuration + "a")
         val storeProduct2 = stubStoreProduct(
             storeProduct.productId,

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -393,7 +393,7 @@ class DeviceCacheTest {
     @Test
     fun `caching offerings works`() {
         val storeProduct = mockk<StoreProduct>().also {
-            every { it.productId } returns "onemonth_freetrial"
+            every { it.id } returns "onemonth_freetrial"
         }
         val packageObject = Package(
             "custom",

--- a/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
@@ -10,7 +10,7 @@ import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.models.StoreProduct
-import com.revenuecat.purchases.models.toSubscriptionPeriod
+import com.revenuecat.purchases.models.toPeriod
 import com.revenuecat.purchases.utils.stubINAPPStoreProduct
 import com.revenuecat.purchases.utils.stubPricingPhase
 import com.revenuecat.purchases.utils.stubSubscriptionOption
@@ -407,7 +407,7 @@ class OfferingsTest {
         duration: String = monthlyDuration,
         basePlanId: String = monthlyBasePlan,
     ): StoreProduct {
-        val period = duration.toSubscriptionPeriod()
+        val period = duration.toPeriod()
 
         val basePlanPricingPhase = stubPricingPhase(
             price = 1.99,

--- a/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
@@ -10,6 +10,7 @@ import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.toSubscriptionPeriod
 import com.revenuecat.purchases.utils.stubINAPPStoreProduct
 import com.revenuecat.purchases.utils.stubPricingPhase
 import com.revenuecat.purchases.utils.stubSubscriptionOption
@@ -406,9 +407,11 @@ class OfferingsTest {
         duration: String = monthlyDuration,
         basePlanId: String = monthlyBasePlan,
     ): StoreProduct {
+        val period = duration.toSubscriptionPeriod()
+
         val basePlanPricingPhase = stubPricingPhase(
             price = 1.99,
-            billingPeriod = duration,
+            billingPeriod = period,
             recurrenceMode = ProductDetails.RecurrenceMode.INFINITE_RECURRING
         )
         val basePlanSubscriptionOption =
@@ -417,12 +420,12 @@ class OfferingsTest {
         val offerPricingPhases = listOf(
             stubPricingPhase(
                 price = 0.0,
-                billingPeriod = duration,
+                billingPeriod = period,
                 recurrenceMode = ProductDetails.RecurrenceMode.NON_RECURRING
             ),
             basePlanPricingPhase
         )
-        val offerSubscriptionOption = stubSubscriptionOption(basePlanId, productId, duration, offerPricingPhases)
+        val offerSubscriptionOption = stubSubscriptionOption(basePlanId, productId, period, offerPricingPhases)
         return stubStoreProduct(
             productId,
             basePlanSubscriptionOption,

--- a/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/OfferingsTest.kt
@@ -9,8 +9,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.StoreProduct
-import com.revenuecat.purchases.models.toPeriod
 import com.revenuecat.purchases.utils.stubINAPPStoreProduct
 import com.revenuecat.purchases.utils.stubPricingPhase
 import com.revenuecat.purchases.utils.stubSubscriptionOption
@@ -407,7 +407,7 @@ class OfferingsTest {
         duration: String = monthlyDuration,
         basePlanId: String = monthlyBasePlan,
     ): StoreProduct {
-        val period = duration.toPeriod()
+        val period = Period.create(duration)
 
         val basePlanPricingPhase = stubPricingPhase(
             price = 1.99,

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
@@ -42,7 +42,7 @@ class PackageCardAdapter(
             val product = currentPackage.product
             binding.currentPackage = currentPackage
             binding.isSubscription = product.type == ProductType.SUBS
-            binding.isActive = activeSubscriptions.contains(product.productId)
+            binding.isActive = activeSubscriptions.contains(product.id)
 
             binding.packageBuyButton.setOnClickListener {
                 listener.onPurchasePackageClicked(

--- a/examples/purchase-tester/src/main/res/layout/package_card.xml
+++ b/examples/purchase-tester/src/main/res/layout/package_card.xml
@@ -71,7 +71,7 @@
                     app:layout_constraintEnd_toStartOf="@+id/package_card_barrier"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/package_product_description"
-                    bind:detail="@{currentPackage.product.productId}"
+                    bind:detail="@{currentPackage.product.id}"
                     bind:header="@{`Sku:`}"
                     tools:text="$rc_monthly" />
 

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -445,7 +445,7 @@ internal class AmazonBilling constructor(
              * since there's no terms and we can just use the sku
              */
             val amazonPurchaseWrapper = receipt.toStoreTransaction(
-                productId = storeProduct.productId,
+                productId = storeProduct.id,
                 presentedOfferingIdentifier = presentedOfferingIdentifier,
                 purchaseState = PurchaseState.PURCHASED,
                 userData

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/PurchaseHandler.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/PurchaseHandler.kt
@@ -42,7 +42,7 @@ class PurchaseHandler(
         onSuccess: (Receipt, UserData) -> Unit,
         onError: (PurchasesError) -> Unit
     ) {
-        log(LogIntent.PURCHASE, PurchaseStrings.PURCHASING_PRODUCT.format(storeProduct.productId))
+        log(LogIntent.PURCHASE, PurchaseStrings.PURCHASING_PRODUCT.format(storeProduct.id))
 
         startProxyActivity(mainHandler, activity, storeProduct, presentedOfferingIdentifier, onSuccess, onError)
     }
@@ -61,7 +61,7 @@ class PurchaseHandler(
         val intent = ProxyAmazonBillingActivity.newStartIntent(
             activity,
             resultReceiver,
-            storeProduct.productId,
+            storeProduct.id,
             purchasingServiceProvider
         )
         // ProxyAmazonBillingActivity will initiate the purchase
@@ -80,8 +80,8 @@ class PurchaseHandler(
                 val requestId = resultData?.get(ProxyAmazonBillingActivity.EXTRAS_REQUEST_ID) as? RequestId
                 if (requestId != null) {
                     purchaseCallbacks[requestId] = onSuccess to onError
-                    productTypes[storeProduct.productId] = storeProduct.type
-                    presentedOfferingsByProductIdentifier[storeProduct.productId] = presentedOfferingIdentifier
+                    productTypes[storeProduct.id] = storeProduct.type
+                    presentedOfferingsByProductIdentifier[storeProduct.id] = presentedOfferingIdentifier
                 } else {
                     errorLog("No RequestId coming from ProxyAmazonBillingActivity")
                 }

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
@@ -22,7 +22,7 @@ sealed class AmazonPurchasingData : PurchasingData {
         val storeProduct: AmazonStoreProduct,
     ) : AmazonPurchasingData() {
         override val productId: String
-            get() = storeProduct.productId
+            get() = storeProduct.id
         override val productType: ProductType
             get() = storeProduct.type
     }
@@ -31,7 +31,7 @@ sealed class AmazonPurchasingData : PurchasingData {
 @Parcelize
 @TypeParceler<JSONObject, JSONObjectParceler>()
 data class AmazonStoreProduct(
-    override val productId: String,
+    override val id: String,
     override val type: ProductType,
     override val title: String,
     override val description: String,
@@ -49,7 +49,7 @@ data class AmazonStoreProduct(
         get() = AmazonPurchasingData.Product(this)
 
     override val sku: String
-        get() = productId
+        get() = id
 
     // We use this to not include the originalJSON in the equals
     /*override fun equals(other: Any?) = other is StoreProduct && ComparableData(this) == ComparableData(other)

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.utils.JSONObjectParceler
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
@@ -34,7 +35,7 @@ data class AmazonStoreProduct(
     override val type: ProductType,
     override val title: String,
     override val description: String,
-    override val subscriptionPeriod: String?,
+    override val period: Period?,
 
     override val price: com.revenuecat.purchases.models.Price,
     override val subscriptionOptions: List<SubscriptionOption>,
@@ -71,7 +72,7 @@ fun Product.toStoreProduct(marketplace: String): StoreProduct? {
         productType.toRevenueCatProductType(),
         title,
         description,
-        subscriptionPeriod = null,
+        period = null,
         priceInfo,
         emptyList(),
         defaultOption = null,

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
@@ -74,7 +74,7 @@ class ProductDataHandlerTest {
 
         assertThat(receivedStoreProducts).isNotNull
 
-        val receivedSkus = receivedStoreProducts!!.map { it.productId }
+        val receivedSkus = receivedStoreProducts!!.map { it.id }
         assertThat(receivedSkus).hasSameElementsAs(expectedSkus)
 
         assertThat(purchasingServiceProvider.getProductDataCalledTimes).isZero
@@ -114,7 +114,7 @@ class ProductDataHandlerTest {
         assertThat(receivedStoreProducts).isNotNull
 
         val expectedSkus = expectedProductData.keys
-        val receivedSkus = receivedStoreProducts!!.map { it.productId }
+        val receivedSkus = receivedStoreProducts!!.map { it.id }
         assertThat(receivedSkus).hasSameElementsAs(expectedSkus)
 
         assertThat(purchasingServiceProvider.getProductDataCalledTimes).isOne
@@ -151,7 +151,7 @@ class ProductDataHandlerTest {
         )
 
         val expectedSkus = expectedProductData.keys
-        val receivedSkus = receivedStoreProducts!!.map { it.productId }
+        val receivedSkus = receivedStoreProducts!!.map { it.id }
         assertThat(receivedSkus).hasSameElementsAs(expectedSkus)
 
         assertThat(underTest.productDataCache).isNotEmpty

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/findDefaultOffer.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/findDefaultOffer.kt
@@ -16,7 +16,7 @@ fun List<GoogleSubscriptionOption>.findDefaultOffer(): GoogleSubscriptionOption?
 private fun findLongestFreeTrial(offers: List<GoogleSubscriptionOption>): GoogleSubscriptionOption? {
     return offers.mapNotNull { offer ->
         offer.freePricingPhase?.let { pricingPhase ->
-            Pair(offer, parseBillPeriodToDays(pricingPhase.billingPeriod))
+            Pair(offer, parseBillPeriodToDays(pricingPhase.billingPeriod.iso8601))
         }
     }.maxByOrNull { it.second }?.first
 }

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/findDefaultOffer.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/findDefaultOffer.kt
@@ -40,7 +40,7 @@ private const val DAYS_IN_DAY = 1
 private const val DAYS_IN_WEEK = 7
 private const val DAYS_IN_MONTH = 30
 private const val DAYS_IN_YEAR = 365
-private const val DAYS_IN_UNIT = mapOf(
+private val DAYS_IN_UNIT = mapOf(
     Period.Unit.DAY to DAYS_IN_DAY,
     Period.Unit.WEEK to DAYS_IN_WEEK,
     Period.Unit.MONTH to DAYS_IN_MONTH,

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/findDefaultOffer.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/findDefaultOffer.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.google
 
+import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.PricingPhase
@@ -47,6 +48,7 @@ private val DAYS_IN_UNIT = mapOf(
     Period.Unit.YEAR to DAYS_IN_YEAR,
 )
 
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal fun billingPeriodToDays(period: Period): Int {
     val days = DAYS_IN_UNIT[period.unit] ?: 0
     return period.value * days

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/pricingPhaseConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/pricingPhaseConversions.kt
@@ -4,11 +4,11 @@ import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.toRecurrenceMode
-import com.revenuecat.purchases.models.toSubscriptionPeriod
+import com.revenuecat.purchases.models.toPeriod
 
 fun ProductDetails.PricingPhase.toRevenueCatPricingPhase(): PricingPhase {
     return PricingPhase(
-        billingPeriod.toSubscriptionPeriod(),
+        billingPeriod.toPeriod(),
         recurrenceMode.toRecurrenceMode(),
         billingCycleCount,
         Price(formattedPrice, priceAmountMicros, priceCurrencyCode)

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/pricingPhaseConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/pricingPhaseConversions.kt
@@ -4,10 +4,11 @@ import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.toRecurrenceMode
+import com.revenuecat.purchases.models.toSubscriptionPeriod
 
 fun ProductDetails.PricingPhase.toRevenueCatPricingPhase(): PricingPhase {
     return PricingPhase(
-        billingPeriod,
+        billingPeriod.toSubscriptionPeriod(),
         recurrenceMode.toRecurrenceMode(),
         billingCycleCount,
         Price(formattedPrice, priceAmountMicros, priceCurrencyCode)

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/pricingPhaseConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/pricingPhaseConversions.kt
@@ -1,14 +1,14 @@
 package com.revenuecat.purchases.google
 
 import com.android.billingclient.api.ProductDetails
+import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.toRecurrenceMode
-import com.revenuecat.purchases.models.toPeriod
 
 fun ProductDetails.PricingPhase.toRevenueCatPricingPhase(): PricingPhase {
     return PricingPhase(
-        billingPeriod.toPeriod(),
+        Period.create(billingPeriod),
         recurrenceMode.toRecurrenceMode(),
         billingCycleCount,
         Price(formattedPrice, priceAmountMicros, priceCurrencyCode)

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.models.GoogleStoreProduct
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.toSubscriptionPeriod
 import com.revenuecat.purchases.strings.PurchaseStrings
 
 // In-apps don't have base plan nor offers
@@ -27,7 +28,7 @@ fun ProductDetails.toStoreProduct(
         price,
         title,
         description,
-        offerDetails.firstOrNull { it.isBasePlan }?.subscriptionBillingPeriod,
+        offerDetails.firstOrNull { it.isBasePlan }?.subscriptionBillingPeriod?.toSubscriptionPeriod(),
         subscriptionOptions,
         defaultOffer,
         this

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -7,7 +7,6 @@ import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.models.GoogleStoreProduct
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.StoreProduct
-import com.revenuecat.purchases.models.toSubscriptionPeriod
 import com.revenuecat.purchases.strings.PurchaseStrings
 
 // In-apps don't have base plan nor offers
@@ -19,7 +18,8 @@ fun ProductDetails.toStoreProduct(
     val subscriptionOptions = offerDetails.map { it.toSubscriptionOption(productId, this) }
     val defaultOffer = subscriptionOptions.findDefaultOffer()
 
-    val basePlanPrice = subscriptionOptions.firstOrNull { it.isBasePlan }?.fullPricePhase?.price
+    val basePlan = subscriptionOptions.firstOrNull { it.isBasePlan }
+    val basePlanPrice = basePlan?.fullPricePhase?.price
     val price = createOneTimeProductPrice() ?: basePlanPrice ?: return null
 
     return GoogleStoreProduct(
@@ -28,7 +28,7 @@ fun ProductDetails.toStoreProduct(
         price,
         title,
         description,
-        offerDetails.firstOrNull { it.isBasePlan }?.subscriptionBillingPeriod?.toSubscriptionPeriod(),
+        basePlan?.period,
         subscriptionOptions,
         defaultOffer,
         this

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -24,6 +24,7 @@ fun ProductDetails.toStoreProduct(
 
     return GoogleStoreProduct(
         productId,
+        basePlan?.id,
         productType.toRevenueCatProductType(),
         price,
         title,
@@ -53,15 +54,14 @@ fun List<ProductDetails>.toStoreProducts(): List<StoreProduct> {
     forEach { productDetails ->
         val basePlans = productDetails.subscriptionOfferDetails?.filter { it.isBasePlan } ?: emptyList()
 
-        val offerDetailsBySubPeriod = productDetails.subscriptionOfferDetails?.groupBy {
-            it.subscriptionBillingPeriod
+        val offerDetailsByBasePlanId = productDetails.subscriptionOfferDetails?.groupBy {
+            it.basePlanId
         } ?: emptyMap()
 
         // Maps basePlans to StoreProducts, if any
         // Otherwise, maps productDetail to StoreProduct
         basePlans.takeUnless { it.isEmpty() }?.forEach { basePlan ->
-            val basePlanBillingPeriod = basePlan.subscriptionBillingPeriod
-            val offerDetailsForBasePlan = offerDetailsBySubPeriod[basePlanBillingPeriod] ?: emptyList()
+            val offerDetailsForBasePlan = offerDetailsByBasePlanId[basePlan.basePlanId] ?: emptyList()
 
             productDetails.toStoreProduct(offerDetailsForBasePlan)?.let {
                 storeProducts.add(it)

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -28,7 +28,7 @@ fun ProductDetails.toStoreProduct(
         price,
         title,
         description,
-        basePlan?.period,
+        basePlan?.billingPeriod,
         subscriptionOptions,
         defaultOffer,
         this

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -41,7 +41,7 @@ import com.revenuecat.purchases.models.RecurrenceMode
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.Period
-import com.revenuecat.purchases.models.toSubscriptionPeriod
+import com.revenuecat.purchases.models.toPeriod
 import com.revenuecat.purchases.utils.createMockProductDetailsNoOffers
 import com.revenuecat.purchases.utils.mockOneTimePurchaseOfferDetails
 import com.revenuecat.purchases.utils.mockProductDetails
@@ -626,7 +626,7 @@ class BillingWrapperTest {
                 get() = "subscriptionOption"
             override val pricingPhases: List<PricingPhase>
                 get() = listOf(PricingPhase(
-                    billingPeriod = "P1M".toSubscriptionPeriod(),
+                    billingPeriod = "P1M".toPeriod(),
                     recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                     billingCycleCount = 0,
                     price = Price(

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -40,6 +40,8 @@ import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.RecurrenceMode
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.toSubscriptionPeriod
 import com.revenuecat.purchases.utils.createMockProductDetailsNoOffers
 import com.revenuecat.purchases.utils.mockOneTimePurchaseOfferDetails
 import com.revenuecat.purchases.utils.mockProductDetails
@@ -624,7 +626,7 @@ class BillingWrapperTest {
                 get() = "subscriptionOption"
             override val pricingPhases: List<PricingPhase>
                 get() = listOf(PricingPhase(
-                    billingPeriod = "",
+                    billingPeriod = "P1M".toSubscriptionPeriod(),
                     recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                     billingCycleCount = 0,
                     price = Price(
@@ -685,7 +687,7 @@ class BillingWrapperTest {
                 get() = ""
             override val description: String
                 get() = ""
-            override val subscriptionPeriod: String?
+            override val period: Period?
                 get() = null
             override val subscriptionOptions: List<SubscriptionOption>
                 get() = listOf(defaultOption)

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -676,7 +676,7 @@ class BillingWrapperTest {
         }
 
         val storeProduct = object : StoreProduct {
-            override val productId: String
+            override val id: String
                 get() = "mock-sku"
             override val type: ProductType
                 get() = ProductType.SUBS
@@ -695,7 +695,7 @@ class BillingWrapperTest {
             override val purchasingData: PurchasingData
                 get() = purchasingInfo
             override val sku: String
-                get() = productId
+                get() = id
 
             override fun describeContents(): Int = 0
 

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -41,7 +41,6 @@ import com.revenuecat.purchases.models.RecurrenceMode
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.Period
-import com.revenuecat.purchases.models.toPeriod
 import com.revenuecat.purchases.utils.createMockProductDetailsNoOffers
 import com.revenuecat.purchases.utils.mockOneTimePurchaseOfferDetails
 import com.revenuecat.purchases.utils.mockProductDetails
@@ -626,7 +625,7 @@ class BillingWrapperTest {
                 get() = "subscriptionOption"
             override val pricingPhases: List<PricingPhase>
                 get() = listOf(PricingPhase(
-                    billingPeriod = "P1M".toPeriod(),
+                    billingPeriod = Period.create("P1M"),
                     recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                     billingCycleCount = 0,
                     price = Price(

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/FindBestOfferTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/FindBestOfferTest.kt
@@ -4,7 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
-import com.revenuecat.purchases.models.toPeriod
+import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.utils.mockPricingPhase
 import com.revenuecat.purchases.utils.mockProductDetails
 import com.revenuecat.purchases.utils.mockSubscriptionOfferDetails
@@ -299,7 +299,7 @@ class PeriodOfferTest(private val period: String, private val days: Int) {
 
     @Test
     fun `period to number of days is correct`() {
-        val actualDays = billingPeriodToDays(period.toPeriod())
+        val actualDays = billingPeriodToDays(Period.create(period))
         assertThat(actualDays).isEqualTo(days)
     }
 }

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/FindBestOfferTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/FindBestOfferTest.kt
@@ -4,7 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
-import com.revenuecat.purchases.models.toSubscriptionPeriod
+import com.revenuecat.purchases.models.toPeriod
 import com.revenuecat.purchases.utils.mockPricingPhase
 import com.revenuecat.purchases.utils.mockProductDetails
 import com.revenuecat.purchases.utils.mockSubscriptionOfferDetails
@@ -292,13 +292,14 @@ class PeriodOfferTest(private val period: String, private val days: Int) {
                 arrayOf("P4D", 4),
                 arrayOf("P2W", 14),
                 arrayOf("P5X", 0),
+                arrayOf("cat", 0)
             )
         }
     }
 
     @Test
     fun `period to number of days is correct`() {
-        val actualDays = billingPeriodToDays(period.toSubscriptionPeriod())
+        val actualDays = billingPeriodToDays(period.toPeriod())
         assertThat(actualDays).isEqualTo(days)
     }
 }

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/FindBestOfferTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/FindBestOfferTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
+import com.revenuecat.purchases.models.toSubscriptionPeriod
 import com.revenuecat.purchases.utils.mockPricingPhase
 import com.revenuecat.purchases.utils.mockProductDetails
 import com.revenuecat.purchases.utils.mockSubscriptionOfferDetails
@@ -288,13 +289,16 @@ class PeriodOfferTest(private val period: String, private val days: Int) {
                 arrayOf("P1Y", 365),
                 arrayOf("P2Y", 730),
                 arrayOf("P3M", 90),
+                arrayOf("P4D", 4),
+                arrayOf("P2W", 14),
+                arrayOf("P5X", 0),
             )
         }
     }
 
     @Test
-    fun `parsed period is correct`() {
-        val actualDays = parseBillPeriodToDays(period)
+    fun `period to number of days is correct`() {
+        val actualDays = billingPeriodToDays(period.toSubscriptionPeriod())
         assertThat(actualDays).isEqualTo(days)
     }
 }

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -5,10 +5,10 @@ import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
 import com.revenuecat.purchases.models.GooglePurchasingData
 import com.revenuecat.purchases.models.GoogleStoreProduct
+import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.RecurrenceMode
-import com.revenuecat.purchases.models.toPeriod
 import com.revenuecat.purchases.utils.mockProductDetails
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.Test
@@ -33,7 +33,7 @@ class StoreProductTest {
         val subscriptionOption1 = GoogleSubscriptionOption(
             id = "subscriptionOptionId",
             pricingPhases = listOf(PricingPhase(
-                billingPeriod = "P1M".toPeriod(),
+                billingPeriod = Period.create("P1M"),
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = 0,
                 price = Price(
@@ -53,7 +53,7 @@ class StoreProductTest {
         val subscriptionOption2 = GoogleSubscriptionOption(
             id = "subscriptionOptionId",
             pricingPhases = listOf(PricingPhase(
-                billingPeriod = "P1M".toPeriod(),
+                billingPeriod = Period.create("P1M"),
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = 0,
                 price = Price(
@@ -77,7 +77,7 @@ class StoreProductTest {
             price = price1,
             title = "TITLE",
             description = "DESCRIPTION",
-            period = "P1M".toPeriod(),
+            period = Period.create("P1M"),
             subscriptionOptions = listOf(subscriptionOption1),
             defaultOption = null,
             productDetails = productDetails
@@ -89,7 +89,7 @@ class StoreProductTest {
             price = price2,
             title = "TITLE",
             description = "DESCRIPTION",
-            period = "P1M".toPeriod(),
+            period = Period.create("P1M"),
             subscriptionOptions = listOf(subscriptionOption2),
             defaultOption = null,
             productDetails = productDetails
@@ -115,7 +115,7 @@ class StoreProductTest {
         val subscriptionOption1 = GoogleSubscriptionOption(
             id = "subscriptionOptionId",
             pricingPhases = listOf(PricingPhase(
-                billingPeriod = "P1M".toPeriod(),
+                billingPeriod = Period.create("P1M"),
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = 0,
                 price = Price(
@@ -135,7 +135,7 @@ class StoreProductTest {
         val subscriptionOption2 = GoogleSubscriptionOption(
             id = "subscriptionOptionId",
             pricingPhases = listOf(PricingPhase(
-                billingPeriod = "P1M".toPeriod(),
+                billingPeriod = Period.create("P1M"),
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = 0,
                 price = Price(
@@ -159,7 +159,7 @@ class StoreProductTest {
             price = price1,
             title = "TITLE",
             description = "DESCRIPTION",
-            period = "P1M".toPeriod(),
+            period = Period.create("P1M"),
             subscriptionOptions = listOf(subscriptionOption1),
             defaultOption = null,
             productDetails = productDetails
@@ -171,7 +171,7 @@ class StoreProductTest {
             price = price2,
             title = "TITLE",
             description = "DESCRIPTION",
-            period = "P1M".toPeriod(),
+            period = Period.create("P1M"),
             subscriptionOptions = listOf(subscriptionOption2),
             defaultOption = null,
             productDetails = productDetails

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -73,6 +73,7 @@ class StoreProductTest {
 
         val storeProduct1 = GoogleStoreProduct(
             productId = "product_id",
+            basePlanId = "base_plan_id",
             type = ProductType.SUBS,
             price = price1,
             title = "TITLE",
@@ -85,6 +86,7 @@ class StoreProductTest {
 
         val storeProduct2 = GoogleStoreProduct(
             productId = "product_id",
+            basePlanId = "base_plan_id",
             type = ProductType.SUBS,
             price = price2,
             title = "TITLE",
@@ -155,6 +157,7 @@ class StoreProductTest {
 
         val storeProduct1 = GoogleStoreProduct(
             productId = "product_id",
+            basePlanId = "base_plan_id",
             type = ProductType.SUBS,
             price = price1,
             title = "TITLE",
@@ -167,6 +170,7 @@ class StoreProductTest {
 
         val storeProduct2 = GoogleStoreProduct(
             productId = "product_id",
+            basePlanId = "base_plan_id",
             type = ProductType.SUBS,
             price = price2,
             title = "TITLE",

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -8,7 +8,7 @@ import com.revenuecat.purchases.models.GoogleStoreProduct
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.RecurrenceMode
-import com.revenuecat.purchases.models.toSubscriptionPeriod
+import com.revenuecat.purchases.models.toPeriod
 import com.revenuecat.purchases.utils.mockProductDetails
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.Test
@@ -33,7 +33,7 @@ class StoreProductTest {
         val subscriptionOption1 = GoogleSubscriptionOption(
             id = "subscriptionOptionId",
             pricingPhases = listOf(PricingPhase(
-                billingPeriod = "P1M".toSubscriptionPeriod(),
+                billingPeriod = "P1M".toPeriod(),
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = 0,
                 price = Price(
@@ -53,7 +53,7 @@ class StoreProductTest {
         val subscriptionOption2 = GoogleSubscriptionOption(
             id = "subscriptionOptionId",
             pricingPhases = listOf(PricingPhase(
-                billingPeriod = "P1M".toSubscriptionPeriod(),
+                billingPeriod = "P1M".toPeriod(),
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = 0,
                 price = Price(
@@ -77,7 +77,7 @@ class StoreProductTest {
             price = price1,
             title = "TITLE",
             description = "DESCRIPTION",
-            period = "P1M".toSubscriptionPeriod(),
+            period = "P1M".toPeriod(),
             subscriptionOptions = listOf(subscriptionOption1),
             defaultOption = null,
             productDetails = productDetails
@@ -89,7 +89,7 @@ class StoreProductTest {
             price = price2,
             title = "TITLE",
             description = "DESCRIPTION",
-            period = "P1M".toSubscriptionPeriod(),
+            period = "P1M".toPeriod(),
             subscriptionOptions = listOf(subscriptionOption2),
             defaultOption = null,
             productDetails = productDetails
@@ -115,7 +115,7 @@ class StoreProductTest {
         val subscriptionOption1 = GoogleSubscriptionOption(
             id = "subscriptionOptionId",
             pricingPhases = listOf(PricingPhase(
-                billingPeriod = "P1M".toSubscriptionPeriod(),
+                billingPeriod = "P1M".toPeriod(),
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = 0,
                 price = Price(
@@ -135,7 +135,7 @@ class StoreProductTest {
         val subscriptionOption2 = GoogleSubscriptionOption(
             id = "subscriptionOptionId",
             pricingPhases = listOf(PricingPhase(
-                billingPeriod = "P1M".toSubscriptionPeriod(),
+                billingPeriod = "P1M".toPeriod(),
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = 0,
                 price = Price(
@@ -159,7 +159,7 @@ class StoreProductTest {
             price = price1,
             title = "TITLE",
             description = "DESCRIPTION",
-            period = "P1M".toSubscriptionPeriod(),
+            period = "P1M".toPeriod(),
             subscriptionOptions = listOf(subscriptionOption1),
             defaultOption = null,
             productDetails = productDetails
@@ -171,7 +171,7 @@ class StoreProductTest {
             price = price2,
             title = "TITLE",
             description = "DESCRIPTION",
-            period = "P1M".toSubscriptionPeriod(),
+            period = "P1M".toPeriod(),
             subscriptionOptions = listOf(subscriptionOption2),
             defaultOption = null,
             productDetails = productDetails

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.models.GoogleStoreProduct
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.RecurrenceMode
+import com.revenuecat.purchases.models.toSubscriptionPeriod
 import com.revenuecat.purchases.utils.mockProductDetails
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.Test
@@ -32,7 +33,7 @@ class StoreProductTest {
         val subscriptionOption1 = GoogleSubscriptionOption(
             id = "subscriptionOptionId",
             pricingPhases = listOf(PricingPhase(
-                billingPeriod = "",
+                billingPeriod = "P1M".toSubscriptionPeriod(),
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = 0,
                 price = Price(
@@ -52,7 +53,7 @@ class StoreProductTest {
         val subscriptionOption2 = GoogleSubscriptionOption(
             id = "subscriptionOptionId",
             pricingPhases = listOf(PricingPhase(
-                billingPeriod = "",
+                billingPeriod = "P1M".toSubscriptionPeriod(),
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = 0,
                 price = Price(
@@ -76,7 +77,7 @@ class StoreProductTest {
             price = price1,
             title = "TITLE",
             description = "DESCRIPTION",
-            subscriptionPeriod = "P1M",
+            period = "P1M".toSubscriptionPeriod(),
             subscriptionOptions = listOf(subscriptionOption1),
             defaultOption = null,
             productDetails = productDetails
@@ -88,7 +89,7 @@ class StoreProductTest {
             price = price2,
             title = "TITLE",
             description = "DESCRIPTION",
-            subscriptionPeriod = "P1M",
+            period = "P1M".toSubscriptionPeriod(),
             subscriptionOptions = listOf(subscriptionOption2),
             defaultOption = null,
             productDetails = productDetails
@@ -114,7 +115,7 @@ class StoreProductTest {
         val subscriptionOption1 = GoogleSubscriptionOption(
             id = "subscriptionOptionId",
             pricingPhases = listOf(PricingPhase(
-                billingPeriod = "",
+                billingPeriod = "P1M".toSubscriptionPeriod(),
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = 0,
                 price = Price(
@@ -134,7 +135,7 @@ class StoreProductTest {
         val subscriptionOption2 = GoogleSubscriptionOption(
             id = "subscriptionOptionId",
             pricingPhases = listOf(PricingPhase(
-                billingPeriod = "",
+                billingPeriod = "P1M".toSubscriptionPeriod(),
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = 0,
                 price = Price(
@@ -158,7 +159,7 @@ class StoreProductTest {
             price = price1,
             title = "TITLE",
             description = "DESCRIPTION",
-            subscriptionPeriod = "P1M",
+            period = "P1M".toSubscriptionPeriod(),
             subscriptionOptions = listOf(subscriptionOption1),
             defaultOption = null,
             productDetails = productDetails
@@ -170,7 +171,7 @@ class StoreProductTest {
             price = price2,
             title = "TITLE",
             description = "DESCRIPTION",
-            subscriptionPeriod = "P1M",
+            period = "P1M".toSubscriptionPeriod(),
             subscriptionOptions = listOf(subscriptionOption2),
             defaultOption = null,
             productDetails = productDetails

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/SubscriptionOptionTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/SubscriptionOptionTest.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.google
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
 import com.revenuecat.purchases.models.GooglePurchasingData
+import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.RecurrenceMode
@@ -44,6 +45,8 @@ class SubscriptionOptionTest {
         assertThat(subscriptionOption.freePhase).isNull()
         assertThat(subscriptionOption.introPhase).isNull()
         assertThat(subscriptionOption.fullPricePhase).isEqualTo(recurringPhase)
+        assertThat(subscriptionOption.billingPeriod?.unit).isEqualTo(Period.Unit.MONTH)
+        assertThat(subscriptionOption.billingPeriod?.value).isEqualTo(1)
     }
 
     @Test

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/SubscriptionOptionTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/SubscriptionOptionTest.kt
@@ -7,7 +7,7 @@ import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.RecurrenceMode
-import com.revenuecat.purchases.models.toSubscriptionPeriod
+import com.revenuecat.purchases.models.toPeriod
 import com.revenuecat.purchases.utils.mockProductDetails
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.Test
@@ -20,7 +20,7 @@ class SubscriptionOptionTest {
         val productDetails = mockProductDetails()
 
         val recurringPhase = PricingPhase(
-            billingPeriod = "P1M".toSubscriptionPeriod(),
+            billingPeriod = "P1M".toPeriod(),
             recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
             billingCycleCount = 0,
             price = Price(
@@ -54,7 +54,7 @@ class SubscriptionOptionTest {
         val productDetails = mockProductDetails()
 
         val recurringPhase = PricingPhase(
-            billingPeriod = "P3M".toSubscriptionPeriod(),
+            billingPeriod = "P3M".toPeriod(),
             recurrenceMode = RecurrenceMode.NON_RECURRING,
             billingCycleCount = 0,
             price = Price(
@@ -86,7 +86,7 @@ class SubscriptionOptionTest {
         val productDetails = mockProductDetails()
 
         val freePhase = PricingPhase(
-            billingPeriod = "P1M".toSubscriptionPeriod(),
+            billingPeriod = "P1M".toPeriod(),
             recurrenceMode = RecurrenceMode.NON_RECURRING,
             billingCycleCount = 1,
             price = Price(
@@ -97,7 +97,7 @@ class SubscriptionOptionTest {
         )
 
         val recurringPhase = PricingPhase(
-            billingPeriod = "P1M".toSubscriptionPeriod(),
+            billingPeriod = "P1M".toPeriod(),
             recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
             billingCycleCount = 0,
             price = Price(
@@ -129,7 +129,7 @@ class SubscriptionOptionTest {
         val productDetails = mockProductDetails()
 
         val introPhase = PricingPhase(
-            billingPeriod = "P1M".toSubscriptionPeriod(),
+            billingPeriod = "P1M".toPeriod(),
             recurrenceMode = RecurrenceMode.NON_RECURRING,
             billingCycleCount = 1,
             price = Price(
@@ -140,7 +140,7 @@ class SubscriptionOptionTest {
         )
 
         val recurringPhase = PricingPhase(
-            billingPeriod = "P1M".toSubscriptionPeriod(),
+            billingPeriod = "P1M".toPeriod(),
             recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
             billingCycleCount = 0,
             price = Price(

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/SubscriptionOptionTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/SubscriptionOptionTest.kt
@@ -7,7 +7,6 @@ import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.RecurrenceMode
-import com.revenuecat.purchases.models.toPeriod
 import com.revenuecat.purchases.utils.mockProductDetails
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.Test
@@ -20,7 +19,7 @@ class SubscriptionOptionTest {
         val productDetails = mockProductDetails()
 
         val recurringPhase = PricingPhase(
-            billingPeriod = "P1M".toPeriod(),
+            billingPeriod = Period.create("P1M"),
             recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
             billingCycleCount = 0,
             price = Price(
@@ -54,7 +53,7 @@ class SubscriptionOptionTest {
         val productDetails = mockProductDetails()
 
         val recurringPhase = PricingPhase(
-            billingPeriod = "P3M".toPeriod(),
+            billingPeriod = Period.create("P3M"),
             recurrenceMode = RecurrenceMode.NON_RECURRING,
             billingCycleCount = 0,
             price = Price(
@@ -86,7 +85,7 @@ class SubscriptionOptionTest {
         val productDetails = mockProductDetails()
 
         val freePhase = PricingPhase(
-            billingPeriod = "P1M".toPeriod(),
+            billingPeriod = Period.create("P1M"),
             recurrenceMode = RecurrenceMode.NON_RECURRING,
             billingCycleCount = 1,
             price = Price(
@@ -97,7 +96,7 @@ class SubscriptionOptionTest {
         )
 
         val recurringPhase = PricingPhase(
-            billingPeriod = "P1M".toPeriod(),
+            billingPeriod = Period.create("P1M"),
             recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
             billingCycleCount = 0,
             price = Price(
@@ -129,7 +128,7 @@ class SubscriptionOptionTest {
         val productDetails = mockProductDetails()
 
         val introPhase = PricingPhase(
-            billingPeriod = "P1M".toPeriod(),
+            billingPeriod = Period.create("P1M"),
             recurrenceMode = RecurrenceMode.NON_RECURRING,
             billingCycleCount = 1,
             price = Price(
@@ -140,7 +139,7 @@ class SubscriptionOptionTest {
         )
 
         val recurringPhase = PricingPhase(
-            billingPeriod = "P1M".toPeriod(),
+            billingPeriod = Period.create("P1M"),
             recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
             billingCycleCount = 0,
             price = Price(

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/SubscriptionOptionTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/SubscriptionOptionTest.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.models.GooglePurchasingData
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.RecurrenceMode
+import com.revenuecat.purchases.models.toSubscriptionPeriod
 import com.revenuecat.purchases.utils.mockProductDetails
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.Test
@@ -18,7 +19,7 @@ class SubscriptionOptionTest {
         val productDetails = mockProductDetails()
 
         val recurringPhase = PricingPhase(
-            billingPeriod = "P1M",
+            billingPeriod = "P1M".toSubscriptionPeriod(),
             recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
             billingCycleCount = 0,
             price = Price(
@@ -50,7 +51,7 @@ class SubscriptionOptionTest {
         val productDetails = mockProductDetails()
 
         val recurringPhase = PricingPhase(
-            billingPeriod = "P3M",
+            billingPeriod = "P3M".toSubscriptionPeriod(),
             recurrenceMode = RecurrenceMode.NON_RECURRING,
             billingCycleCount = 0,
             price = Price(
@@ -82,7 +83,7 @@ class SubscriptionOptionTest {
         val productDetails = mockProductDetails()
 
         val freePhase = PricingPhase(
-            billingPeriod = "",
+            billingPeriod = "P1M".toSubscriptionPeriod(),
             recurrenceMode = RecurrenceMode.NON_RECURRING,
             billingCycleCount = 1,
             price = Price(
@@ -93,7 +94,7 @@ class SubscriptionOptionTest {
         )
 
         val recurringPhase = PricingPhase(
-            billingPeriod = "P1M",
+            billingPeriod = "P1M".toSubscriptionPeriod(),
             recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
             billingCycleCount = 0,
             price = Price(
@@ -125,7 +126,7 @@ class SubscriptionOptionTest {
         val productDetails = mockProductDetails()
 
         val introPhase = PricingPhase(
-            billingPeriod = "",
+            billingPeriod = "P1M".toSubscriptionPeriod(),
             recurrenceMode = RecurrenceMode.NON_RECURRING,
             billingCycleCount = 1,
             price = Price(
@@ -136,7 +137,7 @@ class SubscriptionOptionTest {
         )
 
         val recurringPhase = PricingPhase(
-            billingPeriod = "P1M",
+            billingPeriod = "P1M".toSubscriptionPeriod(),
             recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
             billingCycleCount = 0,
             price = Price(

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleStoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleStoreProduct.kt
@@ -9,7 +9,8 @@ import kotlinx.parcelize.RawValue
 
 @Parcelize
 data class GoogleStoreProduct(
-    override val productId: String,
+    val productId: String,
+    val basePlanId: String?,
     override val type: ProductType,
     override val price: Price,
     override val title: String,
@@ -20,12 +21,17 @@ data class GoogleStoreProduct(
     val productDetails: @RawValue ProductDetails // TODO parcelize?
 ) : StoreProduct, Parcelable {
 
+    override val id: String
+        get() = basePlanId?.let {
+            "$productId:$basePlanId"
+        } ?: productId
+
     override val purchasingData: PurchasingData
         get() = if (type == ProductType.SUBS && defaultOption != null) {
             defaultOption.purchasingData
         } else {
             GooglePurchasingData.InAppProduct(
-                productId,
+                id,
                 productDetails
             )
         }

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleStoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleStoreProduct.kt
@@ -14,7 +14,7 @@ data class GoogleStoreProduct(
     override val price: Price,
     override val title: String,
     override val description: String,
-    override val subscriptionPeriod: String?,
+    override val period: Period?,
     override val subscriptionOptions: List<GoogleSubscriptionOption>,
     override val defaultOption: GoogleSubscriptionOption?,
     val productDetails: @RawValue ProductDetails // TODO parcelize?

--- a/public/src/main/java/com/revenuecat/purchases/models/Period.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/Period.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 /**
- * Represents subscription or pricing phase billing period
+ * Represents subscription or [PricingPhase] billing period
  */
 @Parcelize
 data class Period(
@@ -26,17 +26,17 @@ data class Period(
     val iso8601: String
 ) : Parcelable {
     @SuppressWarnings("MagicNumber")
-    enum class Unit(val identifier: Int) {
-        DAY(0),
-        WEEK(1),
-        MONTH(2),
-        YEAR(3),
-        UNKNOWN(4)
+    enum class Unit {
+        DAY,
+        WEEK,
+        MONTH,
+        YEAR,
+        UNKNOWN
     }
 }
 
 // Would use Duration.parse but only available API 26 and up
-fun String.toSubscriptionPeriod(): Period {
+fun String.toPeriod(): Period {
     // Takes from https://stackoverflow.com/a/32045167
     val regex = "^P(?!\$)(\\d+(?:\\.\\d+)?Y)?(\\d+(?:\\.\\d+)?M)?(\\d+(?:\\.\\d+)?W)?(\\d+(?:\\.\\d+)?D)?\$"
         .toRegex()

--- a/public/src/main/java/com/revenuecat/purchases/models/Period.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/Period.kt
@@ -25,6 +25,14 @@ data class Period(
      */
     val iso8601: String
 ) : Parcelable {
+
+    companion object Factory {
+        fun create(iso8601: String): Period {
+            val pair = iso8601.toPeriod()
+            return Period(pair.first, pair.second, iso8601)
+        }
+    }
+
     @SuppressWarnings("MagicNumber")
     enum class Unit {
         DAY,
@@ -36,7 +44,7 @@ data class Period(
 }
 
 // Would use Duration.parse but only available API 26 and up
-fun String.toPeriod(): Period {
+private fun String.toPeriod(): Pair<Int, Period.Unit> {
     // Takes from https://stackoverflow.com/a/32045167
     val regex = "^P(?!\$)(\\d+(?:\\.\\d+)?Y)?(\\d+(?:\\.\\d+)?M)?(\\d+(?:\\.\\d+)?W)?(\\d+(?:\\.\\d+)?D)?\$"
         .toRegex()
@@ -55,17 +63,17 @@ fun String.toPeriod(): Period {
         val dayInt = toInt(day)
 
         return if (yearInt > 0) {
-            Period(yearInt, Period.Unit.YEAR, this)
+            Pair(yearInt, Period.Unit.YEAR)
         } else if (monthInt > 0) {
-            Period(monthInt, Period.Unit.MONTH, this)
+            Pair(monthInt, Period.Unit.MONTH)
         } else if (weekInt > 0) {
-            Period(weekInt, Period.Unit.WEEK, this)
+            Pair(weekInt, Period.Unit.WEEK)
         } else if (dayInt > 0) {
-            Period(dayInt, Period.Unit.DAY, this)
+            Pair(dayInt, Period.Unit.DAY)
         } else {
-            Period(0, Period.Unit.UNKNOWN, this)
+            Pair(0, Period.Unit.UNKNOWN)
         }
     }
 
-    return Period(0, Period.Unit.UNKNOWN, this)
+    return Pair(0, Period.Unit.UNKNOWN)
 }

--- a/public/src/main/java/com/revenuecat/purchases/models/Period.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/Period.kt
@@ -1,0 +1,71 @@
+package com.revenuecat.purchases.models
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Represents subscription or pricing phase billing period
+ */
+@Parcelize
+data class Period(
+    /**
+     * The number of period units.
+     */
+    val value: Int,
+
+    /**
+     * The increment of time that a subscription period is specified in.
+     */
+    val unit: Unit,
+
+    /**
+     * Specified in ISO 8601 format. For example, P1W equates to one week,
+     * P1M equates to one month, P3M equates to three months, P6M equates to six months,
+     * and P1Y equates to one year
+     */
+    val iso8601: String
+) : Parcelable {
+    @SuppressWarnings("MagicNumber")
+    enum class Unit(val identifier: Int) {
+        DAY(0),
+        WEEK(1),
+        MONTH(2),
+        YEAR(3),
+        UNKNOWN(4)
+    }
+}
+
+// Would use Duration.parse but only available API 26 and up
+fun String.toSubscriptionPeriod(): Period {
+    // Takes from https://stackoverflow.com/a/32045167
+    val regex = "^P(?!\$)(\\d+(?:\\.\\d+)?Y)?(\\d+(?:\\.\\d+)?M)?(\\d+(?:\\.\\d+)?W)?(\\d+(?:\\.\\d+)?D)?\$"
+        .toRegex()
+        .matchEntire(this)
+
+    regex?.let { periodResult ->
+        val toInt = fun(part: String): Int {
+            return part.dropLast(1).toIntOrNull() ?: 0
+        }
+
+        val (year, month, week, day) = periodResult.destructured
+
+        val yearInt = toInt(year)
+        val monthInt = toInt(month)
+        val weekInt = toInt(week)
+        val dayInt = toInt(day)
+
+        return if (yearInt > 0) {
+            Period(yearInt, Period.Unit.YEAR, this)
+        } else if (monthInt > 0) {
+            Period(monthInt, Period.Unit.MONTH, this)
+        } else if (weekInt > 0) {
+            Period(weekInt, Period.Unit.WEEK, this)
+        } else if (dayInt > 0) {
+            Period(dayInt, Period.Unit.DAY, this)
+        } else {
+            Period(0, Period.Unit.UNKNOWN, this)
+        }
+    }
+
+    return Period(0, Period.Unit.UNKNOWN, this)
+}

--- a/public/src/main/java/com/revenuecat/purchases/models/PricingPhase.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/PricingPhase.kt
@@ -9,7 +9,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class PricingPhase(
     /**
-     * Billing period for which the [PricingPhase] applies, in ISO 8601 format (i.e. one month -> P1M)
+     * Billing period for which the [PricingPhase] applies.
      */
     val billingPeriod: Period,
 

--- a/public/src/main/java/com/revenuecat/purchases/models/PricingPhase.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/PricingPhase.kt
@@ -11,7 +11,7 @@ data class PricingPhase(
     /**
      * Billing period for which the [PricingPhase] applies, in ISO 8601 format (i.e. one month -> P1M)
      */
-    val billingPeriod: String,
+    val billingPeriod: Period,
 
     /**
      * [RecurrenceMode] of the [PricingPhase]

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
@@ -9,9 +9,13 @@ import kotlinx.parcelize.IgnoredOnParcel
  */
 interface StoreProduct : Parcelable {
     /**
-     * The product ID
+     * The product ID.
+     * Google INAPP: "<productId>"
+     * Google Sub: "<productId:basePlanID>"
+     * Amazon INAPP: "<sku>"
+     * Amazon Sub: "<termSku>"
      */
-    val productId: String
+    val id: String
 
     /**
      * Type of product. One of [ProductType].
@@ -28,6 +32,11 @@ interface StoreProduct : Parcelable {
 
     /**
      * Title of the product.
+     *
+     * If you are using Google subscriptions with multiple base plans, this title
+     * will be the same for every subscription duration (monthly, yearly, etc) as
+     * base plans don't have their own titles. Google suggests using the duration
+     * as a way to title base plans.
      */
     val title: String
 

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
@@ -37,13 +37,11 @@ interface StoreProduct : Parcelable {
     val description: String
 
     /**
-     * Subscription period, specified in ISO 8601 format. For example, P1W equates to one week,
-     * P1M equates to one month, P3M equates to three months, P6M equates to six months,
-     * and P1Y equates to one year.
+     * Subscription period.
      *
      * Note: Returned only for Google subscriptions. Null for Amazon or for INAPP products.
      */
-    val subscriptionPeriod: String?
+    val period: Period?
 
     /**
      * List of SubscriptionOptions. Empty list for INAPP products.

--- a/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOption.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOption.kt
@@ -33,9 +33,9 @@ interface SubscriptionOption : Parcelable {
         get() = pricingPhases.size == 1
 
     /**
-     * The subscription period of the `fullPricePhase`
+     * The subscription period of `fullPricePhase` (after free and intro trials trials).
      */
-    val period: Period?
+    val billingPeriod: Period?
         get() = fullPricePhase?.billingPeriod
 
     /**

--- a/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOption.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOption.kt
@@ -33,6 +33,12 @@ interface SubscriptionOption : Parcelable {
         get() = pricingPhases.size == 1
 
     /**
+     * The subscription period of the `fullPricePhase`
+     */
+    val period: Period?
+        get() = fullPricePhase?.billingPeriod
+
+    /**
      * The full price [PricingPhase] of the subscription.
      * Looks for the last price phase of the SubscriptionOption.
      */

--- a/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOption.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOption.kt
@@ -33,7 +33,7 @@ interface SubscriptionOption : Parcelable {
         get() = pricingPhases.size == 1
 
     /**
-     * The subscription period of `fullPricePhase` (after free and intro trials trials).
+     * The subscription period of `fullPricePhase` (after free and intro trials).
      */
     val billingPeriod: Period?
         get() = fullPricePhase?.billingPeriod

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1087,8 +1087,8 @@ class Purchases internal constructor(
             appInBackground,
             { offeringsJSON ->
                 try {
-                    val productIdentifiers = extractProductIdentifiers(offeringsJSON)
-                    if (productIdentifiers.isEmpty()) {
+                    val allRequestedProductIdentifiers = extractProductIdentifiers(offeringsJSON)
+                    if (allRequestedProductIdentifiers.isEmpty()) {
                         handleErrorFetchingOfferings(
                             PurchasesError(
                                 PurchasesErrorCode.ConfigurationError,
@@ -1097,11 +1097,10 @@ class Purchases internal constructor(
                             completion
                         )
                     } else {
-                        getStoreProductsById(productIdentifiers, { productsById ->
+                        getStoreProductsById(allRequestedProductIdentifiers, { productsById ->
+                            logMissingProducts(allRequestedProductIdentifiers, productsById)
+
                             val offerings = offeringsJSON.createOfferings(productsById)
-
-                            logMissingProducts(offerings, productsById)
-
                             if (offerings.all.isEmpty()) {
                                 handleErrorFetchingOfferings(
                                     PurchasesError(
@@ -1175,11 +1174,9 @@ class Purchases internal constructor(
     }
 
     private fun logMissingProducts(
-        offerings: Offerings,
+        allProductIdsInOfferings: Set<String>,
         storeProductByID: Map<String, List<StoreProduct>>
-    ) = offerings.all.values
-        .flatMap { it.availablePackages }
-        .map { it.product.productId }
+    ) = allProductIdsInOfferings
         .filterNot { storeProductByID.containsKey(it) }
         .takeIf { it.isNotEmpty() }
         ?.let { missingProducts ->
@@ -1245,7 +1242,7 @@ class Purchases internal constructor(
                             }
                         } else {
                             storeProducts.firstOrNull() { product ->
-                                product.productId == purchase.productIds.firstOrNull()
+                                product.id == purchase.productIds.firstOrNull()
                             }
                         }
 
@@ -1341,7 +1338,9 @@ class Purchases internal constructor(
             ProductType.SUBS,
             productIds,
             { subscriptionProducts ->
-                val productsById = subscriptionProducts.groupBy { subProduct -> subProduct.productId }.toMutableMap()
+                val productsById = subscriptionProducts
+                    .groupBy { subProduct -> subProduct.purchasingData.productId }
+                    .toMutableMap()
                 val subscriptionIds = productsById.keys
 
                 val inAppProductIds = productIds - subscriptionIds
@@ -1350,7 +1349,7 @@ class Purchases internal constructor(
                         ProductType.INAPP,
                         inAppProductIds,
                         { inAppProducts ->
-                            productsById.putAll(inAppProducts.map { it.productId to listOf(it) })
+                            productsById.putAll(inAppProducts.map { it.purchasingData.productId to listOf(it) })
                             onCompleted(productsById)
                         }, {
                             onError(it)

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -177,7 +177,7 @@ class PostingTransactionsTests {
             onError = { _, _ -> }
         )
         assertThat(postedReceiptInfoSlot.isCaptured).isTrue
-        assertThat(postedReceiptInfoSlot.captured.duration).isEqualTo(mockStoreProduct.subscriptionPeriod)
+        assertThat(postedReceiptInfoSlot.captured.duration).isEqualTo(mockStoreProduct.period?.iso8601)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -32,7 +32,6 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
-import com.revenuecat.purchases.google.isBasePlan
 import com.revenuecat.purchases.google.toGoogleProductType
 import com.revenuecat.purchases.google.toStoreProduct
 import com.revenuecat.purchases.google.toInAppStoreProduct
@@ -1061,7 +1060,7 @@ class PurchasesTest {
         )
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
             getMockedPurchaseList(
-                offerings[stubOfferingIdentifier]!!.monthly!!.product.productId,
+                offerings[stubOfferingIdentifier]!!.monthly!!.product.id,
                 purchaseToken,
                 ProductType.SUBS
             )
@@ -4453,19 +4452,19 @@ class PurchasesTest {
         offeringIdentifier: String?,
         subscriptionOptionId: String? = this.subscriptionOptionId
     ): ReceiptInfo {
-        if (type == ProductType.SUBS) {
+        return if (type == ProductType.SUBS) {
             val productDetails = createMockProductDetailsFreeTrial(productId, 2.00)
 
             val storeProduct = productDetails.toStoreProduct(
                 productDetails.subscriptionOfferDetails!!
             )!!
 
-            return mockQueryingProductDetails(storeProduct, offeringIdentifier, subscriptionOptionId)
+            mockQueryingProductDetails(storeProduct, offeringIdentifier, subscriptionOptionId)
         } else {
             val productDetails = createMockOneTimeProductDetails(productId, 2.00)
             val storeProduct = productDetails.toInAppStoreProduct()!!
 
-            return mockQueryingProductDetails(storeProduct, offeringIdentifier, null)
+            mockQueryingProductDetails(storeProduct, offeringIdentifier, null)
         }
     }
 
@@ -4474,8 +4473,10 @@ class PurchasesTest {
         offeringIdentifier: String?,
         subscriptionOptionId: String? = this.subscriptionOptionId
     ): ReceiptInfo {
+        val productId = storeProduct.purchasingData.productId
+
         val receiptInfo = ReceiptInfo(
-            productIDs = listOf(storeProduct.productId),
+            productIDs = listOf(productId),
             offeringIdentifier = offeringIdentifier,
             storeProduct = storeProduct,
             subscriptionOptionId = if (storeProduct.type == ProductType.SUBS) subscriptionOptionId else null
@@ -4484,7 +4485,7 @@ class PurchasesTest {
         every {
             mockBillingAbstract.queryProductDetailsAsync(
                 storeProduct.type,
-                setOf(storeProduct.productId),
+                setOf(productId),
                 captureLambda(),
                 any()
             )

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -30,7 +30,7 @@ fun stubStoreProduct(
     subscriptionOptions: List<SubscriptionOption> = defaultOption?.let { listOf(defaultOption) } ?: emptyList(),
     price: Price = subscriptionOptions.first().fullPricePhase!!.price
 ): StoreProduct = object : StoreProduct {
-    override val productId: String
+    override val id: String
         get() = productId
     override val type: ProductType
         get() = ProductType.SUBS
@@ -62,7 +62,7 @@ fun stubStoreProduct(
 fun stubINAPPStoreProduct(
     productId: String
 ): StoreProduct = object : StoreProduct {
-    override val productId: String
+    override val id: String
         get() = productId
     override val type: ProductType
         get() = ProductType.INAPP

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.toRecurrenceMode
 
 @SuppressWarnings("MatchingDeclarationName")
@@ -22,7 +23,10 @@ private data class StubPurchasingData(
 @SuppressWarnings("EmptyFunctionBlock")
 fun stubStoreProduct(
     productId: String,
-    defaultOption: SubscriptionOption? = stubSubscriptionOption("monthly_base_plan", productId, "P1M",),
+    defaultOption: SubscriptionOption? = stubSubscriptionOption(
+        "monthly_base_plan", productId,
+        Period(1, Period.Unit.MONTH, "P1M"),
+    ),
     subscriptionOptions: List<SubscriptionOption> = defaultOption?.let { listOf(defaultOption) } ?: emptyList(),
     price: Price = subscriptionOptions.first().fullPricePhase!!.price
 ): StoreProduct = object : StoreProduct {
@@ -36,7 +40,7 @@ fun stubStoreProduct(
         get() = ""
     override val description: String
         get() = ""
-    override val subscriptionPeriod: String?
+    override val period: Period?
         get() = subscriptionOptions.firstOrNull { it.isBasePlan }?.pricingPhases?.get(0)?.billingPeriod
     override val subscriptionOptions: List<SubscriptionOption>
         get() = subscriptionOptions
@@ -68,7 +72,7 @@ fun stubINAPPStoreProduct(
         get() = ""
     override val description: String
         get() = ""
-    override val subscriptionPeriod: String?
+    override val period: Period?
         get() = null
     override val subscriptionOptions: List<SubscriptionOption>
         get() = listOf(defaultOption)
@@ -90,7 +94,7 @@ fun stubINAPPStoreProduct(
 fun stubSubscriptionOption(
     id: String,
     productId: String,
-    duration: String = "P1M",
+    duration: Period = Period(1, Period.Unit.MONTH, "P1M"),
     pricingPhases: List<PricingPhase> = listOf(stubPricingPhase(billingPeriod = duration))
 ): SubscriptionOption = object : SubscriptionOption {
     override val id: String
@@ -109,7 +113,7 @@ fun stubSubscriptionOption(
 }
 
 fun stubFreeTrialPricingPhase(
-    billingPeriod: String = "P1M",
+    billingPeriod: Period = Period(1, Period.Unit.MONTH, "P1M"),
     priceCurrencyCodeValue: String = "USD",
 ) = stubPricingPhase(
     billingPeriod = billingPeriod,
@@ -120,7 +124,7 @@ fun stubFreeTrialPricingPhase(
 )
 
 fun stubPricingPhase(
-    billingPeriod: String = "P1M",
+    billingPeriod: Period = Period(1, Period.Unit.MONTH, "P1M"),
     priceCurrencyCodeValue: String = "USD",
     price: Double = 4.99,
     recurrenceMode: Int = ProductDetails.RecurrenceMode.INFINITE_RECURRING,


### PR DESCRIPTION
This also contains the following PRS:
- #810
- #813
- #814
- #815

## Motivation

[CF-1002](https://revenuecats.atlassian.net/browse/CF-1002)
[CF-1192](https://revenuecats.atlassian.net/browse/CF-1192)

## Description

Replaces the `String` subscription and billing period (in the ISO 8601 format like "P1M", "P4D", or "P1Y") with a new `Period` and `Unit` class. This is similar to how its done on [iOS with SubscriptionPeriod](https://github.com/RevenueCat/purchases-ios/blob/main/Sources/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift).

- New `Period` class
  - `value: Int`
  - `unit: Unit`
  - `iso8601: String`
- New `Unit` enum
  - `DAY`
  - `WEEK`
  - `MONTH`
  - `YEAR`

This prevents the user from having to understand the ISO 8601 duration format and can now...
- Use the `Unit` to more easily filter out lengths like day, week, month, and year
- Easily see how many units with `value`

This has been applied to:
- `StoreProduct`
  - `subscriptionPeriod` changed from `String` to `Period`
- `SubscriptionOption`
  - Added new `billingPeriod: Period?` (which is the period of the full price phase)
- `PricingPhase` 
  - `billingPeriod` changes from `String` to `Period`

### Example Usage

#### Generating period description

Previously...

```kotlin
val title = product.defaultOption?.pricingPhases?.lastOrNull()?.billingPeriod?.let { period ->
    when (period) {
        "P1W" -> "Weekly"
        "P4W" -> "Every 4  Weeks"
        "P1M" -> "Monthly"
        "P3M" -> "Every 3 Months"
        "P6M" -> "Every 6 Months"
        "P1Y" -> "Yearly"
        else -> {
            null
        }
    }
}
```

Now...

```kotlin
val title = product.defaultOption?.pricingPhases?.lastOrNull()?.billingPeriod?.let { period ->
    when (period.unit) {
        Period.Unit.DAY -> "Every ${period.value} day(s)"
        Period.Unit.WEEK -> "Every ${period.value} week(s)"
        Period.Unit.MONTH -> "Every ${period.value} month(s)"
        Period.Unit.YEAR -> "Every ${period.value} year(s)"
        else -> {
            "Unknown"
        }
    }
}
```

### Finding Monthly Plan

Previously...

```kotlin
val monthlyOption = product.subscriptionOptions.firstOrNull {
    it.fullPricePhase?.billingPeriod?.iso8601?.endsWith("M") == true
}
```

Now...

```kotlin
val monthlyOption = product.subscriptionOptions.firstOrNull {
    it.billingPeriod?.unit == Period.Unit.MONTH
}
```


[CF-1002]: https://revenuecats.atlassian.net/browse/CF-1002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CF-1192]: https://revenuecats.atlassian.net/browse/CF-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ