### PR TITLE
Improve diagnostics counters system by adding anonymization and changing counter name to an enum

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Anonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Anonymizer.kt
@@ -19,6 +19,10 @@ class Anonymizer {
         return mapToAnonymize.mapValues { (_, value) -> anonymizedAny(value) }
     }
 
+    fun anonymizedStringMap(mapToAnonymize: Map<String, String>): Map<String, String> {
+        return mapToAnonymize.mapValues { (_, value) -> anonymizedString(value) }
+    }
+
     private fun anonymizedAny(valueToAnonymize: Any): Any {
         return when (valueToAnonymize) {
             is String -> anonymizedString(valueToAnonymize)

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizer.kt
@@ -8,7 +8,7 @@ class DiagnosticsAnonymizer(
     fun anonymizeEntryIfNeeded(diagnosticsEntry: DiagnosticsEntry): DiagnosticsEntry {
         return when (diagnosticsEntry) {
             is DiagnosticsEntry.Event -> anonymizeEvent(diagnosticsEntry)
-            is DiagnosticsEntry.Counter -> diagnosticsEntry
+            is DiagnosticsEntry.Counter -> anonymizeCounter(diagnosticsEntry)
             is DiagnosticsEntry.Histogram -> diagnosticsEntry
         }
     }
@@ -16,6 +16,12 @@ class DiagnosticsAnonymizer(
     private fun anonymizeEvent(diagnosticsEvent: DiagnosticsEntry.Event): DiagnosticsEntry {
         return diagnosticsEvent.copy(
             properties = anonymizer.anonymizedMap(diagnosticsEvent.properties)
+        )
+    }
+
+    private fun anonymizeCounter(diagnosticsCounter: DiagnosticsEntry.Counter): DiagnosticsEntry {
+        return diagnosticsCounter.copy(
+            tags = anonymizer.anonymizedStringMap(diagnosticsCounter.tags)
         )
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsCounterName.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsCounterName.kt
@@ -1,0 +1,5 @@
+package com.revenuecat.purchases.common.diagnostics
+
+enum class DiagnosticsCounterName {
+    HTTP_REQUEST_PERFORMED,
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
@@ -40,7 +40,7 @@ sealed class DiagnosticsEntry(val diagnosticType: String) {
     }
 
     data class Counter(
-        val name: String,
+        val name: DiagnosticsCounterName,
         val tags: Map<String, String>,
         val value: Int
     ) : DiagnosticsEntry("counter") {
@@ -57,7 +57,7 @@ sealed class DiagnosticsEntry(val diagnosticType: String) {
         private fun toJSONObject() = JSONObject().apply {
             put(VERSION_KEY, VERSION)
             put(TYPE_KEY, diagnosticType)
-            put(NAME_KEY, name.lowercase())
+            put(NAME_KEY, name.name.lowercase())
             put(TAGS_KEY, JSONObject(tags))
             put(VALUE_KEY, value)
         }

--- a/common/src/test/java/com/revenuecat/purchases/common/AnonymizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/AnonymizerTest.kt
@@ -50,10 +50,29 @@ class AnonymizerTest {
 
     // endregion
 
+    // region anonymizeStringMap
+
+    @Test
+    fun `anonymizedStringMap anonymizes string fields if needed`() {
+        val originalMap = mapOf(
+            "key-1" to "string with some.pii@revenuecat.com and 192.168.1.1.",
+            "key-2" to "string without pii",
+            "key-3" to "string with other.pii@revenuecat.com"
+        )
+        val expectedMap = mapOf(
+            "key-1" to "string with ***** and *****.",
+            "key-2" to "string without pii",
+            "key-3" to "string with *****"
+        )
+        assertThat(anonymizer.anonymizedStringMap(originalMap)).isEqualTo(expectedMap)
+    }
+
+    // endregion
+
     // region anonymizeMap
 
     @Test
-    fun `anonymizeMap anonymizes all string fields if needed`() {
+    fun `anonymizedMap anonymizes all string fields if needed`() {
         val originalMap = mapOf(
             "key-1" to 1234,
             "key-2" to "string with some.pii@revenuecat.com and 192.168.1.1.",
@@ -72,7 +91,7 @@ class AnonymizerTest {
     }
 
     @Test
-    fun `anonymizeMap anonymizes lists`() {
+    fun `anonymizedMap anonymizes lists`() {
         val originalMap = mapOf(
             "key-1" to 1234,
             "key-2" to "string with some.pii@revenuecat.com and 192.168.1.1.",
@@ -91,7 +110,7 @@ class AnonymizerTest {
     }
 
     @Test
-    fun `anonymizeMap anonymizes nested maps`() {
+    fun `anonymizedMap anonymizes nested maps`() {
         val originalMap = mapOf(
             "key-1" to 1234,
             "key-2" to "string with some.pii@revenuecat.com and 192.168.1.1.",

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsAnonymizerTest.kt
@@ -59,14 +59,24 @@ class DiagnosticsAnonymizerTest {
     }
 
     @Test
-    fun `anonymizeEntryIfNeeded does not anonymize counter`() {
+    fun `anonymizeEntryIfNeeded anonymizes counter tags`() {
+        val originalPropertiesMap = mapOf("key-1" to "value-1")
+        val expectedPropertiesMap = mapOf("key-1" to "anonymized-value-1")
         val counterToAnonymize = DiagnosticsEntry.Counter(
-            name = "metric-name",
-            tags = emptyMap(),
+            name = DiagnosticsCounterName.HTTP_REQUEST_PERFORMED,
+            tags = originalPropertiesMap,
             value = 123
         )
+        val expectedCounter = DiagnosticsEntry.Counter(
+            name = DiagnosticsCounterName.HTTP_REQUEST_PERFORMED,
+            tags = expectedPropertiesMap,
+            value = 123
+        )
+        every {
+            anonymizer.anonymizedStringMap(originalPropertiesMap)
+        } returns expectedPropertiesMap
         val anonymizedCounter = diagnosticsAnonymizer.anonymizeEntryIfNeeded(counterToAnonymize)
-        assertThat(anonymizedCounter).isEqualTo(counterToAnonymize)
+        assertThat(anonymizedCounter).isEqualTo(expectedCounter)
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
@@ -46,7 +46,7 @@ class DiagnosticsEntryTest {
     @Test
     fun `toString transforms counter to correct JSON`() {
         val event = DiagnosticsEntry.Counter(
-            name = "test_metric_name",
+            name = DiagnosticsCounterName.HTTP_REQUEST_PERFORMED,
             tags = mapOf("test-key-1" to "test-value-1", "test-key-2" to "test-value-2"),
             value = 2
         )
@@ -54,7 +54,7 @@ class DiagnosticsEntryTest {
         val expectedString = "{" +
             "\"version\":1," +
             "\"type\":\"counter\"," +
-            "\"name\":\"test_metric_name\"," +
+            "\"name\":\"http_request_performed\"," +
             "\"tags\":{\"test-key-1\":\"test-value-1\",\"test-key-2\":\"test-value-2\"}," +
             "\"value\":2" +
             "}"


### PR DESCRIPTION
### Description
This PR adds anonymization to diagnostics counters and converts the counters names to an enum.

This is in preparation of possibly sending some counters to get entitlement verification results as counters, instead of events for now.
