### PR TITLE
Disable offline entitlements in observer mode

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -96,6 +96,8 @@ class OfflineEntitlementsManager(
         }
     }
 
+    // We disable offline entitlements in observer mode (finishTransactions = true) since it doesn't
+    // provide any value and simplifies operations in that mode.
     private fun isOfflineEntitlementsEnabled() = appConfig.finishTransactions
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -128,7 +128,8 @@ internal class PurchasesFactory(
             val offlineEntitlementsManager = OfflineEntitlementsManager(
                 backend,
                 offlineCustomerInfoCalculator,
-                cache
+                cache,
+                appConfig
             )
 
             val identityManager = IdentityManager(


### PR DESCRIPTION
### Description
SDK-3139

This PR will disable offline entitlements entirely in observer mode. We won't update the product-entitlement cache either. This feature doesn't provide any value for users in observer mode so can disable it for them without consequences.