### PR TITLE
Remove flavors temporarily to fix deployment

### DIFF
--- a/base-application.gradle
+++ b/base-application.gradle
@@ -9,10 +9,6 @@ android {
     defaultConfig {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
-        // Library modules have a new dimension used to add extra APIs for integration tests
-        // Our applications however don't need the extra flavor. This makes sure that we use the
-        // flavor without the extra APIs in our applications.
-        missingDimensionStrategy 'extraAPIs', 'defaults'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/feature/amazon/build.gradle
+++ b/feature/amazon/build.gradle
@@ -74,8 +74,6 @@ task cleanAmazonLibrary(type: Delete) {
 }
 
 afterEvaluate {
-    preDefaultsDebugBuild.dependsOn cleanAmazonLibrary
-    preDefaultsReleaseBuild.dependsOn cleanAmazonLibrary
-    preIntegrationTestDebugBuild.dependsOn cleanAmazonLibrary
-    preIntegrationTestReleaseBuild.dependsOn cleanAmazonLibrary
+    preDebugBuild.dependsOn cleanAmazonLibrary
+    preReleaseBuild.dependsOn cleanAmazonLibrary
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ purchaseTesterMinSdkVersion=21
 
 #Do not sign releases. When calling uploadArchives pass -PRELEASE_SIGNING_ENABLED=true
 RELEASE_SIGNING_ENABLED=false
-ANDROID_VARIANT_TO_PUBLISH=defaultsRelease
+ANDROID_VARIANT_TO_PUBLISH=release
 SONATYPE_HOST=DEFAULT
 SONATYPE_AUTOMATIC_RELEASE=true
 

--- a/library.gradle
+++ b/library.gradle
@@ -7,17 +7,6 @@ android {
     compileSdkVersion compileVersion
     buildToolsVersion buildToolsVersion
 
-    flavorDimensions "extraAPIs"
-    productFlavors {
-        defaults {
-            dimension "extraAPIs"
-        }
-        integrationTest {
-            dimension "extraAPIs"
-            minSdkVersion 21 // Needed because mockk-android requires API 21
-        }
-    }
-
     defaultConfig {
         minSdkVersion minVersion
         targetSdkVersion compileVersion

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -4,16 +4,6 @@ apply plugin: 'org.jetbrains.dokka'
 
 android {
     namespace 'com.revenuecat.purchases.api'
-
-    productFlavors {
-        integrationTest {
-            testApplicationId obtainTestApplicationId()
-            testBuildType obtainTestBuildType()
-            packagingOptions {
-                resources.excludes.add("META-INF/*")
-            }
-        }
-    }
 }
 
 def obtainTestApplicationId() {
@@ -63,17 +53,6 @@ dependencies {
     testImplementation "io.mockk:mockk:$mockkVersion"
     testImplementation "org.assertj:assertj-core:$assertJVersion"
     testImplementation "com.android.billingclient:billing:$billingVersion"
-
-    integrationTestImplementation 'androidx.appcompat:appcompat:1.4.1'
-    integrationTestImplementation 'com.google.android.material:material:1.6.0'
-    integrationTestImplementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    androidTestIntegrationTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestIntegrationTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestIntegrationTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestIntegrationTestImplementation 'androidx.test.ext:junit-ktx:1.1.3'
-    androidTestIntegrationTestImplementation 'org.assertj:assertj-core:3.22.0'
-    androidTestIntegrationTestImplementation "io.mockk:mockk-android:$mockkVersion"
-    androidTestIntegrationTestImplementation "io.mockk:mockk-agent:$mockkVersion"
 }
 
 tasks.dokkaHtmlPartial.configure {


### PR DESCRIPTION
### Description
We found an issue in 6.1.0 that made the listener functions in the `listenerConversions.kt` file not accessible when being deployed in Maven. We tracked it down to the flavors that were added to run integration tests. We are removing these temporarily.