### PR TITLE
Fix storing test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,8 +155,14 @@ jobs:
       - android/save-build-cache
       - store_artifacts:
           path: build/reports
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
       - store_test_results:
-          path: build/test-results
+          path: ~/test-results/junit/
 
   docs-deploy:
     <<: *android-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,11 +155,11 @@ jobs:
       - run:
           name: Save test results
           command: |
-            mkdir -p ~/test-results/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
+            mkdir -p build/test-results
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} build/test-results \;
           when: always
       - store_test_results:
-          path: ~/test-results/junit/
+          path: build/test-results
 
   detekt:
     <<: *android-executor


### PR DESCRIPTION
`store_test_results` wasn't working because the modules render the test results in their own folders. This change fixes the issue by moving all test results into another folder and storing that folder instead