### PR TITLE
Filter out expired purchases from queryPurchases in Amazon store

### DIFF
--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -107,7 +107,7 @@ internal class AmazonBilling constructor(
         onReceivePurchaseHistory: (List<StoreTransaction>) -> Unit,
         onReceivePurchaseHistoryError: PurchasesErrorCallback
     ) {
-        queryAmazonPurchases(
+        queryPurchases(
             filterOnlyActivePurchases = false,
             onSuccess = {
                 onReceivePurchaseHistory(it.values.toList())
@@ -263,7 +263,7 @@ internal class AmazonBilling constructor(
         onError: (PurchasesError) -> Unit
     ) {
         if (checkObserverMode()) return
-        queryAmazonPurchases(
+        queryPurchases(
             filterOnlyActivePurchases = true,
             onSuccess,
             onError
@@ -331,7 +331,7 @@ internal class AmazonBilling constructor(
         }
     }
 
-    private fun queryAmazonPurchases(
+    private fun queryPurchases(
         filterOnlyActivePurchases: Boolean,
         onSuccess: (Map<String, StoreTransaction>) -> Unit,
         onError: (PurchasesError) -> Unit
@@ -341,6 +341,9 @@ internal class AmazonBilling constructor(
                 purchaseUpdatesHandler.queryPurchases(
                     onSuccess = onSuccess@{ receipts, userData ->
                         val filteredReceipts = if (filterOnlyActivePurchases) {
+                            // This filters out expired receipts according to the current date.
+                            // Note that this is not calculating the expiration date of the purchase,
+                            // where we would use the backend requestDate as part of the calculation.
                             receipts.filter { it.cancelDate == null || it.cancelDate > dateProvider.now }
                         } else {
                             receipts

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/helpers/dummies.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/helpers/dummies.kt
@@ -34,7 +34,7 @@ fun dummyReceipt(
     productType: ProductType = ProductType.SUBSCRIPTION,
     purchaseDate: Date = Date(),
     receiptId: String = "receipt_id",
-    cancelDate: Date? = Date()
+    cancelDate: Date? = null
 ): Receipt {
     return ReceiptBuilder()
         .setReceiptId(receiptId)


### PR DESCRIPTION
### Description
SDK-2993

Until now, Amazon returned the whole purchase history with `queryPurchases`. This modifies the behavior in the Amazon store so we mimick what we do for Google, where `queryPurchases` only returns active purchases. 

To do this, we use the `cancelDate` field in Amazon purchases, whose [documentation](https://developer.amazon.com/docs/in-app-purchasing/iap-rvs-for-android-apps.html#cancel-date-and-renewal-date) is: 
![image](https://user-images.githubusercontent.com/808417/227913918-dadf9a85-dc81-427b-9c82-cc542a739b12.png)

#### TODO
- [ ] Test that changes behave as expected
