### PR TITLE
Entitlement verification: Refactor SigningManager to make it not-nullable

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
@@ -29,4 +29,11 @@ sealed class SignatureVerificationMode {
             is Enforced ->
                 true
         }
+
+    val verifier: SignatureVerifier?
+        get() = when (this) {
+            is SignatureVerificationMode.Disabled -> null
+            is SignatureVerificationMode.Informational -> signatureVerifier
+            is SignatureVerificationMode.Enforced -> signatureVerifier
+        }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
@@ -1,0 +1,32 @@
+package com.revenuecat.purchases.common.verification
+
+import com.revenuecat.purchases.EntitlementVerificationMode
+
+sealed class SignatureVerificationMode {
+    companion object {
+        fun fromEntitlementVerificationMode(
+            verificationMode: EntitlementVerificationMode,
+            signatureVerifier: SignatureVerifier? = null
+        ): SignatureVerificationMode {
+            return when (verificationMode) {
+                EntitlementVerificationMode.DISABLED -> Disabled
+                EntitlementVerificationMode.INFORMATIONAL ->
+                    Informational(signatureVerifier ?: DefaultSignatureVerifier())
+                EntitlementVerificationMode.ENFORCED ->
+                    Enforced(signatureVerifier ?: DefaultSignatureVerifier())
+            }
+        }
+    }
+    object Disabled : SignatureVerificationMode()
+    data class Informational(val signatureVerifier: SignatureVerifier) : SignatureVerificationMode()
+    data class Enforced(val signatureVerifier: SignatureVerifier) : SignatureVerificationMode()
+
+    val shouldVerify: Boolean
+        get() = when (this) {
+            Disabled ->
+                false
+            is Informational,
+            is Enforced ->
+                true
+        }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -2,16 +2,22 @@ package com.revenuecat.purchases.common.verification
 
 import android.util.Base64
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.strings.NetworkStrings
 import java.security.SecureRandom
 
 class SigningManager(
-    private val signatureVerifier: SignatureVerifier
+    val signatureVerificationMode: SignatureVerificationMode
 ) {
     private companion object {
         const val NONCE_BYTES_SIZE = 12
         const val SALT_BYTES_SIZE = 16
+    }
+
+    fun shouldVerifyEndpoint(endpoint: Endpoint): Boolean {
+        return endpoint.supportsSignatureValidation && signatureVerificationMode.shouldVerify
     }
 
     fun createRandomNonce(): String {
@@ -22,26 +28,28 @@ class SigningManager(
 
     @Suppress("LongParameterList", "ReturnCount")
     fun verifyResponse(
-        requestPath: String,
+        urlPath: String,
+        responseCode: Int,
         signature: String?,
         nonce: String,
         body: String?,
         requestTime: String?,
         eTag: String?
     ): HTTPResult.VerificationStatus {
+        val signatureVerifier = getVerifier() ?: return HTTPResult.VerificationStatus.NOT_VERIFIED
+
         if (signature == null) {
-            errorLog(NetworkStrings.VERIFICATION_MISSING_SIGNATURE.format(requestPath))
+            errorLog(NetworkStrings.VERIFICATION_MISSING_SIGNATURE.format(urlPath))
             return HTTPResult.VerificationStatus.ERROR
         }
         if (requestTime == null) {
-            errorLog(NetworkStrings.VERIFICATION_MISSING_REQUEST_TIME.format(requestPath))
+            errorLog(NetworkStrings.VERIFICATION_MISSING_REQUEST_TIME.format(urlPath))
             return HTTPResult.VerificationStatus.ERROR
         }
 
-        // No body means NOT_MODIFIED response. We verify the etag instead.
-        val signatureMessage = body ?: eTag
+        val signatureMessage = getSignatureMessage(responseCode, body, eTag)
         if (signatureMessage == null) {
-            errorLog(NetworkStrings.VERIFICATION_MISSING_BODY_OR_ETAG.format(requestPath))
+            errorLog(NetworkStrings.VERIFICATION_MISSING_BODY_OR_ETAG.format(urlPath))
             return HTTPResult.VerificationStatus.ERROR
         }
 
@@ -51,10 +59,23 @@ class SigningManager(
         val signatureToVerify = decodedSignature.copyOfRange(SALT_BYTES_SIZE, decodedSignature.size)
         val messageToVerify = saltBytes + decodedNonce + requestTime.toByteArray() + signatureMessage.toByteArray()
         val verificationResult = signatureVerifier.verify(signatureToVerify, messageToVerify)
+
         return if (verificationResult) {
             HTTPResult.VerificationStatus.SUCCESS
         } else {
             HTTPResult.VerificationStatus.ERROR
         }
+    }
+
+    private fun getVerifier(): SignatureVerifier? {
+        return when (signatureVerificationMode) {
+            is SignatureVerificationMode.Disabled -> null
+            is SignatureVerificationMode.Informational -> signatureVerificationMode.signatureVerifier
+            is SignatureVerificationMode.Enforced -> signatureVerificationMode.signatureVerifier
+        }
+    }
+
+    private fun getSignatureMessage(responseCode: Int, body: String?, eTag: String?): String? {
+        return if (responseCode == RCHTTPStatusCodes.NOT_MODIFIED) eTag else body
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -36,7 +36,7 @@ class SigningManager(
         requestTime: String?,
         eTag: String?
     ): HTTPResult.VerificationStatus {
-        val signatureVerifier = getVerifier() ?: return HTTPResult.VerificationStatus.NOT_VERIFIED
+        val signatureVerifier = signatureVerificationMode.verifier ?: return HTTPResult.VerificationStatus.NOT_VERIFIED
 
         if (signature == null) {
             errorLog(NetworkStrings.VERIFICATION_MISSING_SIGNATURE.format(urlPath))
@@ -65,14 +65,6 @@ class SigningManager(
         } else {
             errorLog(NetworkStrings.VERIFICATION_ERROR)
             HTTPResult.VerificationStatus.ERROR
-        }
-    }
-
-    private fun getVerifier(): SignatureVerifier? {
-        return when (signatureVerificationMode) {
-            is SignatureVerificationMode.Disabled -> null
-            is SignatureVerificationMode.Informational -> signatureVerificationMode.signatureVerifier
-            is SignatureVerificationMode.Enforced -> signatureVerificationMode.signatureVerifier
         }
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -63,6 +63,7 @@ class SigningManager(
         return if (verificationResult) {
             HTTPResult.VerificationStatus.SUCCESS
         } else {
+            errorLog(NetworkStrings.VERIFICATION_ERROR)
             HTTPResult.VerificationStatus.ERROR
         }
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/entitlementVerificationModeExtensions.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/entitlementVerificationModeExtensions.kt
@@ -1,9 +1,0 @@
-package com.revenuecat.purchases.common.verification
-
-import com.revenuecat.purchases.EntitlementVerificationMode
-
-val EntitlementVerificationMode.shouldVerify: Boolean
-    get() = when (this) {
-        EntitlementVerificationMode.DISABLED -> false
-        EntitlementVerificationMode.INFORMATIONAL, EntitlementVerificationMode.ENFORCED -> true
-    }

--- a/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.common
 
 import android.content.Context
-import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.ETagManager
@@ -22,6 +21,8 @@ abstract class BaseHTTPClientTest {
 
     protected lateinit var server: MockWebServer
     protected lateinit var baseURL: URL
+
+    protected lateinit var mockSigningManager: SigningManager
 
     @Before
     fun setup() {
@@ -49,14 +50,12 @@ abstract class BaseHTTPClientTest {
         diagnosticsTracker: DiagnosticsTracker? = null,
         dateProvider: DateProvider = DefaultDateProvider(),
         eTagManager: ETagManager = mockETagManager,
-        signingManagerIfEnabled: SigningManager? = null,
-        verificationMode: EntitlementVerificationMode = EntitlementVerificationMode.DISABLED,
+        signingManager: SigningManager? = null
     ) = HTTPClient(
         appConfig,
         eTagManager,
         diagnosticsTracker,
-        signingManagerIfEnabled,
-        verificationMode,
+        signingManager ?: mockSigningManager,
         dateProvider
     )
 

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.utils.Responses
 import io.mockk.Runs
 import io.mockk.every
@@ -33,6 +34,8 @@ class HTTPClientTest: BaseHTTPClientTest() {
 
     @Before
     fun setupClient() {
+        mockSigningManager = mockk()
+        every { mockSigningManager.shouldVerifyEndpoint(any()) } returns false
         client = createClient()
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -4,7 +4,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.common.verification.SignatureVerificationException
+import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
 import io.mockk.every
 import io.mockk.mockk
@@ -20,23 +22,13 @@ import org.robolectric.annotation.Config
 @Config(manifest = Config.NONE)
 class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
-    private lateinit var signingManager: SigningManager
-
-    private lateinit var informationalVerificationClient: HTTPClient
-    private lateinit var enforcedVerificationClient: HTTPClient
-
     @Before
     fun setupClient() {
-        signingManager = mockk()
-        every { signingManager.createRandomNonce() } returns "test-nonce"
-        informationalVerificationClient = createClient(
-            signingManagerIfEnabled = signingManager,
-            verificationMode = EntitlementVerificationMode.INFORMATIONAL
-        )
-        enforcedVerificationClient = createClient(
-            signingManagerIfEnabled = signingManager,
-            verificationMode = EntitlementVerificationMode.ENFORCED
-        )
+        mockSigningManager = mockk()
+        every { mockSigningManager.signatureVerificationMode } returns mockk<SignatureVerificationMode.Informational>()
+        every { mockSigningManager.shouldVerifyEndpoint(any()) } returns true
+        every { mockSigningManager.createRandomNonce() } returns "test-nonce"
+        client = createClient()
     }
 
     @Test
@@ -49,10 +41,10 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         )
 
         every {
-            signingManager.verifyResponse(any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
         } returns HTTPResult.VerificationStatus.SUCCESS
 
-        informationalVerificationClient.performRequest(
+        client.performRequest(
             baseURL,
             endpoint,
             body = null,
@@ -64,20 +56,51 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
     }
 
     @Test
+    fun `performRequest does not verify response on unsupported endpoints`() {
+        val endpoint = Endpoint.PostDiagnostics
+        every { mockSigningManager.shouldVerifyEndpoint(endpoint) } returns false
+        val expectedResult = HTTPResult.createResult(
+            verificationStatus = HTTPResult.VerificationStatus.NOT_VERIFIED,
+            payload = "{\"test-key\":\"test-value\"}"
+        )
+
+        enqueue(
+            endpoint = endpoint,
+            expectedResult = expectedResult,
+            verificationStatus = HTTPResult.VerificationStatus.NOT_VERIFIED
+        )
+
+        val result = client.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+
+        assertThat(result.verificationStatus).isEqualTo(HTTPResult.VerificationStatus.NOT_VERIFIED)
+        verify(exactly = 0) {
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
     fun `performRequest on informationalClient verifies response with correct parameters when there is success`() {
         val endpoint = Endpoint.GetCustomerInfo("test-user-id")
         val expectedResult = HTTPResult.createResult(
             verificationStatus = HTTPResult.VerificationStatus.SUCCESS,
             payload = "{\"test-key\":\"test-value\"}"
         )
+        val responseCode = expectedResult.responseCode
 
         every {
-            signingManager.verifyResponse(any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
         } returns HTTPResult.VerificationStatus.SUCCESS
 
         every {
             mockETagManager.getHTTPResultFromCacheOrBackend(
-                expectedResult.responseCode,
+                responseCode,
                 expectedResult.payload,
                 eTagHeader = any(),
                 "/v1${endpoint.getPath()}",
@@ -87,13 +110,13 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         } returns expectedResult
         val response = MockResponse()
             .setBody(expectedResult.payload)
-            .setResponseCode(expectedResult.responseCode)
+            .setResponseCode(responseCode)
             .setHeader(HTTPResult.SIGNATURE_HEADER_NAME, "test-signature")
             .setHeader(HTTPResult.REQUEST_TIME_HEADER_NAME, 1234567890L)
             .setHeader(HTTPResult.ETAG_HEADER_NAME, "test-etag")
         server.enqueue(response)
 
-        val result = informationalVerificationClient.performRequest(
+        val result = client.performRequest(
             baseURL,
             endpoint,
             body = null,
@@ -104,8 +127,9 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
         assertThat(result.verificationStatus).isEqualTo(HTTPResult.VerificationStatus.SUCCESS)
         verify(exactly = 1) {
-            signingManager.verifyResponse(
+            mockSigningManager.verifyResponse(
                 endpoint.getPath(),
+                responseCode,
                 "test-signature",
                 "test-nonce",
                 "{\"test-key\":\"test-value\"}",
@@ -125,10 +149,10 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         )
 
         every {
-            signingManager.verifyResponse(any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
         } returns HTTPResult.VerificationStatus.ERROR
 
-        val result = informationalVerificationClient.performRequest(
+        val result = client.performRequest(
             baseURL,
             endpoint,
             body = null,
@@ -141,6 +165,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
     @Test(expected = SignatureVerificationException::class)
     fun `performRequest on enforced client throws verification error`() {
+        every { mockSigningManager.signatureVerificationMode } returns mockk<SignatureVerificationMode.Enforced>()
         val endpoint = Endpoint.GetCustomerInfo("test-user-id")
         enqueue(
             endpoint = endpoint,
@@ -149,10 +174,10 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         )
 
         every {
-            signingManager.verifyResponse(any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
         } returns HTTPResult.VerificationStatus.ERROR
 
-        enforcedVerificationClient.performRequest(
+        client.performRequest(
             baseURL,
             endpoint,
             body = null,
@@ -162,6 +187,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         server.takeRequest()
     }
 
+    @Test
     fun `performRequest on enforced client does not throw if verification success`() {
         val endpoint = Endpoint.GetCustomerInfo("test-user-id")
         enqueue(
@@ -171,10 +197,10 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         )
 
         every {
-            signingManager.verifyResponse(any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
         } returns HTTPResult.VerificationStatus.SUCCESS
 
-        val result = enforcedVerificationClient.performRequest(
+        val result = client.performRequest(
             baseURL,
             endpoint,
             body = null,

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SignatureVerificationModeTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SignatureVerificationModeTest.kt
@@ -1,0 +1,34 @@
+package com.revenuecat.purchases.common.verification
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.EntitlementVerificationMode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class SignatureVerificationModeTest {
+
+    @Test
+    fun `fromEntitlementVerificationMode transforms verification mode correctly`() {
+        assertThat(
+            SignatureVerificationMode.fromEntitlementVerificationMode(EntitlementVerificationMode.DISABLED)
+        ).isEqualTo(SignatureVerificationMode.Disabled)
+        assertThat(
+            SignatureVerificationMode.fromEntitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
+        ).isInstanceOf(SignatureVerificationMode.Informational::class.java)
+        assertThat(
+            SignatureVerificationMode.fromEntitlementVerificationMode(EntitlementVerificationMode.ENFORCED)
+        ).isInstanceOf(SignatureVerificationMode.Enforced::class.java)
+    }
+
+    @Test
+    fun `shouldVerify has correct values for all the verification modes`() {
+        val signatureVerifier = DefaultSignatureVerifier()
+        assertThat(SignatureVerificationMode.Disabled.shouldVerify).isFalse
+        assertThat(SignatureVerificationMode.Informational(signatureVerifier).shouldVerify).isTrue
+        assertThat(SignatureVerificationMode.Enforced(signatureVerifier).shouldVerify).isTrue
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -2,7 +2,9 @@ package com.revenuecat.purchases.common.verification
 
 import android.util.Base64
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -16,28 +18,61 @@ import org.robolectric.annotation.Config
 class SigningManagerTest {
     private lateinit var verifier: SignatureVerifier
 
-    private lateinit var signingManager: SigningManager
+    private lateinit var disabledSigningManager: SigningManager
+    private lateinit var informationalSigningManager: SigningManager
+    private lateinit var enforcedSigningManager: SigningManager
 
     @Before
     fun setUp() {
         verifier = mockk()
 
-        signingManager = SigningManager(verifier)
+        disabledSigningManager = SigningManager(SignatureVerificationMode.Disabled)
+        informationalSigningManager = SigningManager(SignatureVerificationMode.Informational(verifier))
+        enforcedSigningManager = SigningManager(SignatureVerificationMode.Enforced(verifier))
     }
+
+    // region shouldVerifyEndpoint
+
+    @Test
+    fun `shouldVerifyEndpoint returns false if endpoint supports validation but verification mode disabled`() {
+        assertThat(disabledSigningManager.shouldVerifyEndpoint(Endpoint.PostReceipt)).isFalse
+    }
+
+    @Test
+    fun `shouldVerifyEndpoint returns true if endpoint supports validation and verification mode informational`() {
+        assertThat(informationalSigningManager.shouldVerifyEndpoint(Endpoint.PostReceipt)).isTrue
+    }
+
+    @Test
+    fun `shouldVerifyEndpoint returns true if endpoint supports validation and verification mode enforced`() {
+        assertThat(enforcedSigningManager.shouldVerifyEndpoint(Endpoint.PostReceipt)).isTrue
+    }
+
+    @Test
+    fun `shouldVerifyEndpoint returns false if endpoint does not support validation and mode informational`() {
+        assertThat(informationalSigningManager.shouldVerifyEndpoint(Endpoint.PostDiagnostics)).isFalse
+    }
+
+    @Test
+    fun `shouldVerifyEndpoint returns false if endpoint does not support validation and mode enforced`() {
+        assertThat(enforcedSigningManager.shouldVerifyEndpoint(Endpoint.PostDiagnostics)).isFalse
+    }
+
+    // endpoint
 
     // region createRandomNonce
 
     @Test
     fun `createRandomNonce returns 12 base64 encoded random bytes`() {
-        val nonce = signingManager.createRandomNonce()
+        val nonce = disabledSigningManager.createRandomNonce()
         val decodedNonce = Base64.decode(nonce, Base64.DEFAULT)
         assertThat(decodedNonce.size).isEqualTo(12)
     }
 
     @Test
     fun `createRandomNonce returns different nonce on each call`() {
-        val nonce1 = signingManager.createRandomNonce()
-        val nonce2 = signingManager.createRandomNonce()
+        val nonce1 = disabledSigningManager.createRandomNonce()
+        val nonce2 = disabledSigningManager.createRandomNonce()
         assertThat(nonce1).isNotEqualTo(nonce2)
     }
 
@@ -46,67 +81,101 @@ class SigningManagerTest {
     // region verifyResponse
 
     @Test
+    fun `verifyResponse returns NOT_VERIFIED if verification mode disabled`() {
+        val verificationStatus = callVerifyResponse(disabledSigningManager)
+        assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.NOT_VERIFIED)
+    }
+
+    @Test
     fun `verifyResponse returns error if signature is null`() {
-        val verificationStatus = callVerifyResponse(signature = null)
+        val verificationStatus = callVerifyResponse(informationalSigningManager, signature = null)
         assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.ERROR)
     }
 
     @Test
     fun `verifyResponse returns error if request time is null`() {
-        val verificationStatus = callVerifyResponse(requestTime = null)
+        val verificationStatus = callVerifyResponse(informationalSigningManager, requestTime = null)
         assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.ERROR)
     }
 
     @Test
     fun `verifyResponse returns error if both body and etag are null`() {
-        val verificationStatus = callVerifyResponse(body = null, eTag = null)
+        val verificationStatus = callVerifyResponse(informationalSigningManager, body = null, eTag = null)
         assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.ERROR)
     }
 
     @Test
-    fun `verifyResponse verifies if body is null`() {
+    fun `verifyResponse returns error if status code success and body is empty`() {
+        val verificationStatus = callVerifyResponse(informationalSigningManager, body = null)
+        assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.ERROR)
+    }
+
+    @Test
+    fun `verifyResponse returns error if status code not modified and etag is empty`() {
+        val verificationStatus = callVerifyResponse(
+            informationalSigningManager,
+            responseCode = RCHTTPStatusCodes.NOT_MODIFIED,
+            eTag = null
+        )
+        assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.ERROR)
+    }
+
+    @Test
+    fun `verifyResponse returns success if verifier returns success for not modified `() {
         every { verifier.verify(any(), any()) } returns true
-        val verificationStatus = callVerifyResponse(body = null)
+        val verificationStatus = callVerifyResponse(
+            informationalSigningManager,
+            responseCode = RCHTTPStatusCodes.NOT_MODIFIED,
+            body = null,
+            eTag = "test-etag"
+        )
         assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.SUCCESS)
     }
 
     @Test
     fun `verifyResponse returns success if verifier returns success for given parameters`() {
         every { verifier.verify(any(), any()) } returns true
-        val verificationStatus = callVerifyResponse()
+        val verificationStatus = callVerifyResponse(informationalSigningManager)
         assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.SUCCESS)
     }
 
     @Test
     fun `verifyResponse returns error if verifier returns success for given parameters`() {
         every { verifier.verify(any(), any()) } returns false
-        val verificationStatus = callVerifyResponse()
+        val verificationStatus = callVerifyResponse(informationalSigningManager)
         assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.ERROR)
     }
 
     @Test
     fun `verifyResponse with real data verifies correctly`() {
-        signingManager = SigningManager(DefaultSignatureVerifier())
-        val verificationStatus = callVerifyResponse()
+        val signingManager = SigningManager(SignatureVerificationMode.Informational(DefaultSignatureVerifier()))
+        val verificationStatus = callVerifyResponse(signingManager)
         assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.SUCCESS)
     }
 
     @Suppress("MaxLineLength")
     @Test
     fun `verifyResponse with slightly different data does not verify correctly`() {
-        signingManager = SigningManager(DefaultSignatureVerifier())
+        val signingManager = SigningManager(SignatureVerificationMode.Informational(DefaultSignatureVerifier()))
         assertThat(
-            callVerifyResponse(requestTime = "1677005916011") // Wrong request time
+            callVerifyResponse(signingManager, requestTime = "1677005916011") // Wrong request time
         ).isEqualTo(HTTPResult.VerificationStatus.ERROR)
         assertThat(
-            callVerifyResponse(signature = "2bm3QppRywK5ULyCRLS5JJy9sq+84IkMk0Ue4LsywEp87t0tDObpzPlu30l4Desq9X65UFuosqwCLMizruDHbKvPqQLce1hrIuZpgic+cQ8=") // Wrong signature
+            callVerifyResponse(signingManager, signature = "2bm3QppRywK5ULyCRLS5JJy9sq+84IkMk0Ue4LsywEp87t0tDObpzPlu30l4Desq9X65UFuosqwCLMizruDHbKvPqQLce1hrIuZpgic+cQ8=") // Wrong signature
         ).isEqualTo(HTTPResult.VerificationStatus.ERROR)
         assertThat(
-            callVerifyResponse(nonce = "MTIzNDU2Nzg5MGFj") // Wrong nonce
+            callVerifyResponse(signingManager, nonce = "MTIzNDU2Nzg5MGFj") // Wrong nonce
         ).isEqualTo(HTTPResult.VerificationStatus.ERROR)
         assertThat(
-            callVerifyResponse(body = "{\"request_date\":\"2023-02-21T18:58:37Z\",\"request_date_ms\":1677005916011,\"subscriber\":{\"entitlements\":{},\"first_seen\":\"2023-02-21T18:58:35Z\",\"last_seen\":\"2023-02-21T18:58:35Z\",\"management_url\":null,\"non_subscriptions\":{},\"original_app_user_id\":\"login\",\"original_application_version\":null,\"original_purchase_date\":null,\"other_purchases\":{},\"subscriptions\":{}}}\n") // Wrong body
+            callVerifyResponse(signingManager, body = "{\"request_date\":\"2023-02-21T18:58:37Z\",\"request_date_ms\":1677005916011,\"subscriber\":{\"entitlements\":{},\"first_seen\":\"2023-02-21T18:58:35Z\",\"last_seen\":\"2023-02-21T18:58:35Z\",\"management_url\":null,\"non_subscriptions\":{},\"original_app_user_id\":\"login\",\"original_application_version\":null,\"original_purchase_date\":null,\"other_purchases\":{},\"subscriptions\":{}}}\n") // Wrong body
         ).isEqualTo(HTTPResult.VerificationStatus.ERROR)
+    }
+
+    @Test
+    fun `verifyResponse returns success for enforced mode if verifier returns success for given parameters`() {
+        every { verifier.verify(any(), any()) } returns true
+        val verificationStatus = callVerifyResponse(enforcedSigningManager)
+        assertThat(verificationStatus).isEqualTo(HTTPResult.VerificationStatus.SUCCESS)
     }
 
     // endregion
@@ -114,13 +183,15 @@ class SigningManagerTest {
     // region Helpers
 
     private fun callVerifyResponse(
+        signingManager: SigningManager,
         requestPath: String = "test-url-path",
+        responseCode: Int = RCHTTPStatusCodes.SUCCESS,
         signature: String? = "2bm3QppRywK5ULyCRLS5JJy9sq+84IkMk0Ue4LsywEp87t0tDObpzPlu30l4Desq9X65UFuosqwCLMizruDHbKvPqQLce0hrIuZpgic+cQ8=",
         nonce: String = "MTIzNDU2Nzg5MGFi",
         body: String? = "{\"request_date\":\"2023-02-21T18:58:36Z\",\"request_date_ms\":1677005916011,\"subscriber\":{\"entitlements\":{},\"first_seen\":\"2023-02-21T18:58:35Z\",\"last_seen\":\"2023-02-21T18:58:35Z\",\"management_url\":null,\"non_subscriptions\":{},\"original_app_user_id\":\"login\",\"original_application_version\":null,\"original_purchase_date\":null,\"other_purchases\":{},\"subscriptions\":{}}}\n",
         requestTime: String? = "1677005916012",
-        eTag: String? = "test-etag"
-    ) = signingManager.verifyResponse(requestPath, signature, nonce, body, requestTime, eTag)
+        eTag: String? = null
+    ) = signingManager.verifyResponse(requestPath, responseCode, signature, nonce, body, requestTime, eTag)
 
     // endregion
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -20,9 +20,8 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsFileHelper
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.ETagManager
-import com.revenuecat.purchases.common.verification.DefaultSignatureVerifier
+import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
-import com.revenuecat.purchases.common.verification.shouldVerify
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesPoster
@@ -74,18 +73,15 @@ internal class PurchasesFactory(
                 )
             }
 
-            val signingManager = if (verificationMode.shouldVerify) {
-                SigningManager(DefaultSignatureVerifier())
-            } else {
-                null
-            }
+            val signatureVerificationMode = SignatureVerificationMode.fromEntitlementVerificationMode(verificationMode)
+            val signingManager = SigningManager(signatureVerificationMode)
 
             val backend = Backend(
                 apiKey,
                 appConfig,
                 dispatcher,
                 diagnosticsDispatcher,
-                HTTPClient(appConfig, eTagManager, diagnosticsTracker, signingManager, verificationMode)
+                HTTPClient(appConfig, eTagManager, diagnosticsTracker, signingManager)
             )
             val subscriberAttributesPoster = SubscriberAttributesPoster(backend)
 

--- a/strings/src/main/java/com/revenuecat/purchases/strings/NetworkStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/NetworkStrings.kt
@@ -15,4 +15,5 @@ object NetworkStrings {
         " but none provided."
     const val VERIFICATION_MISSING_BODY_OR_ETAG = "Verification: Request to '%s' requires a body or etag" +
         " but none provided."
+    const val VERIFICATION_ERROR = "Verification: Request to '%s' failed verification."
 }


### PR DESCRIPTION
### Description
Depends on #820 

Changes:
- Make `SigningManager` not nullable, so an instance will be created even if verification mode is disabled. SignatureVerifier will still be only created when verification is enabled.
- Pass `responseCode` to verification, so we can use that to decide whether to use the body or the etag to sign.
- Move logic about whether signing is necessary to `SigningManager`.