### PR TITLE
Add back integration test flavors

### DIFF
--- a/base-application.gradle
+++ b/base-application.gradle
@@ -9,6 +9,10 @@ android {
     defaultConfig {
         minSdkVersion minVersion
         targetSdkVersion compileVersion
+        // Library modules have a new dimension used to add extra APIs for integration tests
+        // Our applications however don't need the extra flavor. This makes sure that we use the
+        // flavor without the extra APIs in our applications.
+        missingDimensionStrategy 'extraAPIs', 'defaults'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/feature/amazon/build.gradle
+++ b/feature/amazon/build.gradle
@@ -74,6 +74,8 @@ task cleanAmazonLibrary(type: Delete) {
 }
 
 afterEvaluate {
-    preDebugBuild.dependsOn cleanAmazonLibrary
-    preReleaseBuild.dependsOn cleanAmazonLibrary
+    preDefaultsDebugBuild.dependsOn cleanAmazonLibrary
+    preDefaultsReleaseBuild.dependsOn cleanAmazonLibrary
+    preIntegrationTestDebugBuild.dependsOn cleanAmazonLibrary
+    preIntegrationTestReleaseBuild.dependsOn cleanAmazonLibrary
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ purchaseTesterMinSdkVersion=21
 
 #Do not sign releases. When calling uploadArchives pass -PRELEASE_SIGNING_ENABLED=true
 RELEASE_SIGNING_ENABLED=false
-ANDROID_VARIANT_TO_PUBLISH=release
+ANDROID_VARIANT_TO_PUBLISH=defaultsRelease
 SONATYPE_HOST=DEFAULT
 SONATYPE_AUTOMATIC_RELEASE=true
 

--- a/library.gradle
+++ b/library.gradle
@@ -7,6 +7,17 @@ android {
     compileSdkVersion compileVersion
     buildToolsVersion buildToolsVersion
 
+    flavorDimensions "extraAPIs"
+    productFlavors {
+        defaults {
+            dimension "extraAPIs"
+        }
+        integrationTest {
+            dimension "extraAPIs"
+            minSdkVersion 21 // Needed because mockk-android requires API 21
+        }
+    }
+
     defaultConfig {
         minSdkVersion minVersion
         targetSdkVersion compileVersion

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -4,6 +4,16 @@ apply plugin: 'org.jetbrains.dokka'
 
 android {
     namespace 'com.revenuecat.purchases.api'
+
+    productFlavors {
+        integrationTest {
+            testApplicationId obtainTestApplicationId()
+            testBuildType obtainTestBuildType()
+            packagingOptions {
+                resources.excludes.add("META-INF/*")
+            }
+        }
+    }
 }
 
 def obtainTestApplicationId() {
@@ -53,6 +63,17 @@ dependencies {
     testImplementation "io.mockk:mockk:$mockkVersion"
     testImplementation "org.assertj:assertj-core:$assertJVersion"
     testImplementation "com.android.billingclient:billing:$billingVersion"
+
+    integrationTestImplementation 'androidx.appcompat:appcompat:1.4.1'
+    integrationTestImplementation 'com.google.android.material:material:1.6.0'
+    integrationTestImplementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    androidTestIntegrationTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestIntegrationTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestIntegrationTestImplementation 'androidx.test:rules:1.4.0'
+    androidTestIntegrationTestImplementation 'androidx.test.ext:junit-ktx:1.1.3'
+    androidTestIntegrationTestImplementation 'org.assertj:assertj-core:3.22.0'
+    androidTestIntegrationTestImplementation "io.mockk:mockk-android:$mockkVersion"
+    androidTestIntegrationTestImplementation "io.mockk:mockk-agent:$mockkVersion"
 }
 
 tasks.dokkaHtmlPartial.configure {

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -10,7 +10,8 @@ android {
             testApplicationId obtainTestApplicationId()
             testBuildType obtainTestBuildType()
             packagingOptions {
-                resources.excludes.add("META-INF/*")
+                resources.excludes.add("META-INF/LICENSE.md")
+                resources.excludes.add("META-INF/LICENSE-notice.md")
             }
         }
     }


### PR DESCRIPTION
### Description
We detected that the chnages to support the new integration tests caused compilation issues for top-level kotlin functions. After debugging the issue, we tracked the issue down to this block of code:
```
    productFlavors {
        integrationTest {
            .....
            packagingOptions {
                resources.excludes.add("META-INF/*")
            }
        }
    }
```
We assumed that the `packagingOptions` there would only affect the `integrationTest` flavor, but it actually affects other flavors as well. This was causing a `kotlin_module` file to not be included in the published `aar` file, which caused top level functions to not be accessible by library consumers.
In this PR we change the exclusion to only exclude the files that were duplicated during instrumentation tests: `META-INF/LICENSE.md` and `META-INF/LICENSE-notice.md`. 
Comparing the resulting `AAR`'s:
- In 5.8.2: We had a `META-INF/purchases_latestDependenciesRelease.kotlin_module` file.
- In 6.1.0 (the faulty version): We didn't have any `kotlin_module` files
- In 6.1.1: We had a `META_INF/purchases_release.kotlin_module` file.
- After this fix: We have a `META_INF/purchases_defaultsRelease.kotlin_module` file.

Also, testing this change (by deploying to local maven and using it in a project) we can confirm the issue appears in 6.1.0 and before this change but doesn't appear after this change.

#### TODO
- [ ] Add tests that check against the resulting aar instead of using the modules to make sure this doesn't happen again. Added task SDK-3062 to track this
