### PR TITLE
Added subscription period and free trial period parsing for Amazon

### DIFF
--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStoreProduct.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonStoreProduct.kt
@@ -18,7 +18,7 @@ data class AmazonStoreProduct(
     override val subscriptionOptions: SubscriptionOptions?,
     override val defaultOption: SubscriptionOption?,
     val iconUrl: String,
-    val freeTrialPeriod: String?,
+    val freeTrialPeriod: Period?,
     val originalProductJSON: JSONObject
 ) : StoreProduct {
 

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeProductConversions.kt
@@ -4,6 +4,7 @@ import com.amazon.device.iap.model.Product
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.MICROS_MULTIPLIER
 import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.StoreProduct
 import java.math.BigDecimal
@@ -23,14 +24,43 @@ fun Product.toStoreProduct(marketplace: String): StoreProduct? {
         productType.toRevenueCatProductType(),
         title,
         description,
-        period = null,
+        period = subscriptionPeriod?.createPeriod(),
         priceInfo,
         null,
         defaultOption = null,
         iconUrl = smallIconUrl,
-        freeTrialPeriod = freeTrialPeriod,
+        freeTrialPeriod = freeTrialPeriod?.createPeriod(),
         originalProductJSON = this.toJSON()
     )
+}
+
+@SuppressWarnings("MagicNumber")
+internal fun String.createPeriod(): Period? {
+    // Valid values: Weekly, BiWeekly, Monthly, BiMonthly, Quarterly, SemiAnnually, Annually.
+    // https://developer.amazon.com/docs/in-app-purchasing/iap-implement-iap.html#successful-reques
+
+    return when (this) {
+        "Weekly" -> Period(1, Period.Unit.WEEK, "P1W")
+        "BiWeekly" -> Period(2, Period.Unit.WEEK, "P2W")
+        "Monthly" -> Period(1, Period.Unit.MONTH, "P1M")
+        "BiMonthly" -> Period(2, Period.Unit.MONTH, "P2M")
+        "Quarterly" -> Period(3, Period.Unit.MONTH, "P3M")
+        "SemiAnnually" -> Period(6, Period.Unit.MONTH, "P6M")
+        "Annually" -> Period(1, Period.Unit.YEAR, "P1Y")
+
+        // Handle "7 Days" or "14 Days" or "1 Month" just in case
+        else -> this.split(" ")
+            .takeIf {
+                it.size == 2
+            }
+            ?.let {
+                (it[0].toIntOrNull())?.let { numberValue ->
+                    val letter = it[1].first().uppercase()
+                    val iso = "P$numberValue$letter"
+                    return Period.create(iso)
+                }
+            }
+    }
 }
 
 internal fun String.createPrice(marketplace: String): Price {

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/ProductConverterTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/ProductConverterTest.kt
@@ -2,9 +2,12 @@ package com.revenuecat.purchases.amazon
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.amazon.helpers.dummyAmazonProduct
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.SubscriptionOptions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import com.amazon.device.iap.model.ProductType as AmazonProductType
 import com.revenuecat.purchases.ProductType as RevenueCatProductType
 
@@ -71,7 +74,7 @@ class ProductConverterTest {
     }
 
     @Test
-    fun `subscription period is null`() {
+    fun `subscription period is null for a non-subscriptions`() {
         val product = dummyAmazonProduct()
         val storeProduct = product.toStoreProduct("US")
         assertThat(storeProduct?.period).isNull()
@@ -83,6 +86,35 @@ class ProductConverterTest {
         val product = dummyAmazonProduct(smallIconUrl = expectedSmallIconUrl)
         val storeProduct = product.toStoreProduct("US")
         assertThat(storeProduct?.amazonProduct?.iconUrl).isEqualTo(expectedSmallIconUrl)
+    }
+
+    fun `subscription period is non-null for a subscription`() {
+        val product = dummyAmazonProduct(
+            subscriptionPeriod = "Weekly"
+        )
+        val storeProduct = product.toStoreProduct("US")
+        assertThat(storeProduct?.period).isEqualTo(
+            Period(1, Period.Unit.WEEK, "P1W")
+        )
+    }
+
+    @Test
+    fun `free trial period is null if no free trial period`() {
+        val product = dummyAmazonProduct()
+        val storeProduct = product.toStoreProduct("US")
+        assertThat(storeProduct?.amazonProduct?.freeTrialPeriod).isNull()
+    }
+
+    @Test
+    fun `free trial period is non-null if a free trial period`() {
+        val product = dummyAmazonProduct(
+            subscriptionPeriod = "Quarterly",
+            freeTrialPeriod = "BiWeekly"
+        )
+        val storeProduct = product.toStoreProduct("US")
+        assertThat(storeProduct?.amazonProduct?.freeTrialPeriod).isEqualTo(
+            Period(2, Period.Unit.WEEK, "P2W")
+        )
     }
 
     @Test
@@ -106,5 +138,36 @@ class ProductConverterTest {
         val storeProduct = product.toStoreProduct("US")
 
         assertThat(storeProduct).isNull()
+    }
+}
+
+@RunWith(Parameterized::class)
+class PeriodParsingTest(private val periodRaw: String, private val periodExpected: Period?) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data() : Collection<Array<Any?>> {
+            return listOf(
+                arrayOf("Weekly", Period(1, Period.Unit.WEEK, "P1W")),
+                arrayOf("BiWeekly", Period(2, Period.Unit.WEEK, "P2W")),
+                arrayOf("Monthly", Period(1, Period.Unit.MONTH, "P1M")),
+                arrayOf("BiMonthly", Period(2, Period.Unit.MONTH, "P2M")),
+                arrayOf("Quarterly", Period(3, Period.Unit.MONTH, "P3M")),
+                arrayOf("SemiAnnually", Period(6, Period.Unit.MONTH, "P6M")),
+                arrayOf("Annually", Period(1, Period.Unit.YEAR, "P1Y")),
+                arrayOf("7 Days", Period(7, Period.Unit.DAY, "P7D")),
+                arrayOf("14 Weeks", Period(14, Period.Unit.WEEK, "P14W")),
+                arrayOf("1 Year", Period(1, Period.Unit.YEAR, "P1Y")),
+                arrayOf("3 Pizzas To Go", null),
+                arrayOf("Josh", null)
+            )
+        }
+    }
+
+    @Test
+    fun `period string to Period is correct`() {
+        val period = periodRaw.createPeriod()
+        assertThat(period).isEqualTo(periodExpected)
     }
 }

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/helpers/dummies.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/helpers/dummies.kt
@@ -14,17 +14,21 @@ fun dummyAmazonProduct(
     sku: String = "premium",
     productType: ProductType = ProductType.SUBSCRIPTION,
     description: String = "A product description",
+    subscriptionPeriod: String? = null,
     title: String = "A product title",
     price: String? = "$3.00",
     smallIconUrl: String = "https://icon.url",
+    freeTrialPeriod: String? = null,
     coinsRewardAmount: Int = 100
 ): Product {
     return ProductBuilder()
         .setSku(sku)
         .setProductType(productType)
         .setDescription(description)
+        .setFreeTrialPeriod(freeTrialPeriod)
         .setPrice(price)
         .setSmallIconUrl(smallIconUrl)
+        .setSubscriptionPeriod(subscriptionPeriod)
         .setTitle(title)
         .setCoinsRewardAmount(coinsRewardAmount).build()
 }


### PR DESCRIPTION
### Motivation

[CF-1288](https://revenuecats.atlassian.net/browse/CF-1288)

### Description

Parses Amazon's English language period durations into a `Period` object and an ISO 8601 string 💪 
