### PR TITLE
Clear cached customer info upon entering offline entitlements mode

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -71,6 +71,7 @@ class OfflineEntitlementsManager(
                 synchronized(this@OfflineEntitlementsManager) {
                     debugLog(OfflineEntitlementsStrings.UPDATING_OFFLINE_CUSTOMER_INFO_CACHE)
                     _offlineCustomerInfo = customerInfo
+                    deviceCache.getCachedAppUserID()?.let { deviceCache.clearCustomerInfoCache(it) }
                     val callbacks = offlineCustomerInfoCallbackCache.remove(appUserId)
                     callbacks?.forEach { (onSuccess, _) ->
                         onSuccess(customerInfo)


### PR DESCRIPTION
### Description
SDK-3095

Offline entitlements mode caches the computed customer info in memory. That means it will be lost upon a restart. So if users restart, they would temporarily go back to the cached customer info until we either get a new value from the backend or it fails again and we enter offline entitlement mode again. This can make it so developers see a strange change in customer infos upon a restart after entering offline customer info.

In order to solve this, we are clearing the cached customer info upon entering offline entitlements mode in this PR. This way, next time the user restarts the app, it will have to first try to get the value from the backend, waiting to return a value, avoiding the changes in customer info.
