### PR TITLE
[BC5] Use `rc-ignore-offer` instead of `rc-ignore-befault-offer`

### DIFF
--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -127,7 +127,7 @@ prices would automatically be applied if the user was eligible.
 Now, in v6, a `Package` or `StoreProduct` could contain multiple offers along with a base plan. 
 When passing a `Package` or `StoreProduct` to `purchase()`, the SDK will use the following logic to choose which 
 [SubscriptionOption] to purchase:
-*   - Filters out offers with "rc-ignore-default-offer" tag
+*   - Filters out offers with "rc-ignore-offer" tag
 *   - Uses [SubscriptionOption] with the longest free trial or cheapest first phase
 *   - Falls back to use base plan
 

--- a/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOptions.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOptions.kt
@@ -27,7 +27,7 @@ class SubscriptionOptions(
 
     /**
      * The default [SubscriptionOption]:
-     *   - Filters out offers with "rc-ignore-default-offer" tag
+     *   - Filters out offers with "rc-ignore-offer" tag
      *   - Uses [SubscriptionOption] WITH longest free trial or cheapest first phase
      *   - Falls back to use base plan
      */
@@ -37,7 +37,7 @@ class SubscriptionOptions(
 
             val validOffers = this
                 .filter { !it.isBasePlan }
-                .filter { !it.tags.contains("rc-ignore-default-offer") }
+                .filter { !it.tags.contains("rc-ignore-offer") }
 
             return findLongestFreeTrial(validOffers) ?: findLowestNonFreeOffer(validOffers) ?: basePlan
         }

--- a/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOptions.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOptions.kt
@@ -6,6 +6,10 @@ class SubscriptionOptions(
     private val subscriptionOptions: List<SubscriptionOption>
     ) : List<SubscriptionOption> by subscriptionOptions {
 
+    private companion object {
+        const val RC_IGNORE_OFFER_TAG = "rc-ignore-offer"
+    }
+
     /**
      * The base plan [SubscriptionOption].
      */
@@ -37,7 +41,7 @@ class SubscriptionOptions(
 
             val validOffers = this
                 .filter { !it.isBasePlan }
-                .filter { !it.tags.contains("rc-ignore-offer") }
+                .filter { !it.tags.contains(RC_IGNORE_OFFER_TAG) }
 
             return findLongestFreeTrial(validOffers) ?: findLowestNonFreeOffer(validOffers) ?: basePlan
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
@@ -33,7 +33,7 @@ data class PurchaseParams(val builder: Builder) {
      *
      * If a [Package] or [StoreProduct] is passed in, the [defaultOption] will be purchased. [defaultOption] is
      * selected via the following logic:
-     *   - Filters out offers with "rc-ignore-default-offer" tag
+     *   - Filters out offers with "rc-ignore-offer" tag
      *   - Uses [SubscriptionOption] with the longest free trial or cheapest first phase
      *   - Falls back to use base plan
      */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -399,7 +399,7 @@ class Purchases internal constructor(
      *
      * If a [Package] or [StoreProduct] is used to build the [PurchaseParams], the [defaultOption] will be purchased.
      * [defaultOption] is selected via the following logic:
-     *   - Filters out offers with "rc-ignore-default-offer" tag
+     *   - Filters out offers with "rc-ignore-offer" tag
      *   - Uses [SubscriptionOption] with the longest free trial or cheapest first phase
      *   - Falls back to use base plan
      *
@@ -439,7 +439,7 @@ class Purchases internal constructor(
      * [upgradeInfo.oldSku] and chooses [storeProduct]'s default [SubscriptionOption].
      *
      * The default [SubscriptionOption] logic:
-     *   - Filters out offers with "rc-ignore-default-offer" tag
+     *   - Filters out offers with "rc-ignore-offer" tag
      *   - Uses [SubscriptionOption] WITH longest free trial or cheapest first phase
      *   - Falls back to use base plan
      *
@@ -475,7 +475,7 @@ class Purchases internal constructor(
      * Purchases a [StoreProduct]. If purchasing a subscription, it will choose the default [SubscriptionOption].
      *
      * The default [SubscriptionOption] logic:
-     *   - Filters out offers with "rc-ignore-default-offer" tag
+     *   - Filters out offers with "rc-ignore-offer" tag
      *   - Uses [SubscriptionOption] WITH longest free trial or cheapest first phase
      *   - Falls back to use base plan
      *
@@ -507,7 +507,7 @@ class Purchases internal constructor(
      * [oldProductId]and chooses the default [SubscriptionOption] from [packageToPurchase].
      *
      * The default [SubscriptionOption] logic:
-     *   - Filters out offers with "rc-ignore-default-offer" tag
+     *   - Filters out offers with "rc-ignore-offer" tag
      *   - Uses [SubscriptionOption] WITH longest free trial or cheapest first phase
      *   - Falls back to use base plan
      *
@@ -543,7 +543,7 @@ class Purchases internal constructor(
      * Purchase a [Package]. If purchasing a subscription, it will choose the default [SubscriptionOption].
      *
      * The default [SubscriptionOption] logic:
-     *   - Filters out offers with "rc-ignore-default-offer" tag
+     *   - Filters out offers with "rc-ignore-offer" tag
      *   - Uses [SubscriptionOption] WITH longest free trial or cheapest first phase
      *   - Falls back to use base plan
      *


### PR DESCRIPTION
### Motivation

[CF-1291](https://revenuecats.atlassian.net/browse/CF-1291)

Turns out that `rc-ignore-default-offer` is too long for Google Play to handle 🙈 Max 20 characters so now using `rc-ignore-offer`

### Description

Giant find replace for `rc-ignore-default-offer` to `rc-ignore-offer`


[CF-1291]: https://revenuecats.atlassian.net/browse/CF-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ