### PR TITLE
Trusted entitlements: Add internal mechanism to force signing errors for tests

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
@@ -15,9 +15,15 @@ class AppConfig(
     val store: Store,
     val dangerousSettings: DangerousSettings = DangerousSettings(autoSyncPurchases = true),
     // Should only be used for tests
-    var forceServerErrors: Boolean = false,
-    var forceSigningErrors: Boolean = false,
+    forceServerErrors: Boolean = false,
+    forceSigningErrors: Boolean = false,
 ) {
+    // Should only be used for tests
+    private val integrationTestFlavor = "integrationTest"
+    var forceServerErrors: Boolean = forceServerErrors
+        get() = BuildConfig.FLAVOR == integrationTestFlavor && field
+    var forceSigningErrors: Boolean = forceSigningErrors
+        get() = BuildConfig.FLAVOR == integrationTestFlavor && field
 
     val enableOfflineEntitlements = true
     val languageTag: String = context.getLocale()?.toBCP47() ?: ""

--- a/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
@@ -15,15 +15,15 @@ class AppConfig(
     val store: Store,
     val dangerousSettings: DangerousSettings = DangerousSettings(autoSyncPurchases = true),
     // Should only be used for tests
+    private val runningTests: Boolean = false,
     forceServerErrors: Boolean = false,
     forceSigningErrors: Boolean = false,
 ) {
     // Should only be used for tests
-    private val integrationTestFlavor = "integrationTest"
     var forceServerErrors: Boolean = forceServerErrors
-        get() = BuildConfig.FLAVOR == integrationTestFlavor && field
+        get() = runningTests && field
     var forceSigningErrors: Boolean = forceSigningErrors
-        get() = BuildConfig.FLAVOR == integrationTestFlavor && field
+        get() = runningTests && field
 
     val enableOfflineEntitlements = true
     val languageTag: String = context.getLocale()?.toBCP47() ?: ""

--- a/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/AppConfig.kt
@@ -16,6 +16,7 @@ class AppConfig(
     val dangerousSettings: DangerousSettings = DangerousSettings(autoSyncPurchases = true),
     // Should only be used for tests
     var forceServerErrors: Boolean = false,
+    var forceSigningErrors: Boolean = false,
 ) {
 
     val enableOfflineEntitlements = true
@@ -42,6 +43,7 @@ class AppConfig(
         if (packageName != other.packageName) return false
         if (finishTransactions != other.finishTransactions) return false
         if (forceServerErrors != other.forceServerErrors) return false
+        if (forceSigningErrors != other.forceSigningErrors) return false
         if (baseURL != other.baseURL) return false
 
         return true
@@ -56,6 +58,7 @@ class AppConfig(
         result = 31 * result + packageName.hashCode()
         result = 31 * result + finishTransactions.hashCode()
         result = 31 * result + forceServerErrors.hashCode()
+        result = 31 * result + forceSigningErrors.hashCode()
         result = 31 * result + baseURL.hashCode()
         return result
     }

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -2,14 +2,17 @@ package com.revenuecat.purchases.common.verification
 
 import android.util.Base64
 import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.strings.NetworkStrings
 import java.security.SecureRandom
 
 class SigningManager(
     val signatureVerificationMode: SignatureVerificationMode,
+    val appConfig: AppConfig,
 ) {
     private companion object {
         const val NONCE_BYTES_SIZE = 12
@@ -36,6 +39,10 @@ class SigningManager(
         requestTime: String?,
         eTag: String?,
     ): VerificationResult {
+        if (appConfig.forceSigningErrors) {
+            warnLog("Forcing signing error for request with path: $urlPath")
+            return VerificationResult.FAILED
+        }
         val signatureVerifier = signatureVerificationMode.verifier ?: return VerificationResult.NOT_REQUESTED
 
         if (signature == null) {

--- a/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
@@ -74,6 +74,7 @@ abstract class BaseBackendIntegrationTest {
             every { packageName } returns "com.revenuecat.purchases.backend_tests"
             every { finishTransactions } returns true
             every { forceServerErrors } returns false
+            every { forceSigningErrors } returns false
         }
         dispatcher = Dispatcher(Executors.newSingleThreadScheduledExecutor())
         diagnosticsDispatcher = Dispatcher(Executors.newSingleThreadScheduledExecutor())
@@ -86,7 +87,7 @@ abstract class BaseBackendIntegrationTest {
             every { edit() } returns sharedPreferencesEditor
         }
         eTagManager = ETagManager(sharedPreferences)
-        signingManager = SigningManager(SignatureVerificationMode.Disabled)
+        signingManager = SigningManager(SignatureVerificationMode.Disabled, appConfig)
         httpClient = HTTPClient(appConfig, eTagManager, diagnosticsTrackerIfEnabled = null, signingManager)
         backendHelper = BackendHelper(apiKey(), dispatcher, appConfig, httpClient)
         backend = Backend(appConfig, dispatcher, diagnosticsDispatcher, httpClient, backendHelper)

--- a/common/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -161,6 +161,30 @@ class AppConfigTest {
     }
 
     @Test
+    fun `default forceServerErrors is correct`() {
+        val appConfig = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null,
+            store = Store.PLAY_STORE
+        )
+        assertThat(appConfig.forceServerErrors).isFalse
+    }
+
+    @Test
+    fun `default forceSigningErrors is correct`() {
+        val appConfig = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null,
+            store = Store.PLAY_STORE
+        )
+        assertThat(appConfig.forceSigningErrors).isFalse
+    }
+
+    @Test
     fun `Given two app configs with same data, both are equal`() {
         val x = AppConfig(
             context = mockk(relaxed = true),

--- a/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -67,7 +67,8 @@ abstract class BaseHTTPClientTest {
         platformInfo: PlatformInfo = expectedPlatformInfo,
         proxyURL: URL? = baseURL,
         store: Store = Store.PLAY_STORE,
-        forceServerErrors: Boolean = false
+        forceServerErrors: Boolean = false,
+        forceSigningErrors: Boolean = false,
     ): AppConfig {
         return AppConfig(
             context = context,
@@ -75,7 +76,8 @@ abstract class BaseHTTPClientTest {
             platformInfo = platformInfo,
             proxyURL = proxyURL,
             store = store,
-            forceServerErrors = forceServerErrors
+            forceServerErrors = forceServerErrors,
+            forceSigningErrors = forceSigningErrors,
         )
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -76,6 +76,7 @@ abstract class BaseHTTPClientTest {
             platformInfo = platformInfo,
             proxyURL = proxyURL,
             store = store,
+            runningTests = true,
             forceServerErrors = forceServerErrors,
             forceSigningErrors = forceSigningErrors,
         )

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/purchasesExtensions.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/purchasesExtensions.kt
@@ -7,6 +7,7 @@ fun Purchases.Companion.configure(
     configuration: PurchasesConfiguration,
     overrideBillingAbstract: BillingAbstract,
     forceServerErrors: Boolean = false,
+    forceSigningErrors: Boolean = false,
 ): Purchases {
     return PurchasesFactory().createPurchases(
         configuration,
@@ -14,6 +15,7 @@ fun Purchases.Companion.configure(
         proxyURL,
         overrideBillingAbstract,
         forceServerErrors,
+        forceSigningErrors,
     ).also {
         @SuppressLint("RestrictedApi")
         sharedInstance = it
@@ -29,4 +31,10 @@ var Purchases.forceServerErrors: Boolean
     get() = appConfig.forceServerErrors
     set(value) {
         appConfig.forceServerErrors = value
+    }
+
+var Purchases.forceSigningErrors: Boolean
+    get() = appConfig.forceSigningErrors
+    set(value) {
+        appConfig.forceSigningErrors = value
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -42,13 +42,14 @@ internal class PurchasesFactory(
     private val apiKeyValidator: APIKeyValidator = APIKeyValidator(),
 ) {
 
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "LongParameterList")
     fun createPurchases(
         configuration: PurchasesConfiguration,
         platformInfo: PlatformInfo,
         proxyURL: URL?,
         overrideBillingAbstract: BillingAbstract? = null,
         forceServerErrors: Boolean = false,
+        forceSigningError: Boolean = false,
     ): Purchases {
         validateConfiguration(configuration)
 
@@ -62,6 +63,7 @@ internal class PurchasesFactory(
                 store,
                 dangerousSettings,
                 forceServerErrors,
+                forceSigningError,
             )
 
             val prefs = PreferenceManager.getDefaultSharedPreferences(application)
@@ -86,7 +88,7 @@ internal class PurchasesFactory(
             val signatureVerificationMode = SignatureVerificationMode.fromEntitlementVerificationMode(
                 verificationMode,
             )
-            val signingManager = SigningManager(signatureVerificationMode)
+            val signingManager = SigningManager(signatureVerificationMode, appConfig)
 
             val httpClient = HTTPClient(appConfig, eTagManager, diagnosticsTracker, signingManager)
             val backendHelper = BackendHelper(apiKey, dispatcher, appConfig, httpClient)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.BillingAbstract
+import com.revenuecat.purchases.common.BuildConfig
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.FileHelper
 import com.revenuecat.purchases.common.HTTPClient
@@ -41,6 +42,7 @@ import java.util.concurrent.ThreadFactory
 internal class PurchasesFactory(
     private val apiKeyValidator: APIKeyValidator = APIKeyValidator(),
 ) {
+    private val integrationTestFlavor = "integrationTest"
 
     @Suppress("LongMethod", "LongParameterList")
     fun createPurchases(
@@ -62,6 +64,7 @@ internal class PurchasesFactory(
                 proxyURL,
                 store,
                 dangerousSettings,
+                BuildConfig.FLAVOR == integrationTestFlavor,
                 forceServerErrors,
                 forceSigningError,
             )


### PR DESCRIPTION
### Description
SDK-3182

This allows to force signing errors during tests so we can better test the trusted entitlements feature automatically.

<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
