### PR TITLE
Entitlement verification: Send updated value in listener when verification result changes

### DIFF
--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfoTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfoTest.kt
@@ -1,0 +1,73 @@
+package com.revenuecat.purchases.common
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.EntitlementInfo
+import com.revenuecat.purchases.OwnershipType
+import com.revenuecat.purchases.PeriodType
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.VerificationResult
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Date
+import kotlin.time.Duration.Companion.days
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class EntitlementInfoTest {
+
+    @Test
+    fun `same entitlement info are equal`() {
+        val entitlementInfo1 = createEntitlementInfo()
+        val entitlementInfo2 = createEntitlementInfo()
+        assertThat(entitlementInfo1).isEqualTo(entitlementInfo2)
+    }
+
+    @Test
+    fun `same entitlement info with different verification are not equal`() {
+        val entitlementInfo1 = createEntitlementInfo(verification = VerificationResult.NOT_REQUESTED)
+        val entitlementInfo2 = createEntitlementInfo(verification = VerificationResult.FAILED)
+        val entitlementInfo3 = createEntitlementInfo(verification = VerificationResult.SUCCESS)
+        assertThat(entitlementInfo1).isNotEqualTo(entitlementInfo2)
+        assertThat(entitlementInfo1).isNotEqualTo(entitlementInfo3)
+        assertThat(entitlementInfo2).isNotEqualTo(entitlementInfo3)
+    }
+
+    private fun createEntitlementInfo(
+        identifier: String = "test-entitlement-info-id",
+        isActive: Boolean = true,
+        willRenew: Boolean = true,
+        periodType: PeriodType = PeriodType.NORMAL,
+        latestPurchaseDate: Date = 1.days.ago(),
+        originalPurchaseDate: Date = 2.days.ago(),
+        expirationDate: Date? = 1.days.fromNow(),
+        store: Store = Store.PLAY_STORE,
+        productIdentifier: String = "test-product-id",
+        isSandbox: Boolean = false,
+        unsubscribeDetectedAt: Date? = null,
+        billingIssueDetectedAt: Date? = null,
+        ownershipType: OwnershipType = OwnershipType.PURCHASED,
+        jsonObject: JSONObject = JSONObject("{}"),
+        verification: VerificationResult = VerificationResult.NOT_REQUESTED
+    ): EntitlementInfo {
+        return EntitlementInfo(
+            identifier,
+            isActive,
+            willRenew,
+            periodType,
+            latestPurchaseDate,
+            originalPurchaseDate,
+            expirationDate,
+            store,
+            productIdentifier,
+            isSandbox,
+            unsubscribeDetectedAt,
+            billingIssueDetectedAt,
+            ownershipType,
+            jsonObject,
+            verification
+        )
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.EntitlementInfos
 import com.revenuecat.purchases.OwnershipType
 import com.revenuecat.purchases.PeriodType
 import com.revenuecat.purchases.Store
@@ -1161,6 +1162,27 @@ class EntitlementInfosTests {
 
         verifyOwnershipType(OwnershipType.UNKNOWN)
     }
+
+    // region Equality tests
+
+    @Test
+    fun `same entitlement infos with different verifications are not equal`() {
+        val entitlementInfos1 = EntitlementInfos(emptyMap(), VerificationResult.NOT_REQUESTED)
+        val entitlementInfos2 = EntitlementInfos(emptyMap(), VerificationResult.SUCCESS)
+        val entitlementInfos3 = EntitlementInfos(emptyMap(), VerificationResult.FAILED)
+        assertThat(entitlementInfos1).isNotEqualTo(entitlementInfos2)
+        assertThat(entitlementInfos1).isNotEqualTo(entitlementInfos3)
+        assertThat(entitlementInfos2).isNotEqualTo(entitlementInfos3)
+    }
+
+    @Test
+    fun `same entitlement infos with same verifications are equal`() {
+        val entitlementInfos1 = EntitlementInfos(emptyMap(), VerificationResult.NOT_REQUESTED)
+        val entitlementInfos2 = EntitlementInfos(emptyMap(), VerificationResult.NOT_REQUESTED)
+        assertThat(entitlementInfos1).isEqualTo(entitlementInfos2)
+    }
+
+    // endregion
 
     // region EntitlementInfo active with grace periods
 

--- a/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt
@@ -128,6 +128,7 @@ data class EntitlementInfo constructor(
         if (unsubscribeDetectedAt != other.unsubscribeDetectedAt) return false
         if (billingIssueDetectedAt != other.billingIssueDetectedAt) return false
         if (ownershipType != other.ownershipType) return false
+        if (verification != other.verification) return false
 
         return true
     }

--- a/public/src/main/java/com/revenuecat/purchases/EntitlementInfos.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementInfos.kt
@@ -39,6 +39,7 @@ class EntitlementInfos constructor(
 
         if (all != other.all) return false
         if (active != other.active) return false
+        if (verification != other.verification) return false
 
         return true
     }


### PR DESCRIPTION
### Description
We were not sending updated values in the listener when we only detected a change in the verification result. This fixes that by adding this new property to the equals calculation.