### PR TITLE
Adds forceServerDown dangerous setting

### DIFF
--- a/common/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -225,7 +225,10 @@ class AppConfigTest {
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,
-            dangerousSettings = DangerousSettings(autoSyncPurchases = false)
+            dangerousSettings = DangerousSettings(
+                autoSyncPurchases = false,
+                forceServerDown = true
+            )
         )
 
         assertThat(x).isNotEqualTo(y)

--- a/public/src/main/java/com/revenuecat/purchases/DangerousSettings.kt
+++ b/public/src/main/java/com/revenuecat/purchases/DangerousSettings.kt
@@ -9,5 +9,11 @@ data class DangerousSettings(
      * automatically, and you will have to call syncPurchases whenever a new purchase is completed in order to send it
      * to the RevenueCat's backend. Auto syncing of purchases is enabled by default.
      */
-    val autoSyncPurchases: Boolean = true
+    val autoSyncPurchases: Boolean = true,
+
+    /**
+     * Disable or enable to force and test a situation where the RevenueCat server is down. This is meant to only be
+     * enabled during tests.
+     */
+    val forceServerDown: Boolean = false
 )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -76,4 +76,11 @@ class PurchasesConfigurationTest {
         val purchasesConfiguration = builder.dangerousSettings(dangerousSettings).build()
         assertThat(purchasesConfiguration.dangerousSettings).isEqualTo(dangerousSettings)
     }
+
+    @Test
+    fun `PurchasesConfiguration sets default dangerous settings correctly`() {
+        val purchasesConfiguration = builder.build()
+        assertThat(purchasesConfiguration.dangerousSettings.autoSyncPurchases).isEqualTo(true)
+        assertThat(purchasesConfiguration.dangerousSettings.forceServerDown).isEqualTo(false)
+    }
 }


### PR DESCRIPTION
When working on https://github.com/RevenueCat/purchases-android/pull/885 I thought this DangerousSetting would be a good idea to help testing these sort of scenarios.

This PR doesn't add any usage, just the setting.