### PR TITLE
Add completion callback to syncPurchases API

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -84,7 +84,7 @@ final class PurchasesAPI {
         };
         final SyncPurchasesCallback syncPurchasesCallback = new SyncPurchasesCallback() {
             @Override
-            public void onSuccess() {
+            public void onSuccess(@NonNull CustomerInfo customerInfo) {
             }
 
             @Override

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -8,7 +8,6 @@ import androidx.annotation.Nullable;
 
 import com.revenuecat.purchases.CacheFetchPolicy;
 import com.revenuecat.purchases.CustomerInfo;
-import com.revenuecat.purchases.EntitlementVerificationMode;
 import com.revenuecat.purchases.LogHandler;
 import com.revenuecat.purchases.LogLevel;
 import com.revenuecat.purchases.Offerings;
@@ -24,6 +23,7 @@ import com.revenuecat.purchases.interfaces.LogInCallback;
 import com.revenuecat.purchases.interfaces.PurchaseCallback;
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback;
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback;
+import com.revenuecat.purchases.interfaces.SyncPurchasesCallback;
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener;
 import com.revenuecat.purchases.models.BillingFeature;
 import com.revenuecat.purchases.models.GoogleProrationMode;
@@ -82,8 +82,18 @@ final class PurchasesAPI {
             public void onError(@NotNull PurchasesError error) {
             }
         };
+        final SyncPurchasesCallback syncPurchasesCallback = new SyncPurchasesCallback() {
+            @Override
+            public void onSuccess() {
+            }
+
+            @Override
+            public void onError(@NonNull PurchasesError error) {
+            }
+        };
 
         purchases.syncPurchases();
+        purchases.syncPurchases(syncPurchasesCallback);
         purchases.getOfferings(receiveOfferingsListener);
         purchases.getProducts(productIds, productResponseListener);
         purchases.getProducts(productIds, ProductType.SUBS, productResponseListener);

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -39,7 +39,6 @@ import java.util.concurrent.ExecutorService
 
 @Suppress("unused", "UNUSED_VARIABLE", "EmptyFunctionBlock", "RemoveExplicitTypeArguments", "RedundantLambdaArrow")
 private class PurchasesAPI {
-    val noParametersCallback: () -> Unit = {}
     @SuppressWarnings("LongParameterList")
     fun check(
         purchases: Purchases
@@ -62,7 +61,7 @@ private class PurchasesAPI {
             override fun onError(error: PurchasesError) {}
         }
         val syncPurchasesCallback = object : SyncPurchasesCallback {
-            override fun onSuccess() {}
+            override fun onSuccess(customerInfo: CustomerInfo) {}
             override fun onError(error: PurchasesError) {}
         }
 
@@ -157,10 +156,10 @@ private class PurchasesAPI {
         )
         purchases.syncPurchasesWith(
             onError = { _: PurchasesError -> },
-            onSuccess = noParametersCallback
+            onSuccess = { _: CustomerInfo -> }
         )
         purchases.syncPurchasesWith(
-            onSuccess = noParametersCallback
+            onSuccess = { _: CustomerInfo -> }
         )
         purchases.logInWith(
             "",

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
+import com.revenuecat.purchases.interfaces.SyncPurchasesCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.logInWith
 import com.revenuecat.purchases.logOutWith
@@ -32,11 +33,13 @@ import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.purchaseWith
 import com.revenuecat.purchases.restorePurchasesWith
+import com.revenuecat.purchases.syncPurchasesWith
 import java.net.URL
 import java.util.concurrent.ExecutorService
 
 @Suppress("unused", "UNUSED_VARIABLE", "EmptyFunctionBlock", "RemoveExplicitTypeArguments", "RedundantLambdaArrow")
 private class PurchasesAPI {
+    val noParametersCallback: () -> Unit = {}
     @SuppressWarnings("LongParameterList")
     fun check(
         purchases: Purchases
@@ -58,7 +61,13 @@ private class PurchasesAPI {
             override fun onReceived(customerInfo: CustomerInfo, created: Boolean) {}
             override fun onError(error: PurchasesError) {}
         }
+        val syncPurchasesCallback = object : SyncPurchasesCallback {
+            override fun onSuccess() {}
+            override fun onError(error: PurchasesError) {}
+        }
+
         purchases.syncPurchases()
+        purchases.syncPurchases(syncPurchasesCallback)
         purchases.getOfferings(receiveOfferingsCallback)
 
         purchases.getProducts(productIds, productsResponseCallback)
@@ -145,6 +154,13 @@ private class PurchasesAPI {
         purchases.restorePurchasesWith(
             onError = { _: PurchasesError -> },
             onSuccess = { _: CustomerInfo -> }
+        )
+        purchases.syncPurchasesWith(
+            onError = { _: PurchasesError -> },
+            onSuccess = noParametersCallback
+        )
+        purchases.syncPurchasesWith(
+            onSuccess = noParametersCallback
         )
         purchases.logInWith(
             "",

--- a/purchases/src/main/java/com/revenuecat/purchases/interfaces/SyncPurchasesCallback.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/interfaces/SyncPurchasesCallback.kt
@@ -1,8 +1,9 @@
 package com.revenuecat.purchases.interfaces
 
+import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 
 interface SyncPurchasesCallback {
-    fun onSuccess()
+    fun onSuccess(customerInfo: CustomerInfo)
     fun onError(error: PurchasesError)
 }

--- a/purchases/src/main/java/com/revenuecat/purchases/interfaces/SyncPurchasesCallback.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/interfaces/SyncPurchasesCallback.kt
@@ -1,0 +1,8 @@
+package com.revenuecat.purchases.interfaces
+
+import com.revenuecat.purchases.PurchasesError
+
+interface SyncPurchasesCallback {
+    fun onSuccess()
+    fun onError(error: PurchasesError)
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -17,7 +17,7 @@ import com.revenuecat.purchases.subscriberattributes.getAttributeErrors
 import com.revenuecat.purchases.subscriberattributes.toBackendMap
 
 @Suppress("LongParameterList")
-internal class PostReceiptHelper(
+class PostReceiptHelper(
     private val appConfig: AppConfig,
     private val backend: Backend,
     private val billing: BillingAbstract,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -40,7 +40,7 @@ class PostReceiptHelper(
         isRestore: Boolean,
         appUserID: String,
         marketplace: String?,
-        onSuccess: () -> Unit,
+        onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
         postReceiptAndSubscriberAttributes(
@@ -52,7 +52,7 @@ class PostReceiptHelper(
             marketplace,
             onSuccess = {
                 deviceCache.addSuccessfullyPostedToken(purchaseToken)
-                onSuccess()
+                onSuccess(it)
             },
             onError = { backendError, errorHandlingBehavior, _ ->
                 if (errorHandlingBehavior == PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED) {
@@ -62,7 +62,7 @@ class PostReceiptHelper(
                     errorHandlingBehavior,
                     appUserID,
                     onSuccess = {
-                        onSuccess()
+                        onSuccess(it)
                     },
                     onError = {
                         onError(backendError)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -17,7 +17,7 @@ import com.revenuecat.purchases.subscriberattributes.getAttributeErrors
 import com.revenuecat.purchases.subscriberattributes.toBackendMap
 
 @Suppress("LongParameterList")
-class PostReceiptHelper(
+internal class PostReceiptHelper(
     private val appConfig: AppConfig,
     private val backend: Backend,
     private val billing: BillingAbstract,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -236,7 +236,7 @@ class Purchases internal constructor(
     ) {
         syncPurchasesHelper.syncPurchases(
             isRestore = this.allowSharingPlayStoreAccount,
-            onSuccess = { listener?.onSuccess() },
+            onSuccess = { listener?.onSuccess(it) },
             onError = { listener?.onError(it) }
         )
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -236,6 +236,7 @@ class Purchases internal constructor(
     ) {
         syncPurchasesHelper.syncPurchases(
             isRestore = this.allowSharingPlayStoreAccount,
+            appInBackground = this.state.appInBackground,
             onSuccess = { listener?.onSuccess(it) },
             onError = { listener?.onError(it) }
         )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -47,6 +47,7 @@ import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.PurchaseErrorCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
+import com.revenuecat.purchases.interfaces.SyncPurchasesCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.BillingFeature
 import com.revenuecat.purchases.models.GoogleProrationMode
@@ -97,6 +98,7 @@ class Purchases internal constructor(
     @get:VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal val offlineEntitlementsManager: OfflineEntitlementsManager,
     private val postReceiptHelper: PostReceiptHelper,
+    private val syncPurchasesHelper: SyncPurchasesHelper,
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper())
 ) : LifecycleDelegate {
@@ -217,44 +219,25 @@ class Purchases internal constructor(
 
     /**
      * This method will send all the purchases to the RevenueCat backend. Call this when using your own implementation
-     * for subscriptions anytime a sync is needed, such as when migrating existing users to RevenueCat
+     * for subscriptions anytime a sync is needed, such as when migrating existing users to RevenueCat. The
+     * [SyncPurchasesCallback.onSuccess] callback will be called if all purchases have been synced successfully or
+     * there are no purchases. Otherwise, the [SyncPurchasesCallback.onError] callback will be called with a
+     * [PurchasesError] indicating the first error found.
      *
+     * @param [listener] Called when all purchases have been synced with the backend, either successfully or with
+     * an error. If no purchases are present, the success function will be called.
      * @warning This function should only be called if you're migrating to RevenueCat or in observer mode.
+     * @warning This function could take a relatively long time to execute, depending on the amount of purchases
+     * the user has. Consider that when waiting for this operation to complete.
      */
-    fun syncPurchases() {
-        log(LogIntent.DEBUG, PurchaseStrings.SYNCING_PURCHASES)
-
-        val appUserID = identityManager.currentAppUserID
-
-        billing.queryAllPurchases(
-            appUserID,
-            onReceivePurchaseHistory = { allPurchases ->
-                if (allPurchases.isNotEmpty()) {
-                    allPurchases.forEach { purchase ->
-                        val productInfo = ReceiptInfo(productIDs = purchase.productIds)
-                        postReceiptHelper.postTokenWithoutConsuming(
-                            purchase.purchaseToken,
-                            purchase.storeUserID,
-                            productInfo,
-                            this.allowSharingPlayStoreAccount,
-                            appUserID,
-                            purchase.marketplace,
-                            {
-                                log(LogIntent.PURCHASE, PurchaseStrings.PURCHASE_SYNCED.format(purchase))
-                            },
-                            { error ->
-                                log(
-                                    LogIntent.RC_ERROR, PurchaseStrings.SYNCING_PURCHASES_ERROR_DETAILS
-                                        .format(purchase, error)
-                                )
-                            }
-                        )
-                    }
-                }
-            },
-            onReceivePurchaseHistoryError = {
-                log(LogIntent.RC_ERROR, PurchaseStrings.SYNCING_PURCHASES_ERROR.format(it))
-            }
+    @JvmOverloads
+    fun syncPurchases(
+        listener: SyncPurchasesCallback? = null
+    ) {
+        syncPurchasesHelper.syncPurchases(
+            isRestore = this.allowSharingPlayStoreAccount,
+            onSuccess = { listener?.onSuccess() },
+            onError = { listener?.onError(it) }
         )
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -164,6 +164,12 @@ internal class PurchasesFactory(
                 offlineEntitlementsManager
             )
 
+            val syncPurchasesHelper = SyncPurchasesHelper(
+                billing,
+                identityManager,
+                postReceiptHelper
+            )
+
             return Purchases(
                 application,
                 appUserID,
@@ -178,7 +184,8 @@ internal class PurchasesFactory(
                 offeringParser,
                 diagnosticsSynchronizer,
                 offlineEntitlementsManager,
-                postReceiptHelper
+                postReceiptHelper,
+                syncPurchasesHelper
             )
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -167,6 +167,7 @@ internal class PurchasesFactory(
             val syncPurchasesHelper = SyncPurchasesHelper(
                 billing,
                 identityManager,
+                customerInfoHelper,
                 postReceiptHelper
             )
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
@@ -36,7 +36,7 @@ internal class SyncPurchasesHelper(
                         if (currentPurchase == lastPurchase) {
                             if (errors.isEmpty()) {
                                 debugLog(PurchaseStrings.SYNCED_PURCHASES_SUCCESSFULLY)
-                                retrieveCustomerInfoFromCache(appUserID, onSuccess, onError)
+                                retrieveCustomerInfo(appUserID, onSuccess, onError)
                             } else {
                                 errorLog(PurchaseStrings.SYNCING_PURCHASES_ERROR.format(errors))
                                 onError(errors.first())
@@ -67,7 +67,7 @@ internal class SyncPurchasesHelper(
                         )
                     }
                 } else {
-                    retrieveCustomerInfoFromCache(appUserID, onSuccess, onError)
+                    retrieveCustomerInfo(appUserID, onSuccess, onError)
                 }
             },
             onReceivePurchaseHistoryError = {
@@ -77,14 +77,14 @@ internal class SyncPurchasesHelper(
         )
     }
 
-    private fun retrieveCustomerInfoFromCache(
+    private fun retrieveCustomerInfo(
         appUserID: String,
         onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit
     ) {
         customerInfoHelper.retrieveCustomerInfo(
             appUserID,
-            CacheFetchPolicy.CACHE_ONLY,
+            CacheFetchPolicy.CACHED_OR_FETCHED,
             appInBackground = false,
             callback = object : ReceiveCustomerInfoCallback {
                 override fun onReceived(customerInfo: CustomerInfo) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
@@ -19,6 +19,7 @@ internal class SyncPurchasesHelper(
 ) {
     fun syncPurchases(
         isRestore: Boolean,
+        appInBackground: Boolean,
         onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit
     ) {
@@ -36,7 +37,7 @@ internal class SyncPurchasesHelper(
                         if (currentPurchase == lastPurchase) {
                             if (errors.isEmpty()) {
                                 debugLog(PurchaseStrings.SYNCED_PURCHASES_SUCCESSFULLY)
-                                retrieveCustomerInfo(appUserID, onSuccess, onError)
+                                retrieveCustomerInfo(appUserID, appInBackground, onSuccess, onError)
                             } else {
                                 errorLog(PurchaseStrings.SYNCING_PURCHASES_ERROR.format(errors))
                                 onError(errors.first())
@@ -67,7 +68,7 @@ internal class SyncPurchasesHelper(
                         )
                     }
                 } else {
-                    retrieveCustomerInfo(appUserID, onSuccess, onError)
+                    retrieveCustomerInfo(appUserID, appInBackground, onSuccess, onError)
                 }
             },
             onReceivePurchaseHistoryError = {
@@ -79,13 +80,14 @@ internal class SyncPurchasesHelper(
 
     private fun retrieveCustomerInfo(
         appUserID: String,
+        appInBackground: Boolean,
         onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit
     ) {
         customerInfoHelper.retrieveCustomerInfo(
             appUserID,
             CacheFetchPolicy.CACHED_OR_FETCHED,
-            appInBackground = false,
+            appInBackground = appInBackground,
             callback = object : ReceiveCustomerInfoCallback {
                 override fun onReceived(customerInfo: CustomerInfo) {
                     onSuccess(customerInfo)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
@@ -36,7 +36,7 @@ internal class SyncPurchasesHelper(
                         if (currentPurchase == lastPurchase) {
                             if (errors.isEmpty()) {
                                 debugLog(PurchaseStrings.SYNCED_PURCHASES_SUCCESSFULLY)
-                                retrieveCustomerInfo(appUserID, onSuccess, onError)
+                                retrieveCustomerInfoFromCache(appUserID, onSuccess, onError)
                             } else {
                                 errorLog(PurchaseStrings.SYNCING_PURCHASES_ERROR.format(errors))
                                 onError(errors.first())
@@ -67,7 +67,7 @@ internal class SyncPurchasesHelper(
                         )
                     }
                 } else {
-                    retrieveCustomerInfo(appUserID, onSuccess, onError)
+                    retrieveCustomerInfoFromCache(appUserID, onSuccess, onError)
                 }
             },
             onReceivePurchaseHistoryError = {
@@ -77,7 +77,7 @@ internal class SyncPurchasesHelper(
         )
     }
 
-    private fun retrieveCustomerInfo(
+    private fun retrieveCustomerInfoFromCache(
         appUserID: String,
         onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
@@ -1,0 +1,77 @@
+package com.revenuecat.purchases
+
+import com.revenuecat.purchases.common.BillingAbstract
+import com.revenuecat.purchases.common.LogIntent
+import com.revenuecat.purchases.common.ReceiptInfo
+import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.identity.IdentityManager
+import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.strings.PurchaseStrings
+
+internal class SyncPurchasesHelper(
+    private val billing: BillingAbstract,
+    private val identityManager: IdentityManager,
+    private val postReceiptHelper: PostReceiptHelper
+) {
+    fun syncPurchases(
+        isRestore: Boolean,
+        onSuccess: () -> Unit,
+        onError: (PurchasesError) -> Unit
+    ) {
+        log(LogIntent.DEBUG, PurchaseStrings.SYNCING_PURCHASES)
+
+        val appUserID = identityManager.currentAppUserID
+
+        billing.queryAllPurchases(
+            appUserID,
+            onReceivePurchaseHistory = { allPurchases ->
+                if (allPurchases.isNotEmpty()) {
+                    val lastPurchase = allPurchases.last()
+                    val errors: MutableList<PurchasesError> = mutableListOf()
+                    fun handleLastPurchase(currentPurchase: StoreTransaction, lastPurchase: StoreTransaction) {
+                        if (currentPurchase == lastPurchase) {
+                            if (errors.isEmpty()) {
+                                debugLog(PurchaseStrings.SYNCED_PURCHASES_SUCCESSFULLY)
+                                onSuccess()
+                            } else {
+                                errorLog(PurchaseStrings.SYNCING_PURCHASES_ERROR.format(errors))
+                                onError(errors.first())
+                            }
+                        }
+                    }
+                    allPurchases.forEach { purchase ->
+                        val productInfo = ReceiptInfo(productIDs = purchase.productIds)
+                        postReceiptHelper.postTokenWithoutConsuming(
+                            purchase.purchaseToken,
+                            purchase.storeUserID,
+                            productInfo,
+                            isRestore,
+                            appUserID,
+                            purchase.marketplace,
+                            {
+                                log(LogIntent.PURCHASE, PurchaseStrings.PURCHASE_SYNCED.format(purchase))
+                                handleLastPurchase(purchase, lastPurchase)
+                            },
+                            { error ->
+                                log(
+                                    LogIntent.RC_ERROR, PurchaseStrings.SYNCING_PURCHASES_ERROR_DETAILS
+                                        .format(purchase, error)
+                                )
+                                errors.add(error)
+                                handleLastPurchase(purchase, lastPurchase)
+                            }
+                        )
+                    }
+                } else {
+                    onSuccess()
+                }
+            },
+            onReceivePurchaseHistoryError = {
+                log(LogIntent.RC_ERROR, PurchaseStrings.SYNCING_PURCHASES_ERROR.format(it))
+                onError(it)
+            }
+        )
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -94,11 +94,11 @@ internal fun logInSuccessListener(
 }
 
 internal fun syncPurchasesListener(
-    onSuccess: () -> Unit,
+    onSuccess: (CustomerInfo) -> Unit,
     onError: (error: PurchasesError) -> Unit
 ) = object : SyncPurchasesCallback {
-    override fun onSuccess() {
-        onSuccess()
+    override fun onSuccess(customerInfo: CustomerInfo) {
+        onSuccess(customerInfo)
     }
 
     override fun onError(error: PurchasesError) {
@@ -258,7 +258,7 @@ fun Purchases.restorePurchasesWith(
  */
 fun Purchases.syncPurchasesWith(
     onError: (error: PurchasesError) -> Unit = ON_ERROR_STUB,
-    onSuccess: () -> Unit
+    onSuccess: (CustomerInfo) -> Unit
 ) {
     syncPurchases(syncPurchasesListener(onSuccess, onError))
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.interfaces.ProductChangeCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
+import com.revenuecat.purchases.interfaces.SyncPurchasesCallback
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.SubscriptionOption
@@ -89,6 +90,19 @@ internal fun logInSuccessListener(
 
     override fun onError(error: PurchasesError) {
         onError?.invoke(error)
+    }
+}
+
+internal fun syncPurchasesListener(
+    onSuccess: () -> Unit,
+    onError: (error: PurchasesError) -> Unit
+) = object : SyncPurchasesCallback {
+    override fun onSuccess() {
+        onSuccess()
+    }
+
+    override fun onError(error: PurchasesError) {
+        onError(error)
     }
 }
 
@@ -225,6 +239,28 @@ fun Purchases.restorePurchasesWith(
     onSuccess: (customerInfo: CustomerInfo) -> Unit
 ) {
     restorePurchases(receiveCustomerInfoCallback(onSuccess, onError))
+}
+
+/**
+ * This method will send all the purchases to the RevenueCat backend. Call this when using your own implementation
+ * for subscriptions anytime a sync is needed, such as when migrating existing users to RevenueCat. The
+ * [onSuccess] callback will be called if all purchases have been synced successfully or
+ * there are no purchases. Otherwise, the [onError] callback will be called with a
+ * [PurchasesError] indicating the first error found.
+ *
+ * @param [onError] Called when there was an error syncing one or more of the purchases. Will return the first error
+ * found syncing the purchases.
+ * @param [onSuccess] Called when all purchases have been successfully synced with the backend or if no purchases are
+ * present.
+ * @warning This function should only be called if you're migrating to RevenueCat or in observer mode.
+ * @warning This function could take a relatively long time to execute, depending on the amount of purchases
+ * the user has. Consider that when waiting for this operation to complete.
+ */
+fun Purchases.syncPurchasesWith(
+    onError: (error: PurchasesError) -> Unit = ON_ERROR_STUB,
+    onSuccess: () -> Unit
+) {
+    syncPurchases(syncPurchasesListener(onSuccess, onError))
 }
 
 /**

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -65,6 +65,7 @@ open class BasePurchasesTest {
     protected val mockDiagnosticsSynchronizer = mockk<DiagnosticsSynchronizer>()
     protected val mockOfflineEntitlementsManager = mockk<OfflineEntitlementsManager>()
     internal val mockPostReceiptHelper = mockk<PostReceiptHelper>()
+    protected val mockSyncPurchasesHelper = mockk<SyncPurchasesHelper>()
 
     protected var capturedPurchasesUpdatedListener = slot<BillingAbstract.PurchasesUpdatedListener>()
     protected var capturedBillingWrapperStateListener = slot<BillingAbstract.StateListener>()
@@ -107,7 +108,7 @@ open class BasePurchasesTest {
     @After
     fun tearDown() {
         Purchases.backingFieldSharedInstance = null
-        clearMocks(mockCustomerInfoHelper, mockPostReceiptHelper)
+        clearMocks(mockCustomerInfoHelper, mockPostReceiptHelper, mockSyncPurchasesHelper)
     }
 
     // region Private Methods
@@ -315,7 +316,8 @@ open class BasePurchasesTest {
             offeringParser = OfferingParserFactory.createOfferingParser(Store.PLAY_STORE),
             diagnosticsSynchronizer = mockDiagnosticsSynchronizer,
             offlineEntitlementsManager = mockOfflineEntitlementsManager,
-            postReceiptHelper = mockPostReceiptHelper
+            postReceiptHelper = mockPostReceiptHelper,
+            syncPurchasesHelper = mockSyncPurchasesHelper
         )
         Purchases.sharedInstance = purchases
         purchases.state = purchases.state.copy(appInBackground = false)

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -65,7 +65,7 @@ open class BasePurchasesTest {
     protected val mockDiagnosticsSynchronizer = mockk<DiagnosticsSynchronizer>()
     protected val mockOfflineEntitlementsManager = mockk<OfflineEntitlementsManager>()
     internal val mockPostReceiptHelper = mockk<PostReceiptHelper>()
-    protected val mockSyncPurchasesHelper = mockk<SyncPurchasesHelper>()
+    internal val mockSyncPurchasesHelper = mockk<SyncPurchasesHelper>()
 
     protected var capturedPurchasesUpdatedListener = slot<BillingAbstract.PurchasesUpdatedListener>()
     protected var capturedBillingWrapperStateListener = slot<BillingAbstract.StateListener>()
@@ -166,7 +166,7 @@ open class BasePurchasesTest {
             every {
                 postTokenWithoutConsuming(any(), any(), any(), any(), any(), any(), captureLambda(), any())
             } answers {
-                lambda<() -> Unit>().captured.invoke()
+                lambda<(CustomerInfo) -> Unit>().captured.invoke(mockInfo)
             }
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -889,6 +889,25 @@ class PostReceiptHelperTest {
     }
 
     @Test
+    fun `postTokenWithoutConsuming returns customer info on success`() {
+        mockPostReceiptSuccess(postType = PostType.TOKEN_WITHOUT_CONSUMING)
+
+        var receivedCustomerInfo: CustomerInfo? = null
+        postReceiptHelper.postTokenWithoutConsuming(
+            purchaseToken = postToken,
+            storeUserID = storeUserId,
+            receiptInfo = testReceiptInfo,
+            isRestore = true,
+            appUserID = appUserID,
+            marketplace = marketplace,
+            onSuccess = { receivedCustomerInfo = it },
+            onError = { fail("Should succeed") }
+        )
+
+        assertThat(receivedCustomerInfo).isEqualTo(defaultCustomerInfo)
+    }
+
+    @Test
     fun `postTokenWithoutConsuming adds sent token on success`() {
         val expectedShouldConsumeFlag = true
         every { appConfig.finishTransactions } returns expectedShouldConsumeFlag

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -2666,16 +2666,21 @@ class PurchasesTest: BasePurchasesTest() {
         every {
             mockSyncPurchasesHelper.syncPurchases(any(), captureLambda(), any())
         } answers {
-            lambda<() -> Unit>().captured.invoke()
+            lambda<(CustomerInfo) -> Unit>().captured.invoke(mockInfo)
         }
 
         var successCallCount = 0
+        var receivedCustomerInfo: CustomerInfo? = null
         purchases.syncPurchasesWith(
             { fail("Expected to succeed") },
-            { successCallCount++ }
+            {
+                successCallCount++
+                receivedCustomerInfo = it
+            }
         )
 
         assertThat(successCallCount).isEqualTo(1)
+        assertThat(receivedCustomerInfo).isEqualTo(mockInfo)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -2646,15 +2646,18 @@ class PurchasesTest: BasePurchasesTest() {
     @Test
     fun `syncing transactions calls helper with correct parameters`() {
         val allowSharingAccount = true
+        val appInBackground = true
         purchases.allowSharingPlayStoreAccount = allowSharingAccount
+        purchases.state = purchases.state.copy(appInBackground = appInBackground)
 
-        every { mockSyncPurchasesHelper.syncPurchases(any(), any(), any()) } just Runs
+        every { mockSyncPurchasesHelper.syncPurchases(any(), any(), any(), any()) } just Runs
 
         purchases.syncPurchases()
 
         verify(exactly = 1) {
             mockSyncPurchasesHelper.syncPurchases(
                 allowSharingAccount,
+                appInBackground,
                 any(),
                 any()
             )
@@ -2664,7 +2667,7 @@ class PurchasesTest: BasePurchasesTest() {
     @Test
     fun `syncing transactions calls success callback when process completes successfully`() {
         every {
-            mockSyncPurchasesHelper.syncPurchases(any(), captureLambda(), any())
+            mockSyncPurchasesHelper.syncPurchases(any(), any(), captureLambda(), any())
         } answers {
             lambda<(CustomerInfo) -> Unit>().captured.invoke(mockInfo)
         }
@@ -2686,7 +2689,7 @@ class PurchasesTest: BasePurchasesTest() {
     @Test
     fun `syncing transactions calls error callback when process completes with error`() {
         every {
-            mockSyncPurchasesHelper.syncPurchases(any(), any(), captureLambda())
+            mockSyncPurchasesHelper.syncPurchases(any(), any(), any(), captureLambda())
         } answers {
             lambda<(PurchasesError) -> Unit>().captured.invoke(PurchasesError(PurchasesErrorCode.UnknownError))
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
@@ -252,7 +252,7 @@ class SyncPurchasesHelperTest {
         every {
             customerInfoHelper.retrieveCustomerInfo(
                 appUserID,
-                CacheFetchPolicy.CACHE_ONLY,
+                CacheFetchPolicy.CACHED_OR_FETCHED,
                 false,
                 capture(callbackSlot)
             )
@@ -268,7 +268,7 @@ class SyncPurchasesHelperTest {
         every {
             customerInfoHelper.retrieveCustomerInfo(
                 appUserID,
-                CacheFetchPolicy.CACHE_ONLY,
+                CacheFetchPolicy.CACHED_OR_FETCHED,
                 false,
                 capture(callbackSlot)
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
@@ -1,0 +1,225 @@
+package com.revenuecat.purchases
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.BillingAbstract
+import com.revenuecat.purchases.identity.IdentityManager
+import com.revenuecat.purchases.models.StoreTransaction
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyAll
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SyncPurchasesHelperTest {
+
+    private val appUserID = "test-app-user-id"
+
+    private lateinit var billing: BillingAbstract
+    private lateinit var identityManager: IdentityManager
+    private lateinit var postReceiptHelper: PostReceiptHelper
+
+    private lateinit var syncPurchasesHelper: SyncPurchasesHelper
+
+    @Before
+    fun setUp() {
+        billing = mockk()
+        identityManager = mockk()
+        postReceiptHelper = mockk()
+
+        every { identityManager.currentAppUserID } returns appUserID
+
+        syncPurchasesHelper = SyncPurchasesHelper(
+            billing,
+            identityManager,
+            postReceiptHelper
+        )
+    }
+
+    @Test
+    fun `does not sync if no purchases`() {
+        mockBillingQueryAllPurchasesSuccess(emptyList())
+
+        var successCallCount = 0
+        syncPurchasesHelper.syncPurchases(
+            isRestore = false,
+            onSuccess = { successCallCount++ },
+            onError = { fail("Should not call onError") }
+        )
+
+        assertThat(successCallCount).isEqualTo(1)
+        verify(exactly = 0) {
+            postReceiptHelper.postTokenWithoutConsuming(
+                any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun `calls error if error getting purchases`() {
+        mockBillingQueryAllPurchasesError()
+
+        var error: PurchasesError? = null
+        syncPurchasesHelper.syncPurchases(
+            isRestore = false,
+            onSuccess = { fail("Should not call onSuccess") },
+            onError = { error = it }
+        )
+
+        assertThat(error).isNotNull
+        verify(exactly = 0) {
+            postReceiptHelper.postTokenWithoutConsuming(
+                any(), any(), any(), any(), any(), any(), any(), any()
+            )
+        }
+    }
+
+    @Test
+    fun `posts all receipts without consuming`() {
+        val purchase1 = mockk<StoreTransaction>().apply {
+            every { productIds } returns listOf("test-product-id-1")
+            every { purchaseToken } returns "test-purchase-token-1"
+            every { storeUserID } returns "test-store-user-id"
+            every { marketplace } returns null
+        }
+        val purchase2 = mockk<StoreTransaction>().apply {
+            every { productIds } returns listOf("test-product-id-2")
+            every { purchaseToken } returns "test-purchase-token-2"
+            every { storeUserID } returns "test-store-user-id"
+            every { marketplace } returns "test-marketplace"
+        }
+        mockBillingQueryAllPurchasesSuccess(listOf(purchase1, purchase2))
+
+        every {
+            postReceiptHelper.postTokenWithoutConsuming(any(), any(), any(), any(), any(), any(), captureLambda(), any())
+        } answers {
+            lambda<() -> Unit>().captured.invoke()
+        }
+
+        var successCallCount = 0
+        syncPurchasesHelper.syncPurchases(
+            isRestore = false,
+            onSuccess = { successCallCount++ },
+            onError = { fail("Should have succeeded") }
+        )
+
+        assertThat(successCallCount).isEqualTo(1)
+        verifyAll {
+            postReceiptHelper.postTokenWithoutConsuming(
+                purchaseToken = "test-purchase-token-1",
+                storeUserID = "test-store-user-id",
+                receiptInfo = any(),
+                isRestore = false,
+                appUserID = appUserID,
+                marketplace = null,
+                onSuccess = any(),
+                onError = any()
+            )
+            postReceiptHelper.postTokenWithoutConsuming(
+                purchaseToken = "test-purchase-token-2",
+                storeUserID = "test-store-user-id",
+                receiptInfo = any(),
+                isRestore = false,
+                appUserID = appUserID,
+                marketplace = "test-marketplace",
+                onSuccess = any(),
+                onError = any()
+            )
+        }
+    }
+
+    @Test
+    fun `tries to sync all purchases even if there are errors`() {
+        val purchase1 = mockk<StoreTransaction>().apply {
+            every { productIds } returns listOf("test-product-id-1")
+            every { purchaseToken } returns "test-purchase-token-1"
+            every { storeUserID } returns "test-store-user-id"
+            every { marketplace } returns null
+        }
+        val purchase2 = mockk<StoreTransaction>().apply {
+            every { productIds } returns listOf("test-product-id-2")
+            every { purchaseToken } returns "test-purchase-token-2"
+            every { storeUserID } returns "test-store-user-id"
+            every { marketplace } returns "test-marketplace"
+        }
+        mockBillingQueryAllPurchasesSuccess(listOf(purchase1, purchase2))
+
+        every {
+            postReceiptHelper.postTokenWithoutConsuming(any(), any(), any(), any(), any(), any(), any(), captureLambda())
+        } answers {
+            lambda<(PurchasesError) -> Unit>().captured.invoke(PurchasesError(PurchasesErrorCode.UnknownError))
+        }
+
+        var errorCallCount = 0
+        syncPurchasesHelper.syncPurchases(
+            isRestore = false,
+            onSuccess = { fail("Should error") },
+            onError = { errorCallCount++ }
+        )
+
+        assertThat(errorCallCount).isEqualTo(1)
+        verifyAll {
+            postReceiptHelper.postTokenWithoutConsuming(
+                purchaseToken = "test-purchase-token-1",
+                storeUserID = "test-store-user-id",
+                receiptInfo = any(),
+                isRestore = false,
+                appUserID = appUserID,
+                marketplace = null,
+                onSuccess = any(),
+                onError = any()
+            )
+            postReceiptHelper.postTokenWithoutConsuming(
+                purchaseToken = "test-purchase-token-2",
+                storeUserID = "test-store-user-id",
+                receiptInfo = any(),
+                isRestore = false,
+                appUserID = appUserID,
+                marketplace = "test-marketplace",
+                onSuccess = any(),
+                onError = any()
+            )
+        }
+    }
+
+    @Test
+    fun `calls success callback if no purchases to sync`() {
+        val purchases = emptyList<StoreTransaction>()
+        mockBillingQueryAllPurchasesSuccess(purchases)
+
+        var successCallCount = 0
+        syncPurchasesHelper.syncPurchases(
+            isRestore = false,
+            onSuccess = { successCallCount++ },
+            onError = { fail("Should have succeeded") }
+        )
+
+        assertThat(successCallCount).isEqualTo(1)
+    }
+
+    // region helpers
+
+    private fun mockBillingQueryAllPurchasesSuccess(purchases: List<StoreTransaction>) {
+        every {
+            billing.queryAllPurchases(appUserID, captureLambda(), any())
+        } answers {
+            lambda<(List<StoreTransaction>) -> Unit>().captured.invoke(purchases)
+        }
+    }
+
+    private fun mockBillingQueryAllPurchasesError(
+        error: PurchasesError = PurchasesError(PurchasesErrorCode.UnknownError)
+    ) {
+        every {
+            billing.queryAllPurchases(appUserID, any(), captureLambda())
+        } answers {
+            lambda<(PurchasesError) -> Unit>().captured.invoke(error)
+        }
+    }
+
+    // endregion helpers
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
@@ -22,6 +22,7 @@ class SyncPurchasesHelperTest {
     private val appUserID = "test-app-user-id"
     private val testError = PurchasesError(PurchasesErrorCode.CustomerInfoError)
     private val customerInfoMock = mockk<CustomerInfo>()
+    private val appInBackground = false
 
     private lateinit var billing: BillingAbstract
     private lateinit var identityManager: IdentityManager
@@ -56,6 +57,7 @@ class SyncPurchasesHelperTest {
         var receivedCustomerInfo: CustomerInfo? = null
         syncPurchasesHelper.syncPurchases(
             isRestore = false,
+            appInBackground = appInBackground,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should not call onError") }
         )
@@ -76,6 +78,7 @@ class SyncPurchasesHelperTest {
         var receivedError: PurchasesError? = null
         syncPurchasesHelper.syncPurchases(
             isRestore = false,
+            appInBackground = appInBackground,
             onSuccess = { fail("Should not call onSuccess") },
             onError = { receivedError = it }
         )
@@ -90,6 +93,7 @@ class SyncPurchasesHelperTest {
         var error: PurchasesError? = null
         syncPurchasesHelper.syncPurchases(
             isRestore = false,
+            appInBackground = appInBackground,
             onSuccess = { fail("Should not call onSuccess") },
             onError = { error = it }
         )
@@ -127,6 +131,7 @@ class SyncPurchasesHelperTest {
         var receivedCustomerInfo: CustomerInfo? = null
         syncPurchasesHelper.syncPurchases(
             isRestore = false,
+            appInBackground = appInBackground,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should have succeeded") }
         )
@@ -181,6 +186,7 @@ class SyncPurchasesHelperTest {
         var errorCallCount = 0
         syncPurchasesHelper.syncPurchases(
             isRestore = false,
+            appInBackground = appInBackground,
             onSuccess = { fail("Should error") },
             onError = { errorCallCount++ }
         )
@@ -218,6 +224,7 @@ class SyncPurchasesHelperTest {
         var successCallCount = 0
         syncPurchasesHelper.syncPurchases(
             isRestore = false,
+            appInBackground = appInBackground,
             onSuccess = { successCallCount++ },
             onError = { fail("Should have succeeded") }
         )
@@ -253,7 +260,7 @@ class SyncPurchasesHelperTest {
             customerInfoHelper.retrieveCustomerInfo(
                 appUserID,
                 CacheFetchPolicy.CACHED_OR_FETCHED,
-                false,
+                appInBackground,
                 capture(callbackSlot)
             )
         } answers {
@@ -269,7 +276,7 @@ class SyncPurchasesHelperTest {
             customerInfoHelper.retrieveCustomerInfo(
                 appUserID,
                 CacheFetchPolicy.CACHED_OR_FETCHED,
-                false,
+                appInBackground,
                 capture(callbackSlot)
             )
         } answers {

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -70,7 +70,8 @@ class SubscriberAttributesPurchasesTests {
             offeringParser = OfferingParserFactory.createOfferingParser(Store.PLAY_STORE),
             diagnosticsSynchronizer = null,
             offlineEntitlementsManager = offlineEntitlementsManagerMock,
-            postReceiptHelper = postReceiptHelperMock
+            postReceiptHelper = postReceiptHelperMock,
+            syncPurchasesHelper = mockk()
         )
     }
 

--- a/strings/src/main/java/com/revenuecat/purchases/strings/PurchaseStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/PurchaseStrings.kt
@@ -21,10 +21,10 @@ object PurchaseStrings {
     const val PURCHASE_STARTED = "Purchase started - product: %s"
     const val SYNCING_PURCHASES = "Syncing purchases"
     const val SYNCING_PURCHASE_STORE_USER_ID = "Syncing purchase with token %s, for store user ID %s"
-    const val SYNCING_PURCHASES_ERROR = "Error syncing purchases %s"
+    const val SYNCING_PURCHASES_ERROR = "Error syncing purchases. Error: %s"
     const val SYNCING_PURCHASES_ERROR_DETAILS = "Error syncing purchases %s. Error: %s"
-    const val SYNCING_PURCHASE_ERROR_DETAILS = "Error syncing purchase %s. Error: %s"
     const val SYNCING_PURCHASE_ERROR_DETAILS_USER_ID = "Error syncing purchase %s for store user ID %s. Error: %s"
+    const val SYNCED_PURCHASES_SUCCESSFULLY = "Synced purchases successfully"
     const val SYNCING_PURCHASE_SKIPPING = "Skipping syncing purchase %s for store user ID %s. " +
         "It has already been posted"
     const val UPDATING_PENDING_PURCHASE_QUEUE = "Updating pending purchase queue"


### PR DESCRIPTION
### Description
This PR adds a new optional parameter to the `syncPurchases` function containing a success and error callbacks for that operation. Also added a new Kotlin-only version `syncPurchasesWith` to provide an easier Kotlin API.

Additionally, while doing this, I decided to move the logic from `syncPurchases` to a new `SyncPurchasesHelper`, so it can be better tested in isolation.