### PR TITLE
Fix bundle install on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,8 +172,9 @@ jobs:
 
   prepare-next-version:
     executor:
-      name: new-android/android-machine
+      name: new-android/android-docker
       resource-class: large
+      tag: 2023.02.1
     steps:
       - checkout
       - install-sdkman
@@ -187,8 +188,9 @@ jobs:
 
   deploy-snapshot:
     executor:
-      name: new-android/android-machine
+      name: new-android/android-docker
       resource-class: large
+      tag: 2023.02.1
     steps:
       - checkout
       - install-sdkman

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,9 +182,9 @@ jobs:
           cache-version: v1
       - revenuecat/setup-git-credentials
       - revenuecat/trust-github-key
-      - run:
-          name: Prepare next version
-          command: bundle exec fastlane prepare_next_version
+#      - run:
+#          name: Prepare next version
+#          command: bundle exec fastlane prepare_next_version
 
   deploy-snapshot:
     executor:
@@ -201,10 +201,10 @@ jobs:
       - new-android/restore-build-cache:
           cache-prefix: v1a
       - prepare-signing-key
-      - run:
-          name: Deployment
-          command: |
-            bundle exec fastlane android deploy_snapshot
+#      - run:
+#          name: Deployment
+#          command: |
+#            bundle exec fastlane android deploy_snapshot
       - new-android/save-gradle-cache:
           cache-prefix: v1a
       - new-android/save-build-cache:
@@ -401,11 +401,7 @@ workflows:
             - hold
           <<: *release-branches
       - deploy: *release-tags
-      - deploy-snapshot:
-          filters:
-            branches:
-              only:
-                - main
+      - deploy-snapshot
       - docs-deploy: *release-tags
       - publish-purchase-tester-latest-dependencies-release:
           requires:
@@ -418,8 +414,7 @@ workflows:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      - prepare-next-version:
-          <<: *only-main-branch
+      - prepare-next-version
 
   weekly-run-workflow:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ aliases:
       name: android/android-docker
       resource-class: large
       tag: 2023.02.1
+    environment:
+      JVM_OPTS: -Xmx6g
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
 
 version: 2.1
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ aliases:
           - /^.*-amazon*/
       branches:
         ignore: /.*/
-  
+
   release-branches: &release-branches
     filters:
       tags:
@@ -26,6 +26,7 @@ aliases:
 version: 2.1
 orbs:
   android: circleci/android@0.2.1
+  new-android: circleci/android@2.2.0
   android-wordpress-orb: wordpress-mobile/android@1.0.15
   gcp-cli: circleci/gcp-cli@2.1.0
   revenuecat: revenuecat/sdks-common-config@2.0.0
@@ -170,7 +171,9 @@ jobs:
       - android/save-build-cache
 
   prepare-next-version:
-    executor: android-executor
+    executor:
+      name: new-android/android-machine
+      resource-class: large
     steps:
       - checkout
       - install-sdkman
@@ -183,24 +186,27 @@ jobs:
           command: bundle exec fastlane prepare_next_version
 
   deploy-snapshot:
-    executor: android-executor
+    executor:
+      name: new-android/android-machine
+      resource-class: large
     steps:
       - checkout
       - install-sdkman
-      - restore_cache:
-          key: 1-gems-{{ checksum "Gemfile.lock" }}
-      - run: bundle check || bundle install --path vendor/bundle
-      - save_cache:
-          key: 1-gems-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
-      - android-wordpress-orb/restore-gradle-cache
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
+      - new-android/restore-gradle-cache:
+          cache-prefix: v1a
+      - new-android/restore-build-cache:
+          cache-prefix: v1a
       - prepare-signing-key
       - run:
           name: Deployment
           command: |
             bundle exec fastlane android deploy_snapshot
-      - android-wordpress-orb/save-gradle-cache
+      - new-android/save-gradle-cache:
+          cache-prefix: v1a
+      - new-android/save-build-cache:
+          cache-prefix: v1a
 
   assemble-sample-app:
     executor: android-executor
@@ -420,7 +426,7 @@ workflows:
         - equal: [ "release-train", << pipeline.schedule.name >> ]
     jobs:
       - revenuecat/automatic-bump
-  
+
   manual-trigger-bump:
     when:
       equal: [ bump, << pipeline.parameters.action >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,11 +401,7 @@ workflows:
             - hold
           <<: *release-branches
       - deploy: *release-tags
-      - deploy-snapshot:
-          filters:
-            branches:
-              only:
-                - main
+      - deploy-snapshot: *only-main-branch
       - docs-deploy: *release-tags
       - publish-purchase-tester-latest-dependencies-release:
           requires:
@@ -418,8 +414,7 @@ workflows:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      - prepare-next-version:
-          <<: *only-main-branch
+      - prepare-next-version: *only-main-branch
 
   weekly-run-workflow:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,9 +182,9 @@ jobs:
           cache-version: v1
       - revenuecat/setup-git-credentials
       - revenuecat/trust-github-key
-#      - run:
-#          name: Prepare next version
-#          command: bundle exec fastlane prepare_next_version
+      - run:
+          name: Prepare next version
+          command: bundle exec fastlane prepare_next_version
 
   deploy-snapshot:
     executor:
@@ -201,10 +201,10 @@ jobs:
       - new-android/restore-build-cache:
           cache-prefix: v1a
       - prepare-signing-key
-#      - run:
-#          name: Deployment
-#          command: |
-#            bundle exec fastlane android deploy_snapshot
+      - run:
+          name: Deployment
+          command: |
+            bundle exec fastlane android deploy_snapshot
       - new-android/save-gradle-cache:
           cache-prefix: v1a
       - new-android/save-build-cache:
@@ -401,7 +401,11 @@ workflows:
             - hold
           <<: *release-branches
       - deploy: *release-tags
-      - deploy-snapshot
+      - deploy-snapshot:
+          filters:
+            branches:
+              only:
+                - main
       - docs-deploy: *release-tags
       - publish-purchase-tester-latest-dependencies-release:
           requires:
@@ -414,7 +418,8 @@ workflows:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      - prepare-next-version
+      - prepare-next-version:
+          <<: *only-main-branch
 
   weekly-run-workflow:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,15 @@ aliases:
       branches:
         only: main
 
+  android-executor: &android-executor
+    executor:
+      name: android/android-docker
+      resource-class: large
+      tag: 2023.02.1
+
 version: 2.1
 orbs:
-  android: circleci/android@0.2.1
-  new-android: circleci/android@2.2.0
-  android-wordpress-orb: wordpress-mobile/android@1.0.15
+  android: circleci/android@2.2.0
   gcp-cli: circleci/gcp-cli@2.1.0
   revenuecat: revenuecat/sdks-common-config@2.0.0
   codecov: codecov/codecov@3.2.4
@@ -37,16 +41,6 @@ parameters:
     type: enum
     enum: [default, bump]
     default: default
-
-executors:
-  android-executor:
-    docker:
-      - image: circleci/android:api-28
-    resource_class: large
-    working_directory: ~/purchases-android
-    environment:
-      JVM_OPTS: -Xmx6g
-      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
 
 commands:
   install-sdkman:
@@ -65,11 +59,11 @@ commands:
 
   android-dependencies:
     steps:
-      - android-wordpress-orb/restore-gradle-cache
+      - android/restore-gradle-cache
       - run:
           name: Download Dependencies
           command: ./gradlew androidDependencies
-      - android-wordpress-orb/save-gradle-cache
+      - android/save-gradle-cache
 
   prepare-signing-key:
     steps:
@@ -93,7 +87,7 @@ commands:
 jobs:
 
   test:
-    executor: android-executor
+    <<: *android-executor
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
@@ -127,16 +121,16 @@ jobs:
           path: build/test-results
 
   docs-deploy:
-    executor: android-executor
+    <<: *android-executor
     steps:
       - checkout
       - install-sdkman
-      - android-wordpress-orb/restore-gradle-cache
+      - android/restore-gradle-cache
       - android/restore-build-cache
       - run:
           name: Dokka
           command: ./gradlew dokkaHtmlMultiModule
-      - android-wordpress-orb/save-gradle-cache
+      - android/save-gradle-cache
       - android/save-build-cache
       - run:
           name: Install awscli
@@ -152,7 +146,7 @@ jobs:
           command: aws cloudfront create-invalidation --distribution-id EPTW7F3CB566V --paths "/*"
 
   deploy:
-    executor: android-executor
+    <<: *android-executor
     steps:
       - checkout
       - install-sdkman
@@ -161,20 +155,17 @@ jobs:
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - prepare-signing-key
-      - android-wordpress-orb/restore-gradle-cache
+      - android/restore-gradle-cache
       - android/restore-build-cache
       - run:
           name: Deployment
           command: |
             bundle exec fastlane android deploy
-      - android-wordpress-orb/save-gradle-cache
+      - android/save-gradle-cache
       - android/save-build-cache
 
   prepare-next-version:
-    executor:
-      name: new-android/android-docker
-      resource-class: large
-      tag: 2023.02.1
+    <<: *android-executor
     steps:
       - checkout
       - install-sdkman
@@ -187,36 +178,33 @@ jobs:
           command: bundle exec fastlane prepare_next_version
 
   deploy-snapshot:
-    executor:
-      name: new-android/android-docker
-      resource-class: large
-      tag: 2023.02.1
+    <<: *android-executor
     steps:
       - checkout
       - install-sdkman
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
-      - new-android/restore-gradle-cache:
+      - android/restore-gradle-cache:
           cache-prefix: v1a
-      - new-android/restore-build-cache:
+      - android/restore-build-cache:
           cache-prefix: v1a
       - prepare-signing-key
       - run:
           name: Deployment
           command: |
             bundle exec fastlane android deploy_snapshot
-      - new-android/save-gradle-cache:
+      - android/save-gradle-cache:
           cache-prefix: v1a
-      - new-android/save-build-cache:
+      - android/save-build-cache:
           cache-prefix: v1a
 
   assemble-sample-app:
-    executor: android-executor
+    <<: *android-executor
     steps:
       - checkout
       - install-sdkman
       - android/accept-licenses
-      - android-wordpress-orb/restore-gradle-cache
+      - android/restore-gradle-cache
       - android/restore-build-cache
       - run:
           name: Prepare Keystore
@@ -233,18 +221,18 @@ jobs:
           path: examples/purchase-tester/build/outputs/apk/latestDependencies/release/purchase-tester-latestDependencies-release.apk
       - store_artifacts:
           path: examples/purchase-tester/build/outputs/apk/latestDependencies/debug/purchase-tester-latestDependencies-debug.apk
-      - android-wordpress-orb/save-gradle-cache
+      - android/save-gradle-cache
       - android/save-build-cache
 
   publish-purchase-tester-latest-dependencies-release:
-    executor: android-executor
+    <<: *android-executor
     steps:
       - checkout
       - install-sdkman
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - android/accept-licenses
-      - android-wordpress-orb/restore-gradle-cache
+      - android/restore-gradle-cache
       - android/restore-build-cache
       - run:
           name: Prepare Keystore
@@ -256,7 +244,7 @@ jobs:
             bundle exec fastlane android build_purchase_tester_bundle
       - store_artifacts:
           path: examples/purchase-tester/build/outputs/bundle/latestDependenciesRelease/purchase-tester-latestDependencies-release.aab
-      - android-wordpress-orb/save-gradle-cache
+      - android/save-gradle-cache
       - android/save-build-cache
       - run:
             name: Publish aab
@@ -264,7 +252,7 @@ jobs:
               bundle exec fastlane android publish_purchase_tester aab_path:'examples/purchase-tester/build/outputs/bundle/latestDependenciesRelease/purchase-tester-latestDependencies-release.aab'
 
   integration-tests-build:
-    executor: android-executor
+    <<: *android-executor
     steps:
       - checkout
       - install-sdkman


### PR DESCRIPTION
- Updated to the latest version of https://circleci.com/developer/orbs/orb/circleci/android, which was long overdue. This removed a warning we were getting in CircleCI
- Updating to the latest version of the Android docker image also fixed issues we were seeing in main like https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/4469/workflows/6a4748b9-c235-40c5-b057-83f37c3fefef/jobs/12176, which were due to using an old version of ruby
- Removed the usage of `android-wordpress-orb`