### PR TITLE
[BC5] Rename `introTrial` to `introOffer` on `SubscriptionOptions`

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/SubscriptionOptionsAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/SubscriptionOptionsAPI.java
@@ -13,7 +13,7 @@ final class SubscriptionOptionsAPI {
         SubscriptionOptions subscriptionOptions = new SubscriptionOptions(new ArrayList());
 
         SubscriptionOption freeTrial = subscriptionOptions.getFreeTrial();
-        SubscriptionOption introTrial = subscriptionOptions.getIntroTrial();
+        SubscriptionOption introOffer = subscriptionOptions.getIntroOffer();
         List<SubscriptionOption> tagOptions = subscriptionOptions.withTag("pick-this-one");
 
         for (SubscriptionOption subscriptionOption : subscriptionOptions) {

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/SubscriptionOptionsAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/SubscriptionOptionsAPI.kt
@@ -8,7 +8,7 @@ private class SubscriptionOptionsAPI {
         val subscriptionOptions = SubscriptionOptions(emptyList())
 
         val freeTrial = subscriptionOptions.freeTrial
-        val introTrial = subscriptionOptions.introTrial
+        val introOffer = subscriptionOptions.introOffer
         val tagOptions = subscriptionOptions.withTag("pick-this-one")
 
         subscriptionOptions.forEach {

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -71,7 +71,7 @@ be found through `subscriptionOptions`:
 val basePlan = storeProduct.subscriptionOptions?.basePlan
 val defaultOffer = storeProduct.subscriptionOptions?.defaultOffer
 val freeOffer = storeProduct.subscriptionOptions?.freeTrial
-val trialOffer = storeProduct.subscriptionOptions?.introTrial
+val introOffer = storeProduct.subscriptionOptions?.introOffer
 val offersForLapsedCustomers = storeProduct.subscriptionOptions?.withTag("lapsed-customers")
 ```
 

--- a/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOptions.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOptions.kt
@@ -26,7 +26,7 @@ class SubscriptionOptions(
      * The first [SubscriptionOption] with an intro trial [PricingPhase].
      * There can be a free trial [PricingPhase] and intro trial [PricingPhase] in the same [SubscriptionOption].
      */
-    val introTrial: SubscriptionOption?
+    val introOffer: SubscriptionOption?
         get() = this.firstOrNull { it.introPhase != null }
 
     /**

--- a/public/src/test/java/com/revenuecat/purchases/common/models/SubscriptionOptionsTest.kt
+++ b/public/src/test/java/com/revenuecat/purchases/common/models/SubscriptionOptionsTest.kt
@@ -95,7 +95,7 @@ class SubscriptionOptionsTest {
 
     @Test
     fun `Can find intro trial`() {
-        val introTrial = subscriptionOptions.introTrial
+        val introTrial = subscriptionOptions.introOffer
         assertThat(introTrial).isNotNull
         assertThat(introTrial?.pricingPhases?.first()?.price?.amountMicros).isEqualTo(2990000L)
     }


### PR DESCRIPTION
### Motivation

[CF-1292](https://revenuecats.atlassian.net/browse/CF-1292)

Rename `introTrial` to `introOffer` since "trial" usually refers to free in most of other references

### Description

Rename `introTrial` to `introOffer` in `SubscriptionOptions`

[CF-1292]: https://revenuecats.atlassian.net/browse/CF-1292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ