### PR TITLE
Entitlement verification: Return updated request time from header in CustomerInfo in 304 responses

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.strings.NetworkStrings
 import com.revenuecat.purchases.utils.filterNotNullValues
 import org.json.JSONArray
@@ -46,6 +47,9 @@ class Backend(
     private val httpClient: HTTPClient
 ) {
     internal val authenticationHeaders = mapOf("Authorization" to "Bearer ${this.apiKey}")
+
+    val verificationMode: SignatureVerificationMode
+        get() = httpClient.signingManager.signatureVerificationMode
 
     @get:Synchronized @set:Synchronized
     @Volatile var callbacks = mutableMapOf<CallbackCacheKey, MutableList<CustomerInfoCallback>>()

--- a/common/src/main/java/com/revenuecat/purchases/common/CustomerInfoFactory.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/CustomerInfoFactory.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.utils.parsePurchaseDates
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.Collections.emptyMap
+import java.util.Date
 
 /**
  * Builds a CustomerInfo
@@ -20,11 +21,15 @@ import java.util.Collections.emptyMap
 object CustomerInfoFactory {
     @Throws(JSONException::class)
     fun buildCustomerInfo(httpResult: HTTPResult): CustomerInfo {
-        return buildCustomerInfo(httpResult.body, httpResult.verificationResult)
+        return buildCustomerInfo(httpResult.body, httpResult.requestDate, httpResult.verificationResult)
     }
 
     @Throws(JSONException::class)
-    fun buildCustomerInfo(body: JSONObject, verificationResult: VerificationResult): CustomerInfo {
+    fun buildCustomerInfo(
+        body: JSONObject,
+        overrideRequestDate: Date?,
+        verificationResult: VerificationResult
+    ): CustomerInfo {
         val subscriber = body.getJSONObject("subscriber")
 
         val nonSubscriptions = subscriber.getJSONObject("non_subscriptions")
@@ -47,7 +52,7 @@ object CustomerInfoFactory {
 
         val entitlements = subscriber.optJSONObject("entitlements")
 
-        val requestDate = Iso8601Utils.parse(body.getString("request_date"))
+        val requestDate = overrideRequestDate ?: Iso8601Utils.parse(body.getString("request_date"))
 
         val firstSeen = Iso8601Utils.parse(subscriber.getString("first_seen"))
 

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -40,7 +40,7 @@ class HTTPClient(
     private val appConfig: AppConfig,
     private val eTagManager: ETagManager,
     private val diagnosticsTrackerIfEnabled: DiagnosticsTracker?,
-    private val signingManager: SigningManager,
+    val signingManager: SigningManager,
     private val dateProvider: DateProvider = DefaultDateProvider()
 ) {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -193,6 +193,7 @@ class HTTPClient(
             getETagHeader(connection),
             urlPathWithVersion,
             refreshETag,
+            getRequestDateHeader(connection),
             verificationResult
         )
     }
@@ -302,10 +303,21 @@ class HTTPClient(
             signature = connection.getHeaderField(HTTPResult.SIGNATURE_HEADER_NAME),
             nonce = nonce,
             body = payload,
-            requestTime = connection.getHeaderField(HTTPResult.REQUEST_TIME_HEADER_NAME),
+            requestTime = getRequestTimeHeader(connection),
             eTag = getETagHeader(connection),
         )
     }
 
     private fun getETagHeader(connection: URLConnection) = connection.getHeaderField(HTTPResult.ETAG_HEADER_NAME)
+    private fun getRequestTimeHeader(connection: URLConnection): String? {
+        return connection.getHeaderField(HTTPResult.REQUEST_TIME_HEADER_NAME)?.takeIf { it.isNotBlank() }
+    }
+    private fun getRequestDateHeader(connection: URLConnection): Date? {
+        val requestTimeMillis = getRequestTimeHeader(connection)?.toLong()
+        return if (requestTimeMillis == null) {
+            null
+        } else {
+            Date(requestTimeMillis)
+        }
+    }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -313,11 +313,8 @@ class HTTPClient(
         return connection.getHeaderField(HTTPResult.REQUEST_TIME_HEADER_NAME)?.takeIf { it.isNotBlank() }
     }
     private fun getRequestDateHeader(connection: URLConnection): Date? {
-        val requestTimeMillis = getRequestTimeHeader(connection)?.toLong()
-        return if (requestTimeMillis == null) {
-            null
-        } else {
-            Date(requestTimeMillis)
+        return getRequestTimeHeader(connection)?.toLong()?.let {
+            Date(it)
         }
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -24,7 +24,7 @@ import java.util.Date
 private const val CACHE_REFRESH_PERIOD_IN_FOREGROUND = 60000 * 5
 private const val CACHE_REFRESH_PERIOD_IN_BACKGROUND = 60000 * 60 * 25
 private const val SHARED_PREFERENCES_PREFIX = "com.revenuecat.purchases."
-internal const val PURCHASER_INFO_SCHEMA_VERSION = 3
+internal const val CUSTOMER_INFO_SCHEMA_VERSION = 3
 
 open class DeviceCache(
     private val preferences: SharedPreferences,
@@ -114,7 +114,7 @@ open class DeviceCache(
                     cachedJSONObject.remove(CUSTOMER_INFO_VERIFICATION_RESULT_KEY)
                     cachedJSONObject.remove(CUSTOMER_INFO_REQUEST_DATE_KEY)
                     val verificationResult = VerificationResult.valueOf(verificationResultString)
-                    return if (schemaVersion == PURCHASER_INFO_SCHEMA_VERSION) {
+                    return if (schemaVersion == CUSTOMER_INFO_SCHEMA_VERSION) {
                         CustomerInfoFactory.buildCustomerInfo(cachedJSONObject, requestDate, verificationResult)
                     } else {
                         null
@@ -128,7 +128,7 @@ open class DeviceCache(
     @Synchronized
     fun cacheCustomerInfo(appUserID: String, info: CustomerInfo) {
         val jsonObject = info.rawData.also {
-            it.put(CUSTOMER_INFO_SCHEMA_VERSION_KEY, PURCHASER_INFO_SCHEMA_VERSION)
+            it.put(CUSTOMER_INFO_SCHEMA_VERSION_KEY, CUSTOMER_INFO_SCHEMA_VERSION)
             it.put(CUSTOMER_INFO_VERIFICATION_RESULT_KEY, info.entitlements.verification.name)
             it.put(CUSTOMER_INFO_REQUEST_DATE_KEY, info.requestDate.time)
         }

--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -35,6 +35,7 @@ open class DeviceCache(
     companion object {
         private const val CUSTOMER_INFO_SCHEMA_VERSION_KEY = "schema_version"
         private const val CUSTOMER_INFO_VERIFICATION_RESULT_KEY = "verification_result"
+        private const val CUSTOMER_INFO_REQUEST_DATE_KEY = "customer_info_request_date"
     }
 
     val legacyAppUserIDCacheKey: String by lazy { "$SHARED_PREFERENCES_PREFIX$apiKey" }
@@ -106,11 +107,15 @@ open class DeviceCache(
                     val verificationResultString = if (cachedJSONObject.has(CUSTOMER_INFO_VERIFICATION_RESULT_KEY)) {
                         cachedJSONObject.getString(CUSTOMER_INFO_VERIFICATION_RESULT_KEY)
                     } else VerificationResult.NOT_REQUESTED.name
+                    val requestDate = cachedJSONObject.optLong(CUSTOMER_INFO_REQUEST_DATE_KEY).takeIf { it > 0 }?.let {
+                        Date(it)
+                    }
                     cachedJSONObject.remove(CUSTOMER_INFO_SCHEMA_VERSION_KEY)
                     cachedJSONObject.remove(CUSTOMER_INFO_VERIFICATION_RESULT_KEY)
+                    cachedJSONObject.remove(CUSTOMER_INFO_REQUEST_DATE_KEY)
                     val verificationResult = VerificationResult.valueOf(verificationResultString)
                     return if (schemaVersion == PURCHASER_INFO_SCHEMA_VERSION) {
-                        CustomerInfoFactory.buildCustomerInfo(cachedJSONObject, verificationResult)
+                        CustomerInfoFactory.buildCustomerInfo(cachedJSONObject, requestDate, verificationResult)
                     } else {
                         null
                     }
@@ -125,6 +130,7 @@ open class DeviceCache(
         val jsonObject = info.rawData.also {
             it.put(CUSTOMER_INFO_SCHEMA_VERSION_KEY, PURCHASER_INFO_SCHEMA_VERSION)
             it.put(CUSTOMER_INFO_VERIFICATION_RESULT_KEY, info.entitlements.verification.name)
+            it.put(CUSTOMER_INFO_REQUEST_DATE_KEY, info.requestDate.time)
         }
         preferences.edit()
             .putString(

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -92,7 +92,7 @@ class ETagManager(
     }
 
     @Synchronized
-    internal fun clearCaches() {
+    fun clearCaches() {
         prefs.edit().clear().apply()
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -64,14 +64,15 @@ class ETagManager(
         )
         eTagHeader?.let { eTagInResponse ->
             if (shouldUseCachedVersion(responseCode)) {
-                // This assumes we won't store verification failures in the cache and we will clear the cache when
-                // enabling verification.
-                val storedResult = getStoredResult(urlPathWithVersion)
-                val transformedResult = storedResult?.copy(
-                    verificationResult = verificationResult,
-                    requestDate = requestDate ?: storedResult.requestDate
-                )
-                return transformedResult
+                val storedResult = getStoredResult(urlPathWithVersion)?.let { storedResult ->
+                    storedResult.copy(
+                        // This assumes we won't store verification failures in the cache and we will clear the cache
+                        // when enabling verification.
+                        verificationResult = verificationResult,
+                        requestDate = requestDate ?: storedResult.requestDate
+                    )
+                }
+                return storedResult
                     ?: if (refreshETag) {
                         log(LogIntent.WARNING, NetworkStrings.ETAG_CALL_ALREADY_RETRIED.format(resultFromBackend))
                         resultFromBackend

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -92,7 +92,7 @@ class ETagManager(
     }
 
     @Synchronized
-    fun clearCaches() {
+    internal fun clearCaches() {
         prefs.edit().clear().apply()
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPResult.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPResult.kt
@@ -2,16 +2,19 @@ package com.revenuecat.purchases.common.networking
 
 import com.revenuecat.purchases.VerificationResult
 import org.json.JSONObject
+import java.util.Date
 
 private const val SERIALIZATION_NAME_RESPONSE_CODE = "responseCode"
 private const val SERIALIZATION_NAME_PAYLOAD = "payload"
 private const val SERIALIZATION_NAME_ORIGIN = "origin"
+private const val SERIALIZATION_NAME_REQUEST_DATE = "requestDate"
 private const val SERIALIZATION_NAME_VERIFICATION_RESULT = "verificationResult"
 
 data class HTTPResult(
     val responseCode: Int,
     val payload: String,
     val origin: Origin,
+    val requestDate: Date?,
     val verificationResult: VerificationResult
 ) {
     companion object {
@@ -28,12 +31,17 @@ data class HTTPResult(
             } else {
                 Origin.CACHE
             }
+            val requestDate: Date? = if (jsonObject.has(SERIALIZATION_NAME_REQUEST_DATE)) {
+                Date(jsonObject.getLong(SERIALIZATION_NAME_REQUEST_DATE))
+            } else {
+                null
+            }
             val verificationResult: VerificationResult = if (jsonObject.has(SERIALIZATION_NAME_VERIFICATION_RESULT)) {
                 VerificationResult.valueOf(jsonObject.getString(SERIALIZATION_NAME_VERIFICATION_RESULT))
             } else {
                 VerificationResult.NOT_REQUESTED
             }
-            return HTTPResult(responseCode, payload, origin, verificationResult)
+            return HTTPResult(responseCode, payload, origin, requestDate, verificationResult)
         }
     }
 
@@ -48,6 +56,7 @@ data class HTTPResult(
             put(SERIALIZATION_NAME_RESPONSE_CODE, responseCode)
             put(SERIALIZATION_NAME_PAYLOAD, payload)
             put(SERIALIZATION_NAME_ORIGIN, origin.name)
+            put(SERIALIZATION_NAME_REQUEST_DATE, requestDate?.time)
             put(SERIALIZATION_NAME_VERIFICATION_RESULT, verificationResult.name)
         }
         return jsonObject.toString()

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -490,7 +490,7 @@ class BackendTest {
         val updatedInfo = createCustomerInfo(Responses.validEmptyPurchaserResponse)
 
         assertThat(initialInfo).isEqualTo(
-            CustomerInfoFactory.buildCustomerInfo(initialInfo.rawData, verificationResult)
+            CustomerInfoFactory.buildCustomerInfo(initialInfo.rawData, null, verificationResult)
         )
 
         mockResponse(

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -15,7 +15,7 @@ import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.caching.InMemoryCachedObject
-import com.revenuecat.purchases.common.caching.PURCHASER_INFO_SCHEMA_VERSION
+import com.revenuecat.purchases.common.caching.CUSTOMER_INFO_SCHEMA_VERSION
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.utils.Responses
@@ -42,7 +42,7 @@ class DeviceCacheTest {
 
     private val validCachedCustomerInfo by lazy {
         JSONObject(Responses.validFullPurchaserResponse).apply {
-            put("schema_version", PURCHASER_INFO_SCHEMA_VERSION)
+            put("schema_version", CUSTOMER_INFO_SCHEMA_VERSION)
             put("verification_result", VerificationResult.SUCCESS)
         }.toString()
     }
@@ -97,7 +97,7 @@ class DeviceCacheTest {
     }
 
     @Test
-    fun `given a purchaser info, the key in the cache is correct`() {
+    fun `given a customer info, the key in the cache is correct`() {
         mockString(cache.customerInfoCacheKey(appUserID), Responses.validFullPurchaserResponse)
         cache.getCachedCustomerInfo(appUserID)
         verify {
@@ -106,7 +106,7 @@ class DeviceCacheTest {
     }
 
     @Test
-    fun `given a valid purchaser info, the JSON is parsed correctly`() {
+    fun `given a valid customer info, the JSON is parsed correctly`() {
         mockString(cache.customerInfoCacheKey(appUserID), validCachedCustomerInfo)
         val info = cache.getCachedCustomerInfo(appUserID)
         assertThat(info).`as`("info is not null").isNotNull
@@ -114,10 +114,10 @@ class DeviceCacheTest {
     }
 
     @Test
-    fun `given a valid purchaser info without verification result, the JSON is parsed correctly`() {
+    fun `given a valid customer info without verification result, the JSON is parsed correctly`() {
         val deprecatedValidCachedCustomerInfo by lazy {
             JSONObject(Responses.validFullPurchaserResponse).apply {
-                put("schema_version", PURCHASER_INFO_SCHEMA_VERSION)
+                put("schema_version", CUSTOMER_INFO_SCHEMA_VERSION)
             }.toString()
         }
         mockString(cache.customerInfoCacheKey(appUserID), deprecatedValidCachedCustomerInfo)
@@ -127,10 +127,10 @@ class DeviceCacheTest {
     }
 
     @Test
-    fun `given a valid purchaser info without request date, the JSON is parsed correctly`() {
+    fun `given a valid customer info without request date, the JSON is parsed correctly`() {
         val deprecatedValidCachedCustomerInfo by lazy {
             JSONObject(Responses.validFullPurchaserResponse).apply {
-                put("schema_version", PURCHASER_INFO_SCHEMA_VERSION)
+                put("schema_version", CUSTOMER_INFO_SCHEMA_VERSION)
             }.toString()
         }
         mockString(cache.customerInfoCacheKey(appUserID), deprecatedValidCachedCustomerInfo)
@@ -140,10 +140,10 @@ class DeviceCacheTest {
     }
 
     @Test
-    fun `given a valid purchaser info with request date, the JSON is parsed correctly`() {
+    fun `given a valid customer info with request date, the JSON is parsed correctly`() {
         val deprecatedValidCachedCustomerInfo by lazy {
             JSONObject(Responses.validFullPurchaserResponse).apply {
-                put("schema_version", PURCHASER_INFO_SCHEMA_VERSION)
+                put("schema_version", CUSTOMER_INFO_SCHEMA_VERSION)
                 put("customer_info_request_date", 1234567890L)
             }.toString()
         }
@@ -154,28 +154,28 @@ class DeviceCacheTest {
     }
 
     @Test
-    fun `given a invalid purchaser info, the information is null`() {
+    fun `given a invalid customer info, the information is null`() {
         mockString(cache.customerInfoCacheKey(appUserID), "not json")
         val info = cache.getCachedCustomerInfo(appUserID)
         assertThat(info).`as`("info is null").isNull()
     }
 
     @Test
-    fun `given a valid cached purchaser info, the created customer info does not have schema version information`() {
+    fun `given a valid cached customer info, the created customer info does not have schema version information`() {
         mockString(cache.customerInfoCacheKey(appUserID), validCachedCustomerInfo)
         val info = cache.getCachedCustomerInfo(appUserID)
         assertThat(info?.rawData?.has("schema_version")).isFalse
     }
 
     @Test
-    fun `given a valid purchaser info, the created customer info does not have verification result information`() {
+    fun `given a valid customer info, the created customer info does not have verification result information`() {
         mockString(cache.customerInfoCacheKey(appUserID), validCachedCustomerInfo)
         val info = cache.getCachedCustomerInfo(appUserID)
         assertThat(info?.rawData?.has("verification_result")).isFalse
     }
 
     @Test
-    fun `given a purchaser info, the information is cached`() {
+    fun `given a customer info, the information is cached`() {
         val info = createCustomerInfo(Responses.validFullPurchaserResponse)
 
         cache.cacheCustomerInfo(appUserID, info)
@@ -188,7 +188,7 @@ class DeviceCacheTest {
     }
 
     @Test
-    fun `given a purchaser info, the information is cached with a verification result`() {
+    fun `given a customer info, the information is cached with a verification result`() {
         every {
             mockEditor.putLong(cache.customerInfoLastUpdatedCacheKey(appUserID), any())
         } returns mockEditor
@@ -208,7 +208,7 @@ class DeviceCacheTest {
     }
 
     @Test
-    fun `given a purchaser info, the information is cached with a schema version`() {
+    fun `given a customer info, the information is cached with a schema version`() {
         every {
             mockEditor.putLong(cache.customerInfoLastUpdatedCacheKey(appUserID), any())
         } returns mockEditor
@@ -223,11 +223,11 @@ class DeviceCacheTest {
 
         val cachedJSON = JSONObject(infoJSONSlot.captured)
         assertThat(cachedJSON.has("schema_version")).isTrue
-        assertThat(cachedJSON.getInt("schema_version")).isEqualTo(PURCHASER_INFO_SCHEMA_VERSION)
+        assertThat(cachedJSON.getInt("schema_version")).isEqualTo(CUSTOMER_INFO_SCHEMA_VERSION)
     }
 
     @Test
-    fun `given a purchaser info, the information is cached with a request date`() {
+    fun `given a customer info, the information is cached with a request date`() {
         every {
             mockEditor.putLong(cache.customerInfoLastUpdatedCacheKey(appUserID), any())
         } returns mockEditor
@@ -246,14 +246,14 @@ class DeviceCacheTest {
     }
 
     @Test
-    fun `given an older version of purchaser info, nothing is returned`() {
+    fun `given an older version of customer info, nothing is returned`() {
         mockString(cache.customerInfoCacheKey(appUserID), oldCachedCustomerInfo)
         val info = cache.getCachedCustomerInfo(appUserID)
         assertThat(info).`as`("info is null").isNull()
     }
 
     @Test
-    fun `given a valid version purchaser info, it is returned`() {
+    fun `given a valid version customer info, it is returned`() {
         mockString(cache.customerInfoCacheKey(appUserID), validCachedCustomerInfo)
         val info = cache.getCachedCustomerInfo(appUserID)
         assertThat(info).`as`("info is not null").isNotNull()
@@ -365,7 +365,7 @@ class DeviceCacheTest {
     }
 
     @Test
-    fun `invalidating purchaser info caches`() {
+    fun `invalidating customer info caches`() {
         mockLong(cache.customerInfoLastUpdatedCacheKey(appUserID), Date(0).time)
         assertThat(cache.isCustomerInfoCacheStale(appUserID, appInBackground = false)).isTrue()
         mockLong(cache.customerInfoLastUpdatedCacheKey(appUserID), Date().time)
@@ -510,13 +510,13 @@ class DeviceCacheTest {
     }
 
     @Test
-    fun `timestamp is set when caching purchaser info`() {
+    fun `timestamp is set when caching customer info`() {
         cache.cacheCustomerInfo("waldo", mockk(relaxed = true))
         assertThat(slotForPutLong.captured).isNotNull()
     }
 
     @Test
-    fun `clearing purchaser info caches clears the shared preferences`() {
+    fun `clearing customer info caches clears the shared preferences`() {
         cache.cacheCustomerInfo(appUserID, mockk(relaxed = true))
         assertThat(slotForPutLong.captured).isNotNull()
 

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
@@ -86,7 +86,7 @@ class EntitlementInfosTests {
             }
         )
 
-        val subscriberInfo = createCustomerInfo(response, VerificationResult.SUCCESS)
+        val subscriberInfo = createCustomerInfo(response, null, VerificationResult.SUCCESS)
         assertThat(subscriberInfo.entitlements.all).hasSize(2)
         assertThat(subscriberInfo.entitlements.verification).isEqualTo(VerificationResult.SUCCESS)
         subscriberInfo.entitlements.all.onEach { entry ->
@@ -139,7 +139,7 @@ class EntitlementInfosTests {
             }
         )
 
-        val subscriberInfo = createCustomerInfo(response, VerificationResult.FAILED)
+        val subscriberInfo = createCustomerInfo(response, null, VerificationResult.FAILED)
         assertThat(subscriberInfo.entitlements.verification).isEqualTo(VerificationResult.FAILED)
         assertThat(subscriberInfo.entitlements["pro_cat"]?.verification).isEqualTo(VerificationResult.FAILED)
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -16,6 +16,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.util.Date
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -166,6 +167,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
                 eTagHeader = any(),
                 "/v1${endpoint.getPath()}",
                 refreshETag = false,
+                requestDate = Date(1234567890L),
                 verificationResult = VerificationResult.SUCCESS
             )
         } returns expectedResult
@@ -252,7 +254,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
         assertThat(thrownCorrectException).isTrue
         verify(exactly = 0) {
-            mockETagManager.getHTTPResultFromCacheOrBackend(any(), any(), any(), any(), any(), any())
+            mockETagManager.getHTTPResultFromCacheOrBackend(any(), any(), any(), any(), any(), any(), any())
         }
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPResultMockFactory.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPResultMockFactory.kt
@@ -3,10 +3,12 @@ package com.revenuecat.purchases.common
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import java.util.Date
 
 fun HTTPResult.Companion.createResult(
     responseCode: Int = RCHTTPStatusCodes.SUCCESS,
     payload: String = "{}",
     origin: HTTPResult.Origin = HTTPResult.Origin.BACKEND,
+    requestDate: Date? = null,
     verificationResult: VerificationResult = VerificationResult.NOT_REQUESTED
-) = HTTPResult(responseCode, payload, origin, verificationResult)
+) = HTTPResult(responseCode, payload, origin, requestDate, verificationResult)

--- a/common/src/test/java/com/revenuecat/purchases/common/MockCustomerInfoFactory.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/MockCustomerInfoFactory.kt
@@ -3,17 +3,20 @@ package com.revenuecat.purchases.common
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.VerificationResult
 import org.json.JSONObject
+import java.util.Date
 
 fun createCustomerInfo(
     response: String,
+    requestDate: Date? = null,
     verificationResult: VerificationResult = VerificationResult.NOT_REQUESTED
 ): CustomerInfo {
-    return createCustomerInfo(JSONObject(response), verificationResult)
+    return createCustomerInfo(JSONObject(response), requestDate, verificationResult)
 }
 
 fun createCustomerInfo(
     jsonObject: JSONObject,
+    requestDate: Date? = null,
     verificationResult: VerificationResult = VerificationResult.NOT_REQUESTED
 ): CustomerInfo {
-    return CustomerInfoFactory.buildCustomerInfo(jsonObject, verificationResult)
+    return CustomerInfoFactory.buildCustomerInfo(jsonObject, requestDate, verificationResult)
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -411,11 +411,11 @@ class ETagManagerTest {
     @Test
     fun `getHTTPResultFromCacheOrBackend should use requestDate from header even if cached is different`() {
         val expectedDate = Date(1234567890)
-        val httpResult = HTTPResult.createResult(
+        val cachedHttpResult = HTTPResult.createResult(
             origin = HTTPResult.Origin.CACHE,
             requestDate = Date(1000)
         )
-        mockCachedHTTPResult("etag", "/v1/subscribers/appUserID", httpResult)
+        mockCachedHTTPResult("etag", "/v1/subscribers/appUserID", cachedHttpResult)
         val result = underTest.getHTTPResultFromCacheOrBackend(
             responseCode = RCHTTPStatusCodes.SUCCESS,
             payload = "",

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -16,6 +16,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.util.Date
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -224,6 +225,7 @@ class ETagManagerTest {
             eTagHeader = eTagInResponse,
             urlPathWithVersion = path,
             refreshETag = false,
+            requestDate = null,
             verificationResult = VerificationResult.NOT_REQUESTED
         )
 
@@ -245,6 +247,7 @@ class ETagManagerTest {
             eTagHeader = eTagInResponse,
             urlPathWithVersion = path,
             refreshETag = false,
+            requestDate = null,
             verificationResult = VerificationResult.NOT_REQUESTED
         )
 
@@ -268,6 +271,7 @@ class ETagManagerTest {
             eTagHeader = eTagInResponse,
             urlPathWithVersion = path,
             refreshETag = false,
+            requestDate = null,
             verificationResult = VerificationResult.NOT_REQUESTED
         )
 
@@ -292,6 +296,7 @@ class ETagManagerTest {
             eTagHeader = eTagInResponse,
             urlPathWithVersion = path,
             refreshETag = true,
+            requestDate = null,
             verificationResult = VerificationResult.NOT_REQUESTED
         )
 
@@ -315,6 +320,7 @@ class ETagManagerTest {
             eTagHeader = eTagInResponse,
             urlPathWithVersion = path,
             refreshETag = false,
+            requestDate = null,
             verificationResult = VerificationResult.NOT_REQUESTED
         )
 
@@ -338,6 +344,7 @@ class ETagManagerTest {
             eTagHeader = eTagInResponse,
             urlPathWithVersion = path,
             refreshETag = true,
+            requestDate = null,
             verificationResult = VerificationResult.NOT_REQUESTED
         )
 
@@ -357,6 +364,7 @@ class ETagManagerTest {
             eTagHeader = "etag",
             urlPathWithVersion = "/v1/subscribers/appUserID",
             refreshETag = false,
+            requestDate = null,
             verificationResult = VerificationResult.SUCCESS
         )
 
@@ -376,10 +384,49 @@ class ETagManagerTest {
             eTagHeader = "etag",
             urlPathWithVersion = "/v1/subscribers/appUserID",
             refreshETag = false,
+            requestDate = null,
             verificationResult = VerificationResult.FAILED
         )
 
         assertThat(result?.verificationResult).isEqualTo(VerificationResult.FAILED)
+    }
+
+    @Test
+    fun `getHTTPResultFromCacheOrBackend should use requestDate from header when no cached version exists`() {
+        val expectedDate = Date(1234567890)
+        mockCachedHTTPResult(expectedETag = null, "/v1/subscribers/appUserID")
+        val result = underTest.getHTTPResultFromCacheOrBackend(
+            responseCode = RCHTTPStatusCodes.SUCCESS,
+            payload = "",
+            eTagHeader = "etag",
+            urlPathWithVersion = "/v1/subscribers/appUserID",
+            refreshETag = false,
+            requestDate = expectedDate,
+            verificationResult = VerificationResult.NOT_REQUESTED
+        )
+
+        assertThat(result?.requestDate).isEqualTo(expectedDate)
+    }
+
+    @Test
+    fun `getHTTPResultFromCacheOrBackend should use requestDate from header even if cached is different`() {
+        val expectedDate = Date(1234567890)
+        val httpResult = HTTPResult.createResult(
+            origin = HTTPResult.Origin.CACHE,
+            requestDate = Date(1000)
+        )
+        mockCachedHTTPResult("etag", "/v1/subscribers/appUserID", httpResult)
+        val result = underTest.getHTTPResultFromCacheOrBackend(
+            responseCode = RCHTTPStatusCodes.SUCCESS,
+            payload = "",
+            eTagHeader = "etag",
+            urlPathWithVersion = "/v1/subscribers/appUserID",
+            refreshETag = false,
+            requestDate = expectedDate,
+            verificationResult = VerificationResult.NOT_REQUESTED
+        )
+
+        assertThat(result?.requestDate).isEqualTo(expectedDate)
     }
 
     private fun mockCachedHTTPResult(

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.util.Date
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -17,6 +18,25 @@ class HTTPResultTest {
             200,
             "{\"test-key\":\"test-value\"}",
             HTTPResult.Origin.BACKEND,
+            Date(1678180617000), // Tuesday, March 7, 2023 9:16:57 AM GMT,
+            VerificationResult.SUCCESS
+        )
+        assertThat(result.serialize()).isEqualTo("{" +
+            "\"responseCode\":200," +
+            "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"," +
+            "\"origin\":\"BACKEND\"," +
+            "\"requestDate\":1678180617000," +
+            "\"verificationResult\":\"SUCCESS\"}"
+        )
+    }
+
+    @Test
+    fun `result with null requestDate is serialized correctly`() {
+        val result = HTTPResult(
+            200,
+            "{\"test-key\":\"test-value\"}",
+            HTTPResult.Origin.BACKEND,
+            null,
             VerificationResult.SUCCESS
         )
         assertThat(result.serialize()).isEqualTo("{" +
@@ -33,22 +53,25 @@ class HTTPResultTest {
             200,
             "{\"test-key\":\"test-value\"}",
             HTTPResult.Origin.BACKEND,
+            Date(1678180617000),
             VerificationResult.FAILED
         )
         val result = HTTPResult.deserialize("{" +
             "\"responseCode\":200," +
             "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"," +
             "\"origin\":\"BACKEND\"," +
+            "\"requestDate\":1678180617000," +
             "\"verificationResult\":\"FAILED\"}")
         assertThat(result).isEqualTo(expectedResult)
     }
 
     @Test
-    fun `result defaults to CACHE origin and NOT_REQUESTED verification result if not part of serialized string`() {
+    fun `result defaults when deserializing are expected if data not part of serialized string`() {
         val expectedResult = HTTPResult(
             200,
             "{\"test-key\":\"test-value\"}",
             HTTPResult.Origin.CACHE,
+            null,
             VerificationResult.NOT_REQUESTED
         )
         val result = HTTPResult.deserialize("{" +

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
@@ -66,6 +66,7 @@ class AmazonBackendTest {
         responseCode = 200,
         payload = successfulRVSResponse(),
         origin = HTTPResult.Origin.BACKEND,
+        requestDate = null,
         verificationResult = VerificationResult.NOT_REQUESTED
     )
     private var unsuccessfulResult = HTTPResult(
@@ -77,6 +78,7 @@ class AmazonBackendTest {
                 }
             """.trimIndent(),
         origin = HTTPResult.Origin.BACKEND,
+        requestDate = null,
         verificationResult = VerificationResult.NOT_REQUESTED
     )
 

--- a/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -7,9 +7,7 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.caching.DeviceCache
-import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
-import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.networking.ETagManager
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode

--- a/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -7,7 +7,9 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.networking.ETagManager
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
@@ -126,6 +128,7 @@ class IdentityManager(
     private fun invalidateCustomerInfoAndETagCacheIfNeeded(appUserID: String) {
         val cachedCustomerInfo = deviceCache.getCachedCustomerInfo(appUserID)
         if (shouldInvalidateCustomerInfoAndETagCache(cachedCustomerInfo)) {
+            log(LogIntent.USER, IdentityStrings.INVALIDATING_CACHED_CUSTOMER_INFO)
             deviceCache.clearCustomerInfoCache(appUserID)
             eTagManager.clearCaches()
         }

--- a/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -8,8 +8,8 @@ import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
-import com.revenuecat.purchases.common.networking.ETagManager
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.strings.IdentityStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
@@ -21,9 +21,7 @@ class IdentityManager(
     private val deviceCache: DeviceCache,
     private val subscriberAttributesCache: SubscriberAttributesCache,
     private val subscriberAttributesManager: SubscriberAttributesManager,
-    private val backend: Backend,
-    private val eTagManager: ETagManager,
-    private val signatureVerificationMode: SignatureVerificationMode
+    private val backend: Backend
 ) {
 
     val currentAppUserID: String
@@ -126,16 +124,16 @@ class IdentityManager(
     private fun invalidateCustomerInfoAndETagCacheIfNeeded(appUserID: String) {
         val cachedCustomerInfo = deviceCache.getCachedCustomerInfo(appUserID)
         if (shouldInvalidateCustomerInfoAndETagCache(cachedCustomerInfo)) {
-            log(LogIntent.USER, IdentityStrings.INVALIDATING_CACHED_CUSTOMER_INFO)
+            infoLog(IdentityStrings.INVALIDATING_CACHED_CUSTOMER_INFO)
             deviceCache.clearCustomerInfoCache(appUserID)
-            eTagManager.clearCaches()
+            backend.clearCaches()
         }
     }
 
     private fun shouldInvalidateCustomerInfoAndETagCache(customerInfo: CustomerInfo?): Boolean {
         return customerInfo != null &&
             customerInfo.entitlements.verification == VerificationResult.NOT_REQUESTED &&
-            signatureVerificationMode != SignatureVerificationMode.Disabled
+            backend.verificationMode != SignatureVerificationMode.Disabled
     }
 
     private fun isUserIDAnonymous(appUserID: String): Boolean {

--- a/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -134,7 +134,7 @@ class IdentityManager(
     private fun shouldInvalidateCustomerInfoAndETagCache(customerInfo: CustomerInfo?): Boolean {
         return customerInfo != null &&
             customerInfo.entitlements.verification == VerificationResult.NOT_REQUESTED &&
-            signatureVerificationMode is SignatureVerificationMode.Informational
+            signatureVerificationMode != SignatureVerificationMode.Disabled
     }
 
     private fun isUserIDAnonymous(appUserID: String): Boolean {

--- a/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -3,11 +3,14 @@ package com.revenuecat.purchases.identity
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.common.networking.ETagManager
+import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.strings.IdentityStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
@@ -18,7 +21,9 @@ class IdentityManager(
     private val deviceCache: DeviceCache,
     private val subscriberAttributesCache: SubscriberAttributesCache,
     private val subscriberAttributesManager: SubscriberAttributesManager,
-    private val backend: Backend
+    private val backend: Backend,
+    private val eTagManager: ETagManager,
+    private val signatureVerificationMode: SignatureVerificationMode
 ) {
 
     val currentAppUserID: String
@@ -41,6 +46,7 @@ class IdentityManager(
         deviceCache.cacheAppUserID(appUserIDToUse)
         subscriberAttributesCache.cleanUpSubscriberAttributeCache(appUserIDToUse)
         deviceCache.cleanupOldAttributionData()
+        invalidateCustomerInfoAndETagCacheIfNeeded(appUserIDToUse)
     }
 
     fun logIn(
@@ -115,6 +121,20 @@ class IdentityManager(
         if (isUserIDAnonymous(oldAppUserId)) {
             subscriberAttributesManager.copyUnsyncedSubscriberAttributes(oldAppUserId, newAppUserId)
         }
+    }
+
+    private fun invalidateCustomerInfoAndETagCacheIfNeeded(appUserID: String) {
+        val cachedCustomerInfo = deviceCache.getCachedCustomerInfo(appUserID)
+        if (shouldInvalidateCustomerInfoAndETagCache(cachedCustomerInfo)) {
+            deviceCache.clearCustomerInfoCache(appUserID)
+            eTagManager.clearCaches()
+        }
+    }
+
+    private fun shouldInvalidateCustomerInfoAndETagCache(customerInfo: CustomerInfo?): Boolean {
+        return customerInfo != null &&
+            customerInfo.entitlements.verification == VerificationResult.NOT_REQUESTED &&
+            signatureVerificationMode is SignatureVerificationMode.Informational
     }
 
     private fun isUserIDAnonymous(appUserID: String): Boolean {

--- a/feature/identity/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/feature/identity/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -421,12 +421,30 @@ class IdentityManagerTests {
     }
 
     @Test
-    fun `we invalidate customer info and etag caches if verification is enabled and cached customer info is not requested`() {
+    fun `we invalidate customer info and etag caches if verification is informational and cached customer info is not requested`() {
         val userId = "test-app-user-id"
         setupCustomerInfoCacheInvalidationTest(
             userId,
             VerificationResult.NOT_REQUESTED,
             SignatureVerificationMode.Informational(mockk()),
+            true
+        )
+        identityManager.configure(userId)
+        verify(exactly = 1) {
+            mockDeviceCache.clearCustomerInfoCache(userId)
+        }
+        verify(exactly = 1) {
+            mockETagManager.clearCaches()
+        }
+    }
+
+    @Test
+    fun `we invalidate customer info and etag caches if verification is enforced and cached customer info is not requested`() {
+        val userId = "test-app-user-id"
+        setupCustomerInfoCacheInvalidationTest(
+            userId,
+            VerificationResult.NOT_REQUESTED,
+            SignatureVerificationMode.Enforced(mockk()),
             true
         )
         identityManager.configure(userId)

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -438,5 +438,5 @@ class SubscriberAttributesPosterTests {
     private fun createResult(
         responseCode: Int,
         responseBody: String
-    ) = HTTPResult(responseCode, responseBody, HTTPResult.Origin.BACKEND, VerificationResult.NOT_REQUESTED)
+    ) = HTTPResult(responseCode, responseBody, HTTPResult.Origin.BACKEND, null, VerificationResult.NOT_REQUESTED)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -109,7 +109,9 @@ internal class PurchasesFactory(
                 cache,
                 subscriberAttributesCache,
                 subscriberAttributesManager,
-                backend
+                backend,
+                eTagManager,
+                signatureVerificationMode
             )
 
             val customerInfoHelper = CustomerInfoHelper(cache, backend, identityManager)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -109,9 +109,7 @@ internal class PurchasesFactory(
                 cache,
                 subscriberAttributesCache,
                 subscriberAttributesManager,
-                backend,
-                eTagManager,
-                signatureVerificationMode
+                backend
             )
 
             val customerInfoHelper = CustomerInfoHelper(cache, backend, identityManager)

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -62,6 +62,7 @@ class PostingTransactionsTests {
     internal data class PostReceiptCompletionContainer(
         val info: CustomerInfo = CustomerInfoFactory.buildCustomerInfo(
             JSONObject(Responses.validFullPurchaserResponse),
+            null,
             VerificationResult.NOT_REQUESTED
         ),
         val body: JSONObject = JSONObject(Responses.validFullPurchaserResponse)

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -816,6 +816,7 @@ class PurchasesTest {
 
         val mockInfo = CustomerInfoFactory.buildCustomerInfo(
             JSONObject(Responses.validFullPurchaserResponse),
+            null,
             VerificationResult.NOT_REQUESTED
         )
         every {

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -74,6 +74,7 @@ class SubscriberAttributesPurchasesTests {
     internal data class PostReceiptCompletionContainer(
         val info: CustomerInfo = CustomerInfoFactory.buildCustomerInfo(
             JSONObject(Responses.validFullPurchaserResponse),
+            null,
             VerificationResult.NOT_REQUESTED
         ),
         val body: JSONObject = JSONObject(Responses.validFullPurchaserResponse)

--- a/strings/src/main/java/com/revenuecat/purchases/strings/IdentityStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/IdentityStrings.kt
@@ -10,6 +10,6 @@ object IdentityStrings {
     const val SETTING_NEW_ANON_ID = "Setting new anonymous App User ID - %s"
     const val LOG_OUT_CALLED_ON_ANONYMOUS_USER = "Called logOut but the current user is anonymous"
     const val LOG_OUT_SUCCESSFUL = "Logged out successfully"
-    const val INVALIDATING_CACHED_CUSTOMER_INFO = "Detected cached unverified CustomerInfo but verification is enabled." +
-        " Invalidating cache."
+    const val INVALIDATING_CACHED_CUSTOMER_INFO = "Detected cached unverified CustomerInfo but verification " +
+        "is enabled. Invalidating cache."
 }

--- a/strings/src/main/java/com/revenuecat/purchases/strings/IdentityStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/IdentityStrings.kt
@@ -10,4 +10,6 @@ object IdentityStrings {
     const val SETTING_NEW_ANON_ID = "Setting new anonymous App User ID - %s"
     const val LOG_OUT_CALLED_ON_ANONYMOUS_USER = "Called logOut but the current user is anonymous"
     const val LOG_OUT_SUCCESSFUL = "Logged out successfully"
+    const val INVALIDATING_CACHED_CUSTOMER_INFO = "Detected cached unverified CustomerInfo but verification is enabled." +
+        " Invalidating cache."
 }

--- a/strings/src/main/java/com/revenuecat/purchases/strings/IdentityStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/IdentityStrings.kt
@@ -10,6 +10,6 @@ object IdentityStrings {
     const val SETTING_NEW_ANON_ID = "Setting new anonymous App User ID - %s"
     const val LOG_OUT_CALLED_ON_ANONYMOUS_USER = "Called logOut but the current user is anonymous"
     const val LOG_OUT_SUCCESSFUL = "Logged out successfully"
-    const val INVALIDATING_CACHED_CUSTOMER_INFO = "Detected cached unverified CustomerInfo but verification " +
+    const val INVALIDATING_CACHED_CUSTOMER_INFO = "Detected unverified cached CustomerInfo but verification " +
         "is enabled. Invalidating cache."
 }


### PR DESCRIPTION
### Description
Completes [SDK-2897](https://linear.app/revenuecat/issue/SDK-2897/requestdate-not-returning-updated-value)

With this PR, we will update `CustomerInfo`'s `requestDate` with the latest value even when a 304 response is received.
