### PR TITLE
Perform product entitlement mapping request after more critical requests

### DIFF
--- a/common/src/defaults/kotlin/com/revenuecat/purchases/common/DispatcherConstants.kt
+++ b/common/src/defaults/kotlin/com/revenuecat/purchases/common/DispatcherConstants.kt
@@ -1,0 +1,8 @@
+package com.revenuecat.purchases.common
+
+import kotlin.time.Duration.Companion.milliseconds
+
+object DispatcherConstants {
+    val jitterDelay = 5000L.milliseconds
+    val jitterLongDelay = 10000L.milliseconds
+}

--- a/common/src/defaults/kotlin/com/revenuecat/purchases/common/DispatcherConstants.kt
+++ b/common/src/defaults/kotlin/com/revenuecat/purchases/common/DispatcherConstants.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.common
 
 import kotlin.time.Duration.Companion.milliseconds
 
+// These values are modified in the `integrationTest` flavor to make the tests run faster.
 object DispatcherConstants {
     val jitterDelay = 5000L.milliseconds
     val jitterLongDelay = 10000L.milliseconds

--- a/common/src/integrationTest/kotlin/com/revenuecat/purchases/common/DispatcherConstants.kt
+++ b/common/src/integrationTest/kotlin/com/revenuecat/purchases/common/DispatcherConstants.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.common
 
 import kotlin.time.Duration.Companion.milliseconds
 
+// These values are reduced from the values used in the original code to make the tests run faster.
 object DispatcherConstants {
     val jitterDelay = 500L.milliseconds
     val jitterLongDelay = 1000L.milliseconds

--- a/common/src/integrationTest/kotlin/com/revenuecat/purchases/common/DispatcherConstants.kt
+++ b/common/src/integrationTest/kotlin/com/revenuecat/purchases/common/DispatcherConstants.kt
@@ -1,0 +1,8 @@
+package com.revenuecat.purchases.common
+
+import kotlin.time.Duration.Companion.milliseconds
+
+object DispatcherConstants {
+    val jitterDelay = 500L.milliseconds
+    val jitterLongDelay = 1000L.milliseconds
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Backend.kt
@@ -454,7 +454,7 @@ class Backend(
                 dispatcher,
                 path,
                 onSuccessHandler to onErrorHandler,
-                Delay.DEFAULT
+                Delay.LONG
             )
         }
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/Dispatcher.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Dispatcher.kt
@@ -60,7 +60,6 @@ open class Dispatcher(
             if (!executorService.isShutdown) {
                 val future = if (delay != Delay.NONE && executorService is ScheduledExecutorService) {
                     val delayToApply = (delay.minDelay.inWholeMilliseconds..delay.maxDelay.inWholeMilliseconds).random()
-                    errorLog("TEST: EXECUTING REQUEST WITH DELAY: $delayToApply")
                     executorService.schedule(command, delayToApply, TimeUnit.MILLISECONDS)
                 } else {
                     executorService.submit(command)

--- a/common/src/main/java/com/revenuecat/purchases/common/Dispatcher.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/Dispatcher.kt
@@ -16,13 +16,10 @@ import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
-private const val JITTERING_DELAY_MILLISECONDS = 5000L
-private const val JITTERING_LONG_DELAY_MILLISECONDS = 10000L
-
 enum class Delay(val minDelay: Duration, val maxDelay: Duration) {
     NONE(0.milliseconds, 0.milliseconds),
-    DEFAULT(0.milliseconds, JITTERING_DELAY_MILLISECONDS.milliseconds),
-    LONG(JITTERING_DELAY_MILLISECONDS.milliseconds, JITTERING_LONG_DELAY_MILLISECONDS.milliseconds)
+    DEFAULT(0.milliseconds, DispatcherConstants.jitterDelay),
+    LONG(DispatcherConstants.jitterDelay, DispatcherConstants.jitterLongDelay)
 }
 
 open class Dispatcher(

--- a/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -1931,7 +1931,7 @@ class BackendTest {
     }
 
     @Test
-    fun `getProductEntitlementMapping call is enqueued with default delay`() {
+    fun `getProductEntitlementMapping call is enqueued with long delay`() {
         mockResponse(
             endpoint = productEntitlementMappingEndpoint,
             body = null,
@@ -1948,7 +1948,7 @@ class BackendTest {
 
         val calledDelay = dispatcher.calledDelay
         assertThat(calledDelay).isNotNull
-        assertThat(calledDelay).isEqualTo(Delay.DEFAULT)
+        assertThat(calledDelay).isEqualTo(Delay.LONG)
     }
 
     // endregion

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -40,7 +40,7 @@ open class BasePurchasesIntegrationTest {
     protected open val initialActivePurchasesToUse: Map<String, StoreTransaction> = emptyMap()
     protected open val initialForceServerErrors: Boolean = false
 
-    protected val testTimeout = 7.seconds
+    protected val testTimeout = 15.seconds
     protected val currentTimestamp = Date().time
     protected val testUserId = "android-integration-test-$currentTimestamp"
     protected val proxyUrl = Constants.proxyUrl.takeIf { it != "NO_PROXY_URL" }

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -40,7 +40,7 @@ open class BasePurchasesIntegrationTest {
     protected open val initialActivePurchasesToUse: Map<String, StoreTransaction> = emptyMap()
     protected open val initialForceServerErrors: Boolean = false
 
-    protected val testTimeout = 15.seconds
+    protected val testTimeout = 5.seconds
     protected val currentTimestamp = Date().time
     protected val testUserId = "android-integration-test-$currentTimestamp"
     protected val proxyUrl = Constants.proxyUrl.takeIf { it != "NO_PROXY_URL" }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -173,7 +173,6 @@ class Purchases internal constructor(
             log(LogIntent.WARNING, AUTO_SYNC_PURCHASES_DISABLED)
         }
 
-        offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
     }
 
@@ -203,9 +202,9 @@ class Purchases internal constructor(
             )
         }
         offeringsManager.onAppForeground(identityManager.currentAppUserID)
-        offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         updatePendingPurchaseQueue()
         synchronizeSubscriberAttributesIfNeeded()
+        offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
     }
 
     // region Public Methods

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -108,11 +108,6 @@ class PurchasesTest: BasePurchasesTest() {
     }
 
     @Test
-    fun `product entitlement mappings are updated if staled on constructor`() {
-        verify(exactly = 1) { mockOfflineEntitlementsManager.updateProductEntitlementMappingCacheIfStale() }
-    }
-
-    @Test
     fun getsSubscriptionSkus() {
         val skus = listOf("onemonth_freetrial")
 
@@ -1537,7 +1532,7 @@ class PurchasesTest: BasePurchasesTest() {
         )
         mockOfferingsManagerAppForeground()
         Purchases.sharedInstance.onAppForegrounded()
-        verify(exactly = 2) {
+        verify(exactly = 1) {
             mockOfflineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         }
     }


### PR DESCRIPTION
### Description
The product entitlement mapping info is not critical most times, so we can perform it as the last step when initializing the SDK as a small optimization.
