### PR TITLE
Fix integration tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -451,6 +451,15 @@ workflows:
       - detekt
       - assemble-sample-app
       - run-backend-integration-tests
+      - integration-tests-build
+      - purchases-integration-tests-build
+      - run-firebase-tests-purchases-integration-test:
+          requires:
+            - purchases-integration-tests-build
+      - run-firebase-tests-purchases-load-shedder-integration-test
+      - run-firebase-tests:
+          requires:
+            - integration-tests-build
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -451,15 +451,6 @@ workflows:
       - detekt
       - assemble-sample-app
       - run-backend-integration-tests
-      - integration-tests-build
-      - purchases-integration-tests-build
-      - run-firebase-tests-purchases-integration-test:
-          requires:
-            - purchases-integration-tests-build
-      - run-firebase-tests-purchases-load-shedder-integration-test
-      - run-firebase-tests:
-          requires:
-            - integration-tests-build
 
   deploy:
     when:

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/offlineentitlements/BaseOfflineEntitlementsIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/offlineentitlements/BaseOfflineEntitlementsIntegrationTest.kt
@@ -19,6 +19,7 @@ abstract class BaseOfflineEntitlementsIntegrationTest : BasePurchasesIntegration
     protected val initialActivePurchases = mapOf(
         initialActiveTransaction.purchaseToken.sha1() to initialActiveTransaction
     )
+    private val entitlementsToGrant = listOf("pro_cat", "another_pro_4")
 
     // region helpers
 
@@ -38,7 +39,7 @@ abstract class BaseOfflineEntitlementsIntegrationTest : BasePurchasesIntegration
 
     protected fun assertCustomerInfoHasExpectedPurchaseData(customerInfo: CustomerInfo) {
         Assertions.assertThat(customerInfo.entitlements.active.keys).containsExactlyInAnyOrderElementsOf(
-            entitlementsToVerify
+            entitlementsToGrant
         )
         Assertions.assertThat(customerInfo.activeSubscriptions).containsExactly(
             "${Constants.productIdToPurchase}:${Constants.basePlanIdToPurchase}"

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/offlineentitlements/BaseOfflineEntitlementsIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/offlineentitlements/BaseOfflineEntitlementsIntegrationTest.kt
@@ -19,7 +19,7 @@ abstract class BaseOfflineEntitlementsIntegrationTest : BasePurchasesIntegration
     protected val initialActivePurchases = mapOf(
         initialActiveTransaction.purchaseToken.sha1() to initialActiveTransaction
     )
-    private val entitlementsToGrant = listOf("pro_cat", "another_pro_4")
+    private val expectedEntitlements = listOf("pro_cat", "another_pro_4")
 
     // region helpers
 
@@ -39,7 +39,7 @@ abstract class BaseOfflineEntitlementsIntegrationTest : BasePurchasesIntegration
 
     protected fun assertCustomerInfoHasExpectedPurchaseData(customerInfo: CustomerInfo) {
         Assertions.assertThat(customerInfo.entitlements.active.keys).containsExactlyInAnyOrderElementsOf(
-            entitlementsToGrant
+            expectedEntitlements
         )
         Assertions.assertThat(customerInfo.activeSubscriptions).containsExactly(
             "${Constants.productIdToPurchase}:${Constants.basePlanIdToPurchase}"


### PR DESCRIPTION
### Description
After adding the integration tests for offline entitlements in #1006, I was testing running each set of tests separately. However, I was changing the parameters we use to run integration tests between normal integration tests and the offline entitlement tests in order to make them pass. In order to make them compatible, I'm just hardcoding the entitlements we verify are granted after purchases during offline entitlements integration tests.