### PR TITLE
Log message when trying configure the SDK multiple times

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -33,6 +33,7 @@ import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.common.debugLogsEnabled
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
@@ -2074,6 +2075,9 @@ class Purchases internal constructor(
         fun configure(
             configuration: PurchasesConfiguration
         ): Purchases {
+            if (isConfigured) {
+                infoLog(ConfigureStrings.INSTANCE_ALREADY_EXISTS)
+            }
             return PurchasesFactory().createPurchases(
                 configuration,
                 platformInfo,

--- a/strings/src/main/java/com/revenuecat/purchases/strings/ConfigureStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/ConfigureStrings.kt
@@ -33,4 +33,6 @@ object ConfigureStrings {
         "after the transaction is finished, so make sure purchases are synced before \n" +
         "finishing any consumable transaction, otherwise RevenueCat won’t register the \n" +
         "purchase."
+    const val INSTANCE_ALREADY_EXISTS = "Purchases instance already set. " +
+        "Did you mean to configure two Purchases objects?"
 }


### PR DESCRIPTION
### Description
Completes [SDK-2916](https://linear.app/revenuecat/issue/SDK-2916/log-error-message-when-trying-to-configure-sdk-when-its-already-been)

When configuring the SDK multiple times, we will log a message indicating this fact. This log can be helpful to debug issues. This is based on the same log that we have in iOS.