### PR TITLE
Sync pending purchases before getting customer info

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
@@ -31,7 +31,7 @@ internal class CustomerInfoHelper(
         debugLog(CustomerInfoStrings.RETRIEVING_CUSTOMER_INFO.format(fetchPolicy))
         when (fetchPolicy) {
             CacheFetchPolicy.CACHE_ONLY -> getCustomerInfoCacheOnly(appUserID, callback)
-            CacheFetchPolicy.FETCH_CURRENT -> postPendingPurchasesIfNeededAndFetchCustomerInfo(
+            CacheFetchPolicy.FETCH_CURRENT -> postPendingPurchasesAndFetchCustomerInfo(
                 appUserID,
                 appInBackground,
                 allowSharingPlayStoreAccount,
@@ -71,7 +71,7 @@ internal class CustomerInfoHelper(
         }
     }
 
-    private fun postPendingPurchasesIfNeededAndFetchCustomerInfo(
+    private fun postPendingPurchasesAndFetchCustomerInfo(
         appUserID: String,
         appInBackground: Boolean,
         allowSharingPlayStoreAccount: Boolean,
@@ -144,7 +144,7 @@ internal class CustomerInfoHelper(
             updateCachedCustomerInfoIfStale(appUserID, appInBackground, allowSharingPlayStoreAccount)
         } else {
             log(LogIntent.DEBUG, CustomerInfoStrings.NO_CACHED_CUSTOMERINFO)
-            postPendingPurchasesIfNeededAndFetchCustomerInfo(
+            postPendingPurchasesAndFetchCustomerInfo(
                 appUserID,
                 appInBackground,
                 allowSharingPlayStoreAccount,
@@ -160,7 +160,7 @@ internal class CustomerInfoHelper(
         callback: ReceiveCustomerInfoCallback? = null,
     ) {
         if (deviceCache.isCustomerInfoCacheStale(appUserID, appInBackground)) {
-            postPendingPurchasesIfNeededAndFetchCustomerInfo(
+            postPendingPurchasesAndFetchCustomerInfo(
                 appUserID,
                 appInBackground,
                 allowSharingPlayStoreAccount,
@@ -188,7 +188,7 @@ internal class CustomerInfoHelper(
                     CustomerInfoStrings.CUSTOMERINFO_STALE_UPDATING_BACKGROUND
                 } else CustomerInfoStrings.CUSTOMERINFO_STALE_UPDATING_FOREGROUND,
             )
-            postPendingPurchasesIfNeededAndFetchCustomerInfo(appUserID, appInBackground, allowSharingPlayStoreAccount)
+            postPendingPurchasesAndFetchCustomerInfo(appUserID, appInBackground, allowSharingPlayStoreAccount)
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -204,6 +204,7 @@ class Purchases internal constructor(
                 identityManager.currentAppUserID,
                 fetchPolicy = CacheFetchPolicy.FETCH_CURRENT,
                 appInBackground = false,
+                allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
             )
         }
         offeringsManager.onAppForeground(identityManager.currentAppUserID)
@@ -635,6 +636,7 @@ class Purchases internal constructor(
                 identityManager.currentAppUserID,
                 CacheFetchPolicy.default(),
                 state.appInBackground,
+                allowSharingPlayStoreAccount,
                 receiveCustomerInfoCallback(
                     onSuccess = { customerInfo ->
                         dispatch { callback?.onReceived(customerInfo, false) }
@@ -708,6 +710,7 @@ class Purchases internal constructor(
             identityManager.currentAppUserID,
             fetchPolicy,
             state.appInBackground,
+            allowSharingPlayStoreAccount,
             callback,
         )
     }
@@ -1112,6 +1115,7 @@ class Purchases internal constructor(
                 appUserID,
                 CacheFetchPolicy.FETCH_CURRENT,
                 appInBackground,
+                allowSharingPlayStoreAccount,
                 completion,
             )
             offeringsManager.fetchAndCacheOfferings(appUserID, appInBackground)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -155,7 +155,6 @@ internal class PurchasesFactory(
                 offlineEntitlementsManager,
             )
 
-
             val postReceiptHelper = PostReceiptHelper(
                 appConfig,
                 backend,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -155,24 +155,6 @@ internal class PurchasesFactory(
                 offlineEntitlementsManager,
             )
 
-            val customerInfoHelper = CustomerInfoHelper(
-                cache,
-                backend,
-                offlineEntitlementsManager,
-                customerInfoUpdateHandler,
-            )
-            val offeringParser = OfferingParserFactory.createOfferingParser(store)
-
-            var diagnosticsSynchronizer: DiagnosticsSynchronizer? = null
-            if (diagnosticsFileHelper != null && diagnosticsTracker != null) {
-                diagnosticsSynchronizer = DiagnosticsSynchronizer(
-                    diagnosticsFileHelper,
-                    diagnosticsTracker,
-                    backend,
-                    diagnosticsDispatcher,
-                    DiagnosticsSynchronizer.initializeSharedPreferences(context),
-                )
-            }
 
             val postReceiptHelper = PostReceiptHelper(
                 appConfig,
@@ -182,19 +164,6 @@ internal class PurchasesFactory(
                 cache,
                 subscriberAttributesManager,
                 offlineEntitlementsManager,
-            )
-
-            val syncPurchasesHelper = SyncPurchasesHelper(
-                billing,
-                identityManager,
-                customerInfoHelper,
-                postReceiptHelper,
-            )
-
-            val offeringsManager = OfferingsManager(
-                offeringsCache,
-                backend,
-                OfferingsFactory(billing, offeringParser),
             )
 
             val postTransactionWithProductDetailsHelper = PostTransactionWithProductDetailsHelper(
@@ -209,6 +178,39 @@ internal class PurchasesFactory(
                 dispatcher,
                 identityManager,
                 postTransactionWithProductDetailsHelper,
+            )
+
+            val customerInfoHelper = CustomerInfoHelper(
+                cache,
+                backend,
+                offlineEntitlementsManager,
+                customerInfoUpdateHandler,
+                postPendingTransactionsHelper,
+            )
+            val offeringParser = OfferingParserFactory.createOfferingParser(store)
+
+            var diagnosticsSynchronizer: DiagnosticsSynchronizer? = null
+            if (diagnosticsFileHelper != null && diagnosticsTracker != null) {
+                diagnosticsSynchronizer = DiagnosticsSynchronizer(
+                    diagnosticsFileHelper,
+                    diagnosticsTracker,
+                    backend,
+                    diagnosticsDispatcher,
+                    DiagnosticsSynchronizer.initializeSharedPreferences(context),
+                )
+            }
+
+            val syncPurchasesHelper = SyncPurchasesHelper(
+                billing,
+                identityManager,
+                customerInfoHelper,
+                postReceiptHelper,
+            )
+
+            val offeringsManager = OfferingsManager(
+                offeringsCache,
+                backend,
+                OfferingsFactory(billing, offeringParser),
             )
 
             return Purchases(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
@@ -37,7 +37,7 @@ internal class SyncPurchasesHelper(
                         if (currentPurchase == lastPurchase) {
                             if (errors.isEmpty()) {
                                 debugLog(PurchaseStrings.SYNCED_PURCHASES_SUCCESSFULLY)
-                                retrieveCustomerInfo(appUserID, appInBackground, onSuccess, onError)
+                                retrieveCustomerInfo(appUserID, appInBackground, isRestore, onSuccess, onError)
                             } else {
                                 errorLog(PurchaseStrings.SYNCING_PURCHASES_ERROR.format(errors))
                                 onError(errors.first())
@@ -69,7 +69,7 @@ internal class SyncPurchasesHelper(
                         )
                     }
                 } else {
-                    retrieveCustomerInfo(appUserID, appInBackground, onSuccess, onError)
+                    retrieveCustomerInfo(appUserID, appInBackground, isRestore, onSuccess, onError)
                 }
             },
             onReceivePurchaseHistoryError = {
@@ -82,6 +82,7 @@ internal class SyncPurchasesHelper(
     private fun retrieveCustomerInfo(
         appUserID: String,
         appInBackground: Boolean,
+        isRestore: Boolean,
         onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -89,6 +90,7 @@ internal class SyncPurchasesHelper(
             appUserID,
             CacheFetchPolicy.CACHED_OR_FETCHED,
             appInBackground = appInBackground,
+            allowSharingPlayStoreAccount = isRestore,
             callback = object : ReceiveCustomerInfoCallback {
                 override fun onReceived(customerInfo: CustomerInfo) {
                     onSuccess(customerInfo)

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -216,14 +216,20 @@ open class BasePurchasesTest {
     // region Protected methods
     protected fun mockCustomerInfoHelper(errorGettingCustomerInfo: PurchasesError? = null) {
         with(mockCustomerInfoHelper) {
+            val slot = slot<ReceiveCustomerInfoCallback>()
             every {
-                retrieveCustomerInfo(any(), any(), appInBackground = false, allowSharingPlayStoreAccount = false, any())
+                retrieveCustomerInfo(
+                    any(),
+                    any(),
+                    appInBackground = false,
+                    allowSharingPlayStoreAccount = false,
+                    capture(slot),
+                )
             } answers {
-                val callback = arg<ReceiveCustomerInfoCallback?>(4)
                 if (errorGettingCustomerInfo == null) {
-                    callback?.onReceived(mockInfo)
+                    slot.captured.onReceived(mockInfo)
                 } else {
-                    callback?.onError(errorGettingCustomerInfo)
+                    slot.captured.onError(errorGettingCustomerInfo)
                 }
             }
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -217,9 +217,9 @@ open class BasePurchasesTest {
     protected fun mockCustomerInfoHelper(errorGettingCustomerInfo: PurchasesError? = null) {
         with(mockCustomerInfoHelper) {
             every {
-                retrieveCustomerInfo(any(), any(), false, any())
+                retrieveCustomerInfo(any(), any(), appInBackground = false, allowSharingPlayStoreAccount = false, any())
             } answers {
-                val callback = arg<ReceiveCustomerInfoCallback?>(3)
+                val callback = arg<ReceiveCustomerInfoCallback?>(4)
                 if (errorGettingCustomerInfo == null) {
                     callback?.onReceived(mockInfo)
                 } else {

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -216,20 +216,20 @@ open class BasePurchasesTest {
     // region Protected methods
     protected fun mockCustomerInfoHelper(errorGettingCustomerInfo: PurchasesError? = null) {
         with(mockCustomerInfoHelper) {
-            val slot = slot<ReceiveCustomerInfoCallback>()
+            val slotList = mutableListOf<ReceiveCustomerInfoCallback?>()
             every {
                 retrieveCustomerInfo(
                     any(),
                     any(),
                     appInBackground = false,
                     allowSharingPlayStoreAccount = false,
-                    capture(slot),
+                    captureNullable(slotList),
                 )
             } answers {
                 if (errorGettingCustomerInfo == null) {
-                    slot.captured.onReceived(mockInfo)
+                    slotList.firstOrNull()?.onReceived(mockInfo)
                 } else {
-                    slot.captured.onError(errorGettingCustomerInfo)
+                    slotList.firstOrNull()?.onError(errorGettingCustomerInfo)
                 }
             }
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
@@ -66,21 +66,6 @@ class PostPendingTransactionsHelperTest {
     // region syncPendingPurchaseQueue
 
     @Test
-    fun `if billing client not connected do not query purchases`() {
-        changeBillingConnected(false)
-        syncAndAssertError(PurchasesError(PurchasesErrorCode.StoreProblemError, "Billing client disconnected"))
-        verify(exactly = 0) {
-            billing.queryPurchases(any(), any(), any())
-        }
-    }
-
-    @Test
-    fun `if billing client not connected error callback called`() {
-        changeBillingConnected(false)
-        syncAndAssertError(PurchasesError(PurchasesErrorCode.StoreProblemError, "Billing client disconnected"))
-    }
-
-    @Test
     fun `skip posting pending purchases if autosync is off`() {
         changeAutoSyncEnabled(false)
         syncAndAssertSuccessful(null)

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesTest.kt
@@ -26,6 +26,7 @@ class PurchasesCoroutinesTest : BasePurchasesTest() {
                 any(),
                 any(),
                 any(),
+                any(),
             )
         }
         assertThat(result).isNotNull
@@ -40,6 +41,7 @@ class PurchasesCoroutinesTest : BasePurchasesTest() {
         verify(exactly = 1) {
             mockCustomerInfoHelper.retrieveCustomerInfo(
                 appUserId,
+                any(),
                 any(),
                 any(),
                 any(),
@@ -64,6 +66,7 @@ class PurchasesCoroutinesTest : BasePurchasesTest() {
         verify(exactly = 1) {
             mockCustomerInfoHelper.retrieveCustomerInfo(
                 appUserId,
+                any(),
                 any(),
                 any(),
                 any(),

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesTest.kt
@@ -1857,7 +1857,7 @@ class PurchasesTest: BasePurchasesTest() {
 
         verify(exactly = 1) {
             mockCompletion.onReceived(any(), any())
-            mockCustomerInfoHelper.retrieveCustomerInfo(appUserID, any(), false, any())
+            mockCustomerInfoHelper.retrieveCustomerInfo(appUserID, any(), any(), any(), any())
         }
     }
 
@@ -2024,7 +2024,8 @@ class PurchasesTest: BasePurchasesTest() {
             mockCustomerInfoHelper.retrieveCustomerInfo(
                 appUserID,
                 CacheFetchPolicy.FETCH_CURRENT,
-                false,
+                appInBackground = false,
+                allowSharingPlayStoreAccount = false,
                 any()
             )
         }
@@ -2061,6 +2062,7 @@ class PurchasesTest: BasePurchasesTest() {
                 appUserId,
                 CacheFetchPolicy.FETCH_CURRENT,
                 false,
+                allowSharingPlayStoreAccount = false,
                 null
             )
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
@@ -23,6 +23,7 @@ class SyncPurchasesHelperTest {
     private val testError = PurchasesError(PurchasesErrorCode.CustomerInfoError)
     private val customerInfoMock = mockk<CustomerInfo>()
     private val appInBackground = false
+    private val isRestore = false
 
     private lateinit var billing: BillingAbstract
     private lateinit var identityManager: IdentityManager
@@ -56,7 +57,7 @@ class SyncPurchasesHelperTest {
 
         var receivedCustomerInfo: CustomerInfo? = null
         syncPurchasesHelper.syncPurchases(
-            isRestore = false,
+            isRestore = isRestore,
             appInBackground = appInBackground,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should not call onError") }
@@ -77,7 +78,7 @@ class SyncPurchasesHelperTest {
 
         var receivedError: PurchasesError? = null
         syncPurchasesHelper.syncPurchases(
-            isRestore = false,
+            isRestore = isRestore,
             appInBackground = appInBackground,
             onSuccess = { fail("Should not call onSuccess") },
             onError = { receivedError = it }
@@ -92,7 +93,7 @@ class SyncPurchasesHelperTest {
 
         var error: PurchasesError? = null
         syncPurchasesHelper.syncPurchases(
-            isRestore = false,
+            isRestore = isRestore,
             appInBackground = appInBackground,
             onSuccess = { fail("Should not call onSuccess") },
             onError = { error = it }
@@ -130,7 +131,7 @@ class SyncPurchasesHelperTest {
 
         var receivedCustomerInfo: CustomerInfo? = null
         syncPurchasesHelper.syncPurchases(
-            isRestore = false,
+            isRestore = isRestore,
             appInBackground = appInBackground,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should have succeeded") }
@@ -142,7 +143,7 @@ class SyncPurchasesHelperTest {
                 purchaseToken = "test-purchase-token-1",
                 storeUserID = "test-store-user-id",
                 receiptInfo = any(),
-                isRestore = false,
+                isRestore = isRestore,
                 appUserID = appUserID,
                 marketplace = null,
                 onSuccess = any(),
@@ -152,7 +153,7 @@ class SyncPurchasesHelperTest {
                 purchaseToken = "test-purchase-token-2",
                 storeUserID = "test-store-user-id",
                 receiptInfo = any(),
-                isRestore = false,
+                isRestore = isRestore,
                 appUserID = appUserID,
                 marketplace = "test-marketplace",
                 onSuccess = any(),
@@ -185,7 +186,7 @@ class SyncPurchasesHelperTest {
 
         var errorCallCount = 0
         syncPurchasesHelper.syncPurchases(
-            isRestore = false,
+            isRestore = isRestore,
             appInBackground = appInBackground,
             onSuccess = { fail("Should error") },
             onError = { errorCallCount++ }
@@ -197,7 +198,7 @@ class SyncPurchasesHelperTest {
                 purchaseToken = "test-purchase-token-1",
                 storeUserID = "test-store-user-id",
                 receiptInfo = any(),
-                isRestore = false,
+                isRestore = isRestore,
                 appUserID = appUserID,
                 marketplace = null,
                 onSuccess = any(),
@@ -207,7 +208,7 @@ class SyncPurchasesHelperTest {
                 purchaseToken = "test-purchase-token-2",
                 storeUserID = "test-store-user-id",
                 receiptInfo = any(),
-                isRestore = false,
+                isRestore = isRestore,
                 appUserID = appUserID,
                 marketplace = "test-marketplace",
                 onSuccess = any(),
@@ -223,7 +224,7 @@ class SyncPurchasesHelperTest {
 
         var successCallCount = 0
         syncPurchasesHelper.syncPurchases(
-            isRestore = false,
+            isRestore = isRestore,
             appInBackground = appInBackground,
             onSuccess = { successCallCount++ },
             onError = { fail("Should have succeeded") }
@@ -261,6 +262,7 @@ class SyncPurchasesHelperTest {
                 appUserID,
                 CacheFetchPolicy.CACHED_OR_FETCHED,
                 appInBackground,
+                isRestore,
                 capture(callbackSlot)
             )
         } answers {
@@ -277,6 +279,7 @@ class SyncPurchasesHelperTest {
                 appUserID,
                 CacheFetchPolicy.CACHED_OR_FETCHED,
                 appInBackground,
+                isRestore,
                 capture(callbackSlot)
             )
         } answers {

--- a/strings/src/main/java/com/revenuecat/purchases/strings/CustomerInfoStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/CustomerInfoStrings.kt
@@ -8,6 +8,7 @@ object CustomerInfoStrings {
     const val CUSTOMERINFO_STALE_UPDATING_FOREGROUND = "CustomerInfo cache is stale, updating from " +
         "network in foreground."
     const val CUSTOMERINFO_UPDATED_FROM_NETWORK = "CustomerInfo updated from network."
+    const val CUSTOMERINFO_UPDATED_FROM_SYNCING_PENDING_PURCHASES = "CustomerInfo updated syncing pending purchases."
     const val CUSTOMERINFO_UPDATED_NOTIFYING_LISTENER = "CustomerInfo updated, sending to listener."
     const val SENDING_LATEST_CUSTOMERINFO_TO_LISTENER = "Sending latest CustomerInfo to listener."
     const val VENDING_CACHE = "Vending CustomerInfo from cache."

--- a/strings/src/main/java/com/revenuecat/purchases/strings/CustomerInfoStrings.kt
+++ b/strings/src/main/java/com/revenuecat/purchases/strings/CustomerInfoStrings.kt
@@ -8,7 +8,8 @@ object CustomerInfoStrings {
     const val CUSTOMERINFO_STALE_UPDATING_FOREGROUND = "CustomerInfo cache is stale, updating from " +
         "network in foreground."
     const val CUSTOMERINFO_UPDATED_FROM_NETWORK = "CustomerInfo updated from network."
-    const val CUSTOMERINFO_UPDATED_FROM_SYNCING_PENDING_PURCHASES = "CustomerInfo updated syncing pending purchases."
+    const val CUSTOMERINFO_UPDATED_FROM_SYNCING_PENDING_PURCHASES = "CustomerInfo updated from syncing " +
+        "pending purchases."
     const val CUSTOMERINFO_UPDATED_NOTIFYING_LISTENER = "CustomerInfo updated, sending to listener."
     const val SENDING_LATEST_CUSTOMERINFO_TO_LISTENER = "Sending latest CustomerInfo to listener."
     const val VENDING_CACHE = "Vending CustomerInfo from cache."


### PR DESCRIPTION
### Description
Followup to #1052 and #1058 

This changes the behavior of fetching customer info. Now, when fetching customer info, we will first try to sync any pending purchases if any. If there are pending purchases, we will return the customer info from the last request sent. If there aren't, we will then hit the current customer info endpoint to get the latest customer info. 