### PR TITLE
Require experimental annotation for trusted entitlements API

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -8,7 +8,7 @@ import androidx.annotation.Nullable;
 
 import com.revenuecat.purchases.CacheFetchPolicy;
 import com.revenuecat.purchases.CustomerInfo;
-import com.revenuecat.purchases.EntitlementVerificationMode;
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI;
 import com.revenuecat.purchases.LogHandler;
 import com.revenuecat.purchases.LogLevel;
 import com.revenuecat.purchases.Offerings;
@@ -28,9 +28,9 @@ import com.revenuecat.purchases.interfaces.SyncPurchasesCallback;
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener;
 import com.revenuecat.purchases.models.BillingFeature;
 import com.revenuecat.purchases.models.GoogleProrationMode;
-import com.revenuecat.purchases.models.SubscriptionOption;
 import com.revenuecat.purchases.models.StoreProduct;
 import com.revenuecat.purchases.models.StoreTransaction;
+import com.revenuecat.purchases.models.SubscriptionOption;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -40,6 +40,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+
+import kotlin.OptIn;
 
 @SuppressWarnings({"unused"})
 final class PurchasesAPI {
@@ -184,6 +186,7 @@ final class PurchasesAPI {
         purchases.setCreative("");
     }
 
+    @OptIn(markerClass = ExperimentalPreviewRevenueCatPurchasesAPI.class)
     static void checkConfiguration(final Context context,
                                    final ExecutorService executorService) throws MalformedURLException {
         final List<? extends BillingFeature> features = new ArrayList<>();

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -8,7 +8,6 @@ import androidx.annotation.Nullable;
 
 import com.revenuecat.purchases.CacheFetchPolicy;
 import com.revenuecat.purchases.CustomerInfo;
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI;
 import com.revenuecat.purchases.LogHandler;
 import com.revenuecat.purchases.LogLevel;
 import com.revenuecat.purchases.Offerings;
@@ -40,8 +39,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-
-import kotlin.OptIn;
 
 @SuppressWarnings({"unused"})
 final class PurchasesAPI {
@@ -186,7 +183,6 @@ final class PurchasesAPI {
         purchases.setCreative("");
     }
 
-    @OptIn(markerClass = ExperimentalPreviewRevenueCatPurchasesAPI.class)
     static void checkConfiguration(final Context context,
                                    final ExecutorService executorService) throws MalformedURLException {
         final List<? extends BillingFeature> features = new ArrayList<>();
@@ -199,7 +195,6 @@ final class PurchasesAPI {
                 .observerMode(false)
                 .service(executorService)
                 .diagnosticsEnabled(true)
-                .informationalVerificationModeAndDiagnosticsEnabled(true)
                 .build();
 
         Purchases.configure(build);

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementInfoAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementInfoAPI.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.apitester.kotlin
 
 import com.revenuecat.purchases.EntitlementInfo
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.OwnershipType
 import com.revenuecat.purchases.PeriodType
 import com.revenuecat.purchases.Store
@@ -10,6 +11,7 @@ import java.util.Date
 
 @Suppress("unused", "UNUSED_VARIABLE", "DEPRECATION", "LongParameterList")
 private class EntitlementInfoAPI {
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     fun check(entitlementInfo: EntitlementInfo) {
         with(entitlementInfo) {
             val identifier: String = identifier

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementInfosAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementInfosAPI.kt
@@ -2,10 +2,12 @@ package com.revenuecat.apitester.kotlin
 
 import com.revenuecat.purchases.EntitlementInfo
 import com.revenuecat.purchases.EntitlementInfos
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.VerificationResult
 
 @Suppress("unused", "UNUSED_VARIABLE", "DEPRECATION")
 private class EntitlementInfosAPI {
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     fun check(infos: EntitlementInfos) {
         val active: Map<String, EntitlementInfo> = infos.active
         val all: Map<String, EntitlementInfo> = infos.all

--- a/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -7,6 +7,7 @@ package com.revenuecat.purchases.common.caching
 
 import android.content.SharedPreferences
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.CustomerInfoFactory
 import com.revenuecat.purchases.common.DateProvider
@@ -135,6 +136,7 @@ open class DeviceCache(
     }
 
     @Synchronized
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     fun cacheCustomerInfo(appUserID: String, info: CustomerInfo) {
         val jsonObject = info.rawData.also {
             it.put(CUSTOMER_INFO_SCHEMA_VERSION_KEY, CUSTOMER_INFO_SCHEMA_VERSION)

--- a/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -7,6 +7,7 @@ package com.revenuecat.purchases.common
 
 import android.content.SharedPreferences
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.caching.CUSTOMER_INFO_SCHEMA_VERSION
@@ -34,6 +35,7 @@ import kotlin.time.Duration.Companion.minutes
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 class DeviceCacheTest {
 
     private val validCachedCustomerInfo by lazy {

--- a/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.common
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.EntitlementInfos
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.OwnershipType
 import com.revenuecat.purchases.PeriodType
 import com.revenuecat.purchases.Store
@@ -19,6 +20,7 @@ import kotlin.time.Duration.Companion.days
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 class EntitlementInfosTests {
 
     private var response = JSONObject()

--- a/config/detekt/detekt-baseline.xml
+++ b/config/detekt/detekt-baseline.xml
@@ -2,7 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>CyclomaticComplexMethod:EntitlementInfo.kt$EntitlementInfo$override fun equals(other: Any?): Boolean</ID>
+    <ID>CyclomaticComplexMethod:EntitlementInfo.kt$EntitlementInfo$@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class) override fun equals(other: Any?): Boolean</ID>
     <ID>DestructuringDeclarationWithTooManyEntries:Period.kt$val (year, month, week, day) = periodResult.destructured</ID>
     <ID>EmptyCatchBlock:Purchases.kt$Purchases.Companion.&lt;no name provided>${ }</ID>
     <ID>Filename:backendHelpers.kt$com.revenuecat.purchases.subscriberattributes.backendHelpers.kt</ID>

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.revenuecat.purchases.EntitlementVerificationMode
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
@@ -109,6 +110,7 @@ class ConfigureFragment : Fragment() {
         return binding.root
     }
 
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private suspend fun configureSDK() {
         val apiKey = binding.apiKeyInput.text.toString()
         val proxyUrl = binding.proxyUrlInput.text?.toString() ?: ""

--- a/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/feature/identity/src/main/java/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.identity
 
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
@@ -141,6 +142,7 @@ class IdentityManager(
     }
 
     @Suppress("UnusedPrivateMember", "FunctionOnlyReturningConstant")
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private fun shouldInvalidateCustomerInfoAndETagCache(customerInfo: CustomerInfo?): Boolean {
         return customerInfo != null &&
             customerInfo.entitlements.verification == VerificationResult.NOT_REQUESTED &&

--- a/feature/identity/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/feature/identity/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.identity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.EntitlementInfos
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
@@ -573,6 +574,7 @@ class IdentityManagerTests {
 
     // region helper functions
 
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private fun setupCustomerInfoCacheInvalidationTest(
         userId: String,
         verificationResult: VerificationResult,

--- a/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt
@@ -54,6 +54,7 @@ data class EntitlementInfo(
     val billingIssueDetectedAt: Date?,
     val ownershipType: OwnershipType,
     private val jsonObject: JSONObject,
+    @ExperimentalPreviewRevenueCatPurchasesAPI
     val verification: VerificationResult = VerificationResult.NOT_REQUESTED,
 ) : Parcelable, RawDataContainer<JSONObject> {
 
@@ -106,6 +107,7 @@ data class EntitlementInfo(
         get() = jsonObject
 
     /** @suppress */
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     override fun toString(): String {
         return "EntitlementInfo(" +
             "identifier='$identifier', " +
@@ -126,6 +128,7 @@ data class EntitlementInfo(
     }
 
     /** @suppress */
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/public/src/main/java/com/revenuecat/purchases/EntitlementInfos.kt
+++ b/public/src/main/java/com/revenuecat/purchases/EntitlementInfos.kt
@@ -13,6 +13,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 class EntitlementInfos(
     val all: Map<String, EntitlementInfo>,
+    @ExperimentalPreviewRevenueCatPurchasesAPI
     val verification: VerificationResult,
 ) : Parcelable {
 
@@ -36,6 +37,7 @@ class EntitlementInfos(
     operator fun get(s: String) = all[s]
 
     /** @suppress */
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -95,6 +95,7 @@ open class PurchasesConfiguration(builder: Builder) {
          *
          * Default mode is disabled.
          */
+        @ExperimentalPreviewRevenueCatPurchasesAPI
         fun informationalVerificationModeAndDiagnosticsEnabled(enabled: Boolean) = apply {
             if (enabled) {
                 this.verificationMode = EntitlementVerificationMode.INFORMATIONAL

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -91,10 +91,11 @@ open class PurchasesConfiguration(builder: Builder) {
          * The result of the verification can be obtained from [EntitlementInfos.verification] or
          * [EntitlementInfo.verification].
          *
-         * This feature is currently in beta and the behavior may change.
+         * This feature is currently in beta and the behavior may change. Only available in Kotlin.
          *
          * Default mode is disabled.
          */
+        @JvmSynthetic
         @ExperimentalPreviewRevenueCatPurchasesAPI
         fun informationalVerificationModeAndDiagnosticsEnabled(enabled: Boolean) = apply {
             if (enabled) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -94,6 +94,8 @@ open class PurchasesConfiguration(builder: Builder) {
          * This feature is currently in beta and the behavior may change. Only available in Kotlin.
          *
          * Default mode is disabled.
+         *
+         * @warning This function is marked as [ExperimentalPreviewRevenueCatPurchasesAPI] and may change in the future.
          */
         @JvmSynthetic
         @ExperimentalPreviewRevenueCatPurchasesAPI

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -72,6 +72,7 @@ class PurchasesConfigurationTest {
     }
 
     @Test
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     fun `PurchasesConfiguration sets informational mode and diagnostics correctly`() {
         val purchasesConfiguration = builder.informationalVerificationModeAndDiagnosticsEnabled(true).build()
         assertThat(purchasesConfiguration.diagnosticsEnabled).isTrue


### PR DESCRIPTION
### Description
This PR has changes from #1060 and is based on #1061 

This adds a require opt in requirement to use the trusted entitlements API.


