### PR TITLE
Fix purchase tester navigation

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -13,12 +13,13 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.transition.MaterialContainerTransform
 import com.revenuecat.purchases.CustomerInfo
-import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PurchaseParams
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.getCustomerInfoWith
+import com.revenuecat.purchases.getOfferingsWith
 import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
@@ -33,7 +34,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
     lateinit var binding: FragmentOfferingBinding
 
     private val args: OfferingFragmentArgs by navArgs()
-    private val offering: Offering by lazy { args.offering }
+    private val offeringId: String by lazy { args.offeringId }
     private var activeSubscriptions: Set<String> = setOf()
 
     private val purchaseErrorCallback: (error: PurchasesError, userCancelled: Boolean) -> Unit =
@@ -65,6 +66,17 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         }
 
         binding = FragmentOfferingBinding.inflate(inflater)
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        Purchases.sharedInstance.getOfferingsWith(::showError, ::populateOfferings)
+    }
+
+    private fun populateOfferings(offerings: Offerings) {
+        val offering = offerings.getOffering(offeringId) ?: return
         binding.offering = offering
 
         binding.offeringDetailsPackagesRecycler.layoutManager = LinearLayoutManager(requireContext())
@@ -74,8 +86,6 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
                 activeSubscriptions,
                 this
             )
-
-        return binding.root
     }
 
     override fun onPurchasePackageClicked(

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -92,9 +92,10 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
 
         val offeringCardTransitionName = getString(R.string.offering_fragment_transition)
         val extras = FragmentNavigatorExtras(cardView to offeringCardTransitionName)
-        val directions = OverviewFragmentDirections.actionOverviewFragmentToOfferingFragment(offering)
+        val directions = OverviewFragmentDirections.actionOverviewFragmentToOfferingFragment(offering.identifier)
         // uncomment line below and comment line above to test deprecated purchase methods
-//        val directions = OverviewFragmentDirections.actionOverviewFragmentToDeprecatedOfferingFragment(offering)
+//        val directions = OverviewFragmentDirections.
+//        actionOverviewFragmentToDeprecatedOfferingFragment(offering.identifier)
         findNavController().navigate(directions, extras)
     }
 

--- a/examples/purchase-tester/src/main/res/navigation/nav_graph.xml
+++ b/examples/purchase-tester/src/main/res/navigation/nav_graph.xml
@@ -46,16 +46,16 @@
             android:name="com.revenuecat.purchasetester.OfferingFragment"
             android:label="OfferingFragment">
         <argument
-                android:name="offering"
-                app:argType="com.revenuecat.purchases.Offering" />
+                android:name="offeringId"
+                app:argType="string" />
     </fragment>
     <fragment
             android:id="@+id/deprecatedOfferingFragment"
             android:name="com.revenuecat.purchasetester.DeprecatedOfferingFragment"
             android:label="DeprecatedOfferingFragment">
         <argument
-                android:name="offering"
-                app:argType="com.revenuecat.purchases.Offering" />
+                android:name="offeringId"
+                app:argType="string" />
     </fragment>
     <fragment
             android:id="@+id/configureFragment"


### PR DESCRIPTION
My last [PR](https://github.com/RevenueCat/purchases-android/pull/866) broke purchase tester 🥴 

Unfortunately, now that offering isn't parcelable, we can't pass it through safeargs for navigation from `OverviewFragment` to `OfferingFragment`. This updates the app to pass offering ID through instead, and re-fetch offerings on the `OfferingFragment`. It's ugly and makes me want to reconsider if we can somehow make `StoreProduct` Parcelable... but for now, just want to fix purchase tester crashing