### PR TITLE
Add setting to disable offline entitlememnts to DangerousSettings

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -8,7 +8,7 @@ import androidx.annotation.Nullable;
 
 import com.revenuecat.purchases.CacheFetchPolicy;
 import com.revenuecat.purchases.CustomerInfo;
-import com.revenuecat.purchases.EntitlementVerificationMode;
+import com.revenuecat.purchases.DangerousSettings;
 import com.revenuecat.purchases.LogHandler;
 import com.revenuecat.purchases.LogLevel;
 import com.revenuecat.purchases.Offerings;
@@ -173,8 +173,19 @@ final class PurchasesAPI {
         purchases.setCreative("");
     }
 
+    static void checkDangerousSettings(final Boolean autoSyncPurchases,
+                                       final Boolean offlineEntitlementsEnabled) {
+        final DangerousSettings dangerousSettings = new DangerousSettings(
+                autoSyncPurchases,
+                offlineEntitlementsEnabled
+        );
+        final DangerousSettings dangerousSettings2 = new DangerousSettings(autoSyncPurchases);
+        final DangerousSettings dangerousSettings3 = new DangerousSettings();
+    }
+
     static void checkConfiguration(final Context context,
-                                   final ExecutorService executorService) throws MalformedURLException {
+                                   final ExecutorService executorService,
+                                   final DangerousSettings dangerousSettings) throws MalformedURLException {
         final List<? extends BillingFeature> features = new ArrayList<>();
 
         final boolean configured = Purchases.isConfigured();
@@ -185,6 +196,7 @@ final class PurchasesAPI {
                 .observerMode(false)
                 .service(executorService)
                 .diagnosticsEnabled(true)
+                .dangerousSettings(dangerousSettings)
                 // Trusted entitlements: Commented out until ready to be made public
                 // .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
                 .build();

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import com.revenuecat.purchases.CacheFetchPolicy
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.DangerousSettings
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Offerings
@@ -199,8 +200,22 @@ private class PurchasesAPI {
         }
     }
 
+    fun checkDangerousSettings(autoSyncPurchases: Boolean, offlineEntitlementsEnabled: Boolean) {
+        val dangerousSettings = DangerousSettings(
+            autoSyncPurchases = autoSyncPurchases,
+            offlineEntitlementsEnabled = offlineEntitlementsEnabled
+        )
+        val dangerousSettings2 = DangerousSettings(
+            autoSyncPurchases = autoSyncPurchases
+        )
+        val dangerousSettings3 = DangerousSettings(
+            offlineEntitlementsEnabled = offlineEntitlementsEnabled
+        )
+        val dangerousSettings4 = DangerousSettings()
+    }
+
     @Suppress("RemoveRedundantQualifierName", "RedundantLambdaArrow", "ForbiddenComment")
-    fun checkConfiguration(context: Context, executorService: ExecutorService) {
+    fun checkConfiguration(context: Context, executorService: ExecutorService, dangerousSettings: DangerousSettings) {
         val features: List<BillingFeature> = ArrayList()
         val configured: Boolean = Purchases.isConfigured
 
@@ -210,6 +225,7 @@ private class PurchasesAPI {
             .observerMode(false)
             .service(executorService)
             .diagnosticsEnabled(true)
+            .dangerousSettings(dangerousSettings)
             // Trusted entitlements: Commented out until ready to be made public
             // .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
             .build()

--- a/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
@@ -13,7 +13,7 @@ class AppConfig(
     val platformInfo: PlatformInfo,
     proxyURL: URL?,
     val store: Store,
-    val dangerousSettings: DangerousSettings = DangerousSettings(autoSyncPurchases = true),
+    val dangerousSettings: DangerousSettings = DangerousSettings(),
     // Should only be used for tests
     var forceServerErrors: Boolean = false
 ) {

--- a/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -102,7 +102,8 @@ class OfflineEntitlementsManager(
 
     // We disable offline entitlements in observer mode (finishTransactions = true) since it doesn't
     // provide any value and simplifies operations in that mode.
-    private fun isOfflineEntitlementsEnabled() = appConfig.finishTransactions
+    private fun isOfflineEntitlementsEnabled() = appConfig.finishTransactions &&
+        appConfig.dangerousSettings.offlineEntitlementsEnabled
 }
 
 private typealias OfflineCustomerInfoCallback = Pair<(CustomerInfo) -> Unit, (PurchasesError) -> Unit>

--- a/common/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -263,7 +263,7 @@ class AppConfigTest {
             "AppConfig(" +
                 "platformInfo=PlatformInfo(flavor=native, version=3.2.0), " +
                 "store=PLAY_STORE, " +
-                "dangerousSettings=DangerousSettings(autoSyncPurchases=true), " +
+                "dangerousSettings=DangerousSettings(autoSyncPurchases=true, offlineEntitlementsEnabled=true), " +
                 "languageTag='', " +
                 "versionName='', " +
                 "packageName='', " +

--- a/public/src/main/java/com/revenuecat/purchases/DangerousSettings.kt
+++ b/public/src/main/java/com/revenuecat/purchases/DangerousSettings.kt
@@ -9,5 +9,18 @@ data class DangerousSettings(
      * automatically, and you will have to call syncPurchases whenever a new purchase is completed in order to send it
      * to the RevenueCat's backend. Auto syncing of purchases is enabled by default.
      */
-    val autoSyncPurchases: Boolean = true
-)
+    val autoSyncPurchases: Boolean = true,
+
+    /**
+     * Disable or enable offline entitlements. If this is disabled, RevenueCat will not try to provide entitlements in
+     * the unlikely case of an outage in our servers. This will prevent entitlements from being available for your
+     * users during an outage. This is enabled by default.
+     */
+    val offlineEntitlementsEnabled: Boolean = DEFAULT_OFFLINE_ENTITLEMENTS_ENABLED
+) {
+    companion object {
+        private const val DEFAULT_OFFLINE_ENTITLEMENTS_ENABLED = true
+    }
+
+    constructor(autoSyncPurchases: Boolean) : this(autoSyncPurchases, DEFAULT_OFFLINE_ENTITLEMENTS_ENABLED)
+}


### PR DESCRIPTION
### Description
This PR adds an option to disable offline entitlements in dangerous settings. This setting will disable getting the product-entitlement mapping + calculating offline customer info. This shouldn't be needed but we are adding it in a just in case basis.