### PR TITLE
Upgrade to AGP 8.0

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=11.0.17-librca
+java=17.0.6-librca

--- a/base-application.gradle
+++ b/base-application.gradle
@@ -25,6 +25,10 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+
+    buildFeatures {
+        buildConfig true
+    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     }
     dependencies {
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.22.0"
-        classpath 'com.android.tools.build:gradle:7.4.0'
+        classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.21"
         classpath "org.jetbrains.kotlinx:kover:0.6.1"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,6 +1,10 @@
 apply from: "$rootProject.projectDir/library.gradle"
 android {
     namespace 'com.revenuecat.purchases.common'
+
+    buildFeatures {
+        buildConfig true
+    }
 }
 
 dependencies {

--- a/common/consumer-rules.pro
+++ b/common/consumer-rules.pro
@@ -1,0 +1,2 @@
+-dontwarn com.google.errorprone.annotations.CanIgnoreReturnValue
+-dontwarn com.google.errorprone.annotations.Immutable

--- a/examples/MagicWeather/app/build.gradle
+++ b/examples/MagicWeather/app/build.gradle
@@ -44,6 +44,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    namespace 'com.revenuecat.sample'
 
 }
 

--- a/examples/MagicWeather/app/build.gradle
+++ b/examples/MagicWeather/app/build.gradle
@@ -44,6 +44,9 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    buildFeatures {
+        buildConfig true
+    }
     namespace 'com.revenuecat.sample'
 
 }
@@ -56,10 +59,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.navigation:navigation-fragment:2.3.3'
-    implementation 'androidx.navigation:navigation-ui:2.3.3'
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.3'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.3.3'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
 }

--- a/examples/MagicWeather/app/src/main/AndroidManifest.xml
+++ b/examples/MagicWeather/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.revenuecat.sample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name=".MainApplication"

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallFragment.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -42,6 +41,9 @@ class PaywallFragment : Fragment() {
                 is PaywallItem.Option -> {
                     purchaseOption(item.subscriptionOption)
                 }
+                else -> {
+                    // Do nothing
+                }
             }
         })
 
@@ -63,7 +65,8 @@ class PaywallFragment : Fragment() {
     }
 
     private fun purchaseProduct(item: StoreProduct) {
-        Purchases.sharedInstance.purchaseProductWith(requireActivity(), item,
+        Purchases.sharedInstance.purchaseWith(
+            PurchaseParams.Builder(requireActivity(), item).build(),
             onError = { error, userCancelled ->
                 if (!userCancelled) {
                     buildError(context, error.message)
@@ -75,7 +78,8 @@ class PaywallFragment : Fragment() {
     }
 
     private fun purchaseOption(item: SubscriptionOption) {
-        Purchases.sharedInstance.purchaseSubscriptionOptionWith(requireActivity(), item,
+        Purchases.sharedInstance.purchaseWith(
+            PurchaseParams.Builder(requireActivity(), item).build(),
             onError = { error, userCancelled ->
                 if (!userCancelled) {
                     buildError(context, error.message)

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallFragment.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/ui/paywall/PaywallFragment.kt
@@ -41,7 +41,7 @@ class PaywallFragment : Fragment() {
                 is PaywallItem.Option -> {
                     purchaseOption(item.subscriptionOption)
                 }
-                else -> {
+                is PaywallItem.Title -> {
                     // Do nothing
                 }
             }

--- a/examples/MagicWeather/build.gradle
+++ b/examples/MagicWeather/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/examples/MagicWeather/build.gradle
+++ b/examples/MagicWeather/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext.compileVersion = 31
     ext.kotlinVersion = "1.6.21"
-    ext.purchasesVersion = "6.0.0-alpha.4"
+    ext.purchasesVersion = "6.1.1"
     ext.lifecycleVersion = "2.5.0"
     ext.androidxCoreVersion = "1.8.0"
     repositories {

--- a/examples/MagicWeather/gradle.properties
+++ b/examples/MagicWeather/gradle.properties
@@ -19,3 +19,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/examples/MagicWeather/gradle.properties
+++ b/examples/MagicWeather/gradle.properties
@@ -16,6 +16,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=false
+android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official

--- a/examples/MagicWeather/gradle.properties
+++ b/examples/MagicWeather/gradle.properties
@@ -16,9 +16,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.defaults.buildfeatures.buildconfig=true
-android.nonTransitiveRClass=false
-android.nonFinalResIds=false

--- a/examples/MagicWeather/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/MagicWeather/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip

--- a/examples/purchase-tester/build.gradle
+++ b/examples/purchase-tester/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.4.2'
+        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3'
     }
 }
 
@@ -70,6 +70,6 @@ dependencies {
     implementation 'com.google.android.material:material:1.6.0'
     implementation "androidx.datastore:datastore-preferences:1.0.0"
 
-    implementation "androidx.navigation:navigation-fragment-ktx:2.5.2"
-    implementation "androidx.navigation:navigation-ui-ktx:2.5.2"
+    implementation "androidx.navigation:navigation-fragment-ktx:2.5.3"
+    implementation "androidx.navigation:navigation-ui-ktx:2.5.3"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,6 +47,3 @@ SONATYPE_HOST=DEFAULT
 SONATYPE_AUTOMATIC_RELEASE=true
 
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
-android.defaults.buildfeatures.buildconfig=true
-android.nonTransitiveRClass=false
-android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,3 +47,6 @@ SONATYPE_HOST=DEFAULT
 SONATYPE_AUTOMATIC_RELEASE=true
 
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip


### PR DESCRIPTION
### Description
Android Studio Flamingo 8.0 was released a few days ago. As part of the upgrade, it's recommended to upgrade to AGP 8.0 and Gradle 8.0. This PR performs that upgrade. 

AGP Upgrade assistant steps run:
<img width="512" alt="image" src="https://user-images.githubusercontent.com/808417/232712992-78dc47dc-d13e-45f0-be06-f1c971b79e77.png">

In our case:
- For R8, we currently keep everything, which is not the best practice but protects us from most issues from running R8 in full mode. These are the changes we should be aware of for R8 full mode: https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#r8-full-mode. We do have issues with external dependencies though, being the Tink library.
- The `BuildConfig` files are used in a couple places so I enabled them only in the modules that use them (`common`, `purchase-tester` and `MagicWeather`).
- The `R` file related steps don't affect us much since we don't really use R resources in the SDK (we do in the sample apps but changes don't affect us there)
