### PR TITLE
Make personalized price checkbox

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
@@ -51,7 +51,8 @@ class PackageCardAdapter(
                 listener.onPurchasePackageClicked(
                     binding.root,
                     currentPackage,
-                    binding.isUpgradeCheckbox.isChecked
+                    binding.isUpgradeCheckbox.isChecked,
+                    binding.isPersonalizedCheckbox.isChecked
                 )
             }
 
@@ -59,7 +60,8 @@ class PackageCardAdapter(
                 listener.onPurchaseProductClicked(
                     binding.root,
                     product,
-                    binding.isUpgradeCheckbox.isChecked
+                    binding.isUpgradeCheckbox.isChecked,
+                    binding.isPersonalizedCheckbox.isChecked
                 )
             }
 
@@ -72,7 +74,8 @@ class PackageCardAdapter(
                     listener.onPurchaseSubscriptionOptionClicked(
                         binding.root,
                         subscriptionOption,
-                        binding.isUpgradeCheckbox.isChecked
+                        binding.isUpgradeCheckbox.isChecked,
+                        binding.isPersonalizedCheckbox.isChecked
                     )
                 } else {
                     showErrorMessage(errorStartingPurchase)
@@ -139,17 +142,20 @@ class PackageCardAdapter(
         fun onPurchasePackageClicked(
             cardView: View,
             currentPackage: Package,
-            isUpgrade: Boolean
+            isUpgrade: Boolean,
+            isPersonalizedPrice: Boolean,
         )
         fun onPurchaseProductClicked(
             cardView: View,
             currentProduct: StoreProduct,
-            isUpgrade: Boolean
+            isUpgrade: Boolean,
+            isPersonalizedPrice: Boolean,
         )
         fun onPurchaseSubscriptionOptionClicked(
             cardView: View,
             subscriptionOption: SubscriptionOption,
-            isUpgrade: Boolean
+            isUpgrade: Boolean,
+            isPersonalizedPrice: Boolean,
         )
     }
 }

--- a/examples/purchase-tester/src/main/res/layout/package_card.xml
+++ b/examples/purchase-tester/src/main/res/layout/package_card.xml
@@ -148,6 +148,17 @@
                     app:layout_constraintStart_toStartOf="@+id/package_buy_button"
                     app:layout_constraintEnd_toEndOf="@id/package_buy_button"
                     app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toTopOf="@+id/is_personalized_checkbox"/>
+
+            <com.google.android.material.checkbox.MaterialCheckBox
+                    android:id="@+id/is_personalized_checkbox"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text="Is personalized price?"
+                    android:enabled="@{isPlayStore}"
+                    app:layout_constraintStart_toStartOf="@+id/package_buy_button"
+                    app:layout_constraintEnd_toEndOf="@id/package_buy_button"
+                    app:layout_constraintTop_toTopOf="@id/is_upgrade_checkbox"
                     app:layout_constraintBottom_toTopOf="@+id/package_buy_button"/>
 
             <com.google.android.material.button.MaterialButton
@@ -158,7 +169,7 @@
                     android:textSize="10dp"
                     app:layout_constraintBottom_toTopOf="@+id/product_buy_button"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/is_upgrade_checkbox"
+                    app:layout_constraintTop_toBottomOf="@+id/is_personalized_checkbox"
                     app:layout_constraintStart_toStartOf="@+id/option_buy_button"/>
 
             <com.google.android.material.button.MaterialButton


### PR DESCRIPTION
The extra modal for setting isPersonalized price for each purchase was being a bit annoying.
Moved it to a checkbox.

![image](https://user-images.githubusercontent.com/273236/227571372-6cd0d28c-f9ee-42f5-865b-65082329a0d4.png)


### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids
