### PR TITLE
Offline entitlements: Initialize OfflineEntitlementsManager and perform cache update on SDK configuration

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -179,7 +179,8 @@ class Purchases internal constructor(
             log(LogIntent.WARNING, AUTO_SYNC_PURCHASES_DISABLED)
         }
 
-        offlineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
+        // Offline entitlements: Commenting out for now until backend is ready
+        // offlineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
         diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
     }
 
@@ -213,7 +214,8 @@ class Purchases internal constructor(
             fetchAndCacheOfferings(identityManager.currentAppUserID, appInBackground = false)
             log(LogIntent.RC_SUCCESS, OfferingStrings.OFFERINGS_UPDATED_FROM_NETWORK)
         }
-        offlineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
+        // Offline entitlements: Commenting out for now until backend is ready
+        // offlineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
         updatePendingPurchaseQueue()
         synchronizeSubscriberAttributesIfNeeded()
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -35,6 +35,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
 import com.revenuecat.purchases.google.isSuccessful
@@ -106,6 +107,7 @@ class Purchases internal constructor(
     @set:JvmSynthetic @get:JvmSynthetic internal var appConfig: AppConfig,
     private val customerInfoHelper: CustomerInfoHelper,
     diagnosticsSynchronizer: DiagnosticsSynchronizer?,
+    private val offlineEntitlementsManager: OfflineEntitlementsManager,
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper())
 ) : LifecycleDelegate {
@@ -177,6 +179,7 @@ class Purchases internal constructor(
             log(LogIntent.WARNING, AUTO_SYNC_PURCHASES_DISABLED)
         }
 
+        offlineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
         diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -107,6 +107,7 @@ class Purchases internal constructor(
     @set:JvmSynthetic @get:JvmSynthetic internal var appConfig: AppConfig,
     private val customerInfoHelper: CustomerInfoHelper,
     diagnosticsSynchronizer: DiagnosticsSynchronizer?,
+    @Suppress("UnusedPrivateMember")
     private val offlineEntitlementsManager: OfflineEntitlementsManager,
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper())

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -213,6 +213,7 @@ class Purchases internal constructor(
             fetchAndCacheOfferings(identityManager.currentAppUserID, appInBackground = false)
             log(LogIntent.RC_SUCCESS, OfferingStrings.OFFERINGS_UPDATED_FROM_NETWORK)
         }
+        offlineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
         updatePendingPurchaseQueue()
         synchronizeSubscriberAttributesIfNeeded()
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsFileHelper
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.ETagManager
+import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
 import com.revenuecat.purchases.identity.IdentityManager
@@ -118,6 +119,8 @@ internal class PurchasesFactory(
 
             val customerInfoHelper = CustomerInfoHelper(cache, backend, identityManager)
 
+            val offlineEntitlementsManager = OfflineEntitlementsManager(backend, cache)
+
             var diagnosticsSynchronizer: DiagnosticsSynchronizer? = null
             if (diagnosticsFileHelper != null && diagnosticsTracker != null) {
                 diagnosticsSynchronizer = DiagnosticsSynchronizer(
@@ -140,7 +143,8 @@ internal class PurchasesFactory(
                 subscriberAttributesManager,
                 appConfig,
                 customerInfoHelper,
-                diagnosticsSynchronizer
+                diagnosticsSynchronizer,
+                offlineEntitlementsManager
             )
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.common.PostReceiptDataErrorCallback
 import com.revenuecat.purchases.common.PostReceiptDataSuccessCallback
 import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.SubscriberAttributeError
+import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.google.BillingWrapper
 import com.revenuecat.purchases.google.toStoreTransaction
 import com.revenuecat.purchases.models.StoreProduct
@@ -42,6 +43,7 @@ class PostingTransactionsTests {
     private val backendMock = mockk<Backend>(relaxed = true)
     private val billingWrapperMock = mockk<BillingWrapper>(relaxed = true)
     private val customerInfoHelperMock = mockk<CustomerInfoHelper>()
+    private val offlineEntitlementsManagerMock = mockk<OfflineEntitlementsManager>()
     private var postReceiptError: PostReceiptErrorContainer? = null
     private var postReceiptSuccess: PostReceiptCompletionContainer? = null
     private var subscriberAttribute = SubscriberAttribute("key", "value")
@@ -122,6 +124,9 @@ class PostingTransactionsTests {
         every {
             customerInfoHelperMock.sendUpdatedCustomerInfoToDelegateIfChanged(any())
         } just runs
+        every {
+            offlineEntitlementsManagerMock.updateProductEntitlementMappingsCacheIfStale()
+        } just runs
 
         underTest = Purchases(
             application = mockk(relaxed = true),
@@ -145,7 +150,8 @@ class PostingTransactionsTests {
                 store = Store.PLAY_STORE
             ),
             customerInfoHelper = customerInfoHelperMock,
-            diagnosticsSynchronizer = null
+            diagnosticsSynchronizer = null,
+            offlineEntitlementsManager = offlineEntitlementsManagerMock
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -219,10 +219,11 @@ class PurchasesTest {
         verify(exactly = 1) { mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded() }
     }
 
-    @Test
-    fun `product entitlement mappings are updated if staled on constructor`() {
-        verify(exactly = 1) { mockOfflineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale() }
-    }
+//    Offline entitlements: Commenting out for now until backend is ready
+//    @Test
+//    fun `product entitlement mappings are updated if staled on constructor`() {
+//        verify(exactly = 1) { mockOfflineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale() }
+//    }
 
     @Test
     fun getsSubscriptionSkus() {
@@ -531,18 +532,19 @@ class PurchasesTest {
         }
     }
 
-    @Test
-    fun `fetch product entitlement mapping on foreground if it's stale`() {
-        mockSuccessfulQueryPurchases(
-            queriedSUBS = emptyMap(),
-            queriedINAPP = emptyMap(),
-            notInCache = emptyList()
-        )
-        Purchases.sharedInstance.onAppForegrounded()
-        verify(exactly = 2) {
-            mockOfflineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
-        }
-    }
+//    Offline entitlements: Commenting out for now until backend is ready
+//    @Test
+//    fun `fetch product entitlement mapping on foreground if it's stale`() {
+//        mockSuccessfulQueryPurchases(
+//            queriedSUBS = emptyMap(),
+//            queriedINAPP = emptyMap(),
+//            notInCache = emptyList()
+//        )
+//        Purchases.sharedInstance.onAppForegrounded()
+//        verify(exactly = 2) {
+//            mockOfflineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
+//        }
+//    }
 
     private fun mockSynchronizeSubscriberAttributesForAllUsers() {
         every {

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -30,6 +30,7 @@ import com.revenuecat.purchases.common.ReplaceSkuInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.createOfferings
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
+import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
 import com.revenuecat.purchases.google.toGoogleProductType
@@ -100,6 +101,7 @@ class PurchasesTest {
     private val mockSubscriberAttributesManager = mockk<SubscriberAttributesManager>()
     private val mockCustomerInfoHelper = mockk<CustomerInfoHelper>()
     private val mockDiagnosticsSynchronizer = mockk<DiagnosticsSynchronizer>()
+    private val mockOfflineEntitlementsManager = mockk<OfflineEntitlementsManager>()
 
     private var capturedPurchasesUpdatedListener = slot<BillingAbstract.PurchasesUpdatedListener>()
     private var capturedBillingWrapperStateListener = slot<BillingAbstract.StateListener>()
@@ -158,6 +160,9 @@ class PurchasesTest {
         every {
             mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
         } just Runs
+        every {
+            mockOfflineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
+        } just Runs
 
         anonymousSetup(false)
     }
@@ -212,6 +217,11 @@ class PurchasesTest {
     @Test
     fun `diagnostics is synced if needed on constructor`() {
         verify(exactly = 1) { mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded() }
+    }
+
+    @Test
+    fun `product entitlement mappings are updated if staled on constructor`() {
+        verify(exactly = 1) { mockOfflineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale() }
     }
 
     @Test
@@ -4149,7 +4159,8 @@ class PurchasesTest {
                 dangerousSettings = DangerousSettings(autoSyncPurchases = autoSync)
             ),
             customerInfoHelper = mockCustomerInfoHelper,
-            diagnosticsSynchronizer = mockDiagnosticsSynchronizer
+            diagnosticsSynchronizer = mockDiagnosticsSynchronizer,
+            offlineEntitlementsManager = mockOfflineEntitlementsManager
         )
         Purchases.sharedInstance = purchases
         purchases.state = purchases.state.copy(appInBackground = false)

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -531,6 +531,19 @@ class PurchasesTest {
         }
     }
 
+    @Test
+    fun `fetch product entitlement mapping on foreground if it's stale`() {
+        mockSuccessfulQueryPurchases(
+            queriedSUBS = emptyMap(),
+            queriedINAPP = emptyMap(),
+            notInCache = emptyList()
+        )
+        Purchases.sharedInstance.onAppForegrounded()
+        verify(exactly = 2) {
+            mockOfflineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
+        }
+    }
+
     private fun mockSynchronizeSubscriberAttributesForAllUsers() {
         every {
             mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(appUserId)

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -18,6 +18,7 @@ import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.PostReceiptDataErrorCallback
 import com.revenuecat.purchases.common.PostReceiptDataSuccessCallback
 import com.revenuecat.purchases.common.SubscriberAttributeError
+import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
 import com.revenuecat.purchases.common.toPurchasesError
 import com.revenuecat.purchases.identity.IdentityManager
@@ -52,6 +53,7 @@ class SubscriberAttributesPurchasesTests {
     private val backendMock = mockk<Backend>(relaxed = true)
     private val billingWrapperMock = mockk<BillingAbstract>(relaxed = true)
     private val customerInfoHelperMock = mockk<CustomerInfoHelper>()
+    private val offlineEntitlementsManagerMock = mockk<OfflineEntitlementsManager>()
     private lateinit var applicationMock: Application
 
     private var postReceiptError: PostReceiptErrorContainer? = null
@@ -134,6 +136,9 @@ class SubscriberAttributesPurchasesTests {
         every {
             customerInfoHelperMock.sendUpdatedCustomerInfoToDelegateIfChanged(any())
         } just runs
+        every {
+            offlineEntitlementsManagerMock.updateProductEntitlementMappingsCacheIfStale()
+        } just runs
 
         underTest = Purchases(
             application = mockk<Application>(relaxed = true).also { applicationMock = it },
@@ -154,7 +159,8 @@ class SubscriberAttributesPurchasesTests {
                 store = Store.PLAY_STORE
             ),
             customerInfoHelper = customerInfoHelperMock,
-            diagnosticsSynchronizer = null
+            diagnosticsSynchronizer = null,
+            offlineEntitlementsManager = offlineEntitlementsManagerMock
         )
     }
 


### PR DESCRIPTION
### Description
3rd part of SDK-2986
Based on #893 

This PR glues previous code so we perform the backend request to get the product-entitlement mapping and store it in the device cache. This will happen if the cache is stale and: 
- When the SDK is first initialized
- When the app is foregrounded

