### PR TITLE
Return error in queryPurchases if error connecting to billing client

### DIFF
--- a/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/feature/google/src/main/java/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -443,13 +443,17 @@ class BillingWrapper(
         }
     }
 
-    @Suppress("ReturnCount")
+    @Suppress("ReturnCount", "LongMethod")
     override fun queryPurchases(
         appUserID: String,
         onSuccess: (Map<String, StoreTransaction>) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
-        executeRequestOnUIThread {
+        executeRequestOnUIThread { connectionError ->
+            if (connectionError != null) {
+                onError(connectionError)
+                return@executeRequestOnUIThread
+            }
             withConnectedClient {
                 log(LogIntent.DEBUG, RestoreStrings.QUERYING_PURCHASE)
 

--- a/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/feature/google/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -111,6 +111,8 @@ class BillingWrapperTest {
 
     private val billingClientOKResult = BillingClient.BillingResponseCode.OK.buildResult()
     private val billingClientErrorResult = BillingClient.BillingResponseCode.ERROR.buildResult()
+    private val billingClientBillingUnavailableResult =
+        BillingClient.BillingResponseCode.BILLING_UNAVAILABLE.buildResult()
     private val appUserId = "jerry"
     private var mockActivity = mockk<Activity>()
 
@@ -1254,6 +1256,26 @@ class BillingWrapperTest {
         }
 
         assertThat(purchasesByHashedToken).isNotNull
+    }
+
+    @Test
+    fun `queryPurchases returns error if error connecting`() {
+        every { mockClient.isReady } returns false
+
+        var receivedError: PurchasesError? = null
+        wrapper.queryPurchases(
+            appUserID = "appUserID",
+            onSuccess = { fail("should be an error") },
+            onError = { receivedError = it}
+        )
+
+        billingClientStateListener!!.onBillingSetupFinished(billingClientBillingUnavailableResult)
+
+        verify(exactly = 0) {
+            mockClient.queryPurchasesAsync(any<QueryPurchasesParams>(), any())
+        }
+
+        assertThat(receivedError).isNotNull
     }
 
     @Test


### PR DESCRIPTION
### Description
I noticed Google's `queryPurchases` method would never end if we got a connection error to the billing client (either a `FEATURE_NOT_SUPPORTED` or `BILLING_UNAVAILABLE` error).

This makes it so the method returns the error in the error callback.