### PR TITLE
[BC5] Cleaning up some TODOs in the code

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
@@ -24,7 +24,6 @@ final class StoreProductAPI {
         SubscriptionOptions subscriptionOptions = product.getSubscriptionOptions();
         SubscriptionOption defaultOption = product.getDefaultOption();
 
-        // TODOBC5 can we find an easier way to do this in java?
         GoogleStoreProduct underlyingProduct = GoogleStoreProductKt.getGoogleProduct(product);
     }
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/DeprecatedOfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/DeprecatedOfferingFragment.kt
@@ -203,7 +203,8 @@ class DeprecatedOfferingFragment : Fragment(), DeprecatedPackageCardAdapter.Pack
     }
 
     private fun showOldSubIdPicker(callback: (String?) -> Unit) {
-        val activeSubIds = activeSubscriptions.map { it.split(":").first() } // TODOBC5 remove sub Id parsing
+        // Removes base plan id to get the sub id
+        val activeSubIds = activeSubscriptions.map { it.split(":").first() }
         if (activeSubIds.isEmpty()) {
             Toast.makeText(
                 requireContext(),

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -177,7 +177,8 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
     }
 
     private fun showOldSubIdPicker(callback: (String?) -> Unit) {
-        val activeSubIds = activeSubscriptions.map { it.split(":").first() } // TODOBC5 remove sub Id parsing
+        // Removes base plan id to get the sub id
+        val activeSubIds = activeSubscriptions.map { it.split(":").first() }
         if (activeSubIds.isEmpty()) {
             Toast.makeText(
                 requireContext(),

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreProduct.kt
@@ -61,7 +61,9 @@ interface StoreProduct {
      */
     val defaultOption: SubscriptionOption?
 
-    // TODO javadocs
+    /**
+     * Contains only data that is required to make the purchase.
+     */
     val purchasingData: PurchasingData
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1291,7 +1291,6 @@ class Purchases internal constructor(
                     productIds = purchase.productIds.toSet(),
                     onReceive = { storeProducts ->
 
-                        // TODO BC5 confirm multi line purchases
                         val purchasedStoreProduct = if (purchase.type == ProductType.SUBS) {
                             storeProducts.firstOrNull { product ->
                                 product.subscriptionOptions?.let { subscriptionOptions ->


### PR DESCRIPTION
### Motivation

Getting rid of TODOs in the code when this goes into production

### Description

- Added comment to splitting product ids by ":" in purchase tester because probably fine 🤷‍♂️ 
- Added javadoc to `purchasingData` on `StoreProduct`
- Removing comment about multi-line purchases because don't need to worry about that (yet)
