### PR TITLE
Purchase.Builder Follow-up

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/DeprecatedPurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/DeprecatedPurchasesAPI.java
@@ -51,8 +51,6 @@ final class DeprecatedPurchasesAPI {
         purchases.purchaseProduct(activity, storeProduct, makePurchaseListener);
         purchases.purchasePackage(activity, packageToPurchase, upgradeInfo, purchaseChangeListener);
         purchases.purchasePackage(activity, packageToPurchase, makePurchaseListener);
-        purchases.purchaseSubscriptionOption(activity, subscriptionOption, upgradeInfo, purchaseChangeListener);
-        purchases.purchaseSubscriptionOption(activity, subscriptionOption, makePurchaseListener);
     }
 
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -19,7 +19,6 @@ import com.revenuecat.purchases.PurchasesError;
 import com.revenuecat.purchases.UpgradeInfo;
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback;
 import com.revenuecat.purchases.interfaces.LogInCallback;
-import com.revenuecat.purchases.interfaces.NewPurchaseCallback;
 import com.revenuecat.purchases.interfaces.ProductChangeCallback;
 import com.revenuecat.purchases.interfaces.PurchaseCallback;
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback;
@@ -115,7 +114,7 @@ final class PurchasesAPI {
                                 final StoreProduct storeProduct,
                                 final Package packageToPurchase,
                                 final SubscriptionOption subscriptionOption) {
-        final NewPurchaseCallback purchaseCallback = new NewPurchaseCallback() {
+        final PurchaseCallback purchaseCallback = new PurchaseCallback() {
             @Override
             public void onCompleted(@Nullable StoreTransaction storeTransaction, @NonNull CustomerInfo customerInfo) {
             }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/DeprecatedPurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/DeprecatedPurchasesAPI.kt
@@ -48,11 +48,19 @@ private class DeprecatedPurchasesAPI {
         )
         purchases.purchaseProductWith(
             activity,
+            storeProduct) { _: StoreTransaction, _: CustomerInfo -> }
+        purchases.purchaseProductWith(
+            activity,
             storeProduct,
             upgradeInfo,
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
         )
+        purchases.purchaseProductWith(
+            activity,
+            storeProduct,
+            upgradeInfo) { _: StoreTransaction?, _: CustomerInfo -> }
+
         purchases.purchasePackageWith(
             activity,
             packageToPurchase,
@@ -60,12 +68,21 @@ private class DeprecatedPurchasesAPI {
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
         )
+        purchases.purchasePackageWith(
+            activity,
+            packageToPurchase,
+            upgradeInfo) { _: StoreTransaction?, _: CustomerInfo -> }
+
         purchases.purchasePackageWith(
             activity,
             packageToPurchase,
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
         )
+
+        purchases.purchasePackageWith(
+            activity,
+            packageToPurchase) { _: StoreTransaction, _: CustomerInfo -> }
 
         purchases.allowSharingPlayStoreAccount = true
         purchases.getSubscriptionSkusWith(

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/DeprecatedPurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/DeprecatedPurchasesAPI.kt
@@ -14,7 +14,6 @@ import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.purchasePackageWith
 import com.revenuecat.purchases.purchaseProductWith
-import com.revenuecat.purchases.purchaseSubscriptionOptionWith
 
 @Suppress("unused")
 private class DeprecatedPurchasesAPI {
@@ -41,14 +40,6 @@ private class DeprecatedPurchasesAPI {
         purchases.purchasePackage(activity, packageToPurchase, upgradeInfo, purchaseChangeCallback)
         purchases.purchasePackage(activity, packageToPurchase, purchaseCallback)
 
-        purchases.purchaseSubscriptionOption(
-            activity,
-            subscriptionOption,
-            upgradeInfo,
-            purchaseChangeCallback
-        )
-        purchases.purchaseSubscriptionOption(activity, subscriptionOption, purchaseCallback)
-
         purchases.purchaseProductWith(
             activity,
             storeProduct,
@@ -74,19 +65,6 @@ private class DeprecatedPurchasesAPI {
             packageToPurchase,
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
-        )
-        purchases.purchaseSubscriptionOptionWith(
-            activity,
-            subscriptionOption,
-            onError = { _: PurchasesError, _: Boolean -> },
-            onSuccess = { _: StoreTransaction, _: CustomerInfo -> }
-        )
-        purchases.purchaseSubscriptionOptionWith(
-            activity,
-            subscriptionOption,
-            upgradeInfo,
-            onError = { _: PurchasesError, _: Boolean -> },
-            onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
         )
 
         purchases.allowSharingPlayStoreAccount = true

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -155,6 +155,8 @@ private class PurchasesAPI {
             onError = { _: PurchasesError, _: Boolean -> },
             onSuccess = { _: StoreTransaction?, _: CustomerInfo -> }
         )
+        purchases.purchaseWith(
+            purchaseParams) { _: StoreTransaction?, _: CustomerInfo -> }
     }
 
     fun check(purchases: Purchases, attributes: Map<String, String>) {

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -16,7 +16,7 @@ import com.revenuecat.purchases.getCustomerInfoWith
 import com.revenuecat.purchases.getOfferingsWith
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
-import com.revenuecat.purchases.interfaces.NewPurchaseCallback
+import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
@@ -91,8 +91,8 @@ private class PurchasesAPI {
         packageToPurchase: Package,
         subscriptionOption: SubscriptionOption
     ) {
-        val purchaseCallback = object : NewPurchaseCallback {
-            override fun onCompleted(storeTransaction: StoreTransaction?, customerInfo: CustomerInfo) {}
+        val purchaseCallback = object : PurchaseCallback {
+            override fun onCompleted(storeTransaction: StoreTransaction, customerInfo: CustomerInfo) {}
             override fun onError(error: PurchasesError, userCancelled: Boolean) {}
         }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/ReplaceProductInfo.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/ReplaceProductInfo.kt
@@ -5,5 +5,5 @@ import com.revenuecat.purchases.models.StoreTransaction
 
 data class ReplaceProductInfo(
     val oldPurchase: StoreTransaction,
-    @BillingFlowParams.ProrationMode val prorationMode: Int
+    @BillingFlowParams.ProrationMode val prorationMode: Int? = null
 )

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/DeprecatedOfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/DeprecatedOfferingFragment.kt
@@ -1,0 +1,256 @@
+package com.revenuecat.purchasetester
+
+import android.graphics.Color
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.transition.MaterialContainerTransform
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.UpgradeInfo
+import com.revenuecat.purchases.getCustomerInfoWith
+import com.revenuecat.purchases.models.GoogleProrationMode
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.purchasePackageWith
+import com.revenuecat.purchases.purchaseProductWith
+import com.revenuecat.purchases_sample.R
+import com.revenuecat.purchases_sample.databinding.FragmentOfferingBinding
+
+@SuppressWarnings("TooManyFunctions")
+class DeprecatedOfferingFragment : Fragment(), DeprecatedPackageCardAdapter.PackageCardAdapterListener {
+
+    lateinit var binding: FragmentOfferingBinding
+
+    private val args: OfferingFragmentArgs by navArgs()
+    private val offering: Offering by lazy { args.offering }
+    private var activeSubscriptions: Set<String> = setOf()
+
+    private val purchaseErrorCallback: (error: PurchasesError, userCancelled: Boolean) -> Unit =
+        { error, userCancelled ->
+            toggleLoadingIndicator(false)
+            if (!userCancelled) {
+                showUserError(requireActivity(), error)
+            }
+        }
+
+    private val successfulPurchaseCallback: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit =
+        { storeTransaction, _ ->
+            toggleLoadingIndicator(false)
+            handleSuccessfulPurchase(storeTransaction.orderId)
+        }
+
+    private val successfulUpgradeCallback: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit =
+        { storeTransaction, _ ->
+            toggleLoadingIndicator(false)
+            handleSuccessfulPurchase(storeTransaction?.orderId)
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        sharedElementEnterTransition = MaterialContainerTransform().apply {
+            drawingViewId = R.id.nav_host_fragment
+            duration = requireContext().resources.getInteger(R.integer.transition_duration).toLong()
+            scrimColor = Color.TRANSPARENT
+        }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        Purchases.sharedInstance.getCustomerInfoWith {
+            activeSubscriptions = it.activeSubscriptions
+        }
+
+        binding = FragmentOfferingBinding.inflate(inflater)
+        binding.offering = offering
+
+        binding.offeringDetailsPackagesRecycler.layoutManager = LinearLayoutManager(requireContext())
+        binding.offeringDetailsPackagesRecycler.adapter =
+            DeprecatedPackageCardAdapter(
+                offering.availablePackages,
+                activeSubscriptions,
+                this
+            )
+
+        return binding.root
+    }
+
+    override fun onPurchasePackageClicked(
+        cardView: View,
+        currentPackage: Package,
+        isUpgrade: Boolean
+    ) {
+        toggleLoadingIndicator(true)
+
+        if (isUpgrade) {
+            promptForUpgradeInfo { upgradeInfo ->
+                upgradeInfo?.let {
+                    startPurchasePackage(currentPackage, upgradeInfo)
+                }
+            }
+        } else {
+            startPurchasePackage(currentPackage, null)
+        }
+    }
+
+    override fun onPurchaseProductClicked(
+        cardView: View,
+        currentProduct: StoreProduct,
+        isUpgrade: Boolean
+    ) {
+        toggleLoadingIndicator(true)
+
+        if (isUpgrade) {
+            promptForUpgradeInfo { upgradeInfo ->
+                upgradeInfo?.let {
+                    startPurchaseProduct(currentProduct, upgradeInfo)
+                }
+            }
+        } else {
+            startPurchaseProduct(currentProduct, null)
+        }
+    }
+
+    private fun promptForUpgradeInfo(callback: (UpgradeInfo?) -> Unit) {
+        showOldSubIdPicker { subId ->
+            subId?.let {
+                showProrationModePicker { prorationMode, error ->
+                    if (error == null) {
+                        prorationMode?.let {
+                            callback(UpgradeInfo(subId, prorationMode.playBillingClientMode))
+                        } ?: callback(UpgradeInfo(subId))
+                    } else {
+                        callback(null)
+                    }
+                }
+            } ?: callback(null)
+        }
+    }
+
+    private fun startPurchaseProduct(
+        currentProduct: StoreProduct,
+        upgradeInfo: UpgradeInfo?
+    ) {
+        when {
+            upgradeInfo == null -> Purchases.sharedInstance.purchaseProductWith(
+                requireActivity(),
+                currentProduct,
+                purchaseErrorCallback,
+                successfulPurchaseCallback
+            )
+            upgradeInfo != null -> Purchases.sharedInstance.purchaseProductWith(
+                requireActivity(),
+                currentProduct,
+                upgradeInfo,
+                purchaseErrorCallback,
+                successfulUpgradeCallback
+            )
+        }
+    }
+
+    private fun handleSuccessfulPurchase(orderId: String?) {
+        context?.let {
+            Toast.makeText(
+                it,
+                "Successful purchase, order id: $orderId",
+                Toast.LENGTH_SHORT
+            ).show()
+            findNavController().navigateUp()
+        }
+    }
+
+    private fun startPurchasePackage(
+        currentPackage: Package,
+        upgradeInfo: UpgradeInfo?
+    ) {
+        when {
+            upgradeInfo == null -> Purchases.sharedInstance.purchasePackageWith(
+                requireActivity(),
+                currentPackage,
+                purchaseErrorCallback,
+                successfulPurchaseCallback
+            )
+            upgradeInfo != null -> Purchases.sharedInstance.purchasePackageWith(
+                requireActivity(),
+                currentPackage,
+                upgradeInfo,
+                purchaseErrorCallback,
+                successfulUpgradeCallback
+            )
+        }
+    }
+
+    private fun toggleLoadingIndicator(isLoading: Boolean) {
+        binding.purchaseProgress.visibility = if (isLoading) View.VISIBLE else View.GONE
+    }
+
+    private fun showOldSubIdPicker(callback: (String?) -> Unit) {
+        val activeSubIds = activeSubscriptions.map { it.split(":").first() } // TODOBC5 remove sub Id parsing
+        if (activeSubIds.isEmpty()) {
+            Toast.makeText(
+                requireContext(),
+                "Cannot upgrade without an existing active subscription.",
+                Toast.LENGTH_LONG
+            ).show()
+            toggleLoadingIndicator(false)
+            callback(null)
+            return
+        }
+
+        var selectedUpgradeSubId: String = activeSubIds[0]
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle("Choose which active sub to switch from")
+            .setSingleChoiceItems(activeSubIds.toTypedArray(), 0) { _, which ->
+                selectedUpgradeSubId = activeSubIds[which]
+            }
+            .setPositiveButton("Continue") { dialog, _ ->
+                dialog.dismiss()
+                callback(selectedUpgradeSubId)
+            }
+            .setNegativeButton("Cancel purchase") { dialog, _ ->
+                dialog.dismiss()
+                toggleLoadingIndicator(false)
+                callback(null)
+            }
+            .setOnDismissListener {
+                toggleLoadingIndicator(false)
+                callback(null)
+            }
+            .show()
+    }
+
+    private fun showProrationModePicker(callback: (GoogleProrationMode?, Error?) -> Unit) {
+        val prorationModeOptions = GoogleProrationMode.values()
+        var selectedProrationMode: GoogleProrationMode? = null
+
+        val prorationModeNames = prorationModeOptions.map { it.name }.toTypedArray()
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle("Choose ProrationMode")
+            .setSingleChoiceItems(prorationModeNames, -1) { _, selectedIndex ->
+                selectedProrationMode = prorationModeOptions.elementAt(selectedIndex)
+            }
+            .setPositiveButton("Start purchase") { dialog, _ ->
+                dialog.dismiss()
+                callback(selectedProrationMode, null)
+            }
+            .setNegativeButton("Cancel purchase") { dialog, _ ->
+                dialog.dismiss()
+                toggleLoadingIndicator(false)
+                callback(null, Error("Purchase cancelled"))
+            }
+            .setOnDismissListener {
+                toggleLoadingIndicator(false)
+                callback(null, Error("Selection dismissed"))
+            }
+            .show()
+    }
+}

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/DeprecatedPackageCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/DeprecatedPackageCardAdapter.kt
@@ -3,15 +3,11 @@ package com.revenuecat.purchasetester
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.RadioButton
-import androidx.core.view.children
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.models.googleProduct
-import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases_sample.databinding.PackageCardBinding
 
@@ -36,8 +32,6 @@ class DeprecatedPackageCardAdapter(
     inner class PackageViewHolder(private val binding: PackageCardBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        private val nothingCheckedIndex = -1
-
         fun bind(currentPackage: Package) {
             val product = currentPackage.product
             binding.currentPackage = currentPackage
@@ -52,6 +46,8 @@ class DeprecatedPackageCardAdapter(
                 )
             }
 
+            binding.packageBuyButton.text = "Buy package (deprecated)"
+
             binding.productBuyButton.setOnClickListener {
                 listener.onPurchaseProductClicked(
                     binding.root,
@@ -59,6 +55,10 @@ class DeprecatedPackageCardAdapter(
                     binding.isUpgradeCheckbox.isChecked
                 )
             }
+            binding.productBuyButton.text = "Buy product (deprecated)"
+
+            binding.optionBuyButton.visibility = View.INVISIBLE
+            binding.packageSubscriptionOptionGroup.visibility = View.INVISIBLE
 
             binding.packageType.detail = if (currentPackage.packageType == PackageType.CUSTOM) {
                 "custom -> ${currentPackage.packageType.identifier}"
@@ -68,50 +68,11 @@ class DeprecatedPackageCardAdapter(
 
             binding.packageDetailsJsonObject.detail = product.googleProduct?.productDetails?.toString() ?: "TODO Amazon"
 
-            bindSubscriptionOptions(product)
-
             binding.root.setOnClickListener {
                 with(binding.packageDetailsContainer) {
                     visibility = if (visibility == View.GONE) View.VISIBLE else View.GONE
                 }
             }
-        }
-
-        private fun bindSubscriptionOptions(product: StoreProduct) {
-            binding.packageSubscriptionOptionGroup.removeAllViews()
-            val numberOfSubscriptionOptions = product.subscriptionOptions?.size ?: 0
-            val defaultOption = product.defaultOption
-            product.subscriptionOptions?.forEach { subscriptionOption ->
-                val radioButton = RadioButton(binding.root.context).apply {
-                    text = subscriptionOption.toButtonString(subscriptionOption == defaultOption)
-                    tag = subscriptionOption
-                }
-                binding.packageSubscriptionOptionGroup.addView(radioButton)
-                if (numberOfSubscriptionOptions == 1) binding.packageSubscriptionOptionGroup.check(radioButton.id)
-            }
-        }
-
-        private fun getSelectedSubscriptionOption(): SubscriptionOption? {
-            val selectedButtonId = binding.packageSubscriptionOptionGroup.checkedRadioButtonId
-            return binding.packageSubscriptionOptionGroup.children
-                .filter { it.id == selectedButtonId }
-                .firstOrNull()
-                ?.tag as? SubscriptionOption
-        }
-
-        private fun validateStartPurchase(product: StoreProduct): String? {
-            if (product.type == ProductType.SUBS &&
-                binding.packageSubscriptionOptionGroup.checkedRadioButtonId == nothingCheckedIndex) {
-                return "Please choose subscription option first"
-            }
-            return null
-        }
-
-        private fun showErrorMessage(errorMessage: String) {
-            MaterialAlertDialogBuilder(binding.root.context)
-                .setMessage(errorMessage)
-                .setPositiveButton("OK") { dialog, _ -> dialog.dismiss() }
-                .show()
         }
     }
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/DeprecatedPackageCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/DeprecatedPackageCardAdapter.kt
@@ -1,0 +1,130 @@
+package com.revenuecat.purchasetester
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.RadioButton
+import androidx.core.view.children
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.models.googleProduct
+import com.revenuecat.purchases.models.SubscriptionOption
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases_sample.databinding.PackageCardBinding
+
+class DeprecatedPackageCardAdapter(
+    private val packages: List<Package>,
+    private val activeSubscriptions: Set<String>,
+    private val listener: PackageCardAdapterListener
+) :
+    RecyclerView.Adapter<DeprecatedPackageCardAdapter.PackageViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PackageViewHolder {
+        val binding = PackageCardBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return PackageViewHolder(binding)
+    }
+
+    override fun getItemCount(): Int = packages.size
+
+    override fun onBindViewHolder(holder: PackageViewHolder, position: Int) {
+        holder.bind(packages[position])
+    }
+
+    inner class PackageViewHolder(private val binding: PackageCardBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        private val nothingCheckedIndex = -1
+
+        fun bind(currentPackage: Package) {
+            val product = currentPackage.product
+            binding.currentPackage = currentPackage
+            binding.isSubscription = product.type == ProductType.SUBS
+            binding.isActive = activeSubscriptions.contains(product.id)
+
+            binding.packageBuyButton.setOnClickListener {
+                listener.onPurchasePackageClicked(
+                    binding.root,
+                    currentPackage,
+                    binding.isUpgradeCheckbox.isChecked
+                )
+            }
+
+            binding.productBuyButton.setOnClickListener {
+                listener.onPurchaseProductClicked(
+                    binding.root,
+                    product,
+                    binding.isUpgradeCheckbox.isChecked
+                )
+            }
+
+            binding.packageType.detail = if (currentPackage.packageType == PackageType.CUSTOM) {
+                "custom -> ${currentPackage.packageType.identifier}"
+            } else {
+                currentPackage.packageType.toString()
+            }
+
+            binding.packageDetailsJsonObject.detail = product.googleProduct?.productDetails?.toString() ?: "TODO Amazon"
+
+            bindSubscriptionOptions(product)
+
+            binding.root.setOnClickListener {
+                with(binding.packageDetailsContainer) {
+                    visibility = if (visibility == View.GONE) View.VISIBLE else View.GONE
+                }
+            }
+        }
+
+        private fun bindSubscriptionOptions(product: StoreProduct) {
+            binding.packageSubscriptionOptionGroup.removeAllViews()
+            val numberOfSubscriptionOptions = product.subscriptionOptions?.size ?: 0
+            val defaultOption = product.defaultOption
+            product.subscriptionOptions?.forEach { subscriptionOption ->
+                val radioButton = RadioButton(binding.root.context).apply {
+                    text = subscriptionOption.toButtonString(subscriptionOption == defaultOption)
+                    tag = subscriptionOption
+                }
+                binding.packageSubscriptionOptionGroup.addView(radioButton)
+                if (numberOfSubscriptionOptions == 1) binding.packageSubscriptionOptionGroup.check(radioButton.id)
+            }
+        }
+
+        private fun getSelectedSubscriptionOption(): SubscriptionOption? {
+            val selectedButtonId = binding.packageSubscriptionOptionGroup.checkedRadioButtonId
+            return binding.packageSubscriptionOptionGroup.children
+                .filter { it.id == selectedButtonId }
+                .firstOrNull()
+                ?.tag as? SubscriptionOption
+        }
+
+        private fun validateStartPurchase(product: StoreProduct): String? {
+            if (product.type == ProductType.SUBS &&
+                binding.packageSubscriptionOptionGroup.checkedRadioButtonId == nothingCheckedIndex) {
+                return "Please choose subscription option first"
+            }
+            return null
+        }
+
+        private fun showErrorMessage(errorMessage: String) {
+            MaterialAlertDialogBuilder(binding.root.context)
+                .setMessage(errorMessage)
+                .setPositiveButton("OK") { dialog, _ -> dialog.dismiss() }
+                .show()
+        }
+    }
+
+    interface PackageCardAdapterListener {
+        fun onPurchasePackageClicked(
+            cardView: View,
+            currentPackage: Package,
+            isUpgrade: Boolean
+        )
+        fun onPurchaseProductClicked(
+            cardView: View,
+            currentProduct: StoreProduct,
+            isUpgrade: Boolean
+        )
+    }
+}

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -92,7 +92,9 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
 
         val offeringCardTransitionName = getString(R.string.offering_fragment_transition)
         val extras = FragmentNavigatorExtras(cardView to offeringCardTransitionName)
-        val directions = OverviewFragmentDirections.actionOverviewFragmentToOfferingFragment(offering)
+//        val directions = OverviewFragmentDirections.actionOverviewFragmentToOfferingFragment(offering)
+        // uncomment line below and comment line above to test deprecated purchase methods
+        val directions = OverviewFragmentDirections.actionOverviewFragmentToDeprecatedOfferingFragment(offering)
         findNavController().navigate(directions, extras)
     }
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -92,9 +92,9 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
 
         val offeringCardTransitionName = getString(R.string.offering_fragment_transition)
         val extras = FragmentNavigatorExtras(cardView to offeringCardTransitionName)
-//        val directions = OverviewFragmentDirections.actionOverviewFragmentToOfferingFragment(offering)
+        val directions = OverviewFragmentDirections.actionOverviewFragmentToOfferingFragment(offering)
         // uncomment line below and comment line above to test deprecated purchase methods
-        val directions = OverviewFragmentDirections.actionOverviewFragmentToDeprecatedOfferingFragment(offering)
+//        val directions = OverviewFragmentDirections.actionOverviewFragmentToDeprecatedOfferingFragment(offering)
         findNavController().navigate(directions, extras)
     }
 

--- a/examples/purchase-tester/src/main/res/navigation/nav_graph.xml
+++ b/examples/purchase-tester/src/main/res/navigation/nav_graph.xml
@@ -30,6 +30,9 @@
                 android:id="@+id/action_overviewFragment_to_offeringFragment"
                 app:destination="@id/offeringFragment" />
         <action
+                android:id="@+id/action_overviewFragment_to_deprecatedOfferingFragment"
+                app:destination="@id/deprecatedOfferingFragment" />
+        <action
                 android:id="@+id/action_overviewFragment_to_loginFragment"
                 app:destination="@id/loginFragment"
                 app:popUpTo="@id/nav_graph.xml" />
@@ -42,6 +45,14 @@
             android:id="@+id/offeringFragment"
             android:name="com.revenuecat.purchasetester.OfferingFragment"
             android:label="OfferingFragment">
+        <argument
+                android:name="offering"
+                app:argType="com.revenuecat.purchases.Offering" />
+    </fragment>
+    <fragment
+            android:id="@+id/deprecatedOfferingFragment"
+            android:name="com.revenuecat.purchasetester.DeprecatedOfferingFragment"
+            android:label="DeprecatedOfferingFragment">
         <argument
                 android:name="offering"
                 app:argType="com.revenuecat.purchases.Offering" />

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
@@ -6,7 +6,9 @@ import com.revenuecat.purchases.common.ReplaceProductInfo
 fun BillingFlowParams.Builder.setUpgradeInfo(replaceProductInfo: ReplaceProductInfo) {
     val subscriptionUpdateParams = BillingFlowParams.SubscriptionUpdateParams.newBuilder().apply {
         setOldPurchaseToken(replaceProductInfo.oldPurchase.purchaseToken)
-        setReplaceProrationMode(replaceProductInfo.prorationMode)
+        replaceProductInfo.prorationMode?.let {
+            setReplaceProrationMode(it)
+        }
     }
     setSubscriptionUpdateParams(subscriptionUpdateParams.build())
 }

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -24,8 +24,7 @@
 | Deprecated              | Replace with                                                                           |
 |-------------------------|----------------------------------------------------------------------------------------|
 | `UpgradeInfo`           | `PurchaseParams.Builder.oldProductId` and `PurchaseParams.Builder.googleProrationMode` |
-| `ProductChangeCallback` | `NewPurchaseCallback`                                                                  |
-| `PurchaseCallback`      | `NewPurchaseCallback`                                                                  |
+| `ProductChangeCallback` | `PurchaseCallback`                                                                     |
 
 
 ### StoreProduct changes
@@ -132,9 +131,9 @@ When passing a `Package` or `StoreProduct` to `purchase()`, the SDK will use the
 
 For more control, create your `PurchaseParams.Builder` with the desired `SubscriptionOption`.
 
-| New                                            |
-|------------------------------------------------|
-| `purchase(PurchaseParams, NewPurchaseCallback` |
+| New                                         |
+|---------------------------------------------|
+| `purchase(PurchaseParams, PurchaseCallback` |
 
 Replaces all of the following: 
 

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -29,7 +29,8 @@
 
 ### StoreProduct changes
 
-StoreProduct has been made an interface, which `GoogleStoreProduct` and `AmazonStoreProduct` implement.
+`StoreProduct` has been made an interface, which `GoogleStoreProduct` and `AmazonStoreProduct` implement. 
+`StoreProduct` is no longer `Parcelable`.
 
 | Previous                      | New                                                                           |
 |-------------------------------|-------------------------------------------------------------------------------|
@@ -131,9 +132,9 @@ When passing a `Package` or `StoreProduct` to `purchase()`, the SDK will use the
 
 For more control, create your `PurchaseParams.Builder` with the desired `SubscriptionOption`.
 
-| New                                         |
-|---------------------------------------------|
-| `purchase(PurchaseParams, PurchaseCallback` |
+| New                                          |
+|----------------------------------------------|
+| `purchase(PurchaseParams, PurchaseCallback)` |
 
 Replaces all of the following: 
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
@@ -6,7 +6,7 @@ import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.SubscriptionOption
 
-open class PurchaseParams(builder: Builder) {
+data class PurchaseParams(val builder: Builder) {
 
     val isPersonalizedPrice: Boolean
     val oldProductId: String?

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
@@ -74,7 +74,7 @@ open class PurchaseParams(builder: Builder) {
          * for more info.
          *
          * Default is false.
-         *  Ignored for Amazon Appstore purchases.
+         * Ignored for Amazon Appstore purchases.
          */
         fun isPersonalizedPrice(isPersonalizedPrice: Boolean) = apply {
             this.isPersonalizedPrice = isPersonalizedPrice

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -488,51 +488,6 @@ class Purchases internal constructor(
     }
 
     /**
-     * Purchase a subscription [StoreProduct]'s [SubscriptionOption].
-     * @param [activity] Current activity
-     * @param [subscriptionOption] Your choice of [SubscriptionOption]s available for a subscription StoreProduct
-     * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldProductId and the optional
-     * prorationMode. Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
-     * @param [listener] The PurchaseCallback that will be called when purchase completes.
-     */
-    @Deprecated(
-        "Use purchase() and PurchaseParams.Builder instead",
-        ReplaceWith("purchase()")
-    )
-    fun purchaseSubscriptionOption(
-        activity: Activity,
-        subscriptionOption: SubscriptionOption,
-        upgradeInfo: UpgradeInfo,
-        listener: ProductChangeCallback
-    ) {
-        val purchaseOptionBuilder =
-            PurchaseParams.Builder(subscriptionOption, activity).oldProductId(upgradeInfo.oldSku)
-                // TODO fix proration
-                .googleProrationMode(GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION)
-        purchase(purchaseOptionBuilder.build(), listener as NewPurchaseCallback)
-    }
-
-    /**
-     * Purchase a subscription [StoreProduct]'s [SubscriptionOption].
-     * @param [activity] Current activity
-     * @param [subscriptionOption] Your choice of [SubscriptionOption]s available for a subscription StoreProduct
-     * @param [callback] The PurchaseCallback that will be called when purchase completes
-     */
-    @Deprecated(
-        "Use purchase() and PurchaseParams.Builder instead",
-        ReplaceWith("purchase()")
-    )
-
-    fun purchaseSubscriptionOption(
-        activity: Activity,
-        subscriptionOption: SubscriptionOption,
-        callback: PurchaseCallback
-    ) {
-        val purchase = PurchaseParams.Builder(subscriptionOption, activity).build()
-        purchaseNonUpgradeWithDeprecatedCallback(purchase, callback)
-    }
-
-    /**
      * Purchases a [Package].
      * If [packageToPurchase] represents a subscription, upgrades from the subscription specified by [upgradeInfo]'s
      * [oldProductId]and chooses the default [SubscriptionOption] from [packageToPurchase].

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1592,9 +1592,8 @@ class Purchases internal constructor(
                 state = state.copy(
                     purchaseCallbacksByProductId = state.purchaseCallbacksByProductId + mapOfProductIdToListener
                 )
+                userPurchasing = identityManager.currentAppUserID
             }
-
-            userPurchasing = identityManager.currentAppUserID
         }
         userPurchasing?.let { appUserID ->
             replaceOldPurchaseWithNewProduct(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesState.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesState.kt
@@ -1,11 +1,12 @@
 package com.revenuecat.purchases
 
-import com.revenuecat.purchases.interfaces.NewPurchaseCallback
+import com.revenuecat.purchases.interfaces.ProductChangeCallback
+import com.revenuecat.purchases.interfaces.PurchaseCallback
 
 internal data class PurchasesState(
     val allowSharingPlayStoreAccount: Boolean? = null,
-    val purchaseCallbacksByProductId: Map<String, NewPurchaseCallback> = emptyMap(),
-    val productChangeCallback: NewPurchaseCallback? = null,
+    val purchaseCallbacksByProductId: Map<String, PurchaseCallback> = emptyMap(),
+    val productChangeCallback: ProductChangeCallback? = null,
     val appInBackground: Boolean = true,
     val firstTimeInForeground: Boolean = true
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesState.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesState.kt
@@ -6,7 +6,7 @@ import com.revenuecat.purchases.interfaces.PurchaseCallback
 internal data class PurchasesState(
     val allowSharingPlayStoreAccount: Boolean? = null,
     val purchaseCallbacksByProductId: Map<String, PurchaseCallback> = emptyMap(),
-    val productChangeCallback: ProductChangeCallback? = null,
+    val deprecatedProductChangeCallback: ProductChangeCallback? = null,
     val appInBackground: Boolean = true,
     val firstTimeInForeground: Boolean = true
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/ProductChangeCallback.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/ProductChangeCallback.kt
@@ -11,7 +11,10 @@ import com.revenuecat.purchases.models.StoreTransaction
 /**
  * Interface to be implemented when upgrading or downgrading a purchase.
  */
-// TODO BC5 deprecate and/or rename
+@Deprecated(
+    "Use PurchaseCallback for all purchases now, even product changes",
+    ReplaceWith("PurchaseCallback")
+)
 interface ProductChangeCallback : PurchaseErrorCallback {
     /**
      * Will be called after the product change has been completed

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/PurchaseCallback.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/PurchaseCallback.kt
@@ -1,10 +1,7 @@
 package com.revenuecat.purchases.interfaces
 
 import com.revenuecat.purchases.CustomerInfo
-import com.revenuecat.purchases.PurchasesError
-import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.models.StoreTransaction
-import com.revenuecat.purchases.strings.PurchaseStrings
 
 interface PurchaseCallback : PurchaseErrorCallback {
     /**
@@ -13,35 +10,4 @@ interface PurchaseCallback : PurchaseErrorCallback {
      * @param customerInfo Updated [CustomerInfo].
      */
     fun onCompleted(storeTransaction: StoreTransaction, customerInfo: CustomerInfo)
-}
-
-// TODO rename, update docs
-interface NewPurchaseCallback : PurchaseErrorCallback {
-    /**
-     * Will be called after the purchase has completed
-     * @param storeTransaction StoreTransaction object for the purchased product. Null for deferred purchases.
-     * @param customerInfo Updated [CustomerInfo].
-     */
-    fun onCompleted(storeTransaction: StoreTransaction?, customerInfo: CustomerInfo)
-}
-
-@Deprecated("Deprecated in favor of NewPurchaseCallback. This helper will be removed in a future release.")
-fun PurchaseCallback.toNewPurchaseCallback(): NewPurchaseCallback {
-    return object : NewPurchaseCallback {
-        override fun onCompleted(storeTransaction: StoreTransaction?, customerInfo: CustomerInfo) {
-            storeTransaction?.let {
-                this@toNewPurchaseCallback.onCompleted(it, customerInfo)
-            } ?: run {
-                val nullTransactionError = PurchasesError(
-                    PurchasesErrorCode.StoreProblemError,
-                    PurchaseStrings.NULL_TRANSACTION_ON_PURCHASE_ERROR
-                )
-                this@toNewPurchaseCallback.onError(nullTransactionError, false)
-            }
-        }
-
-        override fun onError(error: PurchasesError, userCancelled: Boolean) {
-            this@toNewPurchaseCallback.onError(error, userCancelled)
-        }
-    }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -40,19 +40,6 @@ internal fun productChangeCompletedListener(
     }
 }
 
-internal fun purchaseCompletedCallback(
-    onSuccess: (transaction: StoreTransaction?, customerInfo: CustomerInfo) -> Unit,
-    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit
-) = object : PurchaseCallback {
-    override fun onCompleted(storeTransaction: StoreTransaction, customerInfo: CustomerInfo) {
-        onSuccess(storeTransaction, customerInfo)
-    }
-
-    override fun onError(error: PurchasesError, userCancelled: Boolean) {
-        onError(error, userCancelled)
-    }
-}
-
 internal fun getStoreProductsCallback(
     onReceived: (storeProducts: List<StoreProduct>) -> Unit,
     onError: (error: PurchasesError) -> Unit

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -170,55 +170,6 @@ fun Purchases.purchaseProductWith(
     purchaseWith(purchaseProductBuilder.build(), onError, onSuccess)
 }
 
-/**
- * Purchase a subscription [StoreProduct]'s [SubscriptionOption].
- * @param [activity] Current activity
- * @param [subscriptionOption] Your choice of [SubscriptionOption]s available for a subscription StoreProduct
- * @param [onSuccess] Will be called after the purchase has completed
- * @param [onError] Will be called if there was an error with the purchase
- */
-@Deprecated(
-    "Use purchase() and PurchaseParams.Builder instead",
-    ReplaceWith("purchase()")
-)
-fun Purchases.purchaseSubscriptionOptionWith(
-    activity: Activity,
-    subscriptionOption: SubscriptionOption,
-    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
-    onSuccess: (purchase: StoreTransaction, customerInfo: CustomerInfo) -> Unit
-) {
-    val purchase = PurchaseParams.Builder(subscriptionOption, activity).build()
-    purchaseNonUpgradeWithDeprecatedCallback(
-        purchase,
-        purchaseCompletedCallback(onSuccess, onError)
-    )
-}
-
-/**
- * Purchase a subscription [StoreProduct]'s [SubscriptionOption], upgrading from an old product.
- * @param [activity] Current activity
- * @param [subscriptionOption] Your choice of [SubscriptionOption]s available for a subscription StoreProduct
- * @param [upgradeInfo] The upgradeInfo you wish to upgrade from, containing the oldSku and the optional prorationMode.
- * Amazon Appstore doesn't support changing products so upgradeInfo is ignored for Amazon purchases.
- * @param [onSuccess] Will be called after the purchase has completed
- * @param [onError] Will be called if there was an error with the purchase
- */
-@Suppress("LongParameterList")
-@Deprecated(
-    "Use purchaseWith and PurchaseParams.Builder instead",
-    ReplaceWith("purchaseWith()")
-)
-fun Purchases.purchaseSubscriptionOptionWith(
-    activity: Activity,
-    subscriptionOption: SubscriptionOption,
-    upgradeInfo: UpgradeInfo,
-    onError: (error: PurchasesError, userCancelled: Boolean) -> Unit = ON_PURCHASE_ERROR_STUB,
-    onSuccess: (purchase: StoreTransaction?, customerInfo: CustomerInfo) -> Unit
-) {
-    val purchaseOptionBuilder =
-        PurchaseParams.Builder(subscriptionOption, activity).oldProductId(upgradeInfo.oldSku)
-    // TODO BC5 figure out proration mode
-//            .googleProrationMode(upgradeInfo.googleProrationMode)
     purchaseWith(purchaseOptionBuilder.build(), onError, onSuccess)
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -3,7 +3,6 @@ package com.revenuecat.purchases
 import android.app.Activity
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
-import com.revenuecat.purchases.interfaces.NewPurchaseCallback
 import com.revenuecat.purchases.interfaces.ProductChangeCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
@@ -44,9 +43,9 @@ internal fun productChangeCompletedListener(
 internal fun purchaseCompletedCallback(
     onSuccess: (transaction: StoreTransaction?, customerInfo: CustomerInfo) -> Unit,
     onError: (error: PurchasesError, userCancelled: Boolean) -> Unit
-) = object : NewPurchaseCallback {
-    override fun onCompleted(transaction: StoreTransaction?, customerInfo: CustomerInfo) {
-        onSuccess(transaction, customerInfo)
+) = object : PurchaseCallback {
+    override fun onCompleted(storeTransaction: StoreTransaction, customerInfo: CustomerInfo) {
+        onSuccess(storeTransaction, customerInfo)
     }
 
     override fun onError(error: PurchasesError, userCancelled: Boolean) {

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchaseParamsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchaseParamsTest.kt
@@ -1,0 +1,73 @@
+//  Purchases
+//
+//  Copyright © 2019 RevenueCat, Inc. All rights reserved.
+//
+
+package com.revenuecat.purchases
+
+import android.app.Activity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.utils.STUB_OFFERING_IDENTIFIER
+import com.revenuecat.purchases.utils.stubOfferings
+import com.revenuecat.purchases.utils.stubStoreProduct
+import com.revenuecat.purchases.utils.stubSubscriptionOption
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.exp
+
+// endregion
+@RunWith(AndroidJUnit4::class)
+class PurchaseParamsTest {
+
+    @Test
+    fun `Initializing with Package sets proper presentedOfferingIdentifier`() {
+        val storeProduct = stubStoreProduct("abc")
+        val (_, offerings) = stubOfferings(storeProduct)
+        val purchasePackageParams = PurchaseParams.Builder(
+            offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!,
+            mockk()
+        ).build()
+
+        assertThat(purchasePackageParams.presentedOfferingIdentifier).isEqualTo(STUB_OFFERING_IDENTIFIER)
+    }
+
+    @Test
+    fun `Initializing with Package sets proper purchasingData`() {
+        val storeProduct = stubStoreProduct("abc")
+        val (_, offerings) = stubOfferings(storeProduct)
+        val packageToPurchase = offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!
+        val purchasePackageParams = PurchaseParams.Builder(
+            packageToPurchase,
+            mockk<Activity>()
+        ).build()
+
+        val expectedPurchasingData = packageToPurchase.product.purchasingData
+        assertThat(purchasePackageParams.purchasingData).isEqualTo(expectedPurchasingData)
+    }
+
+    @Test
+    fun `Initializing with product sets proper purchasingData`() {
+        val storeProduct = stubStoreProduct("abc")
+        val purchasePackageParams = PurchaseParams.Builder(
+            storeProduct,
+            mockk()
+        ).build()
+
+        val expectedPurchasingData = storeProduct.purchasingData
+        assertThat(purchasePackageParams.purchasingData).isEqualTo(expectedPurchasingData)
+    }
+
+    @Test
+    fun `Initializing with option sets proper purchasingData`() {
+        val basePlanSubscriptionOption = stubSubscriptionOption("base-plan-purchase-option", "abc")
+        val purchasePackageParams = PurchaseParams.Builder(
+            basePlanSubscriptionOption,
+            mockk()
+        ).build()
+
+        val expectedPurchasingData = basePlanSubscriptionOption.purchasingData
+        assertThat(purchasePackageParams.purchasingData).isEqualTo(expectedPurchasingData)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchaseParamsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchaseParamsTest.kt
@@ -16,7 +16,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 
-// endregion
 @RunWith(AndroidJUnit4::class)
 class PurchaseParamsTest {
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchaseParamsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchaseParamsTest.kt
@@ -15,7 +15,6 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlin.math.exp
 
 // endregion
 @RunWith(AndroidJUnit4::class)

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -483,9 +483,9 @@ class PurchasesTest {
 
         var callCount = 0
         // use deprecated version of function because deferred upgrades not allowed with new version
-        purchases.purchaseSubscriptionOptionWith(
+        purchases.purchaseProductWith(
             mockActivity,
-            receiptInfo.storeProduct!!.subscriptionOptions!!.first(),
+            receiptInfo.storeProduct!!,
             UpgradeInfo(oldPurchase.productIds[0]),
             onError = { _, _ ->
                 fail("should be success")

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -29,7 +29,6 @@ import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.ReplaceProductInfo
 import com.revenuecat.purchases.common.buildCustomerInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
-import com.revenuecat.purchases.common.createOfferings
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
 import com.revenuecat.purchases.google.toGoogleProductType

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -54,9 +54,13 @@ import com.revenuecat.purchases.utils.Responses
 import com.revenuecat.purchases.utils.SyncDispatcher
 import com.revenuecat.purchases.utils.createMockOneTimeProductDetails
 import com.revenuecat.purchases.utils.createMockProductDetailsFreeTrial
+import com.revenuecat.purchases.utils.ONE_OFFERINGS_RESPONSE
 import com.revenuecat.purchases.utils.stubFreeTrialPricingPhase
 import com.revenuecat.purchases.utils.stubGooglePurchase
+import com.revenuecat.purchases.utils.STUB_OFFERING_IDENTIFIER
+import com.revenuecat.purchases.utils.stubOfferings
 import com.revenuecat.purchases.utils.stubPricingPhase
+import com.revenuecat.purchases.utils.STUB_PRODUCT_IDENTIFIER
 import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
 import com.revenuecat.purchases.utils.stubSubscriptionOption
 import com.revenuecat.purchases.utils.stubStoreProduct
@@ -122,20 +126,11 @@ class PurchasesTest {
     private var receivedOfferings: Offerings? = null
     private val mockInfo = mockk<CustomerInfo>()
 
-    private val stubOfferingIdentifier = "offering_a"
-    private val stubProductIdentifier = "monthly_freetrial"
-    private val oneOfferingsResponse = "{'offerings': [" +
-        "{'identifier': '$stubOfferingIdentifier', " +
-        "'description': 'This is the base offering', " +
-        "'packages': [" +
-        "{'identifier': '\$rc_monthly','platform_product_identifier': '$stubProductIdentifier'," +
-        "'platform_product_plan_identifier': 'p1m'}]}]," +
-        "'current_offering_id': '$stubOfferingIdentifier'}"
     private val oneOfferingWithNoProductsResponse = "{'offerings': [" +
-        "{'identifier': '$stubOfferingIdentifier', " +
+        "{'identifier': '$STUB_OFFERING_IDENTIFIER', " +
         "'description': 'This is the base offering', " +
         "'packages': []}]," +
-        "'current_offering_id': '$stubOfferingIdentifier'}"
+        "'current_offering_id': '$STUB_OFFERING_IDENTIFIER'}"
 
     private val inAppProductId = "inapp"
     private val inAppPurchaseToken = "token_inapp"
@@ -165,7 +160,7 @@ class PurchasesTest {
         mockkStatic("com.revenuecat.purchases.common.OfferingFactoriesKt")
         mockkStatic(ProcessLifecycleOwner::class)
 
-        val productIds = listOf(stubProductIdentifier)
+        val productIds = listOf(STUB_PRODUCT_IDENTIFIER)
         mockCache()
         mockBackend()
         mockBillingWrapper()
@@ -588,7 +583,7 @@ class PurchasesTest {
     @Test
     fun canMakePurchaseOfAPackage() {
         val (_, offerings) = stubOfferings("onemonth_freetrial")
-        val packageToPurchase = offerings[stubOfferingIdentifier]!!.monthly!!
+        val packageToPurchase = offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!
         val purchasePackageParams = getPurchaseParams(packageToPurchase)
         purchases.purchaseWith(
             purchasePackageParams
@@ -600,7 +595,28 @@ class PurchasesTest {
                 eq(appUserId),
                 packageToPurchase.product.defaultOption!!.purchasingData,
                 null,
-                stubOfferingIdentifier
+                STUB_OFFERING_IDENTIFIER
+            )
+        }
+    }
+
+    @Test
+    fun `purchase of package passes presentedOfferingIdentifier through to purchase`() {
+        val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
+        val expectedOfferingIdentifier = STUB_OFFERING_IDENTIFIER
+
+        purchases.purchasePackageWith(
+            mockActivity,
+            offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!
+        ) { _, _ -> }
+
+        verify {
+            mockBillingAbstract.makePurchaseAsync(
+                eq(mockActivity),
+                eq(appUserId),
+                storeProduct.subscriptionOptions!!.first().purchasingData,
+                null,
+                expectedOfferingIdentifier
             )
         }
     }
@@ -610,7 +626,7 @@ class PurchasesTest {
         val (storeProduct, offerings) = stubOfferings("onemonth_freetrial")
         val oldPurchase = mockPurchaseFound()
         val purchasePackageUpgradeParams = getPurchaseParams(
-            offerings[stubOfferingIdentifier]!!.monthly!!,
+            offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!,
             oldPurchase.productIds[0]
         )
 
@@ -624,7 +640,7 @@ class PurchasesTest {
                 eq(appUserId),
                 storeProduct.defaultOption!!.purchasingData,
                 ReplaceProductInfo(oldPurchase, ProrationMode.IMMEDIATE_WITHOUT_PRORATION),
-                stubOfferingIdentifier
+                STUB_OFFERING_IDENTIFIER
             )
         }
     }
@@ -1000,7 +1016,7 @@ class PurchasesTest {
         val (_, offerings) = stubOfferings(storeProduct)
 
         mockQueryingProductDetails(storeProduct, null)
-        val packageToPurchase = offerings[stubOfferingIdentifier]!!.monthly!!
+        val packageToPurchase = offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!
         val purchasePackageParams = getPurchaseParams(packageToPurchase)
         purchases.purchaseWith(
             purchasePackageParams,
@@ -1014,7 +1030,7 @@ class PurchasesTest {
                 appUserId,
                 expectedDefaultSubscriptionOption.purchasingData,
                 null,
-                stubOfferingIdentifier
+                STUB_OFFERING_IDENTIFIER
             )
         }
     }
@@ -1033,7 +1049,7 @@ class PurchasesTest {
         var callCount = 0
 
         val purchasePackageUpgradeParams = getPurchaseParams(
-            offerings[stubOfferingIdentifier]!!.monthly!!,
+            offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!,
             oldPurchase.productIds[0])
         purchases.purchaseWith(
             purchasePackageUpgradeParams,
@@ -1045,7 +1061,7 @@ class PurchasesTest {
         )
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(
             getMockedPurchaseList(
-                offerings[stubOfferingIdentifier]!!.monthly!!.product.id,
+                offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!.product.id,
                 purchaseToken,
                 ProductType.SUBS
             )
@@ -1065,7 +1081,7 @@ class PurchasesTest {
         // use deprecated version of method because deferred purchases aren't supported with new version
         purchases.purchasePackageWith(
             mockActivity,
-            offerings[stubOfferingIdentifier]!!.monthly!!,
+            offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!,
             UpgradeInfo(oldPurchase.productIds[0]),
             onError = { _, _ ->
                 fail("should be success")
@@ -1096,7 +1112,7 @@ class PurchasesTest {
         var receivedError: PurchasesError? = null
         var receivedUserCancelled: Boolean? = null
         val purchasePackageUpgradeParams = getPurchaseParams(
-            offerings[stubOfferingIdentifier]!!.monthly!!,
+            offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!,
             oldPurchase.productIds[0]
         )
         purchases.purchaseWith(
@@ -1124,7 +1140,7 @@ class PurchasesTest {
         var receivedUserCancelled: Boolean? = null
         val purchasePackageUpgradeParams =
             getPurchaseParams(
-                offerings[stubOfferingIdentifier]!!.monthly!!,
+                offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!,
                 oldPurchase.productIds[0])
         purchases.purchaseWith(
             purchasePackageUpgradeParams,
@@ -1157,7 +1173,7 @@ class PurchasesTest {
         var receivedUserCancelled: Boolean? = null
 
         val purchasePackageUpgradeParams = getPurchaseParams(
-            offerings[stubOfferingIdentifier]!!.monthly!!,
+            offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!,
             oldPurchase.productIds[0]
         )
         purchases.purchaseWith(
@@ -1175,7 +1191,7 @@ class PurchasesTest {
                 eq(appUserId),
                 storeProduct.subscriptionOptions!!.first().purchasingData,
                 ReplaceProductInfo(oldPurchase, ProrationMode.IMMEDIATE_WITHOUT_PRORATION),
-                stubOfferingIdentifier
+                STUB_OFFERING_IDENTIFIER
             )
         }
         assertThat(receivedError).isNotNull
@@ -1216,7 +1232,7 @@ class PurchasesTest {
         var receivedUserCancelled: Boolean? = null
 
         val purchasePackageUpgradeParams = getPurchaseParams(
-            offerings[stubOfferingIdentifier]!!.monthly!!,
+            offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!,
             oldPurchase.productIds[0]
         )
         purchases.purchaseWith(
@@ -1234,7 +1250,7 @@ class PurchasesTest {
                 eq(appUserId),
                 storeProduct.subscriptionOptions!!.first().purchasingData,
                 ReplaceProductInfo(oldPurchase, ProrationMode.IMMEDIATE_WITHOUT_PRORATION),
-                stubOfferingIdentifier
+                STUB_OFFERING_IDENTIFIER
             )
         }
         assertThat(receivedError).isNotNull
@@ -1266,7 +1282,7 @@ class PurchasesTest {
 
         purchases.purchasePackageWith(
             mockActivity,
-            offerings[stubOfferingIdentifier]!!.monthly!!,
+            offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!,
             UpgradeInfo(oldPurchase.productIds[0])
         ) { _, _ -> }
 
@@ -1504,7 +1520,7 @@ class PurchasesTest {
 
     @Test
     fun `if no cached offerings, backend is hit when getting offerings`() {
-        val productIds = listOf(stubProductIdentifier)
+        val productIds = listOf(STUB_PRODUCT_IDENTIFIER)
         mockProducts()
         mockStoreProduct(productIds, productIds, ProductType.SUBS)
         val (_, _) = stubOfferings("onemonth_freetrial")
@@ -1532,7 +1548,7 @@ class PurchasesTest {
 
     @Test
     fun `if no cached offerings, backend is hit when getting offerings when on background`() {
-        val productIds = listOf(stubProductIdentifier)
+        val productIds = listOf(STUB_PRODUCT_IDENTIFIER)
         mockProducts()
         mockStoreProduct(productIds, productIds, ProductType.SUBS)
         val (_, _) = stubOfferings("onemonth_freetrial")
@@ -1562,7 +1578,7 @@ class PurchasesTest {
 
     @Test
     fun `products are populated when getting offerings`() {
-        val productIds = listOf(stubProductIdentifier)
+        val productIds = listOf(STUB_PRODUCT_IDENTIFIER)
         mockProducts()
         mockStoreProduct(productIds, productIds, ProductType.SUBS)
         val (_, _) = stubOfferings("onemonth_freetrial")
@@ -1580,7 +1596,7 @@ class PurchasesTest {
 
         assertThat(receivedOfferings).isNotNull
         assertThat(receivedOfferings!!.all.size).isEqualTo(1)
-        assertThat(receivedOfferings!![stubOfferingIdentifier]!!.monthly!!.product).isNotNull
+        assertThat(receivedOfferings!![STUB_OFFERING_IDENTIFIER]!!.monthly!!.product).isNotNull
     }
 
     @Test
@@ -1611,7 +1627,7 @@ class PurchasesTest {
 
     @Test
     fun `configuration error if products are not set up when fetching offerings`() {
-        val productIds = listOf(stubProductIdentifier)
+        val productIds = listOf(STUB_PRODUCT_IDENTIFIER)
 
         mockProducts()
         clearMocks(mockBillingAbstract)
@@ -4241,7 +4257,7 @@ class PurchasesTest {
         }
     }
 
-    private fun mockProducts(response: String = oneOfferingsResponse) {
+    private fun mockProducts(response: String = ONE_OFFERINGS_RESPONSE) {
         every {
             mockBackend.getOfferings(any(), any(), captureLambda(), any())
         } answers {
@@ -4634,34 +4650,6 @@ class PurchasesTest {
 
         buildPurchases(anonymous)
         mockSubscriberAttributesManager(userIdToUse)
-    }
-
-    private fun stubOfferings(storeProduct: StoreProduct): Pair<StoreProduct, Offerings> {
-        val jsonObject = JSONObject(oneOfferingsResponse)
-        val packageObject = Package(
-            "\$rc_monthly",
-            PackageType.MONTHLY,
-            storeProduct,
-            stubOfferingIdentifier
-        )
-        val offering = Offering(
-            stubOfferingIdentifier,
-            "This is the base offering",
-            listOf(packageObject)
-        )
-        val offerings = Offerings(
-            offering,
-            mapOf(offering.identifier to offering)
-        )
-        every {
-            jsonObject.createOfferings(any())
-        } returns offerings
-        return Pair(storeProduct, offerings)
-    }
-
-    private fun stubOfferings(productId: String): Pair<StoreProduct, Offerings> {
-        val storeProduct = stubStoreProduct(productId)
-        return stubOfferings(storeProduct)
     }
 
 // endregion

--- a/strings/src/main/java/com/revenuecat/purchases/strings/PurchaseStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/PurchaseStrings.kt
@@ -38,6 +38,8 @@ object PurchaseStrings {
     const val INVALID_PURCHASE_TYPE = "Purchase for a %s purchase must be a %s."
     const val INVALID_STORE_PRODUCT_TYPE = "StoreProduct for a %s purchase must be a %s."
     const val INVALID_PRODUCT_NO_PRICE = "Error finding a price for %s."
+    const val INVALID_CALLBACK_TYPE_INTERNAL_ERROR = "Internal SDK error -- invalid callback type passed to " +
+        "startProductChange."
     const val NULL_TRANSACTION_ON_PURCHASE_ERROR = "Error purchasing. Null transaction returned from a succcessful " +
         "non-upgrade purchase."
 }

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -8,7 +8,6 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.common.MICROS_MULTIPLIER
-import com.revenuecat.purchases.common.createOfferings
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.PurchasingData
@@ -17,8 +16,6 @@ import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.SubscriptionOptions
 import com.revenuecat.purchases.models.toRecurrenceMode
-import io.mockk.every
-import org.json.JSONObject
 
 @SuppressWarnings("MatchingDeclarationName")
 private data class StubPurchasingData(
@@ -155,7 +152,6 @@ fun stubPricingPhase(
 )
 
 fun stubOfferings(storeProduct: StoreProduct): Pair<StoreProduct, Offerings> {
-    val jsonObject = JSONObject(ONE_OFFERINGS_RESPONSE)
     val packageObject = Package(
         "\$rc_monthly",
         PackageType.MONTHLY,
@@ -171,9 +167,6 @@ fun stubOfferings(storeProduct: StoreProduct): Pair<StoreProduct, Offerings> {
         offering,
         mapOf(offering.identifier to offering)
     )
-    every {
-        jsonObject.createOfferings(any())
-    } returns offerings
     return Pair(storeProduct, offerings)
 }
 


### PR DESCRIPTION
Follow-up PR addressing the following:
* have the  deprecated listenerConversions call into new listenerConversions to keep all retrofitting in purchases
* have the deprecated purchase methods in purchases directly call startPurchase without PurchaseParams (so no more breaking change on which prorationmodes can be used with the deprecated methods)
* remove all subscriptionOption purchase methods
* add PurchaseParamsTests
* make PurchaseParams a data class
* deprecate ProductChangeCallback, use PurchaseCallback everywhere else, split startProductChange methods between the two kinds of callbacks