### PR TITLE
Add back integration tests automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,8 @@ jobs:
       - android/restore-build-cache
       - run:
           name: Run Tests
+          # We are running tests in the "defaults" flavor only. If we ever add/remove flavors, we will need to update
+          # this command.
           command: ./gradlew lint testDefaultsDebugUnitTest testDefaultsReleaseUnitTest
       - run:
           name: Consolidate artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
       - android/restore-build-cache
       - run:
           name: Run Tests
-          command: ./gradlew lint test
+          command: ./gradlew lint testDefaultsDebugUnitTest testDefaultsReleaseUnitTest
       - run:
           name: Consolidate artifacts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,6 +432,14 @@ workflows:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - integration-tests-build: *release-branches
+      - purchases-integration-tests-build: *release-branches
+      - run-firebase-tests-purchases-integration-test:
+          requires:
+            - purchases-integration-tests-build
+      - run-firebase-tests-purchases-load-shedder-integration-test:
+          <<: *release-branches
+          context:
+            - slack-secrets
       - run-firebase-tests:
           requires:
             - integration-tests-build
@@ -439,6 +447,8 @@ workflows:
           type: approval
           requires:
             - run-firebase-tests
+            - run-firebase-tests-purchases-integration-test
+            - run-firebase-tests-purchases-load-shedder-integration-test
           <<: *release-branches
       - revenuecat/tag-current-branch:
           requires:
@@ -459,6 +469,16 @@ workflows:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - prepare-next-version: *only-main-branch
+
+  daily-load-shedder-integration-tests:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "load-shedder-integration-tests", << pipeline.schedule.name >> ]
+    jobs:
+      - run-firebase-tests-purchases-load-shedder-integration-test:
+          context:
+            - slack-secrets
 
   weekly-run-workflow:
     when:


### PR DESCRIPTION
### Description
We added the integration tests flavor back in #962, but we didn't bring back the CircleCI automations. Also, since unit tests are taking twice as long after adding this flavor, we are making CircleCI unit tests run only on the `defaults` flavor.
