### PR TITLE
Revert "Support requests without ETags (#894)"

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -135,7 +135,7 @@ class HTTPClient(
             val fullURL = URL(baseURL, urlPathWithVersion)
 
             nonce = if (shouldSignResponse) signingManager.createRandomNonce() else null
-            val headers = getHeaders(requestHeaders, urlPathWithVersion, endpoint.supportsETags, refreshETag, nonce)
+            val headers = getHeaders(requestHeaders, urlPathWithVersion, refreshETag, nonce)
 
             val httpRequest = HTTPRequest(fullURL, headers, jsonBody)
 
@@ -215,11 +215,10 @@ class HTTPClient(
     private fun getHeaders(
         authenticationHeaders: Map<String, String>,
         urlPath: String,
-        supportsETag: Boolean,
         refreshETag: Boolean,
         nonce: String?
     ): Map<String, String> {
-        return mutableMapOf(
+        return mapOf(
             "Content-Type" to "application/json",
             "X-Platform" to getXPlatformHeader(),
             "X-Platform-Flavor" to appConfig.platformInfo.flavor,
@@ -232,12 +231,8 @@ class HTTPClient(
             "X-Observer-Mode-Enabled" to if (appConfig.finishTransactions) "false" else "true",
             "X-Nonce" to nonce
         )
-            .apply {
-                putAll(authenticationHeaders)
-                if (supportsETag) {
-                    putAll(eTagManager.getETagHeader(urlPath, refreshETag))
-                }
-            }
+            .plus(authenticationHeaders)
+            .plus(eTagManager.getETagHeader(urlPath, refreshETag))
             .filterNotNullValues()
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -45,10 +45,4 @@ sealed class Endpoint(val pathTemplate: String, val name: String) {
             GetProductEntitlementMappings ->
                 false
         }
-
-    val supportsETags: Boolean
-        get() = when (this) {
-            GetProductEntitlementMappings -> false
-            else -> true
-        }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -10,7 +10,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.Endpoint
-import com.revenuecat.purchases.common.networking.HTTPRequest
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.utils.Responses
@@ -144,39 +143,6 @@ class HTTPClientTest: BaseHTTPClientTest() {
         assertThat(request.getHeader("X-Client-Version")).isEqualTo("")
         assertThat(request.getHeader("X-Client-Bundle-ID")).isEqualTo("mock-package-name")
         assertThat(request.getHeader("X-Observer-Mode-Enabled")).isEqualTo("false")
-    }
-
-    @Test
-    fun `adds eTag header if endpoint supports it`() {
-        val expectedResult = HTTPResult.createResult()
-        val endpoint = Endpoint.LogIn
-        enqueue(
-            endpoint,
-            expectedResult
-        )
-
-        client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
-
-        val request = server.takeRequest()
-
-        assertThat(request.headers.names().contains(HTTPRequest.ETAG_HEADER_NAME)).isTrue
-        assertThat(request.getHeader(HTTPRequest.ETAG_HEADER_NAME)).isEqualTo("")
-    }
-
-    @Test
-    fun `does not add eTag header if endpoint does not supports it`() {
-        val expectedResult = HTTPResult.createResult()
-        val endpoint = Endpoint.GetProductEntitlementMappings
-        enqueue(
-            endpoint,
-            expectedResult
-        )
-
-        client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
-
-        val request = server.takeRequest()
-
-        assertThat(request.headers.names().contains(HTTPRequest.ETAG_HEADER_NAME)).isFalse
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -91,30 +91,4 @@ class EndpointTest {
             assertThat(endpoint.supportsSignatureValidation).isFalse
         }
     }
-
-    @Test
-    fun `supportsETags returns true for expected values`() {
-        val expectedSupportsETagsEndpoints = listOf(
-            Endpoint.GetCustomerInfo("test-user-id"),
-            Endpoint.LogIn,
-            Endpoint.PostReceipt,
-            Endpoint.GetAmazonReceipt("test-user-id", "test-receipt-id"),
-            Endpoint.GetOfferings("test-user-id"),
-            Endpoint.PostAttributes("test-user-id"),
-            Endpoint.PostDiagnostics
-        )
-        for (endpoint in expectedSupportsETagsEndpoints) {
-            assertThat(endpoint.supportsETags).isTrue
-        }
-    }
-
-    @Test
-    fun `supportsETags returns false for expected values`() {
-        val expectedDoesNotSupportETagsEndpoints = listOf(
-            Endpoint.GetProductEntitlementMappings
-        )
-        for (endpoint in expectedDoesNotSupportETagsEndpoints) {
-            assertThat(endpoint.supportsETags).isFalse
-        }
-    }
 }


### PR DESCRIPTION
### Description
This PR reverts #894 since we don't need this functionality currently so we can just remove it and add it back if it becomes necessary in the future.