### PR TITLE
Entitlement verification: Architecture and API

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/EntitlementVerificationModeAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/EntitlementVerificationModeAPI.java
@@ -1,0 +1,14 @@
+package com.revenuecat.apitester.java;
+
+import com.revenuecat.purchases.EntitlementVerificationMode;
+
+@SuppressWarnings({"unused"})
+final class EntitlementVerificationModeAPI {
+    static void check(final EntitlementVerificationMode verificationMode) {
+        switch (verificationMode) {
+            case DISABLED:
+            case INFORMATIONAL:
+            case ENFORCED:
+        }
+    }
+}

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 import com.revenuecat.purchases.BillingFeature;
 import com.revenuecat.purchases.CacheFetchPolicy;
 import com.revenuecat.purchases.CustomerInfo;
+import com.revenuecat.purchases.EntitlementVerificationMode;
 import com.revenuecat.purchases.LogHandler;
 import com.revenuecat.purchases.LogLevel;
 import com.revenuecat.purchases.Offerings;
@@ -135,6 +136,7 @@ final class PurchasesAPI {
                 .observerMode(false)
                 .service(executorService)
                 .diagnosticsEnabled(true)
+                .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
                 .build();
 
         Purchases.configure(build);

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesErrorAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesErrorAPI.java
@@ -39,6 +39,7 @@ final class PurchasesErrorAPI {
             case UnsupportedError:
             case EmptySubscriberAttributesError:
             case CustomerInfoError:
+            case SignatureVerificationError:
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementVerificationModeAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementVerificationModeAPI.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.apitester.kotlin
+
+import com.revenuecat.purchases.EntitlementVerificationMode
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class EntitlementVerificationModeAPI {
+    fun check(verificationMode: EntitlementVerificationMode) {
+        when (verificationMode) {
+            EntitlementVerificationMode.DISABLED,
+            EntitlementVerificationMode.INFORMATIONAL,
+            EntitlementVerificationMode.ENFORCED
+            -> {}
+        }.exhaustive
+    }
+}

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import com.revenuecat.purchases.BillingFeature
 import com.revenuecat.purchases.CacheFetchPolicy
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Offerings
@@ -208,6 +209,7 @@ private class PurchasesAPI {
             .observerMode(false)
             .service(executorService)
             .diagnosticsEnabled(true)
+            .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
             .build()
 
         Purchases.configure(build)

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesErrorAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesErrorAPI.kt
@@ -38,7 +38,8 @@ private class PurchasesErrorAPI {
             PurchasesErrorCode.ConfigurationError,
             PurchasesErrorCode.UnsupportedError,
             PurchasesErrorCode.EmptySubscriberAttributesError,
-            PurchasesErrorCode.CustomerInfoError
+            PurchasesErrorCode.CustomerInfoError,
+            PurchasesErrorCode.SignatureVerificationError
             -> {}
         }.exhaustive
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/Dispatcher.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Dispatcher.kt
@@ -7,6 +7,7 @@ package com.revenuecat.purchases.common
 
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.verification.SignatureVerificationException
 import org.json.JSONException
 import java.io.IOException
 import java.util.concurrent.ExecutorService
@@ -42,6 +43,8 @@ open class Dispatcher(
                 onError(e.toPurchasesError().also { errorLog(it) })
             } catch (e: SecurityException) {
                 // This can happen if a user disables the INTERNET permission.
+                onError(e.toPurchasesError().also { errorLog(it) })
+            } catch (e: SignatureVerificationException) {
                 onError(e.toPurchasesError().also { errorLog(it) })
             }
         }

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.common.verification.SignatureVerificationException
 import com.revenuecat.purchases.common.verification.SigningManager
+import com.revenuecat.purchases.common.verification.shouldVerify
 import com.revenuecat.purchases.strings.NetworkStrings
 import com.revenuecat.purchases.utils.filterNotNullValues
 import org.json.JSONException

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -7,6 +7,7 @@ package com.revenuecat.purchases.common
 
 import android.os.Build
 import androidx.annotation.VisibleForTesting
+import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.ETagManager
@@ -14,6 +15,8 @@ import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPRequest
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import com.revenuecat.purchases.common.verification.SignatureVerificationException
+import com.revenuecat.purchases.common.verification.SigningManager
 import com.revenuecat.purchases.strings.NetworkStrings
 import com.revenuecat.purchases.utils.filterNotNullValues
 import org.json.JSONException
@@ -28,6 +31,7 @@ import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
 import java.net.MalformedURLException
 import java.net.URL
+import java.net.URLConnection
 import java.util.Date
 import kotlin.time.Duration
 
@@ -35,6 +39,8 @@ class HTTPClient(
     private val appConfig: AppConfig,
     private val eTagManager: ETagManager,
     private val diagnosticsTrackerIfEnabled: DiagnosticsTracker?,
+    private val signingManagerIfEnabled: SigningManager?,
+    private val entitlementVerificationMode: EntitlementVerificationMode,
     private val dateProvider: DateProvider = DefaultDateProvider()
 ) {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -122,6 +128,7 @@ class HTTPClient(
         return callResult
     }
 
+    @Suppress("ThrowsCount")
     private fun performCall(
         baseURL: URL,
         endpoint: Endpoint,
@@ -133,10 +140,14 @@ class HTTPClient(
         val path = endpoint.getPath()
         val urlPathWithVersion = "/v1$path"
         val connection: HttpURLConnection
+        val shouldSignResponse = shouldSignResponse(endpoint)
+        val nonce: String?
         try {
             val fullURL = URL(baseURL, urlPathWithVersion)
 
-            val headers = getHeaders(requestHeaders, urlPathWithVersion, refreshETag)
+            nonce = if (shouldSignResponse) signingManagerIfEnabled?.createRandomNonce() else null
+            val headers = getHeaders(requestHeaders, urlPathWithVersion, refreshETag, nonce)
+
             val httpRequest = HTTPRequest(fullURL, headers, jsonBody)
 
             connection = getConnection(httpRequest)
@@ -162,12 +173,24 @@ class HTTPClient(
             throw IOException(NetworkStrings.HTTP_RESPONSE_PAYLOAD_NULL)
         }
 
+        val verificationStatus = if (shouldSignResponse && nonce != null) {
+            verifyResponse(path, connection, payload, nonce)
+        } else {
+            HTTPResult.VerificationStatus.NOT_VERIFIED
+        }
+
+        if (verificationStatus == HTTPResult.VerificationStatus.ERROR &&
+            entitlementVerificationMode == EntitlementVerificationMode.ENFORCED) {
+            throw SignatureVerificationException(path)
+        }
+
         return eTagManager.getHTTPResultFromCacheOrBackend(
             responseCode,
             payload,
-            connection,
+            getETagHeader(connection),
             urlPathWithVersion,
-            refreshETag
+            refreshETag,
+            verificationStatus
         )
     }
 
@@ -199,7 +222,8 @@ class HTTPClient(
     private fun getHeaders(
         authenticationHeaders: Map<String, String>,
         urlPath: String,
-        refreshETag: Boolean
+        refreshETag: Boolean,
+        nonce: String?
     ): Map<String, String> {
         return mapOf(
             "Content-Type" to "application/json",
@@ -211,7 +235,8 @@ class HTTPClient(
             "X-Client-Locale" to appConfig.languageTag,
             "X-Client-Version" to appConfig.versionName,
             "X-Client-Bundle-ID" to appConfig.packageName,
-            "X-Observer-Mode-Enabled" to if (appConfig.finishTransactions) "false" else "true"
+            "X-Observer-Mode-Enabled" to if (appConfig.finishTransactions) "false" else "true",
+            "X-Nonce" to nonce
         )
             .plus(authenticationHeaders)
             .plus(eTagManager.getETagHeader(urlPath, refreshETag))
@@ -260,4 +285,26 @@ class HTTPClient(
         Store.AMAZON -> "amazon"
         else -> "android"
     }
+
+    private fun shouldSignResponse(endpoint: Endpoint): Boolean {
+        return endpoint.supportsSignatureValidation && entitlementVerificationMode.shouldVerify
+    }
+
+    private fun verifyResponse(
+        urlPath: String,
+        connection: URLConnection,
+        payload: String?,
+        nonce: String
+    ): HTTPResult.VerificationStatus {
+        return signingManagerIfEnabled?.verifyResponse(
+            requestPath = urlPath,
+            signature = connection.getHeaderField(HTTPResult.SIGNATURE_HEADER_NAME),
+            nonce = nonce,
+            body = payload,
+            requestTime = connection.getHeaderField(HTTPResult.REQUEST_TIME_HEADER_NAME),
+            eTag = getETagHeader(connection),
+        ) ?: HTTPResult.VerificationStatus.NOT_VERIFIED
+    }
+
+    private fun getETagHeader(connection: URLConnection) = connection.getHeaderField(HTTPResult.ETAG_HEADER_NAME)
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/errors.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/errors.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.common
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.verification.SignatureVerificationException
 import org.json.JSONException
 import java.io.IOException
 
@@ -44,6 +45,9 @@ fun Exception.toPurchasesError(): PurchasesError {
         }
         is SecurityException -> {
             PurchasesError(PurchasesErrorCode.InsufficientPermissionsError, localizedMessage)
+        }
+        is SignatureVerificationException -> {
+            PurchasesError(PurchasesErrorCode.SignatureVerificationError, localizedMessage)
         }
         else -> PurchasesError(PurchasesErrorCode.UnknownError, localizedMessage)
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -28,4 +28,17 @@ sealed class Endpoint(val pathTemplate: String, val name: String) {
         ) : Endpoint("/receipts/amazon/%s/%s", "get_amazon_receipt") {
         override fun getPath() = pathTemplate.format(Uri.encode(userId), receiptId)
     }
+
+    val supportsSignatureValidation: Boolean
+        get() = when (this) {
+            is GetCustomerInfo,
+            LogIn,
+            PostReceipt ->
+                true
+            is GetAmazonReceipt,
+            is GetOfferings,
+            is PostAttributes,
+            PostDiagnostics ->
+                false
+        }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPRequest.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPRequest.kt
@@ -7,4 +7,8 @@ internal data class HTTPRequest(
     val fullURL: URL,
     val headers: Map<String, String>,
     val body: JSONObject?
-)
+) {
+    companion object {
+        const val ETAG_HEADER_NAME = "X-RevenueCat-ETag"
+    }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPResult.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPResult.kt
@@ -5,28 +5,19 @@ import org.json.JSONObject
 private const val SERIALIZATION_NAME_RESPONSE_CODE = "responseCode"
 private const val SERIALIZATION_NAME_PAYLOAD = "payload"
 private const val SERIALIZATION_NAME_ORIGIN = "origin"
+private const val SERIALIZATION_NAME_VERIFICATION_STATUS = "verificationStatus"
 
 data class HTTPResult(
     val responseCode: Int,
     val payload: String,
-    val origin: Origin
+    val origin: Origin,
+    val verificationStatus: VerificationStatus
 ) {
-    enum class Origin {
-        BACKEND, CACHE
-    }
-
-    val body: JSONObject = payload.takeIf { it.isNotBlank() }?.let { JSONObject(it) } ?: JSONObject()
-
-    fun serialize(): String {
-        val jsonObject = JSONObject().apply {
-            put(SERIALIZATION_NAME_RESPONSE_CODE, responseCode)
-            put(SERIALIZATION_NAME_PAYLOAD, payload)
-            put(SERIALIZATION_NAME_ORIGIN, origin.name)
-        }
-        return jsonObject.toString()
-    }
-
     companion object {
+        const val ETAG_HEADER_NAME = "X-RevenueCat-ETag"
+        const val SIGNATURE_HEADER_NAME = "X-Signature"
+        const val REQUEST_TIME_HEADER_NAME = "X-RevenueCat-Request-Time"
+
         fun deserialize(serialized: String): HTTPResult {
             val jsonObject = JSONObject(serialized)
             val responseCode = jsonObject.getInt(SERIALIZATION_NAME_RESPONSE_CODE)
@@ -36,7 +27,32 @@ data class HTTPResult(
             } else {
                 Origin.CACHE
             }
-            return HTTPResult(responseCode, payload, origin)
+            val verificationStatus: VerificationStatus = if (jsonObject.has(SERIALIZATION_NAME_VERIFICATION_STATUS)) {
+                VerificationStatus.valueOf(jsonObject.getString(SERIALIZATION_NAME_VERIFICATION_STATUS))
+            } else {
+                VerificationStatus.NOT_VERIFIED
+            }
+            return HTTPResult(responseCode, payload, origin, verificationStatus)
         }
+    }
+
+    enum class Origin {
+        BACKEND, CACHE
+    }
+
+    enum class VerificationStatus {
+        NOT_VERIFIED, SUCCESS, ERROR
+    }
+
+    val body: JSONObject = payload.takeIf { it.isNotBlank() }?.let { JSONObject(it) } ?: JSONObject()
+
+    fun serialize(): String {
+        val jsonObject = JSONObject().apply {
+            put(SERIALIZATION_NAME_RESPONSE_CODE, responseCode)
+            put(SERIALIZATION_NAME_PAYLOAD, payload)
+            put(SERIALIZATION_NAME_ORIGIN, origin.name)
+            put(SERIALIZATION_NAME_VERIFICATION_STATUS, verificationStatus.name)
+        }
+        return jsonObject.toString()
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationException.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationException.kt
@@ -1,0 +1,5 @@
+package com.revenuecat.purchases.common.verification
+
+class SignatureVerificationException(
+    apiPath: String
+) : Exception("Failed signature verification for request with path $apiPath")

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerifier.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerifier.kt
@@ -1,0 +1,21 @@
+package com.revenuecat.purchases.common.verification
+
+import android.util.Base64
+
+interface SignatureVerifier {
+    fun verify(signatureToVerify: ByteArray, messageToVerify: ByteArray): Boolean
+}
+
+class DefaultSignatureVerifier(publicKey: String = DEFAULT_PUBLIC_KEY) : SignatureVerifier {
+    companion object {
+        private const val DEFAULT_PUBLIC_KEY = "" // WIP: Add B64 encoded public key here
+    }
+
+    @Suppress("UnusedPrivateMember") // WIP: Remove suppress
+    private val publicKeyBytes = Base64.decode(publicKey, Base64.DEFAULT)
+
+    override fun verify(signatureToVerify: ByteArray, messageToVerify: ByteArray): Boolean {
+        // WIP: Add library
+        return true
+    }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -1,0 +1,60 @@
+package com.revenuecat.purchases.common.verification
+
+import android.util.Base64
+import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.strings.NetworkStrings
+import java.security.SecureRandom
+
+class SigningManager(
+    private val signatureVerifier: SignatureVerifier
+) {
+    private companion object {
+        const val NONCE_BYTES_SIZE = 12
+        const val SALT_BYTES_SIZE = 16
+    }
+
+    fun createRandomNonce(): String {
+        val bytes = ByteArray(NONCE_BYTES_SIZE)
+        SecureRandom().nextBytes(bytes)
+        return String(Base64.encode(bytes, Base64.DEFAULT))
+    }
+
+    @Suppress("LongParameterList", "ReturnCount")
+    fun verifyResponse(
+        requestPath: String,
+        signature: String?,
+        nonce: String,
+        body: String?,
+        requestTime: String?,
+        eTag: String?
+    ): HTTPResult.VerificationStatus {
+        if (signature == null) {
+            errorLog(NetworkStrings.VERIFICATION_MISSING_SIGNATURE.format(requestPath))
+            return HTTPResult.VerificationStatus.ERROR
+        }
+        if (requestTime == null) {
+            errorLog(NetworkStrings.VERIFICATION_MISSING_REQUEST_TIME.format(requestPath))
+            return HTTPResult.VerificationStatus.ERROR
+        }
+
+        // No body means NOT_MODIFIED response. We verify the etag instead.
+        val signatureMessage = body ?: eTag
+        if (signatureMessage == null) {
+            errorLog(NetworkStrings.VERIFICATION_MISSING_BODY_OR_ETAG.format(requestPath))
+            return HTTPResult.VerificationStatus.ERROR
+        }
+
+        val decodedNonce = Base64.decode(nonce, Base64.DEFAULT)
+        val decodedSignature = Base64.decode(signature, Base64.DEFAULT)
+        val saltBytes = decodedSignature.copyOfRange(0, SALT_BYTES_SIZE)
+        val signatureToVerify = decodedSignature.copyOfRange(SALT_BYTES_SIZE, decodedSignature.size)
+        val messageToVerify = saltBytes + decodedNonce + requestTime.toByteArray() + signatureMessage.toByteArray()
+        val verificationResult = signatureVerifier.verify(signatureToVerify, messageToVerify)
+        return if (verificationResult) {
+            HTTPResult.VerificationStatus.SUCCESS
+        } else {
+            HTTPResult.VerificationStatus.ERROR
+        }
+    }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/entitlementVerificationModeExtensions.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/entitlementVerificationModeExtensions.kt
@@ -1,0 +1,9 @@
+package com.revenuecat.purchases.common.verification
+
+import com.revenuecat.purchases.EntitlementVerificationMode
+
+val EntitlementVerificationMode.shouldVerify: Boolean
+    get() = when (this) {
+        EntitlementVerificationMode.DISABLED -> false
+        EntitlementVerificationMode.INFORMATIONAL, EntitlementVerificationMode.ENFORCED -> true
+    }

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -150,7 +150,7 @@ class BackendTest {
     ): CustomerInfo {
         val info: CustomerInfo = mockk()
 
-        val result = HTTPResult(responseCode, resultBody ?: "{}", HTTPResult.Origin.BACKEND)
+        val result = HTTPResult.createResult(responseCode, resultBody ?: "{}")
 
         if (shouldMockCustomerInfo) {
             every {

--- a/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -1,0 +1,104 @@
+package com.revenuecat.purchases.common
+
+import android.content.Context
+import com.revenuecat.purchases.EntitlementVerificationMode
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
+import com.revenuecat.purchases.common.networking.ETagManager
+import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.networking.HTTPRequest
+import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.verification.SigningManager
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import java.net.URL
+import java.util.Locale
+
+abstract class BaseHTTPClientTest {
+
+    protected lateinit var server: MockWebServer
+    protected lateinit var baseURL: URL
+
+    @Before
+    fun setup() {
+        server = MockWebServer()
+        baseURL = server.url("/v1").toUrl()
+    }
+
+    @After
+    fun teardown() {
+        server.shutdown()
+    }
+
+    protected val mockETagManager = mockk<ETagManager>().also {
+        every {
+            it.getETagHeader(any(), any())
+        } answers {
+            mapOf(HTTPRequest.ETAG_HEADER_NAME to "")
+        }
+    }
+    protected val expectedPlatformInfo = PlatformInfo("flutter", "2.1.0")
+    protected lateinit var client: HTTPClient
+
+    protected fun createClient(
+        appConfig: AppConfig = createAppConfig(),
+        diagnosticsTracker: DiagnosticsTracker? = null,
+        dateProvider: DateProvider = DefaultDateProvider(),
+        eTagManager: ETagManager = mockETagManager,
+        signingManagerIfEnabled: SigningManager? = null,
+        verificationMode: EntitlementVerificationMode = EntitlementVerificationMode.DISABLED,
+    ) = HTTPClient(
+        appConfig,
+        eTagManager,
+        diagnosticsTracker,
+        signingManagerIfEnabled,
+        verificationMode,
+        dateProvider
+    )
+
+    protected fun createAppConfig(
+        context: Context = createContext(),
+        observerMode: Boolean = false,
+        platformInfo: PlatformInfo = expectedPlatformInfo,
+        proxyURL: URL? = baseURL,
+        store: Store = Store.PLAY_STORE
+    ): AppConfig {
+        return AppConfig(
+            context = context,
+            observerMode = observerMode,
+            platformInfo = platformInfo,
+            proxyURL = proxyURL,
+            store = store
+        )
+    }
+
+    protected fun enqueue(
+        endpoint: Endpoint,
+        expectedResult: HTTPResult,
+        verificationStatus: HTTPResult.VerificationStatus = HTTPResult.VerificationStatus.NOT_VERIFIED
+    ) {
+        every {
+            mockETagManager.getHTTPResultFromCacheOrBackend(
+                expectedResult.responseCode,
+                expectedResult.payload,
+                eTagHeader = any(),
+                "/v1${endpoint.getPath()}",
+                refreshETag = false,
+                verificationStatus = verificationStatus
+            )
+        } returns expectedResult
+        val response = MockResponse().setBody(expectedResult.payload).setResponseCode(expectedResult.responseCode)
+        server.enqueue(response)
+    }
+
+    private fun createContext(): Context {
+        return mockk<Context>(relaxed = true).apply {
+            every { packageName } answers { "mock-package-name" }
+            every { getLocale() } returns Locale.US
+        }
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -1,0 +1,187 @@
+package com.revenuecat.purchases.common
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.EntitlementVerificationMode
+import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.verification.SignatureVerificationException
+import com.revenuecat.purchases.common.verification.SigningManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import okhttp3.mockwebserver.MockResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class HTTPClientVerificationTest: BaseHTTPClientTest() {
+
+    private lateinit var signingManager: SigningManager
+
+    private lateinit var informationalVerificationClient: HTTPClient
+    private lateinit var enforcedVerificationClient: HTTPClient
+
+    @Before
+    fun setupClient() {
+        signingManager = mockk()
+        every { signingManager.createRandomNonce() } returns "test-nonce"
+        informationalVerificationClient = createClient(
+            signingManagerIfEnabled = signingManager,
+            verificationMode = EntitlementVerificationMode.INFORMATIONAL
+        )
+        enforcedVerificationClient = createClient(
+            signingManagerIfEnabled = signingManager,
+            verificationMode = EntitlementVerificationMode.ENFORCED
+        )
+    }
+
+    @Test
+    fun `performRequest adds nonce header to request if endpoint supports it`() {
+        val endpoint = Endpoint.GetCustomerInfo("test-user-id")
+        enqueue(
+            endpoint = endpoint,
+            expectedResult = HTTPResult.createResult(verificationStatus = HTTPResult.VerificationStatus.SUCCESS),
+            verificationStatus = HTTPResult.VerificationStatus.SUCCESS
+        )
+
+        every {
+            signingManager.verifyResponse(any(), any(), any(), any(), any(), any())
+        } returns HTTPResult.VerificationStatus.SUCCESS
+
+        informationalVerificationClient.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            requestHeaders = emptyMap()
+        )
+
+        val recordedRequest = server.takeRequest()
+        assertThat(recordedRequest.getHeader("X-Nonce")).isEqualTo("test-nonce")
+    }
+
+    @Test
+    fun `performRequest on informationalClient verifies response with correct parameters when there is success`() {
+        val endpoint = Endpoint.GetCustomerInfo("test-user-id")
+        val expectedResult = HTTPResult.createResult(
+            verificationStatus = HTTPResult.VerificationStatus.SUCCESS,
+            payload = "{\"test-key\":\"test-value\"}"
+        )
+
+        every {
+            signingManager.verifyResponse(any(), any(), any(), any(), any(), any())
+        } returns HTTPResult.VerificationStatus.SUCCESS
+
+        every {
+            mockETagManager.getHTTPResultFromCacheOrBackend(
+                expectedResult.responseCode,
+                expectedResult.payload,
+                eTagHeader = any(),
+                "/v1${endpoint.getPath()}",
+                refreshETag = false,
+                verificationStatus = HTTPResult.VerificationStatus.SUCCESS
+            )
+        } returns expectedResult
+        val response = MockResponse()
+            .setBody(expectedResult.payload)
+            .setResponseCode(expectedResult.responseCode)
+            .setHeader(HTTPResult.SIGNATURE_HEADER_NAME, "test-signature")
+            .setHeader(HTTPResult.REQUEST_TIME_HEADER_NAME, 1234567890L)
+            .setHeader(HTTPResult.ETAG_HEADER_NAME, "test-etag")
+        server.enqueue(response)
+
+        val result = informationalVerificationClient.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+
+        assertThat(result.verificationStatus).isEqualTo(HTTPResult.VerificationStatus.SUCCESS)
+        verify(exactly = 1) {
+            signingManager.verifyResponse(
+                endpoint.getPath(),
+                "test-signature",
+                "test-nonce",
+                "{\"test-key\":\"test-value\"}",
+                "1234567890",
+                "test-etag"
+            )
+        }
+    }
+
+    @Test
+    fun `performRequest on informational client does not throw on verification error`() {
+        val endpoint = Endpoint.GetCustomerInfo("test-user-id")
+        enqueue(
+            endpoint = endpoint,
+            expectedResult = HTTPResult.createResult(verificationStatus = HTTPResult.VerificationStatus.ERROR),
+            verificationStatus = HTTPResult.VerificationStatus.ERROR
+        )
+
+        every {
+            signingManager.verifyResponse(any(), any(), any(), any(), any(), any())
+        } returns HTTPResult.VerificationStatus.ERROR
+
+        val result = informationalVerificationClient.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+        assertThat(result.verificationStatus).isEqualTo(HTTPResult.VerificationStatus.ERROR)
+    }
+
+    @Test(expected = SignatureVerificationException::class)
+    fun `performRequest on enforced client throws verification error`() {
+        val endpoint = Endpoint.GetCustomerInfo("test-user-id")
+        enqueue(
+            endpoint = endpoint,
+            expectedResult = HTTPResult.createResult(verificationStatus = HTTPResult.VerificationStatus.ERROR),
+            verificationStatus = HTTPResult.VerificationStatus.ERROR
+        )
+
+        every {
+            signingManager.verifyResponse(any(), any(), any(), any(), any(), any())
+        } returns HTTPResult.VerificationStatus.ERROR
+
+        enforcedVerificationClient.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+    }
+
+    fun `performRequest on enforced client does not throw if verification success`() {
+        val endpoint = Endpoint.GetCustomerInfo("test-user-id")
+        enqueue(
+            endpoint = endpoint,
+            expectedResult = HTTPResult.createResult(verificationStatus = HTTPResult.VerificationStatus.SUCCESS),
+            verificationStatus = HTTPResult.VerificationStatus.SUCCESS
+        )
+
+        every {
+            signingManager.verifyResponse(any(), any(), any(), any(), any(), any())
+        } returns HTTPResult.VerificationStatus.SUCCESS
+
+        val result = enforcedVerificationClient.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+        assertThat(result.verificationStatus).isEqualTo(HTTPResult.VerificationStatus.SUCCESS)
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPResultMockFactory.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPResultMockFactory.kt
@@ -1,0 +1,10 @@
+package com.revenuecat.purchases.common
+
+import com.revenuecat.purchases.common.networking.HTTPResult
+
+fun HTTPResult.Companion.createResult(
+    responseCode: Int = 200,
+    payload: String = "{}",
+    origin: HTTPResult.Origin = HTTPResult.Origin.BACKEND,
+    verificationStatus: HTTPResult.VerificationStatus = HTTPResult.VerificationStatus.NOT_VERIFIED
+) = HTTPResult(responseCode, payload, origin, verificationStatus)

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -58,4 +58,29 @@ class EndpointTest {
         val expectedPath = "/receipts/amazon/test%20user-id/test-receipt-id"
         assertThat(endpoint.getPath()).isEqualTo(expectedPath)
     }
+
+    @Test
+    fun `supportsSignatureValidation returns true for expected values`() {
+        val expectedSupportsValidationEndpoints = listOf(
+            Endpoint.GetCustomerInfo("test-user-id"),
+            Endpoint.LogIn,
+            Endpoint.PostReceipt
+        )
+        for (endpoint in expectedSupportsValidationEndpoints) {
+            assertThat(endpoint.supportsSignatureValidation).isTrue
+        }
+    }
+
+    @Test
+    fun `supportsSignatureValidation returns false for expected values`() {
+        val expectedNotSupportsValidationEndpoints = listOf(
+            Endpoint.GetAmazonReceipt("test-user-id", "test-receipt-id"),
+            Endpoint.GetOfferings("test-user-id"),
+            Endpoint.PostAttributes("test-user-id"),
+            Endpoint.PostDiagnostics
+        )
+        for (endpoint in expectedNotSupportsValidationEndpoints) {
+            assertThat(endpoint.supportsSignatureValidation).isFalse
+        }
+    }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
@@ -12,27 +12,44 @@ class HTTPResultTest {
 
     @Test
     fun `result is serialized correctly`() {
-        val result = HTTPResult(200, "{\"test-key\":\"test-value\"}", HTTPResult.Origin.BACKEND)
+        val result = HTTPResult(
+            200,
+            "{\"test-key\":\"test-value\"}",
+            HTTPResult.Origin.BACKEND,
+            HTTPResult.VerificationStatus.SUCCESS
+        )
         assertThat(result.serialize()).isEqualTo("{" +
             "\"responseCode\":200," +
             "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"," +
-            "\"origin\":\"BACKEND\"}"
+            "\"origin\":\"BACKEND\"," +
+            "\"verificationStatus\":\"SUCCESS\"}"
         )
     }
 
     @Test
     fun `result is deserialized correctly`() {
-        val expectedResult = HTTPResult(200, "{\"test-key\":\"test-value\"}", HTTPResult.Origin.BACKEND)
+        val expectedResult = HTTPResult(
+            200,
+            "{\"test-key\":\"test-value\"}",
+            HTTPResult.Origin.BACKEND,
+            HTTPResult.VerificationStatus.ERROR
+        )
         val result = HTTPResult.deserialize("{" +
             "\"responseCode\":200," +
             "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"," +
-            "\"origin\":\"BACKEND\"}")
+            "\"origin\":\"BACKEND\"," +
+            "\"verificationStatus\":\"ERROR\"}")
         assertThat(result).isEqualTo(expectedResult)
     }
 
     @Test
-    fun `result is defaults to CACHE origin if not part of serialized string`() {
-        val expectedResult = HTTPResult(200, "{\"test-key\":\"test-value\"}", HTTPResult.Origin.CACHE)
+    fun `result defaults to CACHE origin and NOT_VERIFIED verification status if not part of serialized string`() {
+        val expectedResult = HTTPResult(
+            200,
+            "{\"test-key\":\"test-value\"}",
+            HTTPResult.Origin.CACHE,
+            HTTPResult.VerificationStatus.NOT_VERIFIED
+        )
         val result = HTTPResult.deserialize("{" +
             "\"responseCode\":200," +
             "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"}")

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -39,6 +39,13 @@ class SigningManagerTest {
         assertThat(decodedNonce.size).isEqualTo(12)
     }
 
+    @Test
+    fun `createRandomNonce returns different nonce on each call`() {
+        val nonce1 = signingManager.createRandomNonce()
+        val nonce2 = signingManager.createRandomNonce()
+        assertThat(nonce1).isNotEqualTo(nonce2)
+    }
+
     // endregion
 
     // region verifyResponse

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -1,0 +1,99 @@
+package com.revenuecat.purchases.common.verification
+
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.networking.HTTPResult
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class SigningManagerTest {
+    private companion object {
+        const val TEST_SIGNATURE = "Jmax3TdnBIe0/zFeHT5KJrFNoGxWtQAOuYTjnEXDHa0z3/npDG9nRB4vrUkt/ZxVh7SU+P++O3LnObxeuz3tFAILs75bxIqXwp6LqdV7Tgo="
+        const val TEST_NONCE = "NYwvC+KDXzUq9pfg"
+    }
+
+    private lateinit var verifier: SignatureVerifier
+
+    private lateinit var signingManager: SigningManager
+
+    @Before
+    fun setUp() {
+        verifier = mockk()
+
+        signingManager = SigningManager(verifier)
+    }
+
+    // region createRandomNonce
+
+    @Test
+    fun `createRandomNonce returns 12 base64 encoded random bytes`() {
+        val nonce = signingManager.createRandomNonce()
+        val decodedNonce = Base64.decode(nonce, Base64.DEFAULT)
+        assertThat(decodedNonce.size).isEqualTo(12)
+    }
+
+    // endregion
+
+    // region verifyResponse
+
+    @Test
+    fun `verifyResponse returns error if signature is null`() {
+        val verificationStatus = callVerifyResponse(signature = null)
+        assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.ERROR)
+    }
+
+    @Test
+    fun `verifyResponse returns error if request time is null`() {
+        val verificationStatus = callVerifyResponse(requestTime = null)
+        assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.ERROR)
+    }
+
+    @Test
+    fun `verifyResponse returns error if both body and etag are null`() {
+        val verificationStatus = callVerifyResponse(body = null, eTag = null)
+        assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.ERROR)
+    }
+
+    @Test
+    fun `verifyResponse verifies if body is null`() {
+        every { verifier.verify(any(), any()) } returns true
+        val verificationStatus = callVerifyResponse(body = null)
+        assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.SUCCESS)
+    }
+
+    @Test
+    fun `verifyResponse returns success if verifier returns success for given parameters`() {
+        every { verifier.verify(any(), any()) } returns true
+        val verificationStatus = callVerifyResponse()
+        assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.SUCCESS)
+    }
+
+    @Test
+    fun `verifyResponse returns error if verifier returns success for given parameters`() {
+        every { verifier.verify(any(), any()) } returns false
+        val verificationStatus = callVerifyResponse()
+        assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.ERROR)
+    }
+
+    // endregion
+
+    // region Helpers
+
+    private fun callVerifyResponse(
+        requestPath: String = "test-url-path",
+        signature: String? = TEST_SIGNATURE,
+        nonce: String = TEST_NONCE,
+        body: String? = "{\"test-key\":\"test-value\"}",
+        requestTime: String? = "1234567890",
+        eTag: String? = "test-etag"
+    ) = signingManager.verifyResponse(requestPath, signature, nonce, body, requestTime, eTag)
+
+    // endregion
+}

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
@@ -64,7 +64,8 @@ class AmazonBackendTest {
     private var successfulResult = HTTPResult(
         responseCode = 200,
         payload = successfulRVSResponse(),
-        origin = HTTPResult.Origin.BACKEND
+        origin = HTTPResult.Origin.BACKEND,
+        verificationStatus = HTTPResult.VerificationStatus.NOT_VERIFIED
     )
     private var unsuccessfulResult = HTTPResult(
         responseCode = 401,
@@ -74,7 +75,8 @@ class AmazonBackendTest {
                     "Invalid API Key."
                 }
             """.trimIndent(),
-        origin = HTTPResult.Origin.BACKEND
+        origin = HTTPResult.Origin.BACKEND,
+        verificationStatus = HTTPResult.VerificationStatus.NOT_VERIFIED
     )
 
     @Test

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -399,7 +399,7 @@ class SubscriberAttributesPosterTests {
 
         if (clientException == null) {
             everyMockedCall answers {
-                HTTPResult(responseCode, expectedResultBody ?: "{}", HTTPResult.Origin.BACKEND)
+                createResult(responseCode, expectedResultBody ?: "{}")
             }
         } else {
             everyMockedCall throws clientException
@@ -419,11 +419,16 @@ class SubscriberAttributesPosterTests {
                 mapOf("Authorization" to "Bearer $API_KEY")
             )
         } answers {
-            HTTPResult(responseCode, responseBody, HTTPResult.Origin.BACKEND).also {
+            createResult(responseCode, responseBody).also {
                 every {
                     it.body.buildCustomerInfo()
                 } returns mockk()
             }
         }
     }
+
+    private fun createResult(
+        responseCode: Int,
+        responseBody: String
+    ) = HTTPResult(responseCode, responseBody, HTTPResult.Origin.BACKEND, HTTPResult.VerificationStatus.NOT_VERIFIED)
 }

--- a/public/src/main/java/com/revenuecat/purchases/EntitlementVerificationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementVerificationMode.kt
@@ -34,10 +34,4 @@ enum class EntitlementVerificationMode {
         val default: EntitlementVerificationMode
             get() = DISABLED
     }
-
-    val shouldVerify: Boolean
-        get() = when (this) {
-            DISABLED -> false
-            INFORMATIONAL, ENFORCED -> true
-        }
 }

--- a/public/src/main/java/com/revenuecat/purchases/EntitlementVerificationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementVerificationMode.kt
@@ -1,0 +1,43 @@
+package com.revenuecat.purchases
+
+/**
+ * Verification strictness levels for [EntitlementInfo].
+ */
+enum class EntitlementVerificationMode {
+    /**
+     * The SDK will not perform any entitlement verification.
+     */
+    DISABLED,
+
+    /**
+     * Enable entitlement verification.
+     *
+     * If verification fails, this will be indicated with [VerificationResult.FAILED]
+     * but parsing will not fail.
+     *
+     * This can be useful if you want to handle validation failures but still grant access.
+     */
+    INFORMATIONAL,
+
+    /**
+     * Enable entitlement verification.
+     *
+     * If verification fails when fetching [CustomerInfo] and/or [EntitlementInfos]
+     * the request will fail.
+     */
+    ENFORCED;
+
+    companion object {
+        /**
+         * Default entitlement verification mode.
+         */
+        val default: EntitlementVerificationMode
+            get() = DISABLED
+    }
+
+    val shouldVerify: Boolean
+        get() = when (this) {
+            DISABLED -> false
+            INFORMATIONAL, ENFORCED -> true
+        }
+}

--- a/public/src/main/java/com/revenuecat/purchases/errors.kt
+++ b/public/src/main/java/com/revenuecat/purchases/errors.kt
@@ -52,5 +52,6 @@ enum class PurchasesErrorCode(val code: Int, val description: String) {
     UnsupportedError(24, "There was a problem with the operation. Looks like we doesn't support " +
         "that yet. Check the underlying error for more details."),
     EmptySubscriberAttributesError(25, "A request for subscriber attributes returned none."),
-    CustomerInfoError(28, "There was a problem related to the customer info.")
+    CustomerInfoError(28, "There was a problem related to the customer info."),
+    SignatureVerificationError(36, "Request failed signature verification.")
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -13,6 +13,7 @@ open class PurchasesConfiguration(builder: Builder) {
     val store: Store
     val diagnosticsEnabled: Boolean
     val dangerousSettings: DangerousSettings
+    val verificationMode: EntitlementVerificationMode
 
     init {
         this.context = builder.context
@@ -22,6 +23,7 @@ open class PurchasesConfiguration(builder: Builder) {
         this.service = builder.service
         this.store = builder.store
         this.diagnosticsEnabled = builder.diagnosticsEnabled
+        this.verificationMode = builder.verificationMode
         this.dangerousSettings = builder.dangerousSettings
     }
 
@@ -35,6 +37,8 @@ open class PurchasesConfiguration(builder: Builder) {
         @set:JvmSynthetic @get:JvmSynthetic internal var service: ExecutorService? = null
         @set:JvmSynthetic @get:JvmSynthetic internal var store: Store = Store.PLAY_STORE
         @set:JvmSynthetic @get:JvmSynthetic internal var diagnosticsEnabled: Boolean = false
+        @set:JvmSynthetic @get:JvmSynthetic internal var verificationMode: EntitlementVerificationMode =
+            EntitlementVerificationMode.default
         @set:JvmSynthetic @get:JvmSynthetic internal var dangerousSettings: DangerousSettings = DangerousSettings()
 
         fun appUserID(appUserID: String?) = apply {
@@ -61,6 +65,15 @@ open class PurchasesConfiguration(builder: Builder) {
          */
         fun diagnosticsEnabled(diagnosticsEnabled: Boolean) = apply {
             this.diagnosticsEnabled = diagnosticsEnabled
+        }
+
+        // WIP: Make method public once we are ready to support entitlements.
+        /**
+         * Defines how strict [EntitlementInfo] verification ought to be.
+         * Default is [EntitlementVerificationMode.DISABLED].
+         */
+        internal fun entitlementVerificationMode(entitlementVerificationMode: EntitlementVerificationMode) = apply {
+            this.verificationMode = entitlementVerificationMode
         }
 
         /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -67,12 +67,11 @@ open class PurchasesConfiguration(builder: Builder) {
             this.diagnosticsEnabled = diagnosticsEnabled
         }
 
-        // WIP: Make method public once we are ready to support entitlements.
         /**
          * Defines how strict [EntitlementInfo] verification ought to be.
          * Default is [EntitlementVerificationMode.DISABLED].
          */
-        internal fun entitlementVerificationMode(entitlementVerificationMode: EntitlementVerificationMode) = apply {
+        fun entitlementVerificationMode(entitlementVerificationMode: EntitlementVerificationMode) = apply {
             this.verificationMode = entitlementVerificationMode
         }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.ETagManager
 import com.revenuecat.purchases.common.verification.DefaultSignatureVerifier
 import com.revenuecat.purchases.common.verification.SigningManager
+import com.revenuecat.purchases.common.verification.shouldVerify
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesPoster

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -20,6 +20,8 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsFileHelper
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.ETagManager
+import com.revenuecat.purchases.common.verification.DefaultSignatureVerifier
+import com.revenuecat.purchases.common.verification.SigningManager
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesPoster
@@ -71,12 +73,18 @@ internal class PurchasesFactory(
                 )
             }
 
+            val signingManager = if (verificationMode.shouldVerify) {
+                SigningManager(DefaultSignatureVerifier())
+            } else {
+                null
+            }
+
             val backend = Backend(
                 apiKey,
                 appConfig,
                 dispatcher,
                 diagnosticsDispatcher,
-                HTTPClient(appConfig, eTagManager, diagnosticsTracker)
+                HTTPClient(appConfig, eTagManager, diagnosticsTracker, signingManager, verificationMode)
             )
             val subscriberAttributesPoster = SubscriberAttributesPoster(backend)
 

--- a/strings/src/main/java/com/revenuecat/purchases/strings/NetworkStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/NetworkStrings.kt
@@ -10,4 +10,9 @@ object NetworkStrings {
         "Returning result from backend: %s"
     const val SAME_CALL_ALREADY_IN_PROGRESS = "Same call already in progress, adding to callbacks map with key: %s"
     const val PROBLEM_CONNECTING = "Unable to start a network connection due to a network configuration issue: %s"
+    const val VERIFICATION_MISSING_SIGNATURE = "Verification: Request to '%s' requires a signature but none provided."
+    const val VERIFICATION_MISSING_REQUEST_TIME = "Verification: Request to '%s' requires a request time" +
+        " but none provided."
+    const val VERIFICATION_MISSING_BODY_OR_ETAG = "Verification: Request to '%s' requires a body or etag" +
+        " but none provided."
 }


### PR DESCRIPTION
### Description
This PR has the initial changes to support entitlement verification in the Android SDK including the basic architecture and wiring.
I worked on several things so this got bigger than I wanted, sorry about that! Most of the changes are on tests though.

### Changes:
- Add nonce header to request when entitlement verification enabled and endpoint supports it.
- Add `VerificationStatus` to `HTTPResult` indicating whether the verification happened and whether it was successful or not.
- Error request when VerificationMode is `ENFORCED` and signature verification fails.
- Add public API to enable/disable entitlement verification. Current supported modes:
   - `DISABLED`: No verification will be performed
   - `INFORMATIONAL`: Verification will be performed but entitlements will still be granted on error. We will log an error and put this state in the `EntitlementInfo` in a future PR.
   - `ENFORCED`: Verification will be performed and cause the request to fail on verification error, so no entitlements will be granted.


### Remaining tasks (in followup PRs):
- [ ] Add verification library and perform actual verification
- [ ] Add verification status to EntitlementInfo
- [ ] Update response cache with request time 
