### PR TITLE
[EXTERNAL] Add missing `fetchPolicy` parameter to `awaitCustomerInfo` API

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -196,6 +196,8 @@ private class PurchasesAPI {
         purchases: Purchases,
     ) {
         val customerInfo: CustomerInfo = purchases.awaitCustomerInfo()
+        val customerInfoFetchPolicy: CustomerInfo =
+            purchases.awaitCustomerInfo(fetchPolicy = CacheFetchPolicy.FETCH_CURRENT)
     }
 
     fun check(purchases: Purchases, attributes: Map<String, String>) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases
 
+import com.revenuecat.purchases.CacheFetchPolicy.CACHED_OR_FETCHED
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -9,14 +10,22 @@ import kotlin.coroutines.suspendCoroutine
  * Coroutine friendly version of [Purchases.getCustomerInfo].
  *
  * @warning This function is marked as [ExperimentalPreviewRevenueCatPurchasesAPI] and may change in the future.
+ * Only available in Kotlin.
+ *
+ * @param fetchPolicy Specifies cache behavior for customer info retrieval (optional).
+ * Defaults to [CacheFetchPolicy.default]: [CACHED_OR_FETCHED].
  *
  * @throws [PurchasesException] with a [PurchasesError] if there's an error retrieving the customer info.
  * @return The [CustomerInfo] or a [PurchasesException] with the [PurchasesError]
  */
+@JvmSynthetic
 @ExperimentalPreviewRevenueCatPurchasesAPI
-suspend fun Purchases.awaitCustomerInfo(): CustomerInfo {
+suspend fun Purchases.awaitCustomerInfo(
+    fetchPolicy: CacheFetchPolicy = CacheFetchPolicy.default(),
+): CustomerInfo {
     return suspendCoroutine { continuation ->
         getCustomerInfoWith(
+            fetchPolicy,
             onSuccess = continuation::resume,
             onError = { continuation.resumeWithException(PurchasesException(it)) },
         )


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
**Why is this change required? What problem does it solve?**

Follow up from https://github.com/RevenueCat/purchases-android/pull/1077#discussion_r1238268219

<!-- Please link to issues following this format: Resolves #999999 -->

### Description
**Describe your changes in detail**

- Add missing `fetchPolicy` parameter to `awaitCustomerInfo` API

**Please describe in detail how you tested your changes**

- Run `purchases` tests
- Run `examples.purchase-test` app

cc @vegaro @tonidero 