### PR TITLE
[BC5] Re-add `price_string` header on postReceipt

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -195,9 +195,10 @@ class Backend(
             "pricing_phases" to receiptInfo.pricingPhases?.map { it.toMap() }
         ).filterNotNullValues()
 
-        val extraHeaders = marketplace?.let {
-            mapOf("marketplace" to it)
-        } ?: emptyMap()
+        val extraHeaders = mapOf(
+            "price_string" to receiptInfo.storeProduct?.price?.formatted,
+            "marketplace" to marketplace
+        ).filterNotNullValues()
 
         val call = object : Dispatcher.AsyncCall() {
 

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -818,6 +818,27 @@ class BackendTest {
     }
 
     @Test
+    fun `postReceipt passes price_string as header`() {
+        mockPostReceiptResponseAndPost(
+            backend,
+            responseCode = 200,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            observerMode = true,
+            receiptInfo = ReceiptInfo(
+                productIDs,
+                storeProduct = storeProduct
+            ),
+            storeAppUserID = null
+        )
+
+        assertThat(headersSlot.isCaptured).isTrue
+        assertThat(headersSlot.captured.keys).contains("price_string")
+        assertThat(headersSlot.captured["price_string"]).isEqualTo("$4.99")
+    }
+
+    @Test
     fun `postReceipt passes marketplace as header`() {
         mockPostReceiptResponseAndPost(
             backend,
@@ -837,6 +858,30 @@ class BackendTest {
         assertThat(headersSlot.isCaptured).isTrue
         assertThat(headersSlot.captured.keys).contains("marketplace")
         assertThat(headersSlot.captured["marketplace"]).isEqualTo("DE")
+    }
+
+    @Test
+    fun `postReceipt passes price_string and marketplace as header`() {
+        mockPostReceiptResponseAndPost(
+            backend,
+            responseCode = 200,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            observerMode = true,
+            receiptInfo = ReceiptInfo(
+                productIDs,
+                storeProduct = storeProduct
+            ),
+            storeAppUserID = null,
+            marketplace = "US"
+        )
+
+        assertThat(headersSlot.isCaptured).isTrue
+        assertThat(headersSlot.captured.keys).contains("price_string")
+        assertThat(headersSlot.captured["price_string"]).isEqualTo("$4.99")
+        assertThat(headersSlot.captured.keys).contains("marketplace")
+        assertThat(headersSlot.captured["marketplace"]).isEqualTo("US")
     }
 
     // endregion


### PR DESCRIPTION
### Motivation

[CF-1198](https://revenuecats.atlassian.net/browse/CF-1198)

The `price_string` was removed but is needed for Amazon debugging.

### Description

- Adds `price_string` as an extra header on `postReceiptData`



[CF-1198]: https://revenuecats.atlassian.net/browse/CF-1198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ