### PR TITLE
Add Coroutine support to `Purchases#getCustomerInfo(callback: ReceiveCustomerInfoCallback)` API

### DIFF
--- a/api-tester/build.gradle
+++ b/api-tester/build.gradle
@@ -13,6 +13,7 @@ android {
 dependencies {
     implementation project(path: ':public')
     implementation project(path: ':purchases')
+    implementation project(path: ':utils')
     implementation "androidx.annotation:annotation:$annotationVersion"
     implementation project(path: ':feature:amazon')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
     ext.androidxCoreVersion = "1.8.0"
     ext.mockwebserverVersion = "4.2.0"
     ext.tinkVersion = "1.8.0"
+    ext.coroutinesVersion = "1.6.2"
 
     repositories {
         mavenCentral()

--- a/examples/purchase-tester/build.gradle
+++ b/examples/purchase-tester/build.gradle
@@ -63,6 +63,7 @@ repositories {
 dependencies {
     implementation project(path: ':purchases')
     implementation project(path: ':feature:amazon')
+    implementation project(path: ':utils')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -13,6 +13,7 @@ import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.transition.MaterialElevationScale
+import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Purchases
@@ -64,6 +65,14 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
                 viewModel?.customerInfo?.value = info
             }
         }
+//        Purchases.sharedInstance.getCustomerInfoWith(::showError) { info ->
+//            with(binding) {
+//                viewModel?.customerInfo?.value = info
+//            }
+//        }
+
+        // getCustomerInfo coroutine friendly version
+        viewModel.retrieveCustomerInfo()
 
         Purchases.sharedInstance.getOfferingsWith(::showError, ::populateOfferings)
     }
@@ -125,6 +134,16 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
         val intent = Intent(Intent.ACTION_VIEW)
         intent.data = url
         startActivity(intent)
+    }
+
+    override fun customerInfo(customerInfo: CustomerInfo) {
+        with(binding) {
+            viewModel?.customerInfo?.value = customerInfo
+        }
+    }
+
+    override fun customerInfoError(error: PurchasesError) {
+        showError(error)
     }
 
     private fun navigateToLoginFragment() {

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewViewModel.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewViewModel.kt
@@ -4,11 +4,14 @@ import android.net.Uri
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.EntitlementInfo
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.restorePurchasesWith
+import com.revenuecat.purchases.utils.Result
+import kotlinx.coroutines.launch
 
 class OverviewViewModel(private val interactionHandler: OverviewInteractionHandler) : ViewModel() {
 
@@ -80,6 +83,15 @@ class OverviewViewModel(private val interactionHandler: OverviewInteractionHandl
         }
     }
 
+    fun retrieveCustomerInfo() {
+        viewModelScope.launch {
+            when (val result = Purchases.sharedInstance.getCustomerInfo()) {
+                is Result.Success -> interactionHandler.customerInfo(result.value)
+                is Result.Error -> interactionHandler.customerInfoError(result.value)
+            }
+        }
+    }
+
     private fun formatEntitlements(entitlementInfos: Collection<EntitlementInfo>): String {
         return entitlementInfos.joinToString(separator = "\n") { it.toBriefString() }
     }
@@ -91,4 +103,7 @@ interface OverviewInteractionHandler {
     fun toggleCard()
     fun copyToClipboard(text: String)
     fun launchURL(url: Uri)
+
+    fun customerInfo(customerInfo: CustomerInfo)
+    fun customerInfoError(error: PurchasesError)
 }

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     testImplementation "io.mockk:mockk:$mockkVersion"
     testImplementation "org.assertj:assertj-core:$assertJVersion"
     testImplementation "com.android.billingclient:billing:$billingVersion"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
 
     integrationTestImplementation 'androidx.appcompat:appcompat:1.4.1'
     integrationTestImplementation 'com.google.android.material:material:1.6.0'


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
*Why is this change required? What problem does it solve?*

Continuing with my exploration thought that I could kick-off https://github.com/RevenueCat/purchases-android/issues/434 work so opening this PR as a `Draft` to start the Coroutine support discussion 😊 

Some initial questions:

- What's your "policy" around adding new dependencies to the SDK?

https://github.com/RevenueCat/purchases-android/blob/04c818915a94a21fd560674cc2d90a9b5f8f6226/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt#L736-L737

- Do you include / test all the variants of an API in `purchase-tester` app?

https://github.com/RevenueCat/purchases-android/blob/04c818915a94a21fd560674cc2d90a9b5f8f6226/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt#L68-L75

For now, I commented out `getCustomerInfo(callback: ReceiveCustomerInfoCallback)` logic but happy to uncomment and test both variants, even if it's kinda duplicated. Please, let me know 🙏 

**Edit**
I see that there's `api-tester` / `PurchasesAPI`. Where do these checks run? Are these files auto-generated? Wondering how to add `getCustomerInfo` check to `PurchasesAPI.kt` / how to inject the `CoroutineScope` and `launch` the coroutine from there.

BTW, I know that #434 is about creating a separate extensions library but for now I added it directly into `Purchases`.

<!-- Please link to issues following this format: Resolves #999999 -->

### Description
*Describe your changes in detail*

- Add Coroutine support to `Purchases#getCustomerInfo(callback: ReceiveCustomerInfoCallback)` API

*Please describe in detail how you tested your changes*

- Add test coverage to `PurchasesTest`
- Test manually using the `purchase-tester` app

cc @vegaro 