### PR TITLE
[BC5] Make Activity first param in PurchaseParams

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -128,19 +128,19 @@ final class PurchasesAPI {
         GoogleProrationMode prorationMode = GoogleProrationMode.IMMEDIATE_WITH_TIME_PRORATION;
         Boolean isPersonalizedPrice = true;
 
-        PurchaseParams.Builder purchaseProductBuilder = new PurchaseParams.Builder(storeProduct, activity);
+        PurchaseParams.Builder purchaseProductBuilder = new PurchaseParams.Builder(activity, storeProduct);
         purchaseProductBuilder.oldProductId(oldProductId).googleProrationMode(prorationMode)
                 .isPersonalizedPrice(isPersonalizedPrice);
         PurchaseParams purchaseProductParams = purchaseProductBuilder.build();
         purchases.purchase(purchaseProductParams, purchaseCallback);
 
-        PurchaseParams.Builder purchaseOptionBuilder = new PurchaseParams.Builder(subscriptionOption, activity);
+        PurchaseParams.Builder purchaseOptionBuilder = new PurchaseParams.Builder(activity, subscriptionOption);
         purchaseOptionBuilder.oldProductId(oldProductId).googleProrationMode(prorationMode)
                 .isPersonalizedPrice(isPersonalizedPrice);
         PurchaseParams purchaseOptionParams = purchaseOptionBuilder.build();
         purchases.purchase(purchaseOptionParams, purchaseCallback);
 
-        PurchaseParams.Builder purchasePackageBuilder = new PurchaseParams.Builder(packageToPurchase, activity);
+        PurchaseParams.Builder purchasePackageBuilder = new PurchaseParams.Builder(activity, packageToPurchase);
         purchasePackageBuilder.oldProductId(oldProductId).googleProrationMode(prorationMode)
                 .isPersonalizedPrice(isPersonalizedPrice);
         PurchaseParams purchasePackageParams = purchasePackageBuilder.build();

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -104,17 +104,17 @@ private class PurchasesAPI {
         val prorationMode = GoogleProrationMode.IMMEDIATE_WITH_TIME_PRORATION
         val isPersonalizedPrice = true
 
-        val purchasePackageBuilder: PurchaseParams.Builder = PurchaseParams.Builder(packageToPurchase, activity)
+        val purchasePackageBuilder: PurchaseParams.Builder = PurchaseParams.Builder(activity, packageToPurchase)
         purchasePackageBuilder.oldProductId(oldProductId).googleProrationMode(prorationMode)
         val purchasePackageParams: PurchaseParams = purchasePackageBuilder.build()
         purchases.purchase(purchasePackageParams, purchaseCallback)
 
-        val purchaseProductBuilder: PurchaseParams.Builder = PurchaseParams.Builder(storeProduct, activity)
+        val purchaseProductBuilder: PurchaseParams.Builder = PurchaseParams.Builder(activity, storeProduct)
         purchaseProductBuilder.oldProductId(oldProductId).googleProrationMode(prorationMode)
         val purchaseProductParams: PurchaseParams = purchaseProductBuilder.build()
         purchases.purchase(purchaseProductParams, purchaseCallback)
 
-        val purchaseOptionBuilder: PurchaseParams.Builder = PurchaseParams.Builder(subscriptionOption, activity)
+        val purchaseOptionBuilder: PurchaseParams.Builder = PurchaseParams.Builder(activity, subscriptionOption)
         purchaseOptionBuilder.oldProductId(oldProductId).googleProrationMode(prorationMode)
         val purchaseOptionsParams: PurchaseParams = purchaseOptionBuilder.build()
         purchases.purchase(purchaseOptionsParams, purchaseCallback)

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfoTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfoTest.kt
@@ -18,6 +18,10 @@ import kotlin.time.Duration.Companion.days
 @Config(manifest = Config.NONE)
 class EntitlementInfoTest {
 
+    private val oneDayAgo = 1.days.ago()
+    private val twoDaysAgo = 2.days.ago()
+    private val oneDayFromNow = 1.days.fromNow()
+
     @Test
     fun `same entitlement info are equal`() {
         val entitlementInfo1 = createEntitlementInfo()
@@ -40,9 +44,9 @@ class EntitlementInfoTest {
         isActive: Boolean = true,
         willRenew: Boolean = true,
         periodType: PeriodType = PeriodType.NORMAL,
-        latestPurchaseDate: Date = 1.days.ago(),
-        originalPurchaseDate: Date = 2.days.ago(),
-        expirationDate: Date? = 1.days.fromNow(),
+        latestPurchaseDate: Date = oneDayAgo,
+        originalPurchaseDate: Date = twoDaysAgo,
+        expirationDate: Date? = oneDayFromNow,
         store: Store = Store.PLAY_STORE,
         productIdentifier: String = "test-product-id",
         productPlanIdentifier: String = "test-plan-id",

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -92,19 +92,19 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         cardView: View,
         currentPackage: Package,
         isUpgrade: Boolean
-    ) = startPurchase(isUpgrade, PurchaseParams.Builder(currentPackage, requireActivity()))
+    ) = startPurchase(isUpgrade, PurchaseParams.Builder(requireActivity(), currentPackage))
 
     override fun onPurchaseProductClicked(
         cardView: View,
         currentProduct: StoreProduct,
         isUpgrade: Boolean
-    ) = startPurchase(isUpgrade, PurchaseParams.Builder(currentProduct, requireActivity()))
+    ) = startPurchase(isUpgrade, PurchaseParams.Builder(requireActivity(), currentProduct))
 
     override fun onPurchaseSubscriptionOptionClicked(
         cardView: View,
         subscriptionOption: SubscriptionOption,
         isUpgrade: Boolean
-    ) = startPurchase(isUpgrade, PurchaseParams.Builder(subscriptionOption, requireActivity()))
+    ) = startPurchase(isUpgrade, PurchaseParams.Builder(requireActivity(), subscriptionOption))
 
     private fun startPurchase(
         isUpgrade: Boolean,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
@@ -38,22 +38,22 @@ data class PurchaseParams(val builder: Builder) {
      *   - Falls back to use base plan
      */
     open class Builder private constructor(
-        @get:JvmSynthetic internal val purchasingData: PurchasingData,
         @get:JvmSynthetic internal val activity: Activity,
+        @get:JvmSynthetic internal val purchasingData: PurchasingData,
         @get:JvmSynthetic internal val presentedOfferingIdentifier: String? = null
     ) {
-        constructor(packageToPurchase: Package, activity: Activity) :
+        constructor(activity: Activity, packageToPurchase: Package) :
             this(
-                packageToPurchase.product.purchasingData,
                 activity,
+                packageToPurchase.product.purchasingData,
                 packageToPurchase.offering
             )
 
-        constructor(storeProduct: StoreProduct, activity: Activity) :
-            this(storeProduct.purchasingData, activity)
+        constructor(activity: Activity, storeProduct: StoreProduct) :
+            this(activity, storeProduct.purchasingData)
 
-        constructor(subscriptionOption: SubscriptionOption, activity: Activity) :
-            this(subscriptionOption.purchasingData, activity)
+        constructor(activity: Activity, subscriptionOption: SubscriptionOption) :
+            this(activity, subscriptionOption.purchasingData)
 
         @set:JvmSynthetic
         @get:JvmSynthetic

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchaseParamsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchaseParamsTest.kt
@@ -24,8 +24,8 @@ class PurchaseParamsTest {
         val storeProduct = stubStoreProduct("abc")
         val (_, offerings) = stubOfferings(storeProduct)
         val purchasePackageParams = PurchaseParams.Builder(
-            offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!,
-            mockk()
+            mockk(),
+            offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!
         ).build()
 
         assertThat(purchasePackageParams.presentedOfferingIdentifier).isEqualTo(STUB_OFFERING_IDENTIFIER)
@@ -37,8 +37,8 @@ class PurchaseParamsTest {
         val (_, offerings) = stubOfferings(storeProduct)
         val packageToPurchase = offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!
         val purchasePackageParams = PurchaseParams.Builder(
-            packageToPurchase,
-            mockk<Activity>()
+            mockk(),
+            packageToPurchase
         ).build()
 
         val expectedPurchasingData = packageToPurchase.product.purchasingData
@@ -49,8 +49,8 @@ class PurchaseParamsTest {
     fun `Initializing with product sets proper purchasingData`() {
         val storeProduct = stubStoreProduct("abc")
         val purchasePackageParams = PurchaseParams.Builder(
-            storeProduct,
-            mockk()
+            mockk(),
+            storeProduct
         ).build()
 
         val expectedPurchasingData = storeProduct.purchasingData
@@ -61,8 +61,8 @@ class PurchaseParamsTest {
     fun `Initializing with option sets proper purchasingData`() {
         val basePlanSubscriptionOption = stubSubscriptionOption("base-plan-purchase-option", "abc")
         val purchasePackageParams = PurchaseParams.Builder(
-            basePlanSubscriptionOption,
-            mockk()
+            mockk(),
+            basePlanSubscriptionOption
         ).build()
 
         val expectedPurchasingData = basePlanSubscriptionOption.purchasingData

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -4375,9 +4375,9 @@ class PurchasesTest {
         isPersonalizedPrice: Boolean? = null
     ): PurchaseParams {
         val builder = when (purchaseable) {
-            is SubscriptionOption -> PurchaseParams.Builder(purchaseable, mockActivity)
-            is Package -> PurchaseParams.Builder(purchaseable, mockActivity)
-            is StoreProduct -> PurchaseParams.Builder(purchaseable, mockActivity)
+            is SubscriptionOption -> PurchaseParams.Builder(mockActivity, purchaseable)
+            is Package -> PurchaseParams.Builder(mockActivity, purchaseable)
+            is StoreProduct -> PurchaseParams.Builder(mockActivity, purchaseable)
             else -> null
         }
 


### PR DESCRIPTION
### Motivation

[CF-1283](https://revenuecats.atlassian.net/browse/CF-1283)

Might be good to move the `Activity` param as the first param in `PurchaseParams` to make things Android consistent (see [comment here](https://github.com/RevenueCat/purchases-hybrid-common/pull/359#discussion_r1138224884))

### Description

- `Activity` is now first param
- Also fixed a flaky local test in `EntitlementInfoTest` that had nothing to do with this but I think was failing because of creating dates on my machine but weren't equal because milliseconds off? 🤷‍♂️ 


[CF-1283]: https://revenuecats.atlassian.net/browse/CF-1283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ