### PR TITLE
Add defaultsRelease variant tests run configuration

### DIFF
--- a/.run/Debug tests.run.xml
+++ b/.run/Debug tests.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Tests in defaultsRelease variant" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="Debug tests" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -10,7 +10,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="testDefaultsReleaseUnitTest" />
+          <option value="testDefaultsDebugUnitTest" />
         </list>
       </option>
       <option name="vmOptions" />

--- a/.run/Release tests.run.xml
+++ b/.run/Release tests.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Release tests" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="testDefaultsReleaseUnitTest" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Tests in defaultsRelease variant.run.xml
+++ b/.run/Tests in defaultsRelease variant.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Tests in defaultsRelease variant" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="testDefaultsReleaseUnitTest" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
### Description
This adds 2 new run configuration in Android studio to run the tests only in the `defaultsDebug` or `defaultsRelease` variant
<img width="152" alt="image" src="https://github.com/RevenueCat/purchases-android/assets/808417/6b6189aa-21c1-43c9-bfa4-5d0ae5ac05be">

The `All tests` run configuration run the same tests multiple times:
- defaultsDebug
- defaultsRelease
- integrationTestDebug
- integrationTestRelease

Many times, we don't really need to run the tests in all variants, this provides a way so tests are a bit faster to run locally when it's not needed to run in all variants.