### PR TITLE
Support forcing server errors for tests

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
@@ -6,13 +6,16 @@ import com.revenuecat.purchases.Store
 import java.net.URL
 import com.revenuecat.purchases.strings.ConfigureStrings
 
+@Suppress("LongParameterList")
 class AppConfig(
     context: Context,
     observerMode: Boolean,
     val platformInfo: PlatformInfo,
     proxyURL: URL?,
     val store: Store,
-    val dangerousSettings: DangerousSettings = DangerousSettings(autoSyncPurchases = true)
+    val dangerousSettings: DangerousSettings = DangerousSettings(autoSyncPurchases = true),
+    // Should only be used for tests
+    var forceServerErrors: Boolean = false
 ) {
 
     val languageTag: String = context.getLocale()?.toBCP47() ?: ""
@@ -39,6 +42,7 @@ class AppConfig(
         if (versionName != other.versionName) return false
         if (packageName != other.packageName) return false
         if (finishTransactions != other.finishTransactions) return false
+        if (forceServerErrors != other.forceServerErrors) return false
         if (baseURL != other.baseURL) return false
 
         return true
@@ -52,6 +56,7 @@ class AppConfig(
         result = 31 * result + versionName.hashCode()
         result = 31 * result + packageName.hashCode()
         result = 31 * result + finishTransactions.hashCode()
+        result = 31 * result + forceServerErrors.hashCode()
         result = 31 * result + baseURL.hashCode()
         return result
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -101,6 +101,16 @@ class HTTPClient(
         requestHeaders: Map<String, String>,
         refreshETag: Boolean = false
     ): HTTPResult {
+        if (appConfig.forceServerErrors) {
+            debugLog("Forcing server error for request to ${endpoint.getPath()}")
+            return HTTPResult(
+                RCHTTPStatusCodes.ERROR,
+                payload = "",
+                HTTPResult.Origin.BACKEND,
+                requestDate = null,
+                VerificationResult.NOT_REQUESTED
+            )
+        }
         var callSuccessful = false
         val requestStartTime = dateProvider.now
         var callResult: HTTPResult? = null
@@ -112,7 +122,7 @@ class HTTPClient(
         }
         if (callResult == null) {
             log(LogIntent.WARNING, NetworkStrings.ETAG_RETRYING_CALL)
-            return performRequest(baseURL, endpoint, body, requestHeaders, refreshETag = true)
+            callResult = performRequest(baseURL, endpoint, body, requestHeaders, refreshETag = true)
         }
         return callResult
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -102,7 +102,7 @@ class HTTPClient(
         refreshETag: Boolean = false
     ): HTTPResult {
         if (appConfig.forceServerErrors) {
-            debugLog("Forcing server error for request to ${endpoint.getPath()}")
+            warnLog("Forcing server error for request to ${endpoint.getPath()}")
             return HTTPResult(
                 RCHTTPStatusCodes.ERROR,
                 payload = "",

--- a/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
@@ -73,6 +73,7 @@ abstract class BaseBackendIntegrationTest {
             every { versionName } returns "test-version-name"
             every { packageName } returns "com.revenuecat.purchases.backend_tests"
             every { finishTransactions } returns true
+            every { forceServerErrors } returns false
         }
         dispatcher = Dispatcher(Executors.newSingleThreadScheduledExecutor())
         diagnosticsDispatcher = Dispatcher(Executors.newSingleThreadScheduledExecutor())

--- a/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -52,7 +52,7 @@ abstract class BaseHTTPClientTest {
         diagnosticsTracker: DiagnosticsTracker? = null,
         dateProvider: DateProvider = DefaultDateProvider(),
         eTagManager: ETagManager = mockETagManager,
-        signingManager: SigningManager? = null
+        signingManager: SigningManager? = null,
     ) = HTTPClient(
         appConfig,
         eTagManager,
@@ -66,14 +66,16 @@ abstract class BaseHTTPClientTest {
         observerMode: Boolean = false,
         platformInfo: PlatformInfo = expectedPlatformInfo,
         proxyURL: URL? = baseURL,
-        store: Store = Store.PLAY_STORE
+        store: Store = Store.PLAY_STORE,
+        forceServerErrors: Boolean = false
     ): AppConfig {
         return AppConfig(
             context = context,
             observerMode = observerMode,
             platformInfo = platformInfo,
             proxyURL = proxyURL,
-            store = store
+            store = store,
+            forceServerErrors = forceServerErrors
         )
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -101,6 +101,49 @@ class HTTPClientTest: BaseHTTPClientTest() {
         }
     }
 
+    // region forceServerErrors
+
+    @Test
+    fun `returns server error result when forcing server errors`() {
+        val endpoint = Endpoint.LogIn
+
+        client = createClient(appConfig = createAppConfig(forceServerErrors = true))
+
+        val result = client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+
+        assertThat(server.requestCount).isEqualTo(0)
+        assertThat(result.responseCode).isEqualTo(RCHTTPStatusCodes.ERROR)
+        assertThat(result.payload).isEqualTo("")
+        assertThat(result.origin).isEqualTo(HTTPResult.Origin.BACKEND)
+        assertThat(result.requestDate).isNull()
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_REQUESTED)
+    }
+
+    @Test
+    fun `can dynamically change between getting server errors and not`() {
+        val endpoint = Endpoint.LogIn
+
+        val appConfig = createAppConfig(forceServerErrors = true)
+        client = createClient(appConfig = appConfig)
+
+        client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+
+        assertThat(server.requestCount).isEqualTo(0)
+
+        appConfig.forceServerErrors = false
+
+        enqueue(
+            endpoint,
+            expectedResult = HTTPResult.createResult(payload = "{}")
+        )
+
+        client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    // endregion forceServerErrors
+
     // Headers
     @Test
     fun addsHeadersToRequest() {

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/purchasesExtensions.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/purchasesExtensions.kt
@@ -5,15 +5,23 @@ import com.revenuecat.purchases.common.BillingAbstract
 
 fun Purchases.Companion.configure(
     configuration: PurchasesConfiguration,
-    overrideBillingAbstract: BillingAbstract
+    overrideBillingAbstract: BillingAbstract,
+    forceServerErrors: Boolean = false
 ): Purchases {
     return PurchasesFactory().createPurchases(
         configuration,
         platformInfo,
         proxyURL,
-        overrideBillingAbstract
+        overrideBillingAbstract,
+        forceServerErrors
     ).also {
         @SuppressLint("RestrictedApi")
         sharedInstance = it
     }
 }
+
+var Purchases.forceServerErrors: Boolean
+    get() = appConfig.forceServerErrors
+    set(value) {
+        appConfig.forceServerErrors = value
+    }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -44,7 +44,8 @@ internal class PurchasesFactory(
         configuration: PurchasesConfiguration,
         platformInfo: PlatformInfo,
         proxyURL: URL?,
-        overrideBillingAbstract: BillingAbstract? = null
+        overrideBillingAbstract: BillingAbstract? = null,
+        forceServerErrors: Boolean = false
     ): Purchases {
         validateConfiguration(configuration)
 
@@ -56,7 +57,8 @@ internal class PurchasesFactory(
                 platformInfo,
                 proxyURL,
                 store,
-                dangerousSettings
+                dangerousSettings,
+                forceServerErrors
             )
 
             val prefs = PreferenceManager.getDefaultSharedPreferences(application)


### PR DESCRIPTION
### Description
In iOS, this flag lives within `DangerousSettings`. In Android, that's not possible due to our module setup, so I moved this flag to `AppConfig`, which is internal, so there won't be a public API.

