### PR TITLE
[BC5] Fix entitlment info to string plan identifier

### DIFF
--- a/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt
@@ -104,7 +104,7 @@ data class EntitlementInfo internal constructor(
             "expirationDate=$expirationDate, " +
             "store=$store, " +
             "productIdentifier='$productIdentifier', " +
-            "productPlanIdentifier='$productIdentifier', " +
+            "productPlanIdentifier='$productPlanIdentifier', " +
             "isSandbox=$isSandbox, " +
             "unsubscribeDetectedAt=$unsubscribeDetectedAt, " +
             "billingIssueDetectedAt=$billingIssueDetectedAt, " +


### PR DESCRIPTION
### Motivation

Noticed by @aboedo 

### Description

Make `productPlanIdentifier` in the `toString` use `productPlanIdentifier` instead of `productIdentifier` 🤦‍♂️ 
