### PR TITLE
Add backend integration tests and test product entitlement mapping endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,6 +408,29 @@ jobs:
           app_apk_path: integration-tests/build/outputs/apk/release/integration-tests-release.apk
           test_apk_path: integration-tests/build/outputs/apk/androidTest/release/integration-tests-release-androidTest.apk
 
+  run-backend-integration-tests:
+    description: "Run backend integration tests. All variants"
+    <<: *android-executor
+    steps:
+      - checkout
+      - install-sdkman
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
+      - android/restore-build-cache
+      - run:
+          name: Run backend integration tests
+          command: |
+            bundle exec fastlane android run_backend_integration_tests
+      - android/save-build-cache
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p build/test-results
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} build/test-results \;
+          when: always
+      - store_test_results:
+          path: build/test-results
+
 workflows:
   version: 2
   danger:
@@ -425,6 +448,7 @@ workflows:
       - test
       - detekt
       - assemble-sample-app
+      - run-backend-integration-tests
 
   deploy:
     when:

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,6 +1,18 @@
 apply from: "$rootProject.projectDir/library.gradle"
 android {
     namespace 'com.revenuecat.purchases.common'
+
+    testOptions {
+        unitTests {
+            all {
+                if (project.hasProperty('RUN_INTEGRATION_TESTS')) {
+                    include "com/revenuecat/purchases/backend_integration_tests/**"
+                } else {
+                    exclude "com/revenuecat/purchases/backend_integration_tests/**"
+                }
+            }
+        }
+    }
 }
 
 dependencies {

--- a/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/BackendIntegrationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/BackendIntegrationTest.kt
@@ -21,6 +21,7 @@ import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.net.URL
@@ -29,11 +30,23 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 
+// To run these tests in Android Studio, you need to remove the test exclusion in the
+// common module build.gradle and change the API KEY in Constants.kt
 @RunWith(AndroidJUnit4::class)
 class BackendIntegrationTest {
 
     companion object {
         private val TIMEOUT = 5.seconds
+
+        @BeforeClass
+        @JvmStatic
+        fun setupClass() {
+            if (!canRunIntegrationTests()) {
+                error("You need to set required constants in Constants.kt")
+            }
+        }
+
+        private fun canRunIntegrationTests() = Constants.apiKey != "REVENUECAT_API_KEY"
     }
 
     lateinit var appConfig: AppConfig
@@ -47,6 +60,8 @@ class BackendIntegrationTest {
     lateinit var backendHelper: BackendHelper
 
     lateinit var backend: Backend
+
+
 
     @Before
     fun setUp() {

--- a/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/BackendIntegrationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/BackendIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.backend_integration_tests
 
 import android.content.SharedPreferences
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
@@ -93,6 +94,7 @@ class BackendIntegrationTest {
 
     @Test
     fun canPerformProductEntitlementMappingBackendRequest() {
+        var error: PurchasesError? = null
         ensureBlockFinishes { latch ->
             backend.getProductEntitlementMapping(
                 onSuccessHandler = { productEntitlementMapping ->
@@ -100,10 +102,12 @@ class BackendIntegrationTest {
                     latch.countDown()
                 },
                 onErrorHandler = {
-                    fail("Request should succeed")
+                    error = it
+                    latch.countDown()
                 }
             )
         }
+        assertThat(error).isNull()
         verify(exactly = 1) {
             // Verify we save the backend response in the shared preferences
             sharedPreferencesEditor.putString("/v1${Endpoint.GetProductEntitlementMapping.getPath()}", any())

--- a/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/BackendIntegrationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/BackendIntegrationTest.kt
@@ -1,0 +1,105 @@
+package com.revenuecat.purchases.backend_integration_tests
+
+import android.content.SharedPreferences
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.common.AppConfig
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BackendHelper
+import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.HTTPClient
+import com.revenuecat.purchases.common.PlatformInfo
+import com.revenuecat.purchases.common.networking.ETagManager
+import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.verification.SignatureVerificationMode
+import com.revenuecat.purchases.common.verification.SigningManager
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.URL
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
+
+@RunWith(AndroidJUnit4::class)
+class BackendIntegrationTest {
+
+    companion object {
+        private val TIMEOUT = 5.seconds
+    }
+
+    lateinit var appConfig: AppConfig
+    lateinit var dispatcher: Dispatcher
+    lateinit var diagnosticsDispatcher: Dispatcher
+    lateinit var sharedPreferences: SharedPreferences
+    lateinit var sharedPreferencesEditor: SharedPreferences.Editor
+    lateinit var eTagManager: ETagManager
+    lateinit var signingManager: SigningManager
+    lateinit var httpClient: HTTPClient
+    lateinit var backendHelper: BackendHelper
+
+    lateinit var backend: Backend
+
+    @Before
+    fun setUp() {
+        appConfig = mockk<AppConfig>().apply {
+            every { baseURL } returns URL("https://api.revenuecat.com")
+            every { store } returns Store.PLAY_STORE
+            every { platformInfo } returns PlatformInfo("test-flavor", version = null)
+            every { languageTag } returns "en-US"
+            every { versionName } returns "test-version-name"
+            every { packageName } returns "com.revenuecat.purchases.backend_tests"
+            every { finishTransactions } returns true
+        }
+        dispatcher = Dispatcher(Executors.newSingleThreadScheduledExecutor())
+        diagnosticsDispatcher = Dispatcher(Executors.newSingleThreadScheduledExecutor())
+        sharedPreferencesEditor = mockk<SharedPreferences.Editor>().apply {
+            every { putString(any(), any()) } returns this
+            every { apply() } just Runs
+        }
+        sharedPreferences = mockk<SharedPreferences>().apply {
+            every { getString(any(), any()) } answers { secondArg() as String? }
+            every { edit() } returns sharedPreferencesEditor
+        }
+        eTagManager = ETagManager(sharedPreferences)
+        signingManager = SigningManager(SignatureVerificationMode.Disabled)
+        httpClient = HTTPClient(appConfig, eTagManager, diagnosticsTrackerIfEnabled = null, signingManager)
+        backendHelper = BackendHelper(Constants.apiKey, dispatcher, appConfig, httpClient)
+        backend = Backend(appConfig, dispatcher, diagnosticsDispatcher, httpClient, backendHelper)
+    }
+
+    @Test
+    fun canPerformProductEntitlementMappingBackendRequest() {
+        ensureBlockFinishes { latch ->
+            backend.getProductEntitlementMapping(
+                onSuccessHandler = { productEntitlementMapping ->
+                    assertThat(productEntitlementMapping.mappings).isNotEmpty
+                    latch.countDown()
+                },
+                onErrorHandler = {
+                    fail("Request should succeed")
+                }
+            )
+        }
+        verify(exactly = 1) {
+            // Verify we save the backend response in the shared preferences
+            sharedPreferencesEditor.putString("/v1${Endpoint.GetProductEntitlementMapping.getPath()}", any())
+        }
+        verify(exactly = 1) { sharedPreferencesEditor.apply() }
+    }
+
+    private fun ensureBlockFinishes(block: (CountDownLatch) -> Unit) {
+        val latch = CountDownLatch(1)
+        block(latch)
+        latch.await(TIMEOUT.inWholeSeconds, TimeUnit.SECONDS)
+        assertThat(latch.count).isEqualTo(0)
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/Constants.kt
+++ b/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/Constants.kt
@@ -2,4 +2,5 @@ package com.revenuecat.purchases.backend_integration_tests
 
 object Constants {
     const val apiKey = "REVENUECAT_API_KEY"
+    const val loadShedderApiKey = "LOAD_SHEDDER_API_KEY"
 }

--- a/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/Constants.kt
+++ b/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/Constants.kt
@@ -1,0 +1,5 @@
+package com.revenuecat.purchases.backend_integration_tests
+
+object Constants {
+    const val apiKey = "REVENUECAT_API_KEY"
+}

--- a/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderBackendIntegrationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderBackendIntegrationTest.kt
@@ -11,7 +11,7 @@ class LoadShedderBackendIntegrationTest: BaseBackendIntegrationTest() {
     override fun apiKey() = Constants.loadShedderApiKey
 
     @Test
-    fun canPerformProductEntitlementMappingBackendRequest() {
+    fun `can perform product entitlement mapping backend request`() {
         var error: PurchasesError? = null
         ensureBlockFinishes { latch ->
             backend.getProductEntitlementMapping(

--- a/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderBackendIntegrationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderBackendIntegrationTest.kt
@@ -1,0 +1,52 @@
+package com.revenuecat.purchases.backend_integration_tests
+
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class LoadShedderBackendIntegrationTest: BaseBackendIntegrationTest() {
+    override fun apiKey() = Constants.loadShedderApiKey
+
+    @Test
+    fun canPerformProductEntitlementMappingBackendRequest() {
+        var error: PurchasesError? = null
+        ensureBlockFinishes { latch ->
+            backend.getProductEntitlementMapping(
+                onSuccessHandler = { productEntitlementMapping ->
+                    assertThat(productEntitlementMapping.mappings).containsOnlyKeys(
+                        "com.revenuecat.loadshedder.monthly",
+                        "com.revenuecat.loadshedder.monthly:monthly"
+                    )
+                    assertThat(productEntitlementMapping.mappings["com.revenuecat.loadshedder.monthly"]).isEqualTo(
+                        ProductEntitlementMapping.Mapping(
+                            productIdentifier = "com.revenuecat.loadshedder.monthly",
+                            basePlanId = "monthly",
+                            entitlements = listOf("premium", "pro")
+                        )
+                    )
+                    assertThat(productEntitlementMapping.mappings["com.revenuecat.loadshedder.monthly:monthly"]).isEqualTo(
+                        ProductEntitlementMapping.Mapping(
+                            productIdentifier = "com.revenuecat.loadshedder.monthly",
+                            basePlanId = "monthly",
+                            entitlements = listOf("premium", "pro")
+                        )
+                    )
+                    latch.countDown()
+                },
+                onErrorHandler = {
+                    error = it
+                    latch.countDown()
+                }
+            )
+        }
+        assertThat(error).isNull()
+        verify(exactly = 1) {
+            // Verify we save the backend response in the shared preferences
+            sharedPreferencesEditor.putString("/v1${Endpoint.GetProductEntitlementMapping.getPath()}", any())
+        }
+        verify(exactly = 1) { sharedPreferencesEditor.apply() }
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -1,0 +1,42 @@
+package com.revenuecat.purchases.backend_integration_tests
+
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
+    override fun apiKey() = Constants.apiKey
+
+    @Test
+    fun canPerformProductEntitlementMappingBackendRequest() {
+        var error: PurchasesError? = null
+        ensureBlockFinishes { latch ->
+            backend.getProductEntitlementMapping(
+                onSuccessHandler = { productEntitlementMapping ->
+                    assertThat(productEntitlementMapping.mappings.size).isEqualTo(34)
+                    assertThat(productEntitlementMapping.mappings["annual_freetrial"]).isEqualTo(
+                        ProductEntitlementMapping.Mapping(
+                            productIdentifier = "annual_freetrial",
+                            basePlanId = "p1y",
+                            entitlements = listOf("pro_cat")
+                        )
+                    )
+                    latch.countDown()
+                },
+                onErrorHandler = {
+                    error = it
+                    latch.countDown()
+                }
+            )
+        }
+        assertThat(error).isNull()
+        verify(exactly = 1) {
+            // Verify we save the backend response in the shared preferences
+            sharedPreferencesEditor.putString("/v1${Endpoint.GetProductEntitlementMapping.getPath()}", any())
+        }
+        verify(exactly = 1) { sharedPreferencesEditor.apply() }
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -11,7 +11,7 @@ class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
     override fun apiKey() = Constants.apiKey
 
     @Test
-    fun canPerformProductEntitlementMappingBackendRequest() {
+    fun `can perform product entitlement mapping backend request`() {
         var error: PurchasesError? = null
         ensureBlockFinishes { latch ->
             backend.getProductEntitlementMapping(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -169,6 +169,11 @@ platform :android do
       new_text: ENV['REVENUECAT_API_KEY'],
       paths_of_files_to_update: [constants_path]
     )
+    replace_text_in_files(
+      previous_text: 'LOAD_SHEDDER_API_KEY',
+      new_text: ENV['LOAD_SHEDDER_REVENUECAT_API_KEY'],
+      paths_of_files_to_update: [constants_path]
+    )
     gradle(
       task: ':common:test',
       properties: {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -161,6 +161,22 @@ platform :android do
     )
   end
 
+  desc "Build purchases module integration tests pointing to production"
+  lane :run_backend_integration_tests do |options|
+    constants_path = './common/src/test/java/com/revenuecat/purchases/backend_integration_tests/Constants.kt'
+    replace_text_in_files(
+      previous_text: 'REVENUECAT_API_KEY',
+      new_text: ENV['REVENUECAT_API_KEY'],
+      paths_of_files_to_update: [constants_path]
+    )
+    gradle(
+      task: ':common:test',
+      properties: {
+        "RUN_INTEGRATION_TESTS" => true
+      }
+    )
+  end
+
   desc "Build and run purchases module load shedder integration tests"
   desc "This requires the google cloud cli to be installed and initialized."
   lane :run_load_shedder_purchases_integration_tests do |options|

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -95,6 +95,14 @@ Build purchase tester app bundle
 
 Build purchases module integration tests pointing to production
 
+### android run_backend_integration_tests
+
+```sh
+[bundle exec] fastlane android run_backend_integration_tests
+```
+
+Build purchases module integration tests pointing to production
+
 ### android run_load_shedder_purchases_integration_tests
 
 ```sh


### PR DESCRIPTION
### Description
SDK-3015

This PR adds backend integration tests. These are setup as unit tests in the `common` module.

I thought about adding these as instrumentation tests, but that increases the complexity and runtime of these tests, and we can relatively simply run them as unit tests in the JVM.
