### PR TITLE
Entitlement verification: Add Tink dependency to perform signature verification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
     ext.annotationVersion = "1.3.0"
     ext.androidxCoreVersion = "1.8.0"
     ext.mockwebserverVersion = "4.2.0"
+    ext.tinkVersion = "1.8.0"
 
     repositories {
         mavenCentral()

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation project(":strings")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
+    implementation 'com.google.crypto.tink:tink-android:1.8.0'
     latestDependenciesImplementation "com.android.billingclient:billing:$billing4Version"
     unityIAPCompileOnly "com.android.billingclient:billing:$billing4Version"
     testImplementation project(":test-utils")

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation project(":strings")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
-    implementation 'com.google.crypto.tink:tink-android:1.8.0'
+    implementation "com.google.crypto.tink:tink-android:$tinkVersion"
     latestDependenciesImplementation "com.android.billingclient:billing:$billing4Version"
     unityIAPCompileOnly "com.android.billingclient:billing:$billing4Version"
     testImplementation project(":test-utils")

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerifier.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerifier.kt
@@ -21,7 +21,7 @@ class DefaultSignatureVerifier(publicKey: String = DEFAULT_PUBLIC_KEY) : Signatu
         return try {
             verifier.verify(signatureToVerify, messageToVerify)
             true
-        } catch (e: GeneralSecurityException) {
+        } catch (_: GeneralSecurityException) {
             false
         }
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerifier.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerifier.kt
@@ -1,6 +1,8 @@
 package com.revenuecat.purchases.common.verification
 
 import android.util.Base64
+import com.google.crypto.tink.subtle.Ed25519Verify
+import java.security.GeneralSecurityException
 
 interface SignatureVerifier {
     fun verify(signatureToVerify: ByteArray, messageToVerify: ByteArray): Boolean
@@ -8,14 +10,19 @@ interface SignatureVerifier {
 
 class DefaultSignatureVerifier(publicKey: String = DEFAULT_PUBLIC_KEY) : SignatureVerifier {
     companion object {
-        private const val DEFAULT_PUBLIC_KEY = "" // WIP: Add B64 encoded public key here
+        private const val DEFAULT_PUBLIC_KEY = "UC1upXWg5QVmyOSwozp755xLqquBKjjU+di6U8QhMlM="
     }
 
-    @Suppress("UnusedPrivateMember") // WIP: Remove suppress
     private val publicKeyBytes = Base64.decode(publicKey, Base64.DEFAULT)
 
+    private val verifier = Ed25519Verify(publicKeyBytes)
+
     override fun verify(signatureToVerify: ByteArray, messageToVerify: ByteArray): Boolean {
-        // WIP: Add library
-        return true
+        return try {
+            verifier.verify(signatureToVerify, messageToVerify)
+            true
+        } catch (e: GeneralSecurityException) {
+            false
+        }
     }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/DefaultSignatureVerifierTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/DefaultSignatureVerifierTest.kt
@@ -1,0 +1,53 @@
+package com.revenuecat.purchases.common.verification
+
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class DefaultSignatureVerifierTest {
+
+    private val testPublicKey = "WEvg1j3R0lppwHRfLup/lzYZMQMEj5csDHeQe/YP1p4="
+
+    private lateinit var verifier: DefaultSignatureVerifier
+
+    @Before
+    fun setUp() {
+        verifier = DefaultSignatureVerifier(testPublicKey)
+    }
+
+    @Test
+    fun `verify verifies correct message and signature`() {
+        val signature = Base64.decode(
+            "M8K3Bs4jsmiJXOovn7gQHMWs+9XxB9JQkxyAB7iEVo4z+vLOhkoZIyexckvMPJ9b\nUmgwIYkvl6ojWx/bbu2CBw==",
+            Base64.DEFAULT
+        )
+        val message = "Test message".toByteArray()
+        assertThat(verifier.verify(signature, message)).isTrue
+    }
+
+    @Test
+    fun `verify verifies incorrect message`() {
+        val signature = Base64.decode(
+            "M8K3Bs4jsmiJXOovn7gQHMWs+9XxB9JQkxyAB7iEVo4z+vLOhkoZIyexckvMPJ9b\nUmgwIYkvl6ojWx/bbu2CBw==",
+            Base64.DEFAULT
+        )
+        val message = "Test message2".toByteArray()
+        assertThat(verifier.verify(signature, message)).isFalse
+    }
+
+    @Test
+    fun `verify verifies incorrect signature`() {
+        val signature = Base64.decode(
+            "M8K3Bs4jsmiJXOovn7gQHMWs+9XxB9JQkxyAB7iEVo4z+vLOhkoZIyexckvMPJ9b\nUmgwIYkvl6ojWx/bbu3CBw==",
+            Base64.DEFAULT
+        )
+        val message = "Test message".toByteArray()
+        assertThat(verifier.verify(signature, message)).isFalse
+    }
+}


### PR DESCRIPTION
### Description
This PR adds Tink as a dependency to perform signature verification. It also adds our production public key so we can verify responses from the backend.
