### PR TITLE
Fix `PurchasesIntegrationTest` building issue

### DIFF
--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/factories/StoreTransactionFactory.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/factories/StoreTransactionFactory.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.factories
 
 import com.revenuecat.purchases.Constants
 import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.ProrationMode
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.PurchaseType
 import com.revenuecat.purchases.models.StoreTransaction
@@ -23,7 +24,8 @@ object StoreTransactionFactory {
         storeUserID: String? = null,
         purchaseType: PurchaseType = PurchaseType.GOOGLE_PURCHASE,
         marketplace: String? = null,
-        subscriptionOptionId: String? = Constants.basePlanIdToPurchase
+        subscriptionOptionId: String? = Constants.basePlanIdToPurchase,
+        prorationMode: ProrationMode? = null,
     ): StoreTransaction {
         return StoreTransaction(
             orderId,
@@ -39,7 +41,8 @@ object StoreTransactionFactory {
             storeUserID,
             purchaseType,
             marketplace,
-            subscriptionOptionId
+            subscriptionOptionId,
+            prorationMode,
         )
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
*Why is this change required? What problem does it solve?*
- Fixes `PurchasesIntegrationTest` building issue caused by missing `prorationMode` in `StoreTransactionFactory#createStoreTransaction` - regression from https://github.com/RevenueCat/purchases-android/pull/977

CI `run-firebase-tests-purchases-load-shedder-integration-test` job in `main` is currently ❌ https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/5569/workflows/a55166e6-0930-4086-ad32-5328d0a109d8/jobs/15888

```
> Task :purchases:compileIntegrationTestReleaseAndroidTestKotlin
e: /home/circleci/project/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/factories/StoreTransactionFactory.kt: (43, 9): No value passed for parameter 'prorationMode'
```

Regression from #977 

<!-- Please link to issues following this format: Resolves #999999 -->

### Description
*Describe your changes in detail*

- Add default `ProrationMode` (`null`) to `StoreTransactionFactory#createStoreTransaction`

*Please describe in detail how you tested your changes*

- Run `PurchasesIntegrationTest` before the changes ❌ 
- Run `PurchasesIntegrationTest` after the changes ✅ 

cc @swehner