### PR TITLE
Grant grace period for entitlements when the backend is offline

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/EntitlementInfoFactories.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/EntitlementInfoFactories.kt
@@ -104,13 +104,13 @@ private fun isDateActive(
     expirationDate: Date?,
     requestDate: Date
 ): Boolean {
-    val isActive = DateHelper.isDateActive(expirationDate, requestDate)
-    if (!isActive) {
+    val dateActive = DateHelper.isDateActive(expirationDate, requestDate)
+    if (!dateActive.isActive && !dateActive.inGracePeriod) {
         warnLog(
             PurchaseStrings.ENTITLEMENT_EXPIRED_OUTSIDE_GRACE_PERIOD.format(identifier, expirationDate, requestDate)
         )
     }
-    return isActive
+    return dateActive.isActive
 }
 
 private fun getWillRenew(

--- a/common/src/main/java/com/revenuecat/purchases/common/EntitlementInfoFactories.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/EntitlementInfoFactories.kt
@@ -6,6 +6,8 @@ import com.revenuecat.purchases.OwnershipType
 import com.revenuecat.purchases.PeriodType
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.strings.PurchaseStrings
+import com.revenuecat.purchases.utils.DateHelper
 import com.revenuecat.purchases.utils.getDate
 import com.revenuecat.purchases.utils.optDate
 import org.json.JSONObject
@@ -14,7 +16,7 @@ import java.util.Date
 internal fun JSONObject.buildEntitlementInfos(
     subscriptions: JSONObject,
     nonSubscriptionsLatestPurchases: JSONObject,
-    requestDate: Date?,
+    requestDate: Date,
     verificationResult: VerificationResult
 ): EntitlementInfos {
     val all = mutableMapOf<String, EntitlementInfo>()
@@ -68,7 +70,7 @@ internal fun JSONObject.optOwnershipType(name: String) = when (optString(name)) 
 internal fun JSONObject.buildEntitlementInfo(
     identifier: String,
     productData: JSONObject,
-    requestDate: Date?,
+    requestDate: Date,
     verificationResult: VerificationResult
 ): EntitlementInfo {
     val expirationDate = optDate("expires_date")
@@ -79,7 +81,7 @@ internal fun JSONObject.buildEntitlementInfo(
 
     return EntitlementInfo(
         identifier = identifier,
-        isActive = expirationDate == null || expirationDate.after(requestDate ?: Date()),
+        isActive = isDateActive(identifier, expirationDate, requestDate),
         willRenew = getWillRenew(store, expirationDate, unsubscribeDetectedAt,
             billingIssueDetectedAt),
         periodType = productData.optPeriodType("period_type"),
@@ -95,6 +97,20 @@ internal fun JSONObject.buildEntitlementInfo(
         jsonObject = this,
         verification = verificationResult
     )
+}
+
+private fun isDateActive(
+    identifier: String,
+    expirationDate: Date?,
+    requestDate: Date
+): Boolean {
+    val isActive = DateHelper.isDateActive(expirationDate, requestDate)
+    if (!isActive) {
+        warnLog(
+            PurchaseStrings.ENTITLEMENT_EXPIRED_OUTSIDE_GRACE_PERIOD.format(identifier, expirationDate, requestDate)
+        )
+    }
+    return isActive
 }
 
 private fun getWillRenew(

--- a/common/src/test/java/com/revenuecat/purchases/common/CustomerInfoTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/CustomerInfoTest.kt
@@ -16,6 +16,7 @@ import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import kotlin.time.Duration.Companion.days
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -72,6 +73,57 @@ class CustomerInfoTest {
 
         assertThat(actives.size).isEqualTo(1)
         assertThat(actives).contains("onemonth_freetrial")
+    }
+
+    @Test
+    fun `active subscriptions returns expired subscriptions in grace period`() {
+        val response = Responses.createFullPurchaserResponse(
+            oneMonthFreeTrialExpirationDate = 3.days.ago(),
+            threeMonthFreeTrialExpirationDate = 1.days.ago()
+        )
+        val info = createCustomerInfo(response, 2.days.ago())
+        val actives = info.activeSubscriptions
+
+        assertThat(actives.size).isEqualTo(1)
+        assertThat(actives.first()).isEqualTo("threemonth_freetrial")
+    }
+
+    @Test
+    fun `active subscriptions returns multiple non expired subscriptions in grace period`() {
+        val response = Responses.createFullPurchaserResponse(
+            oneMonthFreeTrialExpirationDate = 1.days.ago(),
+            threeMonthFreeTrialExpirationDate = 1.days.ago()
+        )
+        val info = createCustomerInfo(response, 2.days.ago())
+        val actives = info.activeSubscriptions
+
+        assertThat(actives.size).isEqualTo(2)
+        assertThat(actives).containsAll(listOf("onemonth_freetrial", "threemonth_freetrial"))
+    }
+
+    @Test
+    fun `active subscriptions returns nothing if no subscriptions in grace period`() {
+        val response = Responses.createFullPurchaserResponse(
+            oneMonthFreeTrialExpirationDate = 1.days.ago(),
+            threeMonthFreeTrialExpirationDate = 1.days.ago()
+        )
+        val info = createCustomerInfo(response, 5.days.ago())
+        val actives = info.activeSubscriptions
+
+        assertThat(actives.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `active subscriptions returns non-expired subscriptions`() {
+        val response = Responses.createFullPurchaserResponse(
+            oneMonthFreeTrialExpirationDate = 1.days.fromNow(),
+            threeMonthFreeTrialExpirationDate = 2.days.ago()
+        )
+        val info = createCustomerInfo(response, 1.days.ago())
+        val actives = info.activeSubscriptions
+
+        assertThat(actives.size).isEqualTo(1)
+        assertThat(actives.first()).isEqualTo("onemonth_freetrial")
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/CustomerInfoTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/CustomerInfoTest.kt
@@ -8,7 +8,6 @@ package com.revenuecat.purchases.common
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.CustomerInfo
-import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.utils.Responses
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONException
@@ -77,7 +76,7 @@ class CustomerInfoTest {
 
     @Test
     fun `active subscriptions returns expired subscriptions in grace period`() {
-        val response = Responses.createFullPurchaserResponse(
+        val response = Responses.createFullCustomerResponse(
             oneMonthFreeTrialExpirationDate = 3.days.ago(),
             threeMonthFreeTrialExpirationDate = 1.days.ago()
         )
@@ -90,7 +89,7 @@ class CustomerInfoTest {
 
     @Test
     fun `active subscriptions returns multiple non expired subscriptions in grace period`() {
-        val response = Responses.createFullPurchaserResponse(
+        val response = Responses.createFullCustomerResponse(
             oneMonthFreeTrialExpirationDate = 1.days.ago(),
             threeMonthFreeTrialExpirationDate = 1.days.ago()
         )
@@ -103,7 +102,7 @@ class CustomerInfoTest {
 
     @Test
     fun `active subscriptions returns nothing if no subscriptions in grace period`() {
-        val response = Responses.createFullPurchaserResponse(
+        val response = Responses.createFullCustomerResponse(
             oneMonthFreeTrialExpirationDate = 1.days.ago(),
             threeMonthFreeTrialExpirationDate = 1.days.ago()
         )
@@ -115,7 +114,7 @@ class CustomerInfoTest {
 
     @Test
     fun `active subscriptions returns non-expired subscriptions`() {
-        val response = Responses.createFullPurchaserResponse(
+        val response = Responses.createFullCustomerResponse(
             oneMonthFreeTrialExpirationDate = 1.days.fromNow(),
             threeMonthFreeTrialExpirationDate = 2.days.ago()
         )

--- a/common/src/test/java/com/revenuecat/purchases/common/testDurationExtensions.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/testDurationExtensions.kt
@@ -1,0 +1,14 @@
+package com.revenuecat.purchases.common
+
+import com.revenuecat.purchases.utils.add
+import com.revenuecat.purchases.utils.subtract
+import java.util.Date
+import kotlin.time.Duration
+
+fun Duration.fromNow(): Date {
+    return Date().add(this)
+}
+
+fun Duration.ago(): Date {
+    return Date().subtract(this)
+}

--- a/public/src/main/java/com/revenuecat/purchases/CustomerInfo.kt
+++ b/public/src/main/java/com/revenuecat/purchases/CustomerInfo.kt
@@ -10,6 +10,7 @@ import android.os.Parcelable
 import com.revenuecat.purchases.models.RawDataContainer
 import com.revenuecat.purchases.models.Transaction
 import com.revenuecat.purchases.parceler.JSONObjectParceler
+import com.revenuecat.purchases.utils.DateHelper
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
@@ -139,7 +140,7 @@ data class CustomerInfo constructor(
         get() = jsonObject
 
     private fun activeIdentifiers(expirations: Map<String, Date?>): Set<String> {
-        return expirations.filterValues { date -> date == null || date.after(requestDate) }.keys
+        return expirations.filterValues { expirationDate -> DateHelper.isDateActive(expirationDate, requestDate) }.keys
     }
 
     @IgnoredOnParcel

--- a/public/src/main/java/com/revenuecat/purchases/CustomerInfo.kt
+++ b/public/src/main/java/com/revenuecat/purchases/CustomerInfo.kt
@@ -140,7 +140,9 @@ data class CustomerInfo constructor(
         get() = jsonObject
 
     private fun activeIdentifiers(expirations: Map<String, Date?>): Set<String> {
-        return expirations.filterValues { expirationDate -> DateHelper.isDateActive(expirationDate, requestDate) }.keys
+        return expirations.filterValues {
+                expirationDate -> DateHelper.isDateActive(expirationDate, requestDate).isActive
+        }.keys
     }
 
     @IgnoredOnParcel

--- a/strings/src/main/java/com/revenuecat/purchases/strings/PurchaseStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/PurchaseStrings.kt
@@ -33,4 +33,6 @@ object PurchaseStrings {
     const val NOT_RECOGNIZED_PRODUCT_TYPE = "Type of product not recognized."
     const val SKIPPING_AUTOMATIC_SYNC = "Skipping automatic synchronization."
     const val INVALID_PRODUCT_TYPE = "Invalid product type passed to %s."
+    const val ENTITLEMENT_EXPIRED_OUTSIDE_GRACE_PERIOD = "Entitlement %s is no longer active (expired %s) " +
+        "and it's outside grace period window (last updated %s)"
 }

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/Responses.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/Responses.kt
@@ -5,7 +5,7 @@ import java.util.Date
 
 object Responses {
     @Suppress("LongMethod")
-    fun createFullPurchaserResponse(
+    fun createFullCustomerResponse(
         oneMonthFreeTrialExpirationDate: Date? = Iso8601Utils.parse("2100-04-06T20:54:45.975000Z"),
         threeMonthFreeTrialExpirationDate: Date? = Iso8601Utils.parse("1990-08-30T02:40:36Z")
     ): String {
@@ -106,7 +106,7 @@ object Responses {
             """.removeJSONFormatting()
     }
 
-    val validFullPurchaserResponse = createFullPurchaserResponse()
+    val validFullPurchaserResponse = createFullCustomerResponse()
 
     val validEmptyPurchaserResponse = """
                 {

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/Responses.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/Responses.kt
@@ -1,9 +1,15 @@
 package com.revenuecat.purchases.utils
 
 import org.json.JSONObject
+import java.util.Date
 
 object Responses {
-    val validFullPurchaserResponse = """
+    @Suppress("LongMethod")
+    fun createFullPurchaserResponse(
+        oneMonthFreeTrialExpirationDate: Date? = Iso8601Utils.parse("2100-04-06T20:54:45.975000Z"),
+        threeMonthFreeTrialExpirationDate: Date? = Iso8601Utils.parse("1990-08-30T02:40:36Z")
+    ): String {
+        return """
                 {
                   "request_date": "2019-08-16T10:30:42Z",
                   "request_date_ms": 1565951442879,
@@ -63,7 +69,7 @@ object Responses {
                         "purchase_date": "2019-07-26T23:45:40Z",
                         "store": "app_store",
                         "unsubscribe_detected_at": null,
-                        "expires_date": "2100-04-06T20:54:45.975000Z",
+                        "expires_date": "${Iso8601Utils.format(oneMonthFreeTrialExpirationDate)}",
                         "period_type": "normal"
                       },
                       "threemonth_freetrial": {
@@ -74,7 +80,7 @@ object Responses {
                         "store": "app_store",
                         "unsubscribe_detected_at": null,
                         "period_type": "normal",
-                        "expires_date": "1990-08-30T02:40:36Z"
+                        "expires_date": "${Iso8601Utils.format(threeMonthFreeTrialExpirationDate)}"
                       }
                     },
                     "entitlements": {
@@ -98,6 +104,9 @@ object Responses {
                   }
                 }
             """.removeJSONFormatting()
+    }
+
+    val validFullPurchaserResponse = createFullPurchaserResponse()
 
     val validEmptyPurchaserResponse = """
                 {

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/dateExtensions.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/dateExtensions.kt
@@ -1,0 +1,7 @@
+package com.revenuecat.purchases.utils
+
+import java.util.Date
+import kotlin.time.Duration
+
+fun Date.add(duration: Duration) = Date(this.time + duration.inWholeMilliseconds)
+fun Date.subtract(duration: Duration) = add(duration * -1)

--- a/utils/src/main/java/com/revenuecat/purchases/utils/DateHelper.kt
+++ b/utils/src/main/java/com/revenuecat/purchases/utils/DateHelper.kt
@@ -1,0 +1,27 @@
+package com.revenuecat.purchases.utils
+
+import java.util.Date
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+
+class DateHelper private constructor() {
+    companion object {
+        private val ENTITLEMENT_GRACE_PERIOD = 3.days
+
+        /**
+         * Calculates whether a subscription/entitlement is currently active according to the expiration date and last
+         * successful request date, while considering a given grace period
+         */
+        fun isDateActive(
+            expirationDate: Date?,
+            requestDate: Date,
+            gracePeriod: Duration = ENTITLEMENT_GRACE_PERIOD
+        ): Boolean {
+            if (expirationDate == null) return true
+
+            val inGracePeriod = (Date().time - requestDate.time) <= gracePeriod.inWholeMilliseconds
+            val referenceDate = if (inGracePeriod) requestDate else Date()
+            return expirationDate.after(referenceDate)
+        }
+    }
+}

--- a/utils/src/main/java/com/revenuecat/purchases/utils/DateHelper.kt
+++ b/utils/src/main/java/com/revenuecat/purchases/utils/DateHelper.kt
@@ -4,6 +4,8 @@ import java.util.Date
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 
+data class DateActive(val isActive: Boolean, val inGracePeriod: Boolean)
+
 class DateHelper private constructor() {
     companion object {
         private val ENTITLEMENT_GRACE_PERIOD = 3.days
@@ -16,12 +18,12 @@ class DateHelper private constructor() {
             expirationDate: Date?,
             requestDate: Date,
             gracePeriod: Duration = ENTITLEMENT_GRACE_PERIOD
-        ): Boolean {
-            if (expirationDate == null) return true
+        ): DateActive {
+            if (expirationDate == null) return DateActive(isActive = true, inGracePeriod = true)
 
             val inGracePeriod = (Date().time - requestDate.time) <= gracePeriod.inWholeMilliseconds
             val referenceDate = if (inGracePeriod) requestDate else Date()
-            return expirationDate.after(referenceDate)
+            return DateActive(isActive = expirationDate.after(referenceDate), inGracePeriod = inGracePeriod)
         }
     }
 }


### PR DESCRIPTION
### Description
Completes [SDK-2895](https://linear.app/revenuecat/issue/SDK-2895/create-a-grace-period-for-entitlements-when-the-backend-is-offline).

Android equivalent of: https://github.com/RevenueCat/purchases-ios/pull/2288

In this PR we are adding a 3 day grace period to entitlements expiration dates. 
