### PR TITLE
Store offerings response in SharedPreferences

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DateExtensions.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DateExtensions.kt
@@ -14,7 +14,7 @@ import kotlin.time.Duration.Companion.minutes
 private val CACHE_REFRESH_PERIOD_IN_FOREGROUND = 5.minutes
 private val CACHE_REFRESH_PERIOD_IN_BACKGROUND = 25.hours
 
-internal fun Date?.isStale(appInBackground: Boolean, dateProvider: DateProvider = DefaultDateProvider()): Boolean {
+internal fun Date?.isCacheStale(appInBackground: Boolean, dateProvider: DateProvider = DefaultDateProvider()): Boolean {
     return this?.let {
         log(LogIntent.DEBUG, ReceiptStrings.CHECKING_IF_CACHE_STALE.format(appInBackground))
         val cacheDuration = when {
@@ -22,11 +22,11 @@ internal fun Date?.isStale(appInBackground: Boolean, dateProvider: DateProvider 
             else -> CACHE_REFRESH_PERIOD_IN_FOREGROUND
         }
 
-        isStale(cacheDuration, dateProvider)
+        isCacheStale(cacheDuration, dateProvider)
     } ?: true
 }
 
-internal fun Date?.isStale(cacheDuration: Duration, dateProvider: DateProvider = DefaultDateProvider()): Boolean {
+internal fun Date?.isCacheStale(cacheDuration: Duration, dateProvider: DateProvider = DefaultDateProvider()): Boolean {
     return this?.let { cacheLastUpdated ->
         (dateProvider.now.time - cacheLastUpdated.time).milliseconds >= cacheDuration
     } ?: true

--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DateExtensions.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DateExtensions.kt
@@ -1,0 +1,33 @@
+package com.revenuecat.purchases.common.caching
+
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.LogIntent
+import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.strings.ReceiptStrings
+import java.util.Date
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+
+private val CACHE_REFRESH_PERIOD_IN_FOREGROUND = 5.minutes
+private val CACHE_REFRESH_PERIOD_IN_BACKGROUND = 25.hours
+
+internal fun Date?.isStale(appInBackground: Boolean, dateProvider: DateProvider = DefaultDateProvider()): Boolean {
+    return this?.let {
+        log(LogIntent.DEBUG, ReceiptStrings.CHECKING_IF_CACHE_STALE.format(appInBackground))
+        val cacheDuration = when {
+            appInBackground -> CACHE_REFRESH_PERIOD_IN_BACKGROUND
+            else -> CACHE_REFRESH_PERIOD_IN_FOREGROUND
+        }
+
+        isStale(cacheDuration, dateProvider)
+    } ?: true
+}
+
+internal fun Date?.isStale(cacheDuration: Duration, dateProvider: DateProvider = DefaultDateProvider()): Boolean {
+    return this?.let { cacheLastUpdated ->
+        (dateProvider.now.time - cacheLastUpdated.time).milliseconds >= cacheDuration
+    } ?: true
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -153,7 +153,7 @@ open class DeviceCache(
 
     @Synchronized
     fun isCustomerInfoCacheStale(appUserID: String, appInBackground: Boolean) =
-        getCustomerInfoCachesLastUpdated(appUserID).isStale(appInBackground, dateProvider)
+        getCustomerInfoCachesLastUpdated(appUserID).isCacheStale(appInBackground, dateProvider)
 
     @Synchronized
     fun clearCustomerInfoCacheTimestamp(appUserID: String) {
@@ -306,7 +306,7 @@ open class DeviceCache(
 
     @Synchronized
     fun isProductEntitlementMappingCacheStale(): Boolean {
-        return getProductEntitlementMappingLastUpdated().isStale(
+        return getProductEntitlementMappingLastUpdated().isCacheStale(
             PRODUCT_ENTITLEMENT_MAPPING_CACHE_REFRESH_PERIOD,
             dateProvider
         )

--- a/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
@@ -5,7 +5,7 @@ import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.caching.InMemoryCachedObject
-import com.revenuecat.purchases.common.caching.isStale
+import com.revenuecat.purchases.common.caching.isCacheStale
 import org.json.JSONObject
 
 class OfferingsCache(
@@ -36,7 +36,7 @@ class OfferingsCache(
 
     @Synchronized
     fun isOfferingsCacheStale(appInBackground: Boolean): Boolean {
-        return offeringsCachedObject.lastUpdatedAt.isStale(appInBackground, dateProvider)
+        return offeringsCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)
     }
 
     @Synchronized

--- a/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
@@ -1,0 +1,61 @@
+package com.revenuecat.purchases.common.offerings
+
+import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.caching.InMemoryCachedObject
+import com.revenuecat.purchases.common.caching.isStale
+import org.json.JSONObject
+
+class OfferingsCache(
+    private val deviceCache: DeviceCache,
+    private val dateProvider: DateProvider = DefaultDateProvider(),
+    private val offeringsCachedObject: InMemoryCachedObject<Offerings> = InMemoryCachedObject(
+        dateProvider = dateProvider
+    )
+) {
+
+    @Synchronized
+    fun clearCache() {
+        offeringsCachedObject.clearCache()
+        deviceCache.clearOfferingsResponseCache()
+    }
+
+    @Synchronized
+    fun cacheOfferings(offerings: Offerings, offeringsResponse: JSONObject) {
+        offeringsCachedObject.cacheInstance(offerings)
+        deviceCache.cacheOfferingsResponse(offeringsResponse)
+    }
+
+    // region Offerings cache
+
+    val cachedOfferings: Offerings?
+        @Synchronized
+        get() = offeringsCachedObject.cachedInstance
+
+    @Synchronized
+    fun isOfferingsCacheStale(appInBackground: Boolean): Boolean {
+        return offeringsCachedObject.lastUpdatedAt.isStale(appInBackground, dateProvider)
+    }
+
+    @Synchronized
+    fun clearOfferingsCacheTimestamp() {
+        offeringsCachedObject.clearCacheTimestamp()
+    }
+
+    @Synchronized
+    fun setOfferingsCacheTimestampToNow() {
+        offeringsCachedObject.updateCacheTimestamp(dateProvider.now)
+    }
+
+    // endregion Offerings cache
+
+    // region Offerings response cache
+
+    val cachedOfferingsResponse: JSONObject?
+        @Synchronized
+        get() = deviceCache.getOfferingsResponseCache()
+
+    // endregion Offerings response cache
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -635,7 +635,7 @@ class DeviceCacheTest {
         every { mockPrefs.getString(offeringsResponseCacheKey, null) } returns "{\"test-key\": \"test-value\"}"
         val offeringsResponse = cache.getOfferingsResponseCache()
         assertThat(offeringsResponse).isNotNull
-        assertThat(offeringsResponse!!.getString("test-key")).isEqualTo("test-value")
+        assertThat(offeringsResponse?.getString("test-key")).isEqualTo("test-value")
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/caching/DateExtensionsTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/caching/DateExtensionsTest.kt
@@ -1,0 +1,52 @@
+package com.revenuecat.purchases.common.caching
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.utils.subtract
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Date
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class DateExtensionsTest {
+
+    @Test
+    fun `cache date is stale if more than 5 minutes old and app in foreground`() {
+        val date = Date().subtract(6.minutes)
+        assertThat(date.isCacheStale(appInBackground = false)).isTrue
+    }
+
+    @Test
+    fun `cache date is not stale if less than 5 minutes old and app in foreground`() {
+        val date = Date().subtract(4.minutes)
+        assertThat(date.isCacheStale(appInBackground = false)).isFalse
+    }
+
+    @Test
+    fun `cache date is not stale if more than 5 minutes old and app in background`() {
+        val date = Date().subtract(6.minutes)
+        assertThat(date.isCacheStale(appInBackground = true)).isFalse
+    }
+
+    @Test
+    fun `cache date is stale if more than 25 hours old and app in background`() {
+        val date = Date().subtract(26.hours)
+        assertThat(date.isCacheStale(appInBackground = true)).isTrue
+    }
+
+    @Test
+    fun `cache date is stale if more than cache duration time has passed`() {
+        val date = Date().subtract(6.minutes)
+        assertThat(date.isCacheStale(cacheDuration = 5.minutes)).isTrue
+    }
+
+    @Test
+    fun `cache date is not stale if less than cache duration time has passed`() {
+        val date = Date().subtract(4.minutes)
+        assertThat(date.isCacheStale(cacheDuration = 5.minutes)).isFalse
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
@@ -24,7 +24,7 @@ import kotlin.time.Duration.Companion.minutes
 class OfferingsCacheTest {
 
     private val initialDate = Date(1685098228L) // Friday, May 26, 2023 10:50:28 AM GMT
-    private var currentDate = initialDate
+    private lateinit var currentDate: Date
 
     private lateinit var deviceCache: DeviceCache
     private lateinit var dateProvider: DateProvider
@@ -33,6 +33,7 @@ class OfferingsCacheTest {
 
     @Before
     fun setUp() {
+        currentDate = initialDate
         deviceCache = mockk()
         dateProvider = object : DateProvider {
             override val now: Date

--- a/common/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
@@ -1,0 +1,124 @@
+package com.revenuecat.purchases.common.offerings
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.utils.add
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Date
+import kotlin.time.Duration.Companion.minutes
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class OfferingsCacheTest {
+
+    private val initialDate = Date(1685098228L) // Friday, May 26, 2023 10:50:28 AM GMT
+    private var currentDate = initialDate
+
+    private lateinit var deviceCache: DeviceCache
+    private lateinit var dateProvider: DateProvider
+
+    private lateinit var offeringsCache: OfferingsCache
+
+    @Before
+    fun setUp() {
+        deviceCache = mockk()
+        dateProvider = object : DateProvider {
+            override val now: Date
+                get() = currentDate
+        }
+
+        offeringsCache = OfferingsCache(deviceCache, dateProvider = dateProvider)
+    }
+
+    @Test
+    fun `clear cache clears offerings cache and offerings response cache`() {
+        val offeringsResponse = mockk<JSONObject>()
+        every { deviceCache.clearOfferingsResponseCache() } just Runs
+        every { deviceCache.cacheOfferingsResponse(offeringsResponse) } just Runs
+        offeringsCache.cacheOfferings(mockk(), offeringsResponse)
+        assertThat(offeringsCache.cachedOfferings).isNotNull
+        offeringsCache.clearCache()
+        assertThat(offeringsCache.cachedOfferings).isNull()
+        verify(exactly = 1) { deviceCache.clearOfferingsResponseCache() }
+    }
+
+    @Test
+    fun `caching offerings works`() {
+        val offerings = mockk<Offerings>()
+        val offeringsResponse = mockk<JSONObject>()
+        every { deviceCache.cacheOfferingsResponse(offeringsResponse) } just Runs
+        assertThat(offeringsCache.cachedOfferings).isNull()
+        offeringsCache.cacheOfferings(offerings, offeringsResponse)
+        assertThat(offeringsCache.cachedOfferings).isEqualTo(offerings)
+        verify(exactly = 1) { deviceCache.cacheOfferingsResponse(offeringsResponse) }
+    }
+
+    // region offerings cache
+
+    @Test
+    fun `cache is empty initially`() {
+        assertThat(offeringsCache.cachedOfferings).isNull()
+    }
+
+    @Test
+    fun `cache is stale if no cached value`() {
+        assertThat(offeringsCache.isOfferingsCacheStale(false)).isTrue
+        assertThat(offeringsCache.isOfferingsCacheStale(true)).isTrue
+    }
+
+    @Test
+    fun `cache is not stale right after caching value`() {
+        mockDeviceCacheOfferingResponse()
+        offeringsCache.cacheOfferings(mockk(), mockk())
+        assertThat(offeringsCache.isOfferingsCacheStale(false)).isFalse
+    }
+
+    @Test
+    fun `cache is stale if cached value is stale`() {
+        mockDeviceCacheOfferingResponse()
+        offeringsCache.cacheOfferings(mockk(), mockk())
+        currentDate = currentDate.add(6.minutes)
+        assertThat(offeringsCache.isOfferingsCacheStale(false)).isTrue
+    }
+
+    @Test
+    fun `cache is stale if cached value removes update time`() {
+        mockDeviceCacheOfferingResponse()
+        offeringsCache.cacheOfferings(mockk(), mockk())
+        offeringsCache.clearOfferingsCacheTimestamp()
+        assertThat(offeringsCache.isOfferingsCacheStale(false)).isTrue
+    }
+
+    // endregion offerings cache
+
+    // region offerings response cache
+
+    @Test
+    fun `offerings cache returns device cache offerings response`() {
+        val offeringsResponse = mockk<JSONObject>()
+        every { deviceCache.getOfferingsResponseCache() } returns offeringsResponse
+        assertThat(offeringsCache.cachedOfferingsResponse).isEqualTo(offeringsResponse)
+    }
+
+    // endregion offerings response cache
+
+    // region helpers
+
+    fun mockDeviceCacheOfferingResponse() {
+        every { deviceCache.cacheOfferingsResponse(any()) } just Runs
+    }
+
+    // endregion helpers
+}

--- a/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.common.offerings.OfferingsCache
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.strings.IdentityStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
@@ -20,6 +21,7 @@ class IdentityManager(
     private val deviceCache: DeviceCache,
     private val subscriberAttributesCache: SubscriberAttributesCache,
     private val subscriberAttributesManager: SubscriberAttributesManager,
+    private val offeringsCache: OfferingsCache,
     private val backend: Backend,
     private val offlineEntitlementsManager: OfflineEntitlementsManager
 ) {
@@ -73,6 +75,7 @@ class IdentityManager(
                             IdentityStrings.LOG_IN_SUCCESSFUL.format(newAppUserID, created)
                         )
                         deviceCache.clearCachesForAppUserID(oldAppUserID)
+                        offeringsCache.clearCache()
                         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
 
                         deviceCache.cacheAppUserID(newAppUserID)
@@ -90,6 +93,7 @@ class IdentityManager(
     @Synchronized
     private fun reset() {
         deviceCache.clearCachesForAppUserID(currentAppUserID)
+        offeringsCache.clearCache()
         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(currentAppUserID)
         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
         deviceCache.cacheAppUserID(generateRandomID())

--- a/feature/identity/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/feature/identity/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.offerings.OfferingsCache
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
@@ -34,6 +35,7 @@ class IdentityManagerTests {
     private lateinit var mockDeviceCache: DeviceCache
     private lateinit var mockSubscriberAttributesCache: SubscriberAttributesCache
     private lateinit var mockSubscriberAttributesManager: SubscriberAttributesManager
+    private lateinit var mockOfferingsCache: OfferingsCache
     private lateinit var mockBackend: Backend
     private lateinit var mockOfflineEntitlementsManager: OfflineEntitlementsManager
     private lateinit var identityManager: IdentityManager
@@ -55,6 +57,9 @@ class IdentityManagerTests {
             } just Runs
         }
         mockSubscriberAttributesManager = mockk()
+        mockOfferingsCache = mockk<OfferingsCache>().apply {
+            every { clearCache() } just Runs
+        }
 
         mockBackend = mockk()
         mockOfflineEntitlementsManager = mockk<OfflineEntitlementsManager>().apply {
@@ -215,6 +220,7 @@ class IdentityManagerTests {
         verify(exactly = 1) {
             mockSubscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
         }
+        verify(exactly = 1) { mockOfferingsCache.clearCache() }
     }
 
     @Test
@@ -368,6 +374,7 @@ class IdentityManagerTests {
                 identifiedUserID
             )
         }
+        verify(exactly = 1) { mockOfferingsCache.clearCache() }
     }
 
     @Test
@@ -650,11 +657,17 @@ class IdentityManagerTests {
         deviceCache: DeviceCache = mockDeviceCache,
         subscriberAttributesCache: SubscriberAttributesCache = mockSubscriberAttributesCache,
         subscriberAttributesManager: SubscriberAttributesManager = mockSubscriberAttributesManager,
+        offeringsCache: OfferingsCache = mockOfferingsCache,
         backend: Backend = mockBackend,
         offlineEntitlementsManager: OfflineEntitlementsManager = mockOfflineEntitlementsManager
     ): IdentityManager {
         return IdentityManager(
-            deviceCache, subscriberAttributesCache, subscriberAttributesManager, backend, offlineEntitlementsManager
+            deviceCache,
+            subscriberAttributesCache,
+            subscriberAttributesManager,
+            offeringsCache,
+            backend,
+            offlineEntitlementsManager
         )
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -21,6 +21,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsFileHelper
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.ETagManager
+import com.revenuecat.purchases.common.offerings.OfferingsCache
 import com.revenuecat.purchases.common.offerings.OfferingsFactory
 import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineCustomerInfoCalculator
@@ -134,10 +135,13 @@ internal class PurchasesFactory(
                 appConfig
             )
 
+            val offeringsCache = OfferingsCache(cache)
+
             val identityManager = IdentityManager(
                 cache,
                 subscriberAttributesCache,
                 subscriberAttributesManager,
+                offeringsCache,
                 backend,
                 offlineEntitlementsManager
             )
@@ -174,7 +178,7 @@ internal class PurchasesFactory(
             )
 
             val offeringsManager = OfferingsManager(
-                cache,
+                offeringsCache,
                 backend,
                 OfferingsFactory(billing, offeringParser)
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -183,28 +183,16 @@ open class BasePurchasesTest {
                 setCustomerInfoCacheTimestampToNow(appUserId)
             } just Runs
             every {
-                setOfferingsCacheTimestampToNow()
-            } just Runs
-            every {
                 clearCustomerInfoCacheTimestamp(appUserId)
             } just Runs
             every {
                 clearCustomerInfoCache(appUserId)
             } just Runs
             every {
-                clearOfferingsCacheTimestamp()
-            } just Runs
-            every {
                 isCustomerInfoCacheStale(appUserId, any())
             } returns false
             every {
-                isOfferingsCacheStale(any())
-            } returns false
-            every {
                 addSuccessfullyPostedToken(any())
-            } just Runs
-            every {
-                mockCache.cacheOfferings(any())
             } just Runs
         }
     }


### PR DESCRIPTION
### Description
This is the second PR in preparation of persisting offerings (SDK-3094). In this PR, we persist the backend response for offerings, but we aren't using it yet.

#### Main changes
- Created `OfferingsCache` to abstract the caching logic for offerings and the offerings response
- Extracted `isStale` helpers to extension functions so they can be used in the new offerings cache.
