### PR TITLE
Make enabling entitlement verification also enabled diagnostics

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -196,7 +196,7 @@ final class PurchasesAPI {
                 .observerMode(false)
                 .service(executorService)
                 .diagnosticsEnabled(true)
-                .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
+                .informationalVerificationModeAndDiagnosticsEnabled(true)
                 .build();
 
         Purchases.configure(build);

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import com.revenuecat.purchases.CacheFetchPolicy
 import com.revenuecat.purchases.CustomerInfo
-import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.LogLevel
@@ -236,7 +235,7 @@ private class PurchasesAPI {
             .observerMode(false)
             .service(executorService)
             .diagnosticsEnabled(true)
-            .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
+            .informationalVerificationModeAndDiagnosticsEnabled(true)
             .build()
 
         Purchases.configure(build)

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -115,6 +115,7 @@ class ConfigureFragment : Fragment() {
         val verificationModeIndex = binding.verificationOptionsInput.selectedItemPosition
 
         val entitlementVerificationMode = EntitlementVerificationMode.values()[verificationModeIndex]
+        val enableEntitlementVerification = entitlementVerificationMode == EntitlementVerificationMode.INFORMATIONAL
         val useAmazonStore = binding.storeRadioGroup.checkedRadioButtonId == R.id.amazon_store_radio_id
         val useObserverMode = binding.observerModeCheckbox.isChecked
 
@@ -131,7 +132,7 @@ class ConfigureFragment : Fragment() {
 
         val configuration = configurationBuilder
             .diagnosticsEnabled(true)
-            .entitlementVerificationMode(entitlementVerificationMode)
+            .informationalVerificationModeAndDiagnosticsEnabled(enableEntitlementVerification)
             .observerMode(useObserverMode)
             .build()
         Purchases.configure(configuration)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -102,6 +102,9 @@ open class PurchasesConfiguration(builder: Builder) {
             if (enabled) {
                 this.verificationMode = EntitlementVerificationMode.INFORMATIONAL
                 this.diagnosticsEnabled = true
+            } else {
+                this.verificationMode = EntitlementVerificationMode.DISABLED
+                this.diagnosticsEnabled = false
             }
         }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -86,7 +86,7 @@ open class PurchasesConfiguration(builder: Builder) {
          * detected attempts of hacking.
          *
          * When changing from disabled to enabled, the SDK will clear the CustomerInfo cache.
-         * This means users will need to connect to the internet to get back their entitlements.
+         * This means users will need to connect to the internet to get their entitlements back.
          *
          * The result of the verification can be obtained from [EntitlementInfos.verification] or
          * [EntitlementInfo.verification].

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -77,24 +77,32 @@ open class PurchasesConfiguration(builder: Builder) {
          */
         fun diagnosticsEnabled(diagnosticsEnabled: Boolean) = apply {
             this.diagnosticsEnabled = diagnosticsEnabled
+            if (!diagnosticsEnabled) {
+                this.verificationMode = EntitlementVerificationMode.DISABLED
+            }
         }
 
         /**
-         * **Feature in beta**. Defines how strict [EntitlementInfo] verification ought to be.
+         * **Feature in beta**. Enables signature verification of requests to the RevenueCat backend
+         * in informational mode and enables diagnostics reports to RevenueCat to help us analyze this feature.
+         * Informational mode means that the behavior will remain the same but we will provide information about
+         * detected attempts of hacking.
          *
-         * When changing from [EntitlementVerificationMode.DISABLED] to [EntitlementVerificationMode.INFORMATIONAL],
-         * the SDK will clear the CustomerInfo cache. This means users will need to connect to the internet to get
-         * back their entitlements.
+         * When changing from disabled to enabled, the SDK will clear the CustomerInfo cache.
+         * This means users will need to connect to the internet to get back their entitlements.
          *
          * The result of the verification can be obtained from [EntitlementInfos.verification] or
          * [EntitlementInfo.verification].
          *
          * This feature is currently in beta and the behavior may change.
          *
-         * Default mode is [EntitlementVerificationMode.DISABLED].
+         * Default mode is disabled.
          */
-        fun entitlementVerificationMode(entitlementVerificationMode: EntitlementVerificationMode) = apply {
-            this.verificationMode = entitlementVerificationMode
+        fun informationalVerificationModeAndDiagnosticsEnabled(enabled: Boolean) = apply {
+            if (enabled) {
+                this.verificationMode = EntitlementVerificationMode.INFORMATIONAL
+                this.diagnosticsEnabled = true
+            }
         }
 
         /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -77,9 +77,6 @@ open class PurchasesConfiguration(builder: Builder) {
          */
         fun diagnosticsEnabled(diagnosticsEnabled: Boolean) = apply {
             this.diagnosticsEnabled = diagnosticsEnabled
-            if (!diagnosticsEnabled) {
-                this.verificationMode = EntitlementVerificationMode.DISABLED
-            }
         }
 
         /**

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -35,6 +35,7 @@ class PurchasesConfigurationTest {
         assertThat(purchasesConfiguration.service).isNull()
         assertThat(purchasesConfiguration.store).isEqualTo(Store.PLAY_STORE)
         assertThat(purchasesConfiguration.diagnosticsEnabled).isFalse
+        assertThat(purchasesConfiguration.verificationMode).isEqualTo(EntitlementVerificationMode.DISABLED)
         assertThat(purchasesConfiguration.dangerousSettings).isEqualTo(DangerousSettings(autoSyncPurchases = true))
     }
 
@@ -68,6 +69,23 @@ class PurchasesConfigurationTest {
     fun `PurchasesConfiguration sets diagnosticsEnabled correctly`() {
         val purchasesConfiguration = builder.diagnosticsEnabled(true).build()
         assertThat(purchasesConfiguration.diagnosticsEnabled).isTrue
+    }
+
+    @Test
+    fun `PurchasesConfiguration sets informational mode and diagnostics correctly`() {
+        val purchasesConfiguration = builder.informationalVerificationModeAndDiagnosticsEnabled(true).build()
+        assertThat(purchasesConfiguration.diagnosticsEnabled).isTrue
+        assertThat(purchasesConfiguration.verificationMode).isEqualTo(EntitlementVerificationMode.INFORMATIONAL)
+    }
+
+    @Test
+    fun `PurchasesConfiguration disabling diagnostics also disables verification mode`() {
+        val purchasesConfiguration = builder
+            .informationalVerificationModeAndDiagnosticsEnabled(true)
+            .diagnosticsEnabled(false)
+            .build()
+        assertThat(purchasesConfiguration.diagnosticsEnabled).isFalse
+        assertThat(purchasesConfiguration.verificationMode).isEqualTo(EntitlementVerificationMode.DISABLED)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -79,16 +79,6 @@ class PurchasesConfigurationTest {
     }
 
     @Test
-    fun `PurchasesConfiguration disabling diagnostics also disables verification mode`() {
-        val purchasesConfiguration = builder
-            .informationalVerificationModeAndDiagnosticsEnabled(true)
-            .diagnosticsEnabled(false)
-            .build()
-        assertThat(purchasesConfiguration.diagnosticsEnabled).isFalse
-        assertThat(purchasesConfiguration.verificationMode).isEqualTo(EntitlementVerificationMode.DISABLED)
-    }
-
-    @Test
     fun `PurchasesConfiguration sets dangerous settings correctly`() {
         val dangerousSettings = DangerousSettings(autoSyncPurchases = false)
         val purchasesConfiguration = builder.dangerousSettings(dangerousSettings).build()


### PR DESCRIPTION
### Description
SDK-3186

This makes it so enabling entitlement verification informational mode also requires enabling diagnostics. This is meant to be used for the beta.
