### PR TITLE
`toPurchasesError` back to internal

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/errors.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/errors.kt
@@ -56,7 +56,7 @@ fun Exception.toPurchasesError(): PurchasesError {
 private fun BackendErrorCode.toPurchasesError(underlyingErrorMessage: String) =
     PurchasesError(this.toPurchasesErrorCode(), underlyingErrorMessage)
 
-fun HTTPResult.toPurchasesError(): PurchasesError {
+internal fun HTTPResult.toPurchasesError(): PurchasesError {
     val errorCode = if (body.has("code")) body.get("code") as Int else null
     val errorMessage = if (body.has("message")) body.get("message") as String else ""
 


### PR DESCRIPTION
Made `toPurchasesError` back to internal because it's not needed. It was made public in #885 and forgot to make internal before merging