### PR TITLE
Fix issue with missing subscriber attributes if set after login but before login callback

### DIFF
--- a/config/detekt/detekt-baseline.xml
+++ b/config/detekt/detekt-baseline.xml
@@ -55,6 +55,7 @@
     <ID>TooManyFunctions:DeviceCache.kt$DeviceCache</ID>
     <ID>TooManyFunctions:HTTPClient.kt$HTTPClient</ID>
     <ID>TooManyFunctions:Purchases.kt$Purchases : LifecycleDelegate</ID>
+    <ID>TooManyFunctions:SubscriberAttributesCache.kt$SubscriberAttributesCache</ID>
     <ID>TooManyFunctions:listenerConversions.kt$com.revenuecat.purchases.listenerConversions.kt</ID>
     <ID>UnusedPrivateMember:SampleWeatherData.kt$SampleWeatherData.Companion$environment: Environment</ID>
     <ID>VarCouldBeVal:Purchases.kt$Purchases.Companion.&lt;no name provided>$var featureSupportedResultOk = features.all { billingClient.isFeatureSupported(it.playBillingClientName).isSuccessful() }</ID>

--- a/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -24,6 +24,8 @@ class IdentityManager(
     val currentAppUserID: String
         get() = deviceCache.getCachedAppUserID() ?: ""
 
+    private val anonymousIdRegex = "^\\\$RCAnonymousID:([a-f0-9]{32})$".toRegex()
+
     @Synchronized
     fun configure(appUserID: String?) {
         if (appUserID?.isBlank() == true) {
@@ -116,8 +118,7 @@ class IdentityManager(
     }
 
     private fun isUserIDAnonymous(appUserID: String): Boolean {
-        return "^\\\$RCAnonymousID:([a-f0-9]{32})$".toRegex()
-            .matches(appUserID)
+        return anonymousIdRegex.matches(appUserID)
     }
 
     private fun generateRandomID(): String {

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.subscriberattributes
 import android.app.Application
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.SubscriberAttributeError
+import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.subscriberattributes.DeviceIdentifiersFetcher
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
@@ -104,6 +105,17 @@ class SubscriberAttributesManager(
                 )
             }
         }
+    }
+
+    @Synchronized
+    fun copyUnsyncedSubscriberAttributes(originalAppUserId: AppUserID, newAppUserID: AppUserID) {
+        val unsyncedAttributesPreviousUser = deviceCache.getUnsyncedSubscriberAttributes(originalAppUserId)
+        if (unsyncedAttributesPreviousUser.isEmpty()) {
+            return
+        }
+        infoLog(AttributionStrings.COPYING_ATTRIBUTES_FROM_TO_USER.format(originalAppUserId, newAppUserID))
+        deviceCache.setAttributes(newAppUserID, unsyncedAttributesPreviousUser)
+        deviceCache.clearAllSubscriberAttributesFromUser(originalAppUserId)
     }
 
     @Synchronized

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/caching/SubscriberAttributesCache.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/caching/SubscriberAttributesCache.kt
@@ -57,19 +57,23 @@ class SubscriberAttributesCache(
         getAllStoredSubscriberAttributes(appUserID).filterUnsynced(appUserID)
 
     @Synchronized
-    fun clearSubscriberAttributesIfSyncedForSubscriber(appUserID: String) {
-        val unsyncedSubscriberAttributes = getUnsyncedSubscriberAttributes(appUserID)
-        if (unsyncedSubscriberAttributes.isNotEmpty()) {
-            return
-        }
+    fun clearAllSubscriberAttributesFromUser(appUserID: AppUserID) {
         log(LogIntent.DEBUG, AttributionStrings.DELETING_ATTRIBUTES.format(appUserID))
         val allStoredSubscriberAttributes = getAllStoredSubscriberAttributes()
         val updatedStoredSubscriberAttributes =
             allStoredSubscriberAttributes.toMutableMap().also {
                 it.remove(appUserID)
             }.toMap()
-
         deviceCache.putAttributes(updatedStoredSubscriberAttributes)
+    }
+
+    @Synchronized
+    fun clearSubscriberAttributesIfSyncedForSubscriber(appUserID: String) {
+        val unsyncedSubscriberAttributes = getUnsyncedSubscriberAttributes(appUserID)
+        if (unsyncedSubscriberAttributes.isNotEmpty()) {
+            return
+        }
+        clearAllSubscriberAttributesFromUser(appUserID)
     }
 
     @Synchronized

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/caching/SubscriberAttributesCache.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/caching/SubscriberAttributesCache.kt
@@ -70,10 +70,9 @@ class SubscriberAttributesCache(
     @Synchronized
     fun clearSubscriberAttributesIfSyncedForSubscriber(appUserID: AppUserID) {
         val unsyncedSubscriberAttributes = getUnsyncedSubscriberAttributes(appUserID)
-        if (unsyncedSubscriberAttributes.isNotEmpty()) {
-            return
+        if (unsyncedSubscriberAttributes.isEmpty()) {
+            clearAllSubscriberAttributesFromUser(appUserID)
         }
-        clearAllSubscriberAttributesFromUser(appUserID)
     }
 
     @Synchronized

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/caching/SubscriberAttributesCache.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/caching/SubscriberAttributesCache.kt
@@ -68,7 +68,7 @@ class SubscriberAttributesCache(
     }
 
     @Synchronized
-    fun clearSubscriberAttributesIfSyncedForSubscriber(appUserID: String) {
+    fun clearSubscriberAttributesIfSyncedForSubscriber(appUserID: AppUserID) {
         val unsyncedSubscriberAttributes = getUnsyncedSubscriberAttributes(appUserID)
         if (unsyncedSubscriberAttributes.isNotEmpty()) {
             return

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesDeviceCacheTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesDeviceCacheTests.kt
@@ -200,7 +200,44 @@ class SubscriberAttributesDeviceCacheTests {
     }
 
     @Test
-    fun `clearing caches also clears the synced subscriber attributes`() {
+    fun `clearAllSubscriberAttributesFromUser clears the synced subscriber attributes`() {
+        val expectedAttributes = mapOf(
+            "shoesize" to SubscriberAttribute("shoesize", "9", isSynced = true),
+            "tshirtsize" to SubscriberAttribute("tshirtsize", "L", isSynced = true)
+        )
+        mockNotEmptyCache(expectedAttributes)
+        underTest.clearAllSubscriberAttributesFromUser(appUserID)
+        verify(exactly = 1) {
+            mockEditor.putString(
+                "com.revenuecat.purchases.$apiKey.subscriberAttributes",
+                JSONObject().also {
+                    it.put("attributes", JSONObject())
+                }.toString()
+            )
+        }
+    }
+
+    @Test
+    fun `clearAllSubscriberAttributesFromUser also clears the unsynced subscriber attributes`() {
+        val expectedAttributes = mapOf(
+            "shoesize" to SubscriberAttribute("shoesize", "9", isSynced = false),
+            "tshirtsize" to SubscriberAttribute("tshirtsize", "L", isSynced = false)
+        )
+        mockNotEmptyCache(expectedAttributes)
+        underTest.clearAllSubscriberAttributesFromUser(appUserID)
+        verify(exactly = 1) {
+            mockEditor.putString(
+                "com.revenuecat.purchases.$apiKey.subscriberAttributes",
+                JSONObject().also {
+                    it.put("attributes", JSONObject())
+                }.toString()
+            )
+        }
+    }
+
+
+    @Test
+    fun `clearSubscriberAttributesIfSyncedForSubscriber also clears the synced subscriber attributes`() {
         val expectedAttributes = mapOf(
             "tshirtsize" to SubscriberAttribute("tshirtsize", "L", isSynced = true)
         )
@@ -217,7 +254,7 @@ class SubscriberAttributesDeviceCacheTests {
     }
 
     @Test
-    fun `clearing caches doesn't clear the unsynced subscriber attributes`() {
+    fun `clearSubscriberAttributesIfSyncedForSubscriber doesn't clear the unsynced subscriber attributes`() {
         val expectedAttributes = mapOf(
             "tshirtsize" to SubscriberAttribute("tshirtsize", "L", isSynced = false)
         )

--- a/strings/src/main/java/com/revenuecat/purchases/strings/AttributionStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/AttributionStrings.kt
@@ -5,6 +5,7 @@ object AttributionStrings {
     const val ATTRIBUTES_SYNC_SUCCESS = "Subscriber attributes synced successfully for App User ID: %s"
     const val DELETING_ATTRIBUTES = "Deleting subscriber attributes for %s from cache"
     const val DELETING_ATTRIBUTES_OTHER_USERS = "Deleting old synced subscriber attributes that don't belong to %s"
+    const val COPYING_ATTRIBUTES_FROM_TO_USER = "Copying unsynced subscriber attributes from user %s to user %s"
     const val GOOGLE_PLAY_SERVICES_NOT_INSTALLED_FETCHING_ADVERTISING_IDENTIFIER = "GooglePlayServices is not " +
             "installed. Couldn't get advertising identifier. Message: %s"
     const val GOOGLE_PLAY_SERVICES_REPAIRABLE_EXCEPTION_WHEN_FETCHING_ADVERTISING_IDENTIFIER =


### PR DESCRIPTION
### Description
Deals with [SDK-2816](https://linear.app/revenuecat/issue/SDK-2816/fix-issue-with-missing-subscriber-attributes-on-purchases-[android])

There was an issue where subscriber attributes could be delayed to be synced to the backend. This happened when setting a subscriber attribute AFTER the `logIn` call but BEFORE the `logIn` operation was completed.

This issue happens because we start syncing subscriber attributes immediately when calling `logIn`, but if we set any after that but before the login is complete, they will be assigned to the old user id. We would sync those the next time the app is backgrounded/foregrounded but might be missed if there is a purchase in between since when there is a purchase, we only sync the current user's unsynced attributes.

This PR copies all unsynced attributes from the old user id to the new one upon a successful login. This way, the unsynced attributes will be sent if the user tries to purchase.

Note that we only copy these attributes when the old user id was anonymous. This is because there is a possible edge case of copying attributes from a user to a different user if the sync request fails and remains unsynced when changing between user ids.
