### PR TITLE
Bump dokka to 1.8.10 to support Gradle 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.22.0"
         classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.21"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.8.10"
         classpath "org.jetbrains.kotlinx:kover:0.6.1"
     }
 }


### PR DESCRIPTION
### Description
Dokka failed to generate the docs after the gradle plugin 8 update: https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/5693/workflows/aedc539a-ddc4-4478-b99b-45894517aaca/jobs/16381.
```
org.gradle.api.internal.tasks.AbstractTaskDependency: method 'void <init>()' not found
```

Updating to the latest dokka version seems to fix the issue
