### PR TITLE
[BC5] Improve uniqueness and clarity of StoreProduct product ids

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=11.0.13-librca
+java=11.0.17-librca

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
@@ -54,5 +54,8 @@ final class StoreProductAPI {
                 googleStoreProduct.getDefaultOption(),
                 googleStoreProduct.getProductDetails()
         );
+
+        String productId = constructedGoogleStoreProduct.getProductId();
+        String basePlanId = constructedGoogleStoreProduct.getBasePlanId();
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
@@ -15,7 +15,7 @@ import java.util.List;
 @SuppressWarnings({"unused"})
 final class StoreProductAPI {
     static void check(final StoreProduct product) {
-        final String productId = product.getProductId();
+        final String productId = product.getId();
         final String sku = product.getSku();
         final ProductType type = product.getType();
         final Price price = product.getPrice();
@@ -43,7 +43,8 @@ final class StoreProductAPI {
         List<GoogleSubscriptionOption> subscriptionOptions = googleStoreProduct.getSubscriptionOptions();
         GoogleSubscriptionOption defaultOption = googleStoreProduct.getDefaultOption();
         GoogleStoreProduct constructedGoogleStoreProduct = new GoogleStoreProduct(
-                googleStoreProduct.getProductId(),
+                googleStoreProduct.getId(),
+                null,
                 googleStoreProduct.getType(),
                 googleStoreProduct.getPrice(),
                 googleStoreProduct.getTitle(),

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
@@ -53,5 +53,8 @@ private class StoreProductAPI {
             googleStoreProduct.defaultOption,
             googleStoreProduct.productDetails
         )
+
+        val productId = constructedGoogleStoreProduct.productId;
+        val basePlanId = constructedGoogleStoreProduct.basePlanId
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
@@ -54,7 +54,7 @@ private class StoreProductAPI {
             googleStoreProduct.productDetails
         )
 
-        val productId = constructedGoogleStoreProduct.productId;
+        val productId = constructedGoogleStoreProduct.productId
         val basePlanId = constructedGoogleStoreProduct.basePlanId
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
@@ -14,7 +14,7 @@ import com.revenuecat.purchases.models.googleProduct
 private class StoreProductAPI {
     fun check(product: StoreProduct) {
         with(product) {
-            val storeProductId: String = productId
+            val storeProductId: String = id
             val sku: String = sku
             val type: ProductType = type
             val price: Price? = price
@@ -42,7 +42,8 @@ private class StoreProductAPI {
         val subscriptionOptions: List<GoogleSubscriptionOption> = googleStoreProduct.subscriptionOptions
         val defaultOption: GoogleSubscriptionOption? = googleStoreProduct.defaultOption
         val constructedGoogleStoreProduct = GoogleStoreProduct(
-            googleStoreProduct.productId,
+            googleStoreProduct.id,
+            null,
             googleStoreProduct.type,
             googleStoreProduct.price,
             googleStoreProduct.title,

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -595,7 +595,7 @@ class BackendTest {
         val originalDuration = originalSubscriptionOption.pricingPhases[0].billingPeriod.iso8601
         val subscriptionOption = stubSubscriptionOption(originalSubscriptionOption.id, originalDuration + "a")
         val storeProduct2 = stubStoreProduct(
-            storeProduct.productId,
+            storeProduct.id,
             subscriptionOption
         )
 

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -393,7 +393,7 @@ class DeviceCacheTest {
     @Test
     fun `caching offerings works`() {
         val storeProduct = mockk<StoreProduct>().also {
-            every { it.productId } returns "onemonth_freetrial"
+            every { it.id } returns "onemonth_freetrial"
         }
         val packageObject = Package(
             "custom",

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
@@ -42,7 +42,7 @@ class PackageCardAdapter(
             val product = currentPackage.product
             binding.currentPackage = currentPackage
             binding.isSubscription = product.type == ProductType.SUBS
-            binding.isActive = activeSubscriptions.contains(product.productId)
+            binding.isActive = activeSubscriptions.contains(product.id)
 
             binding.packageBuyButton.setOnClickListener {
                 listener.onPurchasePackageClicked(

--- a/examples/purchase-tester/src/main/res/layout/package_card.xml
+++ b/examples/purchase-tester/src/main/res/layout/package_card.xml
@@ -71,7 +71,7 @@
                     app:layout_constraintEnd_toStartOf="@+id/package_card_barrier"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/package_product_description"
-                    bind:detail="@{currentPackage.product.productId}"
+                    bind:detail="@{currentPackage.product.id}"
                     bind:header="@{`Sku:`}"
                     tools:text="$rc_monthly" />
 

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -445,7 +445,7 @@ internal class AmazonBilling constructor(
              * since there's no terms and we can just use the sku
              */
             val amazonPurchaseWrapper = receipt.toStoreTransaction(
-                productId = storeProduct.productId,
+                productId = storeProduct.id,
                 presentedOfferingIdentifier = presentedOfferingIdentifier,
                 purchaseState = PurchaseState.PURCHASED,
                 userData

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/PurchaseHandler.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/handler/PurchaseHandler.kt
@@ -42,7 +42,7 @@ class PurchaseHandler(
         onSuccess: (Receipt, UserData) -> Unit,
         onError: (PurchasesError) -> Unit
     ) {
-        log(LogIntent.PURCHASE, PurchaseStrings.PURCHASING_PRODUCT.format(storeProduct.productId))
+        log(LogIntent.PURCHASE, PurchaseStrings.PURCHASING_PRODUCT.format(storeProduct.id))
 
         startProxyActivity(mainHandler, activity, storeProduct, presentedOfferingIdentifier, onSuccess, onError)
     }
@@ -61,7 +61,7 @@ class PurchaseHandler(
         val intent = ProxyAmazonBillingActivity.newStartIntent(
             activity,
             resultReceiver,
-            storeProduct.productId,
+            storeProduct.id,
             purchasingServiceProvider
         )
         // ProxyAmazonBillingActivity will initiate the purchase
@@ -80,8 +80,8 @@ class PurchaseHandler(
                 val requestId = resultData?.get(ProxyAmazonBillingActivity.EXTRAS_REQUEST_ID) as? RequestId
                 if (requestId != null) {
                     purchaseCallbacks[requestId] = onSuccess to onError
-                    productTypes[storeProduct.productId] = storeProduct.type
-                    presentedOfferingsByProductIdentifier[storeProduct.productId] = presentedOfferingIdentifier
+                    productTypes[storeProduct.id] = storeProduct.type
+                    presentedOfferingsByProductIdentifier[storeProduct.id] = presentedOfferingIdentifier
                 } else {
                     errorLog("No RequestId coming from ProxyAmazonBillingActivity")
                 }

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
@@ -22,7 +22,7 @@ sealed class AmazonPurchasingData : PurchasingData {
         val storeProduct: AmazonStoreProduct,
     ) : AmazonPurchasingData() {
         override val productId: String
-            get() = storeProduct.productId
+            get() = storeProduct.id
         override val productType: ProductType
             get() = storeProduct.type
     }
@@ -31,7 +31,7 @@ sealed class AmazonPurchasingData : PurchasingData {
 @Parcelize
 @TypeParceler<JSONObject, JSONObjectParceler>()
 data class AmazonStoreProduct(
-    override val productId: String,
+    override val id: String,
     override val type: ProductType,
     override val title: String,
     override val description: String,
@@ -49,7 +49,7 @@ data class AmazonStoreProduct(
         get() = AmazonPurchasingData.Product(this)
 
     override val sku: String
-        get() = productId
+        get() = id
 
     // We use this to not include the originalJSON in the equals
     /*override fun equals(other: Any?) = other is StoreProduct && ComparableData(this) == ComparableData(other)

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/handler/ProductDataHandlerTest.kt
@@ -74,7 +74,7 @@ class ProductDataHandlerTest {
 
         assertThat(receivedStoreProducts).isNotNull
 
-        val receivedSkus = receivedStoreProducts!!.map { it.productId }
+        val receivedSkus = receivedStoreProducts!!.map { it.id }
         assertThat(receivedSkus).hasSameElementsAs(expectedSkus)
 
         assertThat(purchasingServiceProvider.getProductDataCalledTimes).isZero
@@ -114,7 +114,7 @@ class ProductDataHandlerTest {
         assertThat(receivedStoreProducts).isNotNull
 
         val expectedSkus = expectedProductData.keys
-        val receivedSkus = receivedStoreProducts!!.map { it.productId }
+        val receivedSkus = receivedStoreProducts!!.map { it.id }
         assertThat(receivedSkus).hasSameElementsAs(expectedSkus)
 
         assertThat(purchasingServiceProvider.getProductDataCalledTimes).isOne
@@ -151,7 +151,7 @@ class ProductDataHandlerTest {
         )
 
         val expectedSkus = expectedProductData.keys
-        val receivedSkus = receivedStoreProducts!!.map { it.productId }
+        val receivedSkus = receivedStoreProducts!!.map { it.id }
         assertThat(receivedSkus).hasSameElementsAs(expectedSkus)
 
         assertThat(underTest.productDataCache).isNotEmpty

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -24,6 +24,7 @@ fun ProductDetails.toStoreProduct(
 
     return GoogleStoreProduct(
         productId,
+        basePlan?.id,
         productType.toRevenueCatProductType(),
         price,
         title,

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -54,15 +54,14 @@ fun List<ProductDetails>.toStoreProducts(): List<StoreProduct> {
     forEach { productDetails ->
         val basePlans = productDetails.subscriptionOfferDetails?.filter { it.isBasePlan } ?: emptyList()
 
-        val offerDetailsBySubPeriod = productDetails.subscriptionOfferDetails?.groupBy {
-            it.subscriptionBillingPeriod
+        val offerDetailsByBasePlanId = productDetails.subscriptionOfferDetails?.groupBy {
+            it.basePlanId
         } ?: emptyMap()
 
         // Maps basePlans to StoreProducts, if any
         // Otherwise, maps productDetail to StoreProduct
         basePlans.takeUnless { it.isEmpty() }?.forEach { basePlan ->
-            val basePlanBillingPeriod = basePlan.subscriptionBillingPeriod
-            val offerDetailsForBasePlan = offerDetailsBySubPeriod[basePlanBillingPeriod] ?: emptyList()
+            val offerDetailsForBasePlan = offerDetailsByBasePlanId[basePlan.basePlanId] ?: emptyList()
 
             productDetails.toStoreProduct(offerDetailsForBasePlan)?.let {
                 storeProducts.add(it)

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -677,7 +677,7 @@ class BillingWrapperTest {
         }
 
         val storeProduct = object : StoreProduct {
-            override val productId: String
+            override val id: String
                 get() = "mock-sku"
             override val type: ProductType
                 get() = ProductType.SUBS
@@ -696,7 +696,7 @@ class BillingWrapperTest {
             override val purchasingData: PurchasingData
                 get() = purchasingInfo
             override val sku: String
-                get() = productId
+                get() = id
 
             override fun describeContents(): Int = 0
 

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -73,6 +73,7 @@ class StoreProductTest {
 
         val storeProduct1 = GoogleStoreProduct(
             productId = "product_id",
+            basePlanId = "base_plan_id",
             type = ProductType.SUBS,
             price = price1,
             title = "TITLE",
@@ -85,6 +86,7 @@ class StoreProductTest {
 
         val storeProduct2 = GoogleStoreProduct(
             productId = "product_id",
+            basePlanId = "base_plan_id",
             type = ProductType.SUBS,
             price = price2,
             title = "TITLE",
@@ -155,6 +157,7 @@ class StoreProductTest {
 
         val storeProduct1 = GoogleStoreProduct(
             productId = "product_id",
+            basePlanId = "base_plan_id",
             type = ProductType.SUBS,
             price = price1,
             title = "TITLE",
@@ -167,6 +170,7 @@ class StoreProductTest {
 
         val storeProduct2 = GoogleStoreProduct(
             productId = "product_id",
+            basePlanId = "base_plan_id",
             type = ProductType.SUBS,
             price = price2,
             title = "TITLE",

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleStoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleStoreProduct.kt
@@ -9,7 +9,8 @@ import kotlinx.parcelize.RawValue
 
 @Parcelize
 data class GoogleStoreProduct(
-    override val productId: String,
+    val productId: String,
+    val basePlanId: String?,
     override val type: ProductType,
     override val price: Price,
     override val title: String,
@@ -20,12 +21,17 @@ data class GoogleStoreProduct(
     val productDetails: @RawValue ProductDetails // TODO parcelize?
 ) : StoreProduct, Parcelable {
 
+    override val id: String
+        get() = basePlanId?.let {
+            "$productId:$basePlanId"
+        } ?: productId
+
     override val purchasingData: PurchasingData
         get() = if (type == ProductType.SUBS && defaultOption != null) {
             defaultOption.purchasingData
         } else {
             GooglePurchasingData.InAppProduct(
-                productId,
+                id,
                 productDetails
             )
         }

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
@@ -10,18 +10,12 @@ import kotlinx.parcelize.IgnoredOnParcel
 interface StoreProduct : Parcelable {
     /**
      * The product ID.
-     *
-     */
-    val productId: String
-
-    /**
-     * The unique ID of the product.
      * Google INAPP: "<productId>"
      * Google Sub: "<productId:basePlanID>"
      * Amazon INAPP: "<sku>"
      * Amazon Sub: "<termSku>"
      */
-    val uniqueId: String
+    val id: String
 
     /**
      * Type of product. One of [ProductType].

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
@@ -32,6 +32,11 @@ interface StoreProduct : Parcelable {
 
     /**
      * Title of the product.
+     *
+     * If you are using Google subscriptions with multiple base plans, this title
+     * will be the same for every subscription duration (monthly, yearly, etc) as
+     * base plans don't have their own titles. Google suggests using the duration
+     * as a way to title base plans.
      */
     val title: String
 

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
@@ -9,9 +9,19 @@ import kotlinx.parcelize.IgnoredOnParcel
  */
 interface StoreProduct : Parcelable {
     /**
-     * The product ID
+     * The product ID.
+     *
      */
     val productId: String
+
+    /**
+     * The unique ID of the product.
+     * Google INAPP: "<productId>"
+     * Google Sub: "<productId:basePlanID>"
+     * Amazon INAPP: "<sku>"
+     * Amazon Sub: "<termSku>"
+     */
+    val uniqueId: String
 
     /**
      * Type of product. One of [ProductType].

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1352,7 +1352,7 @@ class Purchases internal constructor(
                         ProductType.INAPP,
                         inAppProductIds,
                         { inAppProducts ->
-                            productsById.putAll(inAppProducts.map { it.id to listOf(it) })
+                            productsById.putAll(inAppProducts.map { it.purchasingData.productId to listOf(it) })
                             onCompleted(productsById)
                         }, {
                             onError(it)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1174,7 +1174,6 @@ class Purchases internal constructor(
         }
     }
 
-    // TODO: Probably need to add tests for this now
     private fun logMissingProducts(
         offerings: Offerings,
         storeProductByID: Map<String, List<StoreProduct>>

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1343,7 +1343,7 @@ class Purchases internal constructor(
             productIds,
             { subscriptionProducts ->
                 val productsById = subscriptionProducts
-                    .groupBy { subProduct -> subProduct.purchasingData.productId } // TODO: Maybe add parent plan to StoreProduct?
+                    .groupBy { subProduct -> subProduct.purchasingData.productId }
                     .toMutableMap()
                 val subscriptionIds = productsById.keys
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1174,12 +1174,13 @@ class Purchases internal constructor(
         }
     }
 
+    // TODO: Probably need to add tests for this now
     private fun logMissingProducts(
         offerings: Offerings,
         storeProductByID: Map<String, List<StoreProduct>>
     ) = offerings.all.values
         .flatMap { it.availablePackages }
-        .map { it.product.productId }
+        .map { it.product.id }
         .filterNot { storeProductByID.containsKey(it) }
         .takeIf { it.isNotEmpty() }
         ?.let { missingProducts ->
@@ -1245,7 +1246,7 @@ class Purchases internal constructor(
                             }
                         } else {
                             storeProducts.firstOrNull() { product ->
-                                product.productId == purchase.productIds.firstOrNull()
+                                product.id == purchase.productIds.firstOrNull()
                             }
                         }
 
@@ -1341,7 +1342,9 @@ class Purchases internal constructor(
             ProductType.SUBS,
             productIds,
             { subscriptionProducts ->
-                val productsById = subscriptionProducts.groupBy { subProduct -> subProduct.productId }.toMutableMap()
+                val productsById = subscriptionProducts
+                    .groupBy { subProduct -> subProduct.purchasingData.productId } // TODO: Maybe add parent plan to StoreProduct?
+                    .toMutableMap()
                 val subscriptionIds = productsById.keys
 
                 val inAppProductIds = productIds - subscriptionIds
@@ -1350,7 +1353,7 @@ class Purchases internal constructor(
                         ProductType.INAPP,
                         inAppProductIds,
                         { inAppProducts ->
-                            productsById.putAll(inAppProducts.map { it.productId to listOf(it) })
+                            productsById.putAll(inAppProducts.map { it.id to listOf(it) })
                             onCompleted(productsById)
                         }, {
                             onError(it)

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -1060,7 +1060,7 @@ class PurchasesTest {
         )
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
             getMockedPurchaseList(
-                offerings[stubOfferingIdentifier]!!.monthly!!.product.productId,
+                offerings[stubOfferingIdentifier]!!.monthly!!.product.id,
                 purchaseToken,
                 ProductType.SUBS
             )
@@ -4452,19 +4452,19 @@ class PurchasesTest {
         offeringIdentifier: String?,
         subscriptionOptionId: String? = this.subscriptionOptionId
     ): ReceiptInfo {
-        if (type == ProductType.SUBS) {
+        return if (type == ProductType.SUBS) {
             val productDetails = createMockProductDetailsFreeTrial(productId, 2.00)
 
             val storeProduct = productDetails.toStoreProduct(
                 productDetails.subscriptionOfferDetails!!
             )!!
 
-            return mockQueryingProductDetails(storeProduct, offeringIdentifier, subscriptionOptionId)
+            mockQueryingProductDetails(storeProduct, offeringIdentifier, subscriptionOptionId)
         } else {
             val productDetails = createMockOneTimeProductDetails(productId, 2.00)
             val storeProduct = productDetails.toInAppStoreProduct()!!
 
-            return mockQueryingProductDetails(storeProduct, offeringIdentifier, null)
+            mockQueryingProductDetails(storeProduct, offeringIdentifier, null)
         }
     }
 
@@ -4473,8 +4473,10 @@ class PurchasesTest {
         offeringIdentifier: String?,
         subscriptionOptionId: String? = this.subscriptionOptionId
     ): ReceiptInfo {
+        val productId = storeProduct.purchasingData.productId
+
         val receiptInfo = ReceiptInfo(
-            productIDs = listOf(storeProduct.productId),
+            productIDs = listOf(productId),
             offeringIdentifier = offeringIdentifier,
             storeProduct = storeProduct,
             subscriptionOptionId = if (storeProduct.type == ProductType.SUBS) subscriptionOptionId else null
@@ -4483,7 +4485,7 @@ class PurchasesTest {
         every {
             mockBillingAbstract.queryProductDetailsAsync(
                 storeProduct.type,
-                setOf(storeProduct.productId),
+                setOf(productId),
                 captureLambda(),
                 any()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -32,7 +32,6 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
-import com.revenuecat.purchases.google.isBasePlan
 import com.revenuecat.purchases.google.toGoogleProductType
 import com.revenuecat.purchases.google.toStoreProduct
 import com.revenuecat.purchases.google.toInAppStoreProduct

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -30,7 +30,7 @@ fun stubStoreProduct(
     subscriptionOptions: List<SubscriptionOption> = defaultOption?.let { listOf(defaultOption) } ?: emptyList(),
     price: Price = subscriptionOptions.first().fullPricePhase!!.price
 ): StoreProduct = object : StoreProduct {
-    override val productId: String
+    override val id: String
         get() = productId
     override val type: ProductType
         get() = ProductType.SUBS
@@ -62,7 +62,7 @@ fun stubStoreProduct(
 fun stubINAPPStoreProduct(
     productId: String
 ): StoreProduct = object : StoreProduct {
-    override val productId: String
+    override val id: String
         get() = productId
     override val type: ProductType
         get() = ProductType.INAPP


### PR DESCRIPTION
⚠️ Chained off of #806 

## Motivation

[CF-1218](https://revenuecats.atlassian.net/browse/CF-1218)

`StoreProduct`'s `productId` field was a bit confusing on what information it was holding with the introduction of Google's BC5.

In the current implementation, the `productId` field stored the "Subscription ID" which does not include the Base Plan ID. This meant if there was a list of `StoreProduct`s all on the on same subscription (where there were base plans for weekly, monthly, yearly, etc), all the `StoreProduct`s would have identical `productId`s which... could be confusing to the user 😖 

## Description

- Renames `productId` to `id`
- Changes what is stored in `id` for Google subscriptions and updates doc to explain
  - Google INAPP: `"<productId>"`
  - Google Sub: `"<productId:basePlanID>"`
  - Amazon INAPP: `"<sku>"`
  - Amazon Sub: `"<termSku>"`

### Side Notes

- The Google Subscription ID can still be access through `storeProduct.purchasingData.productId` if needed 
- `StoreProduct` can be casted to a `GoogleStoreProduct` to access individual fields:
  - `productId`
  - `basePlanId`

[CF-1218]: https://revenuecats.atlassian.net/browse/CF-1218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ