### PR TITLE
[EXTERNAL] Replace `@Deprecated` usage of `skus` by `productIds` from `PurchasedProductsFetcher`

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcher.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcher.kt
@@ -15,19 +15,19 @@ import java.util.concurrent.TimeUnit
 class PurchasedProductsFetcher(
     private val deviceCache: DeviceCache,
     private val billing: BillingAbstract,
-    private val dateProvider: DateProvider = DefaultDateProvider()
+    private val dateProvider: DateProvider = DefaultDateProvider(),
 ) {
 
     fun queryActiveProducts(
         appUserID: String,
         onSuccess: (List<PurchasedProduct>) -> Unit,
-        onError: (PurchasesError) -> Unit
+        onError: (PurchasesError) -> Unit,
     ) {
         val productEntitlementMapping = deviceCache.getProductEntitlementMapping() ?: run {
             onError(
                 PurchasesError(
                     PurchasesErrorCode.CustomerInfoError,
-                    OfflineEntitlementsStrings.PRODUCT_ENTITLEMENT_MAPPING_REQUIRED
+                    OfflineEntitlementsStrings.PRODUCT_ENTITLEMENT_MAPPING_REQUIRED,
                 )
             )
             return
@@ -42,13 +42,13 @@ class PurchasedProductsFetcher(
                 }
                 onSuccess(purchasedProducts)
             },
-            onError
+            onError,
         )
     }
 
     private fun createPurchasedProduct(
         transaction: StoreTransaction,
-        productEntitlementMapping: ProductEntitlementMapping
+        productEntitlementMapping: ProductEntitlementMapping,
     ): PurchasedProduct {
         val expirationDate = getExpirationDate(transaction)
         val productIdentifier = transaction.productIds.first()
@@ -58,17 +58,16 @@ class PurchasedProductsFetcher(
             mapping?.basePlanId,
             transaction,
             mapping?.entitlements ?: emptyList(),
-            expirationDate
+            expirationDate,
         )
     }
 
     private fun getExpirationDate(
-        purchaseAssociatedToProduct: StoreTransaction
+        purchaseAssociatedToProduct: StoreTransaction,
     ): Date? {
-        return if (purchaseAssociatedToProduct.type == ProductType.SUBS) {
-            Date(dateProvider.now.time + TimeUnit.DAYS.toMillis(1))
-        } else {
-            null
+        return when (purchaseAssociatedToProduct.type) {
+            ProductType.SUBS -> Date(dateProvider.now.time + TimeUnit.DAYS.toMillis(1))
+            else -> null
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
*Why is this change required? What problem does it solve?*

As I continue my journey exploring `purchases-android`'s repo / learning how RevenueCat's Purchases SDK works (refs. https://github.com/RevenueCat/purchases-android/pull/984) noticed that `PurchasedProductsFetcher` was relying on `@Deprecated` usage of `skus` so this is mostly a quick refactoring that addresses that tech debt replacing `skus` occurrences by `productIds`.

<!-- Please link to issues following this format: Resolves #999999 -->

### Description
*Describe your changes in detail*

- Replace `@Deprecated` usage of `skus` by `productIds` from `PurchasedProductsFetcher`
- Refactor `getExpirationDate` `if else` chain by `when`
- When checking that the changes made in `PurchasedProductsFetcher` were working as expected, I landed at `PurchasedProductsFetcherTest` and took a quick pass and refactored the tests to follow the triple `A` (`A`rrange / `A`ct / `A`ssert). I think that normally is good to structure the tests following the triple A 👀 https://speakerdeck.com/guardiola31337/elegant-unit-testing-mobilization-2016?slide=40 http://wiki.c2.com/?ArrangeActAssert

BTW, I'm a big fan of [_Working Effectively with Unit Tests_](https://leanpub.com/wewut/read) 
> when writing tests you should prefer DAMP (Descriptive And Maintainable Procedures) 

Using DAMP you increase maintainability and readability of the tests. But that's my opinion and we can discuss further 😉 

On a side note, I highly recommend you reading that book (if you haven't already). It's 🔝 💯

*Please describe in detail how you tested your changes*

- Run tests locally (including `PurchasedProductsFetcherTest`) to confirm there are no regressions and all tests are ✅ 
