### PR TITLE
Fix integration test

### DIFF
--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.models.GooglePurchasingData
 import com.revenuecat.purchases.models.GoogleStoreProduct
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertWith
 import org.assertj.core.api.Assertions.fail
 import org.junit.Before
 import org.junit.Test
@@ -68,7 +69,10 @@ class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
                             fail("fetching from cache should be success. Error: ${it.message}")
                         },
                         onSuccess = { cachedCustomerInfo ->
-                            assertThat(cachedCustomerInfo).isEqualTo(fetchedCustomerInfo)
+                            assertThat(cachedCustomerInfo)
+                                .usingRecursiveComparison()
+                                .ignoringFields("schemaVersion", "jsonObject")
+                                .isEqualTo(fetchedCustomerInfo)
                             lock.countDown()
                         },
                     )

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
@@ -8,7 +8,6 @@ import com.revenuecat.purchases.models.GooglePurchasingData
 import com.revenuecat.purchases.models.GoogleStoreProduct
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertWith
 import org.assertj.core.api.Assertions.fail
 import org.junit.Before
 import org.junit.Test
@@ -60,13 +59,13 @@ class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
             Purchases.sharedInstance.getCustomerInfoWith(
                 CacheFetchPolicy.FETCH_CURRENT,
                 onError = {
-                    fail("fetching from backend should be success. Error: ${it.message}")
+                    fail("fetching from backend should be success. Error: $it")
                 },
                 onSuccess = { fetchedCustomerInfo ->
                     Purchases.sharedInstance.getCustomerInfoWith(
                         CacheFetchPolicy.CACHE_ONLY,
                         onError = {
-                            fail("fetching from cache should be success. Error: ${it.message}")
+                            fail("fetching from cache should be success. Error: $it")
                         },
                         onSuccess = { cachedCustomerInfo ->
                             assertThat(cachedCustomerInfo)


### PR DESCRIPTION
### Description
This integration test broke in #1073. The error was that the `schemaVersion` field in the customer info didn't match between the fetched and cached customer info. It was actually luck that made it work before 😬 . 

Before that change, this test tried to get customer info twice: On sdk configuration and the first  part of the test. Since both of these happen pretty quickly, we only made the request once and called both callbacks with the same response. However, the first request actually modified the JSONObject, adding the schema version and some other fields in order to cache it in the device. This made it so the JSONObject actually had those fields in the second callback, causing the schemaVersion to have a value. Then, the value returned from cache already has the schemaVersion field set so the test passed.

After the change in #1073, the test still tries to get customer info twice, but the raw json sharing didn't happen, since when we call `getCustomerInfo` we now need to check first for unsynced purchases, causing us to not share the callback, so the schema version that was set in the first callback wasn't shared with the second one, causing the `schemaVersion` field to be 0, causing the test to fail

It took me a while to debug this 😞 
