### PR TITLE
[DO NOT MERGE] Change purchase tester package name to `com.revenuecat.loadShedderIntegrationTests`

### DIFF
--- a/examples/purchase-tester/build.gradle
+++ b/examples/purchase-tester/build.gradle
@@ -18,7 +18,7 @@ android {
         dataBinding true
     }
     defaultConfig {
-        applicationId "com.revenuecat.purchases_sample"
+        applicationId "com.revenuecat.loadShedderIntegrationTests"
         minSdkVersion 21
         versionCode purchaseTesterVersionCode as Integer
         versionName purchaseTesterVersionName
@@ -43,7 +43,7 @@ android {
         }
     }
     testBuildType obtainTestBuildType()
-    namespace 'com.revenuecat.purchases_sample'
+    namespace 'com.revenuecat.loadShedderIntegrationTests'
 }
 
 def obtainTestBuildType() {

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -9,13 +9,13 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.revenuecat.loadShedderIntegrationTests.BuildConfig
+import com.revenuecat.loadShedderIntegrationTests.R
+import com.revenuecat.loadShedderIntegrationTests.databinding.FragmentConfigureBinding
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.amazon.AmazonConfiguration
-import com.revenuecat.purchases_sample.BuildConfig
-import com.revenuecat.purchases_sample.R
-import com.revenuecat.purchases_sample.databinding.FragmentConfigureBinding
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LogLevel.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LogLevel.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchasetester
 
+import com.revenuecat.loadShedderIntegrationTests.R
 import com.revenuecat.purchases.LogLevel
-import com.revenuecat.purchases_sample.R
 
 val LogLevel.colorResource: Int
     get() = when (this) {

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LoginFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LoginFragment.kt
@@ -6,10 +6,10 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import com.revenuecat.loadShedderIntegrationTests.databinding.FragmentLoginBinding
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.logInWith
 import com.revenuecat.purchases.logOutWith
-import com.revenuecat.purchases_sample.databinding.FragmentLoginBinding
 
 class LoginFragment : Fragment() {
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LogsFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/LogsFragment.kt
@@ -11,8 +11,8 @@ import androidx.navigation.ui.NavigationUI
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.revenuecat.purchases_sample.databinding.FragmentLogsBinding
-import com.revenuecat.purchases_sample.databinding.LogRowViewBinding
+import com.revenuecat.loadShedderIntegrationTests.databinding.FragmentLogsBinding
+import com.revenuecat.loadShedderIntegrationTests.databinding.LogRowViewBinding
 
 class LogsFragment : Fragment() {
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainActivity.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainActivity.kt
@@ -2,7 +2,7 @@ package com.revenuecat.purchasetester
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.revenuecat.purchases_sample.R
+import com.revenuecat.loadShedderIntegrationTests.R
 
 class MainActivity : AppCompatActivity() {
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
@@ -11,11 +11,11 @@ import android.util.Log
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.revenuecat.loadShedderIntegrationTests.BuildConfig
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
-import com.revenuecat.purchases_sample.BuildConfig
 
 class MainApplication : Application(), UpdatedCustomerInfoListener {
 
@@ -29,7 +29,6 @@ class MainApplication : Application(), UpdatedCustomerInfoListener {
                 VmPolicy.Builder()
                     .detectLeakedClosableObjects()
                     .penaltyLog()
-                    .penaltyDeath()
                     .build()
             )
         }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingCardAdapter.kt
@@ -5,8 +5,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import androidx.recyclerview.widget.RecyclerView
+import com.revenuecat.loadShedderIntegrationTests.databinding.OfferingCardBinding
 import com.revenuecat.purchases.Offering
-import com.revenuecat.purchases_sample.databinding.OfferingCardBinding
 
 class OfferingCardAdapter(
     private val offerings: List<Offering>,

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -11,6 +11,8 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.transition.MaterialContainerTransform
+import com.revenuecat.loadShedderIntegrationTests.R
+import com.revenuecat.loadShedderIntegrationTests.databinding.FragmentOfferingBinding
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.Purchases
@@ -18,8 +20,6 @@ import com.revenuecat.purchases.getCustomerInfoWith
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.purchasePackageWith
 import com.revenuecat.purchases.purchaseProductWith
-import com.revenuecat.purchases_sample.R
-import com.revenuecat.purchases_sample.databinding.FragmentOfferingBinding
 
 class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListener {
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -13,6 +13,8 @@ import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.transition.MaterialElevationScale
+import com.revenuecat.loadShedderIntegrationTests.R
+import com.revenuecat.loadShedderIntegrationTests.databinding.FragmentOverviewBinding
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Purchases
@@ -20,8 +22,6 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.getCustomerInfoWith
 import com.revenuecat.purchases.getOfferingsWith
 import com.revenuecat.purchases.logOutWith
-import com.revenuecat.purchases_sample.R
-import com.revenuecat.purchases_sample.databinding.FragmentOverviewBinding
 
 @SuppressWarnings("TooManyFunctions")
 class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterListener, OverviewInteractionHandler {

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/PackageCardAdapter.kt
@@ -4,10 +4,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.revenuecat.loadShedderIntegrationTests.databinding.PackageCardBinding
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.models.StoreProduct
-import com.revenuecat.purchases_sample.databinding.PackageCardBinding
 
 class PackageCardAdapter(
     private val packages: List<Package>,


### PR DESCRIPTION
### Description
We created a new app in the play store to run the load shedder integration tests with package name `com.revenuecat.loadShedderIntegrationTests`. In order to manually test that project, we made these changes to purchase tester. However, we don't plan to merge these changes. Once integration tests are ready, they will use this package name.

