### PR TITLE
Get offerings response from disk cache if available

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -65,13 +65,17 @@ class OfferingsManager(
             appUserID,
             appInBackground,
             { createAndCacheOfferings(it, onError, onSuccess) },
-            { backendError ->
-                val cachedOfferingsResponse = offeringsCache.cachedOfferingsResponse
-                if (cachedOfferingsResponse == null) {
-                    handleErrorFetchingOfferings(backendError, onError)
+            { backendError, isServerError ->
+                if (isServerError) {
+                    val cachedOfferingsResponse = offeringsCache.cachedOfferingsResponse
+                    if (cachedOfferingsResponse == null) {
+                        handleErrorFetchingOfferings(backendError, onError)
+                    } else {
+                        warnLog(OfferingStrings.ERROR_FETCHING_OFFERINGS_USING_DISK_CACHE)
+                        createAndCacheOfferings(cachedOfferingsResponse, onError, onSuccess)
+                    }
                 } else {
-                    warnLog(OfferingStrings.ERROR_FETCHING_OFFERINGS_USING_DISK_CACHE)
-                    createAndCacheOfferings(cachedOfferingsResponse, onError, onSuccess)
+                    handleErrorFetchingOfferings(backendError, onError)
                 }
             })
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -43,7 +43,7 @@ class OfferingsManagerTest {
         backend = mockk()
         offeringsFactory = mockk()
 
-        mockBackendResponse()
+        mockBackendResponseSuccess()
 
         offeringsManager = OfferingsManager(
             cache,
@@ -301,18 +301,7 @@ class OfferingsManagerTest {
             cache.cacheOfferings(any(), any())
         } just Runs
 
-        every {
-            backend.getOfferings(
-                any(),
-                any(),
-                any(),
-                captureLambda()
-            )
-        } answers {
-            lambda<(PurchasesError) -> Unit>().captured.invoke(
-                PurchasesError(PurchasesErrorCode.StoreProblemError)
-            )
-        }
+        mockBackendResponseError()
         every { cache.cachedOfferingsResponse } returns null
         mockDeviceCache(wasSuccessful = false)
 
@@ -339,18 +328,7 @@ class OfferingsManagerTest {
             cache.cacheOfferings(any(), any())
         } just Runs
 
-        every {
-            backend.getOfferings(
-                any(),
-                any(),
-                any(),
-                captureLambda()
-            )
-        } answers {
-            lambda<(PurchasesError) -> Unit>().captured.invoke(
-                PurchasesError(PurchasesErrorCode.UnknownBackendError)
-            )
-        }
+        mockBackendResponseError()
         val backendResponse = JSONObject(ONE_OFFERINGS_RESPONSE)
         every { cache.cachedOfferingsResponse } returns backendResponse
         mockDeviceCache(wasSuccessful = false)
@@ -381,18 +359,7 @@ class OfferingsManagerTest {
             cache.cacheOfferings(any(), any())
         } just Runs
 
-        every {
-            backend.getOfferings(
-                any(),
-                any(),
-                any(),
-                captureLambda()
-            )
-        } answers {
-            lambda<(PurchasesError) -> Unit>().captured.invoke(
-                PurchasesError(PurchasesErrorCode.UnknownBackendError)
-            )
-        }
+        mockBackendResponseError()
         val backendResponse = JSONObject(ONE_OFFERINGS_RESPONSE)
         every { cache.cachedOfferingsResponse } returns backendResponse
         mockDeviceCache(wasSuccessful = false)
@@ -435,11 +402,21 @@ class OfferingsManagerTest {
         }
     }
 
-    private fun mockBackendResponse(response: String = ONE_OFFERINGS_RESPONSE) {
+    private fun mockBackendResponseSuccess(response: String = ONE_OFFERINGS_RESPONSE) {
         every {
             backend.getOfferings(any(), any(), captureLambda(), any())
         } answers {
             lambda<(JSONObject) -> Unit>().captured.invoke(JSONObject(response))
+        }
+    }
+
+    private fun mockBackendResponseError(
+        error: PurchasesError = PurchasesError(PurchasesErrorCode.UnknownBackendError)
+    ) {
+        every {
+            backend.getOfferings(any(), any(), any(), captureLambda())
+        } answers {
+            lambda<(PurchasesError) -> Unit>().captured.invoke(error)
         }
     }
 

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -107,6 +107,11 @@ open class BasePurchasesIntegrationTest {
         activityScenarioRule.scenario.onActivity(block)
     }
 
+    protected fun simulateSdkRestart(context: Context, forceServerErrors: Boolean = false) {
+        Purchases.resetSingleton()
+        configureSdk(context, forceServerErrors)
+    }
+
     protected fun configureSdk(context: Context, forceServerErrors: Boolean = false) {
         Purchases.configure(
             PurchasesConfiguration.Builder(context, Constants.apiKey)

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
@@ -106,7 +106,7 @@ class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
     }
 
     @Test
-    fun offeringsArePersisted() {
+    fun offeringsArePersistedAndUsedOnServerErrors() {
         val storeProduct = StoreProductFactory.createGoogleStoreProduct()
         mockBillingAbstract.mockQueryProductDetails(queryProductDetailsSubsReturn = listOf(storeProduct))
 

--- a/strings/src/main/java/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -30,4 +30,5 @@ object OfferingStrings {
         "with identifier %s. This could be due to Products not being configured correctly in " +
         "the RevenueCat dashboard or Play Store.\nTo configure products, follow the instructions in " +
         "https://rev.cat/how-to-configure-offerings.\nMore information: https://rev.cat/why-are-offerings-empty"
+    const val ERROR_FETCHING_OFFERINGS_USING_DISK_CACHE = "Error fetching offerings. Using disk cache."
 }


### PR DESCRIPTION
### Description
Third and final part of persisting offerings in disk to make the system more robust. In this final PR, we use the offerings response cached in #1028 so, in case of a backend error getting offerings, we can calculate the offerings (as long as Play store/Amazon store still give us the product information) as long as we have cached the value before.