### PR TITLE
Add isServerDown to error callback for postReceipt and getCustomerInfo requests

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -125,16 +125,18 @@ class Backend(
                             )
                         }
                     } catch (e: JSONException) {
-                        onError(e.toPurchasesError().also { errorLog(it) }, false)
+                        val isServerError = false
+                        onError(e.toPurchasesError().also { errorLog(it) }, isServerError)
                     }
                 }
             }
 
             override fun onError(error: PurchasesError) {
+                val isServerError = false
                 synchronized(this@Backend) {
                     callbacks.remove(cacheKey)
                 }?.forEach { (_, onError) ->
-                    onError(error, false)
+                    onError(error, isServerError)
                 }
             }
         }
@@ -218,10 +220,11 @@ class Backend(
                             )
                         }
                     } catch (e: JSONException) {
+                        val isServerError = false
                         onError(
                             e.toPurchasesError().also { errorLog(it) },
                             false,
-                            false,
+                            isServerError,
                             null
                         )
                     }
@@ -229,13 +232,14 @@ class Backend(
             }
 
             override fun onError(error: PurchasesError) {
+                val isServerError = false
                 synchronized(this@Backend) {
                     postReceiptCallbacks.remove(cacheKey)
                 }?.forEach { (_, onError) ->
                     onError(
                         error,
                         false,
-                        false,
+                        isServerError,
                         null
                     )
                 }

--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -24,7 +24,7 @@ const val ATTRIBUTES_ERROR_RESPONSE_KEY = "attributes_error_response"
 const val ATTRIBUTE_ERRORS_KEY = "attribute_errors"
 
 /** @suppress */
-internal typealias CustomerInfoCallback = Pair<(CustomerInfo) -> Unit, (PurchasesError) -> Unit>
+internal typealias CustomerInfoCallback = Pair<(CustomerInfo) -> Unit, (PurchasesError, isServerError: Boolean) -> Unit>
 
 /** @suppress */
 typealias PostReceiptCallback = Pair<PostReceiptDataSuccessCallback, PostReceiptDataErrorCallback>
@@ -35,7 +35,12 @@ typealias OfferingsCallback = Pair<(JSONObject) -> Unit, (PurchasesError) -> Uni
 /** @suppress */
 typealias PostReceiptDataSuccessCallback = (CustomerInfo, body: JSONObject) -> Unit
 /** @suppress */
-typealias PostReceiptDataErrorCallback = (PurchasesError, shouldConsumePurchase: Boolean, body: JSONObject?) -> Unit
+typealias PostReceiptDataErrorCallback = (
+    PurchasesError,
+    shouldConsumePurchase: Boolean,
+    isServerError: Boolean,
+    body: JSONObject?
+) -> Unit
 /** @suppress */
 typealias IdentifyCallback = Pair<(CustomerInfo, Boolean) -> Unit, (PurchasesError) -> Unit>
 /** @suppress */
@@ -80,7 +85,7 @@ class Backend(
         appUserID: String,
         appInBackground: Boolean,
         onSuccess: (CustomerInfo) -> Unit,
-        onError: (PurchasesError) -> Unit
+        onError: (PurchasesError, isServerError: Boolean) -> Unit
     ) {
         val endpoint = Endpoint.GetCustomerInfo(appUserID)
         val path = endpoint.getPath()
@@ -114,10 +119,13 @@ class Backend(
                         if (result.isSuccessful()) {
                             onSuccess(CustomerInfoFactory.buildCustomerInfo(result))
                         } else {
-                            onError(result.toPurchasesError().also { errorLog(it) })
+                            onError(
+                                result.toPurchasesError().also { errorLog(it) },
+                                RCHTTPStatusCodes.isServerError(result.responseCode)
+                            )
                         }
                     } catch (e: JSONException) {
-                        onError(e.toPurchasesError().also { errorLog(it) })
+                        onError(e.toPurchasesError().also { errorLog(it) }, false)
                     }
                 }
             }
@@ -126,7 +134,7 @@ class Backend(
                 synchronized(this@Backend) {
                     callbacks.remove(cacheKey)
                 }?.forEach { (_, onError) ->
-                    onError(error)
+                    onError(error, false)
                 }
             }
         }
@@ -205,11 +213,17 @@ class Backend(
                                 purchasesError,
                                 result.responseCode < RCHTTPStatusCodes.ERROR &&
                                     purchasesError.code != PurchasesErrorCode.UnsupportedError,
+                                RCHTTPStatusCodes.isServerError(result.responseCode),
                                 result.body
                             )
                         }
                     } catch (e: JSONException) {
-                        onError(e.toPurchasesError().also { errorLog(it) }, false, null)
+                        onError(
+                            e.toPurchasesError().also { errorLog(it) },
+                            false,
+                            false,
+                            null
+                        )
                     }
                 }
             }
@@ -220,6 +234,7 @@ class Backend(
                 }?.forEach { (_, onError) ->
                     onError(
                         error,
+                        false,
                         false,
                         null
                     )
@@ -368,7 +383,7 @@ class Backend(
                         onSuccessHandler(result.body)
                     } else {
                         val error = result.toPurchasesError()
-                        val shouldRetry = result.responseCode >= RCHTTPStatusCodes.ERROR ||
+                        val shouldRetry = RCHTTPStatusCodes.isServerError(result.responseCode) ||
                             error.code == PurchasesErrorCode.NetworkError
                         onErrorHandler(error, shouldRetry)
                     }

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/RCHTTPStatusCodes.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/RCHTTPStatusCodes.kt
@@ -10,4 +10,5 @@ object RCHTTPStatusCodes {
     const val ERROR = 500
 
     fun isSuccessful(statusCode: Int) = statusCode < BAD_REQUEST
+    fun isServerError(statusCode: Int) = statusCode >= ERROR
 }

--- a/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesPoster.kt
+++ b/feature/subscriber-attributes/src/main/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesPoster.kt
@@ -29,7 +29,7 @@ class SubscriberAttributesPoster(
             },
             { error, responseCode, body ->
                 error?.let {
-                    val internalServerError = responseCode >= RCHTTPStatusCodes.ERROR
+                    val internalServerError = RCHTTPStatusCodes.isServerError(responseCode)
                     val notFoundError = responseCode == RCHTTPStatusCodes.NOT_FOUND
                     val successfullySynced = !(internalServerError || notFoundError)
                     var attributeErrors: List<SubscriberAttributeError> = emptyList()

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -59,6 +59,7 @@ class SubscriberAttributesPosterTests {
 
     private var receivedError: PurchasesError? = null
     private var receivedSyncedSuccessfully: Boolean? = null
+    private var receivedIsServerError: Boolean? = null
     private var receivedAttributeErrors: List<SubscriberAttributeError>? = null
     private var receivedCustomerInfo: CustomerInfo? = null
     private var receivedOnSuccess = false
@@ -70,10 +71,11 @@ class SubscriberAttributesPosterTests {
             receivedAttributeErrors = attributeErrors
         }
 
-    private val expectedOnErrorPostReceipt: (PurchasesError, Boolean, JSONObject?) -> Unit =
-        { error, syncedSuccessfully, body ->
+    private val expectedOnErrorPostReceipt: (PurchasesError, Boolean, Boolean, JSONObject?) -> Unit =
+        { error, syncedSuccessfully, isServerError, body ->
             receivedError = error
             receivedSyncedSuccessfully = syncedSuccessfully
+            receivedIsServerError = isServerError
             receivedAttributeErrors = body.getAttributeErrors()
         }
 
@@ -93,8 +95,8 @@ class SubscriberAttributesPosterTests {
             fail("Shouldn't be error.")
         }
 
-    private val unexpectedOnErrorPostReceipt: (PurchasesError, Boolean, JSONObject?) -> Unit =
-        { _, _, _ ->
+    private val unexpectedOnErrorPostReceipt: (PurchasesError, Boolean, Boolean, JSONObject?) -> Unit =
+        { _, _, _, _ ->
             fail("Shouldn't be success.")
         }
 
@@ -113,6 +115,7 @@ class SubscriberAttributesPosterTests {
         mockkObject(CustomerInfoFactory)
         receivedError = null
         receivedSyncedSuccessfully = null
+        receivedIsServerError = null
         receivedAttributeErrors = null
         receivedCustomerInfo = null
         receivedOnSuccess = false

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
@@ -125,7 +125,7 @@ internal class CustomerInfoHelper(
                 sendUpdatedCustomerInfoToDelegateIfChanged(info)
                 dispatch { callback?.onReceived(info) }
             },
-            { error ->
+            { error, _ ->
                 Log.e("Purchases", "Error fetching customer data: $error")
                 deviceCache.clearCustomerInfoCacheTimestamp(appUserID)
                 dispatch { callback?.onError(error) }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -632,7 +632,7 @@ class Purchases internal constructor(
                                                 dispatch { callback.onReceived(info) }
                                             }
                                         },
-                                        onError = { error, shouldConsumePurchase, body ->
+                                        onError = { error, shouldConsumePurchase, _, body ->
                                             if (shouldConsumePurchase) {
                                                 subscriberAttributesManager.markAsSynced(
                                                     appUserID,
@@ -1376,7 +1376,7 @@ class Purchases internal constructor(
                     customerInfoHelper.sendUpdatedCustomerInfoToDelegateIfChanged(info)
                     onSuccess?.let { it(purchase, info) }
                 },
-                onError = { error, shouldConsumePurchase, body ->
+                onError = { error, shouldConsumePurchase, _, body ->
                     if (shouldConsumePurchase) {
                         subscriberAttributesManager.markAsSynced(
                             appUserID,
@@ -1828,7 +1828,7 @@ class Purchases internal constructor(
                     customerInfoHelper.sendUpdatedCustomerInfoToDelegateIfChanged(info)
                     onSuccess()
                 },
-                onError = { error, shouldConsumePurchase, body ->
+                onError = { error, shouldConsumePurchase, _, body ->
                     if (shouldConsumePurchase) {
                         subscriberAttributesManager.markAsSynced(
                             appUserID,

--- a/purchases/src/test/java/com/revenuecat/purchases/CustomerInfoHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/CustomerInfoHelperTest.kt
@@ -475,7 +475,7 @@ class CustomerInfoHelperTest {
                 every {
                     getCustomerInfo(any(), any(), any(), captureLambda())
                 } answers {
-                    lambda<(PurchasesError) -> Unit>().captured.invoke(errorGettingCustomerInfo)
+                    lambda<(PurchasesError, Boolean) -> Unit>().captured.invoke(errorGettingCustomerInfo, false)
                 }
             } else {
                 every {

--- a/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostingTransactionsTests.kt
@@ -70,6 +70,7 @@ class PostingTransactionsTests {
     internal data class PostReceiptErrorContainer(
         val error: PurchasesError,
         val shouldConsumePurchase: Boolean,
+        val isServerError: Boolean,
         val body: JSONObject?
     )
 
@@ -108,7 +109,7 @@ class PostingTransactionsTests {
             )
         } answers {
             postReceiptError?.let {
-                errorSlot.captured(it.error, it.shouldConsumePurchase, it.body)
+                errorSlot.captured(it.error, it.shouldConsumePurchase, it.isServerError, it.body)
             } ?: postReceiptSuccess?.let {
                 successSlot.captured(it.info, it.body)
             }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -4951,6 +4951,7 @@ class PurchasesTest {
         invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
             true,
+            false,
             JSONObject(Responses.invalidCredentialsErrorResponse)
         )
     }
@@ -4959,6 +4960,7 @@ class PurchasesTest {
         invoke(
             PurchasesError(PurchasesErrorCode.UnexpectedBackendResponseError),
             false,
+            true,
             JSONObject(Responses.internalServerErrorResponse)
         )
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -71,6 +71,7 @@ class SubscriberAttributesPurchasesTests {
     internal data class PostReceiptErrorContainer(
         val error: PurchasesError,
         val shouldConsumePurchase: Boolean,
+        val isServerError: Boolean,
         val body: JSONObject?
     )
 
@@ -109,7 +110,7 @@ class SubscriberAttributesPurchasesTests {
             )
         } answers {
             postReceiptError?.let {
-                errorSlot.captured(it.error, it.shouldConsumePurchase, it.body)
+                errorSlot.captured(it.error, it.shouldConsumePurchase, it.isServerError, it.body)
             } ?: postReceiptCompletion?.let {
                 successSlot.captured(it.info, it.body)
             }
@@ -330,8 +331,9 @@ class SubscriberAttributesPurchasesTests {
     fun `when syncing purchases, attributes are not marked as synced if error is not finishable`() {
         postReceiptError = PostReceiptErrorContainer(
             PurchasesError(PurchasesErrorCode.NetworkError),
-            false,
-            null
+            shouldConsumePurchase = false,
+            isServerError = false,
+            body = null
         )
         underTest.syncPurchases()
 
@@ -413,8 +415,9 @@ class SubscriberAttributesPurchasesTests {
         )
         postReceiptError = PostReceiptErrorContainer(
             PurchasesError(PurchasesErrorCode.NetworkError),
-            false,
-            null
+            shouldConsumePurchase = false,
+            isServerError = false,
+            body = null
         )
 
         underTest.restorePurchasesWith { }
@@ -513,8 +516,9 @@ class SubscriberAttributesPurchasesTests {
     fun `when purchasing, attributes are not marked as synced if error is not finishable`() {
         postReceiptError = PostReceiptErrorContainer(
             JSONException("exception").toPurchasesError(),
-            false,
-            null
+            shouldConsumePurchase = false,
+            isServerError = true,
+            body = null
         )
 
         underTest.postToBackend(
@@ -671,7 +675,8 @@ class SubscriberAttributesPurchasesTests {
     private fun getFinishableErrorResponse(): PostReceiptErrorContainer {
         return PostReceiptErrorContainer(
             PurchasesError(PurchasesErrorCode.UnexpectedBackendResponseError),
-            true,
+            shouldConsumePurchase = true,
+            isServerError = false,
             JSONObject(Responses.badRequestErrorResponse)
         )
     }


### PR DESCRIPTION
### Description
First PR for SDK-2992

In this PR, we add a `isServerError` parameter to the error callback for the `postReceipt` and `getCustomerInfo` backend requests. This will be true if we get a 5xx error code, false otherwise.

This is currently unused but will be used to detect whether we need to compute offline entitlements