### PR TITLE
Fix flaky test in EntitlementInfoTest

### DIFF
--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfoTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfoTest.kt
@@ -18,6 +18,10 @@ import kotlin.time.Duration.Companion.days
 @Config(manifest = Config.NONE)
 class EntitlementInfoTest {
 
+    private val oneDayAgo = 1.days.ago()
+    private val twoDaysAgo = 2.days.ago()
+    private val oneDayFromNow = 1.days.fromNow()
+
     @Test
     fun `same entitlement info are equal`() {
         val entitlementInfo1 = createEntitlementInfo()
@@ -40,9 +44,9 @@ class EntitlementInfoTest {
         isActive: Boolean = true,
         willRenew: Boolean = true,
         periodType: PeriodType = PeriodType.NORMAL,
-        latestPurchaseDate: Date = 1.days.ago(),
-        originalPurchaseDate: Date = 2.days.ago(),
-        expirationDate: Date? = 1.days.fromNow(),
+        latestPurchaseDate: Date = oneDayAgo,
+        originalPurchaseDate: Date = twoDaysAgo,
+        expirationDate: Date? = oneDayFromNow,
         store: Store = Store.PLAY_STORE,
         productIdentifier: String = "test-product-id",
         isSandbox: Boolean = false,


### PR DESCRIPTION
### Description
This fixes a flaky test in `EntitlementInfoTest`. Copied fix in #882 

Basically, we were creating multiple `EntitlementInfoTest` and comparing them but the dates could be different which caused the test to fail.


