### PR TITLE
[EXTERNAL] Add `MagicWeather` app note to the main `README` and fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Sign up to [get started for free](https://app.revenuecat.com/signup).
 
 *Purchases* is the client for the [RevenueCat](https://www.revenuecat.com/) subscription and purchase tracking system. It is an open source framework that provides a wrapper around `BillingClient` and the RevenueCat backend to make implementing in-app subscriptions in `Android` easy - receipt validation and status tracking included!
 
-## Migrating Guides
+## Migration Guides
 | Description | Link |
 | --- | --- |
 | Migrating from v4.x.x to v5.x.x | [V5 API Migration Guide](./migrations/v5-MIGRATION.md) |
@@ -45,8 +45,8 @@ For more detailed information, you can view our complete documentation at [docs.
 
 Please follow the [Quickstart Guide](https://docs.revenuecat.com/docs/) for more information on how to install the SDK.
 
-Or view our Android sample app:
-- [MagicWeather](examples/MagicWeather)
+Or view / build our Android sample app:
+- [MagicWeather](examples/MagicWeather) (open it on a different Android Studio window)
 
 ## Requirements
 - Java 8+


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
*Why is this change required? What problem does it solve?*

Follow-up from https://github.com/RevenueCat/purchases-android/pull/984#discussion_r1209172348

<!-- Please link to issues following this format: Resolves #999999 -->

### Description
*Describe your changes in detail*

- Adds `MagicWeather` app note to the main `README` as discussed in https://github.com/RevenueCat/purchases-android/pull/984#discussion_r1209172348
- Fixes a typo: ~Migrating~ > Migration

<!-- Please describe in detail how you tested your changes -->

cc @tonidero 