### PR TITLE
PurchaseTester gets observable mode for google

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -71,13 +71,11 @@ class ConfigureFragment : Fragment() {
 
         binding.amazonStoreRadioId.setOnCheckedChangeListener { buttonView, isChecked ->
             // Disable observer mode options if Amazon
-            binding.observerModeRadioGroup.isEnabled = !isChecked
-            binding.observerModeOff.isEnabled = !isChecked
-            binding.observerModeOn.isEnabled = !isChecked
+            binding.observerModeCheckbox.isEnabled = !isChecked
 
             // Toggle observer mode off only if Amazon is checked
             if (isChecked) {
-                binding.observerModeOff.isChecked = true
+                binding.observerModeCheckbox.isChecked = false
             }
         }
 
@@ -90,7 +88,7 @@ class ConfigureFragment : Fragment() {
         val verificationModeIndex = binding.verificationOptionsInput.selectedItemPosition
         val entitlementVerificationMode = EntitlementVerificationMode.values()[verificationModeIndex]
         val useAmazonStore = binding.storeRadioGroup.checkedRadioButtonId == R.id.amazon_store_radio_id
-        val useObserverMode = binding.observerModeRadioGroup.checkedRadioButtonId == R.id.observer_mode_on
+        val useObserverMode = binding.observerModeCheckbox.isChecked
 
         val application = (requireActivity().application as MainApplication)
 
@@ -110,7 +108,7 @@ class ConfigureFragment : Fragment() {
         Purchases.configure(configuration)
 
         if (useObserverMode) {
-            ObserverModeBillingClient.start(application)
+            ObserverModeBillingClient.start(application, application.logHandler)
         }
 
         // set attributes to store additional, structured information for a user in RevenueCat.

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -69,6 +69,18 @@ class ConfigureFragment : Fragment() {
             navigateToLogsFragment()
         }
 
+        binding.amazonStoreRadioId.setOnCheckedChangeListener { buttonView, isChecked ->
+            // Disable observer mode options if Amazon
+            binding.observerModeRadioGroup.isEnabled = !isChecked
+            binding.observerModeOff.isEnabled = !isChecked
+            binding.observerModeOn.isEnabled = !isChecked
+
+            // Toggle observer mode off only if Amazon is checked
+            if (isChecked) {
+                binding.observerModeOff.isChecked = true
+            }
+        }
+
         return binding.root
     }
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -78,6 +78,7 @@ class ConfigureFragment : Fragment() {
         val verificationModeIndex = binding.verificationOptionsInput.selectedItemPosition
         val entitlementVerificationMode = EntitlementVerificationMode.values()[verificationModeIndex]
         val useAmazonStore = binding.storeRadioGroup.checkedRadioButtonId == R.id.amazon_store_radio_id
+        val useObserverMode = binding.observerModeRadioGroup.checkedRadioButtonId == R.id.observer_mode_on
 
         val application = (requireActivity().application as MainApplication)
 
@@ -92,8 +93,13 @@ class ConfigureFragment : Fragment() {
         val configuration = configurationBuilder
             .diagnosticsEnabled(true)
             .entitlementVerificationMode(entitlementVerificationMode)
+            .observerMode(useObserverMode)
             .build()
         Purchases.configure(configuration)
+
+        if (useObserverMode) {
+            ObserverModeBillingClient.start(application)
+        }
 
         // set attributes to store additional, structured information for a user in RevenueCat.
         // More info: https://docs.revenuecat.com/docs/user-attributes

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ObserverModeBillingClient.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ObserverModeBillingClient.kt
@@ -1,0 +1,59 @@
+package com.revenuecat.purchasetester
+
+import android.app.Activity
+import android.content.Context
+import com.android.billingclient.api.AcknowledgePurchaseParams
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClientStateListener
+import com.android.billingclient.api.BillingFlowParams
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.PurchasesUpdatedListener
+import com.revenuecat.purchases.Purchases
+
+class ObserverModeBillingClient {
+    companion object : PurchasesUpdatedListener, BillingClientStateListener {
+        private lateinit var billingClient: BillingClient
+
+        fun start(context: Context) {
+            billingClient = BillingClient.newBuilder(context)
+                .setListener(this)
+                .enablePendingPurchases()
+                .build()
+            billingClient.startConnection(this)
+        }
+
+        fun purchase(activity: Activity, productDetails: ProductDetails, offerToken: String?, isOfferPersonalized: Boolean = false) {
+            val flowParams = BillingFlowParams.newBuilder()
+                .setProductDetailsParamsList(
+                    listOf(
+                        BillingFlowParams.ProductDetailsParams.newBuilder()
+                            .setProductDetails(productDetails)
+                            .also { params ->
+                                offerToken?.let {
+                                    params.setOfferToken(it)
+                                }
+                            }
+                            .build()
+                    )
+                )
+                .setIsOfferPersonalized(isOfferPersonalized)
+                .build()
+            billingClient.launchBillingFlow(activity, flowParams)
+        }
+
+        override fun onBillingSetupFinished(billingResult: BillingResult) {
+
+        }
+        override fun onBillingServiceDisconnected() {
+
+        }
+
+        override fun onPurchasesUpdated(billingResult: BillingResult, purchases: MutableList<Purchase>?) {
+            if (billingResult.responseCode == BillingClient.BillingResponseCode.OK && purchases != null) {
+                Purchases.sharedInstance.syncPurchases()
+            }
+        }
+    }
+}

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ObserverModeBillingClient.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ObserverModeBillingClient.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchasetester
 
 import android.app.Activity
 import android.content.Context
-import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingFlowParams
@@ -12,48 +11,51 @@ import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.revenuecat.purchases.Purchases
 
-class ObserverModeBillingClient {
-    companion object : PurchasesUpdatedListener, BillingClientStateListener {
-        private lateinit var billingClient: BillingClient
+object ObserverModeBillingClient : PurchasesUpdatedListener, BillingClientStateListener {
+    private lateinit var billingClient: BillingClient
 
-        fun start(context: Context) {
-            billingClient = BillingClient.newBuilder(context)
-                .setListener(this)
-                .enablePendingPurchases()
-                .build()
-            billingClient.startConnection(this)
-        }
+    fun start(context: Context) {
+        billingClient = BillingClient.newBuilder(context)
+            .setListener(this)
+            .enablePendingPurchases()
+            .build()
+        billingClient.startConnection(this)
+    }
 
-        fun purchase(activity: Activity, productDetails: ProductDetails, offerToken: String?, isOfferPersonalized: Boolean = false) {
-            val flowParams = BillingFlowParams.newBuilder()
-                .setProductDetailsParamsList(
-                    listOf(
-                        BillingFlowParams.ProductDetailsParams.newBuilder()
-                            .setProductDetails(productDetails)
-                            .also { params ->
-                                offerToken?.let {
-                                    params.setOfferToken(it)
-                                }
+    fun purchase(
+        activity: Activity,
+        productDetails: ProductDetails,
+        offerToken: String?,
+        isOfferPersonalized: Boolean = false
+    ) {
+        val flowParams = BillingFlowParams.newBuilder()
+            .setProductDetailsParamsList(
+                listOf(
+                    BillingFlowParams.ProductDetailsParams.newBuilder()
+                        .setProductDetails(productDetails)
+                        .also { params ->
+                            offerToken?.let {
+                                params.setOfferToken(it)
                             }
-                            .build()
-                    )
+                        }
+                        .build()
                 )
-                .setIsOfferPersonalized(isOfferPersonalized)
-                .build()
-            billingClient.launchBillingFlow(activity, flowParams)
-        }
+            )
+            .setIsOfferPersonalized(isOfferPersonalized)
+            .build()
+        billingClient.launchBillingFlow(activity, flowParams)
+    }
 
-        override fun onBillingSetupFinished(billingResult: BillingResult) {
+    override fun onBillingSetupFinished(billingResult: BillingResult) {
+        print("onBillingSetupFinished")
+    }
+    override fun onBillingServiceDisconnected() {
+        print("onBillingServiceDisconnected")
+    }
 
-        }
-        override fun onBillingServiceDisconnected() {
-
-        }
-
-        override fun onPurchasesUpdated(billingResult: BillingResult, purchases: MutableList<Purchase>?) {
-            if (billingResult.responseCode == BillingClient.BillingResponseCode.OK && purchases != null) {
-                Purchases.sharedInstance.syncPurchases()
-            }
+    override fun onPurchasesUpdated(billingResult: BillingResult, purchases: MutableList<Purchase>?) {
+        if (billingResult.responseCode == BillingClient.BillingResponseCode.OK && purchases != null) {
+            Purchases.sharedInstance.syncPurchases()
         }
     }
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ObserverModeBillingClient.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ObserverModeBillingClient.kt
@@ -13,13 +13,16 @@ import com.revenuecat.purchases.Purchases
 
 object ObserverModeBillingClient : PurchasesUpdatedListener, BillingClientStateListener {
     private lateinit var billingClient: BillingClient
+    private lateinit var testerLogHandler: TesterLogHandler
 
-    fun start(context: Context) {
+    fun start(context: Context, testerLogHandler: TesterLogHandler) {
         billingClient = BillingClient.newBuilder(context)
             .setListener(this)
             .enablePendingPurchases()
             .build()
         billingClient.startConnection(this)
+
+        this.testerLogHandler = testerLogHandler
     }
 
     fun purchase(
@@ -47,13 +50,17 @@ object ObserverModeBillingClient : PurchasesUpdatedListener, BillingClientStateL
     }
 
     override fun onBillingSetupFinished(billingResult: BillingResult) {
-        print("onBillingSetupFinished")
+        testerLogHandler.d("[ObserverModeBillingClient]", "Called onBillingSetupFinished")
     }
     override fun onBillingServiceDisconnected() {
-        print("onBillingServiceDisconnected")
+        testerLogHandler.d("[ObserverModeBillingClient]", "Called onBillingServiceDisconnected")
     }
 
     override fun onPurchasesUpdated(billingResult: BillingResult, purchases: MutableList<Purchase>?) {
+        testerLogHandler.d(
+            "[ObserverModeBillingClient]",
+            "Called onPurchasesUpdated with status ${billingResult.responseCode}"
+        )
         if (billingResult.responseCode == BillingClient.BillingResponseCode.OK && purchases != null) {
             Purchases.sharedInstance.syncPurchases()
         }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -114,7 +114,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         if (Purchases.sharedInstance.finishTransactions) {
             startPurchase(isUpgrade, PurchaseParams.Builder(requireActivity(), currentPackage))
         } else {
-            startObservableModePurchase(currentPackage.product.purchasingData)
+            startObserverModePurchase(currentPackage.product.purchasingData)
         }
     }
 
@@ -126,7 +126,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         if (Purchases.sharedInstance.finishTransactions) {
             startPurchase(isUpgrade, PurchaseParams.Builder(requireActivity(), currentProduct))
         } else {
-            startObservableModePurchase(currentProduct.purchasingData)
+            startObserverModePurchase(currentProduct.purchasingData)
         }
     }
 
@@ -138,7 +138,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         if (Purchases.sharedInstance.finishTransactions) {
             startPurchase(isUpgrade, PurchaseParams.Builder(requireActivity(), subscriptionOption))
         } else {
-            startObservableModePurchase(subscriptionOption.purchasingData)
+            startObserverModePurchase(subscriptionOption.purchasingData)
         }
     }
 
@@ -181,7 +181,7 @@ class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListen
         }
     }
 
-    private fun startObservableModePurchase(purchasingData: PurchasingData) {
+    private fun startObserverModePurchase(purchasingData: PurchasingData) {
         when (purchasingData) {
             is GooglePurchasingData.Subscription -> {
                 ObserverModeBillingClient.purchase(

--- a/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
@@ -134,11 +134,43 @@
         </RadioGroup>
 
         <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/observer_mode_label"
+                android:text="Observer Mode"
+                android:textSize="15sp"
+                android:layout_marginTop="20dp"
+                app:layout_constraintTop_toBottomOf="@id/store_label"
+                app:layout_constraintStart_toStartOf="parent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+
+        <RadioGroup
+                android:id="@+id/observer_mode_radio_group"
+                app:layout_constraintTop_toTopOf="@id/observer_mode_label"
+                app:layout_constraintBottom_toBottomOf="@id/observer_mode_label"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:orientation="horizontal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
+            <RadioButton
+                    android:id="@+id/observer_mode_off"
+                    android:text="Off"
+                    android:checked="true"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+            <RadioButton
+                    android:id="@+id/observer_mode_on"
+                    android:text="On"
+                    android:checked="false"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+        </RadioGroup>
+
+        <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/google_unavailable_text_view"
                 android:text="@string/google_store_is_unavailable"
                 android:textAlignment="textEnd"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/store_radio_group"
+                app:layout_constraintTop_toBottomOf="@id/observer_mode_radio_group"
                 app:layout_constraintWidth_percent="0.7"
                 android:visibility="gone"
                 tools:visibility="visible"

--- a/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
@@ -143,34 +143,21 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"/>
 
-        <RadioGroup
-                android:id="@+id/observer_mode_radio_group"
+        <CheckBox
+                android:id="@+id/observer_mode_checkbox"
                 app:layout_constraintTop_toTopOf="@id/observer_mode_label"
                 app:layout_constraintBottom_toBottomOf="@id/observer_mode_label"
                 app:layout_constraintEnd_toEndOf="parent"
                 android:orientation="horizontal"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
-            <RadioButton
-                    android:id="@+id/observer_mode_off"
-                    android:text="Off"
-                    android:checked="true"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"/>
-            <RadioButton
-                    android:id="@+id/observer_mode_on"
-                    android:text="On"
-                    android:checked="false"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"/>
-        </RadioGroup>
+                android:layout_height="wrap_content"/>
 
         <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/google_unavailable_text_view"
                 android:text="@string/google_store_is_unavailable"
                 android:textAlignment="textEnd"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/observer_mode_radio_group"
+                app:layout_constraintTop_toBottomOf="@id/observer_mode_checkbox"
                 app:layout_constraintWidth_percent="0.7"
                 android:visibility="gone"
                 tools:visibility="visible"


### PR DESCRIPTION
## Motivation

Easily test observable mode in Purchase Tester with just a click of a toggle

### Backstory

I knew nothing about how our observer mode worked and never implemented BillingClient directly. My first attempt at this was as a separate app so that I didn't need to worry about any existing app complexities 🤷‍♂️ 

Once I had that new app working, I understand how observer mode and BillingClient worked so adding this into Purchase Tester seemed much easier than I originally thought 😅 

## Description

- Adds option at configuration screen want to enable observer mode
- When enabled...
  1. Starts another instance of billing client to make purchases on
  2. Purchasing package, product, or subscription offer will purchase on new billing client instance
  3. After successful purchase, `syncPurchases()` will get called

⚠️ Only works for Google

## Demo

Explainer demo video in Slack but here is a screenshot 👇 

![Screenshot_20230324_062414](https://user-images.githubusercontent.com/401294/227509097-3bfe159a-d28a-4a8b-8446-0c86d6eaf7f0.png)

