### PR TITLE
[EXTERNAL] Update Kover to 0.7.0 (#1031) via @mikescamell

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,12 +145,12 @@ jobs:
               find . -type f -regex ".*/build/test-results/.*xml" -exec cp --parents {} build/test-results/ \;
       - run:
           name: Kover HTML
-          command: ./gradlew koverMergedHtmlReport
+          command: ./gradlew purchases:koverHtmlReportDefaultsRelease
       - run:
           name: Kover XML
-          command: ./gradlew koverMergedXmlReport
+          command: ./gradlew purchases:koverXmlReportDefaultsRelease
       - codecov/upload:
-          file: build/reports/kover/merged/xml/report.xml
+          file: purchases/build/reports/kover/reportDefaultsRelease.xml
       - android/save-build-cache
       - store_artifacts:
           path: build/reports

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.8.10"
-        classpath "org.jetbrains.kotlinx:kover:0.6.1"
+        classpath "org.jetbrains.kotlinx:kover-gradle-plugin:0.7.0"
     }
 }
 
@@ -87,16 +87,4 @@ apply plugin: 'org.jetbrains.dokka'
 tasks.dokkaHtmlMultiModule.configure {
     outputDirectory.set(file("docs/" + project.property("VERSION_NAME")))
     includes.from("README.md")
-}
-
-apply plugin: 'kover'
-
-koverMerged {
-    enable()
-    filters {
-        projects {
-            // Specifies the projects excluded from the merged tasks
-            excludes.addAll(":api-tester", ":integration-tests", ":examples:purchase-tester")
-        }
-    }
 }

--- a/library.gradle
+++ b/library.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
-apply plugin: 'kover'
 
 android {
     compileSdkVersion compileVersion
@@ -43,3 +42,9 @@ android {
 }
 
 apply plugin: 'com.vanniktech.maven.publish'
+
+project.afterEvaluate {
+    // Remove afterEvaluate
+    // after https://github.com/Kotlin/kotlinx-kover/issues/362 is fixed
+    project.pluginManager.apply("org.jetbrains.kotlinx.kover")
+}

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -95,3 +95,19 @@ tasks.dokkaHtmlPartial.configure {
         }
     }
 }
+
+// Remove afterEvaluate
+// after https://github.com/Kotlin/kotlinx-kover/issues/362 is fixed
+project.afterEvaluate {
+    dependencies {
+        kover(project(":common"))
+        kover(project(":feature:amazon"))
+        kover(project(":feature:google"))
+        kover(project(":feature:identity"))
+        kover(project(":feature:subscriber-attributes"))
+        kover(project(":public"))
+        kover(project(":strings"))
+        kover(project(":test-utils"))
+        kover(project(":utils"))
+    }
+}


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
~Resolves #356 by adding test coverage back.~ Code coverage was added back in a while ago! This PR updates Kover to 0.7.0 and makes the changes necessary to merge reports.

### Description

Kover has recently updated to 0.7.0, so the update was also performed as part of this PR.

It required some changes to how Kover is set up and how the reports are merged. I followed the advice in the [migration
guide](https://github.com/Kotlin/kotlinx-kover/blob/v0.7.0/docs/gradle-plugin/migrations/migration-to-0.7.0.md) and the [android multiproject
example](https://github.com/Kotlin/kotlinx-kover/tree/v0.7.0/examples/android/multiproject).

I also updated the CircleCI script and added the test coverage badge back to the readme.

Obviously, I don't have access to your CI to test this completely, but I have run everything locally to check that it works.

Contributed by @mikescamell