### PR TITLE
[BC5] Maps StoreProducts on basePlanId and not duration (fixes issue with prepaid with same duration as recurring)

### DIFF
--- a/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -54,15 +54,14 @@ fun List<ProductDetails>.toStoreProducts(): List<StoreProduct> {
     forEach { productDetails ->
         val basePlans = productDetails.subscriptionOfferDetails?.filter { it.isBasePlan } ?: emptyList()
 
-        val offerDetailsBySubPeriod = productDetails.subscriptionOfferDetails?.groupBy {
-            it.subscriptionBillingPeriod
+        val offerDetailsByBasePlanId = productDetails.subscriptionOfferDetails?.groupBy {
+            it.basePlanId
         } ?: emptyMap()
 
         // Maps basePlans to StoreProducts, if any
         // Otherwise, maps productDetail to StoreProduct
         basePlans.takeUnless { it.isEmpty() }?.forEach { basePlan ->
-            val basePlanBillingPeriod = basePlan.subscriptionBillingPeriod
-            val offerDetailsForBasePlan = offerDetailsBySubPeriod[basePlanBillingPeriod] ?: emptyList()
+            val offerDetailsForBasePlan = offerDetailsByBasePlanId[basePlan.basePlanId] ?: emptyList()
 
             productDetails.toStoreProduct(offerDetailsForBasePlan)?.let {
                 storeProducts.add(it)

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
@@ -32,6 +32,11 @@ interface StoreProduct : Parcelable {
 
     /**
      * Title of the product.
+     *
+     * If you are using Google subscriptions with multiple base plans, this title
+     * will be the same for every subscription duration (monthly, yearly, etc) as
+     * base plans don't have their own titles. Google suggests using the duration
+     * as a way to title base plans.
      */
     val title: String
 


### PR DESCRIPTION
⚠️ Chained off of #813

## Motivation

[CF-1237](https://revenuecats.atlassian.net/browse/CF-1237)

Bug with having recurring subscription and prepaid subscription of the same duration. 
The subscriptions would get mapped into one `StoreProduct` because previous logic grouped by billing duration.

## Description

- `List<ProductDetails>.toStoreProducts()` now groups base plans by `basePlanId`
- Added new tests that verifies that a `StoreProduct` is created/grouped by base plan id

### Screenshots

| Before | After |
|---|---|
| Prepaid group as a purchase option in recurring subscription | Now its its own package / `StoreProduct` |
| ![Screenshot 2023-02-22 at 8 39 01 PM](https://user-images.githubusercontent.com/401294/220813974-a80c2f92-9e4a-4ad7-9851-90575f0acedf.png) | ![Screenshot 2023-02-22 at 9 09 33 PM](https://user-images.githubusercontent.com/401294/220813988-9cca495b-a801-47ff-9f96-54547f56ce44.png) |

[CF-1237]: https://revenuecats.atlassian.net/browse/CF-1237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ