### PR TITLE
[EXTERNAL] Fix `README` `CONTRIBUTING` guide broken link (#1035) via @pablo-guardiola

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ Or view our Android sample app:
 Our full SDK reference [can be found here](https://sdk.revenuecat.com/android/index.html).
 
 ## Contributing
-Contributions are always welcome! To learn how you can contribute, please see the [Contributing Guide](./Contributing/CONTRIBUTING.md).
+Contributions are always welcome! To learn how you can contribute, please see the [Contributing Guide](./CONTRIBUTING.md).


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the
"Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
*Why is this change required? What problem does it solve?*

Follow-up from
https://github.com/RevenueCat/purchases-android/pull/984#pullrequestreview-1449271470

Quick PR adding a quick `README` fix that I found while exploring `purchases-android`'s repo / learning how RevenueCat's Purchases SDK works.

<!-- Please link to issues following this format: Resolves #999999 -->

### Description
*Describe your changes in detail*

- Fixes `README` `CONTRIBUTING` guide broken link

*Please describe in detail how you tested your changes*

- Easy test 😅 `CONTRIBUTING.md` lives now in the repo's root (`Contributing` folder doesn't exist anymore) so checked that clicking the link redirects me to `CONTRIBUTING`

