### PR TITLE
Add verification for entitlement granting to integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,6 +409,13 @@ workflows:
     jobs:
       - test
       - assemble-sample-app
+      - run-firebase-tests-purchases-load-shedder-integration-test:
+          context:
+            - slack-secrets
+      - purchases-integration-tests-build
+      - run-firebase-tests-purchases-integration-test:
+          requires:
+            - purchases-integration-tests-build
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,13 +409,6 @@ workflows:
     jobs:
       - test
       - assemble-sample-app
-      - run-firebase-tests-purchases-load-shedder-integration-test:
-          context:
-            - slack-secrets
-      - purchases-integration-tests-build
-      - run-firebase-tests-purchases-integration-test:
-          requires:
-            - purchases-integration-tests-build
 
   deploy:
     when:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -187,10 +187,10 @@ platform :android do
       # We copy the test results from google cloud to the ~/gsutil folder. We use the tail -1 to get the latest
       sh "gsutil -m cp -r -U `gsutil ls gs://cloud-test-#{google_project_id} | tail -1` ~/gsutil/ | true"
     rescue => exception
-      send_slack_load_shedder_integration_test(success: false)
+      # send_slack_load_shedder_integration_test(success: false)
       raise
     else
-      send_slack_load_shedder_integration_test(success: true)
+      # send_slack_load_shedder_integration_test(success: true)
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -187,10 +187,10 @@ platform :android do
       # We copy the test results from google cloud to the ~/gsutil folder. We use the tail -1 to get the latest
       sh "gsutil -m cp -r -U `gsutil ls gs://cloud-test-#{google_project_id} | tail -1` ~/gsutil/ | true"
     rescue => exception
-      # send_slack_load_shedder_integration_test(success: false)
+      send_slack_load_shedder_integration_test(success: false)
       raise
     else
-      # send_slack_load_shedder_integration_test(success: true)
+      send_slack_load_shedder_integration_test(success: true)
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -156,7 +156,8 @@ platform :android do
         api_key: ENV['REVENUECAT_API_KEY'],
         google_purchase_token: ENV['GOOGLE_PURCHASE_TOKEN'],
         product_id_to_purchase: ENV['PRODUCT_ID_TO_PURCHASE'],
-        base_plan_id_to_purchase: ENV['BASE_PLAN_ID_TO_PURCHASE']
+        base_plan_id_to_purchase: ENV['BASE_PLAN_ID_TO_PURCHASE'],
+        active_entitlements_to_verify: ENV['ACTIVE_ENTITLEMENTS_TO_VERIFY'] || '',
     )
   end
 
@@ -170,7 +171,8 @@ platform :android do
         api_key: ENV['LOAD_SHEDDER_REVENUECAT_API_KEY'],
         google_purchase_token: ENV['LOAD_SHEDDER_GOOGLE_PURCHASE_TOKEN'],
         product_id_to_purchase: ENV['LOAD_SHEDDER_PRODUCT_ID_TO_PURCHASE'],
-        base_plan_id_to_purchase: ENV['LOAD_SHEDDER_BASE_PLAN_ID_TO_PURCHASE']
+        base_plan_id_to_purchase: ENV['LOAD_SHEDDER_BASE_PLAN_ID_TO_PURCHASE'],
+        active_entitlements_to_verify: ENV['LOAD_SHEDDER_ACTIVE_ENTITLEMENTS_TO_VERIFY'] || ''
       )
 
       # We run the test on google firebase test labs
@@ -193,7 +195,8 @@ platform :android do
   end
 
   def build_purchases_integration_tests(app_name:, api_key:, google_purchase_token:, product_id_to_purchase:,
-                                        base_plan_id_to_purchase:, proxy_url: nil, build_type: 'release')
+                                        base_plan_id_to_purchase:, active_entitlements_to_verify: '',
+                                        proxy_url: nil, build_type: 'release')
     constants_path = './purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/Constants.kt'
     replace_text_in_files(
       previous_text: "REVENUECAT_API_KEY",
@@ -212,6 +215,11 @@ platform :android do
     )
     replace_text_in_files(
       previous_text: "BASE_PLAN_ID_TO_PURCHASE",
+      new_text: base_plan_id_to_purchase,
+      paths_of_files_to_update: [constants_path]
+    )
+    replace_text_in_files(
+      previous_text: "ACTIVE_ENTITLEMENT_IDS_TO_VERIFY",
       new_text: base_plan_id_to_purchase,
       paths_of_files_to_update: [constants_path]
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -220,7 +220,8 @@ platform :android do
     )
     replace_text_in_files(
       previous_text: "ACTIVE_ENTITLEMENT_IDS_TO_VERIFY",
-      new_text: base_plan_id_to_purchase,
+      new_text: active_entitlements_to_verify,
+      allow_empty: true,
       paths_of_files_to_update: [constants_path]
     )
     unless proxy_url.nil?

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/Constants.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/Constants.kt
@@ -6,4 +6,6 @@ object Constants {
     const val googlePurchaseToken = "GOOGLE_PURCHASE_TOKEN"
     const val productIdToPurchase = "PRODUCT_ID_TO_PURCHASE"
     const val basePlanIdToPurchase = "BASE_PLAN_ID_TO_PURCHASE"
+    // comma separated list of active entitlements to verify
+    const val activeEntitlementIdsToVerify = "ACTIVE_ENTITLEMENT_IDS_TO_VERIFY"
 }


### PR DESCRIPTION
### Description
Add verifications to integration tests to check that expected entitlements are active after purchasing and readd check to make sure purchases have the correct identifier after load shedder has been fixed.
