### PR TITLE
Entitlement verification: Not perform verification if request returns error

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -173,7 +173,10 @@ class HTTPClient(
             throw IOException(NetworkStrings.HTTP_RESPONSE_PAYLOAD_NULL)
         }
 
-        val verificationResult = if (shouldSignResponse && nonce != null) {
+        val verificationResult = if (shouldSignResponse &&
+            nonce != null &&
+            RCHTTPStatusCodes.isSuccessful(responseCode)
+        ) {
             verifyResponse(path, responseCode, connection, payload, nonce)
         } else {
             VerificationResult.NOT_VERIFIED

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -333,7 +333,7 @@ class HTTPClientTest: BaseHTTPClientTest() {
         client = createClient(diagnosticsTracker = diagnosticsTracker, dateProvider = dateProvider)
 
         val endpoint = Endpoint.LogIn
-        val responseCode = 400
+        val responseCode = RCHTTPStatusCodes.BAD_REQUEST
         val requestStartTime = 1676379370000L // Tuesday, February 14, 2023 12:56:10:000 PM GMT
         val requestEndTime = 1676379370123L // Tuesday, February 14, 2023 12:56:10:123 PM GMT
         val responseTime = (requestEndTime - requestStartTime).milliseconds
@@ -362,11 +362,11 @@ class HTTPClientTest: BaseHTTPClientTest() {
         client = createClient(diagnosticsTracker = diagnosticsTracker, dateProvider = dateProvider)
 
         val endpoint = Endpoint.LogIn
-        val responseCode = 400
+        val responseCode = RCHTTPStatusCodes.BAD_REQUEST
 
         every {
             mockETagManager.getHTTPResultFromCacheOrBackend(
-                400,
+                RCHTTPStatusCodes.BAD_REQUEST,
                 "not uh json",
                 eTagHeader = any(),
                 "/v1${endpoint.getPath()}",

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.common.verification.SignatureVerificationException
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import io.mockk.every
@@ -58,6 +59,68 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         val endpoint = Endpoint.PostDiagnostics
         every { mockSigningManager.shouldVerifyEndpoint(endpoint) } returns false
         val expectedResult = HTTPResult.createResult(
+            verificationResult = VerificationResult.NOT_VERIFIED,
+            payload = "{\"test-key\":\"test-value\"}"
+        )
+
+        enqueue(
+            endpoint = endpoint,
+            expectedResult = expectedResult,
+            verificationResult = VerificationResult.NOT_VERIFIED
+        )
+
+        val result = client.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_VERIFIED)
+        verify(exactly = 0) {
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `performRequest does not verify response on 400 errors`() {
+        val endpoint = Endpoint.GetCustomerInfo("test-user-id")
+        every { mockSigningManager.shouldVerifyEndpoint(endpoint) } returns true
+        val expectedResult = HTTPResult.createResult(
+            responseCode = RCHTTPStatusCodes.BAD_REQUEST,
+            verificationResult = VerificationResult.NOT_VERIFIED,
+            payload = "{\"test-key\":\"test-value\"}"
+        )
+
+        enqueue(
+            endpoint = endpoint,
+            expectedResult = expectedResult,
+            verificationResult = VerificationResult.NOT_VERIFIED
+        )
+
+        val result = client.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_VERIFIED)
+        verify(exactly = 0) {
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `performRequest does not verify response on 500 errors`() {
+        val endpoint = Endpoint.GetCustomerInfo("test-user-id")
+        every { mockSigningManager.shouldVerifyEndpoint(endpoint) } returns true
+        val expectedResult = HTTPResult.createResult(
+            responseCode = RCHTTPStatusCodes.ERROR,
             verificationResult = VerificationResult.NOT_VERIFIED,
             payload = "{\"test-key\":\"test-value\"}"
         )


### PR DESCRIPTION
### Description
We were performing signature verification when the request failed with 400/500 errors. We don't need to verify those requests since it will fail anyway. Network errors were already handled since they throw an exception that is catched later on.
