### PR TITLE
[BC5] Always use purchasingData property directly on the StoreProduct when purchasing

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
@@ -44,13 +44,13 @@ open class PurchaseParams(builder: Builder) {
     ) {
         constructor(packageToPurchase: Package, activity: Activity) :
             this(
-                packageToPurchase.product.defaultOption?.purchasingData ?: packageToPurchase.product.purchasingData,
+                packageToPurchase.product.purchasingData,
                 activity,
                 packageToPurchase.offering
             )
 
         constructor(storeProduct: StoreProduct, activity: Activity) :
-            this(storeProduct.defaultOption?.purchasingData ?: storeProduct.purchasingData, activity)
+            this(storeProduct.purchasingData, activity)
 
         constructor(subscriptionOption: SubscriptionOption, activity: Activity) :
             this(subscriptionOption.purchasingData, activity)


### PR DESCRIPTION
### Motivation

[CF-1165](https://revenuecats.atlassian.net/browse/CF-1165)

Logic to purchase a `PurchasingData` shouldn't have to check if a `defaultOption` exists. There should be a reusable helper to do this.

### Description

Turns out... I didn't realize the `purchaseData` on `GoogleStoreProduct` was already being overridden to choose the `defaultOption.purchasingData` for SUBS 😇 

See [here](https://github.com/RevenueCat/purchases-android/blob/bc5-support-cleanup-extra-use-of-purchasingData/public/src/main/java/com/revenuecat/purchases/models/GoogleStoreProduct.kt#L29-L37) in `GoogleStoreProduct`

So... this task was a lot shorter than planned because the implementation already existed but just needed to be used

[CF-1165]: https://revenuecats.atlassian.net/browse/CF-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ