### PR TITLE
Fix  build_magic_weather lane

### DIFF
--- a/examples/MagicWeather/app/build.gradle
+++ b/examples/MagicWeather/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.revenuecat.purchases_sample"
         minSdkVersion 26
         targetSdkVersion compileVersion
-        versionCode = rootProject.ext.get("versionCode").toInteger()
-        versionName = rootProject.ext.get("versionName").toString()
+        versionCode rootProject.ext.get("versionCode").toInteger()
+        versionName rootProject.ext.get("versionName").toString()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/examples/MagicWeather/app/build.gradle
+++ b/examples/MagicWeather/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.revenuecat.purchases_sample"
         minSdkVersion 26
         targetSdkVersion compileVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode = rootProject.ext.get("versionCode").toInteger()
+        versionName = rootProject.ext.get("versionName").toString()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/examples/MagicWeather/gradle.properties
+++ b/examples/MagicWeather/gradle.properties
@@ -19,3 +19,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+versionCode=1
+versionName=1.0

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -316,8 +316,8 @@ DESC
         project_dir: project_dir,
         task: task,
         properties: {
-          "android.injected.version.code" => version_code,
-          "android.injected.version.name" => version_name,
+          "versionCode" => version_code,
+          "versionName" => version_name,
         }
       )
 


### PR DESCRIPTION
Looks like our previous solution to inject versionCode and versionName using `android.injected.version.code` and `android.injected.version.name` is broken and the lane fails to set version code and name https://issuetracker.google.com/issues/242730594?pli=1

This PR replaces that injection with just replacing two gradle properties