### PR TITLE
Repost active tokens if order id has changed

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -145,7 +145,6 @@ class Backend(
         subscriberAttributes: Map<String, Map<String, Any?>>,
         receiptInfo: ReceiptInfo,
         storeAppUserID: String?,
-        @SuppressWarnings("UnusedPrivateMember")
         marketplace: String? = null,
         onSuccess: PostReceiptDataSuccessCallback,
         onError: PostReceiptDataErrorCallback

--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -220,13 +220,13 @@ open class DeviceCache(
         val hashedTokens = getPreviouslySentHashedTokens()
         val hashedTokensAndOrderIds = getPreviouslySentOrderIdsPerHashToken()
 
-        if (hashedTokens.isNotEmpty() && hashedTokensAndOrderIds.isEmpty()) {
-            val orderIdsPerHashedToken = mutableMapOf<String, String>()
+        if (hashedTokens.isNotEmpty()) {
+            val migratedTokens = mutableMapOf<String, String>()
             hashedTokens.forEach { hashedToken ->
-                orderIdsPerHashedToken[hashedToken] = ""
+                migratedTokens[hashedToken] = ""
             }
 
-            val editor = setSavedOrderIdsPerTokenHashes(orderIdsPerHashedToken, applyEditor = false)
+            val editor = setSavedOrderIdsPerTokenHashes(hashedTokensAndOrderIds + migratedTokens, applyEditor = false)
             editor.remove(tokensCacheKey)
             editor.apply()
         }

--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -279,7 +279,9 @@ open class DeviceCache(
         }
         val activeTokensWithFixedOrders =
             fixEmptyOrderIds(tokensInCacheThatAreStillActive, activePurchasesByHashedToken)
-        setSavedOrderIdsPerTokenHashes(activeTokensWithFixedOrders)
+        if (tokensInCache != activeTokensWithFixedOrders) {
+            setSavedOrderIdsPerTokenHashes(activeTokensWithFixedOrders)
+        }
     }
 
     /**

--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -219,7 +219,7 @@ open class DeviceCache(
      * @param activePurchasesByHashedToken a map of hashed tokens to store transactions
      */
     @Synchronized
-    fun migrateFromHashedTokensCacheToCacheWithOrderIds(
+    fun migrateHashedTokensCacheToCacheWithOrderIds(
         activePurchasesByHashedToken: Map<String, StoreTransaction>
     ) {
         val hashedTokens = getPreviouslySentHashedTokens()

--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -210,13 +210,10 @@ open class DeviceCache(
 
     /**
      * Migrates data from hashed tokens cache to cache with order IDs. If there are no hashed tokens in the cache, or if
-     * there are already order IDs in the cache, this method does nothing. If there are hashed tokens in the cache, but
-     * no order IDs, it will use the active purchases to get the order IDs of the cached tokens and store them in
-     * the cache.
+     * there are already order IDs in the cache, this method does nothing. If there are hashed tokens in the cache, it
+     * will migrate them to the cache with order IDs (setting an empty order ID), and remove the hashed tokens cache.
      *
      * This method is synchronized to ensure thread safety.
-     *
-     * @param activePurchasesByHashedToken a map of hashed tokens to store transactions
      */
     @Synchronized
     fun migrateHashedTokensCacheToCacheWithOrderIds() {

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -769,10 +769,26 @@ class DeviceCacheTest {
         val sentTokens = cache.getPreviouslySentOrderIdsPerHashToken()
         assertThat(sentTokens).isEmpty()
     }
+
+    @Test
+    fun `addSuccessfullyPostedTokenWithOrderId supports saving new order id for existing token`() {
+        val token1Hash = "token1".sha1()
+        val token2Hash = "token2".sha1()
+
+        val tokensAndOrderIds = mapOf(token1Hash to "order_id", token2Hash to "order_id_2")
+        mockOrderIdsPerTokenCache(tokensAndOrderIds)
+
+        val newMap = tokensAndOrderIds.toMutableMap().also { it[token1Hash] = "order_id_3" }
+        mockSavingOrderIdsPerToken(newMap)
+
+        cache.addSuccessfullyPostedTokenWithOrderId("token1", "order_id_3")
+        verifySavedOrderIdsPerToken(newMap)
+    }
+
     // endregion
 
     // region helpers
-    
+
     private fun mockString(key: String, value: String?) {
         every {
             mockPrefs.getString(eq(key), isNull())

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonCache.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/AmazonCache.kt
@@ -39,6 +39,6 @@ internal class AmazonCache(
 
     @Synchronized
     fun addSuccessfullyPostedToken(token: String) {
-        deviceCache.addSuccessfullyPostedToken(token)
+        deviceCache.addSuccessfullyPostedPurchase(token, null)
     }
 }

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -17,7 +17,6 @@ import com.revenuecat.purchases.amazon.helpers.dummyAmazonProduct
 import com.revenuecat.purchases.amazon.helpers.dummyReceipt
 import com.revenuecat.purchases.amazon.helpers.dummyUserData
 import com.revenuecat.purchases.amazon.helpers.successfulRVSResponse
-import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.StoreProduct
@@ -546,7 +545,7 @@ class AmazonBillingTest {
         } just Runs
 
         every {
-            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
+            mockCache.addSuccessfullyPostedPurchase(dummyReceipt.receiptId)
         } just Runs
 
         underTest.consumeAndSave(
@@ -567,7 +566,7 @@ class AmazonBillingTest {
         }
 
         verify(exactly = 1) {
-            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
+            mockCache.addSuccessfullyPostedPurchase(dummyReceipt.receiptId)
         }
     }
 
@@ -581,7 +580,7 @@ class AmazonBillingTest {
         } just Runs
 
         every {
-            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
+            mockCache.addSuccessfullyPostedPurchase(dummyReceipt.receiptId)
         } just Runs
 
         underTest.consumeAndSave(
@@ -602,7 +601,7 @@ class AmazonBillingTest {
         }
 
         verify(exactly = 1) {
-            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
+            mockCache.addSuccessfullyPostedPurchase(dummyReceipt.receiptId)
         }
     }
 

--- a/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/feature/amazon/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -545,7 +545,7 @@ class AmazonBillingTest {
         } just Runs
 
         every {
-            mockCache.addSuccessfullyPostedPurchase(dummyReceipt.receiptId)
+            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
         } just Runs
 
         underTest.consumeAndSave(
@@ -566,7 +566,7 @@ class AmazonBillingTest {
         }
 
         verify(exactly = 1) {
-            mockCache.addSuccessfullyPostedPurchase(dummyReceipt.receiptId)
+            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
         }
     }
 
@@ -580,7 +580,7 @@ class AmazonBillingTest {
         } just Runs
 
         every {
-            mockCache.addSuccessfullyPostedPurchase(dummyReceipt.receiptId)
+            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
         } just Runs
 
         underTest.consumeAndSave(
@@ -601,7 +601,7 @@ class AmazonBillingTest {
         }
 
         verify(exactly = 1) {
-            mockCache.addSuccessfullyPostedPurchase(dummyReceipt.receiptId)
+            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
         }
     }
 

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -355,9 +355,9 @@ class BillingWrapper(
         val originalGooglePurchase = purchase.originalGooglePurchase
         val alreadyAcknowledged = originalGooglePurchase?.isAcknowledged ?: false
         if (shouldTryToConsume && purchase.type == ProductType.INAPP) {
-            consumePurchase(purchase.purchaseToken) { billingResult, purchaseToken ->
+            consumePurchase(purchase.purchaseToken) { billingResult, _ ->
                 if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                    deviceCache.addSuccessfullyPostedToken(purchaseToken)
+                    deviceCache.addSuccessfullyPostedPurchase(purchase)
                 } else {
                     log(
                         LogIntent.GOOGLE_ERROR, PurchaseStrings.CONSUMING_PURCHASE_ERROR
@@ -366,9 +366,9 @@ class BillingWrapper(
                 }
             }
         } else if (shouldTryToConsume && !alreadyAcknowledged) {
-            acknowledge(purchase.purchaseToken) { billingResult, purchaseToken ->
+            acknowledge(purchase.purchaseToken) { billingResult, _ ->
                 if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                    deviceCache.addSuccessfullyPostedToken(purchaseToken)
+                    deviceCache.addSuccessfullyPostedPurchase(purchase)
                 } else {
                     log(
                         LogIntent.GOOGLE_ERROR, PurchaseStrings.ACKNOWLEDGING_PURCHASE_ERROR
@@ -377,7 +377,7 @@ class BillingWrapper(
                 }
             }
         } else {
-            deviceCache.addSuccessfullyPostedToken(purchase.purchaseToken)
+            deviceCache.addSuccessfullyPostedPurchase(purchase)
         }
     }
 

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -357,7 +357,7 @@ class BillingWrapper(
         if (shouldTryToConsume && purchase.type == ProductType.INAPP) {
             consumePurchase(purchase.purchaseToken) { billingResult, _ ->
                 if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                    deviceCache.addSuccessfullyPostedPurchase(purchase)
+                    deviceCache.addSuccessfullyPostedPurchase(purchase.purchaseToken, purchase.orderId)
                 } else {
                     log(
                         LogIntent.GOOGLE_ERROR, PurchaseStrings.CONSUMING_PURCHASE_ERROR
@@ -368,7 +368,7 @@ class BillingWrapper(
         } else if (shouldTryToConsume && !alreadyAcknowledged) {
             acknowledge(purchase.purchaseToken) { billingResult, _ ->
                 if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                    deviceCache.addSuccessfullyPostedPurchase(purchase)
+                    deviceCache.addSuccessfullyPostedPurchase(purchase.purchaseToken, purchase.orderId)
                 } else {
                     log(
                         LogIntent.GOOGLE_ERROR, PurchaseStrings.ACKNOWLEDGING_PURCHASE_ERROR
@@ -377,7 +377,7 @@ class BillingWrapper(
                 }
             }
         } else {
-            deviceCache.addSuccessfullyPostedPurchase(purchase)
+            deviceCache.addSuccessfullyPostedPurchase(purchase.purchaseToken, purchase.orderId)
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1775,7 +1775,7 @@ class Purchases internal constructor(
                                     RestoreStrings.QUERYING_PURCHASE_WITH_HASH.format(purchase.type, hash)
                                 )
                             }
-                            deviceCache.migrateFromHashedTokensCacheToCacheWithOrderIds(activePurchasesByHashedToken)
+                            deviceCache.migrateHashedTokensCacheToCacheWithOrderIds(activePurchasesByHashedToken)
                             deviceCache.cleanInactiveTokens(activePurchasesByHashedToken.keys)
                             postPurchases(
                                 deviceCache.getActivePurchasesNotInCache(activePurchasesByHashedToken),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1775,6 +1775,7 @@ class Purchases internal constructor(
                                     RestoreStrings.QUERYING_PURCHASE_WITH_HASH.format(purchase.type, hash)
                                 )
                             }
+                            deviceCache.migrateFromHashedTokensCacheToCacheWithOrderIds(activePurchasesByHashedToken)
                             deviceCache.cleanInactiveTokens(activePurchasesByHashedToken.keys)
                             postPurchases(
                                 deviceCache.getActivePurchasesNotInCache(activePurchasesByHashedToken),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1775,8 +1775,7 @@ class Purchases internal constructor(
                                     RestoreStrings.QUERYING_PURCHASE_WITH_HASH.format(purchase.type, hash)
                                 )
                             }
-                            deviceCache.migrateHashedTokensCacheToCacheWithOrderIds(activePurchasesByHashedToken)
-                            deviceCache.cleanInactiveTokens(activePurchasesByHashedToken.keys)
+                            deviceCache.cleanUpTokensCache(activePurchasesByHashedToken)
                             postPurchases(
                                 deviceCache.getActivePurchasesNotInCache(activePurchasesByHashedToken),
                                 allowSharingPlayStoreAccount,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -138,7 +138,7 @@ internal class PurchasesFactory(
             }
 
             val offlineEntitlementsManager = OfflineEntitlementsManager(backend, cache)
-
+            cache.migrateHashedTokensCacheToCacheWithOrderIds()
             return Purchases(
                 application,
                 appUserID,

--- a/strings/src/main/java/com/revenuecat/purchases/strings/ReceiptStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/ReceiptStrings.kt
@@ -3,8 +3,9 @@ package com.revenuecat.purchases.strings
 object ReceiptStrings {
     const val CHECKING_IF_CACHE_STALE = "Checking if cache is stale AppInBackground %s"
     const val CLEANING_PREV_SENT_HASHED_TOKEN = "Cleaning previously sent tokens"
-    const val TOKENS_IN_CACHE = "Tokens in cache before saving %s"
+    const val TOKENS_IN_CACHE = "Tokens in cache before saving:\n%s"
     const val TOKENS_ALREADY_POSTED = "Tokens already posted: %s"
-    const val SAVING_TOKENS_WITH_HASH = "Saving token %s with hash %s"
-    const val SAVING_TOKENS = "Saving tokens %s"
+    const val ERROR_READING_TOKENS_FROM_CACHE = "There was an error reading tokens cache"
+    const val SAVING_ORDER_IDS_PER_TOKENS_WITH_HASH = "Saving order id %s for token %s with hash %s"
+    const val SAVING_TOKENS = "Saving order ids per tokens:\n%s"
 }

--- a/strings/src/main/java/com/revenuecat/purchases/strings/ReceiptStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/ReceiptStrings.kt
@@ -5,6 +5,7 @@ object ReceiptStrings {
     const val CLEANING_PREV_SENT_HASHED_TOKEN = "Cleaning previously sent tokens"
     const val TOKENS_IN_CACHE = "Tokens in cache before saving:\n%s"
     const val TOKENS_ALREADY_POSTED = "Tokens already posted: %s"
+    const val SAVING_TOKENS_WITH_HASH = "Saving token %s with hash %s"
     const val ERROR_READING_TOKENS_FROM_CACHE = "There was an error reading tokens cache"
     const val SAVING_ORDER_IDS_PER_TOKENS_WITH_HASH = "Saving order id %s for token %s with hash %s"
     const val SAVING_TOKENS = "Saving order ids per tokens:\n%s"

--- a/strings/src/main/java/com/revenuecat/purchases/strings/ReceiptStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/ReceiptStrings.kt
@@ -3,10 +3,12 @@ package com.revenuecat.purchases.strings
 object ReceiptStrings {
     const val CHECKING_IF_CACHE_STALE = "Checking if cache is stale AppInBackground %s"
     const val CLEANING_PREV_SENT_HASHED_TOKEN = "Cleaning previously sent tokens"
+    const val EMPTY_ORDER_ID_DETECTED = "Empty order id detected for token %s"
     const val TOKENS_IN_CACHE = "Tokens in cache before saving:\n%s"
     const val TOKENS_ALREADY_POSTED = "Tokens already posted: %s"
     const val SAVING_TOKENS_WITH_HASH = "Saving token %s with hash %s"
     const val ERROR_READING_TOKENS_FROM_CACHE = "There was an error reading tokens cache"
     const val SAVING_ORDER_IDS_PER_TOKENS_WITH_HASH = "Saving order id %s for token %s with hash %s"
+    const val SAVING_ORDER_IDS_FOR_HASH = "Saving order id %s for hash %s"
     const val SAVING_TOKENS = "Saving order ids per tokens:\n%s"
 }


### PR DESCRIPTION
In our current code we keep track of only the posted tokens, so we don't repost to our backend the same purchase over and over. We should change it to repost if the order id changes (when a renewal happens for example), so it behaves the same as iOS. This actually helps with detecting sandbox renewals.




