### PR TITLE
Store and return ETag last refresh time header

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -232,7 +232,7 @@ class HTTPClient(
             "X-Nonce" to nonce
         )
             .plus(authenticationHeaders)
-            .plus(eTagManager.getETagHeader(urlPath, refreshETag))
+            .plus(eTagManager.getETagHeaders(urlPath, refreshETag))
             .filterNotNullValues()
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -3,46 +3,62 @@ package com.revenuecat.purchases.common.networking
 import android.content.Context
 import android.content.SharedPreferences
 import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.DefaultDateProvider
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.strings.NetworkStrings
 import org.json.JSONObject
 import java.util.Date
 
-private const val SERIALIZATION_NAME_ETAG = "eTag"
-private const val SERIALIZATION_NAME_HTTPRESULT = "httpResult"
+data class ETagData(
+    val eTag: String,
+    val lastRefreshTime: Date?
+)
 
 data class HTTPResultWithETag(
-    val eTag: String,
+    val eTagData: ETagData,
     val httpResult: HTTPResult
 ) {
     fun serialize(): String {
         return JSONObject().apply {
-            put(SERIALIZATION_NAME_ETAG, eTag)
+            put(SERIALIZATION_NAME_ETAG, eTagData.eTag)
+            eTagData.lastRefreshTime?.let { put(SERIALIZATION_NAME_LAST_REFRESH_TIME, it.time) }
             put(SERIALIZATION_NAME_HTTPRESULT, httpResult.serialize())
         }.toString()
     }
 
     companion object {
+        private const val SERIALIZATION_NAME_ETAG = "eTag"
+        private const val SERIALIZATION_NAME_LAST_REFRESH_TIME = "lastRefreshTime"
+        private const val SERIALIZATION_NAME_HTTPRESULT = "httpResult"
+
         fun deserialize(serialized: String): HTTPResultWithETag {
             val jsonObject = JSONObject(serialized)
             val eTag = jsonObject.getString(SERIALIZATION_NAME_ETAG)
+            val lastRefreshTime = jsonObject.optLong(SERIALIZATION_NAME_LAST_REFRESH_TIME, -1L)
+                .takeIf { it != -1L }
+                ?.let { Date(it) }
             val serializedHTTPResult = jsonObject.getString(SERIALIZATION_NAME_HTTPRESULT)
-            return HTTPResultWithETag(eTag, HTTPResult.deserialize(serializedHTTPResult))
+            return HTTPResultWithETag(ETagData(eTag, lastRefreshTime), HTTPResult.deserialize(serializedHTTPResult))
         }
     }
 }
 
 class ETagManager(
-    private val prefs: SharedPreferences
+    private val prefs: SharedPreferences,
+    private val dateProvider: DateProvider = DefaultDateProvider()
 ) {
 
-    internal fun getETagHeader(
+    internal fun getETagHeaders(
         path: String,
         refreshETag: Boolean = false
-    ): Map<String, String> {
-        val eTagHeader = HTTPRequest.ETAG_HEADER_NAME to if (refreshETag) "" else getETag(path)
-        return mapOf(eTagHeader)
+    ): Map<String, String?> {
+        val eTagData = if (refreshETag) null else getETagData(path)
+        return mapOf(
+            HTTPRequest.ETAG_HEADER_NAME to eTagData?.eTag.orEmpty(),
+            HTTPRequest.ETAG_LAST_REFRESH_NAME to eTagData?.lastRefreshTime?.time?.toString(),
+        )
     }
 
     @Suppress("LongParameterList")
@@ -115,7 +131,8 @@ class ETagManager(
         eTag: String
     ) {
         val cacheResult = result.copy(origin = HTTPResult.Origin.CACHE)
-        val httpResultWithETag = HTTPResultWithETag(eTag, cacheResult)
+        val eTagData = ETagData(eTag, dateProvider.now)
+        val httpResultWithETag = HTTPResultWithETag(eTagData, cacheResult)
         prefs.edit().putString(path, httpResultWithETag.serialize()).apply()
     }
 
@@ -126,8 +143,8 @@ class ETagManager(
         }
     }
 
-    private fun getETag(path: String): String {
-        return getStoredResultSavedInSharedPreferences(path)?.eTag.orEmpty()
+    private fun getETagData(path: String): ETagData? {
+        return getStoredResultSavedInSharedPreferences(path)?.eTagData
     }
 
     private fun shouldStoreBackendResult(resultFromBackend: HTTPResult): Boolean {

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.common.networking
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
@@ -11,11 +12,13 @@ import com.revenuecat.purchases.strings.NetworkStrings
 import org.json.JSONObject
 import java.util.Date
 
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 data class ETagData(
     val eTag: String,
     val lastRefreshTime: Date?
 )
 
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 data class HTTPResultWithETag(
     val eTagData: ETagData,
     val httpResult: HTTPResult

--- a/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPRequest.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/networking/HTTPRequest.kt
@@ -10,5 +10,6 @@ internal data class HTTPRequest(
 ) {
     companion object {
         const val ETAG_HEADER_NAME = "X-RevenueCat-ETag"
+        const val ETAG_LAST_REFRESH_NAME = "X-RC-Last-Refresh-Time"
     }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -39,7 +39,7 @@ abstract class BaseHTTPClientTest {
 
     protected val mockETagManager = mockk<ETagManager>().also {
         every {
-            it.getETagHeader(any(), any())
+            it.getETagHeaders(any(), any())
         } answers {
             mapOf(HTTPRequest.ETAG_HEADER_NAME to "")
         }

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -267,10 +267,10 @@ class HTTPClientTest: BaseHTTPClientTest() {
         server.takeRequest()
 
         verify(exactly = 1) {
-            mockETagManager.getETagHeader(any(), false)
+            mockETagManager.getETagHeaders(any(), false)
         }
         verify(exactly = 1) {
-            mockETagManager.getETagHeader(any(), true)
+            mockETagManager.getETagHeaders(any(), true)
         }
         assertThat(result.payload).isEqualTo(expectedResult.payload)
         assertThat(result.responseCode).isEqualTo(expectedResult.responseCode)

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.VerificationResult.*
+import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.createResult
 import com.revenuecat.purchases.utils.Responses
 import io.mockk.Runs
@@ -23,8 +24,13 @@ import java.util.Date
 @Config(manifest = Config.NONE)
 class ETagManagerTest {
 
+    private val testDate = Date(1675954145L) // Thursday, February 9, 2023 2:49:05 PM GMT
+    private val testDateProvider = object : DateProvider {
+        override val now: Date
+            get() = testDate
+    }
     private val mockedPrefs = mockk<SharedPreferences>()
-    private val underTest = ETagManager(mockedPrefs)
+    private val underTest = ETagManager(mockedPrefs, testDateProvider)
     private val slotPutStringSharedPreferencesKey = slot<String>()
     private val slotPutSharedPreferencesValue = slot<String>()
     private val mockEditor = mockk<SharedPreferences.Editor>()
@@ -50,10 +56,30 @@ class ETagManagerTest {
         val path = "/v1/subscribers/appUserID"
         mockCachedHTTPResult(expectedETag = null, path = path)
 
-        val requestWithETagHeader = underTest.getETagHeader(path)
-        val eTagHeader = requestWithETagHeader[HTTPRequest.ETAG_HEADER_NAME]
+        val eTagHeaders = underTest.getETagHeaders(path)
+        val eTagHeader = eTagHeaders[HTTPRequest.ETAG_HEADER_NAME]
         assertThat(eTagHeader).isNotNull
         assertThat(eTagHeader).isBlank
+    }
+
+    @Test
+    fun `ETag Last refresh time header is null if there is no ETag saved for that request`() {
+        val path = "/v1/subscribers/appUserID"
+        mockCachedHTTPResult(expectedETag = null, path = path)
+
+        val eTagHeaders = underTest.getETagHeaders(path)
+        val lastRefreshTimeHeader = eTagHeaders[HTTPRequest.ETAG_LAST_REFRESH_NAME]
+        assertThat(lastRefreshTimeHeader).isNull()
+    }
+
+    @Test
+    fun `ETag Last refresh time header is null if there is an ETag saved but no refresh time saved for that request`() {
+        val path = "/v1/subscribers/appUserID"
+        mockCachedHTTPResult(expectedETag = "etag", expectedLastRefreshTime = null, path = path)
+
+        val eTagHeaders = underTest.getETagHeaders(path)
+        val lastRefreshTimeHeader = eTagHeaders[HTTPRequest.ETAG_LAST_REFRESH_NAME]
+        assertThat(lastRefreshTimeHeader).isNull()
     }
 
     @Test
@@ -62,10 +88,29 @@ class ETagManagerTest {
         val expectedETag = "etag"
         mockCachedHTTPResult(expectedETag, path)
 
-        val requestWithETagHeader = underTest.getETagHeader(path)
-        val eTagHeader = requestWithETagHeader[HTTPRequest.ETAG_HEADER_NAME]
+        val eTagHeaders = underTest.getETagHeaders(path)
+        val eTagHeader = eTagHeaders[HTTPRequest.ETAG_HEADER_NAME]
         assertThat(eTagHeader).isNotNull
         assertThat(eTagHeader).isEqualTo(expectedETag)
+    }
+
+    @Test
+    fun `An ETag Last refresh time header is added if there is a refresh time saved for that request`() {
+        val path = "/v1/subscribers/appUserID"
+        mockCachedHTTPResult(expectedETag = "etag", expectedLastRefreshTime = testDate, path = path)
+
+        val eTagHeaders = underTest.getETagHeaders(path)
+        val lastRefreshTimeHeader = eTagHeaders[HTTPRequest.ETAG_LAST_REFRESH_NAME]
+        assertThat(lastRefreshTimeHeader).isEqualTo("1675954145")
+    }
+
+    @Test
+    fun `Expected number of headers are added when there is an Etag and last refresh time saved for that request`() {
+        val path = "/v1/subscribers/appUserID"
+        mockCachedHTTPResult(expectedETag = "etag", expectedLastRefreshTime = testDate, path = path)
+
+        val eTagHeaders = underTest.getETagHeaders(path)
+        assertThat(eTagHeaders.size).isEqualTo(2)
     }
 
     @Test
@@ -131,7 +176,7 @@ class ETagManagerTest {
         val resultStored = resultFromBackend.copy(
             origin = HTTPResult.Origin.CACHE
         )
-        val resultStoredWithETag = HTTPResultWithETag(eTag, resultStored)
+        val resultStoredWithETag = HTTPResultWithETag(ETagData(eTag, testDate), resultStored)
 
         underTest.storeBackendResultIfNoError(path, resultFromBackend, eTag)
 
@@ -183,7 +228,7 @@ class ETagManagerTest {
         val resultStored = resultFromBackend.copy(
             origin = HTTPResult.Origin.CACHE
         )
-        val resultStoredWithETag = HTTPResultWithETag(eTag, resultStored)
+        val resultStoredWithETag = HTTPResultWithETag(ETagData(eTag, testDate), resultStored)
 
         underTest.storeBackendResultIfNoError(path, resultFromBackend, eTag)
 
@@ -208,7 +253,7 @@ class ETagManagerTest {
         val path = "/v1/subscribers/appUserID"
         mockCachedHTTPResult(expectedETag = null, path = path)
 
-        val requestWithETagHeader = underTest.getETagHeader(path, refreshETag = true)
+        val requestWithETagHeader = underTest.getETagHeaders(path, refreshETag = true)
         val eTagHeader = requestWithETagHeader[HTTPRequest.ETAG_HEADER_NAME]
         assertThat(eTagHeader).isNotNull
         assertThat(eTagHeader).isBlank
@@ -230,7 +275,7 @@ class ETagManagerTest {
             verificationResult = NOT_REQUESTED
         )
 
-        assertStoredResponse(path, eTagInResponse, responsePayload)
+        assertStoredResponse(path, eTagInResponse, testDate, responsePayload)
     }
 
     @Test
@@ -330,7 +375,7 @@ class ETagManagerTest {
         assertThat(result.payload).isEqualTo(responsePayload)
         assertThat(result.origin).isEqualTo(HTTPResult.Origin.BACKEND)
 
-        assertStoredResponse(path, eTagInResponse, responsePayload)
+        assertStoredResponse(path, eTagInResponse, testDate, responsePayload)
     }
 
     @Test
@@ -354,7 +399,7 @@ class ETagManagerTest {
         assertThat(result.payload).isEqualTo(responsePayload)
         assertThat(result.origin).isEqualTo(HTTPResult.Origin.BACKEND)
 
-        assertStoredResponse(path, eTagInResponse, responsePayload)
+        assertStoredResponse(path, eTagInResponse, testDate, responsePayload)
     }
 
     @Test
@@ -396,7 +441,7 @@ class ETagManagerTest {
             origin = HTTPResult.Origin.CACHE,
             requestDate = Date(1000)
         )
-        mockCachedHTTPResult("etag", "/v1/subscribers/appUserID", cachedHttpResult)
+        mockCachedHTTPResult("etag", "/v1/subscribers/appUserID", httpResult = cachedHttpResult)
         val result = underTest.getHTTPResultFromCacheOrBackend(
             responseCode = RCHTTPStatusCodes.SUCCESS,
             payload = "",
@@ -444,7 +489,7 @@ class ETagManagerTest {
             origin = HTTPResult.Origin.CACHE,
             verificationResult = cachedVerificationResult
         )
-        mockCachedHTTPResult("etag", "/v1/subscribers/appUserID", httpResult)
+        mockCachedHTTPResult("etag","/v1/subscribers/appUserID", httpResult = httpResult)
         val result = underTest.getHTTPResultFromCacheOrBackend(
             responseCode = RCHTTPStatusCodes.NOT_MODIFIED,
             payload = "",
@@ -461,10 +506,11 @@ class ETagManagerTest {
     private fun mockCachedHTTPResult(
         expectedETag: String?,
         path: String,
+        expectedLastRefreshTime: Date? = Date(),
         httpResult: HTTPResult = HTTPResult.createResult(origin = HTTPResult.Origin.CACHE)
     ): HTTPResultWithETag? {
         val cachedResult = expectedETag?.let {
-            HTTPResultWithETag(expectedETag, httpResult)
+            HTTPResultWithETag(ETagData(expectedETag, expectedLastRefreshTime), httpResult)
         }
         every {
             mockedPrefs.getString(path, null)
@@ -475,6 +521,7 @@ class ETagManagerTest {
     private fun assertStoredResponse(
         path: String,
         eTagInResponse: String,
+        lastRefreshTime: Date?,
         responsePayload: String
     ) {
         assertThat(slotPutStringSharedPreferencesKey.isCaptured).isTrue
@@ -484,7 +531,8 @@ class ETagManagerTest {
         assertThat(slotPutSharedPreferencesValue.captured).isNotNull
 
         val deserializedResult = HTTPResultWithETag.deserialize(slotPutSharedPreferencesValue.captured)
-        assertThat(deserializedResult.eTag).isEqualTo(eTagInResponse)
+        assertThat(deserializedResult.eTagData.eTag).isEqualTo(eTagInResponse)
+        assertThat(deserializedResult.eTagData.lastRefreshTime?.time).isEqualTo(lastRefreshTime?.time)
         assertThat(deserializedResult.httpResult.responseCode).isEqualTo(RCHTTPStatusCodes.SUCCESS)
         assertThat(deserializedResult.httpResult.payload).isEqualTo(responsePayload)
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -78,6 +78,9 @@ class ETagManagerTest {
         mockCachedHTTPResult(expectedETag = "etag", expectedLastRefreshTime = null, path = path)
 
         val eTagHeaders = underTest.getETagHeaders(path)
+        val eTagHeader = eTagHeaders[HTTPRequest.ETAG_HEADER_NAME]
+        assertThat(eTagHeader).isEqualTo("etag")
+
         val lastRefreshTimeHeader = eTagHeaders[HTTPRequest.ETAG_LAST_REFRESH_NAME]
         assertThat(lastRefreshTimeHeader).isNull()
     }


### PR DESCRIPTION
### Description
SDK-3025

Now, when we store a backend result in the cache, we will also store the time it was stored. When we perform the same request with a stored time, we will add a `X-RC-Last-Refresh-Time` header to the request.

#### Tested scenarios:
- Nothing saved for that request: We only send an empty `X-RevenueCat-ETag` header
- Saved ETag for a request but no last refresh time saved: We send the `X-RevenueCat-ETag` header only
- Saved ETag and last refresh time for a request: We send both the `X-RevenueCat-ETag` and `X-RC-Last-Refresh-Time` headers.

