### PR TITLE
Update product entitlement mapping request to new format

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -13,10 +13,12 @@ import com.revenuecat.purchases.common.CustomerInfoFactory
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
 import com.revenuecat.purchases.common.LogIntent
+import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.strings.OfflineEntitlementsStrings
 import com.revenuecat.purchases.strings.ReceiptStrings
 import org.json.JSONException
 import org.json.JSONObject
@@ -322,7 +324,13 @@ open class DeviceCache(
     @Synchronized
     fun getProductEntitlementMapping(): ProductEntitlementMapping? {
         return preferences.getString(productEntitlementMappingCacheKey, null)?.let { jsonString ->
-            return ProductEntitlementMapping.fromJson(JSONObject(jsonString))
+            return try {
+                ProductEntitlementMapping.fromJson(JSONObject(jsonString))
+            } catch (e: JSONException) {
+                errorLog(OfflineEntitlementsStrings.ERROR_PARSING_PRODUCT_ENTITLEMENT_MAPPING.format(jsonString), e)
+                preferences.edit().remove(productEntitlementMappingCacheKey).apply()
+                null
+            }
         }
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -28,7 +28,7 @@ sealed class Endpoint(val pathTemplate: String, val name: String) {
         ) : Endpoint("/receipts/amazon/%s/%s", "get_amazon_receipt") {
         override fun getPath() = pathTemplate.format(Uri.encode(userId), receiptId)
     }
-    object GetProductEntitlementMapping : Endpoint("/products-entitlements", "get_product_entitlement_mapping") {
+    object GetProductEntitlementMapping : Endpoint("/product_entitlement_mapping", "get_product_entitlement_mapping") {
         override fun getPath() = pathTemplate
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMapping.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMapping.kt
@@ -1,49 +1,50 @@
 package com.revenuecat.purchases.common.offlineentitlements
 
+import com.revenuecat.purchases.utils.optNullableString
 import org.json.JSONArray
 import org.json.JSONObject
 
 data class ProductEntitlementMapping(
-    val mappings: List<Mapping>
+    val mappings: Map<String, Mapping>
 ) {
     companion object {
-        private const val PRODUCTS_KEY = "products"
-        private const val PRODUCT_ID_KEY = "id"
+        private const val PRODUCT_ENTITLEMENT_MAPPING_KEY = "product_entitlement_mapping"
+        private const val PRODUCT_ID_KEY = "product_identifier"
+        private const val BASE_PLAN_ID_KEY = "base_plan_id"
         private const val ENTITLEMENTS_KEY = "entitlements"
 
         fun fromJson(json: JSONObject): ProductEntitlementMapping {
-            val productsArray = json.getJSONArray(PRODUCTS_KEY)
-            val mappings = mutableListOf<Mapping>()
-            for (productIndex in 0 until productsArray.length()) {
-                val productObject = productsArray.getJSONObject(productIndex)
+            val productsObject = json.getJSONObject(PRODUCT_ENTITLEMENT_MAPPING_KEY)
+            val mappings = mutableMapOf<String, Mapping>()
+            for (mappingIdentifier in productsObject.keys()) {
+                val productObject = productsObject.getJSONObject(mappingIdentifier)
                 val productIdentifier = productObject.getString(PRODUCT_ID_KEY)
+                val basePlanId = productObject.optNullableString(BASE_PLAN_ID_KEY)
                 val entitlementsArray = productObject.getJSONArray(ENTITLEMENTS_KEY)
                 val entitlements = mutableListOf<String>()
                 for (entitlementIndex in 0 until entitlementsArray.length()) {
                     entitlements.add(entitlementsArray.getString(entitlementIndex))
                 }
-                mappings.add(Mapping(productIdentifier, entitlements))
+                mappings[mappingIdentifier] = Mapping(productIdentifier, basePlanId, entitlements)
             }
             return ProductEntitlementMapping(mappings)
         }
     }
 
     data class Mapping(
-        val identifier: String,
+        val productIdentifier: String,
+        val basePlanId: String?,
         val entitlements: List<String>
     )
 
-    fun toMap(): Map<String, List<String>> {
-        return mappings.associateBy({ it.identifier }, { it.entitlements })
-    }
-
     fun toJson() = JSONObject().apply {
-        val mappingsArray = mappings.map {
+        val mappingsObjects = mappings.mapValues { (_, value) ->
             JSONObject().apply {
-                put(PRODUCT_ID_KEY, it.identifier)
-                put(ENTITLEMENTS_KEY, JSONArray(it.entitlements))
+                put(PRODUCT_ID_KEY, value.productIdentifier)
+                value.basePlanId?.let { put(BASE_PLAN_ID_KEY, it) }
+                put(ENTITLEMENTS_KEY, JSONArray(value.entitlements))
             }
         }
-        put(PRODUCTS_KEY, JSONArray(mappingsArray))
+        put(PRODUCT_ENTITLEMENT_MAPPING_KEY, JSONObject(mappingsObjects))
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProduct.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProduct.kt
@@ -5,6 +5,7 @@ import java.util.Date
 
 data class PurchasedProduct(
     val productIdentifier: String,
+    val basePlanId: String?,
     val storeTransaction: StoreTransaction,
     val isActive: Boolean,
     val entitlements: List<String>,

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcher.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcher.kt
@@ -57,11 +57,13 @@ class PurchasedProductsFetcher(
         val purchaseAssociatedToProduct = allPurchases.first { it.skus[0] == productIdentifier }
         val isActive = activeProducts.contains(productIdentifier)
         val expirationDate = getExpirationDate(isActive, purchaseAssociatedToProduct)
+        val mapping = productEntitlementMapping?.mappings?.get(productIdentifier)
         return PurchasedProduct(
             productIdentifier,
+            mapping?.basePlanId,
             purchaseAssociatedToProduct,
             isActive,
-            productEntitlementMapping?.toMap()?.get(productIdentifier) ?: emptyList(),
+            mapping?.entitlements ?: emptyList(),
             expirationDate
         )
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -14,6 +14,7 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
 import com.revenuecat.purchases.common.offlineentitlements.createProductEntitlementMapping
 import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.GoogleStoreProduct
@@ -1783,7 +1784,7 @@ class BackendTest {
             body = null,
             responseCode = 200,
             clientException = null,
-            resultBody = "{\"products\":[]}",
+            resultBody = "{\"product_entitlement_mapping\":{}}",
             delayed = true
         )
         val lock = CountDownLatch(3)
@@ -1809,7 +1810,7 @@ class BackendTest {
             body = null,
             responseCode = 200,
             clientException = null,
-            resultBody = "{\"products\":[]}",
+            resultBody = "{\"product_entitlement_mapping\":{}}",
             delayed = true
         )
 
@@ -1897,10 +1898,10 @@ class BackendTest {
 
     @Test
     fun `getProductEntitlementMapping calls success handler`() {
-        val resultBody = "{\"products\":[" +
-            "{\"id\":\"test-product-id\"," +
+        val resultBody = "{\"product_entitlement_mapping\":{" +
+            "\"test-product-id\":{\"product_identifier\":\"test-product-id\"," +
             "\"entitlements\":[\"entitlement-1\",\"entitlement-2\"]" +
-            "}]}"
+            "}}}"
         mockResponse(
             endpoint = productEntitlementMappingEndpoint,
             body = null,
@@ -1914,7 +1915,13 @@ class BackendTest {
             {
                 successCalled = true
                 val expectedMapping = createProductEntitlementMapping(
-                    mapOf("test-product-id" to listOf("entitlement-1", "entitlement-2"))
+                    mapOf(
+                        "test-product-id" to ProductEntitlementMapping.Mapping(
+                            "test-product-id",
+                            null,
+                            listOf("entitlement-1", "entitlement-2")
+                        )
+                    )
                 )
                 assertThat(it).isEqualTo(expectedMapping)
             },
@@ -1930,7 +1937,7 @@ class BackendTest {
             body = null,
             responseCode = 200,
             clientException = null,
-            resultBody = "{\"products\":[]}",
+            resultBody = "{\"product_entitlement_mapping\":{}}",
             baseURL = mockBaseURL
         )
         dispatcher.calledDelay = null

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -611,7 +611,7 @@ class DeviceCacheTest {
         verify(exactly = 1) {
             mockEditor.putString(
                 productEntitlementMappingCacheKey,
-                "{\"products\":[{\"id\":\"com.revenuecat.foo_1\",\"entitlements\":[\"pro_1\"]},{\"id\":\"com.revenuecat.foo_2\",\"entitlements\":[\"pro_1\",\"pro_2\"]},{\"id\":\"com.revenuecat.foo_3\",\"entitlements\":[\"pro_2\"]}]}"
+                "{\"product_entitlement_mapping\":{\"com.revenuecat.foo_1:p1m\":{\"product_identifier\":\"com.revenuecat.foo_1\",\"base_plan_id\":\"p1m\",\"entitlements\":[\"pro_1\"]},\"com.revenuecat.foo_1:p1y\":{\"product_identifier\":\"com.revenuecat.foo_1\",\"base_plan_id\":\"p1y\",\"entitlements\":[\"pro_1\",\"pro_2\"]},\"com.revenuecat.foo_1\":{\"product_identifier\":\"com.revenuecat.foo_1\",\"base_plan_id\":\"p1m\",\"entitlements\":[\"pro_1\"]},\"com.revenuecat.foo_2\":{\"product_identifier\":\"com.revenuecat.foo_2\",\"entitlements\":[\"pro_3\"]}}}"
             )
         }
         verify(exactly = 1) {
@@ -624,7 +624,7 @@ class DeviceCacheTest {
     fun `cacheProductEntitlementMapping caches empty mappings in shared preferences correctly`() {
         cache.cacheProductEntitlementMapping(createProductEntitlementMapping(emptyMap()))
         verify(exactly = 1) {
-            mockEditor.putString(productEntitlementMappingCacheKey, "{\"products\":[]}")
+            mockEditor.putString(productEntitlementMappingCacheKey, "{\"product_entitlement_mapping\":{}}")
         }
         verify(exactly = 1) {
             mockEditor.putLong(productEntitlementMappingLastUpdatedCacheKey, currentTime.time)

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -678,6 +678,27 @@ class DeviceCacheTest {
     }
 
     @Test
+    fun `getProductEntitlementMapping returns null if cache has invalid value`() {
+        every {
+            mockPrefs.getString(productEntitlementMappingCacheKey, null)
+        } returns "invalid-json"
+        assertThat(cache.getProductEntitlementMapping()).isNull()
+    }
+
+    @Test
+    fun `getProductEntitlementMapping clears cache if cache has invalid value`() {
+        every {
+            mockPrefs.getString(productEntitlementMappingCacheKey, null)
+        } returns "invalid-json"
+        every {
+            mockEditor.remove(productEntitlementMappingCacheKey)
+        } returns mockEditor
+        cache.getProductEntitlementMapping()
+        verify(exactly = 1) { mockEditor.remove(productEntitlementMappingCacheKey) }
+        verify(exactly = 1) { mockEditor.apply() }
+    }
+
+    @Test
     fun `getProductEntitlementMapping returns correct product entitlements mapping from cache`() {
         val expectedMappings = createProductEntitlementMapping()
         every {

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -62,7 +62,7 @@ class EndpointTest {
     @Test
     fun `GetProductEntitlementMapping has correct path`() {
         val endpoint = Endpoint.GetProductEntitlementMapping
-        val expectedPath = "/products-entitlements"
+        val expectedPath = "/product_entitlement_mapping"
         assertThat(endpoint.getPath()).isEqualTo(expectedPath)
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
@@ -308,6 +308,7 @@ class OfflineCustomerInfoCalculatorTest {
             )
             PurchasedProduct(
                 productIdentifier,
+                null,
                 storeTransaction,
                 true,
                 entitlements,

--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingTest.kt
@@ -14,27 +14,36 @@ class ProductEntitlementMappingTest {
     private val sampleResponseJson = JSONObject(
         """
             {
-                "products": [
-                    {
-                        "id": "com.revenuecat.foo_1",
+                "product_entitlement_mapping": {
+                    "com.revenuecat.foo_1:p1m": {
+                        "product_identifier": "com.revenuecat.foo_1",
+                        "base_plan_id": "p1m",
                         "entitlements": [
                             "pro_1"
                         ]
                     },
-                    {
-                        "id": "com.revenuecat.foo_2",
+                    "com.revenuecat.foo_1:p1y": {
+                        "product_identifier": "com.revenuecat.foo_1",
+                        "base_plan_id": "p1y",
                         "entitlements": [
                             "pro_1",
                             "pro_2"
                         ]
                     },
-                    {
-                        "id": "com.revenuecat.foo_3",
+                    "com.revenuecat.foo_1": {
+                        "product_identifier": "com.revenuecat.foo_1",
+                        "base_plan_id": "p1m",
                         "entitlements": [
-                            "pro_2"
+                            "pro_1"
+                        ]
+                    },
+                    "com.revenuecat.foo_2": {
+                        "product_identifier": "com.revenuecat.foo_2",
+                        "entitlements": [
+                            "pro_3"
                         ]
                     }
-                ]
+                }
             }
         """.trimIndent()
     )
@@ -42,6 +51,25 @@ class ProductEntitlementMappingTest {
     @Test
     fun `fromJson parses mappings correctly`() {
         val productEntitlementMapping = ProductEntitlementMapping.fromJson(sampleResponseJson)
+        assertThat(productEntitlementMapping.mappings.size).isEqualTo(4)
+        assertThat(productEntitlementMapping.mappings).containsKeys(
+            "com.revenuecat.foo_1:p1m",
+            "com.revenuecat.foo_1:p1y",
+            "com.revenuecat.foo_1",
+            "com.revenuecat.foo_2"
+        )
+        assertThat(productEntitlementMapping.mappings["com.revenuecat.foo_1:p1m"]).isEqualTo(
+            ProductEntitlementMapping.Mapping("com.revenuecat.foo_1", "p1m", listOf("pro_1"))
+        )
+        assertThat(productEntitlementMapping.mappings["com.revenuecat.foo_1:p1y"]).isEqualTo(
+            ProductEntitlementMapping.Mapping("com.revenuecat.foo_1", "p1y", listOf("pro_1", "pro_2"))
+        )
+        assertThat(productEntitlementMapping.mappings["com.revenuecat.foo_1"]).isEqualTo(
+            ProductEntitlementMapping.Mapping("com.revenuecat.foo_1", "p1m", listOf("pro_1"))
+        )
+        assertThat(productEntitlementMapping.mappings["com.revenuecat.foo_2"]).isEqualTo(
+            ProductEntitlementMapping.Mapping("com.revenuecat.foo_2", null, listOf("pro_3"))
+        )
         val expectedEntitlementMapping = createProductEntitlementMapping()
         assertThat(productEntitlementMapping).isEqualTo(expectedEntitlementMapping)
     }
@@ -51,7 +79,7 @@ class ProductEntitlementMappingTest {
         val json = JSONObject(
             """
                 {
-                    "products": []
+                    "product_entitlement_mapping": {}
                 }
             """.trimIndent()
         )
@@ -67,27 +95,15 @@ class ProductEntitlementMappingTest {
     }
 
     @Test
-    fun `equals returns false if any mapping has different entitlements`() {
+    fun `equals returns false if mapping are different`() {
         val mappings1 = createProductEntitlementMapping()
         val mappings2 = createProductEntitlementMapping(
-            mapOf(
-                "com.revenuecat.foo_1" to listOf("pro_1"),
-                "com.revenuecat.foo_2" to listOf("pro_1", "pro_3"),
-                "com.revenuecat.foo_3" to listOf("pro_2")
-            )
+            mappings1.mappings.toMutableMap().apply {
+                put("com.revenuecat.foo_1:p1m",
+                    ProductEntitlementMapping.Mapping("com.revenuecat.foo_1", "p1m", listOf("pro_2")))
+            }
         )
         assertThat(mappings1).isNotEqualTo(mappings2)
-    }
-
-    @Test
-    fun `toMap transforms mappings to map`() {
-        val mappingsMap = createProductEntitlementMapping().toMap()
-        val expectedMap = mapOf(
-            "com.revenuecat.foo_1" to listOf("pro_1"),
-            "com.revenuecat.foo_2" to listOf("pro_1", "pro_2"),
-            "com.revenuecat.foo_3" to listOf("pro_2"),
-        )
-        assertThat(mappingsMap).isEqualTo(expectedMap)
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcherTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcherTest.kt
@@ -476,9 +476,9 @@ class PurchasedProductsFetcherTest {
     private fun mockEntitlementMapping(
         productIdentifierToEntitlements: Map<String, List<String>>
     ) {
-        val mappings = productIdentifierToEntitlements.map { (identifier, entitlements) ->
-            ProductEntitlementMapping.Mapping(identifier, entitlements)
-        }.toList()
+        val mappings = productIdentifierToEntitlements.mapValues { (identifier, entitlements) ->
+            ProductEntitlementMapping.Mapping(identifier, null, entitlements)
+        }
         val productEntitlementMapping = ProductEntitlementMapping(mappings)
         every {
             deviceCache.getProductEntitlementMapping()

--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/productEntitlementMappingFactory.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/productEntitlementMappingFactory.kt
@@ -1,11 +1,10 @@
 package com.revenuecat.purchases.common.offlineentitlements
 
 fun createProductEntitlementMapping(
-    mappings: Map<String, List<String>> = mapOf(
-        "com.revenuecat.foo_1" to listOf("pro_1"),
-        "com.revenuecat.foo_2" to listOf("pro_1", "pro_2"),
-        "com.revenuecat.foo_3" to listOf("pro_2")
+    mappings: Map<String, ProductEntitlementMapping.Mapping> = mapOf(
+        "com.revenuecat.foo_1:p1m" to ProductEntitlementMapping.Mapping("com.revenuecat.foo_1", "p1m", listOf("pro_1")),
+        "com.revenuecat.foo_1:p1y" to ProductEntitlementMapping.Mapping("com.revenuecat.foo_1", "p1y", listOf("pro_1", "pro_2")),
+        "com.revenuecat.foo_1" to ProductEntitlementMapping.Mapping("com.revenuecat.foo_1", "p1m", listOf("pro_1")),
+        "com.revenuecat.foo_2" to ProductEntitlementMapping.Mapping("com.revenuecat.foo_2", null, listOf("pro_3")),
     )
-) = ProductEntitlementMapping(
-    mappings.map { (productId, entitlements) -> ProductEntitlementMapping.Mapping(productId, entitlements) }
-)
+) = ProductEntitlementMapping(mappings)

--- a/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/OfflineEntitlementsStrings.kt
@@ -9,4 +9,5 @@ object OfflineEntitlementsStrings {
     const val RESETTING_OFFLINE_CUSTOMER_INFO_CACHE = "Resetting offline customer info cache."
     const val OFFLINE_ENTITLEMENTS_NOT_ENABLED = "Offline entitlements not enabled in this version."
     const val ALREADY_CALCULATING_OFFLINE_CUSTOMER_INFO = "Already calculating offline customer info for %s."
+    const val ERROR_PARSING_PRODUCT_ENTITLEMENT_MAPPING = "Error parsing cached product entitlement mapping: %s"
 }


### PR DESCRIPTION
### Description
We are changing the format of the request to get the product entitlement mapping. This is safe to change since this is still not being used in production.

#### TODO
- [x] Test with actual backend

