### PR TITLE
Fix backend integration test flakiness

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -175,6 +175,8 @@ platform :android do
       new_text: ENV['LOAD_SHEDDER_REVENUECAT_API_KEY'],
       paths_of_files_to_update: [constants_path]
     )
+    # Runing integration test flavor in order to make backend tests run faster, since the jittering is too
+    # long in the `defaults` flavor.
     gradle(
       task: ':common:testIntegrationTestDebugUnitTest',
       properties: {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -176,7 +176,7 @@ platform :android do
       paths_of_files_to_update: [constants_path]
     )
     gradle(
-      task: ':common:test',
+      task: ':common:testIntegrationTestDebugUnitTest',
       properties: {
         "RUN_INTEGRATION_TESTS" => true
       }


### PR DESCRIPTION
### Description
I noticed a lot of flakiness around the backend integration tests. Looks like it's because those were using the long jittering durations for the requests, which can delay the request up to 10s. I changed to execute the backend integration tests only in the integration test flavor which reduces that amount to a maximum of 1s.
