### PR TITLE
[BC5] Update MagicWeather and Purchase Tester with 6.0.0-alpha.4 APIs

### DIFF
--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/data/Constants.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/data/Constants.kt
@@ -7,7 +7,7 @@ object Constants {
 
      Modify this property to reflect your Google Play app's API key.
     */
-    const val GOOGLE_API_KEY = "goog_GncthBrhtStvgWspGnllfHgPeQP"
+    const val GOOGLE_API_KEY = "googl_api_key"
 
     /*
     The API key for your Amazon App Store app. This can be found in via Project Settings >

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/data/Constants.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/data/Constants.kt
@@ -7,7 +7,7 @@ object Constants {
 
      Modify this property to reflect your Google Play app's API key.
     */
-    const val GOOGLE_API_KEY = "googl_api_key"
+    const val GOOGLE_API_KEY = "goog_GncthBrhtStvgWspGnllfHgPeQP"
 
     /*
     The API key for your Amazon App Store app. This can be found in via Project Settings >

--- a/examples/MagicWeather/build.gradle
+++ b/examples/MagicWeather/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext.compileVersion = 31
     ext.kotlinVersion = "1.6.21"
-    ext.purchasesVersion = "6.0.0-alpha.2"
+    ext.purchasesVersion = "6.0.0-alpha.4"
     ext.lifecycleVersion = "2.5.0"
     ext.androidxCoreVersion = "1.8.0"
     repositories {


### PR DESCRIPTION
### Motivation

[CF-1213](https://revenuecats.atlassian.net/browse/CF-1213)

Keep our test and example apps up to date with our latest APIs

### Description

**Magic Weather** got the most updates as **PurchaseTester** has been getting updates for each API improvement PR.

This PR updates **Magic Weather** to use new `Price` and `Period` classes to make the code quiet a bit cleaner. I think this is a good example from a code side of things but the paywall itself could use some love to make it look a little bit prettier (probably out of scope of this PR).

- Magic Weather
  - Updated to `6.0.0-alpha.4`
  - Uses new `Price` property on  `PricingPhase`
  - Uses new `Period` and `Unit` class for showing billing periods
- PurchaseTester
  - Fixed subscription option to show ISO 8601 (because more compact for our use case) instead of a stringed out `Period` objects


[CF-1213]: https://revenuecats.atlassian.net/browse/CF-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ