### PR TITLE
Add store getter to purchases instance

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -18,6 +18,7 @@ import com.revenuecat.purchases.PurchaseParams;
 import com.revenuecat.purchases.Purchases;
 import com.revenuecat.purchases.PurchasesConfiguration;
 import com.revenuecat.purchases.PurchasesError;
+import com.revenuecat.purchases.Store;
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback;
 import com.revenuecat.purchases.interfaces.LogInCallback;
 import com.revenuecat.purchases.interfaces.PurchaseCallback;
@@ -105,6 +106,8 @@ final class PurchasesAPI {
         });
 
         final boolean anonymous = purchases.isAnonymous();
+
+        final Store store = purchases.getStore();
 
         purchases.onAppBackgrounded();
         purchases.onAppForegrounded();

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.PurchaseParams
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.getCustomerInfoWith
 import com.revenuecat.purchases.getOfferingsWith
 import com.revenuecat.purchases.getProductsWith
@@ -81,6 +82,8 @@ private class PurchasesAPI {
         purchases.updatedCustomerInfoListener = UpdatedCustomerInfoListener { _: CustomerInfo? -> }
 
         val anonymous: Boolean = purchases.isAnonymous
+
+        val store: Store = purchases.store
 
         purchases.onAppBackgrounded()
         purchases.onAppForegrounded()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -144,6 +144,12 @@ class Purchases internal constructor(
     val isAnonymous: Boolean
         get() = identityManager.currentUserIsAnonymous()
 
+    /**
+     * The currently configured store
+     */
+    val store: Store
+        get() = appConfig.store
+
     private val lifecycleHandler: AppLifecycleHandler by lazy {
         AppLifecycleHandler(this)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -332,9 +332,9 @@ class PurchasesTest {
 
     @Test
     fun `Setting store in the configuration sets it on the Purchases instance`() {
-        val builder = PurchasesConfiguration.Builder(mockContext, "api").store(Store.AMAZON)
+        val builder = PurchasesConfiguration.Builder(mockContext, "api").store(Store.PLAY_STORE)
         Purchases.configure(builder.build())
-        assertThat(Purchases.sharedInstance.store).isEqualTo(Store.AMAZON)
+        assertThat(Purchases.sharedInstance.store).isEqualTo(Store.PLAY_STORE)
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -330,6 +330,13 @@ class PurchasesTest {
         assertThat(Purchases.sharedInstance.appConfig.finishTransactions).isTrue()
     }
 
+    @Test
+    fun `Setting store in the configuration sets it on the Purchases instance`() {
+        val builder = PurchasesConfiguration.Builder(mockContext, "api").store(Store.AMAZON)
+        Purchases.configure(builder.build())
+        assertThat(Purchases.sharedInstance.store).isEqualTo(Store.AMAZON)
+    }
+
     // endregion
 
     // region get products


### PR DESCRIPTION
### Motivation

Use the `Purchases.shared.store` to limit functionality on hybrid.

Example: `purchaseSubscriptionOptions()` should not be run if Amazon

### Description

- Adds `store` getting property to `Purchases` instance
