### PR TITLE
Report load shedder integration tests results in slack for V6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,6 +429,14 @@ workflows:
     jobs:
       - test
       - assemble-sample-app
+      - purchases-load-shedder-integration-tests-build:
+          context:
+            - slack-secrets
+      - run-firebase-tests-purchases-load-shedder-integration-test:
+          context:
+            - slack-secrets
+          requires:
+            - purchases-load-shedder-integration-tests-build
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,6 +359,10 @@ jobs:
           name: Create purchases integration tests apks
           command: |
             bundle exec fastlane android build_load_shedder_purchases_integration_tests
+      - run:
+          command: |
+            bundle exec fastlane android send_slack_load_shedder_integration_test success:false
+          when: on_fail
       - android/save-build-cache
       - persist_to_workspace:
           root: .
@@ -384,9 +388,19 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
       - run-firebase-tests:
           app_apk_path: purchases/test_artifacts/loadShedderIntegrationTest-app.apk
           test_apk_path: purchases/test_artifacts/loadShedderIntegrationTest-test.apk
+      - run:
+          command: |
+            bundle exec fastlane android send_slack_load_shedder_integration_test success:false
+          when: on_fail
+      - run:
+          command: |
+            bundle exec fastlane android send_slack_load_shedder_integration_test success:true
+          when: on_success
 
   run-firebase-tests:
     description: "Run integration tests for Android in Firebase. Variant latestDependencies"
@@ -423,11 +437,16 @@ workflows:
     jobs:
       - integration-tests-build: *release-branches
       - purchases-integration-tests-build: *release-branches
-      - purchases-load-shedder-integration-tests-build: *release-branches
+      - purchases-load-shedder-integration-tests-build:
+          <<: *release-branches
+          context:
+            - slack-secrets
       - run-firebase-tests-purchases-integration-test:
           requires:
             - purchases-integration-tests-build
       - run-firebase-tests-purchases-load-shedder-integration-test:
+          context:
+            - slack-secrets
           requires:
             - purchases-load-shedder-integration-tests-build
       - run-firebase-tests:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -371,6 +371,16 @@ DESC
       sh("git -C .. clean -fd")
     end
   end
+
+  lane :send_slack_load_shedder_integration_test do |options|
+    success = options[:success] || false
+    message = success ? "Load Shedder Integration Tests finished successfully" : "Load Shedder Integration Tests failed"
+    slack(
+      message: message,
+      slack_url: ENV["SLACK_URL_LOAD_SHEDDER_INTEGRATION_TESTS"],
+      success: success
+    )
+  end
 end
 
 def is_snapshot_version?(version_name)


### PR DESCRIPTION
### Description
This PR adds reporting for the load shedder integration tests to Slack for the latest version in main. Still need to do this for V4 and V5
