### PR TITLE
[BC5] update StoreProduct title doc for Google base plans not having a title

### DIFF
--- a/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
@@ -32,6 +32,11 @@ interface StoreProduct : Parcelable {
 
     /**
      * Title of the product.
+     *
+     * If you are using Google subscriptions with multiple base plans, this title
+     * will be the same for every subscription duration (monthly, yearly, etc) as
+     * base plans don't have their own titles. Google suggests using the duration
+     * as a way to title base plans.
      */
     val title: String
 


### PR DESCRIPTION
⚠️ Chained off of #814

### Motivation

[CF-1210](https://revenuecats.atlassian.net/browse/CF-1210)

The `StoreProduct`'s `title` is the same for every base plan and its kind of confusing.

### Description

This is a "simple" doc change but difficult to put into the proper words 😛 

The new doc explains that if you are using Google subscription with multiple base plans, the `title`  will be the same for every subscription duration (monthly, yearly, etc) ase base plans don't have their own titles.


[CF-1210]: https://revenuecats.atlassian.net/browse/CF-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ