### PR TITLE
Support enabling/disabling offline entitlements

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
@@ -23,6 +23,8 @@ class AppConfig(
         log(LogIntent.INFO, ConfigureStrings.CONFIGURING_PURCHASES_PROXY_URL_SET)
     } ?: URL("https://api.revenuecat.com/")
     val diagnosticsURL = URL("https://api-diagnostics.revenuecat.com/")
+    // For now hardcoded to false until we are ready to enable it.
+    val areOfflineEntitlementsEnabled = false
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -216,10 +216,12 @@ class Backend(
                             onSuccess(CustomerInfoFactory.buildCustomerInfo(result), result.body)
                         } else {
                             val purchasesError = result.toPurchasesError().also { errorLog(it) }
-                            val errorType = determinePostReceiptErrorType(result.responseCode, purchasesError)
+                            val errorHandlingBehavior = determinePostReceiptErrorHandlingBehavior(
+                                result.responseCode, purchasesError
+                            )
                             onError(
                                 purchasesError,
-                                errorType,
+                                errorHandlingBehavior,
                                 result.body
                             )
                         }
@@ -460,7 +462,7 @@ class Backend(
         httpClient.clearCaches()
     }
 
-    private fun determinePostReceiptErrorType(
+    private fun determinePostReceiptErrorHandlingBehavior(
         responseCode: Int,
         purchasesError: PurchasesError
     ) = if (RCHTTPStatusCodes.isServerError(responseCode)) {

--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -216,7 +216,7 @@ class Backend(
                             onSuccess(CustomerInfoFactory.buildCustomerInfo(result), result.body)
                         } else {
                             val purchasesError = result.toPurchasesError().also { errorLog(it) }
-                            val errorType = calculatePostReceiptErrorType(result.responseCode, purchasesError)
+                            val errorType = determinePostReceiptErrorType(result.responseCode, purchasesError)
                             onError(
                                 purchasesError,
                                 errorType,
@@ -460,15 +460,15 @@ class Backend(
         httpClient.clearCaches()
     }
 
-    private fun calculatePostReceiptErrorType(
+    private fun determinePostReceiptErrorType(
         responseCode: Int,
         purchasesError: PurchasesError
     ) = if (RCHTTPStatusCodes.isServerError(responseCode)) {
         PostReceiptErrorType.SERVER_ERROR
-    } else if (purchasesError.code != PurchasesErrorCode.UnsupportedError) {
-        PostReceiptErrorType.CAN_BE_CONSUMED
-    } else {
+    } else if (purchasesError.code == PurchasesErrorCode.UnsupportedError) {
         PostReceiptErrorType.CANNOT_BE_CONSUMED
+    } else {
+        PostReceiptErrorType.CAN_BE_CONSUMED
     }
 
     private fun <K, S, E> MutableMap<K, MutableList<Pair<S, E>>>.addCallback(

--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -37,8 +37,7 @@ typealias PostReceiptDataSuccessCallback = (CustomerInfo, body: JSONObject) -> U
 /** @suppress */
 typealias PostReceiptDataErrorCallback = (
     PurchasesError,
-    shouldConsumePurchase: Boolean,
-    isServerError: Boolean,
+    postReceiptErrorType: PostReceiptErrorType,
     body: JSONObject?
 ) -> Unit
 /** @suppress */
@@ -47,6 +46,12 @@ typealias IdentifyCallback = Pair<(CustomerInfo, Boolean) -> Unit, (PurchasesErr
 typealias DiagnosticsCallback = Pair<(JSONObject) -> Unit, (PurchasesError, Boolean) -> Unit>
 /** @suppress */
 typealias ProductEntitlementCallback = Pair<(ProductEntitlementMapping) -> Unit, (PurchasesError) -> Unit>
+
+enum class PostReceiptErrorType {
+    CAN_BE_CONSUMED,
+    SERVER_ERROR,
+    CANNOT_BE_CONSUMED
+}
 
 class Backend(
     private val appConfig: AppConfig,
@@ -211,20 +216,17 @@ class Backend(
                             onSuccess(CustomerInfoFactory.buildCustomerInfo(result), result.body)
                         } else {
                             val purchasesError = result.toPurchasesError().also { errorLog(it) }
+                            val errorType = calculatePostReceiptErrorType(result.responseCode, purchasesError)
                             onError(
                                 purchasesError,
-                                result.responseCode < RCHTTPStatusCodes.ERROR &&
-                                    purchasesError.code != PurchasesErrorCode.UnsupportedError,
-                                RCHTTPStatusCodes.isServerError(result.responseCode),
+                                errorType,
                                 result.body
                             )
                         }
                     } catch (e: JSONException) {
-                        val isServerError = false
                         onError(
                             e.toPurchasesError().also { errorLog(it) },
-                            false,
-                            isServerError,
+                            PostReceiptErrorType.CANNOT_BE_CONSUMED,
                             null
                         )
                     }
@@ -232,14 +234,12 @@ class Backend(
             }
 
             override fun onError(error: PurchasesError) {
-                val isServerError = false
                 synchronized(this@Backend) {
                     postReceiptCallbacks.remove(cacheKey)
                 }?.forEach { (_, onError) ->
                     onError(
                         error,
-                        false,
-                        isServerError,
+                        PostReceiptErrorType.CANNOT_BE_CONSUMED,
                         null
                     )
                 }
@@ -458,6 +458,17 @@ class Backend(
 
     fun clearCaches() {
         httpClient.clearCaches()
+    }
+
+    private fun calculatePostReceiptErrorType(
+        responseCode: Int,
+        purchasesError: PurchasesError
+    ) = if (RCHTTPStatusCodes.isServerError(responseCode)) {
+        PostReceiptErrorType.SERVER_ERROR
+    } else if (purchasesError.code != PurchasesErrorCode.UnsupportedError) {
+        PostReceiptErrorType.CAN_BE_CONSUMED
+    } else {
+        PostReceiptErrorType.CANNOT_BE_CONSUMED
     }
 
     private fun <K, S, E> MutableMap<K, MutableList<Pair<S, E>>>.addCallback(

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -28,7 +28,7 @@ class OfflineEntitlementsManager(
     @Synchronized
     fun resetOfflineCustomerInfoCache() {
         if (_offlineCustomerInfo != null) {
-            warnLog(OfflineEntitlementsStrings.RESETTING_OFFLINE_CUSTOMER_INFO_CACHE)
+            debugLog(OfflineEntitlementsStrings.RESETTING_OFFLINE_CUSTOMER_INFO_CACHE)
             _offlineCustomerInfo = null
         }
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -8,7 +8,6 @@ import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
-import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.strings.OfflineEntitlementsStrings
 
 class OfflineEntitlementsManager(

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -48,10 +48,15 @@ class OfflineEntitlementsManager(
         offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
             appUserId,
             onSuccess = { customerInfo ->
+                // TODO improve logs
+                warnLog("Updating offline customer info cache")
                 _offlineCustomerInfo = customerInfo
                 onSuccess(customerInfo)
             },
-            onError = onError
+            onError = {
+                errorLog("Error calculating offline customer info: $it")
+                onError(it)
+            }
         )
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -19,26 +19,32 @@ class OfflineEntitlementsManager(
     // We cache the offline customer info in memory, so it's not persisted.
     val offlineCustomerInfo: CustomerInfo?
         get() = _offlineCustomerInfo
-    // TODO make sure we handle concurrency
+    @get:Synchronized @set:Synchronized
     private var _offlineCustomerInfo: CustomerInfo? = null
 
+    private val offlineCustomerInfoCallbackCache = mutableMapOf<String, List<OfflineCustomerInfoCallback>>()
+
     fun resetOfflineCustomerInfoCache() {
-        if (_offlineCustomerInfo != null) {
-            // TODO improve logs
-            warnLog("Resetting offline customer info cache")
+        synchronized(this) {
+            if (_offlineCustomerInfo != null) {
+                warnLog(OfflineEntitlementsStrings.RESETTING_OFFLINE_CUSTOMER_INFO_CACHE)
+                _offlineCustomerInfo = null
+            }
         }
-        _offlineCustomerInfo = null
     }
 
     fun shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest(
         isServerError: Boolean,
         appUserId: String
     ): Boolean {
-        return appConfig.areOfflineEntitlementsEnabled && isServerError && deviceCache.getCachedCustomerInfo(appUserId) == null
+        return appConfig.areOfflineEntitlementsEnabled &&
+            isServerError &&
+            deviceCache.getCachedCustomerInfo(appUserId) == null
     }
 
     fun shouldCalculateOfflineCustomerInfoInPostReceipt(isServerError: Boolean): Boolean {
-        return appConfig.areOfflineEntitlementsEnabled && isServerError
+        return appConfig.areOfflineEntitlementsEnabled &&
+            isServerError
     }
 
     @Suppress("FunctionOnlyReturningConstant")
@@ -47,17 +53,34 @@ class OfflineEntitlementsManager(
         onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit
     ) {
+        synchronized(this) {
+            val alreadyProcessing = offlineCustomerInfoCallbackCache.containsKey(appUserId)
+            val callbacks = offlineCustomerInfoCallbackCache[appUserId] ?: emptyList()
+            offlineCustomerInfoCallbackCache[appUserId] = callbacks + listOf(onSuccess to onError)
+            if (alreadyProcessing) {
+                debugLog(OfflineEntitlementsStrings.ALREADY_CALCULATING_OFFLINE_CUSTOMER_INFO.format(appUserId))
+                return
+            }
+        }
         offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
             appUserId,
             onSuccess = { customerInfo ->
-                // TODO improve logs
-                warnLog("Updating offline customer info cache")
-                _offlineCustomerInfo = customerInfo
-                onSuccess(customerInfo)
+                synchronized(this) {
+                    warnLog("Updating offline customer info cache")
+                    _offlineCustomerInfo = customerInfo
+                    val callbacks = offlineCustomerInfoCallbackCache.remove(appUserId)
+                    callbacks?.forEach { (onSuccess, _) ->
+                        onSuccess(customerInfo)
+                    }
+                }
             },
             onError = {
-                errorLog("Error calculating offline customer info: $it")
-                onError(it)
+                synchronized(this) {
+                    val callbacks = offlineCustomerInfoCallbackCache.remove(appUserId)
+                    callbacks?.forEach { (_, onError) ->
+                        onError(it)
+                    }
+                }
             }
         )
     }
@@ -77,3 +100,5 @@ class OfflineEntitlementsManager(
         }
     }
 }
+
+private typealias OfflineCustomerInfoCallback = Pair<(CustomerInfo) -> Unit, (PurchasesError) -> Unit>

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common.offlineentitlements
 
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.debugLog
@@ -10,6 +11,7 @@ import com.revenuecat.purchases.strings.OfflineEntitlementsStrings
 
 class OfflineEntitlementsManager(
     private val backend: Backend,
+    private val offlineCustomerInfoCalculator: OfflineCustomerInfoCalculator,
     private val deviceCache: DeviceCache
 ) {
     // We cache the offline customer info in memory, so it's not persisted.
@@ -37,9 +39,19 @@ class OfflineEntitlementsManager(
     }
 
     @Suppress("FunctionOnlyReturningConstant")
-    fun calculateAndCacheOfflineCustomerInfo(): CustomerInfo? {
-        // TODO Calculate last offline customer info and assign to _offlineCustomerInfo
-        return null
+    fun calculateAndCacheOfflineCustomerInfo(
+        appUserId: String,
+        onSuccess: (CustomerInfo) -> Unit,
+        onError: (PurchasesError) -> Unit
+    ) {
+        offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
+            appUserId,
+            onSuccess = { customerInfo ->
+                _offlineCustomerInfo = customerInfo
+                onSuccess(customerInfo)
+            },
+            onError = onError
+        )
     }
 
     fun updateProductEntitlementMappingCacheIfStale() {

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.common.offlineentitlements
 
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.debugLog
@@ -10,6 +11,7 @@ import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.strings.OfflineEntitlementsStrings
 
 class OfflineEntitlementsManager(
+    private val appConfig: AppConfig,
     private val backend: Backend,
     private val offlineCustomerInfoCalculator: OfflineCustomerInfoCalculator,
     private val deviceCache: DeviceCache
@@ -32,11 +34,11 @@ class OfflineEntitlementsManager(
         isServerError: Boolean,
         appUserId: String
     ): Boolean {
-        return isServerError && deviceCache.getCachedCustomerInfo(appUserId) == null
+        return appConfig.areOfflineEntitlementsEnabled && isServerError && deviceCache.getCachedCustomerInfo(appUserId) == null
     }
 
     fun shouldCalculateOfflineCustomerInfoInPostReceipt(isServerError: Boolean): Boolean {
-        return isServerError
+        return appConfig.areOfflineEntitlementsEnabled && isServerError
     }
 
     @Suppress("FunctionOnlyReturningConstant")

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -1,15 +1,46 @@
 package com.revenuecat.purchases.common.offlineentitlements
 
+import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.strings.OfflineEntitlementsStrings
 
 class OfflineEntitlementsManager(
     private val backend: Backend,
     private val deviceCache: DeviceCache
 ) {
+    // We cache the offline customer info in memory, so it's not persisted.
+    val offlineCustomerInfo: CustomerInfo?
+        get() = _offlineCustomerInfo
+    private var _offlineCustomerInfo: CustomerInfo? = null
+
+    fun resetOfflineCustomerInfoCache() {
+        if (_offlineCustomerInfo != null) {
+            // TODO improve logs
+            warnLog("Resetting offline customer info cache")
+        }
+        _offlineCustomerInfo = null
+    }
+
+    fun shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest(
+        isServerError: Boolean,
+        appUserId: String
+    ): Boolean {
+        return isServerError && deviceCache.getCachedCustomerInfo(appUserId) == null
+    }
+
+    fun shouldCalculateOfflineCustomerInfoInPostReceipt(isServerError: Boolean): Boolean {
+        return isServerError
+    }
+
+    @Suppress("FunctionOnlyReturningConstant")
+    fun calculateAndCacheOfflineCustomerInfo(): CustomerInfo? {
+        // TODO Calculate last offline customer info and assign to _offlineCustomerInfo
+        return null
+    }
 
     fun updateProductEntitlementMappingCacheIfStale() {
         if (deviceCache.isProductEntitlementMappingCacheStale()) {

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -53,7 +53,7 @@ class OfflineEntitlementsManager(
         if (!appConfig.areOfflineEntitlementsEnabled) {
             onError(PurchasesError(
                 PurchasesErrorCode.UnsupportedError,
-                OfflineEntitlementsStrings.OFFLINE_ENTITLEMENTS_NOT_SUPPORTED
+                OfflineEntitlementsStrings.OFFLINE_ENTITLEMENTS_NOT_ENABLED
             ))
             return
         }

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -17,6 +17,7 @@ class OfflineEntitlementsManager(
     // We cache the offline customer info in memory, so it's not persisted.
     val offlineCustomerInfo: CustomerInfo?
         get() = _offlineCustomerInfo
+    // TODO make sure we handle concurrency
     private var _offlineCustomerInfo: CustomerInfo? = null
 
     fun resetOfflineCustomerInfoCache() {

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -149,9 +149,9 @@ class BackendTest {
         }
 
     private val postReceiptErrorCallback: PostReceiptDataErrorCallback =
-        { error, errorType, _ ->
+        { error, errorHandlingBehavior, _ ->
             this@BackendTest.receivedError = error
-            this@BackendTest.receivedPostReceiptErrorHandlingBehavior = errorType
+            this@BackendTest.receivedPostReceiptErrorHandlingBehavior = errorHandlingBehavior
         }
 
     private val onReceiveCustomerInfoErrorHandler: (PurchasesError, Boolean) -> Unit = { error, isServerError ->

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -66,7 +66,7 @@ class BackendTest {
         receivedError = null
         receivedOfferingsJSON = null
         receivedCustomerInfo = null
-        receivedPostReceiptErrorType = null
+        receivedPostReceiptErrorHandlingBehavior = null
         receivedCustomerInfoCreated = null
         receivedIsServerError = null
     }
@@ -132,7 +132,7 @@ class BackendTest {
     private var receivedCustomerInfoCreated: Boolean? = null
     private var receivedOfferingsJSON: JSONObject? = null
     private var receivedError: PurchasesError? = null
-    private var receivedPostReceiptErrorType: PostReceiptErrorType? = null
+    private var receivedPostReceiptErrorHandlingBehavior: PostReceiptErrorHandlingBehavior? = null
     private var receivedIsServerError: Boolean? = null
     private val noOfferingsResponse = "{'offerings': [], 'current_offering_id': null}"
 
@@ -151,7 +151,7 @@ class BackendTest {
     private val postReceiptErrorCallback: PostReceiptDataErrorCallback =
         { error, errorType, _ ->
             this@BackendTest.receivedError = error
-            this@BackendTest.receivedPostReceiptErrorType = errorType
+            this@BackendTest.receivedPostReceiptErrorHandlingBehavior = errorType
         }
 
     private val onReceiveCustomerInfoErrorHandler: (PurchasesError, Boolean) -> Unit = { error, isServerError ->
@@ -1013,7 +1013,7 @@ class BackendTest {
         assertThat(receivedError!!.code)
             .`as`("Received error code is the right one")
             .isEqualTo(PurchasesErrorCode.UnsupportedError)
-        assertThat(receivedPostReceiptErrorType).isEqualTo(PostReceiptErrorType.CANNOT_BE_CONSUMED)
+        assertThat(receivedPostReceiptErrorHandlingBehavior).isEqualTo(PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
     }
 
     @Test
@@ -1032,7 +1032,7 @@ class BackendTest {
             storeAppUserID = null
         )
 
-        assertThat(receivedPostReceiptErrorType).isEqualTo(PostReceiptErrorType.CAN_BE_CONSUMED)
+        assertThat(receivedPostReceiptErrorHandlingBehavior).isEqualTo(PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED)
     }
 
     @Test
@@ -1051,7 +1051,7 @@ class BackendTest {
             storeAppUserID = null
         )
 
-        assertThat(receivedPostReceiptErrorType).isEqualTo(PostReceiptErrorType.SERVER_ERROR)
+        assertThat(receivedPostReceiptErrorHandlingBehavior).isEqualTo(PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
     }
 
     @Test
@@ -1070,7 +1070,7 @@ class BackendTest {
             storeAppUserID = null
         )
 
-        assertThat(receivedPostReceiptErrorType).isEqualTo(PostReceiptErrorType.CANNOT_BE_CONSUMED)
+        assertThat(receivedPostReceiptErrorHandlingBehavior).isEqualTo(PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common.offlineentitlements
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.AppConfig
@@ -9,10 +10,13 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import io.mockk.CapturingSlot
 import io.mockk.Runs
 import io.mockk.every
+import io.mockk.invoke
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,6 +25,8 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 class OfflineEntitlementsManagerTest {
+
+    private val appUserID = "test-app-user-id"
 
     private lateinit var backendSuccessSlot: CapturingSlot<(ProductEntitlementMapping) -> Unit>
     private lateinit var backendErrorSlot: CapturingSlot<(PurchasesError) -> Unit>
@@ -57,6 +63,220 @@ class OfflineEntitlementsManagerTest {
         )
     }
 
+    // region shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest
+
+    @Test
+    fun `shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest returns true if server error and cached customer info is null`() {
+        every { deviceCache.getCachedCustomerInfo(appUserID) } returns null
+        val isServerError = true
+        val result = offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest(
+            isServerError,
+            appUserID
+        )
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest returns false if offline mode disabled`() {
+        every { appConfig.areOfflineEntitlementsEnabled } returns false
+        val isServerError = true
+        val result = offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest(
+            isServerError,
+            appUserID
+        )
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest returns false if server error and cached customer info is not null`() {
+        every { deviceCache.getCachedCustomerInfo(appUserID) } returns mockk()
+        val isServerError = true
+        val result = offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest(
+            isServerError,
+            appUserID
+        )
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest returns false if not server error and cached customer info is null`() {
+        every { deviceCache.getCachedCustomerInfo(appUserID) } returns null
+        val isServerError = false
+        val result = offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest(
+            isServerError,
+            appUserID
+        )
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest returns false if not server error and cached customer info is not null`() {
+        every { deviceCache.getCachedCustomerInfo(appUserID) } returns mockk()
+        val isServerError = false
+        val result = offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest(
+            isServerError,
+            appUserID
+        )
+        assertThat(result).isFalse
+    }
+
+    // endregion
+
+    // region shouldCalculateOfflineCustomerInfoInPostReceipt
+
+    @Test
+    fun `shouldCalculateOfflineCustomerInfoInPostReceipt returns true if server error`() {
+        val isServerError = true
+        assertThat(offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInPostReceipt(isServerError)).isTrue
+    }
+
+    @Test
+    fun `shouldCalculateOfflineCustomerInfoInPostReceipt returns false if offline entitlements disabled`() {
+        every { appConfig.areOfflineEntitlementsEnabled } returns false
+        val isServerError = true
+        assertThat(offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInPostReceipt(isServerError)).isFalse
+    }
+
+    @Test
+    fun `shouldCalculateOfflineCustomerInfoInPostReceipt returns false if not server error`() {
+        val isServerError = false
+        assertThat(offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInPostReceipt(isServerError)).isFalse
+    }
+
+    // endregion
+
+    // region resetOfflineCustomerInfoCache
+
+    @Test
+    fun `resetOfflineCustomerInfoCache does nothing if offline customer info is null`() {
+        assertThat(offlineEntitlementsManager.offlineCustomerInfo).isNull()
+        offlineEntitlementsManager.resetOfflineCustomerInfoCache()
+        assertThat(offlineEntitlementsManager.offlineCustomerInfo).isNull()
+    }
+
+    @Test
+    fun `resetOfflineCustomerInfoCache changes offline customer info cache to null`() {
+        val customerInfo = mockk<CustomerInfo>()
+        mockCalculateOfflineEntitlements(successCustomerInfo = customerInfo)
+        offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, {}, { fail("Should succeed") })
+        assertThat(offlineEntitlementsManager.offlineCustomerInfo).isEqualTo(customerInfo)
+        offlineEntitlementsManager.resetOfflineCustomerInfoCache()
+        assertThat(offlineEntitlementsManager.offlineCustomerInfo).isNull()
+    }
+
+    // endregion
+
+    // region calculateAndCacheOfflineCustomerInfo
+
+    @Test
+    fun `calculateAndCacheOfflineCustomerInfo returns customer info on success callback`() {
+        val customerInfo = mockk<CustomerInfo>()
+        mockCalculateOfflineEntitlements(successCustomerInfo = customerInfo)
+        var customerInfoFromCallback: CustomerInfo? = null
+        offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
+            appUserID,
+            onSuccess = { customerInfoFromCallback = it },
+            onError = { fail("Should succeed") }
+        )
+        assertThat(customerInfoFromCallback).isEqualTo(customerInfo)
+    }
+
+    @Test
+    fun `calculateAndCacheOfflineCustomerInfo caches customer info on success`() {
+        val customerInfo = mockk<CustomerInfo>()
+        mockCalculateOfflineEntitlements(successCustomerInfo = customerInfo)
+        offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
+            appUserID,
+            onSuccess = {},
+            onError = { fail("Should succeed") }
+        )
+        assertThat(offlineEntitlementsManager.offlineCustomerInfo).isEqualTo(customerInfo)
+    }
+
+    @Test
+    fun `calculateAndCacheOfflineCustomerInfo only computes offline customer info one at a time and calls all success callbacks`() {
+        val customerInfo = mockk<CustomerInfo>()
+        val successCallbackSlot = slot<(CustomerInfo) -> Unit>()
+        every {
+            offlineEntitlementsCalculator.computeOfflineCustomerInfo(appUserID, capture(successCallbackSlot), any())
+        } just Runs
+        var callback1CustomerInfo: CustomerInfo? = null
+        offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
+            appUserID,
+            onSuccess = { callback1CustomerInfo = it },
+            onError = { fail("Should succeed") }
+        )
+        var callback2CustomerInfo: CustomerInfo? = null
+        offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
+            appUserID,
+            onSuccess = { callback2CustomerInfo = it },
+            onError = { fail("Should succeed") }
+        )
+        assertThat(callback1CustomerInfo).isNull()
+        assertThat(callback2CustomerInfo).isNull()
+        verify(exactly = 1) { offlineEntitlementsCalculator.computeOfflineCustomerInfo(any(), any(), any()) }
+        successCallbackSlot.invoke(customerInfo)
+        assertThat(callback1CustomerInfo).isEqualTo(customerInfo)
+        assertThat(callback2CustomerInfo).isEqualTo(customerInfo)
+        verify(exactly = 1) { offlineEntitlementsCalculator.computeOfflineCustomerInfo(any(), any(), any()) }
+    }
+
+    @Test
+    fun `calculateAndCacheOfflineCustomerInfo does not cache customer info on error`() {
+        mockCalculateOfflineEntitlements(error = PurchasesError(PurchasesErrorCode.UnknownError))
+        offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
+            appUserID,
+            onSuccess = { fail("Should error") },
+            onError = {}
+        )
+        assertThat(offlineEntitlementsManager.offlineCustomerInfo).isNull()
+    }
+
+    @Test
+    fun `calculateAndCacheOfflineCustomerInfo returns error`() {
+        val error = PurchasesError(PurchasesErrorCode.UnknownError)
+        mockCalculateOfflineEntitlements(error = error)
+        var receivedError: PurchasesError? = null
+        offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
+            appUserID,
+            onSuccess = { fail("Should error") },
+            onError = { receivedError = it }
+        )
+        assertThat(receivedError).isEqualTo(error)
+    }
+
+    @Test
+    fun `calculateAndCacheOfflineCustomerInfo only computes offline customer info one at a time and calls all error callbacks`() {
+        val error = PurchasesError(PurchasesErrorCode.UnknownError)
+        val errorCallbackSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            offlineEntitlementsCalculator.computeOfflineCustomerInfo(appUserID, any(), capture(errorCallbackSlot))
+        } just Runs
+        var callback1Error: PurchasesError? = null
+        offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
+            appUserID,
+            onSuccess = { fail("Should error") },
+            onError = { callback1Error = it }
+        )
+        var callback2Error: PurchasesError? = null
+        offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
+            appUserID,
+            onSuccess = { fail("Should error") },
+            onError = { callback2Error = it }
+        )
+        assertThat(callback1Error).isNull()
+        assertThat(callback2Error).isNull()
+        verify(exactly = 1) { offlineEntitlementsCalculator.computeOfflineCustomerInfo(any(), any(), any()) }
+        errorCallbackSlot.invoke(error)
+        assertThat(callback1Error).isEqualTo(error)
+        assertThat(callback2Error).isEqualTo(error)
+        verify(exactly = 1) { offlineEntitlementsCalculator.computeOfflineCustomerInfo(any(), any(), any()) }
+    }
+
+    // endregion
+
+    // region updateProductEntitlementMappingCacheIfStale
+
     @Test
     fun `updateProductEntitlementMappingCacheIfStale does nothing if cache not stale`() {
         every { deviceCache.isProductEntitlementMappingCacheStale() } returns false
@@ -83,4 +303,29 @@ class OfflineEntitlementsManagerTest {
         backendSuccessSlot.captured(expectedMappings)
         verify(exactly = 1) { deviceCache.cacheProductEntitlementMapping(expectedMappings) }
     }
+
+    // endregion
+
+    // region helpers
+
+    private fun mockCalculateOfflineEntitlements(
+        successCustomerInfo: CustomerInfo? = null,
+        error: PurchasesError? = null
+    ) {
+        if (successCustomerInfo != null) {
+            every {
+                offlineEntitlementsCalculator.computeOfflineCustomerInfo(appUserID, captureLambda(), any())
+            } answers {
+                lambda<(CustomerInfo) -> Unit>().captured.invoke(successCustomerInfo)
+            }
+        } else if (error != null) {
+            every {
+                offlineEntitlementsCalculator.computeOfflineCustomerInfo(appUserID, any(), captureLambda())
+            } answers {
+                lambda<(PurchasesError) -> Unit>().captured.invoke(error)
+            }
+        }
+    }
+
+    // endregion
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.common.offlineentitlements
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.caching.DeviceCache
 import io.mockk.CapturingSlot
@@ -24,6 +25,7 @@ class OfflineEntitlementsManagerTest {
     private lateinit var backendSuccessSlot: CapturingSlot<(ProductEntitlementMapping) -> Unit>
     private lateinit var backendErrorSlot: CapturingSlot<(PurchasesError) -> Unit>
 
+    private lateinit var appConfig: AppConfig
     private lateinit var backend: Backend
     private lateinit var deviceCache: DeviceCache
     private lateinit var offlineEntitlementsCalculator: OfflineCustomerInfoCalculator
@@ -35,6 +37,7 @@ class OfflineEntitlementsManagerTest {
         backendSuccessSlot = slot()
         backendErrorSlot = slot()
 
+        appConfig = mockk()
         backend = mockk()
         deviceCache = mockk()
         offlineEntitlementsCalculator = mockk()
@@ -42,8 +45,12 @@ class OfflineEntitlementsManagerTest {
         every {
             backend.getProductEntitlementMapping(capture(backendSuccessSlot), capture(backendErrorSlot))
         } just Runs
+        every {
+            appConfig.areOfflineEntitlementsEnabled
+        } returns true
 
         offlineEntitlementsManager = OfflineEntitlementsManager(
+            appConfig,
             backend,
             offlineEntitlementsCalculator,
             deviceCache

--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
@@ -26,6 +26,7 @@ class OfflineEntitlementsManagerTest {
 
     private lateinit var backend: Backend
     private lateinit var deviceCache: DeviceCache
+    private lateinit var offlineEntitlementsCalculator: OfflineCustomerInfoCalculator
 
     private lateinit var offlineEntitlementsManager: OfflineEntitlementsManager
 
@@ -36,6 +37,7 @@ class OfflineEntitlementsManagerTest {
 
         backend = mockk()
         deviceCache = mockk()
+        offlineEntitlementsCalculator = mockk()
 
         every {
             backend.getProductEntitlementMapping(capture(backendSuccessSlot), capture(backendErrorSlot))
@@ -43,6 +45,7 @@ class OfflineEntitlementsManagerTest {
 
         offlineEntitlementsManager = OfflineEntitlementsManager(
             backend,
+            offlineEntitlementsCalculator,
             deviceCache
         )
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
@@ -89,6 +89,17 @@ class OfflineEntitlementsManagerTest {
     }
 
     @Test
+    fun `shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest returns false if not server error and offline mode disabled`() {
+        every { appConfig.areOfflineEntitlementsEnabled } returns false
+        val isServerError = false
+        val result = offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest(
+            isServerError,
+            appUserID
+        )
+        assertThat(result).isFalse
+    }
+
+    @Test
     fun `shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest returns false if server error and cached customer info is not null`() {
         every { deviceCache.getCachedCustomerInfo(appUserID) } returns mockk()
         val isServerError = true
@@ -135,6 +146,13 @@ class OfflineEntitlementsManagerTest {
     fun `shouldCalculateOfflineCustomerInfoInPostReceipt returns false if offline entitlements disabled`() {
         every { appConfig.areOfflineEntitlementsEnabled } returns false
         val isServerError = true
+        assertThat(offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInPostReceipt(isServerError)).isFalse
+    }
+
+    @Test
+    fun `shouldCalculateOfflineCustomerInfoInPostReceipt returns false if not server error and offline entitlements disabled`() {
+        every { appConfig.areOfflineEntitlementsEnabled } returns false
+        val isServerError = false
         assertThat(offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInPostReceipt(isServerError)).isFalse
     }
 

--- a/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.strings.IdentityStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
@@ -19,7 +20,8 @@ class IdentityManager(
     private val deviceCache: DeviceCache,
     private val subscriberAttributesCache: SubscriberAttributesCache,
     private val subscriberAttributesManager: SubscriberAttributesManager,
-    private val backend: Backend
+    private val backend: Backend,
+    private val offlineEntitlementsManager: OfflineEntitlementsManager
 ) {
 
     val currentAppUserID: String
@@ -76,6 +78,7 @@ class IdentityManager(
                         deviceCache.cacheAppUserID(newAppUserID)
                         deviceCache.cacheCustomerInfo(newAppUserID, customerInfo)
                         copySubscriberAttributesToNewUserIfOldIsAnonymous(oldAppUserID, newAppUserID)
+                        offlineEntitlementsManager.resetOfflineCustomerInfoCache()
                     }
                     onSuccess(customerInfo, created)
                 },
@@ -103,6 +106,7 @@ class IdentityManager(
             log(LogIntent.USER, IdentityStrings.LOG_OUT_SUCCESSFUL)
             completion(null)
         }
+        offlineEntitlementsManager.resetOfflineCustomerInfoCache()
     }
 
     @Synchronized

--- a/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -91,6 +91,7 @@ class IdentityManager(
     private fun reset() {
         deviceCache.clearCachesForAppUserID(currentAppUserID)
         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(currentAppUserID)
+        offlineEntitlementsManager.resetOfflineCustomerInfoCache()
         deviceCache.cacheAppUserID(generateRandomID())
     }
 
@@ -106,7 +107,6 @@ class IdentityManager(
             log(LogIntent.USER, IdentityStrings.LOG_OUT_SUCCESSFUL)
             completion(null)
         }
-        offlineEntitlementsManager.resetOfflineCustomerInfoCache()
     }
 
     @Synchronized

--- a/feature/identity/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/feature/identity/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -391,10 +391,10 @@ class IdentityManagerTests {
         mockSubscriberAttributesManagerSynchronize(identifiedUserID)
         every { mockDeviceCache.cleanupOldAttributionData() } just Runs
 
-        var error: PurchasesError? = null
-        identityManager.logOut { error = it }
+        var completionCallCount = 0
+        identityManager.logOut { completionCallCount++ }
 
-        assertThat(error).isNull()
+        assertThat(completionCallCount).isEqualTo(1)
         verify(exactly = 1) { mockOfflineEntitlementsManager.resetOfflineCustomerInfoCache() }
     }
 

--- a/feature/identity/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/feature/identity/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
@@ -34,6 +35,7 @@ class IdentityManagerTests {
     private lateinit var mockSubscriberAttributesCache: SubscriberAttributesCache
     private lateinit var mockSubscriberAttributesManager: SubscriberAttributesManager
     private lateinit var mockBackend: Backend
+    private lateinit var mockOfflineEntitlementsManager: OfflineEntitlementsManager
     private lateinit var identityManager: IdentityManager
     private val stubAnonymousID = "\$RCAnonymousID:ff68f26e432648369a713849a9f93b58"
 
@@ -55,6 +57,9 @@ class IdentityManagerTests {
         mockSubscriberAttributesManager = mockk()
 
         mockBackend = mockk()
+        mockOfflineEntitlementsManager = mockk<OfflineEntitlementsManager>().apply {
+            every { resetOfflineCustomerInfoCache() } just Runs
+        }
         identityManager = createIdentityManager()
     }
 
@@ -237,6 +242,48 @@ class IdentityManagerTests {
     }
 
     @Test
+    fun `login resets offline customer info cache on success`() {
+        val randomCreated: Boolean = Random.nextBoolean()
+        val mockCustomerInfo: CustomerInfo = mockk()
+        mockCachedAnonymousUser()
+        val oldAppUserID = stubAnonymousID
+        val newAppUserID = "new"
+        every {
+            mockBackend.logIn(oldAppUserID, newAppUserID, captureLambda(), any())
+        } answers {
+            lambda<(CustomerInfo, Boolean) -> Unit>().captured.invoke(
+                mockCustomerInfo, randomCreated
+            )
+        }
+        every { mockDeviceCache.cacheCustomerInfo(any(), any()) } just Runs
+        mockSubscriberAttributesManagerSynchronize(newAppUserID)
+        mockSubscriberAttributesManagerCopyAttributes(oldAppUserID, newAppUserID)
+
+        identityManager.logIn(newAppUserID, { _, _ -> }, { })
+
+        verify(exactly = 1) { mockOfflineEntitlementsManager.resetOfflineCustomerInfoCache() }
+    }
+
+    @Test
+    fun `login does not reset offline customer info cache on error`() {
+        mockCachedAnonymousUser()
+        val oldAppUserID = stubAnonymousID
+        val newAppUserID = "new"
+        every {
+            mockBackend.logIn(oldAppUserID, newAppUserID, any(), captureLambda())
+        } answers {
+            lambda<(PurchasesError) -> Unit>().captured.invoke(
+                PurchasesError(PurchasesErrorCode.InvalidCredentialsError)
+            )
+        }
+        mockSubscriberAttributesManagerSynchronize(newAppUserID)
+
+        identityManager.logIn(newAppUserID, { _, _ -> }, { })
+
+        verify(exactly = 0) { mockOfflineEntitlementsManager.resetOfflineCustomerInfoCache() }
+    }
+
+    @Test
     fun `login copies unsynced attributes from old user to new one if old is anonymous on successful completion`() {
         val randomCreated: Boolean = Random.nextBoolean()
         val mockCustomerInfo: CustomerInfo = mockk()
@@ -335,6 +382,20 @@ class IdentityManagerTests {
 
         assertThat(error).isNull()
         assertCorrectlyIdentifiedWithAnonymous()
+    }
+
+    @Test
+    fun `logOut resets offline customer info cache`() {
+        val identifiedUserID = "Waldo"
+        mockIdentifiedUser(identifiedUserID)
+        mockSubscriberAttributesManagerSynchronize(identifiedUserID)
+        every { mockDeviceCache.cleanupOldAttributionData() } just Runs
+
+        var error: PurchasesError? = null
+        identityManager.logOut { error = it }
+
+        assertThat(error).isNull()
+        verify(exactly = 1) { mockOfflineEntitlementsManager.resetOfflineCustomerInfoCache() }
     }
 
     @Test
@@ -589,10 +650,11 @@ class IdentityManagerTests {
         deviceCache: DeviceCache = mockDeviceCache,
         subscriberAttributesCache: SubscriberAttributesCache = mockSubscriberAttributesCache,
         subscriberAttributesManager: SubscriberAttributesManager = mockSubscriberAttributesManager,
-        backend: Backend = mockBackend
+        backend: Backend = mockBackend,
+        offlineEntitlementsManager: OfflineEntitlementsManager = mockOfflineEntitlementsManager
     ): IdentityManager {
         return IdentityManager(
-            deviceCache, subscriberAttributesCache, subscriberAttributesManager, backend
+            deviceCache, subscriberAttributesCache, subscriberAttributesManager, backend, offlineEntitlementsManager
         )
     }
 

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -74,9 +74,9 @@ class SubscriberAttributesPosterTests {
         }
 
     private val expectedOnErrorPostReceipt: PostReceiptDataErrorCallback =
-        { error, errorType, body ->
+        { error, errorHandlingBehavior, body ->
             receivedError = error
-            receivedPostReceiptErrorHandlingBehavior = errorType
+            receivedPostReceiptErrorHandlingBehavior = errorHandlingBehavior
             receivedAttributeErrors = body.getAttributeErrors()
         }
 

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -11,7 +11,7 @@ import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.CustomerInfoFactory
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.PostReceiptDataErrorCallback
-import com.revenuecat.purchases.common.PostReceiptErrorType
+import com.revenuecat.purchases.common.PostReceiptErrorHandlingBehavior
 import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.SubscriberAttributeError
 import com.revenuecat.purchases.common.networking.Endpoint
@@ -61,7 +61,7 @@ class SubscriberAttributesPosterTests {
 
     private var receivedError: PurchasesError? = null
     private var receivedSyncedSuccessfully: Boolean? = null
-    private var receivedPostReceiptErrorType: PostReceiptErrorType? = null
+    private var receivedPostReceiptErrorHandlingBehavior: PostReceiptErrorHandlingBehavior? = null
     private var receivedAttributeErrors: List<SubscriberAttributeError>? = null
     private var receivedCustomerInfo: CustomerInfo? = null
     private var receivedOnSuccess = false
@@ -76,7 +76,7 @@ class SubscriberAttributesPosterTests {
     private val expectedOnErrorPostReceipt: PostReceiptDataErrorCallback =
         { error, errorType, body ->
             receivedError = error
-            receivedPostReceiptErrorType = errorType
+            receivedPostReceiptErrorHandlingBehavior = errorType
             receivedAttributeErrors = body.getAttributeErrors()
         }
 
@@ -116,7 +116,7 @@ class SubscriberAttributesPosterTests {
         mockkObject(CustomerInfoFactory)
         receivedError = null
         receivedSyncedSuccessfully = null
-        receivedPostReceiptErrorType = null
+        receivedPostReceiptErrorHandlingBehavior = null
         receivedAttributeErrors = null
         receivedCustomerInfo = null
         receivedOnSuccess = false

--- a/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/feature/subscriber-attributes/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -10,6 +10,8 @@ import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.CustomerInfoFactory
 import com.revenuecat.purchases.common.HTTPClient
+import com.revenuecat.purchases.common.PostReceiptDataErrorCallback
+import com.revenuecat.purchases.common.PostReceiptErrorType
 import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.SubscriberAttributeError
 import com.revenuecat.purchases.common.networking.Endpoint
@@ -59,7 +61,7 @@ class SubscriberAttributesPosterTests {
 
     private var receivedError: PurchasesError? = null
     private var receivedSyncedSuccessfully: Boolean? = null
-    private var receivedIsServerError: Boolean? = null
+    private var receivedPostReceiptErrorType: PostReceiptErrorType? = null
     private var receivedAttributeErrors: List<SubscriberAttributeError>? = null
     private var receivedCustomerInfo: CustomerInfo? = null
     private var receivedOnSuccess = false
@@ -71,11 +73,10 @@ class SubscriberAttributesPosterTests {
             receivedAttributeErrors = attributeErrors
         }
 
-    private val expectedOnErrorPostReceipt: (PurchasesError, Boolean, Boolean, JSONObject?) -> Unit =
-        { error, syncedSuccessfully, isServerError, body ->
+    private val expectedOnErrorPostReceipt: PostReceiptDataErrorCallback =
+        { error, errorType, body ->
             receivedError = error
-            receivedSyncedSuccessfully = syncedSuccessfully
-            receivedIsServerError = isServerError
+            receivedPostReceiptErrorType = errorType
             receivedAttributeErrors = body.getAttributeErrors()
         }
 
@@ -95,8 +96,8 @@ class SubscriberAttributesPosterTests {
             fail("Shouldn't be error.")
         }
 
-    private val unexpectedOnErrorPostReceipt: (PurchasesError, Boolean, Boolean, JSONObject?) -> Unit =
-        { _, _, _, _ ->
+    private val unexpectedOnErrorPostReceipt: PostReceiptDataErrorCallback =
+        { _, _, _ ->
             fail("Shouldn't be success.")
         }
 
@@ -115,7 +116,7 @@ class SubscriberAttributesPosterTests {
         mockkObject(CustomerInfoFactory)
         receivedError = null
         receivedSyncedSuccessfully = null
-        receivedIsServerError = null
+        receivedPostReceiptErrorType = null
         receivedAttributeErrors = null
         receivedCustomerInfo = null
         receivedOnSuccess = false

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases
 
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.caching.DeviceCache
@@ -10,7 +9,6 @@ import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
-import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
@@ -89,7 +89,7 @@ internal class CustomerInfoHelper(
     private fun afterSetListener(listener: UpdatedCustomerInfoListener?) {
         if (listener != null) {
             log(LogIntent.DEBUG, ConfigureStrings.LISTENER_SET)
-            deviceCache.getCachedCustomerInfo(identityManager.currentAppUserID)?.let {
+            getCachedCustomerInfo(identityManager.currentAppUserID)?.let {
                 sendUpdatedCustomerInfoToDelegateIfChanged(it)
             }
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
@@ -142,8 +142,7 @@ internal class CustomerInfoHelper(
                             sendUpdatedCustomerInfoToDelegateIfChanged(offlineComputedCustomerInfo)
                             dispatch { callback?.onReceived(offlineComputedCustomerInfo) }
                         },
-                        onError = { errorCalculatingOfflineCustomerInfo ->
-                            errorLog("Error calculating offline customer info: $errorCalculatingOfflineCustomerInfo")
+                        onError = {
                             dispatch { callback?.onError(error) }
                         }
                     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
@@ -134,14 +134,18 @@ internal class CustomerInfoHelper(
                 Log.e("Purchases", "Error fetching customer data: $error")
                 deviceCache.clearCustomerInfoCacheTimestamp(appUserID)
                 if (shouldCalculateOfflineCustomerInfo(isServerError, appUserID)) {
-                    val offlineComputedCustomerInfo = offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo()
-                    if (offlineComputedCustomerInfo != null) {
-                        // TODO Improve logs
-                        warnLog("Using offline computed customer info.")
-                        dispatch { callback?.onReceived(offlineComputedCustomerInfo) }
-                    } else {
-                        dispatch { callback?.onError(error) }
-                    }
+                    offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
+                        appUserID,
+                        onSuccess = { offlineComputedCustomerInfo ->
+                            // TODO Improve logs
+                            warnLog("Using offline computed customer info.")
+                            dispatch { callback?.onReceived(offlineComputedCustomerInfo) }
+                        },
+                        onError = { errorCalculatingOfflineCustomerInfo ->
+                            errorLog(errorCalculatingOfflineCustomerInfo)
+                            dispatch { callback?.onError(error) }
+                        }
+                    )
                 } else {
                     offlineEntitlementsManager.resetOfflineCustomerInfoCache()
                     dispatch { callback?.onError(error) }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
@@ -139,10 +139,11 @@ internal class CustomerInfoHelper(
                         onSuccess = { offlineComputedCustomerInfo ->
                             // TODO Improve logs
                             warnLog("Using offline computed customer info.")
+                            sendUpdatedCustomerInfoToDelegateIfChanged(offlineComputedCustomerInfo)
                             dispatch { callback?.onReceived(offlineComputedCustomerInfo) }
                         },
                         onError = { errorCalculatingOfflineCustomerInfo ->
-                            errorLog(errorCalculatingOfflineCustomerInfo)
+                            errorLog("Error calculating offline customer info: $errorCalculatingOfflineCustomerInfo")
                             dispatch { callback?.onError(error) }
                         }
                     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
@@ -148,7 +148,6 @@ internal class CustomerInfoHelper(
                         }
                     )
                 } else {
-                    offlineEntitlementsManager.resetOfflineCustomerInfoCache()
                     dispatch { callback?.onError(error) }
                 }
             })

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsMa
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.strings.OfflineEntitlementsStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.getAttributeErrors
 import com.revenuecat.purchases.subscriberattributes.toBackendMap
@@ -190,13 +191,11 @@ internal class PostReceiptHelper(
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
             onSuccess = { customerInfo ->
-                // TODO Improve logs
-                warnLog("Using offline computed customer info.")
+                warnLog(OfflineEntitlementsStrings.USING_OFFLINE_ENTITLEMENTS_CUSTOMER_INFO)
                 customerInfoHelper.sendUpdatedCustomerInfoToDelegateIfChanged(customerInfo)
                 onSuccess(customerInfo)
             },
             onError = { error ->
-                errorLog("Error calculating offline customer info: $error")
                 onError(error)
             }
         )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -6,7 +6,6 @@ import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.PostReceiptDataErrorCallback
 import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
-import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.models.StoreProduct

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -53,7 +53,7 @@ internal class PostReceiptHelper(
                 deviceCache.addSuccessfullyPostedToken(purchaseToken)
                 onSuccess()
             },
-            onError = { error, shouldConsumePurchase, isServerError, _ ->
+            onError = { backendError, shouldConsumePurchase, isServerError, _ ->
                 if (shouldConsumePurchase) {
                     deviceCache.addSuccessfullyPostedToken(purchaseToken)
                 }
@@ -64,7 +64,7 @@ internal class PostReceiptHelper(
                         onSuccess()
                     },
                     onError = {
-                        onError(error)
+                        onError(backendError)
                     }
                 )
             }
@@ -100,7 +100,7 @@ internal class PostReceiptHelper(
                 billing.consumeAndSave(finishTransactions, purchase)
                 onSuccess?.let { it(purchase, info) }
             },
-            onError = { error, shouldConsumePurchase, isServerError, _ ->
+            onError = { backendError, shouldConsumePurchase, isServerError, _ ->
                 if (shouldConsumePurchase) {
                     billing.consumeAndSave(finishTransactions, purchase)
                 }
@@ -111,7 +111,7 @@ internal class PostReceiptHelper(
                         onSuccess?.let { it(purchase, customerInfo) }
                     },
                     onError = {
-                        onError?.let { it(purchase, error) }
+                        onError?.let { it(purchase, backendError) }
                     }
                 )
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -4,7 +4,6 @@ import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.PostReceiptDataErrorCallback
-import com.revenuecat.purchases.common.PostReceiptDataSuccessCallback
 import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.errorLog

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -174,8 +174,7 @@ class Purchases internal constructor(
             log(LogIntent.WARNING, AUTO_SYNC_PURCHASES_DISABLED)
         }
 
-        // Offline entitlements: Commenting out for now until backend is ready
-        // offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
+        offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
     }
 
@@ -209,8 +208,7 @@ class Purchases internal constructor(
             fetchAndCacheOfferings(identityManager.currentAppUserID, appInBackground = false)
             log(LogIntent.RC_SUCCESS, OfferingStrings.OFFERINGS_UPDATED_FROM_NETWORK)
         }
-        // Offline entitlements: Commenting out for now until backend is ready
-        // offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
+        offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         updatePendingPurchaseQueue()
         synchronizeSubscriberAttributesIfNeeded()
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -38,7 +38,6 @@ import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
-import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.google.isSuccessful
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.interfaces.Callback

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -38,6 +38,7 @@ import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
+import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.google.isSuccessful
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.interfaces.Callback

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -21,7 +21,9 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsFileHelper
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.ETagManager
+import com.revenuecat.purchases.common.offlineentitlements.OfflineCustomerInfoCalculator
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
+import com.revenuecat.purchases.common.offlineentitlements.PurchasedProductsFetcher
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
 import com.revenuecat.purchases.identity.IdentityManager
@@ -116,7 +118,12 @@ internal class PurchasesFactory(
                 attributionFetcher
             )
 
-            val offlineEntitlementsManager = OfflineEntitlementsManager(backend, cache)
+            val offlineCustomerInfoCalculator = OfflineCustomerInfoCalculator(
+                PurchasedProductsFetcher(cache, billing),
+                appConfig
+            )
+
+            val offlineEntitlementsManager = OfflineEntitlementsManager(backend, offlineCustomerInfoCalculator, cache)
 
             val identityManager = IdentityManager(
                 cache,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -116,14 +116,17 @@ internal class PurchasesFactory(
                 attributionFetcher
             )
 
+            val offlineEntitlementsManager = OfflineEntitlementsManager(backend, cache)
+
             val identityManager = IdentityManager(
                 cache,
                 subscriberAttributesCache,
                 subscriberAttributesManager,
-                backend
+                backend,
+                offlineEntitlementsManager
             )
 
-            val customerInfoHelper = CustomerInfoHelper(cache, backend, identityManager)
+            val customerInfoHelper = CustomerInfoHelper(cache, backend, identityManager, offlineEntitlementsManager)
             val offeringParser = OfferingParserFactory.createOfferingParser(store)
 
             var diagnosticsSynchronizer: DiagnosticsSynchronizer? = null
@@ -137,15 +140,14 @@ internal class PurchasesFactory(
                 )
             }
 
-            val offlineEntitlementsManager = OfflineEntitlementsManager(backend, cache)
-
             val postReceiptHelper = PostReceiptHelper(
                 appConfig,
                 backend,
                 billing,
                 customerInfoHelper,
                 cache,
-                subscriberAttributesManager
+                subscriberAttributesManager,
+                offlineEntitlementsManager
             )
 
             return Purchases(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -123,7 +123,12 @@ internal class PurchasesFactory(
                 appConfig
             )
 
-            val offlineEntitlementsManager = OfflineEntitlementsManager(backend, offlineCustomerInfoCalculator, cache)
+            val offlineEntitlementsManager = OfflineEntitlementsManager(
+                appConfig,
+                backend,
+                offlineCustomerInfoCalculator,
+                cache
+            )
 
             val identityManager = IdentityManager(
                 cache,

--- a/purchases/src/test/java/com/revenuecat/purchases/CustomerInfoHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/CustomerInfoHelperTest.kt
@@ -5,9 +5,11 @@ import android.os.Looper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
+import io.mockk.clearAllMocks
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.just
@@ -26,6 +28,7 @@ class CustomerInfoHelperTest {
     private val mockCache = mockk<DeviceCache>()
     private val mockBackend = mockk<Backend>()
     private val mockIdentityManager = mockk<IdentityManager>()
+    private val mockOfflineEntitlementsManager = mockk<OfflineEntitlementsManager>()
     private val mockHandler = mockk<Handler>()
     private val mockLooper = mockk<Looper>()
     private val mockThread = mockk<Thread>()
@@ -46,13 +49,14 @@ class CustomerInfoHelperTest {
             mockCache,
             mockBackend,
             mockIdentityManager,
+            mockOfflineEntitlementsManager,
             mockHandler
         )
     }
 
     @After
     fun tearDown() {
-        clearMocks(mockCache, mockBackend, mockIdentityManager, mockHandler, mockLooper, mockThread, mockInfo)
+        clearAllMocks()
     }
 
     // region updatedCustomerInfoListener

--- a/purchases/src/test/java/com/revenuecat/purchases/CustomerInfoHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/CustomerInfoHelperTest.kt
@@ -73,6 +73,16 @@ class CustomerInfoHelperTest {
     }
 
     @Test
+    fun `setting listener sends offline customer info cached value if it exists over cached value`() {
+        val mockCustomerInfo2 = mockk<CustomerInfo>()
+        every { mockOfflineEntitlementsManager.offlineCustomerInfo } returns mockCustomerInfo2
+        val listenerMock = mockk<UpdatedCustomerInfoListener>(relaxed = true)
+        customerInfoHelper.updatedCustomerInfoListener = listenerMock
+
+        verify(exactly = 1) { listenerMock.onReceived(mockCustomerInfo2) }
+    }
+
+    @Test
     fun `setting listener does not send cached value if it does not exists`() {
         val listenerMock = mockk<UpdatedCustomerInfoListener>(relaxed = true)
         every { mockCache.getCachedCustomerInfo(any()) } returns null

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -7,7 +7,7 @@ import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.CustomerInfoFactory
 import com.revenuecat.purchases.common.PostReceiptDataErrorCallback
 import com.revenuecat.purchases.common.PostReceiptDataSuccessCallback
-import com.revenuecat.purchases.common.PostReceiptErrorType
+import com.revenuecat.purchases.common.PostReceiptErrorHandlingBehavior
 import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.SubscriberAttributeError
 import com.revenuecat.purchases.common.caching.DeviceCache
@@ -303,7 +303,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded marks unsynced attributes as synced on error if finishable error`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
-        mockPostReceiptError(errorType = PostReceiptErrorType.CAN_BE_CONSUMED)
+        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -326,7 +326,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded does not mark unsynced attributes as synced on error if not finishable error`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
-        mockPostReceiptError(errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED)
+        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -349,7 +349,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded calls consume transaction with consuming flag true if not observer mode on error if finishable error`() {
         every { appConfig.finishTransactions } returns true
-        mockPostReceiptError(errorType = PostReceiptErrorType.CAN_BE_CONSUMED)
+        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -368,7 +368,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded calls consume transaction with consuming flag false if observer mode on error if finishable error`() {
         every { appConfig.finishTransactions } returns false
-        mockPostReceiptError(errorType = PostReceiptErrorType.CAN_BE_CONSUMED)
+        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -386,7 +386,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded does not call consume transaction on error if not finishable error`() {
-        mockPostReceiptError(errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED)
+        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -404,7 +404,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded calls error block with expected parameters on error`() {
-        mockPostReceiptError(errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED)
+        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
 
         var errorTransaction: StoreTransaction? = null
         var purchasesError: PurchasesError? = null
@@ -446,7 +446,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded does not calculate offline entitlements customer info if not server error`() {
-        mockPostReceiptError(errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED)
+        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -465,7 +465,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded calculates offline entitlements customer info if server error`() {
-        mockPostReceiptError(errorType = PostReceiptErrorType.SERVER_ERROR)
+        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -484,7 +484,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded returns offline entitlements customer info if server error and success calculating customer info`() {
-        mockPostReceiptError(errorType = PostReceiptErrorType.SERVER_ERROR)
+        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
@@ -511,7 +511,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded does not cache offline entitlements`() {
-        mockPostReceiptError(errorType = PostReceiptErrorType.SERVER_ERROR)
+        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
@@ -536,7 +536,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded does not consume if using offline entitlements`() {
-        mockPostReceiptError(errorType = PostReceiptErrorType.SERVER_ERROR)
+        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
@@ -563,7 +563,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded does not mark attributes as synced if using offline entitlements`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
-        mockPostReceiptError(errorType = PostReceiptErrorType.SERVER_ERROR)
+        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
@@ -916,7 +916,7 @@ class PostReceiptHelperTest {
     fun `postTokenWithoutConsuming marks unsynced attributes as synced on error if finishable error`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
         mockPostReceiptError(
-            errorType = PostReceiptErrorType.CAN_BE_CONSUMED,
+            errorType = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -944,7 +944,7 @@ class PostReceiptHelperTest {
     fun `postTokenWithoutConsuming does not mark unsynced attributes as synced on error if not finishable error`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
         mockPostReceiptError(
-            errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED,
+            errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -971,7 +971,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming adds sent token if finishable error`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorType.CAN_BE_CONSUMED,
+            errorType = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -994,7 +994,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not add sent token on error if not finishable error`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED,
+            errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1017,7 +1017,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming calls error block with expected parameters on error`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED,
+            errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1059,7 +1059,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not consume on non consumable error `() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED,
+            errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1104,7 +1104,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not calculate offline entitlements customer info if not server error`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorType.CAN_BE_CONSUMED,
+            errorType = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1128,7 +1128,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming calculates offline entitlements customer info if server error`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorType.SERVER_ERROR,
+            errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1152,7 +1152,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming returns offline entitlements customer info if server error and success calculating customer info`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorType.SERVER_ERROR,
+            errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1184,7 +1184,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not cache offline entitlements`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorType.SERVER_ERROR,
+            errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1214,7 +1214,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not mark token as consumed if using offline entitlements`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorType.SERVER_ERROR,
+            errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1246,7 +1246,7 @@ class PostReceiptHelperTest {
     fun `postTokenWithoutConsuming does not mark attributes as synced if using offline entitlements`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
         mockPostReceiptError(
-            errorType = PostReceiptErrorType.SERVER_ERROR,
+            errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1326,7 +1326,7 @@ class PostReceiptHelperTest {
     }
 
     private fun mockPostReceiptError(
-        errorType: PostReceiptErrorType,
+        errorType: PostReceiptErrorHandlingBehavior,
         postType: PostType = PostType.TRANSACTION_AND_CONSUME
     ) {
         every {
@@ -1345,9 +1345,9 @@ class PostReceiptHelperTest {
         } answers {
             val callback = lambda<PostReceiptDataErrorCallback>().captured
             when (errorType) {
-                PostReceiptErrorType.CAN_BE_CONSUMED -> callback.invokeWithFinishableError()
-                PostReceiptErrorType.CANNOT_BE_CONSUMED -> callback.invokeWithNotFinishableError()
-                PostReceiptErrorType.SERVER_ERROR -> callback.invokeWithServerError()
+                PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED -> callback.invokeWithFinishableError()
+                PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME -> callback.invokeWithNotFinishableError()
+                PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME -> callback.invokeWithServerError()
             }
         }
 
@@ -1361,7 +1361,7 @@ class PostReceiptHelperTest {
                 PurchasesError(PurchasesErrorCode.UnknownError)
             )
         }
-        if (errorType == PostReceiptErrorType.CAN_BE_CONSUMED) {
+        if (errorType == PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED) {
             every { subscriberAttributesManager.markAsSynced(appUserID, any(), any()) } just Runs
             if (postType == PostType.TRANSACTION_AND_CONSUME) {
                 every { billing.consumeAndSave(any(), mockStoreTransaction) } just Runs
@@ -1381,7 +1381,7 @@ class PostReceiptHelperTest {
     private fun PostReceiptDataErrorCallback.invokeWithFinishableError() {
         invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
-            PostReceiptErrorType.CAN_BE_CONSUMED,
+            PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED,
             JSONObject(Responses.invalidCredentialsErrorResponse)
         )
     }
@@ -1389,7 +1389,7 @@ class PostReceiptHelperTest {
     private fun PostReceiptDataErrorCallback.invokeWithNotFinishableError() {
         invoke(
             PurchasesError(PurchasesErrorCode.UnexpectedBackendResponseError),
-            PostReceiptErrorType.CANNOT_BE_CONSUMED,
+            PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME,
             JSONObject(Responses.internalServerErrorResponse)
         )
     }
@@ -1397,7 +1397,7 @@ class PostReceiptHelperTest {
     private fun PostReceiptDataErrorCallback.invokeWithServerError() {
         invoke(
             PurchasesError(PurchasesErrorCode.UnexpectedBackendResponseError),
-            PostReceiptErrorType.SERVER_ERROR,
+            PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
             JSONObject(Responses.internalServerErrorResponse)
         )
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -303,7 +303,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded marks unsynced attributes as synced on error if finishable error`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
-        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED)
+        mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -326,7 +326,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded does not mark unsynced attributes as synced on error if not finishable error`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
-        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
+        mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -349,7 +349,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded calls consume transaction with consuming flag true if not observer mode on error if finishable error`() {
         every { appConfig.finishTransactions } returns true
-        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED)
+        mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -368,7 +368,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded calls consume transaction with consuming flag false if observer mode on error if finishable error`() {
         every { appConfig.finishTransactions } returns false
-        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED)
+        mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -386,7 +386,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded does not call consume transaction on error if not finishable error`() {
-        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
+        mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -404,7 +404,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded calls error block with expected parameters on error`() {
-        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
+        mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
 
         var errorTransaction: StoreTransaction? = null
         var purchasesError: PurchasesError? = null
@@ -446,7 +446,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded does not calculate offline entitlements customer info if not server error`() {
-        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
+        mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -465,7 +465,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded calculates offline entitlements customer info if server error`() {
-        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
+        mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -484,7 +484,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded returns offline entitlements customer info if server error and success calculating customer info`() {
-        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
+        mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
@@ -511,7 +511,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded does not cache offline entitlements`() {
-        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
+        mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
@@ -536,7 +536,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded does not consume if using offline entitlements`() {
-        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
+        mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
@@ -563,7 +563,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded does not mark attributes as synced if using offline entitlements`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
-        mockPostReceiptError(errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
+        mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
@@ -916,7 +916,7 @@ class PostReceiptHelperTest {
     fun `postTokenWithoutConsuming marks unsynced attributes as synced on error if finishable error`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
         mockPostReceiptError(
-            errorType = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED,
+            errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -944,7 +944,7 @@ class PostReceiptHelperTest {
     fun `postTokenWithoutConsuming does not mark unsynced attributes as synced on error if not finishable error`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
         mockPostReceiptError(
-            errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME,
+            errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -971,7 +971,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming adds sent token if finishable error`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED,
+            errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -994,7 +994,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not add sent token on error if not finishable error`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME,
+            errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1017,7 +1017,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming calls error block with expected parameters on error`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME,
+            errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1059,7 +1059,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not consume on non consumable error `() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME,
+            errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1104,7 +1104,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not calculate offline entitlements customer info if not server error`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED,
+            errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1128,7 +1128,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming calculates offline entitlements customer info if server error`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
+            errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1152,7 +1152,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming returns offline entitlements customer info if server error and success calculating customer info`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
+            errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1184,7 +1184,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not cache offline entitlements`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
+            errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1214,7 +1214,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not mark token as consumed if using offline entitlements`() {
         mockPostReceiptError(
-            errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
+            errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1246,7 +1246,7 @@ class PostReceiptHelperTest {
     fun `postTokenWithoutConsuming does not mark attributes as synced if using offline entitlements`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
         mockPostReceiptError(
-            errorType = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
+            errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1326,7 +1326,7 @@ class PostReceiptHelperTest {
     }
 
     private fun mockPostReceiptError(
-        errorType: PostReceiptErrorHandlingBehavior,
+        errorHandlingBehavior: PostReceiptErrorHandlingBehavior,
         postType: PostType = PostType.TRANSACTION_AND_CONSUME
     ) {
         every {
@@ -1344,7 +1344,7 @@ class PostReceiptHelperTest {
             )
         } answers {
             val callback = lambda<PostReceiptDataErrorCallback>().captured
-            when (errorType) {
+            when (errorHandlingBehavior) {
                 PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED -> callback.invokeWithFinishableError()
                 PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME -> callback.invokeWithNotFinishableError()
                 PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME -> callback.invokeWithServerError()
@@ -1361,7 +1361,7 @@ class PostReceiptHelperTest {
                 PurchasesError(PurchasesErrorCode.UnknownError)
             )
         }
-        if (errorType == PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED) {
+        if (errorHandlingBehavior == PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED) {
             every { subscriberAttributesManager.markAsSynced(appUserID, any(), any()) } just Runs
             if (postType == PostType.TRANSACTION_AND_CONSUME) {
                 every { billing.consumeAndSave(any(), mockStoreTransaction) } just Runs

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.CustomerInfoFactory
 import com.revenuecat.purchases.common.PostReceiptDataErrorCallback
 import com.revenuecat.purchases.common.PostReceiptDataSuccessCallback
+import com.revenuecat.purchases.common.PostReceiptErrorType
 import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.SubscriberAttributeError
 import com.revenuecat.purchases.common.caching.DeviceCache
@@ -302,7 +303,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded marks unsynced attributes as synced on error if finishable error`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
-        mockPostReceiptError(finishableError = true)
+        mockPostReceiptError(errorType = PostReceiptErrorType.CAN_BE_CONSUMED)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -325,7 +326,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded does not mark unsynced attributes as synced on error if not finishable error`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
-        mockPostReceiptError(finishableError = false)
+        mockPostReceiptError(errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -348,7 +349,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded calls consume transaction with consuming flag true if not observer mode on error if finishable error`() {
         every { appConfig.finishTransactions } returns true
-        mockPostReceiptError(finishableError = true)
+        mockPostReceiptError(errorType = PostReceiptErrorType.CAN_BE_CONSUMED)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -367,7 +368,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded calls consume transaction with consuming flag false if observer mode on error if finishable error`() {
         every { appConfig.finishTransactions } returns false
-        mockPostReceiptError(finishableError = true)
+        mockPostReceiptError(errorType = PostReceiptErrorType.CAN_BE_CONSUMED)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -385,7 +386,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded does not call consume transaction on error if not finishable error`() {
-        mockPostReceiptError(finishableError = false)
+        mockPostReceiptError(errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -403,7 +404,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded calls error block with expected parameters on error`() {
-        mockPostReceiptError(finishableError = false)
+        mockPostReceiptError(errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED)
 
         var errorTransaction: StoreTransaction? = null
         var purchasesError: PurchasesError? = null
@@ -445,7 +446,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded does not calculate offline entitlements customer info if not server error`() {
-        mockPostReceiptError(finishableError = true)
+        mockPostReceiptError(errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -464,7 +465,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded calculates offline entitlements customer info if server error`() {
-        mockPostReceiptError(finishableError = false)
+        mockPostReceiptError(errorType = PostReceiptErrorType.SERVER_ERROR)
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
             purchase = mockStoreTransaction,
@@ -483,7 +484,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded returns offline entitlements customer info if server error and success calculating customer info`() {
-        mockPostReceiptError(finishableError = false)
+        mockPostReceiptError(errorType = PostReceiptErrorType.SERVER_ERROR)
 
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
@@ -510,7 +511,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded does not cache offline entitlements`() {
-        mockPostReceiptError(finishableError = false)
+        mockPostReceiptError(errorType = PostReceiptErrorType.SERVER_ERROR)
 
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
@@ -535,7 +536,7 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTransactionAndConsumeIfNeeded does not consume if using offline entitlements`() {
-        mockPostReceiptError(finishableError = false)
+        mockPostReceiptError(errorType = PostReceiptErrorType.SERVER_ERROR)
 
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
@@ -562,7 +563,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTransactionAndConsumeIfNeeded does not mark attributes as synced if using offline entitlements`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
-        mockPostReceiptError(finishableError = false)
+        mockPostReceiptError(errorType = PostReceiptErrorType.SERVER_ERROR)
 
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
@@ -915,7 +916,7 @@ class PostReceiptHelperTest {
     fun `postTokenWithoutConsuming marks unsynced attributes as synced on error if finishable error`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
         mockPostReceiptError(
-            finishableError = true,
+            errorType = PostReceiptErrorType.CAN_BE_CONSUMED,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -943,7 +944,7 @@ class PostReceiptHelperTest {
     fun `postTokenWithoutConsuming does not mark unsynced attributes as synced on error if not finishable error`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
         mockPostReceiptError(
-            finishableError = false,
+            errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -970,7 +971,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming adds sent token if finishable error`() {
         mockPostReceiptError(
-            finishableError = true,
+            errorType = PostReceiptErrorType.CAN_BE_CONSUMED,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -993,7 +994,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not add sent token on error if not finishable error`() {
         mockPostReceiptError(
-            finishableError = false,
+            errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1016,7 +1017,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming calls error block with expected parameters on error`() {
         mockPostReceiptError(
-            finishableError = false,
+            errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1056,9 +1057,9 @@ class PostReceiptHelperTest {
     }
 
     @Test
-    fun `postTokenWithoutConsuming does not consume on error `() {
+    fun `postTokenWithoutConsuming does not consume on non consumable error `() {
         mockPostReceiptError(
-            finishableError = false,
+            errorType = PostReceiptErrorType.CANNOT_BE_CONSUMED,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1103,7 +1104,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not calculate offline entitlements customer info if not server error`() {
         mockPostReceiptError(
-            finishableError = true,
+            errorType = PostReceiptErrorType.CAN_BE_CONSUMED,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1127,7 +1128,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming calculates offline entitlements customer info if server error`() {
         mockPostReceiptError(
-            finishableError = false,
+            errorType = PostReceiptErrorType.SERVER_ERROR,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1151,7 +1152,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming returns offline entitlements customer info if server error and success calculating customer info`() {
         mockPostReceiptError(
-            finishableError = false,
+            errorType = PostReceiptErrorType.SERVER_ERROR,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1183,7 +1184,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not cache offline entitlements`() {
         mockPostReceiptError(
-            finishableError = false,
+            errorType = PostReceiptErrorType.SERVER_ERROR,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1213,7 +1214,7 @@ class PostReceiptHelperTest {
     @Test
     fun `postTokenWithoutConsuming does not mark token as consumed if using offline entitlements`() {
         mockPostReceiptError(
-            finishableError = false,
+            errorType = PostReceiptErrorType.SERVER_ERROR,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1245,7 +1246,7 @@ class PostReceiptHelperTest {
     fun `postTokenWithoutConsuming does not mark attributes as synced if using offline entitlements`() {
         mockUnsyncedSubscriberAttributes(unsyncedSubscriberAttributes)
         mockPostReceiptError(
-            finishableError = false,
+            errorType = PostReceiptErrorType.SERVER_ERROR,
             postType = PostType.TOKEN_WITHOUT_CONSUMING
         )
 
@@ -1325,7 +1326,7 @@ class PostReceiptHelperTest {
     }
 
     private fun mockPostReceiptError(
-        finishableError: Boolean,
+        errorType: PostReceiptErrorType,
         postType: PostType = PostType.TRANSACTION_AND_CONSUME
     ) {
         every {
@@ -1343,8 +1344,11 @@ class PostReceiptHelperTest {
             )
         } answers {
             val callback = lambda<PostReceiptDataErrorCallback>().captured
-            if (finishableError) callback.invokeWithFinishableError()
-            else callback.invokeWithNotFinishableError()
+            when (errorType) {
+                PostReceiptErrorType.CAN_BE_CONSUMED -> callback.invokeWithFinishableError()
+                PostReceiptErrorType.CANNOT_BE_CONSUMED -> callback.invokeWithNotFinishableError()
+                PostReceiptErrorType.SERVER_ERROR -> callback.invokeWithServerError()
+            }
         }
 
         every {
@@ -1357,7 +1361,7 @@ class PostReceiptHelperTest {
                 PurchasesError(PurchasesErrorCode.UnknownError)
             )
         }
-        if (finishableError) {
+        if (errorType == PostReceiptErrorType.CAN_BE_CONSUMED) {
             every { subscriberAttributesManager.markAsSynced(appUserID, any(), any()) } just Runs
             if (postType == PostType.TRANSACTION_AND_CONSUME) {
                 every { billing.consumeAndSave(any(), mockStoreTransaction) } just Runs
@@ -1377,8 +1381,7 @@ class PostReceiptHelperTest {
     private fun PostReceiptDataErrorCallback.invokeWithFinishableError() {
         invoke(
             PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
-            true,
-            false,
+            PostReceiptErrorType.CAN_BE_CONSUMED,
             JSONObject(Responses.invalidCredentialsErrorResponse)
         )
     }
@@ -1386,8 +1389,15 @@ class PostReceiptHelperTest {
     private fun PostReceiptDataErrorCallback.invokeWithNotFinishableError() {
         invoke(
             PurchasesError(PurchasesErrorCode.UnexpectedBackendResponseError),
-            false,
-            true,
+            PostReceiptErrorType.CANNOT_BE_CONSUMED,
+            JSONObject(Responses.internalServerErrorResponse)
+        )
+    }
+
+    private fun PostReceiptDataErrorCallback.invokeWithServerError() {
+        invoke(
+            PurchasesError(PurchasesErrorCode.UnexpectedBackendResponseError),
+            PostReceiptErrorType.SERVER_ERROR,
             JSONObject(Responses.internalServerErrorResponse)
         )
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.common.PostReceiptDataSuccessCallback
 import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.SubscriberAttributeError
 import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.google.toStoreTransaction
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttribute
@@ -74,6 +75,7 @@ class PostReceiptHelperTest {
     private lateinit var customerInfoHelper: CustomerInfoHelper
     private lateinit var deviceCache: DeviceCache
     private lateinit var subscriberAttributesManager: SubscriberAttributesManager
+    private lateinit var offlineEntitlementsManager: OfflineEntitlementsManager
 
     private lateinit var postReceiptHelper: PostReceiptHelper
 
@@ -85,6 +87,8 @@ class PostReceiptHelperTest {
         customerInfoHelper = mockk()
         deviceCache = mockk()
         subscriberAttributesManager = mockk()
+        // TODO remove relaxed
+        offlineEntitlementsManager = mockk(relaxed = true)
 
         postedReceiptInfoSlot = slot()
 
@@ -94,7 +98,8 @@ class PostReceiptHelperTest {
             billing = billing,
             customerInfoHelper = customerInfoHelper,
             deviceCache = deviceCache,
-            subscriberAttributesManager = subscriberAttributesManager
+            subscriberAttributesManager = subscriberAttributesManager,
+            offlineEntitlementsManager = offlineEntitlementsManager
         )
 
         mockUnsyncedSubscriberAttributes()

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -197,11 +197,10 @@ class PurchasesTest {
         verify(exactly = 1) { mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded() }
     }
 
-//    Offline entitlements: Commenting out for now until backend is ready
-//    @Test
-//    fun `product entitlement mappings are updated if staled on constructor`() {
-//        verify(exactly = 1) { mockOfflineEntitlementsManager.updateProductEntitlementMappingCacheIfStale() }
-//    }
+    @Test
+    fun `product entitlement mappings are updated if staled on constructor`() {
+        verify(exactly = 1) { mockOfflineEntitlementsManager.updateProductEntitlementMappingCacheIfStale() }
+    }
 
     @Test
     fun getsSubscriptionSkus() {
@@ -1625,19 +1624,18 @@ class PurchasesTest {
         }
     }
 
-//    Offline entitlements: Commenting out for now until backend is ready
-//    @Test
-//    fun `fetch product entitlement mapping on foreground if it's stale`() {
-//        mockSuccessfulQueryPurchases(
-//            queriedSUBS = emptyMap(),
-//            queriedINAPP = emptyMap(),
-//            notInCache = emptyList()
-//        )
-//        Purchases.sharedInstance.onAppForegrounded()
-//        verify(exactly = 2) {
-//            mockOfflineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
-//        }
-//    }
+    @Test
+    fun `fetch product entitlement mapping on foreground if it's stale`() {
+        mockSuccessfulQueryPurchases(
+            queriedSUBS = emptyMap(),
+            queriedINAPP = emptyMap(),
+            notInCache = emptyList()
+        )
+        Purchases.sharedInstance.onAppForegrounded()
+        verify(exactly = 2) {
+            mockOfflineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
+        }
+    }
 
     @Test
     fun `does not fetch purchaser info on foregrounded if it's not stale`() {

--- a/strings/src/main/java/com/revenuecat/purchases/strings/CustomerInfoStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/CustomerInfoStrings.kt
@@ -13,6 +13,7 @@ object CustomerInfoStrings {
     const val VENDING_CACHE = "Vending CustomerInfo from cache."
     const val RETRIEVING_CUSTOMER_INFO = "Retrieving customer info with policy: %s"
     const val MISSING_CACHED_CUSTOMER_INFO = "Requested a cached CustomerInfo but it's not available."
+    const val ERROR_FETCHING_CUSTOMER_INFO = "Error fetching customer data: %s."
     const val COMPUTING_OFFLINE_CUSTOMER_INFO_FAILED = "Error computing offline CustomerInfo. " +
         "Will return original error. Creation error: %s"
 }

--- a/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
@@ -3,9 +3,10 @@ package com.revenuecat.purchases.strings
 object OfflineEntitlementsStrings {
     const val UPDATING_PRODUCT_ENTITLEMENT_MAPPING = "Product entitlement mappings are stale. Updating."
     const val SUCCESSFULLY_UPDATED_PRODUCT_ENTITLEMENTS = "Successfully updated product entitlement mappings."
-    const val ERROR_UPDATING_PRODUCT_ENTITLEMENTS = "Error updating product entitlement mappings. Error: %s"
+    const val ERROR_UPDATING_PRODUCT_ENTITLEMENTS = "Error updating product entitlement mappings. Error: %s."
     const val USING_OFFLINE_ENTITLEMENTS_CUSTOMER_INFO = "Using offline computed customer info."
-    const val RESETTING_OFFLINE_CUSTOMER_INFO_CACHE = "Resetting offline customer info cache"
+    const val UPDATING_OFFLINE_CUSTOMER_INFO_CACHE = "Updating offline customer info cache."
+    const val RESETTING_OFFLINE_CUSTOMER_INFO_CACHE = "Resetting offline customer info cache."
     const val OFFLINE_ENTITLEMENTS_NOT_SUPPORTED = "Offline entitlements not supported in this version."
-    const val ALREADY_CALCULATING_OFFLINE_CUSTOMER_INFO = "Already calculating offline customer info for %s"
+    const val ALREADY_CALCULATING_OFFLINE_CUSTOMER_INFO = "Already calculating offline customer info for %s."
 }

--- a/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
@@ -7,6 +7,6 @@ object OfflineEntitlementsStrings {
     const val USING_OFFLINE_ENTITLEMENTS_CUSTOMER_INFO = "Using offline computed customer info."
     const val UPDATING_OFFLINE_CUSTOMER_INFO_CACHE = "Updating offline customer info cache."
     const val RESETTING_OFFLINE_CUSTOMER_INFO_CACHE = "Resetting offline customer info cache."
-    const val OFFLINE_ENTITLEMENTS_NOT_SUPPORTED = "Offline entitlements not supported in this version."
+    const val OFFLINE_ENTITLEMENTS_NOT_ENABLED = "Offline entitlements not enabled in this version."
     const val ALREADY_CALCULATING_OFFLINE_CUSTOMER_INFO = "Already calculating offline customer info for %s."
 }

--- a/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
@@ -4,6 +4,7 @@ object OfflineEntitlementsStrings {
     const val UPDATING_PRODUCT_ENTITLEMENT_MAPPING = "Product entitlement mappings are stale. Updating."
     const val SUCCESSFULLY_UPDATED_PRODUCT_ENTITLEMENTS = "Successfully updated product entitlement mappings."
     const val ERROR_UPDATING_PRODUCT_ENTITLEMENTS = "Error updating product entitlement mappings. Error: %s"
+    const val USING_OFFLINE_ENTITLEMENTS_CUSTOMER_INFO = "Using offline computed customer info."
     const val RESETTING_OFFLINE_CUSTOMER_INFO_CACHE = "Resetting offline customer info cache"
     const val OFFLINE_ENTITLEMENTS_NOT_SUPPORTED = "Offline entitlements not supported in this version."
     const val ALREADY_CALCULATING_OFFLINE_CUSTOMER_INFO = "Already calculating offline customer info for %s"

--- a/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
@@ -4,4 +4,6 @@ object OfflineEntitlementsStrings {
     const val UPDATING_PRODUCT_ENTITLEMENT_MAPPING = "Product entitlement mappings are stale. Updating."
     const val SUCCESSFULLY_UPDATED_PRODUCT_ENTITLEMENTS = "Successfully updated product entitlement mappings."
     const val ERROR_UPDATING_PRODUCT_ENTITLEMENTS = "Error updating product entitlement mappings. Error: %s"
+    const val RESETTING_OFFLINE_CUSTOMER_INFO_CACHE = "Resetting offline customer info cache"
+    const val ALREADY_CALCULATING_OFFLINE_CUSTOMER_INFO = "Already calculating offline customer info for %s"
 }

--- a/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
@@ -5,5 +5,6 @@ object OfflineEntitlementsStrings {
     const val SUCCESSFULLY_UPDATED_PRODUCT_ENTITLEMENTS = "Successfully updated product entitlement mappings."
     const val ERROR_UPDATING_PRODUCT_ENTITLEMENTS = "Error updating product entitlement mappings. Error: %s"
     const val RESETTING_OFFLINE_CUSTOMER_INFO_CACHE = "Resetting offline customer info cache"
+    const val OFFLINE_ENTITLEMENTS_NOT_SUPPORTED = "Offline entitlements not supported in this version."
     const val ALREADY_CALCULATING_OFFLINE_CUSTOMER_INFO = "Already calculating offline customer info for %s"
 }


### PR DESCRIPTION
### Description
This PR enables offline entitlements automatically when we receive 5xx response codes in the `postReceipt` requests or on `getCustomerInfo` if there isn't a cached version already. It also disables offline entitlements when we receive a successful response in one of the above requests or logIn/logout.

We went with a stateful approach since we need to return the offline computed customer info from `getCustomerInfo` after a `postReceipt` fails. 

All this is also behind a flag right now that is hardcoded so we don't enter offline entitlements mode yet.

 