### PR TITLE
Query only active purchases when generating offline entitlements customer info

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculator.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculator.kt
@@ -41,11 +41,11 @@ class OfflineCustomerInfoCalculator(
         onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit
     ) {
-        purchasedProductsFetcher.queryPurchasedProducts(
+        purchasedProductsFetcher.queryActiveProducts(
             appUserID,
             onSuccess = { purchasedProducts ->
                 val containsAnyActiveInAppPurchase = purchasedProducts.any {
-                    it.storeTransaction.type == ProductType.INAPP && it.isActive
+                    it.storeTransaction.type == ProductType.INAPP
                 }
                 if (containsAnyActiveInAppPurchase) {
                     val error = PurchasesError(
@@ -54,7 +54,7 @@ class OfflineCustomerInfoCalculator(
                     )
                     errorLog(COMPUTING_OFFLINE_CUSTOMER_INFO_FAILED.format(error))
                     onError(error)
-                    return@queryPurchasedProducts
+                    return@queryActiveProducts
                 }
                 val customerInfo = buildCustomerInfoUsingListOfPurchases(appUserID, purchasedProducts)
                 onSuccess.invoke(customerInfo)

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProduct.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProduct.kt
@@ -7,7 +7,6 @@ data class PurchasedProduct(
     val productIdentifier: String,
     val basePlanId: String?,
     val storeTransaction: StoreTransaction,
-    val isActive: Boolean,
     val entitlements: List<String>,
     val expiresDate: Date?
 )

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/billingClientStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/billingClientStubs.kt
@@ -175,10 +175,13 @@ fun stubPurchaseHistoryRecord(
 fun stubStoreTransactionFromGooglePurchase(
     productIds: List<String>,
     purchaseTime: Long,
+    purchaseToken: String = "abcdefghijipehfnbbnldmai.AO-J1OxqriTepvB7suzlIhxqPIveA0IHtX9amMedK0KK9CsO0S3Zk5H6gdwvV" +
+        "7HzZIJeTzqkY4okyVk8XKTmK1WZKAKSNTKop4dgwSmFnLWsCxYbahUmADg"
 ): StoreTransaction {
     return stubGooglePurchase(
         productIds,
-        purchaseTime
+        purchaseTime,
+        purchaseToken = purchaseToken
     ).toStoreTransaction(ProductType.SUBS, null)
 }
 


### PR DESCRIPTION
### Description
We were querying for the whole history of purchases when generating the offline entitlements customer info. This was done to get more accurate data in that situation. However, it adds complexity for a non-critical use case. This PR removes that functionality, simplifying the use cases for offline entitlements.