### PR TITLE
Entitlement verification: Rename not verified to not requested and error to failed

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/VerificationResultAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/VerificationResultAPI.java
@@ -8,7 +8,7 @@ final class VerificationResultAPI {
         switch (verificationResult) {
             case NOT_REQUESTED:
             case SUCCESS:
-            case ERROR:
+            case FAILED:
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/VerificationResultAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/VerificationResultAPI.java
@@ -6,7 +6,7 @@ import com.revenuecat.purchases.VerificationResult;
 final class VerificationResultAPI {
     static void check(final VerificationResult verificationResult) {
         switch (verificationResult) {
-            case NOT_VERIFIED:
+            case NOT_REQUESTED:
             case SUCCESS:
             case ERROR:
         }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VerificationResultAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VerificationResultAPI.kt
@@ -7,7 +7,7 @@ private class VerificationResultAPI {
 
     fun check(verificationResult: VerificationResult) {
         when (verificationResult) {
-            VerificationResult.NOT_VERIFIED,
+            VerificationResult.NOT_REQUESTED,
             VerificationResult.SUCCESS,
             VerificationResult.ERROR
             -> {}

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VerificationResultAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VerificationResultAPI.kt
@@ -9,7 +9,7 @@ private class VerificationResultAPI {
         when (verificationResult) {
             VerificationResult.NOT_REQUESTED,
             VerificationResult.SUCCESS,
-            VerificationResult.ERROR
+            VerificationResult.FAILED
             -> {}
         }.exhaustive
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/CustomerInfoFactory.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/CustomerInfoFactory.kt
@@ -56,7 +56,7 @@ object CustomerInfoFactory {
             nonSubscriptionsLatestPurchases,
             requestDate,
             verificationResult
-        ) ?: EntitlementInfos(emptyMap(), VerificationResult.NOT_VERIFIED)
+        ) ?: EntitlementInfos(emptyMap(), VerificationResult.NOT_REQUESTED)
 
         val managementURL = subscriber.optNullableString("management_url")
         val originalPurchaseDate = subscriber.optNullableString("original_purchase_date")?.let {

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -179,7 +179,7 @@ class HTTPClient(
             VerificationResult.NOT_REQUESTED
         }
 
-        if (verificationResult == VerificationResult.ERROR &&
+        if (verificationResult == VerificationResult.FAILED &&
             signingManager.signatureVerificationMode is SignatureVerificationMode.Enforced) {
             throw SignatureVerificationException(path)
         }

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -176,7 +176,7 @@ class HTTPClient(
         val verificationResult = if (shouldSignResponse && nonce != null) {
             verifyResponse(path, responseCode, connection, payload, nonce)
         } else {
-            VerificationResult.NOT_VERIFIED
+            VerificationResult.NOT_REQUESTED
         }
 
         if (verificationResult == VerificationResult.ERROR &&

--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -105,7 +105,7 @@ open class DeviceCache(
                     val schemaVersion = cachedJSONObject.optInt(CUSTOMER_INFO_SCHEMA_VERSION_KEY)
                     val verificationResultString = if (cachedJSONObject.has(CUSTOMER_INFO_VERIFICATION_RESULT_KEY)) {
                         cachedJSONObject.getString(CUSTOMER_INFO_VERIFICATION_RESULT_KEY)
-                    } else VerificationResult.NOT_VERIFIED.name
+                    } else VerificationResult.NOT_REQUESTED.name
                     cachedJSONObject.remove(CUSTOMER_INFO_SCHEMA_VERSION_KEY)
                     cachedJSONObject.remove(CUSTOMER_INFO_VERIFICATION_RESULT_KEY)
                     val verificationResult = VerificationResult.valueOf(verificationResultString)

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -119,7 +119,7 @@ class ETagManager(
         val responseCode = resultFromBackend.responseCode
         return responseCode != RCHTTPStatusCodes.NOT_MODIFIED &&
             responseCode < RCHTTPStatusCodes.ERROR &&
-            resultFromBackend.verificationResult != VerificationResult.ERROR
+            resultFromBackend.verificationResult != VerificationResult.FAILED
     }
 
     companion object {

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPResult.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPResult.kt
@@ -31,7 +31,7 @@ data class HTTPResult(
             val verificationResult: VerificationResult = if (jsonObject.has(SERIALIZATION_NAME_VERIFICATION_RESULT)) {
                 VerificationResult.valueOf(jsonObject.getString(SERIALIZATION_NAME_VERIFICATION_RESULT))
             } else {
-                VerificationResult.NOT_VERIFIED
+                VerificationResult.NOT_REQUESTED
             }
             return HTTPResult(responseCode, payload, origin, verificationResult)
         }

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -36,7 +36,7 @@ class SigningManager(
         requestTime: String?,
         eTag: String?
     ): VerificationResult {
-        val signatureVerifier = signatureVerificationMode.verifier ?: return VerificationResult.NOT_VERIFIED
+        val signatureVerifier = signatureVerificationMode.verifier ?: return VerificationResult.NOT_REQUESTED
 
         if (signature == null) {
             errorLog(NetworkStrings.VERIFICATION_MISSING_SIGNATURE.format(urlPath))

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -40,17 +40,17 @@ class SigningManager(
 
         if (signature == null) {
             errorLog(NetworkStrings.VERIFICATION_MISSING_SIGNATURE.format(urlPath))
-            return VerificationResult.ERROR
+            return VerificationResult.FAILED
         }
         if (requestTime == null) {
             errorLog(NetworkStrings.VERIFICATION_MISSING_REQUEST_TIME.format(urlPath))
-            return VerificationResult.ERROR
+            return VerificationResult.FAILED
         }
 
         val signatureMessage = getSignatureMessage(responseCode, body, eTag)
         if (signatureMessage == null) {
             errorLog(NetworkStrings.VERIFICATION_MISSING_BODY_OR_ETAG.format(urlPath))
-            return VerificationResult.ERROR
+            return VerificationResult.FAILED
         }
 
         val decodedNonce = Base64.decode(nonce, Base64.DEFAULT)
@@ -64,7 +64,7 @@ class SigningManager(
             VerificationResult.SUCCESS
         } else {
             errorLog(NetworkStrings.VERIFICATION_ERROR)
-            VerificationResult.ERROR
+            VerificationResult.FAILED
         }
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -485,7 +485,7 @@ class BackendTest {
 
     @Test
     fun `gets updated subscriber after post`() {
-        val verificationResult = VerificationResult.NOT_VERIFIED
+        val verificationResult = VerificationResult.NOT_REQUESTED
         val initialInfo = createCustomerInfo(Responses.validFullPurchaserResponse)
         val updatedInfo = createCustomerInfo(Responses.validEmptyPurchaserResponse)
 

--- a/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -79,7 +79,7 @@ abstract class BaseHTTPClientTest {
     protected fun enqueue(
         endpoint: Endpoint,
         expectedResult: HTTPResult,
-        verificationResult: VerificationResult = VerificationResult.NOT_VERIFIED
+        verificationResult: VerificationResult = VerificationResult.NOT_REQUESTED
     ) {
         every {
             mockETagManager.getHTTPResultFromCacheOrBackend(

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -123,7 +123,7 @@ class DeviceCacheTest {
         mockString(cache.customerInfoCacheKey(appUserID), deprecatedValidCachedCustomerInfo)
         val info = cache.getCachedCustomerInfo(appUserID)
         assertThat(info).`as`("info is not null").isNotNull
-        assertThat(info?.entitlements?.verification).isEqualTo(VerificationResult.NOT_VERIFIED)
+        assertThat(info?.entitlements?.verification).isEqualTo(VerificationResult.NOT_REQUESTED)
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
@@ -139,9 +139,9 @@ class EntitlementInfosTests {
             }
         )
 
-        val subscriberInfo = createCustomerInfo(response, VerificationResult.ERROR)
-        assertThat(subscriberInfo.entitlements.verification).isEqualTo(VerificationResult.ERROR)
-        assertThat(subscriberInfo.entitlements["pro_cat"]?.verification).isEqualTo(VerificationResult.ERROR)
+        val subscriberInfo = createCustomerInfo(response, VerificationResult.FAILED)
+        assertThat(subscriberInfo.entitlements.verification).isEqualTo(VerificationResult.FAILED)
+        assertThat(subscriberInfo.entitlements["pro_cat"]?.verification).isEqualTo(VerificationResult.FAILED)
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -244,7 +244,7 @@ class HTTPClientTest: BaseHTTPClientTest() {
                 eTagHeader = any(),
                 urlPathWithVersion,
                 refreshETag = false,
-                verificationResult = VerificationResult.NOT_VERIFIED
+                verificationResult = VerificationResult.NOT_REQUESTED
             )
         } returns null
 
@@ -255,7 +255,7 @@ class HTTPClientTest: BaseHTTPClientTest() {
                 eTagHeader = any(),
                 urlPathWithVersion,
                 refreshETag = true,
-                verificationResult = VerificationResult.NOT_VERIFIED
+                verificationResult = VerificationResult.NOT_REQUESTED
             )
         } returns expectedResult
 
@@ -371,7 +371,7 @@ class HTTPClientTest: BaseHTTPClientTest() {
                 eTagHeader = any(),
                 "/v1${endpoint.getPath()}",
                 refreshETag = false,
-                verificationResult = VerificationResult.NOT_VERIFIED
+                verificationResult = VerificationResult.NOT_REQUESTED
             )
         } throws JSONException("bad json")
         val response = MockResponse().setBody("not uh json").setResponseCode(responseCode)

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -142,13 +142,13 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         val endpoint = Endpoint.GetCustomerInfo("test-user-id")
         enqueue(
             endpoint = endpoint,
-            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.ERROR),
-            verificationResult = VerificationResult.ERROR
+            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.FAILED),
+            verificationResult = VerificationResult.FAILED
         )
 
         every {
             mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
-        } returns VerificationResult.ERROR
+        } returns VerificationResult.FAILED
 
         val result = client.performRequest(
             baseURL,
@@ -158,7 +158,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         )
 
         server.takeRequest()
-        assertThat(result.verificationResult).isEqualTo(VerificationResult.ERROR)
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.FAILED)
     }
 
     @Test(expected = SignatureVerificationException::class)
@@ -167,13 +167,13 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         val endpoint = Endpoint.GetCustomerInfo("test-user-id")
         enqueue(
             endpoint = endpoint,
-            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.ERROR),
-            verificationResult = VerificationResult.ERROR
+            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.FAILED),
+            verificationResult = VerificationResult.FAILED
         )
 
         every {
             mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
-        } returns VerificationResult.ERROR
+        } returns VerificationResult.FAILED
 
         client.performRequest(
             baseURL,

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -58,14 +58,14 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         val endpoint = Endpoint.PostDiagnostics
         every { mockSigningManager.shouldVerifyEndpoint(endpoint) } returns false
         val expectedResult = HTTPResult.createResult(
-            verificationResult = VerificationResult.NOT_VERIFIED,
+            verificationResult = VerificationResult.NOT_REQUESTED,
             payload = "{\"test-key\":\"test-value\"}"
         )
 
         enqueue(
             endpoint = endpoint,
             expectedResult = expectedResult,
-            verificationResult = VerificationResult.NOT_VERIFIED
+            verificationResult = VerificationResult.NOT_REQUESTED
         )
 
         val result = client.performRequest(
@@ -77,7 +77,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
         server.takeRequest()
 
-        assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_VERIFIED)
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_REQUESTED)
         verify(exactly = 0) {
             mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
         }

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPResultMockFactory.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPResultMockFactory.kt
@@ -8,5 +8,5 @@ fun HTTPResult.Companion.createResult(
     responseCode: Int = RCHTTPStatusCodes.SUCCESS,
     payload: String = "{}",
     origin: HTTPResult.Origin = HTTPResult.Origin.BACKEND,
-    verificationResult: VerificationResult = VerificationResult.NOT_VERIFIED
+    verificationResult: VerificationResult = VerificationResult.NOT_REQUESTED
 ) = HTTPResult(responseCode, payload, origin, verificationResult)

--- a/common/src/test/java/com/revenuecat/purchases/common/MockCustomerInfoFactory.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/MockCustomerInfoFactory.kt
@@ -6,14 +6,14 @@ import org.json.JSONObject
 
 fun createCustomerInfo(
     response: String,
-    verificationResult: VerificationResult = VerificationResult.NOT_VERIFIED
+    verificationResult: VerificationResult = VerificationResult.NOT_REQUESTED
 ): CustomerInfo {
     return createCustomerInfo(JSONObject(response), verificationResult)
 }
 
 fun createCustomerInfo(
     jsonObject: JSONObject,
-    verificationResult: VerificationResult = VerificationResult.NOT_VERIFIED
+    verificationResult: VerificationResult = VerificationResult.NOT_REQUESTED
 ): CustomerInfo {
     return CustomerInfoFactory.buildCustomerInfo(jsonObject, verificationResult)
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -159,7 +159,7 @@ class ETagManagerTest {
         val eTag = "eTag"
 
         val resultFromBackend = HTTPResult.createResult(
-            verificationResult = VerificationResult.ERROR,
+            verificationResult = VerificationResult.FAILED,
             payload = Responses.validEmptyPurchaserResponse
         )
 

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -224,7 +224,7 @@ class ETagManagerTest {
             eTagHeader = eTagInResponse,
             urlPathWithVersion = path,
             refreshETag = false,
-            verificationResult = VerificationResult.NOT_VERIFIED
+            verificationResult = VerificationResult.NOT_REQUESTED
         )
 
         assertStoredResponse(path, eTagInResponse, responsePayload)
@@ -245,7 +245,7 @@ class ETagManagerTest {
             eTagHeader = eTagInResponse,
             urlPathWithVersion = path,
             refreshETag = false,
-            verificationResult = VerificationResult.NOT_VERIFIED
+            verificationResult = VerificationResult.NOT_REQUESTED
         )
 
         assertThat(slotPutStringSharedPreferencesKey.isCaptured).isFalse
@@ -268,7 +268,7 @@ class ETagManagerTest {
             eTagHeader = eTagInResponse,
             urlPathWithVersion = path,
             refreshETag = false,
-            verificationResult = VerificationResult.NOT_VERIFIED
+            verificationResult = VerificationResult.NOT_REQUESTED
         )
 
         assertThat(result).isNull()
@@ -292,7 +292,7 @@ class ETagManagerTest {
             eTagHeader = eTagInResponse,
             urlPathWithVersion = path,
             refreshETag = true,
-            verificationResult = VerificationResult.NOT_VERIFIED
+            verificationResult = VerificationResult.NOT_REQUESTED
         )
 
         assertThat(result).isNotNull
@@ -315,7 +315,7 @@ class ETagManagerTest {
             eTagHeader = eTagInResponse,
             urlPathWithVersion = path,
             refreshETag = false,
-            verificationResult = VerificationResult.NOT_VERIFIED
+            verificationResult = VerificationResult.NOT_REQUESTED
         )
 
         assertThat(result).isNotNull
@@ -338,7 +338,7 @@ class ETagManagerTest {
             eTagHeader = eTagInResponse,
             urlPathWithVersion = path,
             refreshETag = true,
-            verificationResult = VerificationResult.NOT_VERIFIED
+            verificationResult = VerificationResult.NOT_REQUESTED
         )
 
         assertThat(result).isNotNull

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
@@ -33,7 +33,7 @@ class HTTPResultTest {
             200,
             "{\"test-key\":\"test-value\"}",
             HTTPResult.Origin.BACKEND,
-            VerificationResult.ERROR
+            VerificationResult.FAILED
         )
         val result = HTTPResult.deserialize("{" +
             "\"responseCode\":200," +

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
@@ -39,7 +39,7 @@ class HTTPResultTest {
             "\"responseCode\":200," +
             "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"," +
             "\"origin\":\"BACKEND\"," +
-            "\"verificationResult\":\"ERROR\"}")
+            "\"verificationResult\":\"FAILED\"}")
         assertThat(result).isEqualTo(expectedResult)
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
@@ -44,12 +44,12 @@ class HTTPResultTest {
     }
 
     @Test
-    fun `result defaults to CACHE origin and NOT_VERIFIED verification result if not part of serialized string`() {
+    fun `result defaults to CACHE origin and NOT_REQUESTED verification result if not part of serialized string`() {
         val expectedResult = HTTPResult(
             200,
             "{\"test-key\":\"test-value\"}",
             HTTPResult.Origin.CACHE,
-            VerificationResult.NOT_VERIFIED
+            VerificationResult.NOT_REQUESTED
         )
         val result = HTTPResult.deserialize("{" +
             "\"responseCode\":200," +

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -89,25 +89,25 @@ class SigningManagerTest {
     @Test
     fun `verifyResponse returns error if signature is null`() {
         val verificationResult = callVerifyResponse(informationalSigningManager, signature = null)
-        assertThat(verificationResult).isEqualTo(VerificationResult.ERROR)
+        assertThat(verificationResult).isEqualTo(VerificationResult.FAILED)
     }
 
     @Test
     fun `verifyResponse returns error if request time is null`() {
         val verificationResult = callVerifyResponse(informationalSigningManager, requestTime = null)
-        assertThat(verificationResult).isEqualTo(VerificationResult.ERROR)
+        assertThat(verificationResult).isEqualTo(VerificationResult.FAILED)
     }
 
     @Test
     fun `verifyResponse returns error if both body and etag are null`() {
         val verificationResult = callVerifyResponse(informationalSigningManager, body = null, eTag = null)
-        assertThat(verificationResult).isEqualTo(VerificationResult.ERROR)
+        assertThat(verificationResult).isEqualTo(VerificationResult.FAILED)
     }
 
     @Test
     fun `verifyResponse returns error if status code success and body is empty`() {
         val verificationResult = callVerifyResponse(informationalSigningManager, body = null)
-        assertThat(verificationResult).isEqualTo(VerificationResult.ERROR)
+        assertThat(verificationResult).isEqualTo(VerificationResult.FAILED)
     }
 
     @Test
@@ -117,7 +117,7 @@ class SigningManagerTest {
             responseCode = RCHTTPStatusCodes.NOT_MODIFIED,
             eTag = null
         )
-        assertThat(verificationResult).isEqualTo(VerificationResult.ERROR)
+        assertThat(verificationResult).isEqualTo(VerificationResult.FAILED)
     }
 
     @Test
@@ -143,7 +143,7 @@ class SigningManagerTest {
     fun `verifyResponse returns error if verifier returns success for given parameters`() {
         every { verifier.verify(any(), any()) } returns false
         val verificationResult = callVerifyResponse(informationalSigningManager)
-        assertThat(verificationResult).isEqualTo(VerificationResult.ERROR)
+        assertThat(verificationResult).isEqualTo(VerificationResult.FAILED)
     }
 
     @Test
@@ -159,16 +159,16 @@ class SigningManagerTest {
         val signingManager = SigningManager(SignatureVerificationMode.Informational(DefaultSignatureVerifier()))
         assertThat(
             callVerifyResponse(signingManager, requestTime = "1677005916011") // Wrong request time
-        ).isEqualTo(VerificationResult.ERROR)
+        ).isEqualTo(VerificationResult.FAILED)
         assertThat(
             callVerifyResponse(signingManager, signature = "2bm3QppRywK5ULyCRLS5JJy9sq+84IkMk0Ue4LsywEp87t0tDObpzPlu30l4Desq9X65UFuosqwCLMizruDHbKvPqQLce1hrIuZpgic+cQ8=") // Wrong signature
-        ).isEqualTo(VerificationResult.ERROR)
+        ).isEqualTo(VerificationResult.FAILED)
         assertThat(
             callVerifyResponse(signingManager, nonce = "MTIzNDU2Nzg5MGFj") // Wrong nonce
-        ).isEqualTo(VerificationResult.ERROR)
+        ).isEqualTo(VerificationResult.FAILED)
         assertThat(
             callVerifyResponse(signingManager, body = "{\"request_date\":\"2023-02-21T18:58:37Z\",\"request_date_ms\":1677005916011,\"subscriber\":{\"entitlements\":{},\"first_seen\":\"2023-02-21T18:58:35Z\",\"last_seen\":\"2023-02-21T18:58:35Z\",\"management_url\":null,\"non_subscriptions\":{},\"original_app_user_id\":\"login\",\"original_application_version\":null,\"original_purchase_date\":null,\"other_purchases\":{},\"subscriptions\":{}}}\n") // Wrong body
-        ).isEqualTo(VerificationResult.ERROR)
+        ).isEqualTo(VerificationResult.FAILED)
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -81,9 +81,9 @@ class SigningManagerTest {
     // region verifyResponse
 
     @Test
-    fun `verifyResponse returns NOT_VERIFIED if verification mode disabled`() {
+    fun `verifyResponse returns NOT_REQUESTED if verification mode disabled`() {
         val verificationResult = callVerifyResponse(disabledSigningManager)
-        assertThat(verificationResult).isEqualTo(VerificationResult.NOT_VERIFIED)
+        assertThat(verificationResult).isEqualTo(VerificationResult.NOT_REQUESTED)
     }
 
     @Test

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
@@ -66,7 +66,7 @@ class AmazonBackendTest {
         responseCode = 200,
         payload = successfulRVSResponse(),
         origin = HTTPResult.Origin.BACKEND,
-        verificationResult = VerificationResult.NOT_VERIFIED
+        verificationResult = VerificationResult.NOT_REQUESTED
     )
     private var unsuccessfulResult = HTTPResult(
         responseCode = 401,
@@ -77,7 +77,7 @@ class AmazonBackendTest {
                 }
             """.trimIndent(),
         origin = HTTPResult.Origin.BACKEND,
-        verificationResult = VerificationResult.NOT_VERIFIED
+        verificationResult = VerificationResult.NOT_REQUESTED
     )
 
     @Test

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -438,5 +438,5 @@ class SubscriberAttributesPosterTests {
     private fun createResult(
         responseCode: Int,
         responseBody: String
-    ) = HTTPResult(responseCode, responseBody, HTTPResult.Origin.BACKEND, VerificationResult.NOT_VERIFIED)
+    ) = HTTPResult(responseCode, responseBody, HTTPResult.Origin.BACKEND, VerificationResult.NOT_REQUESTED)
 }

--- a/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt
@@ -83,7 +83,7 @@ data class EntitlementInfo constructor(
         billingIssueDetectedAt,
         ownershipType,
         jsonObject,
-        VerificationResult.NOT_VERIFIED
+        VerificationResult.NOT_REQUESTED
     )
 
     @IgnoredOnParcel

--- a/public/src/main/java/com/revenuecat/purchases/EntitlementInfos.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementInfos.kt
@@ -17,7 +17,7 @@ class EntitlementInfos constructor(
     @Deprecated("Use full constructor instead")
     constructor(
         all: Map<String, EntitlementInfo>
-    ) : this(all, VerificationResult.NOT_VERIFIED)
+    ) : this(all, VerificationResult.NOT_REQUESTED)
 
     /**
      * Dictionary of active [EntitlementInfo] objects keyed by entitlement identifier.

--- a/public/src/main/java/com/revenuecat/purchases/VerificationResult.kt
+++ b/public/src/main/java/com/revenuecat/purchases/VerificationResult.kt
@@ -28,5 +28,5 @@ enum class VerificationResult {
     /**
      * Entitlement verification failed, possibly due to a MiTM attack.
      */
-    ERROR
+    FAILED
 }

--- a/public/src/main/java/com/revenuecat/purchases/VerificationResult.kt
+++ b/public/src/main/java/com/revenuecat/purchases/VerificationResult.kt
@@ -18,7 +18,7 @@ enum class VerificationResult {
      * 1. Verification is not enabled in PurchasesConfiguration
      * 2. Data was cached in an older version of the SDK not supporting verification
      */
-    NOT_VERIFIED,
+    NOT_REQUESTED,
 
     /**
      * Entitlements were verified with our server.

--- a/public/src/test/java/com/revenuecat/purchases/ParcelableTests.kt
+++ b/public/src/test/java/com/revenuecat/purchases/ParcelableTests.kt
@@ -23,7 +23,7 @@ class ParcelableTests {
     fun `EntitlementInfos is Parcelable`() = testParcelization(
         EntitlementInfos(
             mapOf("an_identifier" to getEntitlementInfo(identifier = "an_identifier")),
-            verification = VerificationResult.NOT_VERIFIED
+            verification = VerificationResult.NOT_REQUESTED
         )
     )
 
@@ -80,7 +80,7 @@ class ParcelableTests {
             billingIssueDetectedAt = null,
             ownershipType = OwnershipType.UNKNOWN,
             jsonObject = JSONObject(Responses.validFullPurchaserResponse),
-            verification = VerificationResult.NOT_VERIFIED
+            verification = VerificationResult.NOT_REQUESTED
         )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -62,7 +62,7 @@ class PostingTransactionsTests {
     internal data class PostReceiptCompletionContainer(
         val info: CustomerInfo = CustomerInfoFactory.buildCustomerInfo(
             JSONObject(Responses.validFullPurchaserResponse),
-            VerificationResult.NOT_VERIFIED
+            VerificationResult.NOT_REQUESTED
         ),
         val body: JSONObject = JSONObject(Responses.validFullPurchaserResponse)
     )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -816,7 +816,7 @@ class PurchasesTest {
 
         val mockInfo = CustomerInfoFactory.buildCustomerInfo(
             JSONObject(Responses.validFullPurchaserResponse),
-            VerificationResult.NOT_VERIFIED
+            VerificationResult.NOT_REQUESTED
         )
         every {
             mockBackend.postReceiptData(

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -74,7 +74,7 @@ class SubscriberAttributesPurchasesTests {
     internal data class PostReceiptCompletionContainer(
         val info: CustomerInfo = CustomerInfoFactory.buildCustomerInfo(
             JSONObject(Responses.validFullPurchaserResponse),
-            VerificationResult.NOT_VERIFIED
+            VerificationResult.NOT_REQUESTED
         ),
         val body: JSONObject = JSONObject(Responses.validFullPurchaserResponse)
     )


### PR DESCRIPTION
### Description
Following the conversation in [SDK-2896](https://linear.app/revenuecat/issue/SDK-2896/invalidate-devicecache-cache-if-entitlement-verification-is-missing), we are renaming `NOT_VERIFIED` to `NOT_REQUESTED`. We're also renaming `ERROR` to `FAILED` to match iOS.