### PR TITLE
Support requests without ETags

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -135,7 +135,7 @@ class HTTPClient(
             val fullURL = URL(baseURL, urlPathWithVersion)
 
             nonce = if (shouldSignResponse) signingManager.createRandomNonce() else null
-            val headers = getHeaders(requestHeaders, urlPathWithVersion, refreshETag, nonce)
+            val headers = getHeaders(requestHeaders, urlPathWithVersion, endpoint.supportsETags, refreshETag, nonce)
 
             val httpRequest = HTTPRequest(fullURL, headers, jsonBody)
 
@@ -215,10 +215,11 @@ class HTTPClient(
     private fun getHeaders(
         authenticationHeaders: Map<String, String>,
         urlPath: String,
+        supportsETag: Boolean,
         refreshETag: Boolean,
         nonce: String?
     ): Map<String, String> {
-        return mapOf(
+        return mutableMapOf(
             "Content-Type" to "application/json",
             "X-Platform" to getXPlatformHeader(),
             "X-Platform-Flavor" to appConfig.platformInfo.flavor,
@@ -231,8 +232,12 @@ class HTTPClient(
             "X-Observer-Mode-Enabled" to if (appConfig.finishTransactions) "false" else "true",
             "X-Nonce" to nonce
         )
-            .plus(authenticationHeaders)
-            .plus(eTagManager.getETagHeader(urlPath, refreshETag))
+            .apply {
+                putAll(authenticationHeaders)
+                if (supportsETag) {
+                    putAll(eTagManager.getETagHeader(urlPath, refreshETag))
+                }
+            }
             .filterNotNullValues()
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -45,4 +45,10 @@ sealed class Endpoint(val pathTemplate: String, val name: String) {
             GetProductEntitlementMappings ->
                 false
         }
+
+    val supportsETags: Boolean
+        get() = when (this) {
+            GetProductEntitlementMappings -> false
+            else -> true
+        }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -10,6 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.networking.HTTPRequest
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.utils.Responses
@@ -143,6 +144,39 @@ class HTTPClientTest: BaseHTTPClientTest() {
         assertThat(request.getHeader("X-Client-Version")).isEqualTo("")
         assertThat(request.getHeader("X-Client-Bundle-ID")).isEqualTo("mock-package-name")
         assertThat(request.getHeader("X-Observer-Mode-Enabled")).isEqualTo("false")
+    }
+
+    @Test
+    fun `adds eTag header if endpoint supports it`() {
+        val expectedResult = HTTPResult.createResult()
+        val endpoint = Endpoint.LogIn
+        enqueue(
+            endpoint,
+            expectedResult
+        )
+
+        client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+
+        val request = server.takeRequest()
+
+        assertThat(request.headers.names().contains(HTTPRequest.ETAG_HEADER_NAME)).isTrue
+        assertThat(request.getHeader(HTTPRequest.ETAG_HEADER_NAME)).isEqualTo("")
+    }
+
+    @Test
+    fun `does not add eTag header if endpoint does not supports it`() {
+        val expectedResult = HTTPResult.createResult()
+        val endpoint = Endpoint.GetProductEntitlementMappings
+        enqueue(
+            endpoint,
+            expectedResult
+        )
+
+        client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+
+        val request = server.takeRequest()
+
+        assertThat(request.headers.names().contains(HTTPRequest.ETAG_HEADER_NAME)).isFalse
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -91,4 +91,30 @@ class EndpointTest {
             assertThat(endpoint.supportsSignatureValidation).isFalse
         }
     }
+
+    @Test
+    fun `supportsETags returns true for expected values`() {
+        val expectedSupportsETagsEndpoints = listOf(
+            Endpoint.GetCustomerInfo("test-user-id"),
+            Endpoint.LogIn,
+            Endpoint.PostReceipt,
+            Endpoint.GetAmazonReceipt("test-user-id", "test-receipt-id"),
+            Endpoint.GetOfferings("test-user-id"),
+            Endpoint.PostAttributes("test-user-id"),
+            Endpoint.PostDiagnostics
+        )
+        for (endpoint in expectedSupportsETagsEndpoints) {
+            assertThat(endpoint.supportsETags).isTrue
+        }
+    }
+
+    @Test
+    fun `supportsETags returns false for expected values`() {
+        val expectedDoesNotSupportETagsEndpoints = listOf(
+            Endpoint.GetProductEntitlementMappings
+        )
+        for (endpoint in expectedDoesNotSupportETagsEndpoints) {
+            assertThat(endpoint.supportsETags).isFalse
+        }
+    }
 }


### PR DESCRIPTION
### Description
3rd part of SDK-2982

This PR adds support for endpoints to not send an ETag header in requests. Currently only needed for the product entitlement mapping endpoint.
