### PR TITLE
Fix docs deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,9 @@ jobs:
       - android/save-gradle-cache
       - android/save-build-cache
       - run:
+          name: Install pip
+          command: sudo apt update && sudo apt install python3-pip
+      - run:
           name: Install awscli
           command: sudo pip install awscli
       - run:


### PR DESCRIPTION
### Description
After #827, looks like pip isn't installed in the machine anymore. I ssh'ed in the machine to finish docs deployment in #833. Python3 was already installed, so we only needed to install pip. I did this for that and deployment seems to have worked fine after that doing it manually.
