### PR TITLE
Entitlement verification: Return current call verification result over cached version

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -56,7 +56,10 @@ class ETagManager(
         val resultFromBackend = HTTPResult(responseCode, payload, HTTPResult.Origin.BACKEND, verificationResult)
         eTagHeader?.let { eTagInResponse ->
             if (shouldUseCachedVersion(responseCode)) {
+                // This assumes we won't store verification failures in the cache and we will clear the cache when
+                // enabling verification.
                 val storedResult = getStoredResult(urlPathWithVersion)
+                    ?.copy(verificationResult = verificationResult)
                 return storedResult
                     ?: if (refreshETag) {
                         log(LogIntent.WARNING, NetworkStrings.ETAG_CALL_ALREADY_RETRIED.format(resultFromBackend))

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -363,12 +363,32 @@ class ETagManagerTest {
         assertThat(result?.verificationResult).isEqualTo(VerificationResult.SUCCESS)
     }
 
+    @Test
+    fun `getHTTPResultFromCacheOrBackend should use most restrictive verification result when coming from cache`() {
+        val httpResult = HTTPResult.createResult(
+            origin = HTTPResult.Origin.CACHE,
+            verificationResult = VerificationResult.FAILED
+        )
+        mockCachedHTTPResult("etag", "/v1/subscribers/appUserID", httpResult)
+        val result = underTest.getHTTPResultFromCacheOrBackend(
+            responseCode = RCHTTPStatusCodes.NOT_MODIFIED,
+            payload = "",
+            eTagHeader = "etag",
+            urlPathWithVersion = "/v1/subscribers/appUserID",
+            refreshETag = false,
+            verificationResult = VerificationResult.SUCCESS
+        )
+
+        assertThat(result?.verificationResult).isEqualTo(VerificationResult.FAILED)
+    }
+
     private fun mockCachedHTTPResult(
         expectedETag: String?,
-        path: String
+        path: String,
+        httpResult: HTTPResult = HTTPResult.createResult(origin = HTTPResult.Origin.CACHE)
     ): HTTPResultWithETag? {
         val cachedResult = expectedETag?.let {
-            HTTPResultWithETag(expectedETag, HTTPResult.createResult(origin = HTTPResult.Origin.CACHE))
+            HTTPResultWithETag(expectedETag, httpResult)
         }
         every {
             mockedPrefs.getString(path, null)

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -364,10 +364,10 @@ class ETagManagerTest {
     }
 
     @Test
-    fun `getHTTPResultFromCacheOrBackend should use most restrictive verification result when coming from cache`() {
+    fun `getHTTPResultFromCacheOrBackend should use result from latest request even if cached is different`() {
         val httpResult = HTTPResult.createResult(
             origin = HTTPResult.Origin.CACHE,
-            verificationResult = VerificationResult.FAILED
+            verificationResult = VerificationResult.SUCCESS
         )
         mockCachedHTTPResult("etag", "/v1/subscribers/appUserID", httpResult)
         val result = underTest.getHTTPResultFromCacheOrBackend(
@@ -376,7 +376,7 @@ class ETagManagerTest {
             eTagHeader = "etag",
             urlPathWithVersion = "/v1/subscribers/appUserID",
             refreshETag = false,
-            verificationResult = VerificationResult.SUCCESS
+            verificationResult = VerificationResult.FAILED
         )
 
         assertThat(result?.verificationResult).isEqualTo(VerificationResult.FAILED)


### PR DESCRIPTION
### Description
This PR makes sure we expose the current call verification result over the cached version. We shouldn't be storing verification errors in the etag cache. Also, we plan to clear the cache when verification mode is enabled, so we shouldn't have `NOT_REQUESTED` values either, so the etag cache should only contain successful values
