### PR TITLE
Entitlement verification: Hide EntitlementVerificationMode.ENFORCED during beta and improve documentation

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/EntitlementVerificationModeAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/EntitlementVerificationModeAPI.java
@@ -8,7 +8,8 @@ final class EntitlementVerificationModeAPI {
         switch (verificationMode) {
             case DISABLED:
             case INFORMATIONAL:
-            case ENFORCED:
+            // Hidden ENFORCED mode during feature beta
+            // case ENFORCED:
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementVerificationModeAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementVerificationModeAPI.kt
@@ -8,7 +8,8 @@ private class EntitlementVerificationModeAPI {
         when (verificationMode) {
             EntitlementVerificationMode.DISABLED,
             EntitlementVerificationMode.INFORMATIONAL,
-            EntitlementVerificationMode.ENFORCED
+            // Hidden ENFORCED mode during feature beta
+            // EntitlementVerificationMode.ENFORCED
             -> {}
         }.exhaustive
     }

--- a/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt
@@ -29,6 +29,8 @@ import java.util.Date
  * @property billingIssueDetectedAt The date a billing issue was detected. Can be `null` if there is
  * no billing issue or an issue has been resolved. Note: Entitlement may still be active even if
  * there is a billing issue. Check the `isActive` property.
+ * @property verification If entitlement verification was enabled, the result of that verification.
+ * If not, [VerificationResult.NOT_REQUESTED]
  */
 @Parcelize
 @TypeParceler<JSONObject, JSONObjectParceler>()

--- a/public/src/main/java/com/revenuecat/purchases/EntitlementInfos.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementInfos.kt
@@ -7,6 +7,8 @@ import kotlinx.parcelize.Parcelize
  * This class contains all the entitlements associated to the user.
  * @property all Map of all EntitlementInfo [EntitlementInfo] objects (active and inactive) keyed by
  * entitlement identifier.
+ * @property verification If entitlement verification was enabled, the result of that verification.
+ * If not, [VerificationResult.NOT_REQUESTED]
  */
 @Parcelize
 class EntitlementInfos constructor(

--- a/public/src/main/java/com/revenuecat/purchases/EntitlementVerificationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementVerificationMode.kt
@@ -12,20 +12,17 @@ enum class EntitlementVerificationMode {
     /**
      * Enable entitlement verification.
      *
-     * If verification fails, this will be indicated with [VerificationResult.FAILED]
-     * but parsing will not fail.
+     * If verification fails, this will be indicated with [VerificationResult.FAILED] in
+     * the [EntitlementInfos.verification] and [EntitlementInfo.verification] properties but parsing will not fail
+     * (i.e. Entitlements will still be granted).
      *
-     * This can be useful if you want to handle validation failures but still grant access.
+     * This can be useful if you want to handle verification failures to display an error/warning to the user
+     * or to track this situation but still grant access.
      */
-    INFORMATIONAL,
+    INFORMATIONAL;
 
-    /**
-     * Enable entitlement verification.
-     *
-     * If verification fails when fetching [CustomerInfo] and/or [EntitlementInfos]
-     * the request will fail.
-     */
-    ENFORCED;
+    // Hidden ENFORCED mode during feature beta
+    // ENFORCED;
 
     companion object {
         /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -68,8 +68,11 @@ open class PurchasesConfiguration(builder: Builder) {
         }
 
         /**
-         * Defines how strict [EntitlementInfo] verification ought to be.
-         * Default is [EntitlementVerificationMode.DISABLED].
+         * **Feature in beta**. Defines how strict [EntitlementInfo] verification ought to be.
+         *
+         * This feature is currently in beta and the behavior may change.
+         *
+         * Default mode is [EntitlementVerificationMode.DISABLED].
          */
         fun entitlementVerificationMode(entitlementVerificationMode: EntitlementVerificationMode) = apply {
             this.verificationMode = entitlementVerificationMode


### PR DESCRIPTION
### Description
Completes [SDK-2923](https://linear.app/revenuecat/issue/SDK-2923/hide-enforced-mode-for-sdk-security).

We decided to pull the ENFORCED mode during beta of the entitlements verification feature. This PR also improves and adds some missing documentation.

Note that the internal `SignatureVerificationMode.enforced` still exists and tests remain, but it won't be available through the public API.