### PR TITLE
Extracts setup and teardown to BasePurchasesTest

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -47,8 +47,6 @@ import org.junit.Before
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
-@RunWith(AndroidJUnit4::class)
-@Config(manifest = Config.NONE)
 open class BasePurchasesTest {
     protected val mockBillingAbstract: BillingAbstract = mockk()
     protected val mockBackend: Backend = mockk()

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -76,14 +76,8 @@ open class BasePurchasesTest {
     protected lateinit var purchases: Purchases
     protected val mockInfo = mockk<CustomerInfo>()
 
-    @After
-    fun tearDown() {
-        Purchases.backingFieldSharedInstance = null
-        clearMocks(mockCustomerInfoHelper, mockPostReceiptHelper)
-    }
-
     @Before
-    fun setup() {
+    fun setUp() {
         mockkStatic(ProcessLifecycleOwner::class)
 
         val productIds = listOf(STUB_PRODUCT_IDENTIFIER)
@@ -108,6 +102,12 @@ open class BasePurchasesTest {
         } just Runs
 
         anonymousSetup(false)
+    }
+
+    @After
+    fun tearDown() {
+        Purchases.backingFieldSharedInstance = null
+        clearMocks(mockCustomerInfoHelper, mockPostReceiptHelper)
     }
 
     // region Private Methods

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -1,0 +1,355 @@
+//  Purchases
+//
+//  Copyright © 2023 RevenueCat, Inc. All rights reserved.
+//
+
+package com.revenuecat.purchases
+
+import android.app.Application
+import android.content.Context
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.billingclient.api.PurchaseHistoryRecord
+import com.revenuecat.purchases.common.AppConfig
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BillingAbstract
+import com.revenuecat.purchases.common.OfferingParser
+import com.revenuecat.purchases.common.PlatformInfo
+import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
+import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
+import com.revenuecat.purchases.google.toInAppStoreProduct
+import com.revenuecat.purchases.google.toStoreTransaction
+import com.revenuecat.purchases.identity.IdentityManager
+import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
+import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
+import com.revenuecat.purchases.utils.ONE_OFFERINGS_RESPONSE
+import com.revenuecat.purchases.utils.STUB_PRODUCT_IDENTIFIER
+import com.revenuecat.purchases.utils.SyncDispatcher
+import com.revenuecat.purchases.utils.createMockOneTimeProductDetails
+import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
+import com.revenuecat.purchases.utils.stubStoreProduct
+import com.revenuecat.purchases.utils.stubSubscriptionOption
+import io.mockk.Runs
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.slot
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+open class BasePurchasesTest {
+    protected val mockBillingAbstract: BillingAbstract = mockk()
+    protected val mockBackend: Backend = mockk()
+    protected val mockCache: DeviceCache = mockk()
+    protected val updatedCustomerInfoListener: UpdatedCustomerInfoListener = mockk()
+    private val mockApplication = mockk<Application>(relaxed = true)
+    protected val mockContext = mockk<Context>(relaxed = true).apply {
+        every {
+            applicationContext
+        } returns mockApplication
+    }
+    protected val mockIdentityManager = mockk<IdentityManager>()
+    protected val mockSubscriberAttributesManager = mockk<SubscriberAttributesManager>()
+    internal val mockCustomerInfoHelper = mockk<CustomerInfoHelper>()
+    lateinit var mockOfferingParser: OfferingParser
+    protected val mockDiagnosticsSynchronizer = mockk<DiagnosticsSynchronizer>()
+    protected val mockOfflineEntitlementsManager = mockk<OfflineEntitlementsManager>()
+    internal val mockPostReceiptHelper = mockk<PostReceiptHelper>()
+
+    protected var capturedPurchasesUpdatedListener = slot<BillingAbstract.PurchasesUpdatedListener>()
+    protected var capturedBillingWrapperStateListener = slot<BillingAbstract.StateListener>()
+    private val capturedConsumePurchaseWrapper = slot<StoreTransaction>()
+    private val capturedShouldTryToConsume = slot<Boolean>()
+
+    protected val randomAppUserId = "\$RCAnonymousID:ff68f26e432648369a713849a9f93b58"
+    protected val appUserId = "fakeUserID"
+    protected lateinit var purchases: Purchases
+    protected val mockInfo = mockk<CustomerInfo>()
+
+    @After
+    fun tearDown() {
+        Purchases.backingFieldSharedInstance = null
+        clearMocks(mockCustomerInfoHelper, mockPostReceiptHelper)
+    }
+
+    @Before
+    fun setup() {
+        mockkStatic(ProcessLifecycleOwner::class)
+
+        val productIds = listOf(STUB_PRODUCT_IDENTIFIER)
+        mockCache()
+        mockPostReceiptHelper()
+        mockBackend()
+        mockBillingWrapper()
+        mockStoreProduct(productIds, productIds, ProductType.SUBS)
+        mockCustomerInfoHelper()
+
+        every {
+            updatedCustomerInfoListener.onReceived(any())
+        } just Runs
+        every {
+            mockIdentityManager.configure(any())
+        } just Runs
+        every {
+            mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
+        } just Runs
+        every {
+            mockOfflineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
+        } just Runs
+
+        anonymousSetup(false)
+    }
+
+    // region Private Methods
+    private fun mockBillingWrapper() {
+        with(mockBillingAbstract) {
+            every {
+                makePurchaseAsync(any(), any(), any(), any(), any(), any())
+            } just Runs
+            every {
+                purchasesUpdatedListener = capture(capturedPurchasesUpdatedListener)
+            } just Runs
+            every {
+                consumeAndSave(capture(capturedShouldTryToConsume), capture(capturedConsumePurchaseWrapper))
+            } just Runs
+            every {
+                purchasesUpdatedListener = null
+            } just Runs
+            every {
+                stateListener = capture(capturedBillingWrapperStateListener)
+            } just Runs
+            every {
+                isConnected()
+            } returns true
+
+            every {
+                close()
+            } answers {
+                purchasesUpdatedListener = null
+            }
+        }
+    }
+
+    private fun mockBackend() {
+        with(mockBackend) {
+            mockProducts()
+            every {
+                close()
+            } just Runs
+            every {
+                clearCaches()
+            } just Runs
+        }
+    }
+
+    private fun mockPostReceiptHelper() {
+        with(mockPostReceiptHelper) {
+            every {
+                postTransactionAndConsumeIfNeeded(any(), any(), any(), any(), captureLambda(), any())
+            } answers {
+                lambda<SuccessfulPurchaseCallback>().captured.invoke(
+                    firstArg(),
+                    mockInfo
+                )
+            }
+            every {
+                postTokenWithoutConsuming(any(), any(), any(), any(), any(), any(), captureLambda(), any())
+            } answers {
+                lambda<() -> Unit>().captured.invoke()
+            }
+        }
+    }
+
+    private fun mockCache() {
+        with(mockCache) {
+            every {
+                getCachedAppUserID()
+            } returns null
+            every {
+                getCachedCustomerInfo(any())
+            } returns mockInfo
+            every {
+                cacheCustomerInfo(any(), any())
+            } just Runs
+            every {
+                cacheAppUserID(any())
+            } just Runs
+            every {
+                setCustomerInfoCacheTimestampToNow(appUserId)
+            } just Runs
+            every {
+                setOfferingsCacheTimestampToNow()
+            } just Runs
+            every {
+                clearCustomerInfoCacheTimestamp(appUserId)
+            } just Runs
+            every {
+                clearCustomerInfoCache(appUserId)
+            } just Runs
+            every {
+                clearOfferingsCacheTimestamp()
+            } just Runs
+            every {
+                isCustomerInfoCacheStale(appUserId, any())
+            } returns false
+            every {
+                isOfferingsCacheStale(any())
+            } returns false
+            every {
+                addSuccessfullyPostedToken(any())
+            } just Runs
+            every {
+                mockCache.cacheOfferings(any())
+            } just Runs
+        }
+    }
+
+    private fun mockSubscriberAttributesManager() {
+        every {
+            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(appUserId)
+        } just Runs
+    }
+    // endregion
+
+    // region Protected methods
+    protected fun mockCustomerInfoHelper(errorGettingCustomerInfo: PurchasesError? = null) {
+        with(mockCustomerInfoHelper) {
+            every {
+                retrieveCustomerInfo(any(), any(), false, any())
+            } answers {
+                val callback = arg<ReceiveCustomerInfoCallback?>(3)
+                if (errorGettingCustomerInfo == null) {
+                    callback?.onReceived(mockInfo)
+                } else {
+                    callback?.onError(errorGettingCustomerInfo)
+                }
+            }
+            every {
+                cacheCustomerInfo(any())
+            } just runs
+            every {
+                sendUpdatedCustomerInfoToDelegateIfChanged(any())
+            } just runs
+            every {
+                updatedCustomerInfoListener = any()
+            } just runs
+            every {
+                updatedCustomerInfoListener
+            } returns null
+        }
+    }
+
+    protected fun mockProducts(response: String = ONE_OFFERINGS_RESPONSE) {
+        every {
+            mockBackend.getOfferings(any(), any(), captureLambda(), any())
+        } answers {
+            lambda<(JSONObject) -> Unit>().captured.invoke(JSONObject(response))
+        }
+    }
+
+    protected fun mockStoreProduct(
+        productIds: List<String>,
+        productIdsSuccessfullyFetched: List<String>,
+        type: ProductType
+    ): List<StoreProduct> {
+        val storeProducts = productIdsSuccessfullyFetched.map { productId ->
+            if (type == ProductType.SUBS) stubStoreProduct(productId, stubSubscriptionOption("p1m", "P1M"))
+            else createMockOneTimeProductDetails(productId).toInAppStoreProduct()
+        }.mapNotNull { it }
+
+        every {
+            mockBillingAbstract.queryProductDetailsAsync(
+                type,
+                productIds.toSet(),
+                captureLambda(),
+                any()
+            )
+        } answers {
+            lambda<(List<StoreProduct>) -> Unit>().captured.invoke(storeProducts)
+        }
+        return storeProducts
+    }
+
+    protected fun getMockedStoreTransaction(
+        productId: String,
+        purchaseToken: String,
+        productType: ProductType
+    ): StoreTransaction {
+        val p: PurchaseHistoryRecord = stubPurchaseHistoryRecord(
+            productIds = listOf(productId),
+            purchaseToken = purchaseToken
+        )
+
+        return p.toStoreTransaction(productType)
+    }
+
+    protected fun buildPurchases(anonymous: Boolean, autoSync: Boolean = true) {
+        purchases = Purchases(
+            mockApplication,
+            if (anonymous) null else appUserId,
+            mockBackend,
+            mockBillingAbstract,
+            mockCache,
+            dispatcher = SyncDispatcher(),
+            identityManager = mockIdentityManager,
+            subscriberAttributesManager = mockSubscriberAttributesManager,
+            appConfig = AppConfig(
+                context = mockContext,
+                observerMode = false,
+                platformInfo = PlatformInfo("native", "3.2.0"),
+                proxyURL = null,
+                store = Store.PLAY_STORE,
+                dangerousSettings = DangerousSettings(autoSyncPurchases = autoSync)
+            ),
+            customerInfoHelper = mockCustomerInfoHelper,
+            offeringParser = OfferingParserFactory.createOfferingParser(Store.PLAY_STORE),
+            diagnosticsSynchronizer = mockDiagnosticsSynchronizer,
+            offlineEntitlementsManager = mockOfflineEntitlementsManager,
+            postReceiptHelper = mockPostReceiptHelper
+        )
+        Purchases.sharedInstance = purchases
+        purchases.state = purchases.state.copy(appInBackground = false)
+    }
+
+    protected fun anonymousSetup(anonymous: Boolean) {
+        val userIdToUse = if (anonymous) randomAppUserId else appUserId
+
+        every {
+            mockIdentityManager.currentAppUserID
+        } returns userIdToUse
+
+        every {
+            mockIdentityManager.currentUserIsAnonymous()
+        } returns anonymous
+
+        buildPurchases(anonymous)
+        mockSubscriberAttributesManager()
+    }
+
+    protected fun mockCacheStale(
+        customerInfoStale: Boolean = false,
+        offeringsStale: Boolean = false,
+        appInBackground: Boolean = false
+    ) {
+        every {
+            mockCache.isCustomerInfoCacheStale(appUserId, appInBackground)
+        } returns customerInfoStale
+        every {
+            mockCache.isOfferingsCacheStale(appInBackground)
+        } returns offeringsStale
+    }
+
+    // endregion
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -2433,7 +2433,7 @@ class PurchasesTest: BasePurchasesTest() {
 
     @Test
     fun `logOut clears backend caches when successful`() {
-        setup()
+        setUp()
 
         every {
             mockCache.cleanupOldAttributionData()

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -3346,6 +3346,8 @@ class PurchasesTest: BasePurchasesTest() {
             notInCache = listOf(activePurchasedPurchase, activePendingPurchase, activeUnspecifiedPurchase)
         )
 
+        mockQueryingProductDetails("product", ProductType.SUBS, null)
+
         every {
             mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(any(), any(), any(), any(), null, null)
         } just Runs

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -97,37 +97,10 @@ import kotlin.random.Random
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 @Suppress("DEPRECATION")
-class PurchasesTest {
-    private val mockBillingAbstract: BillingAbstract = mockk()
-    private val mockBackend: Backend = mockk()
-    private val mockCache: DeviceCache = mockk()
-    private val updatedCustomerInfoListener: UpdatedCustomerInfoListener = mockk()
-    private val mockApplication = mockk<Application>(relaxed = true)
-    private val mockContext = mockk<Context>(relaxed = true).apply {
-        every {
-            applicationContext
-        } returns mockApplication
-    }
+class PurchasesTest: BasePurchasesTest() {
     private val mockActivity: Activity = mockk()
-    private val mockIdentityManager = mockk<IdentityManager>()
-    private val mockSubscriberAttributesManager = mockk<SubscriberAttributesManager>()
-    private val mockCustomerInfoHelper = mockk<CustomerInfoHelper>()
-    lateinit var mockOfferingParser: OfferingParser
-    private val mockDiagnosticsSynchronizer = mockk<DiagnosticsSynchronizer>()
-    private val mockOfflineEntitlementsManager = mockk<OfflineEntitlementsManager>()
-    private val mockPostReceiptHelper = mockk<PostReceiptHelper>()
-
-    private var capturedPurchasesUpdatedListener = slot<BillingAbstract.PurchasesUpdatedListener>()
-    private var capturedBillingWrapperStateListener = slot<BillingAbstract.StateListener>()
-    private val capturedConsumePurchaseWrapper = slot<StoreTransaction>()
-    private val capturedShouldTryToConsume = slot<Boolean>()
-
-    private val randomAppUserId = "\$RCAnonymousID:ff68f26e432648369a713849a9f93b58"
-    private val appUserId = "fakeUserID"
-    private lateinit var purchases: Purchases
     private var receivedProducts: List<StoreProduct>? = null
     private var receivedOfferings: Offerings? = null
-    private val mockInfo = mockk<CustomerInfo>()
 
     private val oneOfferingWithNoProductsResponse = "{'offerings': [" +
         "{'identifier': '$STUB_OFFERING_IDENTIFIER', " +
@@ -143,43 +116,7 @@ class PurchasesTest {
 
     private val mockLifecycle = mockk<Lifecycle>()
     private val mockLifecycleOwner = mockk<LifecycleOwner>()
-
-    @After
-    fun tearDown() {
-        Purchases.backingFieldSharedInstance = null
-        clearMocks(mockCustomerInfoHelper, mockPostReceiptHelper)
-    }
-
-    @Before
-    fun setup() {
-        mockkStatic(ProcessLifecycleOwner::class)
-
-        val productIds = listOf(STUB_PRODUCT_IDENTIFIER)
-        mockCache()
-        mockPostReceiptHelper()
-        mockBackend()
-        mockBillingWrapper()
-        mockStoreProduct(productIds, productIds, ProductType.SUBS)
-        mockCustomerInfoHelper()
-
-        every {
-            updatedCustomerInfoListener.onReceived(any())
-        } just Runs
-        every {
-            mockIdentityManager.configure(any())
-        } just Runs
-        every {
-            mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
-        } just Runs
-        every {
-            mockOfflineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
-        } just Runs
-
-        anonymousSetup(false)
-    }
-
-    // region setup
-
+    
     @Test
     fun canBeCreated() {
         assertThat(purchases).isNotNull
@@ -3408,7 +3345,6 @@ class PurchasesTest {
             queriedINAPP = emptyMap(),
             notInCache = listOf(activePurchasedPurchase, activePendingPurchase, activeUnspecifiedPurchase)
         )
-        val productInfo = mockQueryingProductDetails("product", ProductType.SUBS, null)
 
         every {
             mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(any(), any(), any(), any(), null, null)
@@ -3624,62 +3560,6 @@ class PurchasesTest {
         return builder!!.build()
     }
 
-    private fun mockBillingWrapper() {
-        with(mockBillingAbstract) {
-            every {
-                makePurchaseAsync(any(), any(), any(), any(), any(), any())
-            } just Runs
-            every {
-                purchasesUpdatedListener = capture(capturedPurchasesUpdatedListener)
-            } just Runs
-            every {
-                consumeAndSave(capture(capturedShouldTryToConsume), capture(capturedConsumePurchaseWrapper))
-            } just Runs
-            every {
-                purchasesUpdatedListener = null
-            } just Runs
-            every {
-                stateListener = capture(capturedBillingWrapperStateListener)
-            } just Runs
-            every {
-                isConnected()
-            } returns true
-
-            every {
-                close()
-            } answers {
-                purchasesUpdatedListener = null
-            }
-        }
-    }
-
-    private fun mockCustomerInfoHelper(errorGettingCustomerInfo: PurchasesError? = null) {
-        with(mockCustomerInfoHelper) {
-            every {
-                retrieveCustomerInfo(any(), any(), false, any())
-            } answers {
-                val callback = arg<ReceiveCustomerInfoCallback?>(3)
-                if (errorGettingCustomerInfo == null) {
-                    callback?.onReceived(mockInfo)
-                } else {
-                    callback?.onError(errorGettingCustomerInfo)
-                }
-            }
-            every {
-                cacheCustomerInfo(any())
-            } just runs
-            every {
-                sendUpdatedCustomerInfoToDelegateIfChanged(any())
-            } just runs
-            every {
-                updatedCustomerInfoListener = any()
-            } just runs
-            every {
-                updatedCustomerInfoListener
-            } returns null
-        }
-    }
-
 //    private fun mockOfferingsParser() {
 //        with(mockOfferingParser) {
 //            every {
@@ -3706,111 +3586,6 @@ class PurchasesTest {
 //            } returns null
 //        }
 //    }
-
-    private fun mockBackend() {
-        with(mockBackend) {
-            mockProducts()
-            every {
-                close()
-            } just Runs
-            every {
-                clearCaches()
-            } just Runs
-        }
-    }
-
-    private fun mockPostReceiptHelper() {
-        with(mockPostReceiptHelper) {
-            every {
-                postTransactionAndConsumeIfNeeded(any(), any(), any(), any(), captureLambda(), any())
-            } answers {
-                lambda<SuccessfulPurchaseCallback>().captured.invoke(
-                    firstArg(),
-                    mockInfo
-                )
-            }
-            every {
-                postTokenWithoutConsuming(any(), any(), any(), any(), any(), any(), captureLambda(), any())
-            } answers {
-                lambda<() -> Unit>().captured.invoke()
-            }
-        }
-    }
-
-    private fun mockCache() {
-        with(mockCache) {
-            every {
-                getCachedAppUserID()
-            } returns null
-            every {
-                getCachedCustomerInfo(any())
-            } returns mockInfo
-            every {
-                cacheCustomerInfo(any(), any())
-            } just Runs
-            every {
-                cacheAppUserID(any())
-            } just Runs
-            every {
-                setCustomerInfoCacheTimestampToNow(appUserId)
-            } just Runs
-            every {
-                setOfferingsCacheTimestampToNow()
-            } just Runs
-            every {
-                clearCustomerInfoCacheTimestamp(appUserId)
-            } just Runs
-            every {
-                clearCustomerInfoCache(appUserId)
-            } just Runs
-            every {
-                clearOfferingsCacheTimestamp()
-            } just Runs
-            every {
-                isCustomerInfoCacheStale(appUserId, any())
-            } returns false
-            every {
-                isOfferingsCacheStale(any())
-            } returns false
-            every {
-                addSuccessfullyPostedToken(any())
-            } just Runs
-            every {
-                mockCache.cacheOfferings(any())
-            } just Runs
-        }
-    }
-
-    private fun mockProducts(response: String = ONE_OFFERINGS_RESPONSE) {
-        every {
-            mockBackend.getOfferings(any(), any(), captureLambda(), any())
-        } answers {
-            lambda<(JSONObject) -> Unit>().captured.invoke(JSONObject(response))
-        }
-    }
-
-    private fun mockStoreProduct(
-        productIds: List<String>,
-        productIdsSuccessfullyFetched: List<String>,
-        type: ProductType
-    ): List<StoreProduct> {
-        val storeProducts = productIdsSuccessfullyFetched.map { productId ->
-            if (type == ProductType.SUBS) stubStoreProduct(productId, stubSubscriptionOption("p1m", "P1M"))
-            else createMockOneTimeProductDetails(productId).toInAppStoreProduct()
-        }.mapNotNull { it }
-
-        every {
-            mockBillingAbstract.queryProductDetailsAsync(
-                type,
-                productIds.toSet(),
-                captureLambda(),
-                any()
-            )
-        } answers {
-            lambda<(List<StoreProduct>) -> Unit>().captured.invoke(storeProducts)
-        }
-        return storeProducts
-    }
 
     private fun mockCloseActions() {
         every {
@@ -3853,19 +3628,6 @@ class PurchasesTest {
         val purchaseHistoryRecordWrapper =
             getMockedStoreTransaction(productId, purchaseToken, productType)
         return listOf(purchaseHistoryRecordWrapper)
-    }
-
-    private fun getMockedStoreTransaction(
-        productId: String,
-        purchaseToken: String,
-        productType: ProductType
-    ): StoreTransaction {
-        val p: PurchaseHistoryRecord = stubPurchaseHistoryRecord(
-            productIds = listOf(productId),
-            purchaseToken = purchaseToken
-        )
-
-        return p.toStoreTransaction(productType)
     }
 
     private fun getMockedPurchaseList(
@@ -3911,34 +3673,6 @@ class PurchasesTest {
         } answers {
             lambda<(Map<String, StoreTransaction>) -> Unit>().captured(purchasesByHashedToken)
         }
-    }
-
-    private fun buildPurchases(anonymous: Boolean, autoSync: Boolean = true) {
-        purchases = Purchases(
-            mockApplication,
-            if (anonymous) null else appUserId,
-            mockBackend,
-            mockBillingAbstract,
-            mockCache,
-            dispatcher = SyncDispatcher(),
-            identityManager = mockIdentityManager,
-            subscriberAttributesManager = mockSubscriberAttributesManager,
-            appConfig = AppConfig(
-                context = mockContext,
-                observerMode = false,
-                platformInfo = PlatformInfo("native", "3.2.0"),
-                proxyURL = null,
-                store = Store.PLAY_STORE,
-                dangerousSettings = DangerousSettings(autoSyncPurchases = autoSync)
-            ),
-            customerInfoHelper = mockCustomerInfoHelper,
-            offeringParser = OfferingParserFactory.createOfferingParser(Store.PLAY_STORE),
-            diagnosticsSynchronizer = mockDiagnosticsSynchronizer,
-            offlineEntitlementsManager = mockOfflineEntitlementsManager,
-            postReceiptHelper = mockPostReceiptHelper
-        )
-        Purchases.sharedInstance = purchases
-        purchases.state = purchases.state.copy(appInBackground = false)
     }
 
     private fun Int.buildResult(): BillingResult {
@@ -3993,25 +3727,6 @@ class PurchasesTest {
         }
 
         return receiptInfo
-    }
-
-    private fun mockCacheStale(
-        customerInfoStale: Boolean = false,
-        offeringsStale: Boolean = false,
-        appInBackground: Boolean = false
-    ) {
-        every {
-            mockCache.isCustomerInfoCacheStale(appUserId, appInBackground)
-        } returns customerInfoStale
-        every {
-            mockCache.isOfferingsCacheStale(appInBackground)
-        } returns offeringsStale
-    }
-
-    private fun mockSubscriberAttributesManager() {
-        every {
-            mockSubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(appUserId)
-        } just Runs
     }
 
     private fun mockPurchaseFound(error: PurchasesError? = null): StoreTransaction {
@@ -4073,20 +3788,6 @@ class PurchasesTest {
         }
     }
 
-    private fun anonymousSetup(anonymous: Boolean) {
-        val userIdToUse = if (anonymous) randomAppUserId else appUserId
+    // endregion
 
-        every {
-            mockIdentityManager.currentAppUserID
-        } returns userIdToUse
-
-        every {
-            mockIdentityManager.currentUserIsAnonymous()
-        } returns anonymous
-
-        buildPurchases(anonymous)
-        mockSubscriberAttributesManager()
-    }
-
-// endregion
 }


### PR DESCRIPTION
Extracted `setup` and `tearDown` from `PurchasesTest.kt` so it's easier not only to split `Purchases.kt` into different test files, but also it's easier to create new tests that depend on creation of a `Purchases` object.