### PR TITLE
Support DEFERRED mode

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -8,6 +8,8 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -8,8 +8,6 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/GoogleProrationModeAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/GoogleProrationModeAPI.java
@@ -8,6 +8,7 @@ final class GoogleProrationModeAPI {
         switch (mode) {
             case IMMEDIATE_WITHOUT_PRORATION:
             case IMMEDIATE_WITH_TIME_PRORATION:
+            case DEFERRED:
             case IMMEDIATE_AND_CHARGE_FULL_PRICE:
             case IMMEDIATE_AND_CHARGE_PRORATED_PRICE:
         }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/GoogleProrationModeAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/GoogleProrationModeAPI.kt
@@ -8,6 +8,7 @@ private class GoogleProrationModeAPI {
         when (mode) {
             GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION,
             GoogleProrationMode.IMMEDIATE_WITH_TIME_PRORATION,
+            GoogleProrationMode.DEFERRED,
             GoogleProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE,
             GoogleProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE -> {}
         }.exhaustive

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -250,7 +250,8 @@ class BillingWrapper(
         }
 
         synchronized(this@BillingWrapper) {
-            // for deferred proration mode the callback will be for the old product
+            // When using DEFERRED proration mode, PurchaseContext needs to be associated with the *old* product we are
+            // switching from. This is because the transaction we receive on successful purchase is for the old product.
             val productId =
                 if (replaceProductInfo?.prorationMode == GoogleProrationMode.DEFERRED) {
                     replaceProductInfo.oldPurchase.productIds.first()

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -252,7 +252,9 @@ class BillingWrapper(
         synchronized(this@BillingWrapper) {
             // for deferred proration mode the callback will be for the old product
             val productId =
-                if (replaceProductInfo?.prorationMode == GoogleProrationMode.DEFERRED) replaceProductInfo.oldPurchase.productIds.first() else googlePurchasingData.productId
+                if (replaceProductInfo?.prorationMode == GoogleProrationMode.DEFERRED) {
+                    replaceProductInfo.oldPurchase.productIds.first()
+                } else googlePurchasingData.productId
             purchaseContext[productId] = PurchaseContext(
                 googlePurchasingData.productType,
                 presentedOfferingIdentifier,
@@ -305,7 +307,6 @@ class BillingWrapper(
                 withConnectedClient {
                     queryPurchaseHistoryAsyncEnsuringOneResponse(productType) {
                             billingResult, purchaseHistoryRecordList ->
-
                         if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
                             purchaseHistoryRecordList.takeUnless { it.isNullOrEmpty() }?.forEach {
                                 log(

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -648,7 +648,6 @@ class BillingWrapper(
                     executePendingRequests()
                     reconnectMilliseconds = RECONNECT_TIMER_START_MILLISECONDS
                 }
-
                 BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED,
                 BillingClient.BillingResponseCode.BILLING_UNAVAILABLE -> {
                     val message =
@@ -670,7 +669,6 @@ class BillingWrapper(
                         }
                     }
                 }
-
                 BillingClient.BillingResponseCode.SERVICE_TIMEOUT,
                 BillingClient.BillingResponseCode.ERROR,
                 BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE,
@@ -682,7 +680,6 @@ class BillingWrapper(
                     )
                     retryBillingServiceConnectionWithExponentialBackoff()
                 }
-
                 BillingClient.BillingResponseCode.ITEM_UNAVAILABLE,
                 BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED,
                 BillingClient.BillingResponseCode.ITEM_NOT_OWNED -> {
@@ -691,7 +688,6 @@ class BillingWrapper(
                             .format(billingResult.toHumanReadableDescription())
                     )
                 }
-
                 BillingClient.BillingResponseCode.DEVELOPER_ERROR -> {
                     // Billing service is already trying to connect. Don't do anything.
                 }
@@ -879,7 +875,6 @@ class BillingWrapper(
             is GooglePurchasingData.InAppProduct -> {
                 buildOneTimePurchaseParams(purchaseInfo, appUserID, isPersonalizedPrice)
             }
-
             is GooglePurchasingData.Subscription -> {
                 buildSubscriptionPurchaseParams(purchaseInfo, replaceProductInfo, appUserID, isPersonalizedPrice)
             }

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -29,7 +29,6 @@ import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCallback
 import com.revenuecat.purchases.PurchasesErrorCode
-import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
@@ -599,7 +598,11 @@ class BillingWrapper(
         val notNullPurchasesList = purchases ?: emptyList()
         if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
             val storeTransactions = mutableListOf<StoreTransaction>()
-            notNullPurchasesList.forEach { purchase -> getStoreTransaction(purchase, {tx -> storeTransactions.add(tx)})}
+            notNullPurchasesList.forEach { purchase ->
+                getStoreTransaction(
+                    purchase,
+                    { tx -> storeTransactions.add(tx) })
+            }
             purchasesUpdatedListener?.onPurchasesUpdated(storeTransactions)
         } else {
             log(LogIntent.GOOGLE_ERROR, BillingStrings.BILLING_WRAPPER_PURCHASES_ERROR

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -603,11 +603,13 @@ class BillingWrapper(
         if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
             val storeTransactions = mutableListOf<StoreTransaction>()
             notNullPurchasesList.forEach { purchase ->
-                getStoreTransaction(
-                    purchase,
-                    { tx -> storeTransactions.add(tx) })
+                getStoreTransaction(purchase) { storeTxn ->
+                    storeTransactions.add(storeTxn)
+                    if (storeTransactions.size == notNullPurchasesList.size) {
+                        purchasesUpdatedListener?.onPurchasesUpdated(storeTransactions)
+                    }
+                }
             }
-            purchasesUpdatedListener?.onPurchasesUpdated(storeTransactions)
         } else {
             log(LogIntent.GOOGLE_ERROR, BillingStrings.BILLING_WRAPPER_PURCHASES_ERROR
                 .format(billingResult.toHumanReadableDescription()) +

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -611,10 +611,6 @@ class BillingWrapper(
                     }
                 }
             }
-        } else if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-            // Forward empty list if result is ok but with a null purchase. Used to happen when doing a product change
-            // in DEFERRED proration mode. Should not happen since Billing Client 5.
-            purchasesUpdatedListener?.onPurchasesUpdated(emptyList())
         } else {
             log(LogIntent.GOOGLE_ERROR, BillingStrings.BILLING_WRAPPER_PURCHASES_ERROR
                 .format(billingResult.toHumanReadableDescription()) +
@@ -630,6 +626,9 @@ class BillingWrapper(
 
             val responseCode =
                 if (purchases == null && billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                    // Result being ok but with a Null purchase used to happen when doing a product change
+                    // in DEFERRED proration mode in Billing Client <= 4. Should not happen in Billing Client 5+ since
+                    // we get the transaction for the previous product.
                     BillingClient.BillingResponseCode.ERROR
                 } else {
                     billingResult.responseCode

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -250,8 +250,8 @@ class BillingWrapper(
         }
 
         synchronized(this@BillingWrapper) {
-            // When using DEFERRED proration mode, PurchaseContext needs to be associated with the *old* product we are
-            // switching from. This is because the transaction we receive on successful purchase is for the old product.
+            // When using DEFERRED proration mode, callback needs to be associated with the *old* product we are
+            // switching from, because the transaction we receive on successful purchase is for the old product.
             val productId =
                 if (replaceProductInfo?.prorationMode == GoogleProrationMode.DEFERRED) {
                     replaceProductInfo.oldPurchase.productIds.first()

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -250,7 +250,10 @@ class BillingWrapper(
         }
 
         synchronized(this@BillingWrapper) {
-            purchaseContext[googlePurchasingData.productId] = PurchaseContext(
+            // for deferred proration mode the callback will be for the old product
+            val productId =
+                if (replaceProductInfo?.prorationMode == GoogleProrationMode.DEFERRED) replaceProductInfo.oldPurchase.productIds.first() else googlePurchasingData.productId
+            purchaseContext[productId] = PurchaseContext(
                 googlePurchasingData.productType,
                 presentedOfferingIdentifier,
                 subscriptionOptionId,

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -601,7 +601,7 @@ class BillingWrapper(
         purchases: List<Purchase>?
     ) {
         val notNullPurchasesList = purchases ?: emptyList()
-        if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+        if (billingResult.responseCode == BillingClient.BillingResponseCode.OK && notNullPurchasesList.isNotEmpty()) {
             val storeTransactions = mutableListOf<StoreTransaction>()
             notNullPurchasesList.forEach { purchase ->
                 getStoreTransaction(purchase) { storeTxn ->
@@ -611,6 +611,10 @@ class BillingWrapper(
                     }
                 }
             }
+        } else if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+            // Forward empty list if result is ok but with a null purchase. Used to happen when doing a product change
+            // in DEFERRED proration mode. Should not happen since Billing Client 5.
+            purchasesUpdatedListener?.onPurchasesUpdated(emptyList())
         } else {
             log(LogIntent.GOOGLE_ERROR, BillingStrings.BILLING_WRAPPER_PURCHASES_ERROR
                 .format(billingResult.toHumanReadableDescription()) +

--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -624,17 +624,16 @@ class BillingWrapper(
                 }"
             )
 
-            val responseCode =
-                if (purchases == null && billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                    // Result being ok but with a Null purchase used to happen when doing a product change
-                    // in DEFERRED proration mode in Billing Client <= 4. Should not happen in Billing Client 5+ since
-                    // we get the transaction for the previous product.
-                    BillingClient.BillingResponseCode.ERROR
-                } else {
-                    billingResult.responseCode
-                }
+            var message = "Error updating purchases. ${billingResult.toHumanReadableDescription()}"
+            var responseCode = billingResult.responseCode
 
-            val message = "Error updating purchases. ${billingResult.toHumanReadableDescription()}"
+            if (purchases == null && billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                // Result being ok but with a Null purchase used to happen when doing a product change
+                // in DEFERRED proration mode in Billing Client <= 4. Should not happen in Billing Client 5+ since
+                // we get the transaction for the previous product.
+                message = "Error: onPurchasesUpdated received an OK BillingResult with a Null purchases list."
+                responseCode = BillingClient.BillingResponseCode.ERROR
+            }
 
             val purchasesError = responseCode.billingResponseToPurchasesError(message).also { errorLog(it) }
 

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -2514,7 +2514,7 @@ class BillingWrapperTest {
 
     private fun mockReplaceSkuInfo(): ReplaceProductInfo {
         val oldPurchase = mockPurchaseHistoryRecordWrapper()
-        return ReplaceProductInfo(oldPurchase, GoogleProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE)
+        return ReplaceProductInfo(oldPurchase, GoogleProrationMode.DEFERRED)
     }
 
     private fun mockQueryPurchasesAsyncResponse(

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -932,16 +932,20 @@ class BillingWrapperTest {
     }
 
     @Test
-    fun `purchasesUpdatedCalls are forwarded with empty list if result is ok but with a null purchase`() {
-        val slot = slot<List<StoreTransaction>>()
+    fun `purchasesUpdatedCalls call the error callback if result is ok but with a null purchase`() {
         every {
-            mockPurchasesListener.onPurchasesUpdated(capture(slot))
+            mockPurchasesListener.onPurchasesFailedToUpdate(any())
         } just Runs
-
-        purchasesUpdatedListener!!.onPurchasesUpdated(billingClientOKResult, null)
-
-        assertThat(slot.isCaptured).isTrue
-        assertThat(slot.captured.isEmpty()).isTrue
+        purchasesUpdatedListener!!.onPurchasesUpdated(
+            BillingClient.BillingResponseCode.OK.buildResult(),
+            null
+        )
+        verify(exactly = 0) {
+            mockPurchasesListener.onPurchasesUpdated(any())
+        }
+        verify {
+            mockPurchasesListener.onPurchasesFailedToUpdate(any())
+        }
     }
 
     @Test

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
@@ -33,6 +33,14 @@ enum class GoogleProrationMode(
     IMMEDIATE_WITH_TIME_PRORATION(BillingFlowParams.ProrationMode.IMMEDIATE_WITH_TIME_PRORATION),
 
     /**
+     * Replacement takes effect when the old plan expires, and the new price will be charged at the same time.
+     *
+     * Example: Samwise's Tier 1 subscription continues until it expires on April 30. On May 1st, the
+     * Tier 2 subscription takes effect, and Samwise is charged $36 for his new subscription tier.
+     */
+    DEFERRED(BillingFlowParams.ProrationMode.DEFERRED),
+
+    /**
      * Replacement takes effect immediately, and the user is charged full price of new plan and is
      * given a full billing cycle of subscription, plus remaining prorated time from the old plan.
      *

--- a/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/GoogleProrationMode.kt
@@ -33,14 +33,6 @@ enum class GoogleProrationMode(
     IMMEDIATE_WITH_TIME_PRORATION(BillingFlowParams.ProrationMode.IMMEDIATE_WITH_TIME_PRORATION),
 
     /**
-     * Replacement takes effect when the old plan expires, and the new price will be charged at the same time.
-     *
-     * Example: Samwise's Tier 1 subscription continues until it expires on April 30. On May 1st, the
-     * Tier 2 subscription takes effect, and Samwise is charged $36 for his new subscription tier.
-     */
-    DEFERRED(BillingFlowParams.ProrationMode.DEFERRED),
-
-    /**
      * Replacement takes effect immediately, and the user is charged full price of new plan and is
      * given a full billing cycle of subscription, plus remaining prorated time from the old plan.
      *
@@ -63,7 +55,15 @@ enum class GoogleProrationMode(
      * so he is charged the difference of $0.50 for his new subscription.
      * On May 1st, Samwise is charged $36 for his new subscription tier and another $36 on May 1 of each year following.
      */
-    IMMEDIATE_AND_CHARGE_PRORATED_PRICE(BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE);
+    IMMEDIATE_AND_CHARGE_PRORATED_PRICE(BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE),
+
+    /**
+     * Replacement takes effect when the old plan expires, and the new price will be charged at the same time.
+     *
+     * Example: Samwise's Tier 1 subscription continues until it expires on April 30. On May 1st, the
+     * Tier 2 subscription takes effect, and Samwise is charged $36 for his new subscription tier.
+     */
+    DEFERRED(BillingFlowParams.ProrationMode.DEFERRED);
 
     override fun describeContents(): Int {
         return 0

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1544,7 +1544,8 @@ class Purchases internal constructor(
 
             if (!state.purchaseCallbacksByProductId.containsKey(purchasingData.productId)) {
                 // for deferred proration mode the callback is for the old product
-                val productId = if (googleProrationMode == GoogleProrationMode.DEFERRED) oldProductId else purchasingData.productId
+                val productId =
+                    if (googleProrationMode == GoogleProrationMode.DEFERRED) oldProductId else purchasingData.productId
                 purchasingData.productId
                 val mapOfProductIdToListener = mapOf(productId to purchaseCallback)
                 state = state.copy(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1386,24 +1386,14 @@ class Purchases internal constructor(
                 }
 
                 if (purchases.isEmpty()) {
-                    if (isDeprecatedProductChangeInProgress) {
-                        // Can happen if the product change is ProrationMode.DEFERRED
-                        invalidateCustomerInfoCache()
-                        getCustomerInfoWith { customerInfo ->
-                            deprecatedProductChangeListener?.let { callback ->
-                                dispatch {
-                                    callback.onCompleted(null, customerInfo)
-                                }
+                    // Can happen if the product change is ProrationMode.DEFERRED
+                    invalidateCustomerInfoCache()
+                    getCustomerInfoWith { customerInfo ->
+                        deprecatedProductChangeListener?.let { callback ->
+                            dispatch {
+                                callback.onCompleted(null, customerInfo)
                             }
                         }
-                    } else {
-                        // the non-deprecated purchase(PurchaseParams, PurchaseCallback) flow doesn't allow for
-                        // DEFERRED, so this is an unexpected state. return an error
-                        val nullTransactionError = PurchasesError(
-                            PurchasesErrorCode.StoreProblemError,
-                            PurchaseStrings.NULL_TRANSACTION_ON_PURCHASE_ERROR
-                        )
-                        getAndClearAllPurchaseCallbacks().forEach { it.dispatch(nullTransactionError) }
                     }
                     return
                 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1529,7 +1529,7 @@ class Purchases internal constructor(
 
             if (!state.purchaseCallbacksByProductId.containsKey(purchasingData.productId)) {
                 // When using DEFERRED proration mode, callback needs to be associated with the *old* product we are
-                // switching from. This is because the transaction we receive on successful purchase is for the old product.
+                // switching from, because the transaction we receive on successful purchase is for the old product.
                 val productId =
                     if (googleProrationMode == GoogleProrationMode.DEFERRED) oldProductId else purchasingData.productId
                 val mapOfProductIdToListener = mapOf(productId to purchaseCallback)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1385,19 +1385,17 @@ class Purchases internal constructor(
                     }
                 }
 
-                if (purchases.isEmpty()) {
-                    if (isDeprecatedProductChangeInProgress) {
-                        // Can happen if the product change is ProrationMode.DEFERRED
-                        invalidateCustomerInfoCache()
-                        getCustomerInfoWith { customerInfo ->
-                            deprecatedProductChangeListener?.let { callback ->
-                                dispatch {
-                                    callback.onCompleted(null, customerInfo)
-                                }
+                if (purchases.isEmpty() && isDeprecatedProductChangeInProgress) {
+                    // Can happen if the product change is ProrationMode.DEFERRED
+                    invalidateCustomerInfoCache()
+                    getCustomerInfoWith { customerInfo ->
+                        deprecatedProductChangeListener?.let { callback ->
+                            dispatch {
+                                callback.onCompleted(null, customerInfo)
                             }
                         }
-                        return
                     }
+                    return
                 }
 
                 postPurchases(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1541,7 +1541,8 @@ class Purchases internal constructor(
             }
 
             if (!state.purchaseCallbacksByProductId.containsKey(purchasingData.productId)) {
-                // for deferred proration mode the callback is for the old product
+                // When using DEFERRED proration mode, callback needs to be associated with the *old* product we are
+                // switching from. This is because the transaction we receive on successful purchase is for the old product.
                 val productId =
                     if (googleProrationMode == GoogleProrationMode.DEFERRED) oldProductId else purchasingData.productId
                 val mapOfProductIdToListener = mapOf(productId to purchaseCallback)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1385,19 +1385,6 @@ class Purchases internal constructor(
                     }
                 }
 
-                if (purchases.isEmpty() && isDeprecatedProductChangeInProgress) {
-                    // Can happen if the product change is ProrationMode.DEFERRED
-                    invalidateCustomerInfoCache()
-                    getCustomerInfoWith { customerInfo ->
-                        deprecatedProductChangeListener?.let { callback ->
-                            dispatch {
-                                callback.onCompleted(null, customerInfo)
-                            }
-                        }
-                    }
-                    return
-                }
-
                 postPurchases(
                     purchases,
                     allowSharingPlayStoreAccount,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1544,7 +1544,6 @@ class Purchases internal constructor(
                 // for deferred proration mode the callback is for the old product
                 val productId =
                     if (googleProrationMode == GoogleProrationMode.DEFERRED) oldProductId else purchasingData.productId
-                purchasingData.productId
                 val mapOfProductIdToListener = mapOf(productId to purchaseCallback)
                 state = state.copy(
                     purchaseCallbacksByProductId = state.purchaseCallbacksByProductId + mapOfProductIdToListener

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/ProductChangeCallback.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/ProductChangeCallback.kt
@@ -19,7 +19,6 @@ interface ProductChangeCallback : PurchaseErrorCallback {
     /**
      * Will be called after the product change has been completed
      * @param storeTransaction StoreTransaction object for the purchased product.
-     * Will be null if the change is deferred.
      * @param customerInfo Updated [CustomerInfo].
      */
     fun onCompleted(storeTransaction: StoreTransaction?, customerInfo: CustomerInfo)

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -54,7 +54,7 @@ class PostReceiptHelperTest {
         ProductType.SUBS,
         null,
         subscriptionOptionId,
-        prorationMode = GoogleProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE
+        prorationMode = GoogleProrationMode.DEFERRED
     )
     private val testReceiptInfo = ReceiptInfo(
         productIDs = listOf("test-product-id-1", "test-product-id-2"),
@@ -619,7 +619,7 @@ class PostReceiptHelperTest {
             onError = { _, _ -> fail("Should succeed") }
         )
         assertThat(postedReceiptInfoSlot.isCaptured).isTrue
-        assertThat(postedReceiptInfoSlot.captured.prorationMode).isEqualTo(GoogleProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE)
+        assertThat(postedReceiptInfoSlot.captured.prorationMode).isEqualTo(GoogleProrationMode.DEFERRED)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -500,8 +500,9 @@ class PurchasesTest {
             onError = { _, _ ->
                 fail("should be successful")
             },
-            onSuccess = { _, _ ->
+            onSuccess = { purchase, _ ->
                 callCount++
+                assertThat(purchase == oldPurchase)
             }
         )
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -489,6 +489,11 @@ class PurchasesTest {
             googleProrationMode = GoogleProrationMode.DEFERRED
         )
         val oldTransaction = getMockedStoreTransaction(productId, "token", ProductType.SUBS)
+        every {
+            mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(oldTransaction, any(), false, appUserId, captureLambda(), any())
+        } answers {
+            lambda<SuccessfulPurchaseCallback>().captured.invoke(oldTransaction, mockk())
+        }
 
         purchases.purchaseWith(
             productChangeParams,

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -448,26 +448,27 @@ class PurchasesTest {
     }
 
     @Test
-    fun `when making a deferred upgrade using the deprecated function, completion is called with the transaction for the old product`() {
-        val productId = listOf("newproduct")
-        val storeProduct = mockStoreProduct(productId, productId, ProductType.SUBS).first()
+    fun `when making a deferred upgrade, completion is called with null purchase`() {
+        val productId = "onemonth_freetrial"
+
+        val receiptInfo = mockQueryingProductDetails(productId, ProductType.SUBS, null)
 
         val oldPurchase = mockPurchaseFound()
-        mockQueryingProductDetails(oldPurchase.productIds.first(), ProductType.SUBS, null)
 
         var callCount = 0
+        // use deprecated version of function because deferred upgrades not allowed with new version
         purchases.purchaseProductWith(
             mockActivity,
-            storeProduct,
-            UpgradeInfo(oldPurchase.productIds[0], ProrationMode.DEFERRED),
+            receiptInfo.storeProduct!!,
+            UpgradeInfo(oldPurchase.productIds[0]),
             onError = { _, _ ->
                 fail("should be success")
             }, onSuccess = { purchase, _ ->
                 callCount++
-                assertThat(purchase == oldPurchase)
+                assertThat(purchase).isNull()
             })
 
-        capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(listOf(oldPurchase))
+        capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(emptyList())
         assertThat(callCount).isEqualTo(1)
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -474,21 +474,21 @@ class PurchasesTest {
     }
 
     @Test
-    fun `when making a deferred upgrade, completion is called with null purchase for new version`() {
-        val productId = "onemonth_freetrial"
-
-        val receiptInfo = mockQueryingProductDetails(productId, ProductType.SUBS, null)
+    fun `when making a deferred upgrade, completion is called with the transaction for the old product`() {
+        val productId = listOf("newproduct")
+        val storeProduct = mockStoreProduct(productId, productId, ProductType.SUBS)
 
         val oldPurchase = mockPurchaseFound()
+        mockQueryingProductDetails(oldPurchase.productIds.first(), ProductType.SUBS, null)
 
         var callCount = 0
 
         val productChangeParams = getPurchaseParams(
-            receiptInfo.storeProduct!!.subscriptionOptions!!.first(),
+            storeProduct.first().subscriptionOptions!!.first(),
             oldPurchase.productIds.first(),
             googleProrationMode = GoogleProrationMode.DEFERRED
         )
-        val oldTransaction = getMockedStoreTransaction(productId, "token", ProductType.SUBS)
+        val oldTransaction = getMockedStoreTransaction(oldPurchase.productIds.first(), "token", ProductType.SUBS)
         every {
             mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(oldTransaction, any(), false, appUserId, captureLambda(), any())
         } answers {

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -488,19 +488,19 @@ class PurchasesTest {
             oldPurchase.productIds.first(),
             googleProrationMode = GoogleProrationMode.DEFERRED
         )
+        val oldTransaction = getMockedStoreTransaction(productId, "token", ProductType.SUBS)
+
         purchases.purchaseWith(
             productChangeParams,
             onError = { _, _ ->
                 fail("should be successful")
             },
-            onSuccess = { purchase, _ ->
+            onSuccess = { _, _ ->
                 callCount++
-                println(purchase)
-                assertThat(purchase).isNotNull()
             }
         )
 
-        capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(emptyList())
+        capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(listOf(oldTransaction))
         assertThat(callCount).isEqualTo(1)
     }
 

--- a/strings/src/main/java/com/revenuecat/purchases/strings/PurchaseStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/PurchaseStrings.kt
@@ -40,8 +40,6 @@ object PurchaseStrings {
     const val INVALID_PRODUCT_NO_PRICE = "Error finding a price for %s."
     const val INVALID_CALLBACK_TYPE_INTERNAL_ERROR = "Internal SDK error -- invalid callback type passed to " +
         "startProductChange."
-    const val NULL_TRANSACTION_ON_PURCHASE_ERROR = "Error purchasing. Null transaction returned from a succcessful " +
-        "non-upgrade purchase."
     const val ENTITLEMENT_EXPIRED_OUTSIDE_GRACE_PERIOD = "Entitlement %s is no longer active (expired %s) " +
         "and it's outside grace period window (last updated %s)"
 }


### PR DESCRIPTION
Support DEFERRED Proration mode.
One problem is that the returned purchase is for the old product, not the new one, so all the callback need to use the replaced productId.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Description

Use old productId in callbacks for when proration mode is deferred.