### PR TITLE
Improve tests on etag cache verification logic

### DIFF
--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -204,12 +204,12 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
     @Test
     fun `performRequest on disabled client does not verify`() {
-        every { mockSigningManager.signatureVerificationMode } returns mockk<SignatureVerificationMode.Disabled>()
+        every { mockSigningManager.shouldVerifyEndpoint(any()) } returns false
         val endpoint = Endpoint.GetCustomerInfo("test-user-id")
         enqueue(
             endpoint = endpoint,
-            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.FAILED),
-            verificationResult = VerificationResult.FAILED
+            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.NOT_REQUESTED),
+            verificationResult = VerificationResult.NOT_REQUESTED
         )
 
         val result = client.performRequest(

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -203,6 +203,30 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
     }
 
     @Test
+    fun `performRequest on disabled client does not verify`() {
+        every { mockSigningManager.signatureVerificationMode } returns mockk<SignatureVerificationMode.Disabled>()
+        val endpoint = Endpoint.GetCustomerInfo("test-user-id")
+        enqueue(
+            endpoint = endpoint,
+            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.FAILED),
+            verificationResult = VerificationResult.FAILED
+        )
+
+        val result = client.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_REQUESTED)
+        verify(exactly = 0) {
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
     fun `performRequest on informational client does not throw on verification error`() {
         val endpoint = Endpoint.GetCustomerInfo("test-user-id")
         enqueue(


### PR DESCRIPTION
### Description
This is improving our test coverage for the tests in the [spreadsheet](https://docs.google.com/spreadsheets/d/1kNcFNB8U47N5_vm8Ww57izMgdp60mdzUxZFK-cm46KU/edit#gid=0). 

Android equivalent of https://github.com/RevenueCat/purchases-ios/pull/2333 
