### PR TITLE
Remove Parcelable implementation for classes with ProductDetails as a member

### DIFF
--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
@@ -1,19 +1,15 @@
 package com.revenuecat.purchases.amazon
 
-import android.os.Parcelable
 import com.amazon.device.iap.model.Product
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.MICROS_MULTIPLIER
 import com.revenuecat.purchases.common.log
-import com.revenuecat.purchases.models.PurchasingData
-import com.revenuecat.purchases.models.SubscriptionOption
-import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.PurchasingData
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.SubscriptionOptions
-import com.revenuecat.purchases.utils.JSONObjectParceler
-import kotlinx.parcelize.Parcelize
-import kotlinx.parcelize.TypeParceler
 import org.json.JSONObject
 import java.math.BigDecimal
 import java.util.regex.Pattern
@@ -29,8 +25,6 @@ sealed class AmazonPurchasingData : PurchasingData {
     }
 }
 
-@Parcelize
-@TypeParceler<JSONObject, JSONObjectParceler>()
 data class AmazonStoreProduct(
     override val id: String,
     override val type: ProductType,
@@ -44,7 +38,7 @@ data class AmazonStoreProduct(
     val iconUrl: String,
     val originalJson: JSONObject,
     val amazonProduct: Product,
-) : StoreProduct, Parcelable {
+) : StoreProduct {
 
     override val purchasingData: AmazonPurchasingData
         get() = AmazonPurchasingData.Product(this)

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -275,7 +275,7 @@ class BillingWrapperTest {
                 fail("shouldn't be an error")
             })
 
-        assertThat(numCallbacks == 1)
+        assert(numCallbacks == 1)
     }
 
     @Test
@@ -799,10 +799,6 @@ class BillingWrapperTest {
                     override val productType: ProductType
                         get() = ProductType.SUBS
                 }
-
-            override fun describeContents(): Int = 0
-
-            override fun writeToParcel(dest: Parcel?, flags: Int) {}
         }
 
         wrapper.makePurchaseAsync(
@@ -851,10 +847,6 @@ class BillingWrapperTest {
                 get() = purchasingInfo
             override val sku: String
                 get() = id
-
-            override fun describeContents(): Int = 0
-
-            override fun writeToParcel(dest: Parcel?, flags: Int) {}
         }
 
         val slot = slot<PurchasesError>()

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -275,7 +275,7 @@ class BillingWrapperTest {
                 fail("shouldn't be an error")
             })
 
-        assert(numCallbacks == 1)
+        assertThat(numCallbacks).isEqualTo(1)
     }
 
     @Test

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/ParcelableTests.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/ParcelableTests.kt
@@ -3,43 +3,58 @@ package com.revenuecat.purchases.google
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.models.GooglePurchasingData
+import com.revenuecat.purchases.models.GoogleSubscriptionOption
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.PricingPhase
+import com.revenuecat.purchases.models.PurchasingData
+import com.revenuecat.purchases.models.RecurrenceMode
+import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.utils.mockProductDetails
 import com.revenuecat.purchases.utils.testParcelization
 import org.junit.Test
 import org.junit.runner.RunWith
 import com.revenuecat.purchases.Package as RevenueCatPackage
 
-//    TODOBC5: After using mocks for ProductDetails, these tests don't make much sense. Leaving for now.
-//@RunWith(AndroidJUnit4::class)
-//class ParcelableTests {
-//    @Test
-//    fun `Package is Parcelable`() = testParcelization(
-//        RevenueCatPackage(
-//            identifier = "test_package",
-//            packageType = PackageType.MONTHLY,
-//            product = mockProductDetails().toStoreProduct(),
-//            offering = "test",
-//            subscriptionPeriod = "P1M",
-//            storeProductIdentifier = "test_store_product_id"
-//        )
-//    )
-//
-//    @Test
-//    fun `Offering is Parcelable`() {
-//        val aPackage = RevenueCatPackage(
-//            identifier = "test_package",
-//            packageType = PackageType.MONTHLY,
-//            product = mockProductDetails().toStoreProduct(),
-//            offering = "test",
-//            subscriptionPeriod = "P1M",
-//            storeProductIdentifier = "test_store_product_id"
-//        )
-//        testParcelization(
-//            Offering(
-//                identifier = "test",
-//                serverDescription = "description test",
-//                availablePackages = listOf(aPackage)
-//            )
-//        )
-//    }
-//}
+@RunWith(AndroidJUnit4::class)
+class ParcelableTests {
+
+    private val price = Price(
+        "$3.99",
+        3990000L,
+        "USD"
+    )
+
+    private val period = Period(
+        0,
+        Period.Unit.MONTH,
+        "iso date strijng"
+    )
+
+    private val phase = PricingPhase(
+        period,
+        RecurrenceMode.FINITE_RECURRING,
+        null,
+        price
+    )
+
+    @Test
+    fun `Price is Parcelable`() {
+        testParcelization(price)
+    }
+
+    @Test
+    fun `Period is Parcelable`() {
+        testParcelization(phase)
+    }
+
+    @Test
+    fun `PricingPhase is Parcelable`() {
+        testParcelization(phase)
+    }
+
+
+
+}

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -26,6 +26,7 @@
 | `UpgradeInfo`           | `PurchaseParams.Builder.oldProductId` and `PurchaseParams.Builder.googleProrationMode` |
 | `ProductChangeCallback` | `PurchaseCallback`                                                                     |
 
+`Offering`, `Offerings`, `Package`, and `StoreProduct` are no longer Parcelable.
 
 ### StoreProduct changes
 

--- a/public/src/main/java/com/revenuecat/purchases/Offering.kt
+++ b/public/src/main/java/com/revenuecat/purchases/Offering.kt
@@ -5,10 +5,6 @@
 
 package com.revenuecat.purchases
 
-import android.os.Parcelable
-import kotlinx.parcelize.IgnoredOnParcel
-import kotlinx.parcelize.Parcelize
-
 /**
  * An offering is a collection of [Package] available for the user to purchase.
  * For more info see https://docs.revenuecat.com/docs/entitlements
@@ -16,48 +12,46 @@ import kotlinx.parcelize.Parcelize
  * @property serverDescription Offering description defined in RevenueCat dashboard.
  * @property availablePackages Array of [Package] objects available for purchase.
  */
-@Parcelize
 data class Offering constructor(
     val identifier: String,
     val serverDescription: String,
     val availablePackages: List<Package>
-) : Parcelable {
+) {
 
     /**
      * Lifetime package type configured in the RevenueCat dashboard, if available.
      */
-    @IgnoredOnParcel val lifetime by lazy { findPackage(PackageType.LIFETIME) }
+    val lifetime by lazy { findPackage(PackageType.LIFETIME) }
 
     /**
      * Annual package type configured in the RevenueCat dashboard, if available.
      */
-    @IgnoredOnParcel
     val annual by lazy { findPackage(PackageType.ANNUAL) }
 
     /**
      * Six month package type configured in the RevenueCat dashboard, if available.
      */
-    @IgnoredOnParcel val sixMonth by lazy { findPackage(PackageType.SIX_MONTH) }
+    val sixMonth by lazy { findPackage(PackageType.SIX_MONTH) }
 
     /**
      * Three month package type configured in the RevenueCat dashboard, if available.
      */
-    @IgnoredOnParcel val threeMonth by lazy { findPackage(PackageType.THREE_MONTH) }
+    val threeMonth by lazy { findPackage(PackageType.THREE_MONTH) }
 
     /**
      * Two month package type configured in the RevenueCat dashboard, if available.
      */
-    @IgnoredOnParcel val twoMonth by lazy { findPackage(PackageType.TWO_MONTH) }
+    val twoMonth by lazy { findPackage(PackageType.TWO_MONTH) }
 
     /**
      * Monthly package type configured in the RevenueCat dashboard, if available.
      */
-    @IgnoredOnParcel val monthly by lazy { findPackage(PackageType.MONTHLY) }
+    val monthly by lazy { findPackage(PackageType.MONTHLY) }
 
     /**
      * Weekly package type configured in the RevenueCat dashboard, if available.
      */
-    @IgnoredOnParcel val weekly by lazy { findPackage(PackageType.WEEKLY) }
+    val weekly by lazy { findPackage(PackageType.WEEKLY) }
 
     private fun findPackage(packageType: PackageType) =
         availablePackages.firstOrNull { it.identifier == packageType.identifier }

--- a/public/src/main/java/com/revenuecat/purchases/Offerings.kt
+++ b/public/src/main/java/com/revenuecat/purchases/Offerings.kt
@@ -1,19 +1,15 @@
 package com.revenuecat.purchases
 
-import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
-
 /**
  * This class contains all the offerings configured in RevenueCat dashboard.
  * For more info see https://docs.revenuecat.com/docs/entitlements
  * @property current Current offering configured in the RevenueCat dashboard.
  * @property all Dictionary of all Offerings [Offering] objects keyed by their identifier.
  */
-@Parcelize
 data class Offerings(
     val current: Offering?,
     val all: Map<String, Offering>
-) : Parcelable {
+) {
 
     /**
      * Retrieves an specific offering by its identifier.

--- a/public/src/main/java/com/revenuecat/purchases/Package.kt
+++ b/public/src/main/java/com/revenuecat/purchases/Package.kt
@@ -1,8 +1,6 @@
 package com.revenuecat.purchases
 
-import android.os.Parcelable
 import com.revenuecat.purchases.models.StoreProduct
-import kotlinx.parcelize.Parcelize
 
 /**
  * Contains information about the product available for the user to purchase. For more info see https://docs.revenuecat.com/docs/entitlements
@@ -11,13 +9,12 @@ import kotlinx.parcelize.Parcelize
  * @property product [StoreProduct] assigned to this package.
  * @property offering offering this package was returned from.
  */
-@Parcelize
 data class Package(
     val identifier: String,
     val packageType: PackageType,
     val product: StoreProduct,
     val offering: String
-) : Parcelable
+)
 
 /**
  *  Enumeration of all possible Package types.

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleStoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleStoreProduct.kt
@@ -1,13 +1,8 @@
 package com.revenuecat.purchases.models
 
-import android.os.Parcelable
 import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.ProductType
-import kotlinx.parcelize.IgnoredOnParcel
-import kotlinx.parcelize.Parcelize
-import kotlinx.parcelize.RawValue
 
-@Parcelize
 data class GoogleStoreProduct(
     val productId: String,
     val basePlanId: String?,
@@ -18,8 +13,8 @@ data class GoogleStoreProduct(
     override val period: Period?,
     override val subscriptionOptions: SubscriptionOptions?,
     override val defaultOption: SubscriptionOption?,
-    val productDetails: @RawValue ProductDetails // TODO parcelize?
-) : StoreProduct, Parcelable {
+    val productDetails: ProductDetails
+) : StoreProduct {
 
     override val id: String
         get() = basePlanId?.let {
@@ -39,7 +34,6 @@ data class GoogleStoreProduct(
     /**
      * The sku of the StoreProduct
      */
-    @IgnoredOnParcel
     @Deprecated(
         "Replaced with productId",
         ReplaceWith("productId")

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleSubscriptionOption.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleSubscriptionOption.kt
@@ -1,17 +1,11 @@
 package com.revenuecat.purchases.models
 
-import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
-import kotlinx.parcelize.RawValue
-
 /**
  * Defines an option for purchasing a Google subscription
  */
-@Parcelize
 data class GoogleSubscriptionOption(
     override val id: String,
     override val pricingPhases: List<PricingPhase>,
     override val tags: List<String>,
-
-    override val purchasingData: @RawValue PurchasingData
-) : SubscriptionOption, Parcelable
+    override val purchasingData: PurchasingData
+) : SubscriptionOption

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
@@ -1,13 +1,11 @@
 package com.revenuecat.purchases.models
 
-import android.os.Parcelable
 import com.revenuecat.purchases.ProductType
-import kotlinx.parcelize.IgnoredOnParcel
 
 /**
  * Represents an in-app product's or subscription's listing details.
  */
-interface StoreProduct : Parcelable {
+interface StoreProduct {
     /**
      * The product ID.
      * Google INAPP: "<productId>"
@@ -69,7 +67,6 @@ interface StoreProduct : Parcelable {
     /**
      * The sku of the StoreProduct
      */
-    @IgnoredOnParcel
     @Deprecated(
         "Replaced with id",
         ReplaceWith("id")

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
@@ -105,6 +105,49 @@ data class StoreTransaction(
     )
     val skus: List<String>
         get() = productIds
+
+    override fun equals(other: Any?) = other is StoreTransaction &&
+        ComparableData(this) == ComparableData(other)
+    override fun hashCode() = ComparableData(this).hashCode()
+}
+
+/**
+ * Contains fields to be used for equality, which ignores jsonObject.
+ * jsonObject is excluded because we're already using the parsed fields for comparisons,
+ * and to avoid complicating parcelization
+ */
+private data class ComparableData(
+    val orderId: String?,
+    val productIds: List<String>,
+    val type: ProductType,
+    val purchaseTime: Long,
+    val purchaseToken: String,
+    val purchaseState: PurchaseState,
+    val isAutoRenewing: Boolean?,
+    val signature: String?,
+    val presentedOfferingIdentifier: String?,
+    val storeUserID: String?,
+    val purchaseType: PurchaseType,
+    val marketplace: String?,
+    val subscriptionOptionId: String?
+) {
+    constructor(
+        storeTransaction: StoreTransaction
+    ) : this(
+        orderId = storeTransaction.orderId,
+            productIds = storeTransaction.productIds,
+            type = storeTransaction.type,
+            purchaseTime = storeTransaction.purchaseTime,
+            purchaseToken = storeTransaction.purchaseToken,
+            purchaseState = storeTransaction.purchaseState,
+            isAutoRenewing = storeTransaction.isAutoRenewing,
+            signature = storeTransaction.signature,
+            presentedOfferingIdentifier = storeTransaction.presentedOfferingIdentifier,
+            storeUserID = storeTransaction.storeUserID,
+            purchaseType = storeTransaction.purchaseType,
+            marketplace = storeTransaction.marketplace,
+            subscriptionOptionId = storeTransaction.subscriptionOptionId
+    )
 }
 
 enum class PurchaseType {

--- a/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOption.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOption.kt
@@ -1,11 +1,9 @@
 package com.revenuecat.purchases.models
 
-import android.os.Parcelable
-
 /**
  * A purchase-able entity for a subscription product.
  */
-interface SubscriptionOption : Parcelable {
+interface SubscriptionOption {
     /**
      * For Google subscriptions:
      * If this SubscriptionOption represents a base plan, this will be the basePlanId.

--- a/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOptions.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOptions.kt
@@ -1,13 +1,10 @@
 package com.revenuecat.purchases.models
 
-import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
 class SubscriptionOptions(
     private val subscriptionOptions: List<SubscriptionOption>
-    ) : List<SubscriptionOption> by subscriptionOptions, Parcelable {
+    ) : List<SubscriptionOption> by subscriptionOptions {
 
     /**
      * The base plan [SubscriptionOption].

--- a/public/src/test/java/com/revenuecat/purchases/ParcelableTests.kt
+++ b/public/src/test/java/com/revenuecat/purchases/ParcelableTests.kt
@@ -3,6 +3,9 @@ package com.revenuecat.purchases
 import android.net.Uri
 import android.os.Parcel
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.models.PurchaseState
+import com.revenuecat.purchases.models.PurchaseType
+import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.utils.JSONObjectParceler
 import com.revenuecat.purchases.utils.JSONObjectParceler.write
 import com.revenuecat.purchases.utils.Responses
@@ -39,6 +42,28 @@ class ParcelableTests {
             originalPurchaseDate = Date(System.currentTimeMillis())
         )
     )
+
+    @Test
+    fun `StoreTransaction is parcelable`() {
+        testParcelization(
+            StoreTransaction(
+                "orderId",
+                listOf("productId1", "productId2"),
+                ProductType.UNKNOWN,
+                0L,
+                "purchaseToken",
+                PurchaseState.PENDING,
+                true,
+                null,
+                JSONObject("originalJson"),
+                "offering_a",
+                "userId",
+                PurchaseType.GOOGLE_PURCHASE,
+                null,
+                "optionId"
+            )
+        )
+    }
 
     @Test
     fun `JSONObjectParceler works`() {

--- a/public/src/test/java/com/revenuecat/purchases/ParcelableTests.kt
+++ b/public/src/test/java/com/revenuecat/purchases/ParcelableTests.kt
@@ -55,7 +55,7 @@ class ParcelableTests {
                 PurchaseState.PENDING,
                 true,
                 null,
-                JSONObject("originalJson"),
+                JSONObject(emptyMap<String, String>()),
                 "offering_a",
                 "userId",
                 PurchaseType.GOOGLE_PURCHASE,

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.utils
 
-import android.os.Parcel
 import com.android.billingclient.api.ProductDetails
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
@@ -8,12 +7,12 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.common.MICROS_MULTIPLIER
+import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.PurchasingData
-import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.StoreProduct
-import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.SubscriptionOptions
 import com.revenuecat.purchases.models.toRecurrenceMode
 
@@ -67,10 +66,6 @@ fun stubStoreProduct(
         )
     override val sku: String
         get() = productId
-
-    override fun describeContents(): Int = 0
-
-    override fun writeToParcel(dest: Parcel?, flags: Int) {}
 }
 
 @SuppressWarnings("EmptyFunctionBlock")
@@ -99,10 +94,6 @@ fun stubINAPPStoreProduct(
         )
     override val sku: String
         get() = productId
-
-    override fun describeContents(): Int = 0
-
-    override fun writeToParcel(dest: Parcel?, flags: Int) {}
 }
 
 @SuppressWarnings("EmptyFunctionBlock")
@@ -122,9 +113,6 @@ fun stubSubscriptionOption(
         get() = StubPurchasingData(
             productId = productId
         )
-
-    override fun describeContents(): Int = 0
-    override fun writeToParcel(dest: Parcel?, flags: Int) {}
 }
 
 fun stubFreeTrialPricingPhase(


### PR DESCRIPTION
Because ProductDetails does not have a public constructor, `StoreProduct`, `Package`, `Offering`, `PurchasingData` and `Offerings` are no longer Parcelable.

This PR takes away the implementation/annotation for those classes and updates unit tests accordingly. It also adds a missing test for `StoreProduct`, which caught a failure in parcelization. This is now fixed with the inner `ComparableData` class, copying the pattern we use in `CustomerInfo` to exclude the JSONObject.