### PR TITLE
CAT-859 Expose whether or not a SubscriptionOption is Prepaid in the SDK

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/SubscriptionOptionAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/SubscriptionOptionAPI.java
@@ -18,6 +18,7 @@ final class SubscriptionOptionAPI {
         String presentedOfferingId = subscriptionOption.getPresentedOfferingIdentifier();
         PurchasingData purchasingData = subscriptionOption.getPurchasingData();
         String id = subscriptionOption.getId();
+        Boolean isPrepaid = subscriptionOption.isPrepaid();
     }
 
     static void checkGoogleSubscriptionOption(GoogleSubscriptionOption googleSubscriptionOption) {

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/SubscriptionOptionAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/SubscriptionOptionAPI.kt
@@ -10,5 +10,6 @@ private class SubscriptionOptionAPI {
         val tags: List<String> = subscriptionOption.tags
         val isBasePlan: Boolean = subscriptionOption.isBasePlan
         val presentedOfferingId: String? = subscriptionOption.presentedOfferingIdentifier
+        val isPrepaid: Boolean = subscriptionOption.isPrepaid
     }
 }

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/SubscriptionOptionTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/SubscriptionOptionTest.kt
@@ -49,6 +49,7 @@ class SubscriptionOptionTest {
         assertThat(subscriptionOption.fullPricePhase).isEqualTo(recurringPhase)
         assertThat(subscriptionOption.billingPeriod?.unit).isEqualTo(Period.Unit.MONTH)
         assertThat(subscriptionOption.billingPeriod?.value).isEqualTo(1)
+        assertThat(subscriptionOption.isPrepaid).isFalse
     }
 
     @Test
@@ -121,6 +122,7 @@ class SubscriptionOptionTest {
         assertThat(subscriptionOption.freePhase).isEqualTo(freePhase)
         assertThat(subscriptionOption.introPhase).isNull()
         assertThat(subscriptionOption.fullPricePhase).isEqualTo(recurringPhase)
+        assertThat(subscriptionOption.isPrepaid).isFalse
     }
 
     @Test
@@ -162,5 +164,6 @@ class SubscriptionOptionTest {
         assertThat(subscriptionOption.freePhase).isNull()
         assertThat(subscriptionOption.introPhase).isEqualTo(introPhase)
         assertThat(subscriptionOption.fullPricePhase).isEqualTo(recurringPhase)
+        assertThat(subscriptionOption.isPrepaid).isFalse
     }
 }

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/SubscriptionOptionTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/SubscriptionOptionTest.kt
@@ -79,6 +79,7 @@ class SubscriptionOptionTest {
         assertThat(subscriptionOption.freePhase).isNull()
         assertThat(subscriptionOption.introPhase).isNull()
         assertThat(subscriptionOption.fullPricePhase).isEqualTo(recurringPhase)
+        assertThat(subscriptionOption.isPrepaid).isTrue
     }
 
     @Test

--- a/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOption.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOption.kt
@@ -45,6 +45,13 @@ interface SubscriptionOption {
         get() = fullPricePhase?.billingPeriod
 
     /**
+     * True if the subscription is pre-paid.
+     * Not applicable for Amazon subscriptions.
+     */
+    val isPrepaid: Boolean
+        get() =  this.fullPricePhase?.recurrenceMode == RecurrenceMode.NON_RECURRING
+
+    /**
      * The full price [PricingPhase] of the subscription.
      * Looks for the last price phase of the SubscriptionOption.
      */

--- a/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOption.kt
+++ b/public/src/main/java/com/revenuecat/purchases/models/SubscriptionOption.kt
@@ -49,7 +49,7 @@ interface SubscriptionOption {
      * Not applicable for Amazon subscriptions.
      */
     val isPrepaid: Boolean
-        get() =  this.fullPricePhase?.recurrenceMode == RecurrenceMode.NON_RECURRING
+        get() = this.fullPricePhase?.recurrenceMode == RecurrenceMode.NON_RECURRING
 
     /**
      * The full price [PricingPhase] of the subscription.


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
Ticket https://linear.app/revenuecat/issue/CAT-859/%5Bsdk%5D-expose-in-the-store-product-if-the-product-is-a-pre-piad-plan-or
We need to support prepaid subscriptions that were introduced starting BC 5. The SDK can check if a pricing phase's recurrence mode is NON_RECURRING to determine prepaid status.

Tested with unit tests.
