### PR TITLE
Entitlement verification: Add entitlement verification options to purchase tester

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -1,14 +1,15 @@
 package com.revenuecat.purchasetester
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.get
+import android.widget.ArrayAdapter
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
@@ -36,6 +37,11 @@ class ConfigureFragment : Fragment() {
         dataStoreUtils = DataStoreUtils(requireActivity().applicationContext.configurationDataStore)
         binding = FragmentConfigureBinding.inflate(inflater)
 
+        binding.verificationOptionsInput.adapter = ArrayAdapter(
+            requireContext(),
+            android.R.layout.simple_spinner_item,
+            EntitlementVerificationMode.values()
+        )
         setupSupportedStoresRadioButtons()
 
         lifecycleScope.launch {
@@ -69,6 +75,8 @@ class ConfigureFragment : Fragment() {
     private suspend fun configureSDK() {
         val apiKey = binding.apiKeyInput.text.toString()
         val proxyUrl = binding.proxyUrlInput.text?.toString() ?: ""
+        val verificationModeIndex = binding.verificationOptionsInput.selectedItemPosition
+        val entitlementVerificationMode = EntitlementVerificationMode.values()[verificationModeIndex]
         val useAmazonStore = binding.storeRadioGroup.checkedRadioButtonId == R.id.amazon_store_radio_id
 
         val application = (requireActivity().application as MainApplication)
@@ -83,6 +91,7 @@ class ConfigureFragment : Fragment() {
 
         val configuration = configurationBuilder
             .diagnosticsEnabled(true)
+            .entitlementVerificationMode(entitlementVerificationMode)
             .build()
         Purchases.configure(configuration)
 

--- a/examples/purchase-tester/src/main/res/drawable/spinner_bg.xml
+++ b/examples/purchase-tester/src/main/res/drawable/spinner_bg.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <color android:color="@color/lightGrey" />
+    </item>
+    <item android:gravity="center_vertical|end">
+        <layer-list>
+            <item android:width="12dp" android:height="12dp" android:gravity="center" android:bottom="10dp">
+                <rotate
+                        android:fromDegrees="45"
+                        android:toDegrees="45">
+                    <shape android:shape="rectangle">
+                        <solid android:color="#666666" />
+                    </shape>
+                </rotate>
+            </item>
+            <item android:width="30dp" android:height="10dp" android:bottom="21dp" android:gravity="center">
+                <shape android:shape="rectangle">
+                    <solid android:color="@color/lightGrey"/>
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+</layer-list>

--- a/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
@@ -11,7 +11,7 @@
             android:id="@+id/login_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:padding="@dimen/padding_large">
+            android:padding="@dimen/padding_medium">
 
         <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/configure_icon"
@@ -76,11 +76,37 @@
                 android:layout_height="wrap_content"/>
 
         <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/verification_options_label"
+                android:text="@string/entitlement_verification"
+                android:textSize="15sp"
+                android:layout_marginTop="20dp"
+                app:layout_constraintTop_toBottomOf="@id/proxy_url_label"
+                app:layout_constraintStart_toStartOf="parent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+
+        <androidx.appcompat.widget.AppCompatSpinner
+                android:id="@+id/verification_options_input"
+                android:background="@drawable/spinner_bg"
+                app:layout_constraintTop_toTopOf="@id/verification_options_label"
+                app:layout_constraintBottom_toBottomOf="@id/verification_options_label"
+                app:layout_constraintEnd_toEndOf="parent"
+                tools:listitem="@android:layout/simple_spinner_item"
+                android:paddingEnd="25dp"
+                android:minHeight="0dp"
+                android:spinnerMode="dropdown"
+                android:textAlignment="textEnd"
+                app:layout_constraintWidth_percent="0.55"
+                android:layout_marginStart="20dp"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"/>
+
+        <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/store_label"
                 android:text="@string/store"
                 android:textSize="15sp"
                 android:layout_marginTop="20dp"
-                app:layout_constraintTop_toBottomOf="@id/proxy_url_input"
+                app:layout_constraintTop_toBottomOf="@id/verification_options_input"
                 app:layout_constraintStart_toStartOf="parent"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"/>

--- a/examples/purchase-tester/src/main/res/values/dimens.xml
+++ b/examples/purchase-tester/src/main/res/values/dimens.xml
@@ -1,5 +1,6 @@
 <resources>
     <dimen name="padding_tiny">4dp</dimen>
     <dimen name="padding_small">8dp</dimen>
+    <dimen name="padding_medium">16dp</dimen>
     <dimen name="padding_large">32dp</dimen>
 </resources>

--- a/examples/purchase-tester/src/main/res/values/strings.xml
+++ b/examples/purchase-tester/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="sdk_configuration">SDK Configuration</string>
     <string name="api_key">API Key</string>
     <string name="proxy_url_optional">Proxy URL (optional)</string>
+    <string name="entitlement_verification">Entitlement verification</string>
     <string name="store">Store</string>
     <string name="google">Google</string>
     <string name="amazon">Amazon</string>


### PR DESCRIPTION
### Description
Depends on #826 
Deals with [SDK-2894](https://linear.app/revenuecat/issue/SDK-2894/add-verification-options-and-verification-values-to-purchasetester)

This PR adds a dropdown to the purchase tester sdk configuration screen to configure what entitlement verification mode to use.

| 1  | 2 |
| ------------- | ------------- |
| <img width="329" alt="image" src="https://user-images.githubusercontent.com/808417/222105299-6de74f63-d7d6-455b-aa3e-5e06e1f16e88.png"> | <img width="327" alt="image" src="https://user-images.githubusercontent.com/808417/222105131-03377db2-e8a8-4c27-99a2-08816b92b098.png"> |


