### PR TITLE
[BC5] Fixes logMissingProducts never logging missing products

### DIFF
--- a/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -54,15 +54,14 @@ fun List<ProductDetails>.toStoreProducts(): List<StoreProduct> {
     forEach { productDetails ->
         val basePlans = productDetails.subscriptionOfferDetails?.filter { it.isBasePlan } ?: emptyList()
 
-        val offerDetailsBySubPeriod = productDetails.subscriptionOfferDetails?.groupBy {
-            it.subscriptionBillingPeriod
+        val offerDetailsByBasePlanId = productDetails.subscriptionOfferDetails?.groupBy {
+            it.basePlanId
         } ?: emptyMap()
 
         // Maps basePlans to StoreProducts, if any
         // Otherwise, maps productDetail to StoreProduct
         basePlans.takeUnless { it.isEmpty() }?.forEach { basePlan ->
-            val basePlanBillingPeriod = basePlan.subscriptionBillingPeriod
-            val offerDetailsForBasePlan = offerDetailsBySubPeriod[basePlanBillingPeriod] ?: emptyList()
+            val offerDetailsForBasePlan = offerDetailsByBasePlanId[basePlan.basePlanId] ?: emptyList()
 
             productDetails.toStoreProduct(offerDetailsForBasePlan)?.let {
                 storeProducts.add(it)

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
@@ -32,6 +32,11 @@ interface StoreProduct : Parcelable {
 
     /**
      * Title of the product.
+     *
+     * If you are using Google subscriptions with multiple base plans, this title
+     * will be the same for every subscription duration (monthly, yearly, etc) as
+     * base plans don't have their own titles. Google suggests using the duration
+     * as a way to title base plans.
      */
     val title: String
 


### PR DESCRIPTION
⚠️ Chained off of #810

### Motivation

Fixes an issue where `logMissingProducts` was never logging missing products

### Description

`logMissingProducts` takes 2 parameters. The first being an array of all product ids and the second being a map containing all product ids fetched from Billing Client.

🐛 There was a bug where the first parameter was getting an array of all product ids from `Offerings` but `Offerings` already removes all the products that were not found

🔨 The fix in this PR is to pass all the product ids from the raw API JSON response containing all the product ids that are being requested into Billing Client
