### PR TITLE
Refactors BillingAbstract to not depend on Backend

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/BackendHelper.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/BackendHelper.kt
@@ -1,0 +1,63 @@
+package com.revenuecat.purchases.common
+
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import org.json.JSONObject
+
+class BackendHelper(
+    private val apiKey: String,
+    private val dispatcher: Dispatcher,
+    private val appConfig: AppConfig,
+    private val httpClient: HTTPClient
+) {
+    internal val authenticationHeaders = mapOf("Authorization" to "Bearer ${this.apiKey}")
+
+    fun performRequest(
+        endpoint: Endpoint,
+        body: Map<String, Any?>?,
+        onError: (PurchasesError) -> Unit,
+        onCompleted: (PurchasesError?, Int, JSONObject) -> Unit
+    ) {
+        enqueue(object : Dispatcher.AsyncCall() {
+            override fun call(): HTTPResult {
+                return httpClient.performRequest(
+                    appConfig.baseURL,
+                    endpoint,
+                    body,
+                    authenticationHeaders
+                )
+            }
+
+            override fun onError(error: PurchasesError) {
+                onError(error)
+            }
+
+            override fun onCompletion(result: HTTPResult) {
+                val error = if (!result.isSuccessful()) {
+                    result.toPurchasesError().also { errorLog(it) }
+                } else {
+                    null
+                }
+                onCompleted(error, result.responseCode, result.body)
+            }
+        }, dispatcher)
+    }
+
+    fun enqueue(
+        call: Dispatcher.AsyncCall,
+        dispatcher: Dispatcher,
+        delay: Delay = Delay.NONE
+    ) {
+        if (dispatcher.isClosed()) {
+            errorLog("Enqueuing operation in closed dispatcher.")
+        } else {
+            dispatcher.enqueue(call, delay)
+        }
+    }
+}
+
+fun HTTPResult.isSuccessful(): Boolean {
+    return responseCode < RCHTTPStatusCodes.UNSUCCESSFUL
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -37,7 +37,7 @@ import java.util.Date
 import kotlin.time.Duration
 
 class HTTPClient(
-    val appConfig: AppConfig,
+    private val appConfig: AppConfig,
     private val eTagManager: ETagManager,
     private val diagnosticsTrackerIfEnabled: DiagnosticsTracker?,
     val signingManager: SigningManager,

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -37,7 +37,7 @@ import java.util.Date
 import kotlin.time.Duration
 
 class HTTPClient(
-    private val appConfig: AppConfig,
+    val appConfig: AppConfig,
     private val eTagManager: ETagManager,
     private val diagnosticsTrackerIfEnabled: DiagnosticsTracker?,
     val signingManager: SigningManager,

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -65,16 +65,27 @@ class BackendTest {
         every { diagnosticsURL } returns mockDiagnosticsBaseURL
     }
     private val dispatcher = SyncDispatcher()
+    private val backendHelper = BackendHelper(API_KEY, dispatcher, mockAppConfig, mockClient)
     private var backend: Backend = Backend(
-        API_KEY,
         mockAppConfig,
         dispatcher,
         dispatcher,
-        mockClient
+        mockClient,
+        backendHelper
     )
+    private val asyncDispatcher = Dispatcher(
+        ThreadPoolExecutor(
+            1,
+            2,
+            0,
+            TimeUnit.MILLISECONDS,
+            LinkedBlockingQueue()
+        )
+    )
+    private var asyncBackendHelper: BackendHelper = BackendHelper(API_KEY, asyncDispatcher, mockAppConfig, mockClient)
     private var asyncBackend: Backend = Backend(
-        API_KEY,
         mockAppConfig,
+        asyncDispatcher,
         Dispatcher(
             ThreadPoolExecutor(
                 1,
@@ -84,16 +95,8 @@ class BackendTest {
                 LinkedBlockingQueue()
             )
         ),
-        Dispatcher(
-            ThreadPoolExecutor(
-                1,
-                2,
-                0,
-                TimeUnit.MILLISECONDS,
-                LinkedBlockingQueue()
-            )
-        ),
-        mockClient
+        mockClient,
+        asyncBackendHelper
     )
     private val appUserID = "jerry"
     private val defaultTimeout = 200L

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBackend.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBackend.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases.amazon
 
 import com.revenuecat.purchases.PurchasesError
-import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.networking.Endpoint
 import org.json.JSONObject
 
@@ -11,7 +11,7 @@ typealias PostAmazonReceiptCallback = Pair<(response: JSONObject) -> Unit, (Purc
 typealias CallbackCacheKey = List<String>
 
 class AmazonBackend(
-    private val backend: Backend
+    private val backendHelper: BackendHelper
 ) {
 
     @get:Synchronized @set:Synchronized
@@ -29,7 +29,7 @@ class AmazonBackend(
         )
 
         val call = {
-            backend.performRequest(
+            backendHelper.performRequest(
                 Endpoint.GetAmazonReceipt(storeUserID, receiptId),
                 null,
                 { error ->

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -23,7 +23,7 @@ import com.revenuecat.purchases.amazon.listener.ProductDataResponseListener
 import com.revenuecat.purchases.amazon.listener.PurchaseResponseListener
 import com.revenuecat.purchases.amazon.listener.PurchaseUpdatesResponseListener
 import com.revenuecat.purchases.amazon.listener.UserDataResponseListener
-import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.ReplaceSkuInfo
@@ -70,11 +70,11 @@ internal class AmazonBilling constructor(
     @Suppress("unused")
     constructor(
         applicationContext: Context,
-        backend: Backend,
         cache: DeviceCache,
         observerMode: Boolean,
-        mainHandler: Handler
-    ) : this(applicationContext, AmazonBackend(backend), AmazonCache(cache), observerMode, mainHandler)
+        mainHandler: Handler,
+        backendHelper: BackendHelper
+    ) : this(applicationContext, AmazonBackend(backendHelper), AmazonCache(cache), observerMode, mainHandler)
 
     var connected = false
 

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
@@ -6,17 +6,21 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.amazon.helpers.successfulRVSResponse
 import com.revenuecat.purchases.common.AppConfig
-import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BackendHelper
+import com.revenuecat.purchases.common.CustomerInfoFactory
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.utils.SyncDispatcher
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.unmockkObject
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
@@ -27,17 +31,36 @@ private const val API_KEY = "TEST_API_KEY"
 @RunWith(AndroidJUnit4::class)
 class AmazonBackendTest {
 
-    private var mockClient = mockk<HTTPClient>()
-    private val mockBaseURL = URL("http://mock-api-test.revenuecat.com/")
-    private val mockAppConfig = mockk<AppConfig>().apply {
-        every { baseURL } returns mockBaseURL
-    }
-    private val dispatcher = SyncDispatcher()
+    private lateinit var mockClient: HTTPClient
+    private lateinit var mockAppConfig: AppConfig
+    private lateinit var dispatcher: SyncDispatcher
+    private lateinit var backendHelper: BackendHelper
 
-    private val backendHelper = BackendHelper(API_KEY, dispatcher, mockAppConfig, mockClient)
+    private val baseURL = URL("http://mock-api-test.revenuecat.com/")
 
     private var receivedOnSuccess: JSONObject? = null
     private var receivedError: PurchasesError? = null
+    private lateinit var underTest: AmazonBackend
+
+    @Before
+    fun setup() {
+        mockClient = mockk()
+        mockAppConfig = mockk<AppConfig>().apply {
+            every { baseURL } returns this@AmazonBackendTest.baseURL
+        }
+        dispatcher = SyncDispatcher()
+        backendHelper = BackendHelper(API_KEY, dispatcher, mockAppConfig, mockClient)
+        receivedOnSuccess = null
+        receivedError = null
+        underTest = AmazonBackend(backendHelper)
+    }
+
+    @After
+    fun tearDown() {
+        receivedOnSuccess = null
+        receivedError = null
+        clearAllMocks()
+    }
 
     private val expectedOnSuccess: (JSONObject) -> Unit = {
         receivedOnSuccess = it
@@ -54,8 +77,6 @@ class AmazonBackendTest {
     private val unexpectedOnError: (PurchasesError) -> Unit = { _ ->
         Assertions.fail("Shouldn't be error.")
     }
-
-    private var underTest = AmazonBackend(backendHelper)
 
     private var successfulResult = HTTPResult(
         responseCode = 200,
@@ -81,7 +102,7 @@ class AmazonBackendTest {
     fun `When getting Amazon receipt data is successful, onSuccess is called`() {
         every {
             mockClient.performRequest(
-                baseURL = mockBaseURL,
+                baseURL = baseURL,
                 endpoint = Endpoint.GetAmazonReceipt("store_user_id", "receipt_id"),
                 body = null,
                 requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
@@ -102,7 +123,7 @@ class AmazonBackendTest {
     fun `when Amazon receipt data call returns an error, errors are passed along`() {
         every {
             mockClient.performRequest(
-                baseURL = mockBaseURL,
+                baseURL = baseURL,
                 endpoint = Endpoint.GetAmazonReceipt("store_user_id", "receipt_id"),
                 body = null,
                 requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
@@ -124,7 +145,7 @@ class AmazonBackendTest {
     fun `when Amazon receipt data call fails, errors are passed along`() {
         every {
             mockClient.performRequest(
-                baseURL = mockBaseURL,
+                baseURL = baseURL,
                 endpoint = Endpoint.GetAmazonReceipt("store_user_id", "receipt_id"),
                 body = null,
                 requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.amazon.helpers.successfulRVSResponse
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
@@ -33,13 +34,7 @@ class AmazonBackendTest {
     }
     private val dispatcher = SyncDispatcher()
 
-    private var backend: Backend = Backend(
-        API_KEY,
-        mockAppConfig,
-        dispatcher,
-        dispatcher,
-        mockClient
-    )
+    private val backendHelper = BackendHelper(API_KEY, dispatcher, mockAppConfig, mockClient)
 
     private var receivedOnSuccess: JSONObject? = null
     private var receivedError: PurchasesError? = null
@@ -60,7 +55,7 @@ class AmazonBackendTest {
         Assertions.fail("Shouldn't be error.")
     }
 
-    private var underTest = AmazonBackend(backend)
+    private var underTest = AmazonBackend(backendHelper)
 
     private var successfulResult = HTTPResult(
         responseCode = 200,

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.BillingFactory
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import io.mockk.mockk
@@ -17,14 +18,14 @@ class BillingFactoryAmazonTest {
     @Test
     fun `AmazonBilling can be created`() {
         val mockApplication = mockk<Application>(relaxed = true)
-        val mockBackend = mockk<Backend>(relaxed = true)
+        val mockBackendHelper = mockk<BackendHelper>(relaxed = true)
         val mockCache = mockk<DeviceCache>(relaxed = true)
         val mockDiagnosticsTracker = mockk<DiagnosticsTracker>(relaxed = true)
 
         BillingFactory.createBilling(
             Store.AMAZON,
             mockApplication,
-            mockBackend,
+            mockBackendHelper,
             mockCache,
             observerMode = false,
             mockDiagnosticsTracker
@@ -34,13 +35,13 @@ class BillingFactoryAmazonTest {
     @Test
     fun `AmazonBilling can be created without diagnostics tracker`() {
         val mockApplication = mockk<Application>(relaxed = true)
-        val mockBackend = mockk<Backend>(relaxed = true)
+        val mockBackendHelper = mockk<BackendHelper>(relaxed = true)
         val mockCache = mockk<DeviceCache>(relaxed = true)
 
         BillingFactory.createBilling(
             Store.AMAZON,
             mockApplication,
-            mockBackend,
+            mockBackendHelper,
             mockCache,
             observerMode = false,
             diagnosticsTrackerIfEnabled = null

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesPoster.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesPoster.kt
@@ -2,13 +2,13 @@ package com.revenuecat.purchases.subscriberattributes
 
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
-import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.SubscriberAttributeError
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 
 class SubscriberAttributesPoster(
-    private val backend: Backend
+    private val backendHelper: BackendHelper
 ) {
 
     fun postSubscriberAttributes(
@@ -21,7 +21,7 @@ class SubscriberAttributesPoster(
             attributeErrors: List<SubscriberAttributeError>
         ) -> Unit
     ) {
-        backend.performRequest(
+        backendHelper.performRequest(
             Endpoint.PostAttributes(appUserID),
             mapOf("attributes" to attributes),
             { error ->

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.CustomerInfoFactory
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.ReceiptInfo
@@ -41,14 +42,20 @@ class SubscriberAttributesPosterTests {
     }
     private val appUserID = "jerry"
     private val dispatcher = SyncDispatcher()
-    private var backend: Backend = Backend(
+    private var backendHelper = BackendHelper(
         API_KEY,
+        dispatcher,
+        mockAppConfig,
+        mockClient
+    )
+    private var backend: Backend = Backend(
         mockAppConfig,
         dispatcher,
         dispatcher,
-        mockClient
+        mockClient,
+        backendHelper
     )
-    private var subscriberAttributesPoster = SubscriberAttributesPoster(backend)
+    private var subscriberAttributesPoster = SubscriberAttributesPoster(backendHelper)
 
     private var receivedError: PurchasesError? = null
     private var receivedSyncedSuccessfully: Boolean? = null

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -10,6 +10,7 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
     signingConfigs {
         release {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import android.content.Context
 import android.os.Handler
 import androidx.annotation.VisibleForTesting
-import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
@@ -18,7 +18,7 @@ object BillingFactory {
     fun createBilling(
         store: Store,
         application: Application,
-        backend: Backend,
+        backendHelper: BackendHelper,
         cache: DeviceCache,
         observerMode: Boolean,
         diagnosticsTrackerIfEnabled: DiagnosticsTracker?
@@ -34,16 +34,16 @@ object BillingFactory {
                 Class.forName("com.revenuecat.purchases.amazon.AmazonBilling")
                     .getConstructor(
                         Context::class.java,
-                        Backend::class.java,
                         DeviceCache::class.java,
                         Boolean::class.java,
-                        Handler::class.java
+                        Handler::class.java,
+                        BackendHelper::class.java
                     ).newInstance(
                         application.applicationContext,
-                        backend,
                         cache,
                         observerMode,
-                        Handler(application.mainLooper)
+                        Handler(application.mainLooper),
+                        backendHelper
                     ) as BillingAbstract
             } catch (e: ClassNotFoundException) {
                 errorLog("Make sure purchases-amazon is added as dependency", e)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -9,6 +9,7 @@ import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.common.Anonymizer
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.FileHelper
@@ -81,26 +82,29 @@ internal class PurchasesFactory(
             val signatureVerificationMode = SignatureVerificationMode.Disabled
             val signingManager = SigningManager(signatureVerificationMode)
 
+            val httpClient = HTTPClient(appConfig, eTagManager, diagnosticsTracker, signingManager)
+            val backendHelper = BackendHelper(apiKey, dispatcher, appConfig, httpClient)
             val backend = Backend(
-                apiKey,
                 appConfig,
                 dispatcher,
                 diagnosticsDispatcher,
-                HTTPClient(appConfig, eTagManager, diagnosticsTracker, signingManager)
+                httpClient,
+                backendHelper
             )
-            val subscriberAttributesPoster = SubscriberAttributesPoster(backend)
-
             val cache = DeviceCache(prefs, apiKey)
 
             // Override used for integration tests.
             val billing: BillingAbstract = overrideBillingAbstract ?: BillingFactory.createBilling(
                 store,
                 application,
-                backend,
+                backendHelper,
                 cache,
                 observerMode,
                 diagnosticsTracker
             )
+
+            val subscriberAttributesPoster = SubscriberAttributesPoster(backendHelper)
+
             val attributionFetcher = AttributionFetcherFactory.createAttributionFetcher(store, dispatcher)
 
             val subscriberAttributesCache = SubscriberAttributesCache(cache)

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases
 import android.app.Application
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import io.mockk.mockk
@@ -15,14 +16,14 @@ class BillingFactoryTest {
     @Test
     fun `BillingWrapper can be created`() {
         val mockApplication = mockk<Application>(relaxed = true)
-        val mockBackend = mockk<Backend>(relaxed = true)
+        val mockBackendHelper = mockk<BackendHelper>(relaxed = true)
         val mockCache = mockk<DeviceCache>(relaxed = true)
         val mockDiagnosticsTracker = mockk<DiagnosticsTracker>(relaxed = true)
 
         BillingFactory.createBilling(
             Store.PLAY_STORE,
             mockApplication,
-            mockBackend,
+            mockBackendHelper,
             mockCache,
             observerMode = false,
             mockDiagnosticsTracker
@@ -32,13 +33,13 @@ class BillingFactoryTest {
     @Test
     fun `BillingWrapper can be created without diagnostics tracker`() {
         val mockApplication = mockk<Application>(relaxed = true)
-        val mockBackend = mockk<Backend>(relaxed = true)
+        val mockBackendHelper = mockk<BackendHelper>(relaxed = true)
         val mockCache = mockk<DeviceCache>(relaxed = true)
 
         BillingFactory.createBilling(
             Store.PLAY_STORE,
             mockApplication,
-            mockBackend,
+            mockBackendHelper,
             mockCache,
             observerMode = false,
             diagnosticsTrackerIfEnabled = null


### PR DESCRIPTION
When working on https://github.com/RevenueCat/purchases-android/pull/885 I had to refactor the AmazonBackend to not depend on Backend. 

The reason is that I was adding a dependency to `CustomerInfoResponseHandler(billing)` on Backend, which was creating a circular dependency between `BillingAbstract` and `Backend`.

I noticed the only reason why `BillingAbstract` had a dependency on `Backend` was for `AmazonBackend` to make some calls to the backend. So I removed that dependency in `BillingAbstract` by creating a new `BackendHelper`, that both `Backend` and `BillingAbstract` depend on