### PR TITLE
[EXTERNAL] Add `awaitCustomerInfo` / coroutines tests to `TrustedEntitlementsInformationalModeIntegrationTest`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", ve
 androidx-lifecycle-livedata = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "lifecycle" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "multidex" }
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidxNavigation" }

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     integrationTestImplementation libs.material
     integrationTestImplementation libs.androidx.constraintlayout
 
+    androidTestIntegrationTestImplementation libs.androidx.lifecycle.runtime.ktx
     androidTestIntegrationTestImplementation libs.androidx.test.espresso.core
     androidTestIntegrationTestImplementation libs.androidx.test.runner
     androidTestIntegrationTestImplementation libs.androidx.test.rules

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -2,12 +2,15 @@ package com.revenuecat.purchases
 
 import android.content.Context
 import android.preference.PreferenceManager
+import androidx.lifecycle.lifecycleScope
 import androidx.test.ext.junit.rules.activityScenarioRule
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.models.StoreTransaction
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions
 import org.junit.After
 import org.junit.BeforeClass
@@ -163,6 +166,14 @@ open class BasePurchasesIntegrationTest {
             )
         } answers {
             callbackSlot.captured.invoke(activePurchases)
+        }
+    }
+
+    protected fun runTestActivityLifecycleScope(
+        testBody: suspend CoroutineScope.() -> Unit,
+    ) {
+        activity.lifecycleScope.launch {
+            testBody()
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
**Why is this change required? What problem does it solve?**

Follow up from https://github.com/RevenueCat/purchases-android/pull/1071#discussion_r1232485138

<!-- Please link to issues following this format: Resolves #999999 -->

### Description
**Describe your changes in detail**

- Adds `awaitCustomerInfo` / coroutines tests to `TrustedEntitlementsInformationalModeIntegrationTest`

**Please describe in detail how you tested your changes**

- Run integration tests locally ✅ 

cc @tonidero @vegaro @NachoSoto 
