### PR TITLE
Workaround bug in android 4 for JSON objects with List<String>

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -128,7 +128,7 @@ class HTTPClient(
         requestHeaders: Map<String, String>,
         refreshETag: Boolean
     ): HTTPResult? {
-        val jsonBody = mapConverter.convertToJSON(body)
+        val jsonBody = body?.let { mapConverter.convertToJSON(body) }
         val path = endpoint.getPath()
         val urlPathWithVersion = "/v1$path"
         val connection: HttpURLConnection

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
 import com.revenuecat.purchases.strings.NetworkStrings
 import com.revenuecat.purchases.utils.filterNotNullValues
+import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.BufferedReader
@@ -239,6 +240,16 @@ class HTTPClient(
     private fun Map<String, Any?>.convert(): JSONObject {
         val mapWithoutInnerMaps = mapValues { (_, value) ->
             value.tryCast<Map<String, Any?>>(ifSuccess = { convert() })
+            when (value) {
+                is List<*> -> {
+                    if (value.all { it is String }) {
+                        JSONObject(mapOf("temp_key" to JSONArray(value))).getJSONArray("temp_key")
+                    } else {
+                        value
+                    }
+                }
+                else -> value.tryCast<Map<String, Any?>>(ifSuccess = { convert() })
+            }
         }
         return JSONObject(mapWithoutInnerMaps)
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -128,7 +128,7 @@ class HTTPClient(
         requestHeaders: Map<String, String>,
         refreshETag: Boolean
     ): HTTPResult? {
-        val jsonBody = body?.let { mapConverter.convertToJSON(body) }
+        val jsonBody = body?.let { mapConverter.convertToJSON(it) }
         val path = endpoint.getPath()
         val urlPathWithVersion = "/v1$path"
         val connection: HttpURLConnection

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -21,9 +21,7 @@ import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
 import com.revenuecat.purchases.strings.NetworkStrings
 import com.revenuecat.purchases.utils.filterNotNullValues
-import org.json.JSONArray
 import org.json.JSONException
-import org.json.JSONObject
 import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.IOException

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
@@ -17,10 +17,7 @@ class MapConverter {
      * @param inputMap The input map to convert.
      * @return A JSONObject representing the input map.
      */
-    internal fun convertToJSON(inputMap: Map<String, Any?>?): JSONObject {
-        if (inputMap == null) {
-            return JSONObject()
-        }
+    internal fun convertToJSON(inputMap: Map<String, Any?>): JSONObject {
         val mapWithoutInnerMaps = inputMap.mapValues { (_, value) ->
             value.tryCast<Map<String, Any?>>(ifSuccess = { convertToJSON(this) })
             when (value) {

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
@@ -17,16 +17,12 @@ class MapConverter {
      * @param inputMap The input map to convert.
      * @return A JSONObject representing the input map.
      */
-    fun convertToJSON(inputMap: Map<String, Any?>?): JSONObject {
-        return inputMap.convert()
-    }
-
-    private fun Map<String, Any?>?.convert(): JSONObject {
-        if (this == null) {
+    internal fun convertToJSON(inputMap: Map<String, Any?>?): JSONObject {
+        if (inputMap == null) {
             return JSONObject()
         }
-        val mapWithoutInnerMaps = mapValues { (_, value) ->
-            value.tryCast<Map<String, Any?>>(ifSuccess = { convert() })
+        val mapWithoutInnerMaps = inputMap.mapValues { (_, value) ->
+            value.tryCast<Map<String, Any?>>(ifSuccess = { convertToJSON(this) })
             when (value) {
                 is List<*> -> {
                     if (value.all { it is String }) {
@@ -35,10 +31,14 @@ class MapConverter {
                         value
                     }
                 }
-                else -> value.tryCast<Map<String, Any?>>(ifSuccess = { convert() })
+                else -> value.tryCast<Map<String, Any?>>(ifSuccess = { convertToJSON(this) })
             }
         }
-        return JSONObject(mapWithoutInnerMaps)
+        return createJSONObject(mapWithoutInnerMaps)
+    }
+
+    internal fun createJSONObject(inputMap: Map<String, Any?>): JSONObject {
+        return JSONObject(inputMap)
     }
 
     /** To avoid Java type erasure, we use a Kotlin inline function with a reified parameter

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
@@ -3,8 +3,20 @@ package com.revenuecat.purchases.common.networking
 import org.json.JSONArray
 import org.json.JSONObject
 
+/**
+ * A class to convert a Map<String, Any?> into a JSONObject.
+ * This was created to workaround a bug in Android 4 , where a List<String> would be incorrectly converted into
+ * a single string instead of a JSONArray of strings. (i.e.: "[\"value1\", \"value2\"]" instead of "[value1, value2]")
+ * This class handles nested maps, lists, and other JSON-compatible types.
+ */
 class MapConverter {
 
+    /**
+     * Converts the given [inputMap] into a JSONObject.
+     *
+     * @param inputMap The input map to convert.
+     * @return A JSONObject representing the input map.
+     */
     fun convertToJSON(inputMap: Map<String, Any?>?): JSONObject {
         return inputMap.convert()
     }
@@ -29,13 +41,14 @@ class MapConverter {
         return JSONObject(mapWithoutInnerMaps)
     }
 
-    // To avoid Java type erasure, we use a Kotlin inline function with a reified parameter
-    // so that we can check the type on runtime.
-    //
-    // Doing something like:
-    // if (value is Map<*, *>) (value as Map<String, Any?>).convert()
-    //
-    // Would give an unchecked cast warning due to Java type erasure
+    /** To avoid Java type erasure, we use a Kotlin inline function with a reified parameter
+     * so that we can check the type on runtime.
+     *
+     * Doing something like:
+     * if (value is Map<*, *>) (value as Map<String, Any?>).convert()
+     *
+     * Would give an unchecked cast warning due to Java type erasure
+     */
     private inline fun <reified T> Any?.tryCast(
         ifSuccess: T.() -> Any?
     ): Any? {

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
@@ -1,0 +1,48 @@
+package com.revenuecat.purchases.common.networking
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+class MapConverter {
+
+    fun convertToJSON(inputMap: Map<String, Any?>?): JSONObject {
+        return inputMap.convert()
+    }
+
+    private fun Map<String, Any?>?.convert(): JSONObject {
+        if (this == null) {
+            return JSONObject()
+        }
+        val mapWithoutInnerMaps = mapValues { (_, value) ->
+            value.tryCast<Map<String, Any?>>(ifSuccess = { convert() })
+            when (value) {
+                is List<*> -> {
+                    if (value.all { it is String }) {
+                        JSONObject(mapOf("temp_key" to JSONArray(value))).getJSONArray("temp_key")
+                    } else {
+                        value
+                    }
+                }
+                else -> value.tryCast<Map<String, Any?>>(ifSuccess = { convert() })
+            }
+        }
+        return JSONObject(mapWithoutInnerMaps)
+    }
+
+    // To avoid Java type erasure, we use a Kotlin inline function with a reified parameter
+    // so that we can check the type on runtime.
+    //
+    // Doing something like:
+    // if (value is Map<*, *>) (value as Map<String, Any?>).convert()
+    //
+    // Would give an unchecked cast warning due to Java type erasure
+    private inline fun <reified T> Any?.tryCast(
+        ifSuccess: T.() -> Any?
+    ): Any? {
+        return if (this is T) {
+            this.ifSuccess()
+        } else {
+            this
+        }
+    }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
@@ -19,7 +19,6 @@ class MapConverter {
      */
     internal fun convertToJSON(inputMap: Map<String, Any?>): JSONObject {
         val mapWithoutInnerMaps = inputMap.mapValues { (_, value) ->
-            value.tryCast<Map<String, Any?>>(ifSuccess = { convertToJSON(this) })
             when (value) {
                 is List<*> -> {
                     if (value.all { it is String }) {

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -1,0 +1,82 @@
+package com.revenuecat.purchases.common.networking
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class MapConverterTest {
+
+    private lateinit var mapConverter: MapConverter
+
+    @Before
+    fun setUp() {
+        mapConverter = MapConverter()
+    }
+
+    @Test
+    fun testConvertToJSON() {
+        val inputMap = mapOf(
+            "key1" to "value1",
+            "key2" to listOf("value2", "value3"),
+            "key3" to mapOf("nestedKey" to "nestedValue")
+        )
+
+        val expectedJson = JSONObject()
+            .put("key1", "value1")
+            .put("key2", JSONArray(listOf("value2", "value3")))
+            .put("key3", JSONObject().put("nestedKey", "nestedValue"))
+
+        val result = mapConverter.convertToJSON(inputMap)
+        assertEquals(expectedJson.toString(), result.toString())
+    }
+
+    @Test
+    fun testConvertToJSONWithNestedArrayOfStrings() {
+        val inputMap = mapOf(
+            "key1" to "value1",
+            "key2" to listOf("value2", "value3"),
+            "key3" to mapOf("nestedKey" to "nestedValue"),
+            "key4" to listOf("value4", "value5")
+        )
+
+        val expectedJson = JSONObject()
+            .put("key1", "value1")
+            .put("key2", JSONArray(listOf("value2", "value3")))
+            .put("key3", JSONObject().put("nestedKey", "nestedValue"))
+            .put("key4", JSONArray(listOf("value4", "value5")))
+
+        val result = mapConverter.convertToJSON(inputMap)
+        assertEquals(expectedJson.toString(), result.toString())
+    }
+
+    @Test
+    fun `test map conversion with mocked List of String conversion`() {
+        val mapConverterMock = mockk<MapConverter>()
+
+        val inputMap = mapOf(
+            "key" to listOf("value1", "value2")
+        )
+
+        val expectedIncorrectJsonArrayString = "[\"value1\",\"value2\"]"
+
+        // Mock the convertToJSON method for the specific input
+        every {
+            mapConverterMock.convertToJSON(match { it == inputMap })
+        } returns JSONObject(mapOf("key" to expectedIncorrectJsonArrayString))
+
+        val resultJson = mapConverterMock.convertToJSON(inputMap)
+        val resultArrayString = resultJson.optString("key")
+
+        assertEquals(expectedIncorrectJsonArrayString, resultArrayString)
+    }
+
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -24,7 +24,7 @@ class MapConverterTest {
     }
 
     @Test
-    fun testConvertToJSON() {
+    fun `test convert to JSON`() {
         val inputMap = mapOf(
             "key1" to "value1",
             "key2" to listOf("value2", "value3"),
@@ -41,7 +41,7 @@ class MapConverterTest {
     }
 
     @Test
-    fun testConvertToJSONWithNestedArrayOfStrings() {
+    fun `test convert to JSON with nested array of strings`() {
         val inputMap = mapOf(
             "key1" to "value1",
             "key2" to listOf("value2", "value3"),

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -65,7 +65,7 @@ class MapConverterTest {
      * (i.e.: "[\"value1\", \"value2\"]" instead of "[value1, value2]")
      */
     @Test
-    fun `test map conversion with mocked List of String conversion`() {
+    fun `test map conversion fixes wrong treatment of arrays of strings in JSON library`() {
         val mapConverterMock = spyk<MapConverter>()
 
         val inputMap = mapOf(

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -69,19 +69,19 @@ class MapConverterTest {
         val mapConverterMock = spyk<MapConverter>()
 
         val inputMap = mapOf(
-            "nested" to listOf("value1", "value2")
+            "product_ids" to listOf("product_1", "product_2")
         )
 
         val mapContainingInputMap = mapOf(
-            "root" to inputMap
+            "subscriber_info" to inputMap
         )
 
-        val incorrectJsonArrayString = "[value1,value2]"
-        val correctedJSONArray = JSONArray(listOf("value1", "value2"))
+        val incorrectJsonArrayString = "[product_1,product_2]"
+        val correctedJSONArray = JSONArray(listOf("product_1", "product_2"))
 
         every {
             mapConverterMock.createJSONObject(match { it == inputMap })
-        } returns JSONObject(mapOf("nested" to incorrectJsonArrayString))
+        } returns JSONObject(mapOf("product_ids" to incorrectJsonArrayString))
 
         val resultJson = mapConverterMock.convertToJSON(mapContainingInputMap)
         val resultArrayString = resultJson.optJSONObject("root")?.optJSONArray("nested")

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -45,14 +45,14 @@ class MapConverterTest {
             "key1" to "value1",
             "key2" to listOf("value2", "value3"),
             "key3" to mapOf("nestedKey" to "nestedValue"),
-            "key4" to listOf("value4", "value5")
+            "key4" to mapOf("nestedArray" to listOf("value4", "value5")),
         )
 
         val expectedJson = JSONObject()
             .put("key1", "value1")
             .put("key2", JSONArray(listOf("value2", "value3")))
             .put("key3", JSONObject().put("nestedKey", "nestedValue"))
-            .put("key4", JSONArray(listOf("value4", "value5")))
+            .put("key4", JSONObject().put("nestedArray", JSONArray(listOf("value4", "value5"))))
 
         val result = mapConverter.convertToJSON(inputMap)
         assertEquals(expectedJson.toString(), result.toString())

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -84,7 +84,7 @@ class MapConverterTest {
         } returns JSONObject(mapOf("product_ids" to incorrectJsonArrayString))
 
         val resultJson = mapConverterMock.convertToJSON(mapContainingInputMap)
-        val resultArrayString = resultJson.optJSONObject("root")?.optJSONArray("nested")
+        val resultArrayString = resultJson.optJSONObject("subscriber_info")?.optJSONArray("product_ids")
 
         assertEquals(correctedJSONArray, resultArrayString)
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -68,7 +68,6 @@ class MapConverterTest {
 
         val expectedIncorrectJsonArrayString = "[\"value1\",\"value2\"]"
 
-        // Mock the convertToJSON method for the specific input
         every {
             mapConverterMock.convertToJSON(match { it == inputMap })
         } returns JSONObject(mapOf("key" to expectedIncorrectJsonArrayString))

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases.common.networking
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every
-import io.mockk.mockk
 import io.mockk.spyk
 import org.json.JSONArray
 import org.json.JSONObject
@@ -66,7 +65,7 @@ class MapConverterTest {
      */
     @Test
     fun `test map conversion fixes wrong treatment of arrays of strings in JSON library`() {
-        val mapConverterMock = spyk<MapConverter>()
+        val mapConverterPartialMock = spyk<MapConverter>()
 
         val inputMap = mapOf(
             "product_ids" to listOf("product_1", "product_2")
@@ -80,10 +79,10 @@ class MapConverterTest {
         val correctedJSONArray = JSONArray(listOf("product_1", "product_2"))
 
         every {
-            mapConverterMock.createJSONObject(match { it == inputMap })
+            mapConverterPartialMock.createJSONObject(match { it == inputMap })
         } returns JSONObject(mapOf("product_ids" to incorrectJsonArrayString))
 
-        val resultJson = mapConverterMock.convertToJSON(mapContainingInputMap)
+        val resultJson = mapConverterPartialMock.convertToJSON(mapContainingInputMap)
         val resultArrayString = resultJson.optJSONObject("subscriber_info")?.optJSONArray("product_ids")
 
         assertEquals(correctedJSONArray, resultArrayString)


### PR DESCRIPTION
Fixes https://linear.app/revenuecat/issue/SDK-3052/400-from-post-receipts-because-product-did-not-have-quotes
https://revenuecats.atlassian.net/browse/CSDK-681

Works around the following bug in android 4:
https://stackoverflow.com/q/37317669
http://fupeg.blogspot.com/2011/07/android-json-bug.html


Essentially, this bug means that when you get a list of product_ids, instead of sending a list of strings, it sends a list with a string in it. 

| Before | After |
| :-: | :-: |
| "product_ids": "[item1, item2]" | "product_ids": ["item1, "item2"] |