### PR TITLE
Rename verification result SUCCESS to VERIFIED

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/VerificationResultAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/VerificationResultAPI.java
@@ -7,7 +7,7 @@ final class VerificationResultAPI {
     static void check(final VerificationResult verificationResult) {
         switch (verificationResult) {
             case NOT_REQUESTED:
-            case SUCCESS:
+            case VERIFIED:
             case FAILED:
         }
     }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VerificationResultAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VerificationResultAPI.kt
@@ -8,7 +8,7 @@ private class VerificationResultAPI {
     fun check(verificationResult: VerificationResult) {
         when (verificationResult) {
             VerificationResult.NOT_REQUESTED,
-            VerificationResult.SUCCESS,
+            VerificationResult.VERIFIED,
             VerificationResult.FAILED
             -> {}
         }.exhaustive

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -61,7 +61,7 @@ class SigningManager(
         val verificationResult = signatureVerifier.verify(signatureToVerify, messageToVerify)
 
         return if (verificationResult) {
-            VerificationResult.SUCCESS
+            VerificationResult.VERIFIED
         } else {
             errorLog(NetworkStrings.VERIFICATION_ERROR.format(urlPath))
             VerificationResult.FAILED

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -43,7 +43,7 @@ class DeviceCacheTest {
     private val validCachedCustomerInfo by lazy {
         JSONObject(Responses.validFullPurchaserResponse).apply {
             put("schema_version", CUSTOMER_INFO_SCHEMA_VERSION)
-            put("verification_result", VerificationResult.SUCCESS)
+            put("verification_result", VerificationResult.VERIFIED)
         }.toString()
     }
 
@@ -110,7 +110,7 @@ class DeviceCacheTest {
         mockString(cache.customerInfoCacheKey(appUserID), validCachedCustomerInfo)
         val info = cache.getCachedCustomerInfo(appUserID)
         assertThat(info).`as`("info is not null").isNotNull
-        assertThat(info?.entitlements?.verification).isEqualTo(VerificationResult.SUCCESS)
+        assertThat(info?.entitlements?.verification).isEqualTo(VerificationResult.VERIFIED)
     }
 
     @Test
@@ -193,7 +193,7 @@ class DeviceCacheTest {
             mockEditor.putLong(cache.customerInfoLastUpdatedCacheKey(appUserID), any())
         } returns mockEditor
 
-        val info = createCustomerInfo(Responses.validFullPurchaserResponse, null, VerificationResult.SUCCESS)
+        val info = createCustomerInfo(Responses.validFullPurchaserResponse, null, VerificationResult.VERIFIED)
         val infoJSONSlot = slot<String>()
 
         every {
@@ -204,7 +204,7 @@ class DeviceCacheTest {
 
         val cachedJSON = JSONObject(infoJSONSlot.captured)
         assertThat(cachedJSON.has("verification_result")).isTrue
-        assertThat(cachedJSON.getString("verification_result")).isEqualTo(VerificationResult.SUCCESS.name)
+        assertThat(cachedJSON.getString("verification_result")).isEqualTo(VerificationResult.VERIFIED.name)
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfoTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfoTest.kt
@@ -29,7 +29,7 @@ class EntitlementInfoTest {
     fun `same entitlement info with different verification are not equal`() {
         val entitlementInfo1 = createEntitlementInfo(verification = VerificationResult.NOT_REQUESTED)
         val entitlementInfo2 = createEntitlementInfo(verification = VerificationResult.FAILED)
-        val entitlementInfo3 = createEntitlementInfo(verification = VerificationResult.SUCCESS)
+        val entitlementInfo3 = createEntitlementInfo(verification = VerificationResult.VERIFIED)
         assertThat(entitlementInfo1).isNotEqualTo(entitlementInfo2)
         assertThat(entitlementInfo1).isNotEqualTo(entitlementInfo3)
         assertThat(entitlementInfo2).isNotEqualTo(entitlementInfo3)

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
@@ -70,11 +70,11 @@ class EntitlementInfosTests {
             }
         )
 
-        val subscriberInfo = createCustomerInfo(response, null, VerificationResult.SUCCESS)
+        val subscriberInfo = createCustomerInfo(response, null, VerificationResult.VERIFIED)
         assertThat(subscriberInfo.entitlements.all).hasSize(2)
-        assertThat(subscriberInfo.entitlements.verification).isEqualTo(VerificationResult.SUCCESS)
+        assertThat(subscriberInfo.entitlements.verification).isEqualTo(VerificationResult.VERIFIED)
         subscriberInfo.entitlements.all.onEach { entry ->
-            assertThat(entry.value.verification).isEqualTo(VerificationResult.SUCCESS)
+            assertThat(entry.value.verification).isEqualTo(VerificationResult.VERIFIED)
         }
 
         verifySubscriberInfo()
@@ -1168,7 +1168,7 @@ class EntitlementInfosTests {
     @Test
     fun `same entitlement infos with different verifications are not equal`() {
         val entitlementInfos1 = EntitlementInfos(emptyMap(), VerificationResult.NOT_REQUESTED)
-        val entitlementInfos2 = EntitlementInfos(emptyMap(), VerificationResult.SUCCESS)
+        val entitlementInfos2 = EntitlementInfos(emptyMap(), VerificationResult.VERIFIED)
         val entitlementInfos3 = EntitlementInfos(emptyMap(), VerificationResult.FAILED)
         assertThat(entitlementInfos1).isNotEqualTo(entitlementInfos2)
         assertThat(entitlementInfos1).isNotEqualTo(entitlementInfos3)

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -281,7 +281,7 @@ class HTTPClientTest: BaseHTTPClientTest() {
         val endpoint = Endpoint.GetCustomerInfo("test-user-id")
         enqueue(
             endpoint = endpoint,
-            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.SUCCESS)
+            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.VERIFIED)
         )
 
         client.performRequest(

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -36,13 +36,13 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         val endpoint = Endpoint.GetCustomerInfo("test-user-id")
         enqueue(
             endpoint = endpoint,
-            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.SUCCESS),
-            verificationResult = VerificationResult.SUCCESS
+            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.VERIFIED),
+            verificationResult = VerificationResult.VERIFIED
         )
 
         every {
             mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
-        } returns VerificationResult.SUCCESS
+        } returns VerificationResult.VERIFIED
 
         client.performRequest(
             baseURL,
@@ -151,14 +151,14 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
     fun `performRequest on informationalClient verifies response with correct parameters when there is success`() {
         val endpoint = Endpoint.GetCustomerInfo("test-user-id")
         val expectedResult = HTTPResult.createResult(
-            verificationResult = VerificationResult.SUCCESS,
+            verificationResult = VerificationResult.VERIFIED,
             payload = "{\"test-key\":\"test-value\"}"
         )
         val responseCode = expectedResult.responseCode
 
         every {
             mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
-        } returns VerificationResult.SUCCESS
+        } returns VerificationResult.VERIFIED
 
         every {
             mockETagManager.getHTTPResultFromCacheOrBackend(
@@ -168,7 +168,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
                 "/v1${endpoint.getPath()}",
                 refreshETag = false,
                 requestDate = Date(1234567890L),
-                verificationResult = VerificationResult.SUCCESS
+                verificationResult = VerificationResult.VERIFIED
             )
         } returns expectedResult
         val response = MockResponse()
@@ -188,7 +188,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
         server.takeRequest()
 
-        assertThat(result.verificationResult).isEqualTo(VerificationResult.SUCCESS)
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.VERIFIED)
         verify(exactly = 1) {
             mockSigningManager.verifyResponse(
                 endpoint.getPath(),
@@ -287,13 +287,13 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         val endpoint = Endpoint.GetCustomerInfo("test-user-id")
         enqueue(
             endpoint = endpoint,
-            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.SUCCESS),
-            verificationResult = VerificationResult.SUCCESS
+            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.VERIFIED),
+            verificationResult = VerificationResult.VERIFIED
         )
 
         every {
             mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
-        } returns VerificationResult.SUCCESS
+        } returns VerificationResult.VERIFIED
 
         val result = client.performRequest(
             baseURL,
@@ -303,6 +303,6 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         )
 
         server.takeRequest()
-        assertThat(result.verificationResult).isEqualTo(VerificationResult.SUCCESS)
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.VERIFIED)
     }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -177,7 +177,7 @@ class ETagManagerTest {
         val eTag = "eTag"
 
         val resultFromBackend = HTTPResult.createResult(
-            verificationResult = SUCCESS,
+            verificationResult = VERIFIED,
             payload = Responses.validEmptyPurchaserResponse
         )
         val resultStored = resultFromBackend.copy(
@@ -366,10 +366,10 @@ class ETagManagerTest {
             urlPathWithVersion = "/v1/subscribers/appUserID",
             refreshETag = false,
             requestDate = null,
-            verificationResult = SUCCESS
+            verificationResult = VERIFIED
         )
 
-        assertThat(result?.verificationResult).isEqualTo(SUCCESS)
+        assertThat(result?.verificationResult).isEqualTo(VERIFIED)
     }
 
     @Test
@@ -419,13 +419,13 @@ class ETagManagerTest {
             )
         val testCases = listOf(
             TestCase(NOT_REQUESTED, NOT_REQUESTED, NOT_REQUESTED),
-            TestCase(NOT_REQUESTED, SUCCESS, SUCCESS),
+            TestCase(NOT_REQUESTED, VERIFIED, VERIFIED),
             TestCase(NOT_REQUESTED, FAILED, FAILED),
-            TestCase(SUCCESS, NOT_REQUESTED, NOT_REQUESTED),
-            TestCase(SUCCESS, SUCCESS, SUCCESS),
-            TestCase(SUCCESS, FAILED, FAILED),
+            TestCase(VERIFIED, NOT_REQUESTED, NOT_REQUESTED),
+            TestCase(VERIFIED, VERIFIED, VERIFIED),
+            TestCase(VERIFIED, FAILED, FAILED),
             TestCase(FAILED, NOT_REQUESTED, NOT_REQUESTED),
-            TestCase(FAILED, SUCCESS, SUCCESS),
+            TestCase(FAILED, VERIFIED, VERIFIED),
             TestCase(FAILED, FAILED, FAILED)
             )
         testCases.onEach {

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/HTTPResultTest.kt
@@ -19,14 +19,14 @@ class HTTPResultTest {
             "{\"test-key\":\"test-value\"}",
             HTTPResult.Origin.BACKEND,
             Date(1678180617000), // Tuesday, March 7, 2023 9:16:57 AM GMT,
-            VerificationResult.SUCCESS
+            VerificationResult.VERIFIED
         )
         assertThat(result.serialize()).isEqualTo("{" +
             "\"responseCode\":200," +
             "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"," +
             "\"origin\":\"BACKEND\"," +
             "\"requestDate\":1678180617000," +
-            "\"verificationResult\":\"SUCCESS\"}"
+            "\"verificationResult\":\"VERIFIED\"}"
         )
     }
 
@@ -37,13 +37,13 @@ class HTTPResultTest {
             "{\"test-key\":\"test-value\"}",
             HTTPResult.Origin.BACKEND,
             null,
-            VerificationResult.SUCCESS
+            VerificationResult.VERIFIED
         )
         assertThat(result.serialize()).isEqualTo("{" +
             "\"responseCode\":200," +
             "\"payload\":\"{\\\"test-key\\\":\\\"test-value\\\"}\"," +
             "\"origin\":\"BACKEND\"," +
-            "\"verificationResult\":\"SUCCESS\"}"
+            "\"verificationResult\":\"VERIFIED\"}"
         )
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -129,14 +129,14 @@ class SigningManagerTest {
             body = null,
             eTag = "test-etag"
         )
-        assertThat(verificationResult).isEqualTo(VerificationResult.SUCCESS)
+        assertThat(verificationResult).isEqualTo(VerificationResult.VERIFIED)
     }
 
     @Test
     fun `verifyResponse returns success if verifier returns success for given parameters`() {
         every { verifier.verify(any(), any()) } returns true
         val verificationResult = callVerifyResponse(informationalSigningManager)
-        assertThat(verificationResult).isEqualTo(VerificationResult.SUCCESS)
+        assertThat(verificationResult).isEqualTo(VerificationResult.VERIFIED)
     }
 
     @Test
@@ -150,7 +150,7 @@ class SigningManagerTest {
     fun `verifyResponse with real data verifies correctly`() {
         val signingManager = SigningManager(SignatureVerificationMode.Informational(DefaultSignatureVerifier()))
         val verificationResult = callVerifyResponse(signingManager)
-        assertThat(verificationResult).isEqualTo(VerificationResult.SUCCESS)
+        assertThat(verificationResult).isEqualTo(VerificationResult.VERIFIED)
     }
 
     @Suppress("MaxLineLength")
@@ -175,7 +175,7 @@ class SigningManagerTest {
     fun `verifyResponse returns success for enforced mode if verifier returns success for given parameters`() {
         every { verifier.verify(any(), any()) } returns true
         val verificationResult = callVerifyResponse(enforcedSigningManager)
-        assertThat(verificationResult).isEqualTo(VerificationResult.SUCCESS)
+        assertThat(verificationResult).isEqualTo(VerificationResult.VERIFIED)
     }
 
     // endregion

--- a/feature/identity/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/feature/identity/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -457,7 +457,7 @@ class IdentityManagerTests {
         val userId = "test-app-user-id"
         setupCustomerInfoCacheInvalidationTest(
             userId,
-            VerificationResult.SUCCESS,
+            VerificationResult.VERIFIED,
             SignatureVerificationMode.Informational(mockk()),
             shouldClearCustomerInfoAndETagCaches = false
         )

--- a/public/src/main/java/com/revenuecat/purchases/VerificationResult.kt
+++ b/public/src/main/java/com/revenuecat/purchases/VerificationResult.kt
@@ -5,9 +5,9 @@ package com.revenuecat.purchases
  *
  * This is accomplished by preventing MiTM attacks between the SDK and the RevenueCat server.
  * With verification enabled, the SDK ensures that the response created by the server was not
- * modified by a third-party, and the entitlements received are exactly what was sent.
+ * modified by a third-party, and the response received is exactly what was sent.
  *
- * - Note: Entitlements are only verified if enabled using PurchasesConfiguration.Builder's
+ * - Note: Verification is only performed if enabled using PurchasesConfiguration.Builder's
  * entitlementVerificationMode property. This is disabled by default.
  */
 enum class VerificationResult {
@@ -19,12 +19,12 @@ enum class VerificationResult {
     NOT_REQUESTED,
 
     /**
-     * Entitlements were verified with our server.
+     * Verification with our server was performed successfully.
      */
     VERIFIED,
 
     /**
-     * Entitlement verification failed, possibly due to a MiTM attack.
+     * Verification failed, possibly due to a MiTM attack.
      */
     FAILED
 }

--- a/public/src/main/java/com/revenuecat/purchases/VerificationResult.kt
+++ b/public/src/main/java/com/revenuecat/purchases/VerificationResult.kt
@@ -21,7 +21,7 @@ enum class VerificationResult {
     /**
      * Entitlements were verified with our server.
      */
-    SUCCESS,
+    VERIFIED,
 
     /**
      * Entitlement verification failed, possibly due to a MiTM attack.

--- a/public/src/test/java/com/revenuecat/purchases/ParcelableTests.kt
+++ b/public/src/test/java/com/revenuecat/purchases/ParcelableTests.kt
@@ -32,7 +32,7 @@ class ParcelableTests {
         CustomerInfo(
             entitlements = EntitlementInfos(
                 mapOf("an_identifier" to getEntitlementInfo(identifier = "an_identifier")),
-                VerificationResult.SUCCESS
+                VerificationResult.VERIFIED
             ),
             purchasedNonSubscriptionSkus = setOf(),
             allExpirationDatesByProduct = mapOf("a_product" to Date(System.currentTimeMillis())),


### PR DESCRIPTION
### Description
This PR renames `VerificationResult.SUCCESS` to `VerificationResult.VERIFIED`. This is to match iOS nomenclature.
