### PR TITLE
Refactor offerings code out of Purchases

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/GoogleOfferingParser.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/GoogleOfferingParser.kt
@@ -1,7 +1,6 @@
-package com.revenuecat.purchases.google
+package com.revenuecat.purchases.common
 
 import com.revenuecat.purchases.ProductType
-import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.models.StoreProduct
 import org.json.JSONObject
 

--- a/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
@@ -1,0 +1,127 @@
+package com.revenuecat.purchases.common.offerings
+
+import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.common.BillingAbstract
+import com.revenuecat.purchases.common.LogIntent
+import com.revenuecat.purchases.common.OfferingParser
+import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.strings.OfferingStrings
+import org.json.JSONException
+import org.json.JSONObject
+
+class OfferingsFactory(
+    private val billing: BillingAbstract,
+    private val offeringParser: OfferingParser
+) {
+
+    fun createOfferings(
+        offeringsJSON: JSONObject,
+        onError: (PurchasesError) -> Unit,
+        onSuccess: (Offerings) -> Unit
+    ) {
+        try {
+            val allRequestedProductIdentifiers = extractProductIdentifiers(offeringsJSON)
+            if (allRequestedProductIdentifiers.isEmpty()) {
+                onError(
+                    PurchasesError(
+                        PurchasesErrorCode.ConfigurationError,
+                        OfferingStrings.CONFIGURATION_ERROR_NO_PRODUCTS_FOR_OFFERINGS
+                    )
+                )
+            } else {
+                getStoreProductsById(allRequestedProductIdentifiers, { productsById ->
+                    logMissingProducts(allRequestedProductIdentifiers, productsById)
+
+                    val offerings = offeringParser.createOfferings(offeringsJSON, productsById)
+                    if (offerings.all.isEmpty()) {
+                        onError(
+                            PurchasesError(
+                                PurchasesErrorCode.ConfigurationError,
+                                OfferingStrings.CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND
+                            )
+                        )
+                    } else {
+                        onSuccess(offerings)
+                    }
+                }, { error ->
+                    onError(error)
+                })
+            }
+        } catch (error: JSONException) {
+            log(LogIntent.RC_ERROR, OfferingStrings.JSON_EXCEPTION_ERROR.format(error.localizedMessage))
+            onError(
+                PurchasesError(
+                    PurchasesErrorCode.UnexpectedBackendResponseError,
+                    error.localizedMessage
+                )
+            )
+        }
+    }
+
+    private fun extractProductIdentifiers(offeringsJSON: JSONObject): Set<String> {
+        val jsonOfferingsArray = offeringsJSON.getJSONArray("offerings")
+        val productIds = mutableSetOf<String>()
+        for (i in 0 until jsonOfferingsArray.length()) {
+            val jsonPackagesArray =
+                jsonOfferingsArray.getJSONObject(i).getJSONArray("packages")
+            for (j in 0 until jsonPackagesArray.length()) {
+                jsonPackagesArray.getJSONObject(j)
+                    .optString("platform_product_identifier").takeIf { it.isNotBlank() }?.let {
+                        productIds.add(it)
+                    }
+            }
+        }
+        return productIds
+    }
+
+    private fun getStoreProductsById(
+        productIds: Set<String>,
+        onCompleted: (Map<String, List<StoreProduct>>) -> Unit,
+        onError: (PurchasesError) -> Unit
+    ) {
+        billing.queryProductDetailsAsync(
+            ProductType.SUBS,
+            productIds,
+            { subscriptionProducts ->
+                val productsById = subscriptionProducts
+                    .groupBy { subProduct -> subProduct.purchasingData.productId }
+                    .toMutableMap()
+                val subscriptionIds = productsById.keys
+
+                val inAppProductIds = productIds - subscriptionIds
+                if (inAppProductIds.isNotEmpty()) {
+                    billing.queryProductDetailsAsync(
+                        ProductType.INAPP,
+                        inAppProductIds,
+                        { inAppProducts ->
+                            productsById.putAll(inAppProducts.map { it.purchasingData.productId to listOf(it) })
+                            onCompleted(productsById)
+                        }, {
+                            onError(it)
+                        }
+                    )
+                } else {
+                    onCompleted(productsById)
+                }
+            }, {
+                onError(it)
+            })
+    }
+
+    private fun logMissingProducts(
+        allProductIdsInOfferings: Set<String>,
+        storeProductByID: Map<String, List<StoreProduct>>
+    ) = allProductIdsInOfferings
+        .filterNot { storeProductByID.containsKey(it) }
+        .takeIf { it.isNotEmpty() }
+        ?.let { missingProducts ->
+            log(
+                LogIntent.GOOGLE_WARNING, OfferingStrings.CANNOT_FIND_PRODUCT_CONFIGURATION_ERROR
+                    .format(missingProducts.joinToString(", "))
+            )
+        }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -25,6 +25,8 @@ class OfferingsManager(
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper())
 ) {
+    val cachedOfferings: Offerings?
+        get() = deviceCache.cachedOfferings
 
     fun isOfferingsCacheStale(appInBackground: Boolean) = deviceCache.isOfferingsCacheStale(appInBackground)
 

--- a/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -31,8 +31,8 @@ class OfferingsManager(
     fun fetchAndCacheOfferings(
         appUserID: String,
         appInBackground: Boolean,
-        onSuccess: ((Offerings) -> Unit)? = null,
-        onError: ((PurchasesError) -> Unit)? = null
+        onError: ((PurchasesError) -> Unit)? = null,
+        onSuccess: ((Offerings) -> Unit)? = null
     ) {
         deviceCache.setOfferingsCacheTimestampToNow()
         backend.getOfferings(

--- a/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -54,6 +54,14 @@ class OfferingsManager(
         }
     }
 
+    fun onAppForeground(appUserID: String) {
+        if (isOfferingsCacheStale(appInBackground = false)) {
+            log(LogIntent.DEBUG, OfferingStrings.OFFERINGS_STALE_UPDATING_IN_FOREGROUND)
+            fetchAndCacheOfferings(appUserID, appInBackground = false)
+            log(LogIntent.RC_SUCCESS, OfferingStrings.OFFERINGS_UPDATED_FROM_NETWORK)
+        }
+    }
+
     fun fetchAndCacheOfferings(
         appUserID: String,
         appInBackground: Boolean,

--- a/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -3,25 +3,18 @@ package com.revenuecat.purchases.common.offerings
 import android.os.Handler
 import android.os.Looper
 import com.revenuecat.purchases.Offerings
-import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.Backend
-import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.LogIntent
-import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.log
-import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.strings.OfferingStrings
-import org.json.JSONException
-import org.json.JSONObject
 
 class OfferingsManager(
     private val deviceCache: DeviceCache,
     private val backend: Backend,
-    private val billing: BillingAbstract,
-    private val offeringParser: OfferingParser,
+    private val offeringsFactory: OfferingsFactory,
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper())
 ) {
@@ -71,73 +64,26 @@ class OfferingsManager(
             appUserID,
             appInBackground,
             { offeringsJSON ->
-                try {
-                    val allRequestedProductIdentifiers = extractProductIdentifiers(offeringsJSON)
-                    if (allRequestedProductIdentifiers.isEmpty()) {
-                        handleErrorFetchingOfferings(
-                            PurchasesError(
-                                PurchasesErrorCode.ConfigurationError,
-                                OfferingStrings.CONFIGURATION_ERROR_NO_PRODUCTS_FOR_OFFERINGS
-                            ),
-                            onError
-                        )
-                    } else {
-                        getStoreProductsById(allRequestedProductIdentifiers, { productsById ->
-                            logMissingProducts(allRequestedProductIdentifiers, productsById)
-
-                            val offerings = offeringParser.createOfferings(offeringsJSON, productsById)
-                            if (offerings.all.isEmpty()) {
-                                handleErrorFetchingOfferings(
-                                    PurchasesError(
-                                        PurchasesErrorCode.ConfigurationError,
-                                        OfferingStrings.CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND
-                                    ),
-                                    onError
-                                )
-                            } else {
-                                synchronized(this@OfferingsManager) {
-                                    deviceCache.cacheOfferings(offerings)
-                                }
-                                dispatch {
-                                    onSuccess?.invoke(offerings)
-                                }
-                            }
-                        }, { error ->
-                            handleErrorFetchingOfferings(error, onError)
-                        })
+                offeringsFactory.createOfferings(
+                    offeringsJSON,
+                    onError = { error ->
+                        handleErrorFetchingOfferings(error, onError)
+                    },
+                    onSuccess = { offerings ->
+                        synchronized(this@OfferingsManager) {
+                            deviceCache.cacheOfferings(offerings)
+                        }
+                        dispatch {
+                            onSuccess?.invoke(offerings)
+                        }
                     }
-                } catch (error: JSONException) {
-                    log(LogIntent.RC_ERROR, OfferingStrings.JSON_EXCEPTION_ERROR.format(error.localizedMessage))
-                    handleErrorFetchingOfferings(
-                        PurchasesError(
-                            PurchasesErrorCode.UnexpectedBackendResponseError,
-                            error.localizedMessage
-                        ),
-                        onError
-                    )
-                }
+                )
             }, { error ->
                 handleErrorFetchingOfferings(error, onError)
             })
     }
 
     private fun isOfferingsCacheStale(appInBackground: Boolean) = deviceCache.isOfferingsCacheStale(appInBackground)
-
-    private fun extractProductIdentifiers(offeringsJSON: JSONObject): Set<String> {
-        val jsonOfferingsArray = offeringsJSON.getJSONArray("offerings")
-        val productIds = mutableSetOf<String>()
-        for (i in 0 until jsonOfferingsArray.length()) {
-            val jsonPackagesArray =
-                jsonOfferingsArray.getJSONObject(i).getJSONArray("packages")
-            for (j in 0 until jsonPackagesArray.length()) {
-                jsonPackagesArray.getJSONObject(j)
-                    .optString("platform_product_identifier").takeIf { it.isNotBlank() }?.let {
-                        productIds.add(it)
-                    }
-            }
-        }
-        return productIds
-    }
 
     private fun handleErrorFetchingOfferings(
         error: PurchasesError,
@@ -159,53 +105,6 @@ class OfferingsManager(
             onError?.invoke(error)
         }
     }
-
-    private fun getStoreProductsById(
-        productIds: Set<String>,
-        onCompleted: (Map<String, List<StoreProduct>>) -> Unit,
-        onError: (PurchasesError) -> Unit
-    ) {
-        billing.queryProductDetailsAsync(
-            ProductType.SUBS,
-            productIds,
-            { subscriptionProducts ->
-                val productsById = subscriptionProducts
-                    .groupBy { subProduct -> subProduct.purchasingData.productId }
-                    .toMutableMap()
-                val subscriptionIds = productsById.keys
-
-                val inAppProductIds = productIds - subscriptionIds
-                if (inAppProductIds.isNotEmpty()) {
-                    billing.queryProductDetailsAsync(
-                        ProductType.INAPP,
-                        inAppProductIds,
-                        { inAppProducts ->
-                            productsById.putAll(inAppProducts.map { it.purchasingData.productId to listOf(it) })
-                            onCompleted(productsById)
-                        }, {
-                            onError(it)
-                        }
-                    )
-                } else {
-                    onCompleted(productsById)
-                }
-            }, {
-                onError(it)
-            })
-    }
-
-    private fun logMissingProducts(
-        allProductIdsInOfferings: Set<String>,
-        storeProductByID: Map<String, List<StoreProduct>>
-    ) = allProductIdsInOfferings
-        .filterNot { storeProductByID.containsKey(it) }
-        .takeIf { it.isNotEmpty() }
-        ?.let { missingProducts ->
-            log(
-                LogIntent.GOOGLE_WARNING, OfferingStrings.CANNOT_FIND_PRODUCT_CONFIGURATION_ERROR
-                    .format(missingProducts.joinToString(", "))
-            )
-        }
 
     private fun dispatch(action: () -> Unit) {
         if (Thread.currentThread() != Looper.getMainLooper().thread) {

--- a/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -1,0 +1,182 @@
+package com.revenuecat.purchases.common.offerings
+
+import android.os.Handler
+import android.os.Looper
+import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BillingAbstract
+import com.revenuecat.purchases.common.LogIntent
+import com.revenuecat.purchases.common.OfferingParser
+import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.strings.OfferingStrings
+import org.json.JSONException
+import org.json.JSONObject
+
+class OfferingsManager(
+    private val deviceCache: DeviceCache,
+    private val backend: Backend,
+    private val billing: BillingAbstract,
+    private val offeringParser: OfferingParser,
+    // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
+    private val mainHandler: Handler? = Handler(Looper.getMainLooper())
+) {
+
+    fun fetchAndCacheOfferings(
+        appUserID: String,
+        appInBackground: Boolean,
+        onSuccess: ((Offerings) -> Unit)? = null,
+        onError: ((PurchasesError) -> Unit)? = null
+    ) {
+        deviceCache.setOfferingsCacheTimestampToNow()
+        backend.getOfferings(
+            appUserID,
+            appInBackground,
+            { offeringsJSON ->
+                try {
+                    val allRequestedProductIdentifiers = extractProductIdentifiers(offeringsJSON)
+                    if (allRequestedProductIdentifiers.isEmpty()) {
+                        handleErrorFetchingOfferings(
+                            PurchasesError(
+                                PurchasesErrorCode.ConfigurationError,
+                                OfferingStrings.CONFIGURATION_ERROR_NO_PRODUCTS_FOR_OFFERINGS
+                            ),
+                            onError
+                        )
+                    } else {
+                        getStoreProductsById(allRequestedProductIdentifiers, { productsById ->
+                            logMissingProducts(allRequestedProductIdentifiers, productsById)
+
+                            val offerings = offeringParser.createOfferings(offeringsJSON, productsById)
+                            if (offerings.all.isEmpty()) {
+                                handleErrorFetchingOfferings(
+                                    PurchasesError(
+                                        PurchasesErrorCode.ConfigurationError,
+                                        OfferingStrings.CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND
+                                    ),
+                                    onError
+                                )
+                            } else {
+                                synchronized(this@OfferingsManager) {
+                                    deviceCache.cacheOfferings(offerings)
+                                }
+                                dispatch {
+                                    onSuccess?.invoke(offerings)
+                                }
+                            }
+                        }, { error ->
+                            handleErrorFetchingOfferings(error, onError)
+                        })
+                    }
+                } catch (error: JSONException) {
+                    log(LogIntent.RC_ERROR, OfferingStrings.JSON_EXCEPTION_ERROR.format(error.localizedMessage))
+                    handleErrorFetchingOfferings(
+                        PurchasesError(
+                            PurchasesErrorCode.UnexpectedBackendResponseError,
+                            error.localizedMessage
+                        ),
+                        onError
+                    )
+                }
+            }, { error ->
+                handleErrorFetchingOfferings(error, onError)
+            })
+    }
+
+    private fun extractProductIdentifiers(offeringsJSON: JSONObject): Set<String> {
+        val jsonOfferingsArray = offeringsJSON.getJSONArray("offerings")
+        val productIds = mutableSetOf<String>()
+        for (i in 0 until jsonOfferingsArray.length()) {
+            val jsonPackagesArray =
+                jsonOfferingsArray.getJSONObject(i).getJSONArray("packages")
+            for (j in 0 until jsonPackagesArray.length()) {
+                jsonPackagesArray.getJSONObject(j)
+                    .optString("platform_product_identifier").takeIf { it.isNotBlank() }?.let {
+                        productIds.add(it)
+                    }
+            }
+        }
+        return productIds
+    }
+
+    private fun handleErrorFetchingOfferings(
+        error: PurchasesError,
+        onError: ((PurchasesError) -> Unit)?
+    ) {
+        val errorCausedByPurchases = setOf(
+            PurchasesErrorCode.ConfigurationError,
+            PurchasesErrorCode.UnexpectedBackendResponseError
+        )
+            .contains(error.code)
+
+        log(
+            if (errorCausedByPurchases) LogIntent.RC_ERROR else LogIntent.GOOGLE_ERROR,
+            OfferingStrings.FETCHING_OFFERINGS_ERROR.format(error)
+        )
+
+        deviceCache.clearOfferingsCacheTimestamp()
+        dispatch {
+            onError?.invoke(error)
+        }
+    }
+
+    private fun getStoreProductsById(
+        productIds: Set<String>,
+        onCompleted: (Map<String, List<StoreProduct>>) -> Unit,
+        onError: (PurchasesError) -> Unit
+    ) {
+        billing.queryProductDetailsAsync(
+            ProductType.SUBS,
+            productIds,
+            { subscriptionProducts ->
+                val productsById = subscriptionProducts
+                    .groupBy { subProduct -> subProduct.purchasingData.productId }
+                    .toMutableMap()
+                val subscriptionIds = productsById.keys
+
+                val inAppProductIds = productIds - subscriptionIds
+                if (inAppProductIds.isNotEmpty()) {
+                    billing.queryProductDetailsAsync(
+                        ProductType.INAPP,
+                        inAppProductIds,
+                        { inAppProducts ->
+                            productsById.putAll(inAppProducts.map { it.purchasingData.productId to listOf(it) })
+                            onCompleted(productsById)
+                        }, {
+                            onError(it)
+                        }
+                    )
+                } else {
+                    onCompleted(productsById)
+                }
+            }, {
+                onError(it)
+            })
+    }
+
+    private fun logMissingProducts(
+        allProductIdsInOfferings: Set<String>,
+        storeProductByID: Map<String, List<StoreProduct>>
+    ) = allProductIdsInOfferings
+        .filterNot { storeProductByID.containsKey(it) }
+        .takeIf { it.isNotEmpty() }
+        ?.let { missingProducts ->
+            log(
+                LogIntent.GOOGLE_WARNING, OfferingStrings.CANNOT_FIND_PRODUCT_CONFIGURATION_ERROR
+                    .format(missingProducts.joinToString(", "))
+            )
+        }
+
+    private fun dispatch(action: () -> Unit) {
+        if (Thread.currentThread() != Looper.getMainLooper().thread) {
+            val handler = mainHandler ?: Handler(Looper.getMainLooper())
+            handler.post(action)
+        } else {
+            action()
+        }
+    }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -26,6 +26,8 @@ class OfferingsManager(
     private val mainHandler: Handler? = Handler(Looper.getMainLooper())
 ) {
 
+    fun isOfferingsCacheStale(appInBackground: Boolean) = deviceCache.isOfferingsCacheStale(appInBackground)
+
     fun fetchAndCacheOfferings(
         appUserID: String,
         appInBackground: Boolean,

--- a/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -25,8 +25,6 @@ class OfferingsManager(
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper())
 ) {
-    fun isOfferingsCacheStale(appInBackground: Boolean) = deviceCache.isOfferingsCacheStale(appInBackground)
-
     fun getOfferings(
         appUserID: String,
         appInBackground: Boolean,
@@ -42,7 +40,7 @@ class OfferingsManager(
             dispatch {
                 onSuccess?.invoke(cachedOfferings)
             }
-            if (deviceCache.isOfferingsCacheStale(appInBackground)) {
+            if (isOfferingsCacheStale(appInBackground)) {
                 log(
                     LogIntent.DEBUG,
                     if (appInBackground) OfferingStrings.OFFERINGS_STALE_UPDATING_IN_BACKGROUND
@@ -122,6 +120,8 @@ class OfferingsManager(
                 handleErrorFetchingOfferings(error, onError)
             })
     }
+
+    private fun isOfferingsCacheStale(appInBackground: Boolean) = deviceCache.isOfferingsCacheStale(appInBackground)
 
     private fun extractProductIdentifiers(offeringsJSON: JSONObject): Set<String> {
         val jsonOfferingsArray = offeringsJSON.getJSONArray("offerings")

--- a/common/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
@@ -1,0 +1,168 @@
+package com.revenuecat.purchases.common.offerings
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.common.BillingAbstract
+import com.revenuecat.purchases.common.GoogleOfferingParser
+import com.revenuecat.purchases.common.OfferingParser
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.strings.OfferingStrings
+import com.revenuecat.purchases.utils.ONE_OFFERINGS_INAPP_PRODUCT_RESPONSE
+import com.revenuecat.purchases.utils.ONE_OFFERINGS_RESPONSE
+import com.revenuecat.purchases.utils.STUB_OFFERING_IDENTIFIER
+import com.revenuecat.purchases.utils.STUB_PRODUCT_IDENTIFIER
+import com.revenuecat.purchases.utils.stubINAPPStoreProduct
+import com.revenuecat.purchases.utils.stubStoreProduct
+import com.revenuecat.purchases.utils.stubSubscriptionOption
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class OfferingsFactoryTest {
+
+    private val oneOfferingWithNoProductsResponse = JSONObject("{'offerings': [" +
+        "{'identifier': '$STUB_OFFERING_IDENTIFIER', " +
+        "'description': 'This is the base offering', " +
+        "'packages': []}]," +
+        "'current_offering_id': '$STUB_OFFERING_IDENTIFIER'}")
+    private val oneOfferingResponse = JSONObject(ONE_OFFERINGS_RESPONSE)
+    private val oneOfferingInAppProductResponse = JSONObject(ONE_OFFERINGS_INAPP_PRODUCT_RESPONSE)
+
+    private val productId = STUB_PRODUCT_IDENTIFIER
+
+    private lateinit var billing: BillingAbstract
+    private lateinit var offeringParser: OfferingParser
+
+    private lateinit var offeringsFactory: OfferingsFactory
+
+    @Before
+    fun setUp() {
+        billing = mockk()
+        offeringParser = GoogleOfferingParser()
+
+        offeringsFactory = OfferingsFactory(
+            billing = billing,
+            offeringParser = offeringParser
+        )
+    }
+
+    @Test
+    fun `configuration error if no products configured`() {
+        var purchasesError: PurchasesError? = null
+        offeringsFactory.createOfferings(
+            oneOfferingWithNoProductsResponse,
+            { purchasesError = it },
+            { fail("Expected error") }
+        )
+        assertThat(purchasesError).isNotNull
+        assertThat(purchasesError!!.code).isEqualTo(PurchasesErrorCode.ConfigurationError)
+        assertThat(purchasesError!!.underlyingErrorMessage).contains(
+            OfferingStrings.CONFIGURATION_ERROR_NO_PRODUCTS_FOR_OFFERINGS
+        )
+    }
+
+    @Test
+    fun `createOfferings returns error if json with wrong format`() {
+        var purchasesError: PurchasesError? = null
+        offeringsFactory.createOfferings(
+            JSONObject("{}"),
+            { purchasesError = it },
+            { fail("Expected error") }
+        )
+        assertThat(purchasesError).isNotNull
+        assertThat(purchasesError!!.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
+    }
+
+    @Test
+    fun `configuration error if products are not set up when fetching offerings`() {
+        val productIds = listOf(productId)
+        mockStoreProduct(productIds, listOf(), ProductType.SUBS)
+        mockStoreProduct(productIds, listOf(), ProductType.INAPP)
+
+        var purchasesError: PurchasesError? = null
+        offeringsFactory.createOfferings(
+            oneOfferingResponse,
+            { purchasesError = it },
+            { fail("Expected error") }
+        )
+
+        assertThat(purchasesError).isNotNull
+        assertThat(purchasesError!!.code).isEqualTo(PurchasesErrorCode.ConfigurationError)
+        assertThat(purchasesError!!.underlyingErrorMessage).contains(
+            OfferingStrings.CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND
+        )
+    }
+
+    @Test
+    fun `returns offerings when products found as subs`() {
+        val productIds = listOf(productId)
+        mockStoreProduct(productIds, productIds, ProductType.SUBS)
+
+        var offerings: Offerings? = null
+        offeringsFactory.createOfferings(
+            oneOfferingResponse,
+            { fail("Expected success. Got error: $it") },
+            { offerings = it }
+        )
+
+        assertThat(offerings).isNotNull
+        assertThat(offerings!!.all.size).isEqualTo(1)
+        assertThat(offerings!![STUB_OFFERING_IDENTIFIER]!!.monthly!!.product).isNotNull
+    }
+
+    @Test
+    fun `returns offerings when products found as inapp`() {
+        val productIds = listOf(productId)
+        mockStoreProduct(productIds, emptyList(), ProductType.SUBS)
+        mockStoreProduct(productIds, productIds, ProductType.INAPP)
+
+        var offerings: Offerings? = null
+        offeringsFactory.createOfferings(
+            oneOfferingInAppProductResponse,
+            { fail("Expected success. Got error: $it") },
+            { offerings = it }
+        )
+
+        assertThat(offerings).isNotNull
+        assertThat(offerings!!.all.size).isEqualTo(1)
+        assertThat(offerings!![STUB_OFFERING_IDENTIFIER]!!.monthly!!.product).isNotNull
+    }
+
+    // region helpers
+
+    private fun mockStoreProduct(
+        productIds: List<String> = listOf(productId),
+        productIdsSuccessfullyFetched: List<String> = listOf(productId),
+        type: ProductType = ProductType.SUBS
+    ): List<StoreProduct> {
+        val storeProducts = productIdsSuccessfullyFetched.map { productId ->
+            if (type == ProductType.SUBS) stubStoreProduct(productId, stubSubscriptionOption("p1m", "P1M"))
+            else stubINAPPStoreProduct(productId)
+        }.map { it }
+
+        every {
+            billing.queryProductDetailsAsync(
+                type,
+                productIds.toSet(),
+                captureLambda(),
+                any()
+            )
+        } answers {
+            lambda<(List<StoreProduct>) -> Unit>().captured.invoke(storeProducts)
+        }
+        return storeProducts
+    }
+
+    // endregion helpers
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -1,0 +1,384 @@
+package com.revenuecat.purchases.common.offerings
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.utils.ONE_OFFERINGS_RESPONSE
+import com.revenuecat.purchases.utils.STUB_OFFERING_IDENTIFIER
+import com.revenuecat.purchases.utils.STUB_PRODUCT_IDENTIFIER
+import com.revenuecat.purchases.utils.stubOfferings
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.json.JSONObject
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class OfferingsManagerTest {
+
+    private val appUserId = "fakeUserID"
+    private val productId = STUB_PRODUCT_IDENTIFIER
+    private val testOfferings = stubOfferings(productId).second
+
+    private lateinit var deviceCache: DeviceCache
+    private lateinit var backend: Backend
+    private lateinit var offeringsFactory: OfferingsFactory
+
+    private lateinit var offeringsManager: OfferingsManager
+
+    @Before
+    fun setUp() {
+        deviceCache = mockk()
+        backend = mockk()
+        offeringsFactory = mockk()
+
+        mockBackendResponse()
+
+        offeringsManager = OfferingsManager(
+            deviceCache,
+            backend,
+            offeringsFactory
+        )
+    }
+
+    // region onAppForeground
+
+    @Test
+    fun `fetch offerings on app foreground if it's stale`() {
+        mockCacheStale(offeringsStale = true)
+        mockDeviceCache()
+        mockOfferingsFactory()
+        offeringsManager.onAppForeground(appUserId)
+        verify(exactly = 1) {
+            backend.getOfferings(appUserId, appInBackground = false, onSuccess = any(), onError = any())
+        }
+        verify(exactly = 1) {
+            deviceCache.isOfferingsCacheStale(appInBackground = false)
+        }
+    }
+
+    @Test
+    fun `does not fetch offerings on app foreground if it's not stale`() {
+        mockCacheStale(offeringsStale = false)
+        offeringsManager.onAppForeground(appUserId)
+        verify(exactly = 0) {
+            backend.getOfferings(appUserId, appInBackground = false, onSuccess = any(), onError = any())
+        }
+        verify(exactly = 1) {
+            deviceCache.isOfferingsCacheStale(appInBackground = false)
+        }
+    }
+
+    // endregion onAppForeground
+
+    // region getOfferings
+
+    @Test
+    fun `if cached offerings are not stale`() {
+        mockOfferingsFactory()
+
+        every {
+            deviceCache.cachedOfferings
+        } returns testOfferings
+        mockCacheStale(offeringsStale = false)
+        mockDeviceCache()
+
+        var receivedOfferings: Offerings? = null
+
+        offeringsManager.getOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { fail("Expected success but got error: $it") },
+            onSuccess = { receivedOfferings = it }
+        )
+
+        assertThat(receivedOfferings).isEqualTo(testOfferings)
+    }
+
+    @Test
+    fun `if cached offerings are not stale in background`() {
+        mockOfferingsFactory()
+
+        every {
+            deviceCache.cachedOfferings
+        } returns testOfferings
+        mockCacheStale(offeringsStale = true, appInBackground = true)
+        mockDeviceCache()
+
+        var receivedOfferings: Offerings? = null
+
+        offeringsManager.getOfferings(
+            appUserId,
+            appInBackground = true,
+            onError = { fail("Expected success but got error: $it") },
+            onSuccess = { receivedOfferings = it }
+        )
+
+        assertThat(receivedOfferings).isEqualTo(testOfferings)
+    }
+
+    @Test
+    fun `if no cached offerings, backend is hit when getting offerings`() {
+        mockOfferingsFactory()
+
+        every {
+            deviceCache.cachedOfferings
+        } returns null
+        every {
+            deviceCache.cacheOfferings(any())
+        } just Runs
+
+        mockDeviceCache()
+
+        var receivedOfferings: Offerings? = null
+        offeringsManager.getOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { Assert.fail("should be a success") },
+            onSuccess = { receivedOfferings = it }
+        )
+
+        assertThat(receivedOfferings).isNotNull
+
+        verify(exactly = 1) {
+            backend.getOfferings(appUserId, appInBackground = false, onSuccess = any(), onError = any())
+        }
+        verify(exactly = 1) {
+            deviceCache.cacheOfferings(any())
+        }
+    }
+
+    @Test
+    fun `if no cached offerings, backend is hit when getting offerings when on background`() {
+        mockDeviceCache()
+        mockOfferingsFactory()
+
+        every {
+            deviceCache.cachedOfferings
+        } returns null
+        every {
+            deviceCache.cacheOfferings(any())
+        } just Runs
+
+        var receivedOfferings: Offerings? = null
+        offeringsManager.getOfferings(
+            appUserId,
+            appInBackground = true,
+            onError = { Assert.fail("should be a success") },
+            onSuccess = { receivedOfferings = it }
+        )
+
+        assertThat(receivedOfferings).isNotNull
+
+        verify(exactly = 1) {
+            backend.getOfferings(appUserId, appInBackground = true, onSuccess = any(), onError = any())
+        }
+        verify(exactly = 1) {
+            deviceCache.cacheOfferings(any())
+        }
+    }
+
+    @Test
+    fun `products are populated when getting offerings`() {
+        mockOfferingsFactory()
+
+        every {
+            deviceCache.cachedOfferings
+        } returns null
+        every {
+            deviceCache.cacheOfferings(any())
+        } just Runs
+
+        mockDeviceCache()
+
+        var receivedOfferings: Offerings? = null
+        offeringsManager.getOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { Assert.fail("should be a success") },
+            onSuccess = { receivedOfferings = it }
+        )
+
+        assertThat(receivedOfferings).isNotNull
+        assertThat(receivedOfferings!!.all.size).isEqualTo(1)
+        assertThat(receivedOfferings!![STUB_OFFERING_IDENTIFIER]!!.monthly!!.product).isNotNull
+    }
+
+    @Test
+    fun `if cached offerings are stale, call backend`() {
+        val (_, offerings) = stubOfferings(productId)
+        mockOfferingsFactory(offerings)
+
+        every {
+            deviceCache.cachedOfferings
+        } returns offerings
+        mockCacheStale(offeringsStale = true)
+        mockDeviceCache()
+
+        var receivedOfferings: Offerings? = null
+        offeringsManager.getOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { Assert.fail("should be a success") },
+            onSuccess = { receivedOfferings = it }
+        )
+
+        assertThat(receivedOfferings).isEqualTo(offerings)
+        verify(exactly = 1) {
+            backend.getOfferings(appUserId, appInBackground = false, onSuccess = any(), onError = any())
+        }
+    }
+
+    @Test
+    fun `if cached offerings are stale when on background, call backend`() {
+        val (_, offerings) = stubOfferings(productId)
+        mockOfferingsFactory(offerings)
+
+        every {
+            deviceCache.cachedOfferings
+        } returns offerings
+        mockCacheStale(offeringsStale = true, appInBackground = true)
+        mockDeviceCache()
+
+        var receivedOfferings: Offerings? = null
+        offeringsManager.getOfferings(
+            appUserId,
+            appInBackground = true,
+            onError = { fail("should be a success") },
+            onSuccess = { receivedOfferings = it }
+        )
+
+        assertThat(receivedOfferings).isEqualTo(offerings)
+        verify(exactly = 1) {
+            backend.getOfferings(appUserId, appInBackground = true, onSuccess = any(), onError = any())
+        }
+    }
+
+    @Test
+    fun getOfferingsIsCached() {
+        every {
+            deviceCache.cachedOfferings
+        } returns null
+        every {
+            deviceCache.cacheOfferings(any())
+        } just Runs
+        mockDeviceCache()
+        val (_, offerings) = stubOfferings(productId)
+        mockOfferingsFactory(offerings)
+
+        var receivedOfferings: Offerings? = null
+        offeringsManager.getOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { Assert.fail("should be a success") },
+            onSuccess = { receivedOfferings = it }
+        )
+
+        assertThat(receivedOfferings).isNotNull
+        assertThat(receivedOfferings).isEqualTo(offerings)
+        verify {
+            deviceCache.cacheOfferings(offerings)
+        }
+    }
+
+    @Test
+    fun getOfferingsErrorIsCalledIfNoBackendResponse() {
+        every {
+            deviceCache.cachedOfferings
+        } returns null
+        every {
+            deviceCache.cacheOfferings(any())
+        } just Runs
+
+        every {
+            backend.getOfferings(
+                any(),
+                any(),
+                any(),
+                captureLambda()
+            )
+        } answers {
+            lambda<(PurchasesError) -> Unit>().captured.invoke(
+                PurchasesError(PurchasesErrorCode.StoreProblemError)
+            )
+        }
+
+        mockDeviceCache(wasSuccessful = false)
+
+        var purchasesError: PurchasesError? = null
+        offeringsManager.getOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { purchasesError = it },
+            onSuccess = { fail("Should be error") }
+        )
+
+        assertThat(purchasesError).isNotNull
+        verify(exactly = 1) {
+            deviceCache.clearOfferingsCacheTimestamp()
+        }
+    }
+
+    // endregion getOfferings
+
+    // region helpers
+
+    private fun mockOfferingsFactory(
+        offerings: Offerings = testOfferings,
+        error: PurchasesError? = null
+    ) {
+        if (error == null) {
+            every {
+                offeringsFactory.createOfferings(any(), any(), captureLambda())
+            } answers {
+                lambda<(Offerings) -> Unit>().captured.invoke(offerings)
+            }
+        } else {
+            every {
+                offeringsFactory.createOfferings(any(), captureLambda(), any())
+            } answers {
+                lambda<(PurchasesError) -> Unit>().captured.invoke(error)
+            }
+        }
+    }
+
+    private fun mockBackendResponse(response: String = ONE_OFFERINGS_RESPONSE) {
+        every {
+            backend.getOfferings(any(), any(), captureLambda(), any())
+        } answers {
+            lambda<(JSONObject) -> Unit>().captured.invoke(JSONObject(response))
+        }
+    }
+
+    private fun mockCacheStale(
+        offeringsStale: Boolean = false,
+        appInBackground: Boolean = false
+    ) {
+        every {
+            deviceCache.isOfferingsCacheStale(appInBackground)
+        } returns offeringsStale
+    }
+
+    private fun mockDeviceCache(wasSuccessful: Boolean = true) {
+        every { deviceCache.setOfferingsCacheTimestampToNow() } just Runs
+        if (wasSuccessful) {
+            every { deviceCache.cacheOfferings(any()) } just Runs
+        } else {
+            every { deviceCache.clearOfferingsCacheTimestamp() } just Runs
+        }
+    }
+
+    // endregion helpers
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/OfferingParserFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/OfferingParserFactory.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.common.errorLog
-import com.revenuecat.purchases.google.GoogleOfferingParser
+import com.revenuecat.purchases.common.GoogleOfferingParser
 
 @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
 object OfferingParserFactory {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -203,7 +203,7 @@ class Purchases internal constructor(
                 appInBackground = false
             )
         }
-        if (deviceCache.isOfferingsCacheStale(appInBackground = false)) {
+        if (offeringsManager.isOfferingsCacheStale(appInBackground = false)) {
             log(LogIntent.DEBUG, OfferingStrings.OFFERINGS_STALE_UPDATING_IN_FOREGROUND)
             offeringsManager.fetchAndCacheOfferings(identityManager.currentAppUserID, appInBackground = false)
             log(LogIntent.RC_SUCCESS, OfferingStrings.OFFERINGS_UPDATED_FROM_NETWORK)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -320,34 +320,12 @@ class Purchases internal constructor(
     fun getOfferings(
         listener: ReceiveOfferingsCallback
     ) {
-        val (appUserID, cachedOfferings) = synchronized(this@Purchases) {
-            identityManager.currentAppUserID to offeringsManager.cachedOfferings
-        }
-        if (cachedOfferings == null) {
-            log(LogIntent.DEBUG, OfferingStrings.NO_CACHED_OFFERINGS_FETCHING_NETWORK)
-            offeringsManager.fetchAndCacheOfferings(
-                appUserID,
-                state.appInBackground,
-                { listener.onError(it) },
-                { listener.onReceived(it) }
-            )
-        } else {
-            log(LogIntent.DEBUG, OfferingStrings.VENDING_OFFERINGS_CACHE)
-            dispatch {
-                listener.onReceived(cachedOfferings)
-            }
-            state.appInBackground.let { appInBackground ->
-                if (deviceCache.isOfferingsCacheStale(appInBackground)) {
-                    log(
-                        LogIntent.DEBUG,
-                        if (appInBackground) OfferingStrings.OFFERINGS_STALE_UPDATING_IN_BACKGROUND
-                        else OfferingStrings.OFFERINGS_STALE_UPDATING_IN_FOREGROUND
-                    )
-                    offeringsManager.fetchAndCacheOfferings(appUserID, appInBackground)
-                    log(LogIntent.RC_SUCCESS, OfferingStrings.OFFERINGS_UPDATED_FROM_NETWORK)
-                }
-            }
-        }
+        offeringsManager.getOfferings(
+            identityManager.currentAppUserID,
+            state.appInBackground,
+            { listener.onError(it) },
+            { listener.onReceived(it) }
+        )
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -61,7 +61,6 @@ import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.strings.ConfigureStrings
 import com.revenuecat.purchases.strings.ConfigureStrings.AUTO_SYNC_PURCHASES_DISABLED
 import com.revenuecat.purchases.strings.CustomerInfoStrings
-import com.revenuecat.purchases.strings.OfferingStrings
 import com.revenuecat.purchases.strings.PurchaseStrings
 import com.revenuecat.purchases.strings.RestoreStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
@@ -203,11 +202,7 @@ class Purchases internal constructor(
                 appInBackground = false
             )
         }
-        if (offeringsManager.isOfferingsCacheStale(appInBackground = false)) {
-            log(LogIntent.DEBUG, OfferingStrings.OFFERINGS_STALE_UPDATING_IN_FOREGROUND)
-            offeringsManager.fetchAndCacheOfferings(identityManager.currentAppUserID, appInBackground = false)
-            log(LogIntent.RC_SUCCESS, OfferingStrings.OFFERINGS_UPDATED_FROM_NETWORK)
-        }
+        offeringsManager.onAppForeground(identityManager.currentAppUserID)
         offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         updatePendingPurchaseQueue()
         synchronizeSubscriberAttributesIfNeeded()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -321,7 +321,7 @@ class Purchases internal constructor(
         listener: ReceiveOfferingsCallback
     ) {
         val (appUserID, cachedOfferings) = synchronized(this@Purchases) {
-            identityManager.currentAppUserID to deviceCache.cachedOfferings
+            identityManager.currentAppUserID to offeringsManager.cachedOfferings
         }
         if (cachedOfferings == null) {
             log(LogIntent.DEBUG, OfferingStrings.NO_CACHED_OFFERINGS_FETCHING_NETWORK)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -23,7 +23,6 @@ import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.Config
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.LogIntent
-import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.ReplaceProductInfo
@@ -34,6 +33,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
@@ -65,8 +65,6 @@ import com.revenuecat.purchases.strings.OfferingStrings
 import com.revenuecat.purchases.strings.PurchaseStrings
 import com.revenuecat.purchases.strings.RestoreStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
-import org.json.JSONException
-import org.json.JSONObject
 import java.net.URL
 import java.util.Collections.emptyMap
 
@@ -93,12 +91,12 @@ class Purchases internal constructor(
     private val subscriberAttributesManager: SubscriberAttributesManager,
     @set:JvmSynthetic @get:JvmSynthetic internal var appConfig: AppConfig,
     private val customerInfoHelper: CustomerInfoHelper,
-    private val offeringParser: OfferingParser,
     diagnosticsSynchronizer: DiagnosticsSynchronizer?,
     @get:VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal val offlineEntitlementsManager: OfflineEntitlementsManager,
     private val postReceiptHelper: PostReceiptHelper,
     private val syncPurchasesHelper: SyncPurchasesHelper,
+    private val offeringsManager: OfferingsManager,
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper())
 ) : LifecycleDelegate {
@@ -207,7 +205,7 @@ class Purchases internal constructor(
         }
         if (deviceCache.isOfferingsCacheStale(appInBackground = false)) {
             log(LogIntent.DEBUG, OfferingStrings.OFFERINGS_STALE_UPDATING_IN_FOREGROUND)
-            fetchAndCacheOfferings(identityManager.currentAppUserID, appInBackground = false)
+            offeringsManager.fetchAndCacheOfferings(identityManager.currentAppUserID, appInBackground = false)
             log(LogIntent.RC_SUCCESS, OfferingStrings.OFFERINGS_UPDATED_FROM_NETWORK)
         }
         offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
@@ -327,7 +325,12 @@ class Purchases internal constructor(
         }
         if (cachedOfferings == null) {
             log(LogIntent.DEBUG, OfferingStrings.NO_CACHED_OFFERINGS_FETCHING_NETWORK)
-            fetchAndCacheOfferings(appUserID, state.appInBackground, listener)
+            offeringsManager.fetchAndCacheOfferings(
+                appUserID,
+                state.appInBackground,
+                { listener.onReceived(it) },
+                { listener.onError(it) }
+            )
         } else {
             log(LogIntent.DEBUG, OfferingStrings.VENDING_OFFERINGS_CACHE)
             dispatch {
@@ -340,7 +343,7 @@ class Purchases internal constructor(
                         if (appInBackground) OfferingStrings.OFFERINGS_STALE_UPDATING_IN_BACKGROUND
                         else OfferingStrings.OFFERINGS_STALE_UPDATING_IN_FOREGROUND
                     )
-                    fetchAndCacheOfferings(appUserID, appInBackground)
+                    offeringsManager.fetchAndCacheOfferings(appUserID, appInBackground)
                     log(LogIntent.RC_SUCCESS, OfferingStrings.OFFERINGS_UPDATED_FROM_NETWORK)
                 }
             }
@@ -638,7 +641,7 @@ class Purchases internal constructor(
                         callback?.onReceived(customerInfo, created)
                         customerInfoHelper.sendUpdatedCustomerInfoToDelegateIfChanged(customerInfo)
                     }
-                    fetchAndCacheOfferings(newAppUserID, state.appInBackground)
+                    offeringsManager.fetchAndCacheOfferings(newAppUserID, state.appInBackground)
                 },
                 onError = { error ->
                     dispatch { callback?.onError(error) }
@@ -1073,116 +1076,6 @@ class Purchases internal constructor(
 
     // region Private Methods
 
-    private fun fetchAndCacheOfferings(
-        appUserID: String,
-        appInBackground: Boolean,
-        completion: ReceiveOfferingsCallback? = null
-    ) {
-        deviceCache.setOfferingsCacheTimestampToNow()
-        backend.getOfferings(
-            appUserID,
-            appInBackground,
-            { offeringsJSON ->
-                try {
-                    val allRequestedProductIdentifiers = extractProductIdentifiers(offeringsJSON)
-                    if (allRequestedProductIdentifiers.isEmpty()) {
-                        handleErrorFetchingOfferings(
-                            PurchasesError(
-                                PurchasesErrorCode.ConfigurationError,
-                                OfferingStrings.CONFIGURATION_ERROR_NO_PRODUCTS_FOR_OFFERINGS
-                            ),
-                            completion
-                        )
-                    } else {
-                        getStoreProductsById(allRequestedProductIdentifiers, { productsById ->
-                            logMissingProducts(allRequestedProductIdentifiers, productsById)
-
-                            val offerings = offeringParser.createOfferings(offeringsJSON, productsById)
-                            if (offerings.all.isEmpty()) {
-                                handleErrorFetchingOfferings(
-                                    PurchasesError(
-                                        PurchasesErrorCode.ConfigurationError,
-                                        OfferingStrings.CONFIGURATION_ERROR_PRODUCTS_NOT_FOUND
-                                    ),
-                                    completion
-                                )
-                            } else {
-                                synchronized(this@Purchases) {
-                                    deviceCache.cacheOfferings(offerings)
-                                }
-                                dispatch {
-                                    completion?.onReceived(offerings)
-                                }
-                            }
-                        }, { error ->
-                            handleErrorFetchingOfferings(error, completion)
-                        })
-                    }
-                } catch (error: JSONException) {
-                    log(LogIntent.RC_ERROR, OfferingStrings.JSON_EXCEPTION_ERROR.format(error.localizedMessage))
-                    handleErrorFetchingOfferings(
-                        PurchasesError(
-                            PurchasesErrorCode.UnexpectedBackendResponseError,
-                            error.localizedMessage
-                        ),
-                        completion
-                    )
-                }
-            }, { error ->
-                handleErrorFetchingOfferings(error, completion)
-            })
-    }
-
-    private fun extractProductIdentifiers(offeringsJSON: JSONObject): Set<String> {
-        val jsonOfferingsArray = offeringsJSON.getJSONArray("offerings")
-        val productIds = mutableSetOf<String>()
-        for (i in 0 until jsonOfferingsArray.length()) {
-            val jsonPackagesArray =
-                jsonOfferingsArray.getJSONObject(i).getJSONArray("packages")
-            for (j in 0 until jsonPackagesArray.length()) {
-                jsonPackagesArray.getJSONObject(j)
-                    .optString("platform_product_identifier").takeIf { it.isNotBlank() }?.let {
-                        productIds.add(it)
-                    }
-            }
-        }
-        return productIds
-    }
-
-    private fun handleErrorFetchingOfferings(
-        error: PurchasesError,
-        completion: ReceiveOfferingsCallback?
-    ) {
-        val errorCausedByPurchases = setOf(
-            PurchasesErrorCode.ConfigurationError,
-            PurchasesErrorCode.UnexpectedBackendResponseError
-        )
-            .contains(error.code)
-
-        log(
-            if (errorCausedByPurchases) LogIntent.RC_ERROR else LogIntent.GOOGLE_ERROR,
-            OfferingStrings.FETCHING_OFFERINGS_ERROR.format(error)
-        )
-
-        deviceCache.clearOfferingsCacheTimestamp()
-        dispatch {
-            completion?.onError(error)
-        }
-    }
-
-    private fun logMissingProducts(
-        allProductIdsInOfferings: Set<String>,
-        storeProductByID: Map<String, List<StoreProduct>>
-    ) = allProductIdsInOfferings
-        .filterNot { storeProductByID.containsKey(it) }
-        .takeIf { it.isNotEmpty() }
-        ?.let { missingProducts ->
-            log(
-                LogIntent.GOOGLE_WARNING, OfferingStrings.CANNOT_FIND_PRODUCT_CONFIGURATION_ERROR
-                    .format(missingProducts.joinToString(", "))
-            )
-        }
-
     private fun getProductsOfTypes(
         productIds: Set<String>,
         types: Set<ProductType>,
@@ -1235,7 +1128,7 @@ class Purchases internal constructor(
                 appInBackground,
                 completion
             )
-            fetchAndCacheOfferings(appUserID, appInBackground)
+            offeringsManager.fetchAndCacheOfferings(appUserID, appInBackground)
         }
     }
 
@@ -1292,40 +1185,6 @@ class Purchases internal constructor(
                 )
             }
         }
-    }
-
-    private fun getStoreProductsById(
-        productIds: Set<String>,
-        onCompleted: (Map<String, List<StoreProduct>>) -> Unit,
-        onError: (PurchasesError) -> Unit
-    ) {
-        billing.queryProductDetailsAsync(
-            ProductType.SUBS,
-            productIds,
-            { subscriptionProducts ->
-                val productsById = subscriptionProducts
-                    .groupBy { subProduct -> subProduct.purchasingData.productId }
-                    .toMutableMap()
-                val subscriptionIds = productsById.keys
-
-                val inAppProductIds = productIds - subscriptionIds
-                if (inAppProductIds.isNotEmpty()) {
-                    billing.queryProductDetailsAsync(
-                        ProductType.INAPP,
-                        inAppProductIds,
-                        { inAppProducts ->
-                            productsById.putAll(inAppProducts.map { it.purchasingData.productId to listOf(it) })
-                            onCompleted(productsById)
-                        }, {
-                            onError(it)
-                        }
-                    )
-                } else {
-                    onCompleted(productsById)
-                }
-            }, {
-                onError(it)
-            })
     }
 
     private fun dispatch(action: () -> Unit) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -328,8 +328,8 @@ class Purchases internal constructor(
             offeringsManager.fetchAndCacheOfferings(
                 appUserID,
                 state.appInBackground,
-                { listener.onReceived(it) },
-                { listener.onError(it) }
+                { listener.onError(it) },
+                { listener.onReceived(it) }
             )
         } else {
             log(LogIntent.DEBUG, OfferingStrings.VENDING_OFFERINGS_CACHE)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -21,6 +21,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsFileHelper
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.ETagManager
+import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineCustomerInfoCalculator
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.offlineentitlements.PurchasedProductsFetcher
@@ -171,6 +172,13 @@ internal class PurchasesFactory(
                 postReceiptHelper
             )
 
+            val offeringsManager = OfferingsManager(
+                cache,
+                backend,
+                billing,
+                offeringParser
+            )
+
             return Purchases(
                 application,
                 appUserID,
@@ -182,11 +190,11 @@ internal class PurchasesFactory(
                 subscriberAttributesManager,
                 appConfig,
                 customerInfoHelper,
-                offeringParser,
                 diagnosticsSynchronizer,
                 offlineEntitlementsManager,
                 postReceiptHelper,
-                syncPurchasesHelper
+                syncPurchasesHelper,
+                offeringsManager
             )
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -21,6 +21,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsFileHelper
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.ETagManager
+import com.revenuecat.purchases.common.offerings.OfferingsFactory
 import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineCustomerInfoCalculator
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
@@ -175,8 +176,7 @@ internal class PurchasesFactory(
             val offeringsManager = OfferingsManager(
                 cache,
                 backend,
-                billing,
-                offeringParser
+                OfferingsFactory(billing, offeringParser)
             )
 
             return Purchases(

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
+import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.google.toInAppStoreProduct
 import com.revenuecat.purchases.google.toStoreTransaction
@@ -61,7 +62,6 @@ open class BasePurchasesTest {
     protected val mockIdentityManager = mockk<IdentityManager>()
     protected val mockSubscriberAttributesManager = mockk<SubscriberAttributesManager>()
     internal val mockCustomerInfoHelper = mockk<CustomerInfoHelper>()
-    lateinit var mockOfferingParser: OfferingParser
     protected val mockDiagnosticsSynchronizer = mockk<DiagnosticsSynchronizer>()
     protected val mockOfflineEntitlementsManager = mockk<OfflineEntitlementsManager>()
     internal val mockPostReceiptHelper = mockk<PostReceiptHelper>()
@@ -313,11 +313,16 @@ open class BasePurchasesTest {
                 dangerousSettings = DangerousSettings(autoSyncPurchases = autoSync)
             ),
             customerInfoHelper = mockCustomerInfoHelper,
-            offeringParser = OfferingParserFactory.createOfferingParser(Store.PLAY_STORE),
             diagnosticsSynchronizer = mockDiagnosticsSynchronizer,
             offlineEntitlementsManager = mockOfflineEntitlementsManager,
             postReceiptHelper = mockPostReceiptHelper,
-            syncPurchasesHelper = mockSyncPurchasesHelper
+            syncPurchasesHelper = mockSyncPurchasesHelper,
+            offeringsManager = OfferingsManager(
+                mockCache,
+                mockBackend,
+                mockBillingAbstract,
+                OfferingParserFactory.createOfferingParser(Store.PLAY_STORE)
+            )
         )
         Purchases.sharedInstance = purchases
         purchases.state = purchases.state.copy(appInBackground = false)

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -8,12 +8,10 @@ package com.revenuecat.purchases
 import android.app.Application
 import android.content.Context
 import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.PurchaseHistoryRecord
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BillingAbstract
-import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
@@ -27,7 +25,6 @@ import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
-import com.revenuecat.purchases.utils.ONE_OFFERINGS_RESPONSE
 import com.revenuecat.purchases.utils.STUB_PRODUCT_IDENTIFIER
 import com.revenuecat.purchases.utils.SyncDispatcher
 import com.revenuecat.purchases.utils.createMockOneTimeProductDetails
@@ -42,11 +39,8 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
-import org.json.JSONObject
 import org.junit.After
 import org.junit.Before
-import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
 open class BasePurchasesTest {
     protected val mockBillingAbstract: BillingAbstract = mockk()
@@ -66,6 +60,7 @@ open class BasePurchasesTest {
     protected val mockOfflineEntitlementsManager = mockk<OfflineEntitlementsManager>()
     internal val mockPostReceiptHelper = mockk<PostReceiptHelper>()
     internal val mockSyncPurchasesHelper = mockk<SyncPurchasesHelper>()
+    protected val mockOfferingsManager = mockk<OfferingsManager>()
 
     protected var capturedPurchasesUpdatedListener = slot<BillingAbstract.PurchasesUpdatedListener>()
     protected var capturedBillingWrapperStateListener = slot<BillingAbstract.StateListener>()
@@ -108,7 +103,7 @@ open class BasePurchasesTest {
     @After
     fun tearDown() {
         Purchases.backingFieldSharedInstance = null
-        clearMocks(mockCustomerInfoHelper, mockPostReceiptHelper, mockSyncPurchasesHelper)
+        clearMocks(mockCustomerInfoHelper, mockPostReceiptHelper, mockSyncPurchasesHelper, mockOfferingsManager)
     }
 
     // region Private Methods
@@ -143,7 +138,6 @@ open class BasePurchasesTest {
 
     private fun mockBackend() {
         with(mockBackend) {
-            mockProducts()
             every {
                 close()
             } just Runs
@@ -250,12 +244,16 @@ open class BasePurchasesTest {
         }
     }
 
-    protected fun mockProducts(response: String = ONE_OFFERINGS_RESPONSE) {
+    protected fun mockOfferingsManagerAppForeground() {
         every {
-            mockBackend.getOfferings(any(), any(), captureLambda(), any())
-        } answers {
-            lambda<(JSONObject) -> Unit>().captured.invoke(JSONObject(response))
-        }
+            mockOfferingsManager.onAppForeground(appUserId)
+        } just Runs
+    }
+
+    protected fun mockOfferingsManagerFetchOfferings(userId: String = appUserId) {
+        every {
+            mockOfferingsManager.fetchAndCacheOfferings(userId, any(), any(), any())
+        } just Runs
     }
 
     protected fun mockStoreProduct(
@@ -317,12 +315,7 @@ open class BasePurchasesTest {
             offlineEntitlementsManager = mockOfflineEntitlementsManager,
             postReceiptHelper = mockPostReceiptHelper,
             syncPurchasesHelper = mockSyncPurchasesHelper,
-            offeringsManager = OfferingsManager(
-                mockCache,
-                mockBackend,
-                mockBillingAbstract,
-                OfferingParserFactory.createOfferingParser(Store.PLAY_STORE)
-            )
+            offeringsManager = mockOfferingsManager
         )
         Purchases.sharedInstance = purchases
         purchases.state = purchases.state.copy(appInBackground = false)
@@ -345,15 +338,11 @@ open class BasePurchasesTest {
 
     protected fun mockCacheStale(
         customerInfoStale: Boolean = false,
-        offeringsStale: Boolean = false,
         appInBackground: Boolean = false
     ) {
         every {
             mockCache.isCustomerInfoCacheStale(appUserId, appInBackground)
         } returns customerInfoStale
-        every {
-            mockCache.isOfferingsCacheStale(appInBackground)
-        } returns offeringsStale
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
 import com.revenuecat.purchases.identity.IdentityManager
@@ -40,6 +41,7 @@ class SubscriberAttributesPurchasesTests {
     private val customerInfoHelperMock = mockk<CustomerInfoHelper>()
     private val offlineEntitlementsManagerMock = mockk<OfflineEntitlementsManager>()
     private val postReceiptHelperMock = mockk<PostReceiptHelper>()
+    private val offeringsManagerMock = mockk<OfferingsManager>()
     private lateinit var applicationMock: Application
 
     @Before
@@ -72,13 +74,13 @@ class SubscriberAttributesPurchasesTests {
             offlineEntitlementsManager = offlineEntitlementsManagerMock,
             postReceiptHelper = postReceiptHelperMock,
             syncPurchasesHelper = mockk(),
-            offeringsManager = mockk()
+            offeringsManager = offeringsManagerMock
         )
     }
 
     @After
     fun tearDown() {
-        clearMocks(customerInfoHelperMock)
+        clearMocks(customerInfoHelperMock, offeringsManagerMock)
     }
 
     @Test
@@ -162,6 +164,7 @@ class SubscriberAttributesPurchasesTests {
         every {
             customerInfoHelperMock.retrieveCustomerInfo(appUserId, CacheFetchPolicy.FETCH_CURRENT,false, any())
         } just Runs
+        every { offeringsManagerMock.isOfferingsCacheStale(any()) } returns false
         underTest.onAppForegrounded()
         verify(exactly = 1) {
             subscriberAttributesManagerMock.synchronizeSubscriberAttributesForAllUsers(appUserId)

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.CacheFetchPolicy
 import com.revenuecat.purchases.CustomerInfoHelper
-import com.revenuecat.purchases.OfferingParserFactory
 import com.revenuecat.purchases.PostReceiptHelper
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.Store
@@ -12,6 +11,7 @@ import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.PlatformInfo
+import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
 import com.revenuecat.purchases.identity.IdentityManager
@@ -48,12 +48,13 @@ class SubscriberAttributesPurchasesTests {
             offlineEntitlementsManagerMock.updateProductEntitlementMappingCacheIfStale()
         } just runs
 
+        val cache: DeviceCache = mockk(relaxed = true)
         underTest = Purchases(
             application = mockk<Application>(relaxed = true).also { applicationMock = it },
             backingFieldAppUserID = appUserId,
             backend = backendMock,
             billing = billingWrapperMock,
-            deviceCache = mockk(relaxed = true),
+            deviceCache = cache,
             dispatcher = SyncDispatcher(),
             identityManager = mockk<IdentityManager>(relaxed = true).apply {
                 every { currentAppUserID } returns appUserId
@@ -67,11 +68,11 @@ class SubscriberAttributesPurchasesTests {
                 store = Store.PLAY_STORE
             ),
             customerInfoHelper = customerInfoHelperMock,
-            offeringParser = OfferingParserFactory.createOfferingParser(Store.PLAY_STORE),
             diagnosticsSynchronizer = null,
             offlineEntitlementsManager = offlineEntitlementsManagerMock,
             postReceiptHelper = postReceiptHelperMock,
-            syncPurchasesHelper = mockk()
+            syncPurchasesHelper = mockk(),
+            offeringsManager = mockk()
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -164,7 +164,9 @@ class SubscriberAttributesPurchasesTests {
         every {
             customerInfoHelperMock.retrieveCustomerInfo(appUserId, CacheFetchPolicy.FETCH_CURRENT,false, any())
         } just Runs
-        every { offeringsManagerMock.isOfferingsCacheStale(any()) } returns false
+        every {
+            offeringsManagerMock.onAppForeground(appUserId)
+        } just Runs
         underTest.onAppForegrounded()
         verify(exactly = 1) {
             subscriberAttributesManagerMock.synchronizeSubscriberAttributesForAllUsers(appUserId)

--- a/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/test-utils/src/main/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -34,6 +34,12 @@ const val ONE_OFFERINGS_RESPONSE = "{'offerings': [" +
     "{'identifier': '\$rc_monthly','platform_product_identifier': '$STUB_PRODUCT_IDENTIFIER'," +
     "'platform_product_plan_identifier': 'p1m'}]}]," +
     "'current_offering_id': '$STUB_OFFERING_IDENTIFIER'}"
+const val ONE_OFFERINGS_INAPP_PRODUCT_RESPONSE = "{'offerings': [" +
+    "{'identifier': '$STUB_OFFERING_IDENTIFIER', " +
+    "'description': 'This is the base offering', " +
+    "'packages': [" +
+    "{'identifier': '\$rc_monthly','platform_product_identifier': '$STUB_PRODUCT_IDENTIFIER'}]}]," +
+    "'current_offering_id': '$STUB_OFFERING_IDENTIFIER'}"
 
 @SuppressWarnings("EmptyFunctionBlock")
 fun stubStoreProduct(


### PR DESCRIPTION
### Description
This is a first PR in preparation of persisting offerings in cache (SDK-3094). There are no behavior changes in this PR. This just extracts most of the code related to offerings from `Purchases` to the new classes `OfferingsManager` and `OfferingsFactory`.

#### Main changes
- Created `OfferingsManager` that will be the entry point for all offerings-related logic
- Created `OfferingsFactory` that allows to create the `Offerings` object from a JSON response. It will query the store to get the necessary products and create the final object.
- Moved `GoogleOfferingParser` from the `feature/google` module to the `common` module. This is to be able to use the actual code in the unit tests more easily.
