### PR TITLE
Automate integration tests for load shedder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,36 @@ commands:
             echo $GPG_SIGNING_KEY_PW_NEW | gpg --batch --pinentry-mode=loopback --passphrase-fd 0 \
             --export-secret-keys > /home/circleci/.gnupg/secring.gpg
 
+  run-firebase-tests:
+    parameters:
+      app_apk_path:
+        type: string
+      test_apk_path:
+        type: string
+    steps:
+      - gcp-cli/initialize:
+          gcloud-service-key: GCLOUD_SERVICE_KEY
+          google-compute-zone: GOOGLE_COMPUTE_ZONE
+          google-project-id: GOOGLE_PROJECT_ID
+      - run:
+          name: Test with Firebase Test Lab
+          command: >
+            gcloud firebase test android run --type instrumentation \
+              --app <<parameters.app_apk_path>> \
+              --test <<parameters.test_apk_path>> \
+              --timeout 2m \
+              --results-bucket cloud-test-${GOOGLE_PROJECT_ID}
+      - run:
+          name: Copy test results data
+          command: |
+            mkdir -p ~/gsutil/
+            gsutil -m cp -r -U `gsutil ls gs://cloud-test-$GOOGLE_PROJECT_ID | tail -1` ~/gsutil/ | true
+          when: always
+      - store_artifacts:
+          path: ~/gsutil/
+      - store_test_results:
+          path: ~/gsutil/
+
 jobs:
 
   test:
@@ -311,13 +341,32 @@ jobs:
       - run:
           name: Create purchases integration tests apks
           command: |
-            bundle exec fastlane android build_purchases_integration_tests
+            bundle exec fastlane android build_default_purchases_integration_tests
       - android/save-build-cache
       - persist_to_workspace:
           root: .
           paths:
             - purchases/test_artifacts/integrationTest-app.apk
             - purchases/test_artifacts/integrationTest-test.apk
+
+  purchases-load-shedder-integration-tests-build:
+    <<: *android-executor
+    steps:
+      - checkout
+      - install-sdkman
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
+      - android/restore-build-cache
+      - run:
+          name: Create purchases integration tests apks
+          command: |
+            bundle exec fastlane android build_load_shedder_purchases_integration_tests
+      - android/save-build-cache
+      - persist_to_workspace:
+          root: .
+          paths:
+            - purchases/test_artifacts/loadShedderIntegrationTest-app.apk
+            - purchases/test_artifacts/loadShedderIntegrationTest-test.apk
 
   run-firebase-tests-purchases-integration-test:
     description: "Run purchases module integration tests for Android in Firebase. Variant integrationTest"
@@ -326,88 +375,42 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - gcp-cli/initialize:
-          gcloud-service-key: GCLOUD_SERVICE_KEY
-          google-compute-zone: GOOGLE_COMPUTE_ZONE
-          google-project-id: GOOGLE_PROJECT_ID
-      - run:
-          name: Test with Firebase Test Lab
-          command: >
-            gcloud firebase test android run --type instrumentation \
-              --app purchases/test_artifacts/integrationTest-app.apk \
-              --test purchases/test_artifacts/integrationTest-test.apk \
-              --timeout 2m \
-              --results-bucket cloud-test-${GOOGLE_PROJECT_ID}
-      - run:
-          name: Copy test results data
-          command: |
-            mkdir -p ~/gsutil/
-            gsutil -m cp -r -U `gsutil ls gs://cloud-test-$GOOGLE_PROJECT_ID | tail -1` ~/gsutil/ | true
-          when: always
-      - store_artifacts:
-          path: ~/gsutil/
-      - store_test_results:
-          path: ~/gsutil/
+      - run-firebase-tests:
+          app_apk_path: purchases/test_artifacts/integrationTest-app.apk
+          test_apk_path: purchases/test_artifacts/integrationTest-test.apk
+
+  run-firebase-tests-purchases-load-shedder-integration-test:
+    description: "Run purchases module integration tests for Android in Firebase. Variant integrationTest"
+    executor: gcp-cli/google
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run-firebase-tests:
+          app_apk_path: purchases/test_artifacts/loadShedderIntegrationTest-app.apk
+          test_apk_path: purchases/test_artifacts/loadShedderIntegrationTest-test.apk
 
   run-firebase-tests-latest-dependencies:
-    description: "Run integration tests for Android in Firebase. Variant latestDependencies"
+    description: "Run purchases module integration tests for Android in Firebase. Variant integrationTest"
     executor: gcp-cli/google
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - gcp-cli/initialize:
-          gcloud-service-key: GCLOUD_SERVICE_KEY
-          google-compute-zone: GOOGLE_COMPUTE_ZONE
-          google-project-id: GOOGLE_PROJECT_ID
-      - run:
-          name: Test with Firebase Test Lab
-          command: >
-            gcloud firebase test android run --type instrumentation \
-              --app integration-tests/build/outputs/apk/latestDependencies/release/integration-tests-latestDependencies-release.apk \
-              --test integration-tests/build/outputs/apk/androidTest/latestDependencies/release/integration-tests-latestDependencies-release-androidTest.apk \
-              --timeout 2m \
-              --results-bucket cloud-test-${GOOGLE_PROJECT_ID}
-      - run:
-          name: Copy test results data
-          command: |
-            mkdir -p ~/gsutil/
-            gsutil -m cp -r -U `gsutil ls gs://cloud-test-$GOOGLE_PROJECT_ID | tail -1` ~/gsutil/ | true
-          when: always
-      - store_artifacts:
-          path: ~/gsutil/
-      - store_test_results:
-          path: ~/gsutil/
+      - run-firebase-tests:
+          app_apk_path: integration-tests/build/outputs/apk/latestDependencies/release/integration-tests-latestDependencies-release.apk
+          test_apk_path: integration-tests/build/outputs/apk/androidTest/latestDependencies/release/integration-tests-latestDependencies-release-androidTest.apk
 
   run-firebase-tests-unityIAP:
-    description: "Run integration tests for Android in Firebase. Variant unityIAP"
+    description: "Run purchases module integration tests for Android in Firebase. Variant integrationTest"
     executor: gcp-cli/google
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - gcp-cli/initialize:
-          gcloud-service-key: GCLOUD_SERVICE_KEY
-          google-compute-zone: GOOGLE_COMPUTE_ZONE
-          google-project-id: GOOGLE_PROJECT_ID
-      - run:
-          name: Test with Firebase Test Lab
-          command: >
-            gcloud firebase test android run --type instrumentation \
-              --app integration-tests/build/outputs/apk/unityIAP/release/integration-tests-unityIAP-release.apk \
-              --test integration-tests/build/outputs/apk/androidTest/unityIAP/release/integration-tests-unityIAP-release-androidTest.apk \
-              --timeout 2m \
-              --results-bucket cloud-test-${GOOGLE_PROJECT_ID}
-      - run:
-          name: Copy test results data
-          command: |
-            mkdir -p ~/gsutil/
-            gsutil -m cp -r -U `gsutil ls gs://cloud-test-$GOOGLE_PROJECT_ID | tail -1` ~/gsutil/ | true
-          when: always
-      - store_artifacts:
-          path: ~/gsutil/
-      - store_test_results:
-          path: ~/gsutil/
+      - run-firebase-tests:
+          app_apk_path: integration-tests/build/outputs/apk/unityIAP/release/integration-tests-unityIAP-release.apk
+          test_apk_path: integration-tests/build/outputs/apk/androidTest/unityIAP/release/integration-tests-unityIAP-release-androidTest.apk
 
 workflows:
   version: 2
@@ -425,6 +428,15 @@ workflows:
     jobs:
       - test
       - assemble-sample-app
+      # Need to remove
+      - purchases-integration-tests-build
+      - purchases-load-shedder-integration-tests-build
+      - run-firebase-tests-purchases-integration-test:
+          requires:
+            - purchases-integration-tests-build
+      - run-firebase-tests-purchases-load-shedder-integration-test:
+          requires:
+            - purchases-load-shedder-integration-tests-build
 
   deploy:
     when:
@@ -433,9 +445,13 @@ workflows:
     jobs:
       - integration-tests-build: *release-branches
       - purchases-integration-tests-build: *release-branches
+      - purchases-load-shedder-integration-tests-build: *release-branches
       - run-firebase-tests-purchases-integration-test:
           requires:
             - purchases-integration-tests-build
+      - run-firebase-tests-purchases-load-shedder-integration-test:
+          requires:
+            - purchases-load-shedder-integration-tests-build
       - run-firebase-tests-latest-dependencies:
           requires:
             - integration-tests-build
@@ -446,6 +462,7 @@ workflows:
           type: approval
           requires:
             - run-firebase-tests-purchases-integration-test
+            - run-firebase-tests-purchases-load-shedder-integration-test
             - run-firebase-tests-latest-dependencies
             - run-firebase-tests-unityIAP
           <<: *release-branches
@@ -468,6 +485,17 @@ workflows:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - prepare-next-version: *only-main-branch
+
+  daily-load-shedder-integration-tests:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "load-shedder-integration-tests", << pipeline.schedule.name >> ]
+    jobs:
+      - purchases-load-shedder-integration-tests-build
+      - run-firebase-tests-purchases-load-shedder-integration-test:
+          requires:
+            - purchases-load-shedder-integration-tests-build
 
   weekly-run-workflow:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,15 +428,6 @@ workflows:
     jobs:
       - test
       - assemble-sample-app
-      # Need to remove
-      - purchases-integration-tests-build
-      - purchases-load-shedder-integration-tests-build
-      - run-firebase-tests-purchases-integration-test:
-          requires:
-            - purchases-integration-tests-build
-      - run-firebase-tests-purchases-load-shedder-integration-test:
-          requires:
-            - purchases-load-shedder-integration-tests-build
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,6 +428,15 @@ workflows:
     jobs:
       - test
       - assemble-sample-app
+      # Need to remove
+      - purchases-integration-tests-build
+      - purchases-load-shedder-integration-tests-build
+      - run-firebase-tests-purchases-integration-test:
+          requires:
+            - purchases-integration-tests-build
+      - run-firebase-tests-purchases-load-shedder-integration-test:
+          requires:
+            - purchases-load-shedder-integration-tests-build
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,7 +391,7 @@ jobs:
           test_apk_path: purchases/test_artifacts/loadShedderIntegrationTest-test.apk
 
   run-firebase-tests-latest-dependencies:
-    description: "Run purchases module integration tests for Android in Firebase. Variant latestDependencies"
+    description: "Run integration tests for Android in Firebase. Variant latestDependencies"
     executor: gcp-cli/google
     steps:
       - checkout
@@ -402,7 +402,7 @@ jobs:
           test_apk_path: integration-tests/build/outputs/apk/androidTest/latestDependencies/release/integration-tests-latestDependencies-release-androidTest.apk
 
   run-firebase-tests-unityIAP:
-    description: "Run purchases module integration tests for Android in Firebase. Variant unityIAP"
+    description: "Run integration tests for Android in Firebase. Variant unityIAP"
     executor: gcp-cli/google
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,7 +380,7 @@ jobs:
           test_apk_path: purchases/test_artifacts/integrationTest-test.apk
 
   run-firebase-tests-purchases-load-shedder-integration-test:
-    description: "Run purchases module integration tests for Android in Firebase. Variant integrationTest"
+    description: "Run purchases module integration tests for Android in Firebase using the load shedder servers. Variant integrationTest"
     executor: gcp-cli/google
     steps:
       - checkout
@@ -391,7 +391,7 @@ jobs:
           test_apk_path: purchases/test_artifacts/loadShedderIntegrationTest-test.apk
 
   run-firebase-tests-latest-dependencies:
-    description: "Run purchases module integration tests for Android in Firebase. Variant integrationTest"
+    description: "Run purchases module integration tests for Android in Firebase. Variant latestDependencies"
     executor: gcp-cli/google
     steps:
       - checkout
@@ -402,7 +402,7 @@ jobs:
           test_apk_path: integration-tests/build/outputs/apk/androidTest/latestDependencies/release/integration-tests-latestDependencies-release-androidTest.apk
 
   run-firebase-tests-unityIAP:
-    description: "Run purchases module integration tests for Android in Firebase. Variant integrationTest"
+    description: "Run purchases module integration tests for Android in Firebase. Variant unityIAP"
     executor: gcp-cli/google
     steps:
       - checkout

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -161,24 +161,42 @@ platform :android do
     )
   end
 
-  desc "Build purchases module integration tests"
-  lane :build_purchases_integration_tests do |options|
+  desc "Build purchases module integration tests pointing to production"
+  lane :build_default_purchases_integration_tests do |options|
+    build_purchases_integration_tests(
+        app_name: 'integrationTest',
+        api_key: ENV['REVENUECAT_API_KEY'],
+        google_purchase_token: ENV['GOOGLE_PURCHASE_TOKEN'],
+        product_id_to_purchase: ENV['PRODUCT_ID_TO_PURCHASE']
+    )
+  end
+
+  desc "Build purchases module integration tests pointing to load shedder"
+  lane :build_load_shedder_purchases_integration_tests do |options|
+    build_purchases_integration_tests(
+        app_name: 'loadShedderIntegrationTest',
+        api_key: ENV['LOAD_SHEDDER_REVENUECAT_API_KEY'],
+        google_purchase_token: ENV['LOAD_SHEDDER_GOOGLE_PURCHASE_TOKEN'],
+        product_id_to_purchase: ENV['LOAD_SHEDDER_PRODUCT_ID_TO_PURCHASE']
+    )
+  end
+
+  def build_purchases_integration_tests(app_name:, api_key:, google_purchase_token:, product_id_to_purchase:,
+                                        proxy_url: nil, build_type: 'release')
     constants_path = './purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/Constants.kt'
-    proxy_url = options[:proxy_url]
-    build_type = options[:build_type] || "release"
     replace_text_in_files(
       previous_text: "REVENUECAT_API_KEY",
-      new_text: ENV["REVENUECAT_API_KEY"],
+      new_text: api_key,
       paths_of_files_to_update: [constants_path]
     )
     replace_text_in_files(
       previous_text: "GOOGLE_PURCHASE_TOKEN",
-      new_text: ENV["GOOGLE_PURCHASE_TOKEN"],
+      new_text: google_purchase_token,
       paths_of_files_to_update: [constants_path]
     )
     replace_text_in_files(
       previous_text: "PRODUCT_ID_TO_PURCHASE",
-      new_text: ENV["PRODUCT_ID_TO_PURCHASE"],
+      new_text: product_id_to_purchase,
       paths_of_files_to_update: [constants_path]
     )
     unless proxy_url.nil?
@@ -193,10 +211,10 @@ platform :android do
     # to have same package name
 
     # Build test apk
-    build_purchases_android_test_apk("com.revenuecat.purchases.integrationtests.test", "integrationTest-app", build_type)
+    build_purchases_android_test_apk("com.revenuecat.purchases.integrationtests.test", "#{app_name}-app", build_type)
 
     # Build app apk
-    build_purchases_android_test_apk("com.revenuecat.purchases.integrationtests", "integrationTest-test", build_type)
+    build_purchases_android_test_apk("com.revenuecat.purchases.integrationtests", "#{app_name}-test", build_type)
   end
 
   desc "Publish purchase tester to test track in Play Console"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -87,13 +87,21 @@ Tag current branch with current version number
 
 Build purchase tester app bundle
 
-### android build_purchases_integration_tests
+### android build_default_purchases_integration_tests
 
 ```sh
-[bundle exec] fastlane android build_purchases_integration_tests
+[bundle exec] fastlane android build_default_purchases_integration_tests
 ```
 
-Build purchases module integration tests
+Build purchases module integration tests pointing to production
+
+### android build_load_shedder_purchases_integration_tests
+
+```sh
+[bundle exec] fastlane android build_load_shedder_purchases_integration_tests
+```
+
+Build purchases module integration tests pointing to load shedder
 
 ### android publish_purchase_tester
 

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
@@ -150,7 +150,7 @@ class PurchasesIntegrationTest {
                 onSuccess = { offerings ->
                     assertThat(offerings.current).isNotNull
                     assertThat(offerings.current?.availablePackages?.size).isEqualTo(1)
-                    assertThat(offerings.current?.monthly?.product?.sku).isEqualTo("monthly_intro_pricing_one_week")
+                    assertThat(offerings.current?.monthly?.product?.sku).isEqualTo(Constants.productIdToPurchase)
 
                     lock.countDown()
                 }


### PR DESCRIPTION
### Description
First part of SDK-3005

This PR adds some automation to be able to run the integration tests against the load shedder servers. Note that this will run it only for the running branch.

#### TODO
- [x] Retry offerings test, failing because of outdated cached offerings response
- [ ] Run tests against other SDK versions
- [ ] Run extra tests against the load shedder, like making sure that the entitlements are granted. 

Will work on those on different PRs