### PR TITLE
Offline entitlements: Add `OfflineEntitlementsManager` and add operation to perform backend request and cache result in device

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -1,0 +1,28 @@
+package com.revenuecat.purchases.common.offlineentitlements
+
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.strings.OfflineEntitlementsStrings
+
+class OfflineEntitlementsManager(
+    private val backend: Backend,
+    private val deviceCache: DeviceCache
+) {
+
+    fun updateProductEntitlementMappingsCacheIfStale() {
+        if (deviceCache.isProductEntitlementMappingsCacheStale()) {
+            debugLog(OfflineEntitlementsStrings.UPDATING_PRODUCT_ENTITLEMENT_MAPPINGS)
+            backend.getProductEntitlementMappings(
+                onSuccessHandler = { productEntitlementMappings ->
+                    deviceCache.cacheProductEntitlementMappings(productEntitlementMappings)
+                    debugLog(OfflineEntitlementsStrings.SUCCESSFULLY_UPDATED_PRODUCT_ENTITLEMENTS)
+                },
+                onErrorHandler = { e ->
+                    errorLog(OfflineEntitlementsStrings.ERROR_UPDATING_PRODUCT_ENTITLEMENTS.format(e))
+                }
+            )
+        }
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
@@ -1,0 +1,76 @@
+package com.revenuecat.purchases.common.offlineentitlements
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.caching.DeviceCache
+import io.mockk.CapturingSlot
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class OfflineEntitlementsManagerTest {
+
+    private lateinit var backendSuccessSlot: CapturingSlot<(ProductEntitlementMappings) -> Unit>
+    private lateinit var backendErrorSlot: CapturingSlot<(PurchasesError) -> Unit>
+
+    private lateinit var backend: Backend
+    private lateinit var deviceCache: DeviceCache
+
+    private lateinit var offlineEntitlementsManager: OfflineEntitlementsManager
+
+    @Before
+    fun setUp() {
+        backendSuccessSlot = slot()
+        backendErrorSlot = slot()
+
+        backend = mockk()
+        deviceCache = mockk()
+
+        every {
+            backend.getProductEntitlementMappings(capture(backendSuccessSlot), capture(backendErrorSlot))
+        } just Runs
+
+        offlineEntitlementsManager = OfflineEntitlementsManager(
+            backend,
+            deviceCache
+        )
+    }
+
+    @Test
+    fun `updateProductEntitlementMappingsCacheIfStale does nothing if cache not stale`() {
+        every { deviceCache.isProductEntitlementMappingsCacheStale() } returns false
+        offlineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
+        verify(exactly = 0) { backend.getProductEntitlementMappings(any(), any()) }
+    }
+
+    @Test
+    fun `updateProductEntitlementMappingsCacheIfStale does nothing if backend request errors`() {
+        every { deviceCache.isProductEntitlementMappingsCacheStale() } returns true
+        offlineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
+        verify(exactly = 1) { backend.getProductEntitlementMappings(any(), any()) }
+        backendErrorSlot.captured(PurchasesError(PurchasesErrorCode.NetworkError))
+        verify(exactly = 0) { deviceCache.cacheProductEntitlementMappings(any()) }
+    }
+
+    @Test
+    fun `updateProductEntitlementMappingsCacheIfStale caches mapping from backend if request successful`() {
+        every { deviceCache.isProductEntitlementMappingsCacheStale() } returns true
+        every { deviceCache.cacheProductEntitlementMappings(any()) } just Runs
+        offlineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
+        verify(exactly = 1) { backend.getProductEntitlementMappings(any(), any()) }
+        val expectedMappings = createProductEntitlementMapping()
+        backendSuccessSlot.captured(expectedMappings)
+        verify(exactly = 1) { deviceCache.cacheProductEntitlementMappings(expectedMappings) }
+    }
+}

--- a/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases.strings
 
 object OfflineEntitlementsStrings {
-    const val UPDATING_PRODUCT_ENTITLEMENT_MAPPINGS = "Updating product entitlement mappings."
+    const val UPDATING_PRODUCT_ENTITLEMENT_MAPPINGS = "Product entitlement mappings are stale. Updating."
     const val SUCCESSFULLY_UPDATED_PRODUCT_ENTITLEMENTS = "Successfully updated product entitlement mappings."
     const val ERROR_UPDATING_PRODUCT_ENTITLEMENTS = "Error updating product entitlement mappings. Error: %s"
 }

--- a/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
@@ -1,0 +1,7 @@
+package com.revenuecat.purchases.strings
+
+object OfflineEntitlementsStrings {
+    const val UPDATING_PRODUCT_ENTITLEMENT_MAPPINGS = "Updating product entitlement mappings."
+    const val SUCCESSFULLY_UPDATED_PRODUCT_ENTITLEMENTS = "Successfully updated product entitlement mappings."
+    const val ERROR_UPDATING_PRODUCT_ENTITLEMENTS = "Error updating product entitlement mappings. Error: %s"
+}


### PR DESCRIPTION
### Description
Second part of SDK-2986
Based on #892 

This PR adds `OfflineEntitlementsManager`. This class will be in charge of performing most of the logic to make sure the SDK can handle entitlements in the unlikely case the servers are down.

Currently, only has one method to update the cache with the product entitlement mappings from the servers.
