### PR TITLE
Default customer info schema version to latest known by SDK

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/CustomerInfoFactory.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/CustomerInfoFactory.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.EntitlementInfos
 import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.caching.CUSTOMER_INFO_SCHEMA_VERSION
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.responses.CustomerInfoResponseJsonKeys
 import com.revenuecat.purchases.common.responses.ProductResponseJsonKeys
@@ -80,7 +81,7 @@ object CustomerInfoFactory {
             allPurchaseDatesByProduct = purchaseDatesByProduct,
             requestDate = requestDate,
             jsonObject = body,
-            schemaVersion = body.optInt("schema_version"),
+            schemaVersion = body.optInt("schema_version", CUSTOMER_INFO_SCHEMA_VERSION),
             firstSeen = firstSeen,
             originalAppUserId = subscriber.optString(CustomerInfoResponseJsonKeys.ORIGINAL_APP_USER_ID),
             managementURL = managementURL?.let { Uri.parse(it) },

--- a/common/src/test/java/com/revenuecat/purchases/common/CustomerInfoFactoryTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/CustomerInfoFactoryTest.kt
@@ -1,0 +1,42 @@
+package com.revenuecat.purchases.common
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.utils.Responses
+import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+class CustomerInfoFactoryTest {
+
+    private val defaultCustomerInfo = CustomerInfoFactory.buildCustomerInfo(
+        JSONObject(Responses.validFullPurchaserResponse),
+        overrideRequestDate = null,
+        verificationResult = VerificationResult.NOT_REQUESTED
+    )
+
+    @Test
+    fun `assigns active entitlements correctly`() {
+        assertThat(defaultCustomerInfo.entitlements.active.keys).isEqualTo(setOf("pro", "forever_pro"))
+    }
+
+    @Test
+    fun `assigns default schema version correctly`() {
+        assertThat(defaultCustomerInfo.schemaVersion).isEqualTo(3)
+    }
+
+    @Test
+    fun `assigns default request date correctly`() {
+        assertThat(defaultCustomerInfo.requestDate).isEqualTo(Date(1565951442000))
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    @Test
+    fun `assigns default verification result correctly`() {
+        assertThat(defaultCustomerInfo.entitlements.verification).isEqualTo(VerificationResult.NOT_REQUESTED)
+    }
+}


### PR DESCRIPTION
### Description
An integration test started failing due to #1073. The error was that the schemaVersion field in the customer info didn't match between the fetched and cached customer info. It was actually luck that made it work before 😬 .

Before that change, this test tried to get customer info twice: On sdk configuration and the first part of the test. Since both of these happen pretty quickly, we only made the request once and called both callbacks with the same response. However, the first request actually modified the JSONObject, adding the schema version and some other fields in order to cache it in the device. This made it so the JSONObject actually had those fields in the second callback, causing the schemaVersion to have a value. Then, the value returned from cache already has the schemaVersion field set so the test passed.

After the change in https://github.com/RevenueCat/purchases-android/pull/1073, the test still tries to get customer info twice, but the raw json sharing didn't happen, since when we call getCustomerInfo we now need to check first for unsynced purchases, causing us to not share the callback, so the schema version that was set in the first callback wasn't shared with the second one, causing the schemaVersion field to be 0, causing the test to fail.

After talking about it, we think defaulting the schema version to the latest known version by the SDK is probably expected behavior, instead of defaulting to 0 before it's been saved.

Followup to #1078 