### PR TITLE
Fix `OfflineCustomerInfoCalculatorTest` `Unresolved reference: ProductType`

### DIFF
--- a/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
@@ -5,6 +5,7 @@ import com.ibm.icu.impl.Assert.fail
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.OwnershipType
 import com.revenuecat.purchases.PeriodType
+import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.Store
@@ -13,22 +14,18 @@ import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.ago
 import com.revenuecat.purchases.common.fromNow
 import com.revenuecat.purchases.models.StoreTransaction
-import com.revenuecat.purchases.utils.add
-import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
 import com.revenuecat.purchases.utils.stubStoreTransactionFromPurchaseHistoryRecord
-import com.revenuecat.purchases.utils.subtract
 import io.mockk.every
 import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.util.Date
-import org.assertj.core.api.Assertions.assertThat
-import org.json.JSONObject
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.minutes
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
*Why is this change required? What problem does it solve?*
- Fixes `OfflineCustomerInfoCalculatorTest` `Unresolved reference: ProductType` caused by a merge conflict between #983 and #959
CI `test` job in `main` is currently ❌ https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/5568/workflows/43815025-8dbf-4b47-a476-f619f7d9065f/jobs/15887
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
*Describe your changes in detail*

- Fixes `OfflineCustomerInfoCalculatorTest` `Unresolved reference: ProductType` caused by a merge conflict between #983 and #959

This was due to `auto-merge` https://github.com/RevenueCat/purchases-android/pull/959 without updating from https://github.com/RevenueCat/purchases-android/pull/983 which landed first

*Please describe in detail how you tested your changes*

Run `OfflineCustomerInfoCalculatorTest` before the changes ❌ 
Run `OfflineCustomerInfoCalculatorTest` after the changes ✅ 

cc @vegaro @tonidero 