### PR TITLE
Entitlement verification: Avoid caching responses with verification errors

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -82,8 +82,7 @@ class ETagManager(
         resultFromBackend: HTTPResult,
         eTagInResponse: String
     ) {
-        val responseCode = resultFromBackend.responseCode
-        if (responseCode != RCHTTPStatusCodes.NOT_MODIFIED && responseCode < RCHTTPStatusCodes.ERROR) {
+        if (shouldStoreBackendResult(resultFromBackend)) {
             storeResult(path, resultFromBackend, eTagInResponse)
         }
     }
@@ -113,6 +112,13 @@ class ETagManager(
 
     private fun getETag(path: String): String {
         return getStoredResultSavedInSharedPreferences(path)?.eTag.orEmpty()
+    }
+
+    private fun shouldStoreBackendResult(resultFromBackend: HTTPResult): Boolean {
+        val responseCode = resultFromBackend.responseCode
+        return responseCode != RCHTTPStatusCodes.NOT_MODIFIED &&
+            responseCode < RCHTTPStatusCodes.ERROR &&
+            resultFromBackend.verificationStatus != HTTPResult.VerificationStatus.ERROR
     }
 
     companion object {

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPResultMockFactory.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPResultMockFactory.kt
@@ -1,9 +1,10 @@
 package com.revenuecat.purchases.common
 
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 
 fun HTTPResult.Companion.createResult(
-    responseCode: Int = 200,
+    responseCode: Int = RCHTTPStatusCodes.SUCCESS,
     payload: String = "{}",
     origin: HTTPResult.Origin = HTTPResult.Origin.BACKEND,
     verificationStatus: HTTPResult.VerificationStatus = HTTPResult.VerificationStatus.NOT_VERIFIED


### PR DESCRIPTION
### Description
Depends on #826 

We should not cache responses where we detect verification errors. This changes ETagManager to follow that behavior
