### PR TITLE
Added ENTITLEMENTS_COMPUTED_ON_DEVICE

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/VerificationResultAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/VerificationResultAPI.java
@@ -7,6 +7,7 @@ package com.revenuecat.apitester.java;
 //final class VerificationResultAPI {
 //    static void check(final VerificationResult verificationResult) {
 //        switch (verificationResult) {
+//            case ENTITLEMENTS_COMPUTED_ON_DEVICE:
 //            case NOT_REQUESTED:
 //            case VERIFIED:
 //            case FAILED:

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/VerificationResultAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/VerificationResultAPI.java
@@ -7,7 +7,7 @@ package com.revenuecat.apitester.java;
 //final class VerificationResultAPI {
 //    static void check(final VerificationResult verificationResult) {
 //        switch (verificationResult) {
-//            case ENTITLEMENTS_COMPUTED_ON_DEVICE:
+//            case VERIFIED_ON_DEVICE:
 //            case NOT_REQUESTED:
 //            case VERIFIED:
 //            case FAILED:

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VerificationResultAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VerificationResultAPI.kt
@@ -8,7 +8,7 @@ package com.revenuecat.apitester.kotlin
 //
 //    fun check(verificationResult: com.revenuecat.purchases.common.verification.VerificationResult) {
 //        when (verificationResult) {
-//            com.revenuecat.purchases.common.verification.VerificationResult.ENTITLEMENTS_COMPUTED_ON_DEVICE,
+//            com.revenuecat.purchases.common.verification.VerificationResult.VERIFIED_ON_DEVICE,
 //            com.revenuecat.purchases.common.verification.VerificationResult.NOT_REQUESTED,
 //            com.revenuecat.purchases.common.verification.VerificationResult.VERIFIED,
 //            com.revenuecat.purchases.common.verification.VerificationResult.FAILED

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VerificationResultAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VerificationResultAPI.kt
@@ -8,6 +8,7 @@ package com.revenuecat.apitester.kotlin
 //
 //    fun check(verificationResult: com.revenuecat.purchases.common.verification.VerificationResult) {
 //        when (verificationResult) {
+//            com.revenuecat.purchases.common.verification.VerificationResult.ENTITLEMENTS_COMPUTED_ON_DEVICE,
 //            com.revenuecat.purchases.common.verification.VerificationResult.NOT_REQUESTED,
 //            com.revenuecat.purchases.common.verification.VerificationResult.VERIFIED,
 //            com.revenuecat.purchases.common.verification.VerificationResult.FAILED

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculator.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculator.kt
@@ -67,7 +67,7 @@ class OfflineCustomerInfoCalculator(
         }
 
         return CustomerInfoFactory.buildCustomerInfo(
-            jsonObject, requestDate, VerificationResult.NOT_REQUESTED
+            jsonObject, requestDate, VerificationResult.ENTITLEMENTS_COMPUTED_ON_DEVICE
         )
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculator.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculator.kt
@@ -67,7 +67,7 @@ class OfflineCustomerInfoCalculator(
         }
 
         return CustomerInfoFactory.buildCustomerInfo(
-            jsonObject, requestDate, VerificationResult.ENTITLEMENTS_COMPUTED_ON_DEVICE
+            jsonObject, requestDate, VerificationResult.VERIFIED_ON_DEVICE
         )
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfoTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfoTest.kt
@@ -35,9 +35,13 @@ class EntitlementInfoTest {
 //        val entitlementInfo1 = createEntitlementInfo(verification = VerificationResult.NOT_REQUESTED)
 //        val entitlementInfo2 = createEntitlementInfo(verification = VerificationResult.FAILED)
 //        val entitlementInfo3 = createEntitlementInfo(verification = VerificationResult.VERIFIED)
+//        val entitlementInfo4 = createEntitlementInfo(verification = VerificationResult.ENTITLEMENTS_COMPUTED_ON_DEVICE)
 //        assertThat(entitlementInfo1).isNotEqualTo(entitlementInfo2)
 //        assertThat(entitlementInfo1).isNotEqualTo(entitlementInfo3)
+//        assertThat(entitlementInfo1).isNotEqualTo(entitlementInfo4)
 //        assertThat(entitlementInfo2).isNotEqualTo(entitlementInfo3)
+//        assertThat(entitlementInfo2).isNotEqualTo(entitlementInfo4)
+//        assertThat(entitlementInfo3).isNotEqualTo(entitlementInfo4)
 //    }
 
     private fun createEntitlementInfo(

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfoTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfoTest.kt
@@ -35,7 +35,7 @@ class EntitlementInfoTest {
 //        val entitlementInfo1 = createEntitlementInfo(verification = VerificationResult.NOT_REQUESTED)
 //        val entitlementInfo2 = createEntitlementInfo(verification = VerificationResult.FAILED)
 //        val entitlementInfo3 = createEntitlementInfo(verification = VerificationResult.VERIFIED)
-//        val entitlementInfo4 = createEntitlementInfo(verification = VerificationResult.ENTITLEMENTS_COMPUTED_ON_DEVICE)
+//        val entitlementInfo4 = createEntitlementInfo(verification = VerificationResult.VERIFIED_ON_DEVICE)
 //        assertThat(entitlementInfo1).isNotEqualTo(entitlementInfo2)
 //        assertThat(entitlementInfo1).isNotEqualTo(entitlementInfo3)
 //        assertThat(entitlementInfo1).isNotEqualTo(entitlementInfo4)

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
@@ -1200,9 +1200,13 @@ class EntitlementInfosTests {
 //        val entitlementInfos1 = EntitlementInfos(emptyMap(), VerificationResult.NOT_REQUESTED)
 //        val entitlementInfos2 = EntitlementInfos(emptyMap(), VerificationResult.VERIFIED)
 //        val entitlementInfos3 = EntitlementInfos(emptyMap(), VerificationResult.FAILED)
+//        val entitlementInfos4 = EntitlementInfos(emptyMap(), VerificationResult.ENTITLEMENTS_COMPUTED_ON_DEVICE)
 //        assertThat(entitlementInfos1).isNotEqualTo(entitlementInfos2)
 //        assertThat(entitlementInfos1).isNotEqualTo(entitlementInfos3)
+//        assertThat(entitlementInfos1).isNotEqualTo(entitlementInfos4)
 //        assertThat(entitlementInfos2).isNotEqualTo(entitlementInfos3)
+//        assertThat(entitlementInfos2).isNotEqualTo(entitlementInfos4)
+//        assertThat(entitlementInfos3).isNotEqualTo(entitlementInfos4)
 //    }
 //
 //    @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
@@ -1200,7 +1200,7 @@ class EntitlementInfosTests {
 //        val entitlementInfos1 = EntitlementInfos(emptyMap(), VerificationResult.NOT_REQUESTED)
 //        val entitlementInfos2 = EntitlementInfos(emptyMap(), VerificationResult.VERIFIED)
 //        val entitlementInfos3 = EntitlementInfos(emptyMap(), VerificationResult.FAILED)
-//        val entitlementInfos4 = EntitlementInfos(emptyMap(), VerificationResult.ENTITLEMENTS_COMPUTED_ON_DEVICE)
+//        val entitlementInfos4 = EntitlementInfos(emptyMap(), VerificationResult.VERIFIED_ON_DEVICE)
 //        assertThat(entitlementInfos1).isNotEqualTo(entitlementInfos2)
 //        assertThat(entitlementInfos1).isNotEqualTo(entitlementInfos3)
 //        assertThat(entitlementInfos1).isNotEqualTo(entitlementInfos4)

--- a/utils/src/main/java/com/revenuecat/purchases/VerificationResult.kt
+++ b/utils/src/main/java/com/revenuecat/purchases/VerificationResult.kt
@@ -26,5 +26,10 @@ enum class VerificationResult {
     /**
      * Verification failed, possibly due to a MiTM attack.
      */
-    FAILED
+    FAILED,
+
+    /**
+     * Entitlements were computed on device.
+     */
+    ENTITLEMENTS_COMPUTED_ON_DEVICE
 }

--- a/utils/src/main/java/com/revenuecat/purchases/VerificationResult.kt
+++ b/utils/src/main/java/com/revenuecat/purchases/VerificationResult.kt
@@ -29,7 +29,7 @@ enum class VerificationResult {
     FAILED,
 
     /**
-     * Entitlements were computed on device.
+     * Verification was performed on device.
      */
-    ENTITLEMENTS_COMPUTED_ON_DEVICE
+    VERIFIED_ON_DEVICE
 }


### PR DESCRIPTION
Used for entitlements computed directly with data from BillingClient

The name of the enum is open to feedback and it's being discussed [here](https://github.com/RevenueCat/purchases-ios/pull/2379#discussion_r1149784192) 