### PR TITLE
Report load shedder integration tests results in slack for V5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,9 +422,6 @@ workflows:
     jobs:
       - test
       - assemble-sample-app
-      - run-firebase-tests-purchases-load-shedder-integration-test:
-          context:
-            - slack-secrets
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,25 +349,6 @@ jobs:
             - purchases/test_artifacts/integrationTest-app.apk
             - purchases/test_artifacts/integrationTest-test.apk
 
-  purchases-load-shedder-integration-tests-build:
-    <<: *android-executor
-    steps:
-      - checkout
-      - install-sdkman
-      - revenuecat/install-gem-unix-dependencies:
-          cache-version: v1
-      - android/restore-build-cache
-      - run:
-          name: Create purchases integration tests apks
-          command: |
-            bundle exec fastlane android build_load_shedder_purchases_integration_tests
-      - android/save-build-cache
-      - persist_to_workspace:
-          root: .
-          paths:
-            - purchases/test_artifacts/loadShedderIntegrationTest-app.apk
-            - purchases/test_artifacts/loadShedderIntegrationTest-test.apk
-
   run-firebase-tests-purchases-integration-test:
     description: "Run purchases module integration tests for Android in Firebase. Variant integrationTest"
     executor: gcp-cli/google
@@ -380,15 +361,28 @@ jobs:
           test_apk_path: purchases/test_artifacts/integrationTest-test.apk
 
   run-firebase-tests-purchases-load-shedder-integration-test:
-    description: "Run purchases module integration tests for Android in Firebase using the load shedder servers. Variant integrationTest"
-    executor: gcp-cli/google
+    description: "Run purchases module integration tests for Android in Firebase using the load shedder servers"
+    <<: *android-executor
     steps:
       - checkout
-      - attach_workspace:
-          at: .
-      - run-firebase-tests:
-          app_apk_path: purchases/test_artifacts/loadShedderIntegrationTest-app.apk
-          test_apk_path: purchases/test_artifacts/loadShedderIntegrationTest-test.apk
+      - install-sdkman
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
+      - gcp-cli/install
+      - gcp-cli/initialize:
+          gcloud-service-key: GCLOUD_SERVICE_KEY
+          google-compute-zone: GOOGLE_COMPUTE_ZONE
+          google-project-id: GOOGLE_PROJECT_ID
+      - android/restore-build-cache
+      - run:
+          name: Build and run load shedder integration tests
+          command: |
+            bundle exec fastlane android run_load_shedder_purchases_integration_tests
+      - android/save-build-cache
+      - store_artifacts:
+          path: ~/gsutil/
+      - store_test_results:
+          path: ~/gsutil/
 
   run-firebase-tests-latest-dependencies:
     description: "Run integration tests for Android in Firebase. Variant latestDependencies"
@@ -436,17 +430,14 @@ workflows:
     jobs:
       - integration-tests-build: *release-branches
       - purchases-integration-tests-build: *release-branches
-      - purchases-load-shedder-integration-tests-build: *release-branches
       - run-firebase-tests-purchases-integration-test:
           requires:
             - purchases-integration-tests-build
       - run-firebase-tests-purchases-load-shedder-integration-test:
-          requires:
-            - purchases-load-shedder-integration-tests-build
+          <<: *release-branches
+          context:
+            - slack-secrets
       - run-firebase-tests-latest-dependencies:
-          requires:
-            - integration-tests-build
-      - run-firebase-tests-unityIAP:
           requires:
             - integration-tests-build
       - hold:
@@ -483,10 +474,9 @@ workflows:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "load-shedder-integration-tests-v5", << pipeline.schedule.name >> ]
     jobs:
-      - purchases-load-shedder-integration-tests-build
       - run-firebase-tests-purchases-load-shedder-integration-test:
-          requires:
-            - purchases-load-shedder-integration-tests-build
+          context:
+            - slack-secrets
 
   weekly-run-workflow:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,6 +422,9 @@ workflows:
     jobs:
       - test
       - assemble-sample-app
+      - run-firebase-tests-purchases-load-shedder-integration-test:
+          context:
+            - slack-secrets
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -443,6 +443,9 @@ workflows:
       - run-firebase-tests-latest-dependencies:
           requires:
             - integration-tests-build
+      - run-firebase-tests-unityIAP:
+          requires:
+            - integration-tests-build
       - hold:
           type: approval
           requires:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -171,14 +171,36 @@ platform :android do
     )
   end
 
-  desc "Build purchases module integration tests pointing to load shedder"
-  lane :build_load_shedder_purchases_integration_tests do |options|
-    build_purchases_integration_tests(
+  desc "Build and run purchases module load shedder integration tests"
+  desc "This requires the google cloud cli to be installed and initialized."
+  lane :run_load_shedder_purchases_integration_tests do |options|
+    begin
+      google_project_id = ENV['GOOGLE_PROJECT_ID'] || UI.user_error!('Google project id not found.')
+      build_purchases_integration_tests(
         app_name: 'loadShedderIntegrationTest',
         api_key: ENV['LOAD_SHEDDER_REVENUECAT_API_KEY'],
         google_purchase_token: ENV['LOAD_SHEDDER_GOOGLE_PURCHASE_TOKEN'],
-        product_id_to_purchase: ENV['LOAD_SHEDDER_PRODUCT_ID_TO_PURCHASE']
-    )
+        product_id_to_purchase: ENV['LOAD_SHEDDER_PRODUCT_ID_TO_PURCHASE'],
+        base_plan_id_to_purchase: ENV['LOAD_SHEDDER_BASE_PLAN_ID_TO_PURCHASE']
+      )
+
+      # We run the test on google firebase test labs
+      sh "gcloud firebase test android run --type instrumentation \
+            --app ../purchases/test_artifacts/loadShedderIntegrationTest-app.apk \
+            --test ../purchases/test_artifacts/loadShedderIntegrationTest-test.apk \
+            --timeout 2m \
+            --results-bucket cloud-test-#{google_project_id}"
+
+      dir_path = File.join(Dir.home, 'gsutil')
+      FileUtils.mkdir_p(dir_path)
+      # We copy the test results from google cloud to the ~/gsutil folder. We use the tail -1 to get the latest
+      sh "gsutil -m cp -r -U `gsutil ls gs://cloud-test-#{google_project_id} | tail -1` ~/gsutil/ | true"
+    rescue => exception
+      send_slack_load_shedder_integration_test(success: false)
+      raise
+    else
+      send_slack_load_shedder_integration_test(success: true)
+    end
   end
 
   def build_purchases_integration_tests(app_name:, api_key:, google_purchase_token:, product_id_to_purchase:,
@@ -309,6 +331,22 @@ platform :android do
       sh("git reset --hard")
       sh("git clean -fd")
     end
+  end
+
+  lane :send_slack_load_shedder_integration_test do |options|
+    success = options[:success] || false
+    message =
+        if success
+            "Android load shedder integration tests V6 finished successfully"
+        else
+            "Android load shedder integration tests V6 failed"
+        end
+    slack(
+      message: message,
+      slack_url: ENV["SLACK_URL_LOAD_SHEDDER_INTEGRATION_TESTS"],
+      success: success,
+      default_payloads: [:git_branch]
+    )
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -180,8 +180,7 @@ platform :android do
         app_name: 'loadShedderIntegrationTest',
         api_key: ENV['LOAD_SHEDDER_REVENUECAT_API_KEY'],
         google_purchase_token: ENV['LOAD_SHEDDER_GOOGLE_PURCHASE_TOKEN'],
-        product_id_to_purchase: ENV['LOAD_SHEDDER_PRODUCT_ID_TO_PURCHASE'],
-        base_plan_id_to_purchase: ENV['LOAD_SHEDDER_BASE_PLAN_ID_TO_PURCHASE']
+        product_id_to_purchase: ENV['LOAD_SHEDDER_PRODUCT_ID_TO_PURCHASE']
       )
 
       # We run the test on google firebase test labs

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -337,9 +337,9 @@ platform :android do
     success = options[:success] || false
     message =
         if success
-            "Android load shedder integration tests V6 finished successfully"
+            "Android load shedder integration tests V5 finished successfully"
         else
-            "Android load shedder integration tests V6 failed"
+            "Android load shedder integration tests V5 failed"
         end
     slack(
       message: message,

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -95,13 +95,15 @@ Build purchase tester app bundle
 
 Build purchases module integration tests pointing to production
 
-### android build_load_shedder_purchases_integration_tests
+### android run_load_shedder_purchases_integration_tests
 
 ```sh
-[bundle exec] fastlane android build_load_shedder_purchases_integration_tests
+[bundle exec] fastlane android run_load_shedder_purchases_integration_tests
 ```
 
-Build purchases module integration tests pointing to load shedder
+Build and run purchases module load shedder integration tests
+
+This requires the google cloud cli to be installed and initialized.
 
 ### android publish_purchase_tester
 
@@ -130,6 +132,15 @@ Builds a Magic Weather APK and prompts for:
 * Amazon pem path (optional)
 
 * New application id (optional)
+
+
+### android send_slack_load_shedder_integration_test
+
+```sh
+[bundle exec] fastlane android send_slack_load_shedder_integration_test
+```
+
+
 
 ----
 


### PR DESCRIPTION
### Description
This PR adds reporting to slack for load shedder integration tests on V5. This is pointing to the latest changes before v6 was merged.