### PR TITLE
Add instrumented test for android v4 json bug

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -17,8 +17,11 @@ dependencies {
     testImplementation "androidx.test:runner:$testLibrariesVersion"
     testImplementation "androidx.test:rules:$testLibrariesVersion"
     testImplementation "androidx.test.ext:junit:$testJUnitVersion"
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "io.mockk:mockk:$mockkVersion"
     testImplementation "org.assertj:assertj-core:$assertJVersion"
     testImplementation "com.squareup.okhttp3:mockwebserver:$mockwebserverVersion"
+    androidTestImplementation 'junit:junit:4.12'
 }

--- a/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
+++ b/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
@@ -16,14 +16,16 @@ class JSONArrayBugInstrumentedTest {
         val incorrectJSONObject = JSONObject(inputMap)
         assertEquals(
             incorrectJSONObject
-                .toString(), ("""{"key1":"value1","key2":[value2, value3],"key3":{"nestedKey":"nestedValue"},"key4":{"nestedArray":[value4, value5]}}""")
+                .toString(), ("""{"key1":"value1","key2":[value2, value3],"key3":{"nestedKey":"nestedValue"},
+                    |"key4":{"nestedArray":[value4, value5]}}""".trimMargin())
         )
         val mapConverter = MapConverter()
 
         val correctJSONObject = mapConverter.convertToJSON(inputMap)
         assertEquals(
             correctJSONObject
-                .toString(), ("""{"key1":"value1","key2":["value2","value3"],"key3":{"nestedKey":"nestedValue"},"key4":{"nestedArray":["value4","value5"]}}""")
+                .toString(), ("""{"key1":"value1","key2":["value2","value3"],"key3":{"nestedKey":"nestedValue"},
+                    |"key4":{"nestedArray":["value4","value5"]}}""".trimMargin())
         )
     }
 }

--- a/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
+++ b/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
@@ -8,24 +8,19 @@ class JSONArrayBugInstrumentedTest {
     @org.junit.Test
     fun testReproduceIncorrectJSONArray() {
         val inputMap = mapOf(
-            "key1" to "value1",
-            "key2" to listOf("value2", "value3"),
-            "key3" to mapOf("nestedKey" to "nestedValue"),
-            "key4" to mapOf("nestedArray" to listOf("value4", "value5")),
+            "key1" to listOf("value2", "value3"),
         )
         val incorrectJSONObject = JSONObject(inputMap)
         assertEquals(
             incorrectJSONObject
-                .toString(), ("""{"key1":"value1","key2":[value2, value3],"key3":{"nestedKey":"nestedValue"},
-                    |"key4":{"nestedArray":[value4, value5]}}""".trimMargin())
+                .toString(), ("""{"key1":[value2, value3]}""".trimMargin())
         )
         val mapConverter = MapConverter()
 
         val correctJSONObject = mapConverter.convertToJSON(inputMap)
         assertEquals(
             correctJSONObject
-                .toString(), ("""{"key1":"value1","key2":["value2","value3"],"key3":{"nestedKey":"nestedValue"},
-                    |"key4":{"nestedArray":["value4","value5"]}}""".trimMargin())
+                .toString(), ("""{"key1":["value2","value3"]}""".trimMargin())
         )
     }
 }

--- a/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
+++ b/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
@@ -1,0 +1,30 @@
+import com.revenuecat.purchases.common.networking.MapConverter
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+
+//@org.junit.runner.RunWith(androidx.test.ext.junit.runners.AndroidJUnit4::class)
+class JSONArrayBugInstrumentedTest {
+    @org.junit.Test
+    fun testReproduceIncorrectJSONArray() {
+        val inputMap = mapOf(
+            "key1" to "value1",
+            "key2" to listOf("value2", "value3"),
+            "key3" to mapOf("nestedKey" to "nestedValue"),
+            "key4" to mapOf("nestedArray" to listOf("value4", "value5")),
+        )
+        val incorrectJSONObject = JSONObject(inputMap)
+        assertEquals(
+            incorrectJSONObject
+                .toString(), ("""{"key1":"value1","key2":[value2, value3],"key3":{"nestedKey":"nestedValue"},"key4":{"nestedArray":[value4, value5]}}""")
+        )
+        val mapConverter = MapConverter()
+
+        val correctJSONObject = mapConverter.convertToJSON(inputMap)
+        assertEquals(
+            correctJSONObject
+                .toString(), ("""{"key1":"value1","key2":["value2","value3"],"key3":{"nestedKey":"nestedValue"},"key4":{"nestedArray":["value4","value5"]}}""")
+        )
+    }
+}
+

--- a/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
+++ b/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
@@ -13,7 +13,7 @@ class JSONArrayBugInstrumentedTest {
         val incorrectJSONObject = JSONObject(inputMap)
         assertEquals(
             incorrectJSONObject
-                .toString(), ("""{"key1":[value2, value3]}""".trimMargin())
+                .toString(), ("""{"key1":["[value2, value3]"]}""".trimMargin())
         )
         val mapConverter = MapConverter()
 

--- a/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
+++ b/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
@@ -19,14 +19,14 @@ class JSONArrayBugInstrumentedTest {
         val incorrectJSONObject = JSONObject(inputMap)
         assertEquals(
             incorrectJSONObject
-                .toString(), ("{\"key1\":[\"value2, value3\"]}")
+                .toString(), "{\"key1\":[\"value2, value3\"]}"
         )
         val mapConverter = MapConverter()
 
         val correctJSONObject = mapConverter.convertToJSON(inputMap)
         assertEquals(
             correctJSONObject
-                .toString(), ("{\"key1\":[\"value2\",\"value3\"]}")
+                .toString(), "{\"key1\":[\"value2\",\"value3\"]}"
         )
     }
 }

--- a/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
+++ b/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
@@ -1,5 +1,5 @@
+import android.os.Build
 import com.revenuecat.purchases.common.networking.MapConverter
-import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 
@@ -7,20 +7,26 @@ import org.junit.Assert.assertEquals
 class JSONArrayBugInstrumentedTest {
     @org.junit.Test
     fun testReproduceIncorrectJSONArray() {
+        // these tests should only be run on Android 4, since that's the version that has the bug.
+        val osLevel = Build.VERSION.SDK_INT
+        if (!(osLevel >= Build.VERSION_CODES.ICE_CREAM_SANDWICH && osLevel <= Build.VERSION_CODES.KITKAT)) {
+            return
+        }
+
         val inputMap = mapOf(
             "key1" to listOf("value2", "value3"),
         )
         val incorrectJSONObject = JSONObject(inputMap)
         assertEquals(
             incorrectJSONObject
-                .toString(), ("""{"key1":["value2, value3"]}""")
+                .toString(), ("{\"key1\":[\"value2, value3\"]}")
         )
         val mapConverter = MapConverter()
 
         val correctJSONObject = mapConverter.convertToJSON(inputMap)
         assertEquals(
             correctJSONObject
-                .toString(), ("""{"key1":["value2","value3"]}""")
+                .toString(), ("{\"key1\":[\"value2\",\"value3\"]}")
         )
     }
 }

--- a/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
+++ b/common/src/androidTest/kotlin/JSONArrayBugInstrumentedTest.kt
@@ -13,14 +13,14 @@ class JSONArrayBugInstrumentedTest {
         val incorrectJSONObject = JSONObject(inputMap)
         assertEquals(
             incorrectJSONObject
-                .toString(), ("""{"key1":["[value2, value3]"]}""".trimMargin())
+                .toString(), ("""{"key1":["value2, value3"]}""")
         )
         val mapConverter = MapConverter()
 
         val correctJSONObject = mapConverter.convertToJSON(inputMap)
         assertEquals(
             correctJSONObject
-                .toString(), ("""{"key1":["value2","value3"]}""".trimMargin())
+                .toString(), ("""{"key1":["value2","value3"]}""")
         )
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -128,7 +128,7 @@ class HTTPClient(
         requestHeaders: Map<String, String>,
         refreshETag: Boolean
     ): HTTPResult? {
-        val jsonBody = mapConverter.convertToJSON(body)
+        val jsonBody = body?.let { mapConverter.convertToJSON(body) }
         val path = endpoint.getPath()
         val urlPathWithVersion = "/v1$path"
         val connection: HttpURLConnection

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
 import com.revenuecat.purchases.strings.NetworkStrings
 import com.revenuecat.purchases.utils.filterNotNullValues
+import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.BufferedReader
@@ -239,6 +240,16 @@ class HTTPClient(
     private fun Map<String, Any?>.convert(): JSONObject {
         val mapWithoutInnerMaps = mapValues { (_, value) ->
             value.tryCast<Map<String, Any?>>(ifSuccess = { convert() })
+            when (value) {
+                is List<*> -> {
+                    if (value.all { it is String }) {
+                        JSONObject(mapOf("temp_key" to JSONArray(value))).getJSONArray("temp_key")
+                    } else {
+                        value
+                    }
+                }
+                else -> value.tryCast<Map<String, Any?>>(ifSuccess = { convert() })
+            }
         }
         return JSONObject(mapWithoutInnerMaps)
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -128,7 +128,7 @@ class HTTPClient(
         requestHeaders: Map<String, String>,
         refreshETag: Boolean
     ): HTTPResult? {
-        val jsonBody = body?.let { mapConverter.convertToJSON(body) }
+        val jsonBody = body?.let { mapConverter.convertToJSON(it) }
         val path = endpoint.getPath()
         val urlPathWithVersion = "/v1$path"
         val connection: HttpURLConnection

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -21,9 +21,7 @@ import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
 import com.revenuecat.purchases.strings.NetworkStrings
 import com.revenuecat.purchases.utils.filterNotNullValues
-import org.json.JSONArray
 import org.json.JSONException
-import org.json.JSONObject
 import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.IOException

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
@@ -17,10 +17,7 @@ class MapConverter {
      * @param inputMap The input map to convert.
      * @return A JSONObject representing the input map.
      */
-    internal fun convertToJSON(inputMap: Map<String, Any?>?): JSONObject {
-        if (inputMap == null) {
-            return JSONObject()
-        }
+    internal fun convertToJSON(inputMap: Map<String, Any?>): JSONObject {
         val mapWithoutInnerMaps = inputMap.mapValues { (_, value) ->
             value.tryCast<Map<String, Any?>>(ifSuccess = { convertToJSON(this) })
             when (value) {

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
@@ -17,16 +17,12 @@ class MapConverter {
      * @param inputMap The input map to convert.
      * @return A JSONObject representing the input map.
      */
-    fun convertToJSON(inputMap: Map<String, Any?>?): JSONObject {
-        return inputMap.convert()
-    }
-
-    private fun Map<String, Any?>?.convert(): JSONObject {
-        if (this == null) {
+    internal fun convertToJSON(inputMap: Map<String, Any?>?): JSONObject {
+        if (inputMap == null) {
             return JSONObject()
         }
-        val mapWithoutInnerMaps = mapValues { (_, value) ->
-            value.tryCast<Map<String, Any?>>(ifSuccess = { convert() })
+        val mapWithoutInnerMaps = inputMap.mapValues { (_, value) ->
+            value.tryCast<Map<String, Any?>>(ifSuccess = { convertToJSON(this) })
             when (value) {
                 is List<*> -> {
                     if (value.all { it is String }) {
@@ -35,10 +31,14 @@ class MapConverter {
                         value
                     }
                 }
-                else -> value.tryCast<Map<String, Any?>>(ifSuccess = { convert() })
+                else -> value.tryCast<Map<String, Any?>>(ifSuccess = { convertToJSON(this) })
             }
         }
-        return JSONObject(mapWithoutInnerMaps)
+        return createJSONObject(mapWithoutInnerMaps)
+    }
+
+    internal fun createJSONObject(inputMap: Map<String, Any?>): JSONObject {
+        return JSONObject(inputMap)
     }
 
     /** To avoid Java type erasure, we use a Kotlin inline function with a reified parameter

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
@@ -3,8 +3,20 @@ package com.revenuecat.purchases.common.networking
 import org.json.JSONArray
 import org.json.JSONObject
 
+/**
+ * A class to convert a Map<String, Any?> into a JSONObject.
+ * This was created to workaround a bug in Android 4 , where a List<String> would be incorrectly converted into
+ * a single string instead of a JSONArray of strings. (i.e.: "[\"value1\", \"value2\"]" instead of "[value1, value2]")
+ * This class handles nested maps, lists, and other JSON-compatible types.
+ */
 class MapConverter {
 
+    /**
+     * Converts the given [inputMap] into a JSONObject.
+     *
+     * @param inputMap The input map to convert.
+     * @return A JSONObject representing the input map.
+     */
     fun convertToJSON(inputMap: Map<String, Any?>?): JSONObject {
         return inputMap.convert()
     }
@@ -29,13 +41,14 @@ class MapConverter {
         return JSONObject(mapWithoutInnerMaps)
     }
 
-    // To avoid Java type erasure, we use a Kotlin inline function with a reified parameter
-    // so that we can check the type on runtime.
-    //
-    // Doing something like:
-    // if (value is Map<*, *>) (value as Map<String, Any?>).convert()
-    //
-    // Would give an unchecked cast warning due to Java type erasure
+    /** To avoid Java type erasure, we use a Kotlin inline function with a reified parameter
+     * so that we can check the type on runtime.
+     *
+     * Doing something like:
+     * if (value is Map<*, *>) (value as Map<String, Any?>).convert()
+     *
+     * Would give an unchecked cast warning due to Java type erasure
+     */
     private inline fun <reified T> Any?.tryCast(
         ifSuccess: T.() -> Any?
     ): Any? {

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
@@ -1,0 +1,48 @@
+package com.revenuecat.purchases.common.networking
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+class MapConverter {
+
+    fun convertToJSON(inputMap: Map<String, Any?>?): JSONObject {
+        return inputMap.convert()
+    }
+
+    private fun Map<String, Any?>?.convert(): JSONObject {
+        if (this == null) {
+            return JSONObject()
+        }
+        val mapWithoutInnerMaps = mapValues { (_, value) ->
+            value.tryCast<Map<String, Any?>>(ifSuccess = { convert() })
+            when (value) {
+                is List<*> -> {
+                    if (value.all { it is String }) {
+                        JSONObject(mapOf("temp_key" to JSONArray(value))).getJSONArray("temp_key")
+                    } else {
+                        value
+                    }
+                }
+                else -> value.tryCast<Map<String, Any?>>(ifSuccess = { convert() })
+            }
+        }
+        return JSONObject(mapWithoutInnerMaps)
+    }
+
+    // To avoid Java type erasure, we use a Kotlin inline function with a reified parameter
+    // so that we can check the type on runtime.
+    //
+    // Doing something like:
+    // if (value is Map<*, *>) (value as Map<String, Any?>).convert()
+    //
+    // Would give an unchecked cast warning due to Java type erasure
+    private inline fun <reified T> Any?.tryCast(
+        ifSuccess: T.() -> Any?
+    ): Any? {
+        return if (this is T) {
+            this.ifSuccess()
+        } else {
+            this
+        }
+    }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/MapConverter.kt
@@ -19,7 +19,6 @@ class MapConverter {
      */
     internal fun convertToJSON(inputMap: Map<String, Any?>): JSONObject {
         val mapWithoutInnerMaps = inputMap.mapValues { (_, value) ->
-            value.tryCast<Map<String, Any?>>(ifSuccess = { convertToJSON(this) })
             when (value) {
                 is List<*> -> {
                     if (value.all { it is String }) {

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -1,0 +1,82 @@
+package com.revenuecat.purchases.common.networking
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class MapConverterTest {
+
+    private lateinit var mapConverter: MapConverter
+
+    @Before
+    fun setUp() {
+        mapConverter = MapConverter()
+    }
+
+    @Test
+    fun testConvertToJSON() {
+        val inputMap = mapOf(
+            "key1" to "value1",
+            "key2" to listOf("value2", "value3"),
+            "key3" to mapOf("nestedKey" to "nestedValue")
+        )
+
+        val expectedJson = JSONObject()
+            .put("key1", "value1")
+            .put("key2", JSONArray(listOf("value2", "value3")))
+            .put("key3", JSONObject().put("nestedKey", "nestedValue"))
+
+        val result = mapConverter.convertToJSON(inputMap)
+        assertEquals(expectedJson.toString(), result.toString())
+    }
+
+    @Test
+    fun testConvertToJSONWithNestedArrayOfStrings() {
+        val inputMap = mapOf(
+            "key1" to "value1",
+            "key2" to listOf("value2", "value3"),
+            "key3" to mapOf("nestedKey" to "nestedValue"),
+            "key4" to listOf("value4", "value5")
+        )
+
+        val expectedJson = JSONObject()
+            .put("key1", "value1")
+            .put("key2", JSONArray(listOf("value2", "value3")))
+            .put("key3", JSONObject().put("nestedKey", "nestedValue"))
+            .put("key4", JSONArray(listOf("value4", "value5")))
+
+        val result = mapConverter.convertToJSON(inputMap)
+        assertEquals(expectedJson.toString(), result.toString())
+    }
+
+    @Test
+    fun `test map conversion with mocked List of String conversion`() {
+        val mapConverterMock = mockk<MapConverter>()
+
+        val inputMap = mapOf(
+            "key" to listOf("value1", "value2")
+        )
+
+        val expectedIncorrectJsonArrayString = "[\"value1\",\"value2\"]"
+
+        // Mock the convertToJSON method for the specific input
+        every {
+            mapConverterMock.convertToJSON(match { it == inputMap })
+        } returns JSONObject(mapOf("key" to expectedIncorrectJsonArrayString))
+
+        val resultJson = mapConverterMock.convertToJSON(inputMap)
+        val resultArrayString = resultJson.optString("key")
+
+        assertEquals(expectedIncorrectJsonArrayString, resultArrayString)
+    }
+
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -24,7 +24,7 @@ class MapConverterTest {
     }
 
     @Test
-    fun testConvertToJSON() {
+    fun `test convert to JSON`() {
         val inputMap = mapOf(
             "key1" to "value1",
             "key2" to listOf("value2", "value3"),
@@ -41,7 +41,7 @@ class MapConverterTest {
     }
 
     @Test
-    fun testConvertToJSONWithNestedArrayOfStrings() {
+    fun `test convert to JSON with nested array of strings`() {
         val inputMap = mapOf(
             "key1" to "value1",
             "key2" to listOf("value2", "value3"),

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -65,7 +65,7 @@ class MapConverterTest {
      * (i.e.: "[\"value1\", \"value2\"]" instead of "[value1, value2]")
      */
     @Test
-    fun `test map conversion with mocked List of String conversion`() {
+    fun `test map conversion fixes wrong treatment of arrays of strings in JSON library`() {
         val mapConverterMock = spyk<MapConverter>()
 
         val inputMap = mapOf(

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -69,19 +69,19 @@ class MapConverterTest {
         val mapConverterMock = spyk<MapConverter>()
 
         val inputMap = mapOf(
-            "nested" to listOf("value1", "value2")
+            "product_ids" to listOf("product_1", "product_2")
         )
 
         val mapContainingInputMap = mapOf(
-            "root" to inputMap
+            "subscriber_info" to inputMap
         )
 
-        val incorrectJsonArrayString = "[value1,value2]"
-        val correctedJSONArray = JSONArray(listOf("value1", "value2"))
+        val incorrectJsonArrayString = "[product_1,product_2]"
+        val correctedJSONArray = JSONArray(listOf("product_1", "product_2"))
 
         every {
             mapConverterMock.createJSONObject(match { it == inputMap })
-        } returns JSONObject(mapOf("nested" to incorrectJsonArrayString))
+        } returns JSONObject(mapOf("product_ids" to incorrectJsonArrayString))
 
         val resultJson = mapConverterMock.convertToJSON(mapContainingInputMap)
         val resultArrayString = resultJson.optJSONObject("root")?.optJSONArray("nested")

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -45,14 +45,14 @@ class MapConverterTest {
             "key1" to "value1",
             "key2" to listOf("value2", "value3"),
             "key3" to mapOf("nestedKey" to "nestedValue"),
-            "key4" to listOf("value4", "value5")
+            "key4" to mapOf("nestedArray" to listOf("value4", "value5")),
         )
 
         val expectedJson = JSONObject()
             .put("key1", "value1")
             .put("key2", JSONArray(listOf("value2", "value3")))
             .put("key3", JSONObject().put("nestedKey", "nestedValue"))
-            .put("key4", JSONArray(listOf("value4", "value5")))
+            .put("key4", JSONObject().put("nestedArray", JSONArray(listOf("value4", "value5"))))
 
         val result = mapConverter.convertToJSON(inputMap)
         assertEquals(expectedJson.toString(), result.toString())

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -84,7 +84,7 @@ class MapConverterTest {
         } returns JSONObject(mapOf("product_ids" to incorrectJsonArrayString))
 
         val resultJson = mapConverterMock.convertToJSON(mapContainingInputMap)
-        val resultArrayString = resultJson.optJSONObject("root")?.optJSONArray("nested")
+        val resultArrayString = resultJson.optJSONObject("subscriber_info")?.optJSONArray("product_ids")
 
         assertEquals(correctedJSONArray, resultArrayString)
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -68,7 +68,6 @@ class MapConverterTest {
 
         val expectedIncorrectJsonArrayString = "[\"value1\",\"value2\"]"
 
-        // Mock the convertToJSON method for the specific input
         every {
             mapConverterMock.convertToJSON(match { it == inputMap })
         } returns JSONObject(mapOf("key" to expectedIncorrectJsonArrayString))

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/MapConverterTest.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases.common.networking
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every
-import io.mockk.mockk
 import io.mockk.spyk
 import org.json.JSONArray
 import org.json.JSONObject
@@ -66,7 +65,7 @@ class MapConverterTest {
      */
     @Test
     fun `test map conversion fixes wrong treatment of arrays of strings in JSON library`() {
-        val mapConverterMock = spyk<MapConverter>()
+        val mapConverterPartialMock = spyk<MapConverter>()
 
         val inputMap = mapOf(
             "product_ids" to listOf("product_1", "product_2")
@@ -80,10 +79,10 @@ class MapConverterTest {
         val correctedJSONArray = JSONArray(listOf("product_1", "product_2"))
 
         every {
-            mapConverterMock.createJSONObject(match { it == inputMap })
+            mapConverterPartialMock.createJSONObject(match { it == inputMap })
         } returns JSONObject(mapOf("product_ids" to incorrectJsonArrayString))
 
-        val resultJson = mapConverterMock.convertToJSON(mapContainingInputMap)
+        val resultJson = mapConverterPartialMock.convertToJSON(mapContainingInputMap)
         val resultArrayString = resultJson.optJSONObject("subscriber_info")?.optJSONArray("product_ids")
 
         assertEquals(correctedJSONArray, resultArrayString)


### PR DESCRIPTION
Adds instrumented test for the android bug. 

I've been able to reproduce the bug using an android v4 device. 

I added the test, but the test itself wouldn't work on a non-android v4 device. Is there a smart way to limit it to only run if OS == 4? 

Otherwise I can do something like check the OS at runtime and then cancel the test. @vegaro @tonidero what's the standard android way of handling this? 