### PR TITLE
Fix original purchase date when different base plans grant different entitlements

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/EntitlementInfoFactories.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/EntitlementInfoFactories.kt
@@ -87,8 +87,9 @@ internal fun JSONObject.buildEntitlementInfo(
     val expirationDate = optDate(EntitlementsResponseJsonKeys.EXPIRES_DATE)
     val unsubscribeDetectedAt = productData.optDate(ProductResponseJsonKeys.UNSUBSCRIBE_DETECTED_AT)
     val billingIssueDetectedAt = productData.optDate(ProductResponseJsonKeys.BILLING_ISSUES_DETECTED_AT)
-
     val store = productData.getStore(ProductResponseJsonKeys.STORE)
+
+    val entitlementPurchaseDate = getDate(ProductResponseJsonKeys.PURCHASE_DATE)
 
     return EntitlementInfo(
         identifier = identifier,
@@ -96,8 +97,8 @@ internal fun JSONObject.buildEntitlementInfo(
         willRenew = getWillRenew(store, expirationDate, unsubscribeDetectedAt,
             billingIssueDetectedAt),
         periodType = productData.optPeriodType(ProductResponseJsonKeys.PERIOD_TYPE),
-        latestPurchaseDate = getDate(ProductResponseJsonKeys.PURCHASE_DATE),
-        originalPurchaseDate = productData.getDate(ProductResponseJsonKeys.ORIGINAL_PURCHASE_DATE),
+        latestPurchaseDate = entitlementPurchaseDate,
+        originalPurchaseDate = this.calculateOriginalPurchaseDate(productData),
         expirationDate = expirationDate,
         store = store,
         productIdentifier = getString(EntitlementsResponseJsonKeys.PRODUCT_IDENTIFIER),
@@ -111,6 +112,40 @@ internal fun JSONObject.buildEntitlementInfo(
         // verificationResult = verificationResult
     )
 }
+
+// If a product's base plans grants different entitlements, the product data section of the customerInfo response
+// might not match the information for the entitlement. If will have the latest purchased plan's information only.
+// This means we only have the original_purchase_date for the latest base plan purchased.
+//
+// For example:
+//
+// An entitlement could have this response from the backend (note the purchase is for p1m):
+// {
+//   "expires_date":"2023-04-11T17:59:03.285Z",
+//   "product_identifier":"prod_1",
+//   "purchase_date":"2023-04-11T16:59:03.285Z",
+//   "product_plan_identifier":"p1m"
+// }
+//
+// But the product data could be for a more recent purchase for another plan (not_bw):
+// {
+//   "billing_issues_detected_at":null,
+//   "is_sandbox":false,
+//   "original_purchase_date":"2023-04-11T17:59:03.285Z",
+//   "purchase_date":"2023-04-11T17:59:03.285Z",
+//   "store":"play_store",
+//   "unsubscribe_detected_at":null,
+//   "product_plan_identifier":"not_bw",
+//   "expires_date":"2023-04-12T18:59:01.115Z",
+//   "period_type":"normal"
+// }
+private fun JSONObject.calculateOriginalPurchaseDate(productData: JSONObject): Date =
+    if (productData.optNullableString(ProductResponseJsonKeys.PRODUCT_PLAN_IDENTIFIER) ==
+        this.optNullableString(EntitlementsResponseJsonKeys.PRODUCT_PLAN_IDENTIFIER)) {
+        productData.getDate(ProductResponseJsonKeys.ORIGINAL_PURCHASE_DATE)
+    } else {
+        this.getDate(EntitlementsResponseJsonKeys.PURCHASE_DATE)
+    }
 
 private fun isDateActive(
     identifier: String,

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
@@ -66,6 +66,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -152,6 +153,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "1999-07-26T23:30:41Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -182,6 +184,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "1999-07-26T23:30:41Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -210,6 +213,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "1999-07-26T23:30:41Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -248,6 +252,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -299,6 +304,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -339,6 +345,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -373,6 +380,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -407,6 +415,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", "2019-07-27T23:30:41Z")
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -441,6 +450,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", "2019-07-27T23:30:41Z")
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -480,6 +490,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "1999-07-26T23:30:41Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -558,6 +569,7 @@ class EntitlementInfosTests {
                     put("purchase_date",  "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -583,6 +595,7 @@ class EntitlementInfosTests {
                     put("purchase_date",  "2019-07-26T23:45:40Z")
                     put("store", "mac_app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -608,6 +621,7 @@ class EntitlementInfosTests {
                     put("purchase_date",  "2019-07-26T23:45:40Z")
                     put("store", "play_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -894,6 +908,7 @@ class EntitlementInfosTests {
                     put("purchase_date",  "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -919,6 +934,7 @@ class EntitlementInfosTests {
                     put("purchase_date",  "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -944,6 +960,7 @@ class EntitlementInfosTests {
                     put("purchase_date",  "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -969,6 +986,7 @@ class EntitlementInfosTests {
                     put("purchase_date",  "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -1076,6 +1094,7 @@ class EntitlementInfosTests {
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
                     put("ownership_type", "PURCHASED")
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -1102,6 +1121,7 @@ class EntitlementInfosTests {
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
                     put("ownership_type", "FAMILY_SHARED")
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -1128,6 +1148,7 @@ class EntitlementInfosTests {
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
                     put("ownership_type", "UNKNOWN")
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -1157,6 +1178,7 @@ class EntitlementInfosTests {
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
                     put("ownership_type", "AN_UNKNOWN_OWNERSHIP_TYPE")
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -1185,6 +1207,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             }
         )
@@ -1228,6 +1251,7 @@ class EntitlementInfosTests {
                     put("expires_date", Iso8601Utils.format(1.days.ago()))
                     put("product_identifier", "monthly_freetrial")
                     put("purchase_date", "2019-07-26T23:45:40Z")
+                    put("product_plan_identifier", "monthly")
                 })
             },
             subscriptions = JSONObject().apply {
@@ -1240,6 +1264,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             },
             requestDate = 2.days.ago()
@@ -1258,6 +1283,7 @@ class EntitlementInfosTests {
                 put("pro_cat", JSONObject().apply {
                     put("expires_date", Iso8601Utils.format(1.days.ago()))
                     put("product_identifier", "monthly_freetrial")
+                    put("product_plan_identifier", "monthly")
                     put("purchase_date", "2019-07-26T23:45:40Z")
                 })
             },
@@ -1271,6 +1297,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             },
             requestDate = 5.days.ago()
@@ -1290,6 +1317,7 @@ class EntitlementInfosTests {
                     put("expires_date", Iso8601Utils.format(1.days.fromNow()))
                     put("product_identifier", "monthly_freetrial")
                     put("purchase_date", "2019-07-26T23:45:40Z")
+                    put("product_plan_identifier", "monthly")
                 })
             },
             subscriptions = JSONObject().apply {
@@ -1302,6 +1330,7 @@ class EntitlementInfosTests {
                     put("purchase_date", "2019-07-26T23:45:40Z")
                     put("store", "app_store")
                     put("unsubscribe_detected_at", JSONObject.NULL)
+                    put("product_plan_identifier", "monthly")
                 })
             },
             requestDate = 5.days.ago()

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
@@ -1215,6 +1215,48 @@ class EntitlementInfosTests {
         verifyOwnershipType(OwnershipType.UNKNOWN)
     }
 
+    @Test
+    fun `entitlement original purchase date is correct if product has been purchased using different base plans`() {
+        stubResponse(
+            entitlements = JSONObject().apply {
+                put("pro_level_a", JSONObject().apply {
+                    put("expires_date", "2023-04-11T17:36:06Z")
+                    put("product_identifier", "gold")
+                    put("purchase_date", "2023-04-11T17:31:06Z")
+                    put("product_plan_identifier", "monthly-gold")
+                })
+                put("pro_level_b", JSONObject().apply {
+                    put("expires_date", "2023-04-11T18:16:03Z")
+                    put("product_identifier", "gold")
+                    put("purchase_date", "2023-04-11T18:11:03Z")
+                    put("product_plan_identifier", "weekly-gold")
+                })
+
+            },
+            subscriptions = JSONObject().apply {
+                put("gold", JSONObject().apply {
+                    put("billing_issues_detected_at", JSONObject.NULL)
+                    put("expires_date", "2023-04-11T18:16:03Z")
+                    put("is_sandbox", false)
+                    put("original_purchase_date", "2023-04-11T17:41:06Z")
+                    put("period_type", "normal")
+                    put("purchase_date", "2019-07-26T23:45:40Z")
+                    put("store", "app_store")
+                    put("unsubscribe_detected_at", "2023-04-11T18:16:06Z")
+                    put("product_plan_identifier", "weekly-gold")
+                })
+            },
+            requestDate = 2.days.ago()
+        )
+
+        val customerInfo = createCustomerInfo(response)
+        assertThat(customerInfo.entitlements.all.size).isEqualTo(2)
+        assertThat(customerInfo.entitlements.all.containsKey("pro_level_a")).isTrue
+        assertThat(customerInfo.entitlements.all.containsKey("pro_level_b")).isTrue
+        assertThat(customerInfo.entitlements["pro_level_a"]?.originalPurchaseDate).isEqualTo("2023-04-11T17:31:06Z")
+        assertThat(customerInfo.entitlements["pro_level_b"]?.originalPurchaseDate).isEqualTo("2023-04-11T17:41:06Z")
+    }
+
     // region Equality tests
 
     // Trusted entitlements: Commented out until ready to be made public

--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
@@ -177,7 +177,7 @@ class OfflineCustomerInfoCalculatorTest {
         )
         assertThat(receivedCustomerInfo).isNotNull
         assertThat(receivedCustomerInfo?.activeSubscriptions!!.size).isEqualTo(1)
-        assertThat(receivedCustomerInfo?.activeSubscriptions).contains("prod_1:not_bw")
+        assertThat(receivedCustomerInfo?.activeSubscriptions).contains("prod_1")
         assertThat(receivedCustomerInfo?.entitlements?.all?.size).isEqualTo(2)
 
         verifyEntitlement(receivedCustomerInfo, entitlementID, p1mProduct, expirationDate = oneHourAgo,

--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
@@ -128,64 +128,6 @@ class OfflineCustomerInfoCalculatorTest {
     }
 
     @Test
-    fun `product with different entitlement per base plan`() {
-        val entitlementID = "pro_1"
-        val secondEntitlementID = "pro_2"
-        val productIdentifier = "prod_1"
-
-        // Made a purchase for p1m and then a purchase for not_bw after that one expired
-        // You can't have an active purchase of the same product different base plans at the same time
-        val oneHourAgo = 1.hours.ago()
-        val twoHoursAgo = 2.hours.ago()
-        val p1mProduct = PurchasedProduct(
-            productIdentifier,
-            stubStoreTransactionFromPurchaseHistoryRecord(
-                productIds = listOf(productIdentifier),
-                purchaseTime = twoHoursAgo.time,
-            ),
-            false,
-            listOf(entitlementID),
-            expiresDate = oneHourAgo
-        )
-
-            val notBwProduct = PurchasedProduct(
-            productIdentifier,
-            stubStoreTransactionFromPurchaseHistoryRecord(
-                productIds = listOf(productIdentifier),
-                purchaseTime = oneHourAgo.time,
-            ),
-            true,
-            listOf(secondEntitlementID),
-            dateInTheFuture
-        )
-
-        every {
-            purchasedProductsFetcher.queryPurchasedProducts(
-                appUserID,
-                captureLambda(),
-                any()
-            )
-        } answers {
-            lambda<(List<PurchasedProduct>) -> Unit>().captured.invoke(listOf(p1mProduct, notBwProduct))
-        }
-
-        var receivedCustomerInfo: CustomerInfo? = null
-        offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
-            appUserID,
-            { receivedCustomerInfo = it },
-            { fail("Should've succeeded") }
-        )
-        assertThat(receivedCustomerInfo).isNotNull
-        assertThat(receivedCustomerInfo?.activeSubscriptions!!.size).isEqualTo(1)
-        assertThat(receivedCustomerInfo?.activeSubscriptions).contains("prod_1")
-        assertThat(receivedCustomerInfo?.entitlements?.all?.size).isEqualTo(2)
-
-        verifyEntitlement(receivedCustomerInfo, entitlementID, p1mProduct, expirationDate = oneHourAgo,
-            purchaseDate = twoHoursAgo)
-        verifyEntitlement(receivedCustomerInfo, secondEntitlementID, notBwProduct, purchaseDate = oneHourAgo)
-    }
-
-    @Test
     fun `multiple products`() {
         val entitlementID = "pro_1"
         val secondEntitlementID = "pro_2"
@@ -337,8 +279,7 @@ class OfflineCustomerInfoCalculatorTest {
         receivedCustomerInfo: CustomerInfo?,
         entitlementID: String,
         purchasedProduct: PurchasedProduct,
-        expirationDate: Date? = dateInTheFuture,
-        purchaseDate: Date? = dateInThePast
+        expirationDate: Date? = dateInTheFuture
     ) {
         val receivedEntitlement = receivedCustomerInfo?.entitlements?.get(entitlementID)
         assertThat(receivedEntitlement?.isActive).isTrue
@@ -347,8 +288,8 @@ class OfflineCustomerInfoCalculatorTest {
         assertThat(receivedEntitlement?.billingIssueDetectedAt).isNull()
         assertThat(receivedEntitlement?.expirationDate).isEqualTo(expirationDate)
         assertThat(receivedEntitlement?.isSandbox).isFalse
-        assertThat(receivedEntitlement?.originalPurchaseDate).isEqualTo(purchaseDate)
-        assertThat(receivedEntitlement?.latestPurchaseDate).isEqualTo(purchaseDate)
+        assertThat(receivedEntitlement?.originalPurchaseDate).isEqualTo(dateInThePast)
+        assertThat(receivedEntitlement?.latestPurchaseDate).isEqualTo(dateInThePast)
         assertThat(receivedEntitlement?.ownershipType).isEqualTo(OwnershipType.UNKNOWN)
         assertThat(receivedEntitlement?.periodType).isEqualTo(PeriodType.NORMAL)
         assertThat(receivedEntitlement?.store).isEqualTo(Store.PLAY_STORE)


### PR DESCRIPTION
I found an edge case when purchasing two base plans from the same product, when each base plan grants a different entitlement. This is a very weird scenario but figured we should fix it.

We build the `original_purchase_date` of the entitlement using the product section of the customer info response, but that information is only valid for the entitlement of the base plan purchased. Which means if another base plan was purchased after the original expired, the information in the product section is only valid for the entitlement that base plan is granting.

To give an example. Imagine `prod_1:p1m` grants `entitlement_1` and `prod_1:p1y` grants `entitlement_2`. `p1m` is purchased, and `entitlement_1` is granted. After `p1m` expires, `p1y` is purchased and `entitlement_2` is granted. At that point, the subscription section of the customer info response will look like:

```
"subscriptions":{
   "prod_1":{
      "billing_issues_detected_at":null,
      "is_sandbox":false,
      "original_purchase_date":"2023-04-11T17:59:03.285Z",
      "purchase_date":"2023-04-11T17:59:03.285Z",
      "store":"play_store",
      "unsubscribe_detected_at":null,
      "product_plan_identifier":"p1y",
      "expires_date":"2024-04-11T17:59:03.285Z",
      "period_type":"normal"
   }
}
```

The `entitlements` section of the response looks like:

```
"entitlements":{
   "entitlement_1":{
      "expires_date":"2023-04-11T17:59:03.285Z",
      "product_identifier":"prod_1",
      "purchase_date":"2023-03-11T16:59:03.285Z",
      "product_plan_identifier":"p1m"
   },
   "entitlement_2":{
      "expires_date":"2024-04-11T17:59:03.285Z",
      "product_identifier":"prod_1",
      "purchase_date":"2023-04-11T17:59:03.285Z",
      "product_plan_identifier":"p1y"
   }
}
```

If we use the information of the `subscription` to build the `original_purchase_date` of `entitlement_1`, we will be setting the wrong `original_purchase_date`.

This can probably be fixed in the backend, but here's a proposed SDK solution, where I check if the product information matches the base plan that's granting the entitlement.