### PR TITLE
Add proration modes to post to backend

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -8,6 +8,8 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -8,8 +8,6 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/GoogleProrationModeAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/GoogleProrationModeAPI.java
@@ -8,6 +8,9 @@ final class GoogleProrationModeAPI {
         switch (mode) {
             case IMMEDIATE_WITHOUT_PRORATION:
             case IMMEDIATE_WITH_TIME_PRORATION:
+            case DEFERRED:
+            case IMMEDIATE_AND_CHARGE_FULL_PRICE:
+            case IMMEDIATE_AND_CHARGE_PRORATED_PRICE:
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/GoogleProrationModeAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/GoogleProrationModeAPI.java
@@ -8,7 +8,6 @@ final class GoogleProrationModeAPI {
         switch (mode) {
             case IMMEDIATE_WITHOUT_PRORATION:
             case IMMEDIATE_WITH_TIME_PRORATION:
-            case DEFERRED:
             case IMMEDIATE_AND_CHARGE_FULL_PRICE:
             case IMMEDIATE_AND_CHARGE_PRORATED_PRICE:
         }

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreTransactionAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreTransactionAPI.java
@@ -1,6 +1,7 @@
 package com.revenuecat.apitester.java;
 
 import com.revenuecat.purchases.ProductType;
+import com.revenuecat.purchases.ProrationMode;
 import com.revenuecat.purchases.models.PurchaseState;
 import com.revenuecat.purchases.models.PurchaseType;
 import com.revenuecat.purchases.models.StoreTransaction;
@@ -27,7 +28,7 @@ final class StoreTransactionAPI {
         final PurchaseType purchaseType = transaction.getPurchaseType();
         final String marketplace = transaction.getMarketplace();
         final String subscriptionOptionId = transaction.getSubscriptionOptionId();
-        final String prorationMode = transaction.getProrationMode();
+        final ProrationMode prorationMode = transaction.getProrationMode();
 
         StoreTransaction constructedStoreTransaction = new StoreTransaction(
                 transaction.getOrderId(),

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreTransactionAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreTransactionAPI.java
@@ -27,6 +27,7 @@ final class StoreTransactionAPI {
         final PurchaseType purchaseType = transaction.getPurchaseType();
         final String marketplace = transaction.getMarketplace();
         final String subscriptionOptionId = transaction.getSubscriptionOptionId();
+        final String prorationMode = transaction.getProrationMode();
 
         StoreTransaction constructedStoreTransaction = new StoreTransaction(
                 transaction.getOrderId(),
@@ -42,7 +43,8 @@ final class StoreTransactionAPI {
                 transaction.getStoreUserID(),
                 transaction.getPurchaseType(),
                 transaction.getMarketplace(),
-                transaction.getSubscriptionOptionId()
+                transaction.getSubscriptionOptionId(),
+                transaction.getProrationMode()
         );
     }
 

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/GoogleProrationModeAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/GoogleProrationModeAPI.kt
@@ -8,7 +8,6 @@ private class GoogleProrationModeAPI {
         when (mode) {
             GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION,
             GoogleProrationMode.IMMEDIATE_WITH_TIME_PRORATION,
-            GoogleProrationMode.DEFERRED,
             GoogleProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE,
             GoogleProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE -> {}
         }.exhaustive

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/GoogleProrationModeAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/GoogleProrationModeAPI.kt
@@ -7,7 +7,10 @@ private class GoogleProrationModeAPI {
     fun check(mode: GoogleProrationMode) {
         when (mode) {
             GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION,
-            GoogleProrationMode.IMMEDIATE_WITH_TIME_PRORATION -> {}
+            GoogleProrationMode.IMMEDIATE_WITH_TIME_PRORATION,
+            GoogleProrationMode.DEFERRED,
+            GoogleProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE,
+            GoogleProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE -> {}
         }.exhaustive
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreTransactionAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreTransactionAPI.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.apitester.kotlin
 
 import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.ProrationMode
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.PurchaseType
 import com.revenuecat.purchases.models.StoreTransaction
@@ -23,8 +24,8 @@ private class StoreTransactionAPI {
             val presentedOfferingIdentifier: String? = presentedOfferingIdentifier
             val su1: String? = storeUserID
             val purchaseType: PurchaseType = purchaseType
-            val subscriptionOptionId = subscriptionOptionId
-            val prorationMode = prorationMode
+            val subscriptionOptionId: String? = subscriptionOptionId
+            val prorationMode: ProrationMode? = prorationMode
 
             val constructedStoreTransaction = StoreTransaction(
                 orderId,

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreTransactionAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreTransactionAPI.kt
@@ -24,6 +24,7 @@ private class StoreTransactionAPI {
             val su1: String? = storeUserID
             val purchaseType: PurchaseType = purchaseType
             val subscriptionOptionId = subscriptionOptionId
+            val prorationMode = prorationMode
 
             val constructedStoreTransaction = StoreTransaction(
                 orderId,
@@ -39,7 +40,8 @@ private class StoreTransactionAPI {
                 storeUserID,
                 purchaseType,
                 marketplace,
-                subscriptionOptionId
+                subscriptionOptionId,
+                prorationMode
             )
         }
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -184,7 +184,7 @@ class Backend(
             "normal_duration" to receiptInfo.duration,
             "store_user_id" to storeAppUserID,
             "pricing_phases" to receiptInfo.pricingPhases?.map { it.toMap() },
-            "proration_mode" to receiptInfo.prorationMode
+            "proration_mode" to receiptInfo.prorationMode?.name
         ).filterNotNullValues()
 
         val extraHeaders = mapOf(

--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -183,7 +183,8 @@ class Backend(
             "attributes" to subscriberAttributes.takeUnless { it.isEmpty() },
             "normal_duration" to receiptInfo.duration,
             "store_user_id" to storeAppUserID,
-            "pricing_phases" to receiptInfo.pricingPhases?.map { it.toMap() }
+            "proration_mode" to receiptInfo.prorationMode,
+            //"pricing_phases" to receiptInfo.pricingPhases?.map { it.toMap() }
         ).filterNotNullValues()
 
         val extraHeaders = mapOf(

--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -183,8 +183,8 @@ class Backend(
             "attributes" to subscriberAttributes.takeUnless { it.isEmpty() },
             "normal_duration" to receiptInfo.duration,
             "store_user_id" to storeAppUserID,
-            "proration_mode" to receiptInfo.prorationMode,
-            //"pricing_phases" to receiptInfo.pricingPhases?.map { it.toMap() }
+            "pricing_phases" to receiptInfo.pricingPhases?.map { it.toMap() },
+            "proration_mode" to receiptInfo.prorationMode
         ).filterNotNullValues()
 
         val extraHeaders = mapOf(

--- a/common/src/main/java/com/revenuecat/purchases/common/ReceiptInfo.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/ReceiptInfo.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.common
 
+import com.revenuecat.purchases.ProrationMode
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.StoreProduct
@@ -14,7 +15,7 @@ class ReceiptInfo(
 
     val price: Double? = storeProduct?.price?.amountMicros?.div(MICROS_MULTIPLIER.toDouble()),
     val currency: String? = storeProduct?.price?.currencyCode,
-    val prorationMode: String? = null,
+    val prorationMode: ProrationMode? = null,
 ) {
 
     val duration: String? = storeProduct?.period?.iso8601?.takeUnless { it.isEmpty() }

--- a/common/src/main/java/com/revenuecat/purchases/common/ReceiptInfo.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/ReceiptInfo.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.SubscriptionOption
 
+@SuppressWarnings("LongParameterList")
 class ReceiptInfo(
     val productIDs: List<String>,
     val offeringIdentifier: String? = null,

--- a/common/src/main/java/com/revenuecat/purchases/common/ReceiptInfo.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/ReceiptInfo.kt
@@ -12,7 +12,8 @@ class ReceiptInfo(
     val storeProduct: StoreProduct? = null,
 
     val price: Double? = storeProduct?.price?.amountMicros?.div(MICROS_MULTIPLIER.toDouble()),
-    val currency: String? = storeProduct?.price?.currencyCode
+    val currency: String? = storeProduct?.price?.currencyCode,
+    val prorationMode: String? = null,
 ) {
 
     val duration: String? = storeProduct?.period?.iso8601?.takeUnless { it.isEmpty() }

--- a/common/src/main/java/com/revenuecat/purchases/common/ReplaceProductInfo.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/ReplaceProductInfo.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.common
 
-import com.android.billingclient.api.BillingFlowParams
 import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.StoreTransaction
 

--- a/common/src/main/java/com/revenuecat/purchases/common/ReplaceProductInfo.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/ReplaceProductInfo.kt
@@ -1,9 +1,10 @@
 package com.revenuecat.purchases.common
 
 import com.android.billingclient.api.BillingFlowParams
+import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.StoreTransaction
 
 data class ReplaceProductInfo(
     val oldPurchase: StoreTransaction,
-    @BillingFlowParams.ProrationMode val prorationMode: Int? = null
+    val prorationMode: GoogleProrationMode? = null
 )

--- a/common/src/main/java/com/revenuecat/purchases/common/ReplaceProductInfo.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/ReplaceProductInfo.kt
@@ -1,9 +1,9 @@
 package com.revenuecat.purchases.common
 
-import com.revenuecat.purchases.models.GoogleProrationMode
+import com.revenuecat.purchases.ProrationMode
 import com.revenuecat.purchases.models.StoreTransaction
 
 data class ReplaceProductInfo(
     val oldPurchase: StoreTransaction,
-    val prorationMode: GoogleProrationMode? = null
+    val prorationMode: ProrationMode? = null
 )

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -408,7 +408,7 @@ class BackendTest {
         )
 
         assertThat(requestBodySlot.captured.keys).contains("proration_mode")
-        assertThat(requestBodySlot.captured["proration_mode"]).isEqualTo("mode1")
+        assertThat(requestBodySlot.captured["proration_mode"]).isEqualTo("IMMEDIATE_WITHOUT_PRORATION")
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -15,6 +15,7 @@ import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.common.offlineentitlements.createProductEntitlementMapping
+import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.GoogleStoreProduct
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
 import com.revenuecat.purchases.models.Period
@@ -376,7 +377,7 @@ class BackendTest {
             productIDs = productIDs,
             storeProduct = storeProduct,
             subscriptionOptionId = subscriptionOption.id,
-            prorationMode = "mode1"
+            prorationMode = GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION
         )
 
         mockPostReceiptResponseAndPost(

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -370,12 +370,13 @@ class BackendTest {
     }
 
     @Test
-    fun `postReceipt passes pricing phases as maps in body`() {
+    fun `postReceipt passes proration mode and pricing phases as maps in body`() {
         val subscriptionOption = storeProduct.subscriptionOptions!!.first()
         val receiptInfo = ReceiptInfo(
             productIDs = productIDs,
             storeProduct = storeProduct,
-            subscriptionOptionId = subscriptionOption.id
+            subscriptionOptionId = subscriptionOption.id,
+            prorationMode = "mode1"
         )
 
         mockPostReceiptResponseAndPost(
@@ -404,6 +405,9 @@ class BackendTest {
                 )
             )
         )
+
+        assertThat(requestBodySlot.captured.keys).contains("proration_mode")
+        assertThat(requestBodySlot.captured["proration_mode"]).isEqualTo("mode1")
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/ReceiptInfoTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/ReceiptInfoTest.kt
@@ -122,7 +122,8 @@ class ReceiptInfoTest {
             storeUserID = null,
             purchaseType = PurchaseType.GOOGLE_PURCHASE,
             marketplace = null,
-            subscriptionOptionId = subscriptionOptionId
+            subscriptionOptionId = subscriptionOptionId,
+            prorationMode = null
         )
     }
 }

--- a/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeTransactionConversions.kt
+++ b/feature/amazon/src/main/java/com/revenuecat/purchases/amazon/storeTransactionConversions.kt
@@ -28,6 +28,7 @@ fun Receipt.toStoreTransaction(
         storeUserID = userData.userId,
         purchaseType = PurchaseType.AMAZON_PURCHASE,
         marketplace = userData.marketplace,
-        subscriptionOptionId = null
+        subscriptionOptionId = null,
+        prorationMode = null,
     )
 }

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
@@ -2,13 +2,19 @@ package com.revenuecat.purchases.google
 
 import com.android.billingclient.api.BillingFlowParams
 import com.revenuecat.purchases.common.ReplaceProductInfo
+import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.models.GoogleProrationMode
 
 fun BillingFlowParams.Builder.setUpgradeInfo(replaceProductInfo: ReplaceProductInfo) {
     val subscriptionUpdateParams = BillingFlowParams.SubscriptionUpdateParams.newBuilder().apply {
         setOldPurchaseToken(replaceProductInfo.oldPurchase.purchaseToken)
         replaceProductInfo.prorationMode?.let {
-            setReplaceProrationMode((it as GoogleProrationMode).playBillingClientMode)
+            val googleProrationMode = it as? GoogleProrationMode
+            if (googleProrationMode == null) {
+                errorLog("Got non-Google proration mode")
+            } else {
+                setReplaceProrationMode(googleProrationMode.playBillingClientMode)
+            }
         }
     }
     setSubscriptionUpdateParams(subscriptionUpdateParams.build())

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
@@ -7,7 +7,7 @@ fun BillingFlowParams.Builder.setUpgradeInfo(replaceProductInfo: ReplaceProductI
     val subscriptionUpdateParams = BillingFlowParams.SubscriptionUpdateParams.newBuilder().apply {
         setOldPurchaseToken(replaceProductInfo.oldPurchase.purchaseToken)
         replaceProductInfo.prorationMode?.let {
-            setReplaceProrationMode(it)
+            setReplaceProrationMode(it.playBillingClientMode)
         }
     }
     setSubscriptionUpdateParams(subscriptionUpdateParams.build())

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingFlowParamsExtensions.kt
@@ -2,12 +2,13 @@ package com.revenuecat.purchases.google
 
 import com.android.billingclient.api.BillingFlowParams
 import com.revenuecat.purchases.common.ReplaceProductInfo
+import com.revenuecat.purchases.models.GoogleProrationMode
 
 fun BillingFlowParams.Builder.setUpgradeInfo(replaceProductInfo: ReplaceProductInfo) {
     val subscriptionUpdateParams = BillingFlowParams.SubscriptionUpdateParams.newBuilder().apply {
         setOldPurchaseToken(replaceProductInfo.oldPurchase.purchaseToken)
         replaceProductInfo.prorationMode?.let {
-            setReplaceProrationMode(it.playBillingClientMode)
+            setReplaceProrationMode((it as GoogleProrationMode).playBillingClientMode)
         }
     }
     setSubscriptionUpdateParams(subscriptionUpdateParams.build())

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -650,7 +650,6 @@ class BillingWrapper(
                     executePendingRequests()
                     reconnectMilliseconds = RECONNECT_TIMER_START_MILLISECONDS
                 }
-
                 BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED,
                 BillingClient.BillingResponseCode.BILLING_UNAVAILABLE -> {
                     val message =
@@ -672,7 +671,6 @@ class BillingWrapper(
                         }
                     }
                 }
-
                 BillingClient.BillingResponseCode.SERVICE_TIMEOUT,
                 BillingClient.BillingResponseCode.ERROR,
                 BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE,
@@ -684,7 +682,6 @@ class BillingWrapper(
                     )
                     retryBillingServiceConnectionWithExponentialBackoff()
                 }
-
                 BillingClient.BillingResponseCode.ITEM_UNAVAILABLE,
                 BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED,
                 BillingClient.BillingResponseCode.ITEM_NOT_OWNED -> {
@@ -693,7 +690,6 @@ class BillingWrapper(
                             .format(billingResult.toHumanReadableDescription())
                     )
                 }
-
                 BillingClient.BillingResponseCode.DEVELOPER_ERROR -> {
                     // Billing service is already trying to connect. Don't do anything.
                 }
@@ -881,7 +877,6 @@ class BillingWrapper(
             is GooglePurchasingData.InAppProduct -> {
                 buildOneTimePurchaseParams(purchaseInfo, appUserID, isPersonalizedPrice)
             }
-
             is GooglePurchasingData.Subscription -> {
                 buildSubscriptionPurchaseParams(purchaseInfo, replaceProductInfo, appUserID, isPersonalizedPrice)
             }

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -251,7 +251,7 @@ class BillingWrapper(
                 googlePurchasingData.productType,
                 presentedOfferingIdentifier,
                 subscriptionOptionId,
-                replaceProductInfo?.prorationMode as GoogleProrationMode
+                replaceProductInfo?.prorationMode as GoogleProrationMode?
             )
         }
         executeRequestOnUIThread {

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -44,6 +44,7 @@ import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.sha256
 import com.revenuecat.purchases.common.toHumanReadableDescription
+import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.GooglePurchasingData
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.PurchaseState
@@ -250,7 +251,7 @@ class BillingWrapper(
                 googlePurchasingData.productType,
                 presentedOfferingIdentifier,
                 subscriptionOptionId,
-                replaceProductInfo?.prorationMode
+                replaceProductInfo?.prorationMode as GoogleProrationMode
             )
         }
         executeRequestOnUIThread {

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -78,7 +78,7 @@ class BillingWrapper(
     @Volatile
     var billingClient: BillingClient? = null
 
-    private val purchaseContext = mutableMapOf<String, PurchaseContext>();
+    private val purchaseContext = mutableMapOf<String, PurchaseContext>()
 
     private val serviceRequests =
         ConcurrentLinkedQueue<(connectionError: PurchasesError?) -> Unit>()

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/PurchaseContext.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/PurchaseContext.kt
@@ -5,7 +5,7 @@ import com.revenuecat.purchases.models.GoogleProrationMode
 
 class PurchaseContext(
     val productType: ProductType,
-    val presentedOffering: String?,
-    val subscriptionOptionSelected: String?,
+    val presentedOfferingId: String?,
+    val selectedSubscriptionOptionId: String?,
     val prorationMode: GoogleProrationMode?
 )

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/PurchaseContext.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/PurchaseContext.kt
@@ -8,6 +8,4 @@ class PurchaseContext(
     val presentedOffering: String?,
     val subscriptionOptionSelected: String?,
     val prorationMode: GoogleProrationMode?
-){
-
-}
+)

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/PurchaseContext.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/PurchaseContext.kt
@@ -1,0 +1,13 @@
+package com.revenuecat.purchases.google
+
+import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.models.GoogleProrationMode
+
+class PurchaseContext(
+    val productType: ProductType,
+    val presentedOffering: String?,
+    val subscriptionOptionSelected: String?,
+    val prorationMode: GoogleProrationMode?
+){
+
+}

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/storeTransactionConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/storeTransactionConversions.kt
@@ -11,7 +11,7 @@ import org.json.JSONObject
 
 fun Purchase.toStoreTransaction(
     productType: ProductType,
-    presentedOfferingIdentifier: String?,
+    presentedOfferingIdentifier: String? = null,
     subscriptionOptionId: String? = null,
     prorationMode: GoogleProrationMode? = null
 ): StoreTransaction = StoreTransaction(
@@ -29,8 +29,16 @@ fun Purchase.toStoreTransaction(
     purchaseType = PurchaseType.GOOGLE_PURCHASE,
     marketplace = null,
     subscriptionOptionId = subscriptionOptionId,
-    prorationMode = prorationMode?.name,
+    prorationMode = prorationMode,
 )
+
+fun Purchase.toStoreTransaction(purchaseContext: PurchaseContext): StoreTransaction =
+    toStoreTransaction(
+        purchaseContext.productType,
+        purchaseContext.presentedOfferingId,
+        purchaseContext.selectedSubscriptionOptionId,
+        purchaseContext.prorationMode
+    )
 
 val StoreTransaction.originalGooglePurchase: Purchase?
     get() =

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/storeTransactionConversions.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/storeTransactionConversions.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.google
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryRecord
 import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.PurchaseType
 import com.revenuecat.purchases.models.StoreTransaction
@@ -11,7 +12,8 @@ import org.json.JSONObject
 fun Purchase.toStoreTransaction(
     productType: ProductType,
     presentedOfferingIdentifier: String?,
-    subscriptionOptionId: String? = null
+    subscriptionOptionId: String? = null,
+    prorationMode: GoogleProrationMode? = null
 ): StoreTransaction = StoreTransaction(
     orderId = this.orderId,
     productIds = this.products,
@@ -26,7 +28,8 @@ fun Purchase.toStoreTransaction(
     storeUserID = null,
     purchaseType = PurchaseType.GOOGLE_PURCHASE,
     marketplace = null,
-    subscriptionOptionId = subscriptionOptionId
+    subscriptionOptionId = subscriptionOptionId,
+    prorationMode = prorationMode?.name,
 )
 
 val StoreTransaction.originalGooglePurchase: Purchase?
@@ -52,6 +55,7 @@ fun PurchaseHistoryRecord.toStoreTransaction(
         storeUserID = null,
         purchaseType = PurchaseType.GOOGLE_RESTORED_PURCHASE,
         marketplace = null,
-        subscriptionOptionId = null
+        subscriptionOptionId = null,
+        prorationMode = null,
     )
 }

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -2514,7 +2514,7 @@ class BillingWrapperTest {
 
     private fun mockReplaceSkuInfo(): ReplaceProductInfo {
         val oldPurchase = mockPurchaseHistoryRecordWrapper()
-        return ReplaceProductInfo(oldPurchase, GoogleProrationMode.DEFERRED)
+        return ReplaceProductInfo(oldPurchase, GoogleProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE)
     }
 
     private fun mockQueryPurchasesAsyncResponse(

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -424,7 +424,7 @@ class BillingWrapperTest {
             assertThat(subsGoogleProductType).isEqualTo(capturedProductDetailsParams[0].zza().productType)
 
             assertThat(upgradeInfo.oldPurchase.purchaseToken).isEqualTo(oldPurchaseTokenSlot.captured)
-            assertThat((upgradeInfo.prorationMode as GoogleProrationMode)?.playBillingClientMode).isEqualTo(prorationModeSlot.captured)
+            assertThat((upgradeInfo.prorationMode as GoogleProrationMode?)?.playBillingClientMode).isEqualTo(prorationModeSlot.captured)
 
             assertThat(isPersonalizedPrice).isEqualTo(isPersonalizedPriceSlot.captured)
             billingClientOKResult

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -35,6 +35,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.firstSku
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.sha256
+import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
@@ -423,7 +424,7 @@ class BillingWrapperTest {
             assertThat(subsGoogleProductType).isEqualTo(capturedProductDetailsParams[0].zza().productType)
 
             assertThat(upgradeInfo.oldPurchase.purchaseToken).isEqualTo(oldPurchaseTokenSlot.captured)
-            assertThat(upgradeInfo.prorationMode).isEqualTo(prorationModeSlot.captured)
+            assertThat(upgradeInfo.prorationMode?.playBillingClientMode).isEqualTo(prorationModeSlot.captured)
 
             assertThat(isPersonalizedPrice).isEqualTo(isPersonalizedPriceSlot.captured)
             billingClientOKResult
@@ -2513,7 +2514,7 @@ class BillingWrapperTest {
 
     private fun mockReplaceSkuInfo(): ReplaceProductInfo {
         val oldPurchase = mockPurchaseHistoryRecordWrapper()
-        return ReplaceProductInfo(oldPurchase, BillingFlowParams.ProrationMode.DEFERRED)
+        return ReplaceProductInfo(oldPurchase, GoogleProrationMode.DEFERRED)
     }
 
     private fun mockQueryPurchasesAsyncResponse(

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -424,7 +424,7 @@ class BillingWrapperTest {
             assertThat(subsGoogleProductType).isEqualTo(capturedProductDetailsParams[0].zza().productType)
 
             assertThat(upgradeInfo.oldPurchase.purchaseToken).isEqualTo(oldPurchaseTokenSlot.captured)
-            assertThat(upgradeInfo.prorationMode?.playBillingClientMode).isEqualTo(prorationModeSlot.captured)
+            assertThat((upgradeInfo.prorationMode as GoogleProrationMode)?.playBillingClientMode).isEqualTo(prorationModeSlot.captured)
 
             assertThat(isPersonalizedPrice).isEqualTo(isPersonalizedPriceSlot.captured)
             billingClientOKResult

--- a/public/src/main/java/com/revenuecat/purchases/ProrationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/ProrationMode.kt
@@ -1,5 +1,14 @@
 package com.revenuecat.purchases
 
-interface ProrationMode {
+import android.os.Parcelable
+import kotlinx.android.parcel.IgnoredOnParcel
+
+/**
+ * Contains information about the proration mode to use in case of a product upgrade.
+ * Use the platform specific subclasses in each implementation.
+ * @property name Identifier of the proration mode to be used
+ */
+interface ProrationMode : Parcelable {
+    @IgnoredOnParcel
     val name: String
 }

--- a/public/src/main/java/com/revenuecat/purchases/ProrationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/ProrationMode.kt
@@ -1,0 +1,5 @@
+package com.revenuecat.purchases
+
+interface ProrationMode {
+    val name: String
+}

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
@@ -33,14 +33,6 @@ enum class GoogleProrationMode(
     IMMEDIATE_WITH_TIME_PRORATION(BillingFlowParams.ProrationMode.IMMEDIATE_WITH_TIME_PRORATION),
 
     /**
-     * Replacement takes effect when the old plan expires, and the new price will be charged at the same time.
-     *
-     * Example: Samwise's Tier 1 subscription continues until it expires on April 30. On May 1st, the
-     * Tier 2 subscription takes effect, and Samwise is charged $36 for his new subscription tier.
-     */
-    DEFERRED(BillingFlowParams.ProrationMode.DEFERRED),
-
-    /**
      * Replacement takes effect immediately, and the user is charged full price of new plan and is
      * given a full billing cycle of subscription, plus remaining prorated time from the old plan.
      *

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
@@ -53,8 +53,9 @@ enum class GoogleProrationMode(
     /**
      * Replacement takes effect immediately, and the billing cycle remains the same.
      *
-     * Example: This mode can be used because the Tier 2 subscription price per time unit ($36/year = $3/month) is greater
-     * than Tier 1 subscription price per time unit ($2/month). Samwise's Tier 1 subscription is immediately ended.
+     * Example: This mode can be used because the Tier 2 subscription price per time unit ($36/year = $3/month) is
+     * greater than Tier 1 subscription price per time unit ($2/month). Samwise's Tier 1 subscription is immediately
+     * ended.
      * Since he paid for a full month but used only half of it, half of a month's subscription ($1) is applied to
      * his new subscription. However, since that new subscription costs $36/year, the remaining 15 days costs $1.50,
      * so he is charged the difference of $0.50 for his new subscription.

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.models
 import android.os.Parcel
 import android.os.Parcelable
 import com.android.billingclient.api.BillingFlowParams
-import com.android.billingclient.api.BillingFlowParams.ProrationMode
+import com.revenuecat.purchases.ProrationMode
 
 /**
  * Enum of possible proration modes to be passed to a Google Play purchase.
@@ -13,7 +13,7 @@ import com.android.billingclient.api.BillingFlowParams.ProrationMode
  */
 enum class GoogleProrationMode(
     @BillingFlowParams.ProrationMode val playBillingClientMode: Int
-) : com.revenuecat.purchases.ProrationMode {
+) : ProrationMode {
     /**
      * Old subscription is cancelled, and new subscription takes effect immediately.
      * User is charged for the full price of the new subscription on the old subscription's expiration date.

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
@@ -1,5 +1,7 @@
 package com.revenuecat.purchases.models
 
+import android.os.Parcel
+import android.os.Parcelable
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingFlowParams.ProrationMode
 
@@ -63,13 +65,29 @@ enum class GoogleProrationMode(
      */
     IMMEDIATE_AND_CHARGE_PRORATED_PRICE(BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE);
 
-    companion object {
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    override fun writeToParcel(out: Parcel, flags: Int) {
+        out.writeString(this.name)
+    }
+
+    companion object CREATOR : Parcelable.Creator<GoogleProrationMode?> {
         fun fromPlayBillingClientMode(
             @BillingFlowParams.ProrationMode playBillingClientMode: Int?
         ): GoogleProrationMode? {
             return playBillingClientMode?.let {
                 values().first { playBillingClientMode == it.playBillingClientMode }
             }
+        }
+
+        override fun createFromParcel(`in`: Parcel): GoogleProrationMode? {
+            return `in`.readString()?.let { GoogleProrationMode.valueOf(it) }
+        }
+
+        override fun newArray(size: Int): Array<GoogleProrationMode?> {
+            return arrayOfNulls(size)
         }
     }
 }

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
@@ -29,8 +29,37 @@ enum class GoogleProrationMode(
      * of the same [StoreProduct].
      */
     IMMEDIATE_WITH_TIME_PRORATION(BillingFlowParams.ProrationMode.IMMEDIATE_WITH_TIME_PRORATION),
+
+    /**
+     * Replacement takes effect when the old plan expires, and the new price will be charged at the same time.
+     *
+     * Example: Samwise's Tier 1 subscription continues until it expires on April 30. On May 1st, the
+     * Tier 2 subscription takes effect, and Samwise is charged $36 for his new subscription tier.
+     */
     DEFERRED(BillingFlowParams.ProrationMode.DEFERRED),
+
+    /**
+     * Replacement takes effect immediately, and the user is charged full price of new plan and is
+     * given a full billing cycle of subscription, plus remaining prorated time from the old plan.
+     *
+     * Example: Samwise's Tier 1 subscription is immediately ended. His Tier 2 subscription begins today and he is
+     * charged $36. Since he paid for a full month but used only half of it, half of a month's subscription ($1)
+     * is applied to his new subscription. Since that new subscription costs $36/year, he would get 1/36th of a year
+     * added on to his subscription period (~10 days). Therefore, Samwise's next charge would be 1 year and 10 days
+     * from today for $36. After that, he is charged $36 each year following.
+     */
     IMMEDIATE_AND_CHARGE_FULL_PRICE(BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE),
+
+    /**
+     * Replacement takes effect immediately, and the billing cycle remains the same.
+     *
+     * Example: This mode can be used because the Tier 2 subscription price per time unit ($36/year = $3/month) is greater
+     * than Tier 1 subscription price per time unit ($2/month). Samwise's Tier 1 subscription is immediately ended.
+     * Since he paid for a full month but used only half of it, half of a month's subscription ($1) is applied to
+     * his new subscription. However, since that new subscription costs $36/year, the remaining 15 days costs $1.50,
+     * so he is charged the difference of $0.50 for his new subscription.
+     * On May 1st, Samwise is charged $36 for his new subscription tier and another $36 on May 1 of each year following.
+     */
     IMMEDIATE_AND_CHARGE_PRORATED_PRICE(BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE);
 
     companion object {

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
@@ -25,5 +25,18 @@ enum class GoogleProrationMode(@BillingFlowParams.ProrationMode val playBillingC
      * The purchase will fail if this mode is used when switching between [SubscriptionOption]s
      * of the same [StoreProduct].
      */
-    IMMEDIATE_WITH_TIME_PRORATION(BillingFlowParams.ProrationMode.IMMEDIATE_WITH_TIME_PRORATION)
+    IMMEDIATE_WITH_TIME_PRORATION(BillingFlowParams.ProrationMode.IMMEDIATE_WITH_TIME_PRORATION),
+    DEFERRED(BillingFlowParams.ProrationMode.DEFERRED),
+    IMMEDIATE_AND_CHARGE_FULL_PRICE(BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE),
+    IMMEDIATE_AND_CHARGE_PRORATED_PRICE(BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE);
+
+    companion object {
+        fun fromPlayBillingClientMode(@BillingFlowParams.ProrationMode playBillingClientMode: Int?): GoogleProrationMode? {
+            return playBillingClientMode?.let {
+                values().first { playBillingClientMode == it.playBillingClientMode }
+            }
+        }
+
+    }
 }
+

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.models
 
 import com.android.billingclient.api.BillingFlowParams
+import com.android.billingclient.api.BillingFlowParams.ProrationMode
 
 /**
  * Enum of possible proration modes to be passed to a Google Play purchase.
@@ -8,7 +9,9 @@ import com.android.billingclient.api.BillingFlowParams
  *
  * See https://developer.android.com/google/play/billing/subscriptions#proration for examples
  */
-enum class GoogleProrationMode(@BillingFlowParams.ProrationMode val playBillingClientMode: Int) {
+enum class GoogleProrationMode(
+    @BillingFlowParams.ProrationMode val playBillingClientMode: Int
+) : com.revenuecat.purchases.ProrationMode {
     /**
      * Old subscription is cancelled, and new subscription takes effect immediately.
      * User is charged for the full price of the new subscription on the old subscription's expiration date.

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
@@ -31,12 +31,12 @@ enum class GoogleProrationMode(@BillingFlowParams.ProrationMode val playBillingC
     IMMEDIATE_AND_CHARGE_PRORATED_PRICE(BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE);
 
     companion object {
-        fun fromPlayBillingClientMode(@BillingFlowParams.ProrationMode playBillingClientMode: Int?): GoogleProrationMode? {
+        fun fromPlayBillingClientMode(
+            @BillingFlowParams.ProrationMode playBillingClientMode: Int?
+        ): GoogleProrationMode? {
             return playBillingClientMode?.let {
                 values().first { playBillingClientMode == it.playBillingClientMode }
             }
         }
-
     }
 }
-

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
@@ -96,7 +96,7 @@ data class StoreTransaction(
     val subscriptionOptionId: String?,
 
     /**
-     * The name of the prorationMode used to perform the upgrade/downgrade of this purchase.
+     * The prorationMode used to perform the upgrade/downgrade of this purchase.
      * Null if it was not an upgrade/downgrade or if the purchase was restored.
      * This is not available for Amazon purchases.
      */

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.models
 
 import android.os.Parcelable
 import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.ProrationMode
 import com.revenuecat.purchases.utils.JSONObjectParceler
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
@@ -95,9 +96,11 @@ data class StoreTransaction(
     val subscriptionOptionId: String?,
 
     /**
-     * The proration_mode string to be sent to the backend.
+     * The name of the prorationMode used to perform the upgrade/downgrade of this purchase.
+     * Null if it was not an upgrade/downgrade or if the purchase was restored.
+     * This is not available for Amazon purchases.
      */
-    val prorationMode: String?
+    val prorationMode: ProrationMode?
 ) : Parcelable {
 
     /**

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
@@ -94,6 +94,9 @@ data class StoreTransaction(
      */
     val subscriptionOptionId: String?,
 
+    /**
+     * The proration_mode string to be sent to the backend.
+     */
     val prorationMode: String?
 ) : Parcelable {
 

--- a/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/StoreTransaction.kt
@@ -92,7 +92,9 @@ data class StoreTransaction(
      * In Google, this will be calculated from the basePlanId and offerId
      * Null for restored transactions and purchases initiated outside of the app.
      */
-    val subscriptionOptionId: String?
+    val subscriptionOptionId: String?,
+
+    val prorationMode: String?
 ) : Parcelable {
 
     /**

--- a/public/src/test/java/com/revenuecat/purchases/ParcelableTests.kt
+++ b/public/src/test/java/com/revenuecat/purchases/ParcelableTests.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases
 import android.net.Uri
 import android.os.Parcel
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.PurchaseType
 import com.revenuecat.purchases.models.StoreTransaction
@@ -83,6 +84,13 @@ class ParcelableTests {
         val created = JSONObjectParceler.create(parcel)
 
         Assertions.assertThat(expected.toString()).isEqualTo(created.toString())
+    }
+
+    @Test
+    fun `GoogleProrationMode is Parcelable`() {
+        GoogleProrationMode.values().forEach { testParcelization(it, true) }
+        val nullMode: GoogleProrationMode? = null
+        testParcelization(nullMode, true)
     }
 
     private fun getEntitlementInfo(

--- a/public/src/test/java/com/revenuecat/purchases/ParcelableTests.kt
+++ b/public/src/test/java/com/revenuecat/purchases/ParcelableTests.kt
@@ -66,7 +66,8 @@ class ParcelableTests {
                 "userId",
                 PurchaseType.GOOGLE_PURCHASE,
                 null,
-                "optionId"
+                "optionId",
+                null
             )
         )
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -75,7 +75,8 @@ internal class PostReceiptHelper(
             productIDs = purchase.productIds,
             offeringIdentifier = purchase.presentedOfferingIdentifier,
             storeProduct = storeProduct,
-            subscriptionOptionId = purchase.subscriptionOptionId
+            subscriptionOptionId = purchase.subscriptionOptionId,
+            prorationMode = purchase.prorationMode
         )
         postReceiptAndSubscriberAttributes(
             appUserID = appUserID,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -16,7 +16,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClientStateListener
-import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -50,6 +50,7 @@ import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.BillingFeature
+import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreProduct
@@ -425,7 +426,7 @@ class Purchases internal constructor(
                     purchasingData,
                     presentedOfferingIdentifier,
                     productId,
-                    googleProrationMode.playBillingClientMode,
+                    googleProrationMode,
                     isPersonalizedPrice,
                     callback
                 )
@@ -474,7 +475,7 @@ class Purchases internal constructor(
             storeProduct.purchasingData,
             null,
             upgradeInfo.oldSku,
-            upgradeInfo.prorationMode,
+            GoogleProrationMode.fromPlayBillingClientMode(upgradeInfo.prorationMode),
             listener
         )
     }
@@ -542,7 +543,7 @@ class Purchases internal constructor(
             packageToPurchase.product.purchasingData,
             packageToPurchase.offering,
             upgradeInfo.oldSku,
-            upgradeInfo.prorationMode,
+            GoogleProrationMode.fromPlayBillingClientMode(upgradeInfo.prorationMode),
             callback
         )
     }
@@ -1524,7 +1525,7 @@ class Purchases internal constructor(
         purchasingData: PurchasingData,
         offeringIdentifier: String?,
         oldProductId: String,
-        @BillingFlowParams.ProrationMode googleProrationMode: Int?,
+        googleProrationMode: GoogleProrationMode,
         isPersonalizedPrice: Boolean?,
         purchaseCallback: PurchaseCallback
     ) {
@@ -1584,7 +1585,7 @@ class Purchases internal constructor(
         purchasingData: PurchasingData,
         offeringIdentifier: String?,
         oldProductId: String,
-        @BillingFlowParams.ProrationMode googleProrationMode: Int?,
+        googleProrationMode: GoogleProrationMode?,
         listener: ProductChangeCallback
     ) {
         if (purchasingData.productType != ProductType.SUBS) {
@@ -1636,7 +1637,7 @@ class Purchases internal constructor(
     private fun replaceOldPurchaseWithNewProduct(
         purchasingData: PurchasingData,
         oldProductId: String,
-        @BillingFlowParams.ProrationMode googleProrationMode: Int?,
+        googleProrationMode: GoogleProrationMode?,
         activity: Activity,
         appUserID: String,
         presentedOfferingIdentifier: String?,

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -450,7 +450,7 @@ class PostReceiptHelperTest {
             onError = { _, _ -> fail("Should succeed") }
         )
         assertThat(postedReceiptInfoSlot.isCaptured).isTrue
-        assertThat(postedReceiptInfoSlot.captured.prorationMode).isEqualTo("DEFERRED")
+        assertThat(postedReceiptInfoSlot.captured.prorationMode).isEqualTo(GoogleProrationMode.DEFERRED)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -52,7 +52,7 @@ class PostReceiptHelperTest {
         ProductType.SUBS,
         null,
         subscriptionOptionId,
-        prorationMode = GoogleProrationMode.DEFERRED
+        prorationMode = GoogleProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE
     )
     private val testReceiptInfo = ReceiptInfo(
         productIDs = listOf("test-product-id-1", "test-product-id-2"),
@@ -450,7 +450,7 @@ class PostReceiptHelperTest {
             onError = { _, _ -> fail("Should succeed") }
         )
         assertThat(postedReceiptInfoSlot.isCaptured).isTrue
-        assertThat(postedReceiptInfoSlot.captured.prorationMode).isEqualTo(GoogleProrationMode.DEFERRED)
+        assertThat(postedReceiptInfoSlot.captured.prorationMode).isEqualTo(GoogleProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.SubscriberAttributeError
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.google.toStoreTransaction
+import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttribute
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
@@ -50,7 +51,8 @@ class PostReceiptHelperTest {
     private val mockStoreTransaction = mockGooglePurchase.toStoreTransaction(
         ProductType.SUBS,
         null,
-        subscriptionOptionId
+        subscriptionOptionId,
+        prorationMode = GoogleProrationMode.DEFERRED
     )
     private val testReceiptInfo = ReceiptInfo(
         productIDs = listOf("test-product-id-1", "test-product-id-2"),
@@ -433,6 +435,22 @@ class PostReceiptHelperTest {
         )
         assertThat(postedReceiptInfoSlot.isCaptured).isTrue
         assertThat(postedReceiptInfoSlot.captured.duration).isEqualTo("P1M")
+    }
+
+    @Test
+    fun `postTransactionAndConsumeIfNeeded posts proration mode`() {
+        mockPostReceiptSuccess()
+
+        postReceiptHelper.postTransactionAndConsumeIfNeeded(
+            purchase = mockStoreTransaction,
+            storeProduct = mockStoreProduct,
+            isRestore = true,
+            appUserID = appUserID,
+            onSuccess = { _, _ -> },
+            onError = { _, _ -> fail("Should succeed") }
+        )
+        assertThat(postedReceiptInfoSlot.isCaptured).isTrue
+        assertThat(postedReceiptInfoSlot.captured.prorationMode).isEqualTo("DEFERRED")
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -43,6 +43,7 @@ import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.BillingFeature
+import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.SubscriptionOption
@@ -502,7 +503,7 @@ class PurchasesTest {
 
         val expectedReplaceProductInfo = ReplaceProductInfo(
             oldTransaction,
-            ProrationMode.IMMEDIATE_WITHOUT_PRORATION
+            GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION
         )
         verify {
             mockBillingAbstract.makePurchaseAsync(
@@ -808,7 +809,7 @@ class PurchasesTest {
                 eq(mockActivity),
                 eq(appUserId),
                 storeProduct.defaultOption!!.purchasingData,
-                ReplaceProductInfo(oldPurchase, ProrationMode.IMMEDIATE_WITHOUT_PRORATION),
+                ReplaceProductInfo(oldPurchase, GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION),
                 STUB_OFFERING_IDENTIFIER,
                 any()
             )
@@ -1308,7 +1309,7 @@ class PurchasesTest {
                 eq(mockActivity),
                 eq(appUserId),
                 storeProduct.subscriptionOptions!!.first().purchasingData,
-                ReplaceProductInfo(oldPurchase, ProrationMode.IMMEDIATE_WITHOUT_PRORATION),
+                ReplaceProductInfo(oldPurchase, GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION),
                 STUB_OFFERING_IDENTIFIER,
                 any()
             )
@@ -1367,7 +1368,7 @@ class PurchasesTest {
                 eq(mockActivity),
                 eq(appUserId),
                 storeProduct.subscriptionOptions!!.first().purchasingData,
-                ReplaceProductInfo(oldPurchase, ProrationMode.IMMEDIATE_WITHOUT_PRORATION),
+                ReplaceProductInfo(oldPurchase, GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION),
                 STUB_OFFERING_IDENTIFIER,
                 any()
             )
@@ -1489,7 +1490,7 @@ class PurchasesTest {
 
         val expectedReplaceProductInfo = ReplaceProductInfo(
             oldTransaction,
-            ProrationMode.IMMEDIATE_WITHOUT_PRORATION
+            GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION
         )
 
         verify {
@@ -1579,7 +1580,7 @@ class PurchasesTest {
 
         val expectedReplaceProductInfo = ReplaceProductInfo(
             oldTransaction,
-            ProrationMode.IMMEDIATE_WITHOUT_PRORATION
+            GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION
         )
 
         verify {

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/ParcelizationTestHelper.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/ParcelizationTestHelper.kt
@@ -5,8 +5,9 @@ import android.os.Parcel
 import android.os.Parcelable
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
 
-inline fun <reified T : Parcelable> testParcelization(value: T) {
+inline fun <reified T : Parcelable> testParcelization(value: T?, areSame: Boolean = false) {
     val key = "key"
 
     // We don't have a good way to access the CREATOR (especially if the
@@ -29,9 +30,12 @@ inline fun <reified T : Parcelable> testParcelization(value: T) {
 
         // assert that the parcelization succeeded
         assertNotSame(inputBundle, outputBundle)
-        assertNotSame(value, outputValue)
-
-        assertEquals(value, outputValue)
+        if (!areSame) {
+            assertNotSame(value, outputValue)
+            assertEquals(value, outputValue)
+        } else {
+            assertSame(value, outputValue)
+        }
     } finally {
         parcel.recycle()
     }


### PR DESCRIPTION
Add missing proration modes and forward them to the Backend when posting receipts

### Motivation
For supporting proration modes we need to send them to the Backend. Added extra parameter in POST receipt.
Added all proration modes in GoogleProrationModes

### Description
* Use GoogleProrationMode internally instead of an enum
* Add an interface that Amazon could potentially implement in the future
