### PR TITLE
[BC5] Rename UpgradeInfo to ProductChangeInfo

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/DeprecatedPurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/DeprecatedPurchasesAPI.java
@@ -5,7 +5,7 @@ import android.app.Activity;
 import com.android.billingclient.api.SkuDetails;
 import com.revenuecat.purchases.Package;
 import com.revenuecat.purchases.Purchases;
-import com.revenuecat.purchases.UpgradeInfo;
+import com.revenuecat.purchases.ProductChangeInfo;
 import com.revenuecat.purchases.models.StoreProduct;
 
 @SuppressWarnings({"unused"})
@@ -15,7 +15,7 @@ final class DeprecatedPurchasesAPI {
                       final SkuDetails skuDetails,
                       final StoreProduct storeProduct,
                       final Package packageToPurchase,
-                      final UpgradeInfo upgradeInfo) {
+                      final ProductChangeInfo productChangeInfo) {
         purchases.setAllowSharingPlayStoreAccount(true);
     }
 

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -15,7 +15,7 @@ import com.revenuecat.purchases.Package;
 import com.revenuecat.purchases.Purchases;
 import com.revenuecat.purchases.PurchasesConfiguration;
 import com.revenuecat.purchases.PurchasesError;
-import com.revenuecat.purchases.UpgradeInfo;
+import com.revenuecat.purchases.ProductChangeInfo;
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback;
 import com.revenuecat.purchases.interfaces.LogInCallback;
 import com.revenuecat.purchases.interfaces.ProductChangeCallback;
@@ -44,7 +44,7 @@ final class PurchasesAPI {
                       final StoreProduct storeProduct,
                       final Package packageToPurchase,
                       final SubscriptionOption subscriptionOption,
-                      final UpgradeInfo upgradeInfo) {
+                      final ProductChangeInfo productChangeInfo) {
         final ArrayList<String> productIds = new ArrayList<>();
 
         final ReceiveOfferingsCallback receiveOfferingsListener = new ReceiveOfferingsCallback() {
@@ -75,11 +75,11 @@ final class PurchasesAPI {
         purchases.syncPurchases();
         purchases.getOfferings(receiveOfferingsListener);
         purchases.getProducts(productIds, productResponseListener);
-        purchases.purchaseProduct(activity, storeProduct, upgradeInfo, purchaseChangeListener);
+        purchases.purchaseProduct(activity, storeProduct, productChangeInfo, purchaseChangeListener);
         purchases.purchaseProduct(activity, storeProduct, makePurchaseListener);
-        purchases.purchasePackage(activity, packageToPurchase, upgradeInfo, purchaseChangeListener);
+        purchases.purchasePackage(activity, packageToPurchase, productChangeInfo, purchaseChangeListener);
         purchases.purchasePackage(activity, packageToPurchase, makePurchaseListener);
-        purchases.purchaseSubscriptionOption(activity, subscriptionOption, upgradeInfo, purchaseChangeListener);
+        purchases.purchaseSubscriptionOption(activity, subscriptionOption, productChangeInfo, purchaseChangeListener);
         purchases.purchaseSubscriptionOption(activity, subscriptionOption, makePurchaseListener);
         purchases.restorePurchases(receiveCustomerInfoListener);
 

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/UpgradeInfoAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/UpgradeInfoAPI.java
@@ -1,22 +1,22 @@
 package com.revenuecat.apitester.java;
 
-import com.revenuecat.purchases.UpgradeInfo;
+import com.revenuecat.purchases.ProductChangeInfo;
 import com.revenuecat.purchases.models.GoogleProrationMode;
 
 @SuppressWarnings({"unused"})
 final class UpgradeInfoAPI {
-    static void check(final UpgradeInfo upgradeInfo) {
-        final String oldProductId = upgradeInfo.getOldProductId();
-        GoogleProrationMode prorationMode = upgradeInfo.getGoogleProrationMode();
+    static void check(final ProductChangeInfo productChangeInfo) {
+        final String oldProductId = productChangeInfo.getOldProductId();
+        GoogleProrationMode prorationMode = productChangeInfo.getGoogleProrationMode();
 
-        UpgradeInfo constructedUpgradeInfo = new UpgradeInfo(
-                upgradeInfo.getOldProductId(),
-                upgradeInfo.getGoogleProrationMode()
+        ProductChangeInfo constructedProductChangeInfo = new ProductChangeInfo(
+                productChangeInfo.getOldProductId(),
+                productChangeInfo.getGoogleProrationMode()
         );
 
-        UpgradeInfo constructedUpgradeInfoNullProrationMode = new UpgradeInfo(upgradeInfo.getOldProductId());
+        ProductChangeInfo constructedProductChangeInfoNullProrationMode = new ProductChangeInfo(productChangeInfo.getOldProductId());
 
-        UpgradeInfo constructedUpgradeInfoProductIdOnly = new UpgradeInfo(upgradeInfo.getOldProductId());
-        UpgradeInfo constructedUpgradeInfoProductIdAndOldSkuOnly = new UpgradeInfo(upgradeInfo.getOldProductId());
+        ProductChangeInfo constructedProductChangeInfoProductIdOnly = new ProductChangeInfo(productChangeInfo.getOldProductId());
+        ProductChangeInfo constructedProductChangeInfoProductIdAndOldSkuOnly = new ProductChangeInfo(productChangeInfo.getOldProductId());
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -11,7 +11,7 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.PurchasesError
-import com.revenuecat.purchases.UpgradeInfo
+import com.revenuecat.purchases.ProductChangeInfo
 import com.revenuecat.purchases.getCustomerInfoWith
 import com.revenuecat.purchases.getNonSubscriptionSkusWith
 import com.revenuecat.purchases.getOfferingsWith
@@ -45,7 +45,7 @@ private class PurchasesAPI {
         storeProduct: StoreProduct,
         packageToPurchase: Package,
         subscriptionOption: SubscriptionOption,
-        upgradeInfo: UpgradeInfo
+        productChangeInfo: ProductChangeInfo
     ) {
         val productIds = ArrayList<String>()
         val receiveOfferingsCallback = object : ReceiveOfferingsCallback {
@@ -78,15 +78,15 @@ private class PurchasesAPI {
         purchases.getProducts(productIds, productsResponseCallback)
 
         // we need these for hybrids... these all fall back on some "best offer" or just purchase the base plan
-        purchases.purchaseProduct(activity, storeProduct, upgradeInfo, purchaseChangeCallback)
+        purchases.purchaseProduct(activity, storeProduct, productChangeInfo, purchaseChangeCallback)
         purchases.purchaseProduct(activity, storeProduct, purchaseCallback)
-        purchases.purchasePackage(activity, packageToPurchase, upgradeInfo, purchaseChangeCallback)
+        purchases.purchasePackage(activity, packageToPurchase, productChangeInfo, purchaseChangeCallback)
         purchases.purchasePackage(activity, packageToPurchase, purchaseCallback)
 
         purchases.purchaseSubscriptionOption(
             activity,
             subscriptionOption,
-            upgradeInfo,
+            productChangeInfo,
             purchaseChangeCallback
         )
         purchases.purchaseSubscriptionOption(activity, subscriptionOption, purchaseCallback)
@@ -121,7 +121,7 @@ private class PurchasesAPI {
         packageToPurchase: Package,
         storeProduct: StoreProduct,
         subscriptionOption: SubscriptionOption,
-        upgradeInfo: UpgradeInfo
+        productChangeInfo: ProductChangeInfo
     ) {
         purchases.getOfferingsWith(
             onError = { _: PurchasesError -> },
@@ -136,14 +136,14 @@ private class PurchasesAPI {
         purchases.purchaseProductWith(
             activity,
             storeProduct,
-            upgradeInfo,
+            productChangeInfo,
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
         )
         purchases.purchasePackageWith(
             activity,
             packageToPurchase,
-            upgradeInfo,
+            productChangeInfo,
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
         )
@@ -162,7 +162,7 @@ private class PurchasesAPI {
         purchases.purchaseSubscriptionOptionWith(
             activity,
             subscriptionOption,
-            upgradeInfo,
+            productChangeInfo,
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
         )

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/UpgradeInfoAPI.kt
@@ -1,22 +1,22 @@
 package com.revenuecat.apitester.kotlin
 
-import com.revenuecat.purchases.UpgradeInfo
+import com.revenuecat.purchases.ProductChangeInfo
 import com.revenuecat.purchases.models.GoogleProrationMode
 
 @Suppress("unused", "UNUSED_VARIABLE", "RemoveExplicitTypeArguments")
 private class UpgradeInfoAPI {
-    fun check(upgradeInfo: UpgradeInfo) {
-        with(upgradeInfo) {
+    fun check(productChangeInfo: ProductChangeInfo) {
+        with(productChangeInfo) {
             val oldProductId: String = oldProductId
             val prorationMode: GoogleProrationMode = googleProrationMode
 
-            val constructedUpgradeInfo =
-                UpgradeInfo(
+            val constructedProductChangeInfo =
+                ProductChangeInfo(
                     oldProductId,
                     googleProrationMode
                 )
 
-            val constructedUpgradeInfoProductIdOnly = UpgradeInfo(oldProductId)
+            val constructedProductChangeInfoProductIdOnly = ProductChangeInfo(oldProductId)
         }
     }
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -17,7 +17,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
-import com.revenuecat.purchases.UpgradeInfo
+import com.revenuecat.purchases.ProductChangeInfo
 import com.revenuecat.purchases.getCustomerInfoWith
 import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.StoreProduct
@@ -140,14 +140,14 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         }
     }
 
-    private fun promptForUpgradeInfo(callback: (UpgradeInfo?) -> Unit) {
+    private fun promptForUpgradeInfo(callback: (ProductChangeInfo?) -> Unit) {
         showOldSubIdPicker { subId ->
             subId?.let {
                 showProrationModePicker { prorationMode, error ->
                     if (error == null) {
                         prorationMode?.let {
-                            callback(UpgradeInfo(subId, prorationMode))
-                        } ?: callback(UpgradeInfo(subId))
+                            callback(ProductChangeInfo(subId, prorationMode))
+                        } ?: callback(ProductChangeInfo(subId))
                     } else {
                         callback(null)
                     }
@@ -158,19 +158,19 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
 
     private fun startPurchaseProduct(
         currentProduct: StoreProduct,
-        upgradeInfo: UpgradeInfo?
+        productChangeInfo: ProductChangeInfo?
     ) {
         when {
-            upgradeInfo == null -> Purchases.sharedInstance.purchaseProductWith(
+            productChangeInfo == null -> Purchases.sharedInstance.purchaseProductWith(
                 requireActivity(),
                 currentProduct,
                 purchaseErrorCallback,
                 successfulPurchaseCallback
             )
-            upgradeInfo != null -> Purchases.sharedInstance.purchaseProductWith(
+            productChangeInfo != null -> Purchases.sharedInstance.purchaseProductWith(
                 requireActivity(),
                 currentProduct,
-                upgradeInfo,
+                productChangeInfo,
                 purchaseErrorCallback,
                 successfulUpgradeCallback
             )
@@ -179,19 +179,19 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
 
     private fun startPurchaseSubscriptionOption(
         subscriptionOption: SubscriptionOption,
-        upgradeInfo: UpgradeInfo?
+        productChangeInfo: ProductChangeInfo?
     ) {
         when {
-            upgradeInfo == null -> Purchases.sharedInstance.purchaseSubscriptionOptionWith(
+            productChangeInfo == null -> Purchases.sharedInstance.purchaseSubscriptionOptionWith(
                 requireActivity(),
                 subscriptionOption,
                 purchaseErrorCallback,
                 successfulPurchaseCallback
             )
-            upgradeInfo != null -> Purchases.sharedInstance.purchaseSubscriptionOptionWith(
+            productChangeInfo != null -> Purchases.sharedInstance.purchaseSubscriptionOptionWith(
                 requireActivity(),
                 subscriptionOption,
-                upgradeInfo,
+                productChangeInfo,
                 purchaseErrorCallback,
                 successfulUpgradeCallback
             )
@@ -211,19 +211,19 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
 
     private fun startPurchasePackage(
         currentPackage: Package,
-        upgradeInfo: UpgradeInfo?
+        productChangeInfo: ProductChangeInfo?
     ) {
         when {
-            upgradeInfo == null -> Purchases.sharedInstance.purchasePackageWith(
+            productChangeInfo == null -> Purchases.sharedInstance.purchasePackageWith(
                 requireActivity(),
                 currentPackage,
                 purchaseErrorCallback,
                 successfulPurchaseCallback
             )
-            upgradeInfo != null -> Purchases.sharedInstance.purchasePackageWith(
+            productChangeInfo != null -> Purchases.sharedInstance.purchasePackageWith(
                 requireActivity(),
                 currentPackage,
-                upgradeInfo,
+                productChangeInfo,
                 purchaseErrorCallback,
                 successfulUpgradeCallback
             )

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -2,16 +2,17 @@
 
 ### Classes
 
-| New                        |
-|----------------------------|
-| `SubscriptionOption`       |
-| `GoogleSubscriptionOption` |
-| `GoogleStoreProduct`       |
-| `AmazonStoreProduct`       |
-| `Price`                    |
-| `PricingPhase`             |
-| `RecurrenceMode`           |
-| `GoogleProrationMode`      |
+| Previous      | New                        |
+|---------------|----------------------------|
+|               | `SubscriptionOption`       |
+|               | `GoogleSubscriptionOption` |
+|               | `GoogleStoreProduct`       |
+|               | `AmazonStoreProduct`       |
+|               | `Price`                    |
+|               | `PricingPhase`             |
+|               | `RecurrenceMode`           |
+|               | `GoogleProrationMode`      |
+| `UpgradeInfo` | `ProductChangeInfo`        |
 
 | Old Location                            | New Location                                   |
 |-----------------------------------------|------------------------------------------------|
@@ -68,7 +69,7 @@ val trialOption = storeProduct.subscriptionOptions?.firstOrNull { it.introPhase 
 |------------|------------|
 | skus       | productIds |
 
-### UpgradeInfo updates
+### ProductChangeInfo updates
 
 
 | Removed       | New                 |
@@ -99,7 +100,7 @@ For more control, the `purchaseSubscriptionOption()` API can be used to manually
 | New                                                                                                      |
 |----------------------------------------------------------------------------------------------------------|
 | `purchaseSubscriptionOption(Activity, StoreProduct, SubscriptionOption, PurchaseCallback)`                   |
-| `purchaseSubscriptionOption(Activity, StoreProduct, SubscriptionOption, UpgradeInfo, ProductChangeCallback)` |
+| `purchaseSubscriptionOption(Activity, StoreProduct, SubscriptionOption, ProductChangeInfo, ProductChangeCallback)` |
 
 | Deprecated                                                       | New                                                   |
 |------------------------------------------------------------------|-------------------------------------------------------|
@@ -111,7 +112,7 @@ For more control, the `purchaseSubscriptionOption()` API can be used to manually
 | New                                                                                                                                                                |
 |--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `purchaseSubscriptionOptionWith(Activity, StoreProduct, SubscriptionOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)`              |
-| `purchaseSubscriptionOptionWith(Activity, StoreProduct, UpgradeInfo, SubscriptionOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)` |
+| `purchaseSubscriptionOptionWith(Activity, StoreProduct, ProductChangeInfo, SubscriptionOption, (PurchasesError, Boolean) -> Unit, (StoreTransaction, CustomerInfo) -> Unit)` |
 
 | Deprecated                                                                                         | New                                                                                     |
 |----------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ProductChangeInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ProductChangeInfo.kt
@@ -3,12 +3,12 @@ package com.revenuecat.purchases
 import com.revenuecat.purchases.models.GoogleProrationMode
 
 /**
- * This object holds the information used when upgrading from another sku.
+ * This object holds the information used when changing from another product.
  * @property oldProductId The old product ID to upgrade from.
  * @property googleProrationMode The [GoogleProrationMode] to use when upgrading the given oldProductId. Defaults to
  * [GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION].
  */
-data class UpgradeInfo @JvmOverloads constructor(
+data class ProductChangeInfo @JvmOverloads constructor(
     val oldProductId: String,
     val googleProrationMode: GoogleProrationMode = GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -132,7 +132,8 @@ fun Purchases.purchaseProductWith(
  * default [SubscriptionOption].
  * @param [activity] Current activity
  * @param [storeProduct] The storeProduct of the product you wish to purchase
- * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
+ * @param [productChangeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and
+ * the optional prorationMode.
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called if there was an error with the purchase
@@ -140,11 +141,11 @@ fun Purchases.purchaseProductWith(
 fun Purchases.purchaseProductWith(
     activity: Activity,
     storeProduct: StoreProduct,
-    upgradeInfo: UpgradeInfo,
+    productChangeInfo: ProductChangeInfo,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
     onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
 ) {
-    purchaseProduct(activity, storeProduct, upgradeInfo, productChangeCompletedListener(onSuccess, onError))
+    purchaseProduct(activity, storeProduct, productChangeInfo, productChangeCompletedListener(onSuccess, onError))
 }
 
 /**
@@ -171,7 +172,8 @@ fun Purchases.purchaseSubscriptionOptionWith(
  * Purchase a subscription [StoreProduct]'s [SubscriptionOption], upgrading from an old product.
  * @param [activity] Current activity
  * @param [subscriptionOption] Your choice of [SubscriptionOption]s available for a subscription StoreProduct
- * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
+ * @param [productChangeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and
+ * the optional prorationMode.
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called if there was an error with the purchase
@@ -180,14 +182,14 @@ fun Purchases.purchaseSubscriptionOptionWith(
 fun Purchases.purchaseSubscriptionOptionWith(
     activity: Activity,
     subscriptionOption: SubscriptionOption,
-    upgradeInfo: UpgradeInfo,
+    productChangeInfo: ProductChangeInfo,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
     onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
 ) {
     purchaseSubscriptionOption(
         activity,
         subscriptionOption,
-        upgradeInfo,
+        productChangeInfo,
         productChangeCompletedListener(onSuccess, onError)
     )
 }
@@ -197,7 +199,8 @@ fun Purchases.purchaseSubscriptionOptionWith(
  * default [SubscriptionOption].
  * @param [activity] Current activity
  * @param [packageToPurchase] The Package you wish to purchase
- * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
+ * @param [productChangeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and
+ * the optional prorationMode.
  * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
  * @param [onSuccess] Will be called after the purchase has completed
  * @param [onError] Will be called if there was an error with the purchase
@@ -205,11 +208,11 @@ fun Purchases.purchaseSubscriptionOptionWith(
 fun Purchases.purchasePackageWith(
     activity: Activity,
     packageToPurchase: Package,
-    upgradeInfo: UpgradeInfo,
+    productChangeInfo: ProductChangeInfo,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
     onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
 ) {
-    purchasePackage(activity, packageToPurchase, upgradeInfo, productChangeCompletedListener(onSuccess, onError))
+    purchasePackage(activity, packageToPurchase, productChangeInfo, productChangeCompletedListener(onSuccess, onError))
 }
 
 /**

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -32,7 +32,6 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
-import com.revenuecat.purchases.google.isBasePlan
 import com.revenuecat.purchases.google.toGoogleProductType
 import com.revenuecat.purchases.google.toStoreProduct
 import com.revenuecat.purchases.google.toInAppStoreProduct
@@ -463,7 +462,7 @@ class PurchasesTest {
         purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             receiptInfo.storeProduct!!.subscriptionOptions[0],
-            UpgradeInfo(oldPurchase.productIds[0]),
+            ProductChangeInfo(oldPurchase.productIds[0]),
             onError = { _, _ ->
                 fail("should be successful")
             }, onSuccess = { _, _ ->
@@ -488,7 +487,7 @@ class PurchasesTest {
         purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             receiptInfo.storeProduct!!.subscriptionOptions[0],
-            UpgradeInfo(oldPurchase.productIds[0]),
+            ProductChangeInfo(oldPurchase.productIds[0]),
             onError = { _, _ ->
                 fail("should be success")
             }, onSuccess = { purchase, _ ->
@@ -522,7 +521,7 @@ class PurchasesTest {
         purchases.purchaseProductWith(
             mockActivity,
             receiptInfo.storeProduct!!,
-            UpgradeInfo(oldSubId),
+            ProductChangeInfo(oldSubId),
             onError = { _, _ ->
             }, onSuccess = { _, _ ->
 
@@ -632,7 +631,7 @@ class PurchasesTest {
         purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            UpgradeInfo(oldPurchase.productIds[0])
+            ProductChangeInfo(oldPurchase.productIds[0])
         ) { _, _ -> }
 
         verify {
@@ -885,7 +884,7 @@ class PurchasesTest {
         purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             receiptInfo.storeProduct!!.subscriptionOptions[0],
-            UpgradeInfo(oldPurchase.productIds[0]),
+            ProductChangeInfo(oldPurchase.productIds[0]),
             onError = { purchaseError, userCancelled ->
                 receivedError = purchaseError
                 receivedUserCancelled = userCancelled
@@ -912,7 +911,7 @@ class PurchasesTest {
         purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             receiptInfo.storeProduct!!.subscriptionOptions[0],
-            UpgradeInfo(oldPurchase.productIds[0]),
+            ProductChangeInfo(oldPurchase.productIds[0]),
             onError = { _, _ -> },
             onSuccess = { _, _ ->
                 fail("should be error")
@@ -922,7 +921,7 @@ class PurchasesTest {
         purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             receiptInfo.storeProduct!!.subscriptionOptions[0],
-            UpgradeInfo(oldPurchase.productIds[0]),
+            ProductChangeInfo(oldPurchase.productIds[0]),
             onError = { error, _ ->
                 receivedError = error
             },
@@ -946,7 +945,7 @@ class PurchasesTest {
         purchases.purchaseSubscriptionOptionWith(
             mockActivity,
             receiptInfo.storeProduct!!.subscriptionOptions[0],
-            UpgradeInfo(oldPurchase.productIds[0]),
+            ProductChangeInfo(oldPurchase.productIds[0]),
             onError = { error, userCancelled ->
                 receivedError = error
                 receivedUserCancelled = userCancelled
@@ -1052,7 +1051,7 @@ class PurchasesTest {
         purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            UpgradeInfo(oldPurchase.productIds[0]),
+            ProductChangeInfo(oldPurchase.productIds[0]),
             onError = { _, _ ->
                 fail("should be successful")
             }, onSuccess = { _, _ ->
@@ -1081,7 +1080,7 @@ class PurchasesTest {
         purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            UpgradeInfo(oldPurchase.productIds[0]),
+            ProductChangeInfo(oldPurchase.productIds[0]),
             onError = { _, _ ->
                 fail("should be success")
             }, onSuccess = { purchase, _ ->
@@ -1114,7 +1113,7 @@ class PurchasesTest {
         purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            UpgradeInfo(oldPurchase.productIds[0]),
+            ProductChangeInfo(oldPurchase.productIds[0]),
             onError = { error, userCancelled ->
                 receivedError = error
                 receivedUserCancelled = userCancelled
@@ -1139,7 +1138,7 @@ class PurchasesTest {
         purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            UpgradeInfo(oldPurchase.productIds[0]),
+            ProductChangeInfo(oldPurchase.productIds[0]),
             onError = { error, userCancelled ->
                 receivedError = error
                 receivedUserCancelled = userCancelled
@@ -1170,7 +1169,7 @@ class PurchasesTest {
         purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            UpgradeInfo(oldPurchase.productIds[0]),
+            ProductChangeInfo(oldPurchase.productIds[0]),
             onError = { error, userCancelled ->
                 receivedError = error
                 receivedUserCancelled = userCancelled
@@ -1226,7 +1225,7 @@ class PurchasesTest {
         purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            UpgradeInfo(oldPurchase.productIds[0]),
+            ProductChangeInfo(oldPurchase.productIds[0]),
             onError = { error, userCancelled ->
                 receivedError = error
                 receivedUserCancelled = userCancelled
@@ -1272,7 +1271,7 @@ class PurchasesTest {
         purchases.purchasePackageWith(
             mockActivity,
             offerings[stubOfferingIdentifier]!!.monthly!!,
-            UpgradeInfo(oldPurchase.productIds[0])
+            ProductChangeInfo(oldPurchase.productIds[0])
         ) { _, _ -> }
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(emptyList())


### PR DESCRIPTION
### Motivation

[CF-1167](https://revenuecats.atlassian.net/browse/CF-1167)

### Description

Rename `UpgradeInfo` to `ProductChangeInfo` because words 🤷‍♂️ 


[CF-1167]: https://revenuecats.atlassian.net/browse/CF-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ