### PR TITLE
Handle other diagnostics-related exceptions

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
@@ -79,7 +79,7 @@ class DiagnosticsSynchronizer(
                         }
                     },
                 )
-            } catch (e: IOException) {
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                 verboseLog("Error syncing diagnostics file: $e")
                 try {
                     resetDiagnosticsStatus()

--- a/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
@@ -13,6 +13,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
@@ -170,6 +171,13 @@ class DiagnosticsSynchronizerTest {
     @Test
     fun `syncDiagnosticsFileIfNeeded deletes file if IOException happens`() {
         every { diagnosticsFileHelper.readDiagnosticsFile() } throws IOException()
+        diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
+        verify(exactly = 1) { diagnosticsFileHelper.deleteDiagnosticsFile()  }
+    }
+
+    @Test
+    fun `syncDiagnosticsFileIfNeeded deletes file if JSONException happens`() {
+        every { diagnosticsFileHelper.readDiagnosticsFile() } throws JSONException("test-exception")
         diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
         verify(exactly = 1) { diagnosticsFileHelper.deleteDiagnosticsFile()  }
     }


### PR DESCRIPTION
### Description
We got reports of some crashes for users using diagnostics https://community.revenuecat.com/questions/2388. I haven't been able to repro the issues, but we shouldn't let the SDK crash due to this. This makes our catch for reading diagnostics events more generic so we handle those more gracefully 
