### PR TITLE
Fix purchases integration tests

### DIFF
--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
@@ -208,7 +208,7 @@ class PurchasesIntegrationTest {
                       },
                 replaceProductInfo = null,
                 presentedOfferingIdentifier = null,
-                isPersonalizedPrice = false
+                isPersonalizedPrice = null
             )
         }
     }


### PR DESCRIPTION
### Description
There was one test failing due to the change in https://github.com/RevenueCat/purchases-android/pull/952. This fixes the verification so the test passes.