### PR TITLE
Revert behavior change when parsing customer info schema version from cache

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -124,7 +124,6 @@ open class DeviceCache(
                     val requestDate = cachedJSONObject.optLong(CUSTOMER_INFO_REQUEST_DATE_KEY).takeIf { it > 0 }?.let {
                         Date(it)
                     }
-                    cachedJSONObject.remove(CUSTOMER_INFO_SCHEMA_VERSION_KEY)
                     cachedJSONObject.remove(CUSTOMER_INFO_VERIFICATION_RESULT_KEY)
                     cachedJSONObject.remove(CUSTOMER_INFO_REQUEST_DATE_KEY)
                     val verificationResult = VerificationResult.valueOf(verificationResultString)

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -154,6 +154,20 @@ class DeviceCacheTest {
     }
 
     @Test
+    fun `given a valid customer info with schema version, the JSON is parsed correctly`() {
+        val deprecatedValidCachedCustomerInfo by lazy {
+            JSONObject(Responses.validFullPurchaserResponse).apply {
+                put("schema_version", CUSTOMER_INFO_SCHEMA_VERSION)
+                put("customer_info_request_date", 1234567890L)
+            }.toString()
+        }
+        mockString(cache.customerInfoCacheKey(appUserID), deprecatedValidCachedCustomerInfo)
+        val info = cache.getCachedCustomerInfo(appUserID)
+        assertThat(info).`as`("info is not null").isNotNull
+        assertThat(info?.schemaVersion).isEqualTo(CUSTOMER_INFO_SCHEMA_VERSION)
+    }
+
+    @Test
     fun `given a valid customer info with request date, the JSON is parsed correctly`() {
         val deprecatedValidCachedCustomerInfo by lazy {
             JSONObject(Responses.validFullPurchaserResponse).apply {


### PR DESCRIPTION
### Description
Fixes a change introduced during [trusted entitlements development](https://github.com/RevenueCat/purchases-android/pull/837/files#diff-677ba224b67c618bd452dc24aa8aaa928996dca6992af94482d42cee3002bbddR109) where the schema version of the cached customer info could be lost. 

This property isn't really used anywhere in this object, so this change wasn't causing any issues. But I believe it's better to keep the previous behavior for now.
