### PR TITLE
Removes strict mode from purchase tester

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
@@ -5,17 +5,15 @@ import android.app.Application
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
-import android.os.StrictMode
-import android.os.StrictMode.VmPolicy
 import android.util.Log
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
-import com.revenuecat.purchases_sample.BuildConfig
 
 class MainApplication : Application(), UpdatedCustomerInfoListener {
 
@@ -24,17 +22,7 @@ class MainApplication : Application(), UpdatedCustomerInfoListener {
     override fun onCreate() {
         super.onCreate()
 
-        if (BuildConfig.DEBUG) {
-            StrictMode.setVmPolicy(
-                VmPolicy.Builder()
-                    .detectLeakedClosableObjects()
-                    .penaltyLog()
-                    .penaltyDeath()
-                    .build()
-            )
-        }
-
-        Purchases.debugLogsEnabled = true
+        Purchases.logLevel = LogLevel.DEBUG
 
         Purchases.logHandler = logHandler
     }


### PR DESCRIPTION
This has already been removed in #657 , but both @aboedo and I got hit by it the other day while testing with purchase tester so I figured it should be removed from main too.

Strict mode was complaining about a leaked closeable violation. I've only seen it in certain emulators so I actually don't think it's related to our code.

![image](https://user-images.githubusercontent.com/664544/228081842-ac92ca65-0492-47ef-ba91-d9e09b91ba7f.png)

I've created a task in Linear SDK-2988 to actually do research make sure this is not a real issue.

