### PR TITLE
Entitlement verification: Fix request verification

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -59,18 +59,7 @@ class HTTPClient(
 
     @Throws(IOException::class)
     private fun readFully(inputStream: InputStream): String {
-        return readFully(buffer(inputStream))
-    }
-
-    @Throws(IOException::class)
-    private fun readFully(reader: BufferedReader): String {
-        val sb = StringBuilder()
-        var line = reader.readLine()
-        while (line != null) {
-            sb.append(line)
-            line = reader.readLine()
-        }
-        return sb.toString()
+        return buffer(inputStream).readText()
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -63,12 +63,12 @@ class SigningManager(
         return if (verificationResult) {
             VerificationResult.SUCCESS
         } else {
-            errorLog(NetworkStrings.VERIFICATION_ERROR)
+            errorLog(NetworkStrings.VERIFICATION_ERROR.format(urlPath))
             VerificationResult.FAILED
         }
     }
 
     private fun getSignatureMessage(responseCode: Int, body: String?, eTag: String?): String? {
-        return if (responseCode == RCHTTPStatusCodes.NOT_MODIFIED) eTag else body
+        return if (responseCode == RCHTTPStatusCodes.NOT_MODIFIED) eTag else body?.let { "$it\n" }
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -69,6 +69,6 @@ class SigningManager(
     }
 
     private fun getSignatureMessage(responseCode: Int, body: String?, eTag: String?): String? {
-        return if (responseCode == RCHTTPStatusCodes.NOT_MODIFIED) eTag else body?.let { "$it\n" }
+        return if (responseCode == RCHTTPStatusCodes.NOT_MODIFIED) eTag else body
     }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -326,6 +326,20 @@ class HTTPClientTest: BaseHTTPClientTest() {
         }
     }
 
+    @Test
+    fun `payload is returned with trailing new lines`() {
+        enqueue(
+            Endpoint.LogIn,
+            expectedResult = HTTPResult.createResult(payload = "{}\n")
+        )
+
+        val result = client.performRequest(baseURL, Endpoint.LogIn, null, emptyMap())
+
+        server.takeRequest()
+
+        assertThat(result.payload).isEqualTo("{}\n")
+    }
+
     // region trackHttpRequestPerformed
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -188,7 +188,7 @@ class SigningManagerTest {
         responseCode: Int = RCHTTPStatusCodes.SUCCESS,
         signature: String? = "2bm3QppRywK5ULyCRLS5JJy9sq+84IkMk0Ue4LsywEp87t0tDObpzPlu30l4Desq9X65UFuosqwCLMizruDHbKvPqQLce0hrIuZpgic+cQ8=",
         nonce: String = "MTIzNDU2Nzg5MGFi",
-        body: String? = "{\"request_date\":\"2023-02-21T18:58:36Z\",\"request_date_ms\":1677005916011,\"subscriber\":{\"entitlements\":{},\"first_seen\":\"2023-02-21T18:58:35Z\",\"last_seen\":\"2023-02-21T18:58:35Z\",\"management_url\":null,\"non_subscriptions\":{},\"original_app_user_id\":\"login\",\"original_application_version\":null,\"original_purchase_date\":null,\"other_purchases\":{},\"subscriptions\":{}}}",
+        body: String? = "{\"request_date\":\"2023-02-21T18:58:36Z\",\"request_date_ms\":1677005916011,\"subscriber\":{\"entitlements\":{},\"first_seen\":\"2023-02-21T18:58:35Z\",\"last_seen\":\"2023-02-21T18:58:35Z\",\"management_url\":null,\"non_subscriptions\":{},\"original_app_user_id\":\"login\",\"original_application_version\":null,\"original_purchase_date\":null,\"other_purchases\":{},\"subscriptions\":{}}}\n",
         requestTime: String? = "1677005916012",
         eTag: String? = null
     ) = signingManager.verifyResponse(requestPath, responseCode, signature, nonce, body, requestTime, eTag)

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -188,7 +188,7 @@ class SigningManagerTest {
         responseCode: Int = RCHTTPStatusCodes.SUCCESS,
         signature: String? = "2bm3QppRywK5ULyCRLS5JJy9sq+84IkMk0Ue4LsywEp87t0tDObpzPlu30l4Desq9X65UFuosqwCLMizruDHbKvPqQLce0hrIuZpgic+cQ8=",
         nonce: String = "MTIzNDU2Nzg5MGFi",
-        body: String? = "{\"request_date\":\"2023-02-21T18:58:36Z\",\"request_date_ms\":1677005916011,\"subscriber\":{\"entitlements\":{},\"first_seen\":\"2023-02-21T18:58:35Z\",\"last_seen\":\"2023-02-21T18:58:35Z\",\"management_url\":null,\"non_subscriptions\":{},\"original_app_user_id\":\"login\",\"original_application_version\":null,\"original_purchase_date\":null,\"other_purchases\":{},\"subscriptions\":{}}}\n",
+        body: String? = "{\"request_date\":\"2023-02-21T18:58:36Z\",\"request_date_ms\":1677005916011,\"subscriber\":{\"entitlements\":{},\"first_seen\":\"2023-02-21T18:58:35Z\",\"last_seen\":\"2023-02-21T18:58:35Z\",\"management_url\":null,\"non_subscriptions\":{},\"original_app_user_id\":\"login\",\"original_application_version\":null,\"original_purchase_date\":null,\"other_purchases\":{},\"subscriptions\":{}}}",
         requestTime: String? = "1677005916012",
         eTag: String? = null
     ) = signingManager.verifyResponse(requestPath, responseCode, signature, nonce, body, requestTime, eTag)


### PR DESCRIPTION
### Description
There was a mismatch in what body the signing expects and what the body we read from the response. We were missing an end of line at the end of the body when verifying the signature. This fixes that issue.
