### PR TITLE
Add non-subscriptions support to offline customer info

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculator.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculator.kt
@@ -3,7 +3,6 @@ package com.revenuecat.purchases.common.offlineentitlements
 import com.google.gson.internal.bind.util.ISO8601Utils
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PeriodType
-import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.VerificationResult
@@ -60,7 +59,7 @@ class OfflineCustomerInfoCalculator(
                 put(CustomerInfoResponseJsonKeys.FIRST_SEEN, formattedDate)
                 val originalPurchaseDate = calculateOriginalPurchaseDate(purchasedProducts)
                 put(CustomerInfoResponseJsonKeys.ORIGINAL_PURCHASE_DATE, originalPurchaseDate)
-                put(CustomerInfoResponseJsonKeys.NON_SUBSCRIPTIONS, JSONObject()) // TODO in another PR
+                put(CustomerInfoResponseJsonKeys.NON_SUBSCRIPTIONS, JSONObject())
                 put(CustomerInfoResponseJsonKeys.SUBSCRIPTIONS, generateSubscriptions(purchasedProducts))
                 put(CustomerInfoResponseJsonKeys.MANAGEMENT_URL, determineManagementURL())
             })
@@ -84,7 +83,7 @@ class OfflineCustomerInfoCalculator(
     ): JSONObject {
         val subscriptions = JSONObject()
 
-        purchasedProducts.filter { it.storeTransaction.type == ProductType.SUBS }.forEach { product ->
+        purchasedProducts.forEach { product ->
             subscriptions.put(product.productIdentifier, JSONObject().apply {
                 put(ProductResponseJsonKeys.BILLING_ISSUES_DETECTED_AT, JSONObject.NULL)
                 put(ProductResponseJsonKeys.IS_SANDBOX, false)

--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
@@ -304,8 +304,7 @@ class OfflineCustomerInfoCalculatorTest {
             val expiresDate = expirationDates[productIdentifier]
             val storeTransaction = stubStoreTransactionFromPurchaseHistoryRecord(
                 productIds = listOf(productIdentifier),
-                purchaseTime = dateInThePast.time,
-                productType = if (expiresDate != null) ProductType.SUBS else ProductType.INAPP
+                purchaseTime = dateInThePast.time
             )
             PurchasedProduct(
                 productIdentifier,

--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
@@ -5,6 +5,7 @@ import com.ibm.icu.impl.Assert.fail
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.OwnershipType
 import com.revenuecat.purchases.PeriodType
+import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.Store
@@ -198,7 +199,6 @@ class OfflineCustomerInfoCalculatorTest {
     fun `two products with overlapping entitlements prioritizes the one with no expiration`() {
         val entitlementID = "pro_1"
 
-        val twoDaysFromNow = 2.days.fromNow()
         val purchasedProducts = mockPurchasedProducts(
             entitlementMap = mapOf(
                 "prod_1" to listOf(entitlementID),
@@ -227,8 +227,33 @@ class OfflineCustomerInfoCalculatorTest {
     }
 
     @Test
-    fun `error is triggered when fetching products fails`() {
+    fun `in app product also grants entitlement`() {
         val entitlementID = "pro_1"
+
+        val productIdentifier = "consumable"
+        val purchasedProducts = mockPurchasedProducts(
+            entitlementMap = mapOf(productIdentifier to listOf(entitlementID)),
+            expirationDates = mapOf(productIdentifier to null)
+        )
+
+        var receivedCustomerInfo: CustomerInfo? = null
+        offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
+            appUserID,
+            { receivedCustomerInfo = it },
+            { fail("Should've succeeded") }
+        )
+        assertThat(receivedCustomerInfo).isNotNull
+
+        assertThat(receivedCustomerInfo?.activeSubscriptions).isEqualTo(listOf("consumable").toSet())
+
+        assertThat(receivedCustomerInfo?.entitlements?.all?.size).isEqualTo(1)
+
+        val purchasedProduct = purchasedProducts.first { it.productIdentifier == "consumable" }
+        verifyEntitlement(receivedCustomerInfo, entitlementID, purchasedProduct, null)
+    }
+
+    @Test
+    fun `error is triggered when fetching products fails`() {
         every {
             purchasedProductsFetcher.queryPurchasedProducts(
                 appUserID,
@@ -276,16 +301,18 @@ class OfflineCustomerInfoCalculatorTest {
         expirationDates: Map<String, Date?> = mapOf("product_1" to dateInTheFuture)
     ): List<PurchasedProduct> {
         val products = entitlementMap.entries.map { (productIdentifier, entitlements) ->
+            val expiresDate = expirationDates[productIdentifier]
             val storeTransaction = stubStoreTransactionFromPurchaseHistoryRecord(
                 productIds = listOf(productIdentifier),
                 purchaseTime = dateInThePast.time,
+                productType = if (expiresDate != null) ProductType.SUBS else ProductType.INAPP
             )
             PurchasedProduct(
                 productIdentifier,
                 storeTransaction,
                 true,
                 entitlements,
-                expirationDates[productIdentifier]
+                expiresDate
             )
         }
 

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/billingClientStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/billingClientStubs.kt
@@ -184,7 +184,7 @@ fun stubStoreTransactionFromGooglePurchase(
 
 fun stubStoreTransactionFromPurchaseHistoryRecord(
     productIds: List<String>,
-    purchaseTime: Long,
+    purchaseTime: Long
 ): StoreTransaction {
     return stubPurchaseHistoryRecord(
         productIds = productIds,


### PR DESCRIPTION
Since we don't have the RevenueCat ID and we are doing this mainly for entitlement granting purposes, I mimicked what the backend does, which is add the non-subscriptions to the subscriptions array.