### PR TITLE
Fix tests after PR merge changes

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -181,7 +181,7 @@ class Purchases internal constructor(
         }
 
         // Offline entitlements: Commenting out for now until backend is ready
-        // offlineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
+        // offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
     }
 
@@ -216,7 +216,7 @@ class Purchases internal constructor(
             log(LogIntent.RC_SUCCESS, OfferingStrings.OFFERINGS_UPDATED_FROM_NETWORK)
         }
         // Offline entitlements: Commenting out for now until backend is ready
-        // offlineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
+        // offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         updatePendingPurchaseQueue()
         synchronizeSubscriberAttributesIfNeeded()
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -125,7 +125,7 @@ class PostingTransactionsTests {
             customerInfoHelperMock.sendUpdatedCustomerInfoToDelegateIfChanged(any())
         } just runs
         every {
-            offlineEntitlementsManagerMock.updateProductEntitlementMappingsCacheIfStale()
+            offlineEntitlementsManagerMock.updateProductEntitlementMappingCacheIfStale()
         } just runs
 
         underTest = Purchases(

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -161,7 +161,7 @@ class PurchasesTest {
             mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
         } just Runs
         every {
-            mockOfflineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
+            mockOfflineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         } just Runs
 
         anonymousSetup(false)
@@ -222,7 +222,7 @@ class PurchasesTest {
 //    Offline entitlements: Commenting out for now until backend is ready
 //    @Test
 //    fun `product entitlement mappings are updated if staled on constructor`() {
-//        verify(exactly = 1) { mockOfflineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale() }
+//        verify(exactly = 1) { mockOfflineEntitlementsManager.updateProductEntitlementMappingCacheIfStale() }
 //    }
 
     @Test
@@ -542,7 +542,7 @@ class PurchasesTest {
 //        )
 //        Purchases.sharedInstance.onAppForegrounded()
 //        verify(exactly = 2) {
-//            mockOfflineEntitlementsManager.updateProductEntitlementMappingsCacheIfStale()
+//            mockOfflineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
 //        }
 //    }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -137,7 +137,7 @@ class SubscriberAttributesPurchasesTests {
             customerInfoHelperMock.sendUpdatedCustomerInfoToDelegateIfChanged(any())
         } just runs
         every {
-            offlineEntitlementsManagerMock.updateProductEntitlementMappingsCacheIfStale()
+            offlineEntitlementsManagerMock.updateProductEntitlementMappingCacheIfStale()
         } just runs
 
         underTest = Purchases(


### PR DESCRIPTION
### Description
After merging #896, tests in main started failing. This is because there was another change in a different PR modifying the name from `mappings` to `mapping` that was merged that modified existing methods. We don't run tests based on the merge commit, so we didn't catch this before.

