### PR TITLE
[PurchaseTester] Update CustomerInfo from listener in overview screen

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
@@ -19,6 +19,9 @@ class MainApplication : Application(), UpdatedCustomerInfoListener {
 
     val logHandler = TesterLogHandler(this)
 
+    private val customerInfoListeners: MutableSet<UpdatedCustomerInfoListener> = mutableSetOf()
+    private var lastCustomerInfo: CustomerInfo? = null
+
     override fun onCreate() {
         super.onCreate()
 
@@ -28,12 +31,19 @@ class MainApplication : Application(), UpdatedCustomerInfoListener {
     }
 
     override fun onReceived(customerInfo: CustomerInfo) {
+        lastCustomerInfo = customerInfo
         val message = "CustomerInfoListener received update at ${customerInfo.requestDate}"
         Toast.makeText(this,
             message,
             Toast.LENGTH_SHORT
         ).show()
         Log.d("CustomerInfoListener", "$message: $customerInfo")
+        customerInfoListeners.forEach { it.onReceived(customerInfo) }
+    }
+
+    fun addCustomerInfoListener(listener: UpdatedCustomerInfoListener) {
+        lastCustomerInfo?.let { listener.onReceived(it) }
+        customerInfoListeners.add(listener)
     }
 }
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainApplication.kt
@@ -30,6 +30,7 @@ class MainApplication : Application(), UpdatedCustomerInfoListener {
         Purchases.logHandler = logHandler
     }
 
+    @Synchronized
     override fun onReceived(customerInfo: CustomerInfo) {
         lastCustomerInfo = customerInfo
         val message = "CustomerInfoListener received update at ${customerInfo.requestDate}"
@@ -41,6 +42,7 @@ class MainApplication : Application(), UpdatedCustomerInfoListener {
         customerInfoListeners.forEach { it.onReceived(customerInfo) }
     }
 
+    @Synchronized
     fun addCustomerInfoListener(listener: UpdatedCustomerInfoListener) {
         lastCustomerInfo?.let { listener.onReceived(it) }
         customerInfoListeners.add(listener)

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -64,10 +64,9 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
         postponeEnterTransition()
         view.doOnPreDraw { startPostponedEnterTransition() }
 
-        (activity?.application as? MainApplication)?.addCustomerInfoListener { info ->
-            with(binding) {
-                viewModel?.customerInfo?.value = info
-            }
+        // This should be done in a ViewModel, but it's a test app ¯\_(ツ)_/¯
+        (activity?.application as? MainApplication)?.lastCustomerInfoLiveData?.observe(viewLifecycleOwner) {
+            viewModel.customerInfo.value = it
         }
 
         Purchases.sharedInstance.getCustomerInfoWith(::showError) { info ->

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchasetester
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -63,10 +64,14 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
         postponeEnterTransition()
         view.doOnPreDraw { startPostponedEnterTransition() }
 
-        Purchases.sharedInstance.getCustomerInfoWith(::showError) { info ->
+        (activity?.application as? MainApplication)?.addCustomerInfoListener { info ->
             with(binding) {
                 viewModel?.customerInfo?.value = info
             }
+        }
+
+        Purchases.sharedInstance.getCustomerInfoWith(::showError) { info ->
+            Log.i("PurchaseTester", "Get Customer info returned Customer info: $info")
         }
 
         Purchases.sharedInstance.getOfferingsWith(::showError, ::populateOfferings)


### PR DESCRIPTION
### Description
Changed PurchaseTester to update the customer info in the overview fragment from the customer info listener instead of the initial result from getting the customer info. This way, we always display the most up to date information.
