### PR TITLE
Fix infinite loop when accesing deprecated property

### DIFF
--- a/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -2,9 +2,8 @@ package com.revenuecat.purchases.google
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.ProductType
-import com.revenuecat.purchases.models.GoogleSubscriptionOption
-import com.revenuecat.purchases.models.GooglePurchasingData
 import com.revenuecat.purchases.models.GoogleStoreProduct
+import com.revenuecat.purchases.models.GoogleSubscriptionOption
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
@@ -100,6 +99,48 @@ class StoreProductTest {
         )
 
         assertThat(storeProduct1).isEqualTo(storeProduct2)
+    }
+
+    @Test
+    fun `GoogleStoreProduct can access computed properties correctly`() {
+        val productDetails = mockProductDetails()
+        val price = Price(
+            formatted = "$1.00",
+            amountMicros = 100,
+            currencyCode = "USD"
+        )
+
+        val subscriptionOption = GoogleSubscriptionOption(
+            productId = productId,
+            basePlanId = basePlanId,
+            offerId = null,
+            pricingPhases = listOf(PricingPhase(
+                billingPeriod = Period.create("P1M"),
+                recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                billingCycleCount = 0,
+                price = price
+            )),
+            tags = emptyList(),
+            productDetails,
+            offerToken
+        )
+
+        val storeProduct = GoogleStoreProduct(
+            productId = "product_id",
+            basePlanId = "base_plan_id",
+            type = ProductType.SUBS,
+            price = price,
+            title = "TITLE",
+            description = "DESCRIPTION",
+            period = Period.create("P1M"),
+            subscriptionOptions = SubscriptionOptions(listOf(subscriptionOption)),
+            defaultOption = subscriptionOption,
+            productDetails = productDetails
+        )
+
+        assertThat(storeProduct.id).isEqualTo("product_id:base_plan_id")
+        assertThat(storeProduct.sku).isEqualTo("product_id")
+        assertThat(storeProduct.purchasingData).isEqualTo(subscriptionOption.purchasingData)
     }
 
     @Test

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleStoreProduct.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleStoreProduct.kt
@@ -98,7 +98,7 @@ data class GoogleStoreProduct(
         ReplaceWith("productId")
     )
     override val sku: String
-        get() = sku
+        get() = productId
 }
 
 /**


### PR DESCRIPTION
### Description
There was an infinite loop when trying to access a Google's `StoreProduct.sku` property. This fixes that and adds a test for it.
