### PR TITLE
[PurchaseTester] Add option to purchase an arbitrary product id

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -137,7 +137,7 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
                             object : PurchaseCallback {
                                 override fun onCompleted(
                                     storeTransaction: StoreTransaction,
-                                    customerInfo: CustomerInfo
+                                    customerInfo: CustomerInfo,
                                 ) {
                                     showToast("Successful purchase, order id: ${storeTransaction.orderId}")
                                 }
@@ -145,13 +145,15 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
                                 override fun onError(error: PurchasesError, userCancelled: Boolean) {
                                     showError(error)
                                 }
-                            })
+                            },
+                        )
                     }
 
                     override fun onError(error: PurchasesError) {
                         showError(error)
                     }
-                })
+                },
+            )
         }
         builder.setNegativeButton("Cancel") { dialog, which ->
             dialog.cancel()

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -3,22 +3,31 @@ package com.revenuecat.purchasetester
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.text.InputType
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import android.widget.Toast
 import androidx.core.view.doOnPreDraw
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.transition.MaterialElevationScale
+import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.PurchaseParams
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.getOfferingsWith
+import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
+import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.logOutWith
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases_sample.R
 import com.revenuecat.purchases_sample.databinding.FragmentOverviewBinding
 
@@ -28,7 +37,7 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
     private lateinit var viewModel: OverviewViewModel
     private lateinit var binding: FragmentOverviewBinding
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = FragmentOverviewBinding.inflate(inflater)
 
         binding.customerInfoLogoutButton.setOnClickListener {
@@ -48,6 +57,10 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
 
         binding.proxyButton.setOnClickListener {
             navigateToProxyFragment()
+        }
+
+        binding.purchaseProductIdButton.setOnClickListener {
+            showPurchaseProductIdDialog()
         }
 
         viewModel = OverviewViewModel(this)
@@ -101,6 +114,50 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
 //        val directions = OverviewFragmentDirections.
 //        actionOverviewFragmentToDeprecatedOfferingFragment(offering.identifier)
         findNavController().navigate(directions, extras)
+    }
+
+    private fun showPurchaseProductIdDialog() {
+        val builder = MaterialAlertDialogBuilder(requireContext())
+        builder.setTitle("Enter the Product ID of you want to purchase:")
+        val input = EditText(context)
+        input.inputType = InputType.TYPE_CLASS_TEXT
+        builder.setView(input)
+        builder.setPositiveButton("Purchase") { dialog, which ->
+            val productId = input.text.toString()
+            Purchases.sharedInstance.getProducts(
+                listOf(productId),
+                object : GetStoreProductsCallback {
+                    override fun onReceived(storeProducts: List<StoreProduct>) {
+                        if (storeProducts.isEmpty()) {
+                            showError("A product with ID $productId does not exist")
+                            return
+                        }
+                        Purchases.sharedInstance.purchase(
+                            PurchaseParams.Builder(requireActivity(), storeProducts.first()).build(),
+                            object : PurchaseCallback {
+                                override fun onCompleted(
+                                    storeTransaction: StoreTransaction,
+                                    customerInfo: CustomerInfo
+                                ) {
+                                    showToast("Successful purchase, order id: ${storeTransaction.orderId}")
+                                }
+
+                                override fun onError(error: PurchasesError, userCancelled: Boolean) {
+                                    showError(error)
+                                }
+                            })
+                    }
+
+                    override fun onError(error: PurchasesError) {
+                        showError(error)
+                    }
+                })
+        }
+        builder.setNegativeButton("Cancel") { dialog, which ->
+            dialog.cancel()
+        }
+        val dialog = builder.create()
+        dialog.show()
     }
 
     override fun displayError(error: PurchasesError) {

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -118,7 +118,7 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
 
     private fun showPurchaseProductIdDialog() {
         val builder = MaterialAlertDialogBuilder(requireContext())
-        builder.setTitle("Enter the Product ID of you want to purchase:")
+        builder.setTitle("Enter the Product ID you want to purchase:")
         val input = EditText(context)
         input.inputType = InputType.TYPE_CLASS_TEXT
         builder.setView(input)

--- a/examples/purchase-tester/src/main/res/layout/fragment_overview.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_overview.xml
@@ -241,6 +241,13 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content">
             <com.google.android.material.button.MaterialButton
+                    android:id="@+id/purchase_product_id_button"
+                    android:text="@string/buy_product"
+                    android:layout_gravity="end|bottom"
+                    android:layout_marginEnd="@dimen/padding_small"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+            <com.google.android.material.button.MaterialButton
                     android:id="@+id/proxy_button"
                     android:text="@string/proxy"
                     android:layout_gravity="end|bottom"

--- a/examples/purchase-tester/src/main/res/values/strings.xml
+++ b/examples/purchase-tester/src/main/res/values/strings.xml
@@ -19,4 +19,5 @@
     <string name="proxy_entitlement_override">Entitlement override (Will grant entitlements)</string>
     <string name="proxy_server_down">Server down (All requests will return 500)</string>
     <string name="proxy">Proxy</string>
+    <string name="buy_product">Buy Product</string>
 </resources>


### PR DESCRIPTION
Current limitation: only supports purchasing OTP products and the first baseplan of a subscription

https://github.com/RevenueCat/purchases-android/assets/1014118/ebb91409-3afe-4f8d-b4a2-fa229995e8f2

