### PR TITLE
Offline entitlements: Add support for fetching ProductEntitlement mappings

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -28,6 +28,9 @@ sealed class Endpoint(val pathTemplate: String, val name: String) {
         ) : Endpoint("/receipts/amazon/%s/%s", "get_amazon_receipt") {
         override fun getPath() = pathTemplate.format(Uri.encode(userId), receiptId)
     }
+    object GetProductEntitlementMappings : Endpoint("/products-entitlements", "get_product_entitlement_mappings") {
+        override fun getPath() = pathTemplate
+    }
 
     val supportsSignatureValidation: Boolean
         get() = when (this) {
@@ -38,7 +41,8 @@ sealed class Endpoint(val pathTemplate: String, val name: String) {
             is GetAmazonReceipt,
             is GetOfferings,
             is PostAttributes,
-            PostDiagnostics ->
+            PostDiagnostics,
+            GetProductEntitlementMappings ->
                 false
         }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -1697,7 +1697,7 @@ class BackendTest {
 
     // endregion
 
-    // region
+    // region getProductEntitlementMappings
 
     @Test
     fun `getProductEntitlementMappings makes call with correct parameters`() {

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -1535,14 +1535,17 @@ class BackendTest {
             delayed = true,
             baseURL = mockDiagnosticsBaseURL
         )
+
         val lock = CountDownLatch(1)
         asyncBackend.postDiagnostics(diagnosticsList, { lock.countDown() }, { _, _ -> fail("expected success") })
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
         assertThat(lock.count).isEqualTo(0)
+
         val lock2 = CountDownLatch(1)
         asyncBackend.postDiagnostics(diagnosticsList, { lock2.countDown() }, { _, _ -> fail("expected success") })
         lock2.await(defaultTimeout, TimeUnit.MILLISECONDS)
         assertThat(lock2.count).isEqualTo(0)
+
         verify(exactly = 2) {
             mockClient.performRequest(
                 baseURL = mockDiagnosticsBaseURL,
@@ -1748,14 +1751,17 @@ class BackendTest {
             resultBody = "{\"products\":[]}",
             delayed = true
         )
+
         val lock = CountDownLatch(1)
         asyncBackend.getProductEntitlementMappings({ lock.countDown() }, { fail("expected succcess") })
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
         assertThat(lock.count).isEqualTo(0)
+
         val lock2 = CountDownLatch(1)
         asyncBackend.getProductEntitlementMappings({ lock2.countDown() }, { fail("expected succcess") })
         lock2.await(defaultTimeout, TimeUnit.MILLISECONDS)
         assertThat(lock2.count).isEqualTo(0)
+
         verify(exactly = 2) {
             mockClient.performRequest(
                 baseURL = mockBaseURL,

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -60,6 +60,13 @@ class EndpointTest {
     }
 
     @Test
+    fun `GetProductEntitlementMappings has correct path`() {
+        val endpoint = Endpoint.GetProductEntitlementMappings
+        val expectedPath = "/products-entitlements"
+        assertThat(endpoint.getPath()).isEqualTo(expectedPath)
+    }
+
+    @Test
     fun `supportsSignatureValidation returns true for expected values`() {
         val expectedSupportsValidationEndpoints = listOf(
             Endpoint.GetCustomerInfo("test-user-id"),
@@ -77,7 +84,8 @@ class EndpointTest {
             Endpoint.GetAmazonReceipt("test-user-id", "test-receipt-id"),
             Endpoint.GetOfferings("test-user-id"),
             Endpoint.PostAttributes("test-user-id"),
-            Endpoint.PostDiagnostics
+            Endpoint.PostDiagnostics,
+            Endpoint.GetProductEntitlementMappings
         )
         for (endpoint in expectedNotSupportsValidationEndpoints) {
             assertThat(endpoint.supportsSignatureValidation).isFalse


### PR DESCRIPTION
### Description
Second part of SDK-2982
Based on #888 

This PR adds support to get product entitlement mappings from the backend.
