### PR TITLE
Fix period serialization

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -377,7 +377,7 @@ class Backend(
 
 internal fun PricingPhase.toMap(): Map<String, Any?> {
     return mapOf(
-        "billingPeriod" to this.billingPeriod,
+        "billingPeriod" to this.billingPeriod.iso8601,
         "billingCycleCount" to this.billingCycleCount,
         "recurrenceMode" to this.recurrenceMode.identifier,
         "formattedPrice" to this.price.formatted,

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -7,6 +7,7 @@ package com.revenuecat.purchases.common
 
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.billingclient.api.ProductDetails.RecurrenceMode
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -301,17 +302,18 @@ class BackendTest {
         assertThat(requestBodySlot.captured.keys).contains("pricing_phases")
         assertThat(requestBodySlot.captured["pricing_phases"]).isEqualTo(mappedExpectedPricingPhases)
 
-        expectedPricingPhases?.forEachIndexed { index, pricingPhase ->
-            val mappedPricingPhase = mappedExpectedPricingPhases?.get(index)
-            assertThat(mappedPricingPhase).isNotNull.withFailMessage(
-                "there should be a mapped version for every pricingPhase"
+        assertThat(mappedExpectedPricingPhases).isEqualTo(
+            listOf(
+                mapOf(
+                    "billingPeriod" to "P1M",
+                    "recurrenceMode" to RecurrenceMode.INFINITE_RECURRING,
+                    "billingCycleCount" to 0,
+                    "formattedPrice" to "\$4.99",
+                    "priceAmountMicros" to 4990000L,
+                    "priceCurrencyCode" to "USD"
+                )
             )
-            assertThat(mappedPricingPhase?.get("billingPeriod")).isEqualTo(pricingPhase.billingPeriod)
-            assertThat(mappedPricingPhase?.get("billingCycleCount")).isEqualTo(pricingPhase.billingCycleCount)
-            assertThat(mappedPricingPhase?.get("formattedPrice")).isEqualTo(pricingPhase.price.formatted)
-            assertThat(mappedPricingPhase?.get("priceCurrencyCode")).isEqualTo(pricingPhase.price.currencyCode)
-            assertThat(mappedPricingPhase?.get("recurrenceMode")).isEqualTo(pricingPhase.recurrenceMode.identifier)
-        }
+        );
     }
 
     @Test


### PR DESCRIPTION
Serialize the iso8601 duration

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
This was causing pricingPhases to serialize a null value

### Description
Use iso8601 for serialization
