### PR TITLE
`Trusted Entitlements`: stable

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 
 import com.revenuecat.purchases.CacheFetchPolicy;
 import com.revenuecat.purchases.CustomerInfo;
+import com.revenuecat.purchases.EntitlementVerificationMode;
 import com.revenuecat.purchases.LogHandler;
 import com.revenuecat.purchases.LogLevel;
 import com.revenuecat.purchases.Offerings;
@@ -195,6 +196,7 @@ final class PurchasesAPI {
                 .observerMode(false)
                 .service(executorService)
                 .diagnosticsEnabled(true)
+                .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
                 .build();
 
         Purchases.configure(build);

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementInfoAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementInfoAPI.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.apitester.kotlin
 
 import com.revenuecat.purchases.EntitlementInfo
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.OwnershipType
 import com.revenuecat.purchases.PeriodType
 import com.revenuecat.purchases.Store
@@ -11,7 +10,6 @@ import java.util.Date
 
 @Suppress("unused", "UNUSED_VARIABLE", "DEPRECATION", "LongParameterList")
 private class EntitlementInfoAPI {
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     fun check(entitlementInfo: EntitlementInfo) {
         with(entitlementInfo) {
             val identifier: String = identifier

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementInfosAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementInfosAPI.kt
@@ -2,7 +2,6 @@ package com.revenuecat.apitester.kotlin
 
 import com.revenuecat.purchases.EntitlementInfo
 import com.revenuecat.purchases.EntitlementInfos
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.VerificationResult
 
 @Suppress("unused", "UNUSED_VARIABLE", "DEPRECATION")

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementInfosAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementInfosAPI.kt
@@ -7,7 +7,6 @@ import com.revenuecat.purchases.VerificationResult
 
 @Suppress("unused", "UNUSED_VARIABLE", "DEPRECATION")
 private class EntitlementInfosAPI {
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     fun check(infos: EntitlementInfos) {
         val active: Map<String, EntitlementInfo> = infos.active
         val all: Map<String, EntitlementInfo> = infos.all

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import com.revenuecat.purchases.CacheFetchPolicy
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.LogLevel
@@ -240,7 +241,7 @@ private class PurchasesAPI {
             .observerMode(false)
             .service(executorService)
             .diagnosticsEnabled(true)
-            .informationalVerificationModeAndDiagnosticsEnabled(true)
+            .verificationModeAndDiagnostics(EntitlementVerificationMode.INFORMATIONAL)
             .build()
 
         Purchases.configure(build)

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -241,7 +241,8 @@ private class PurchasesAPI {
             .observerMode(false)
             .service(executorService)
             .diagnosticsEnabled(true)
-            .verificationModeAndDiagnostics(EntitlementVerificationMode.INFORMATIONAL)
+            .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
+            .informationalVerificationModeAndDiagnosticsEnabled(true)
             .build()
 
         Purchases.configure(build)

--- a/config/detekt/detekt-baseline.xml
+++ b/config/detekt/detekt-baseline.xml
@@ -2,7 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>CyclomaticComplexMethod:EntitlementInfo.kt$EntitlementInfo$@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class) override fun equals(other: Any?): Boolean</ID>
+    <ID>CyclomaticComplexMethod:EntitlementInfo.kt$EntitlementInfo$override fun equals(other: Any?): Boolean</ID>
     <ID>DestructuringDeclarationWithTooManyEntries:Period.kt$val (year, month, week, day) = periodResult.destructured</ID>
     <ID>EmptyCatchBlock:Purchases.kt$Purchases.Companion.&lt;no name provided>${ }</ID>
     <ID>Filename:backendHelpers.kt$com.revenuecat.purchases.subscriberattributes.backendHelpers.kt</ID>

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.revenuecat.purchases.EntitlementVerificationMode
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -110,7 +110,6 @@ class ConfigureFragment : Fragment() {
         return binding.root
     }
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private suspend fun configureSDK() {
         val apiKey = binding.apiKeyInput.text.toString()
         val proxyUrl = binding.proxyUrlInput.text?.toString() ?: ""

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -115,7 +115,6 @@ class ConfigureFragment : Fragment() {
         val verificationModeIndex = binding.verificationOptionsInput.selectedItemPosition
 
         val entitlementVerificationMode = EntitlementVerificationMode.values()[verificationModeIndex]
-        val enableEntitlementVerification = entitlementVerificationMode == EntitlementVerificationMode.INFORMATIONAL
         val useAmazonStore = binding.storeRadioGroup.checkedRadioButtonId == R.id.amazon_store_radio_id
         val useObserverMode = binding.observerModeCheckbox.isChecked
 
@@ -132,7 +131,7 @@ class ConfigureFragment : Fragment() {
 
         val configuration = configurationBuilder
             .diagnosticsEnabled(true)
-            .informationalVerificationModeAndDiagnosticsEnabled(enableEntitlementVerification)
+            .entitlementVerificationMode(entitlementVerificationMode)
             .observerMode(useObserverMode)
             .build()
         Purchases.configure(configuration)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
@@ -54,7 +54,6 @@ data class EntitlementInfo(
     val billingIssueDetectedAt: Date?,
     val ownershipType: OwnershipType,
     private val jsonObject: JSONObject,
-    @ExperimentalPreviewRevenueCatPurchasesAPI
     val verification: VerificationResult = VerificationResult.NOT_REQUESTED,
 ) : Parcelable, RawDataContainer<JSONObject> {
 
@@ -107,7 +106,6 @@ data class EntitlementInfo(
         get() = jsonObject
 
     /** @suppress */
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     override fun toString(): String {
         return "EntitlementInfo(" +
             "identifier='$identifier', " +
@@ -128,7 +126,6 @@ data class EntitlementInfo(
     }
 
     /** @suppress */
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfos.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfos.kt
@@ -13,7 +13,6 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 class EntitlementInfos(
     val all: Map<String, EntitlementInfo>,
-    @ExperimentalPreviewRevenueCatPurchasesAPI
     val verification: VerificationResult,
 ) : Parcelable {
 
@@ -37,7 +36,6 @@ class EntitlementInfos(
     operator fun get(s: String) = all[s]
 
     /** @suppress */
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementVerificationMode.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementVerificationMode.kt
@@ -33,4 +33,7 @@ enum class EntitlementVerificationMode {
         val default: EntitlementVerificationMode
             get() = DISABLED
     }
+
+    val isEnabled: Boolean
+        get() = this != DISABLED
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1586,7 +1586,7 @@ class Purchases internal constructor(
         /**
          * Configures an instance of the Purchases SDK with a specified API key. The instance will
          * be set as a singleton. You should access the singleton instance using [Purchases.sharedInstance]
-         * @param configuration TODO
+         * @param configuration: the [PurchasesConfiguration] object you wish to use to configure [Purchases].
          * @return An instantiated `[Purchases] object that has been set as a singleton.
          */
         @JvmStatic

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -80,10 +80,8 @@ open class PurchasesConfiguration(builder: Builder) {
         }
 
         /**
-         * **Feature in beta**. Enables signature verification of requests to the RevenueCat backend
-         * in informational mode and enables diagnostics reports to RevenueCat to help us analyze this feature.
-         * Informational mode means that the behavior will remain the same but we will provide information about
-         * detected attempts of hacking.
+         * Enables signature verification of requests to the RevenueCat backend
+         * and enables diagnostics reports to RevenueCat to help us analyze this feature.
          *
          * When changing from disabled to enabled, the SDK will clear the CustomerInfo cache.
          * This means users will need to connect to the internet to get their entitlements back.
@@ -91,22 +89,12 @@ open class PurchasesConfiguration(builder: Builder) {
          * The result of the verification can be obtained from [EntitlementInfos.verification] or
          * [EntitlementInfo.verification].
          *
-         * This feature is currently in beta and the behavior may change. Only available in Kotlin.
-         *
          * Default mode is disabled.
-         *
-         * @warning This function is marked as [ExperimentalPreviewRevenueCatPurchasesAPI] and may change in the future.
          */
         @JvmSynthetic
-        @ExperimentalPreviewRevenueCatPurchasesAPI
-        fun informationalVerificationModeAndDiagnosticsEnabled(enabled: Boolean) = apply {
-            if (enabled) {
-                this.verificationMode = EntitlementVerificationMode.INFORMATIONAL
-                this.diagnosticsEnabled = true
-            } else {
-                this.verificationMode = EntitlementVerificationMode.DISABLED
-                this.diagnosticsEnabled = false
-            }
+        fun verificationModeAndDiagnostics(mode: EntitlementVerificationMode) = apply {
+            this.verificationMode = mode
+            this.diagnosticsEnabled = mode.isEnabled
         }
 
         /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -80,6 +80,8 @@ open class PurchasesConfiguration(builder: Builder) {
         }
 
         /**
+         * Deprecated. Use [entitlementVerificationMode] instead.
+         *
          * Enables signature verification of requests to the RevenueCat backend
          * and enables diagnostics reports to RevenueCat to help us analyze this feature.
          *
@@ -90,11 +92,40 @@ open class PurchasesConfiguration(builder: Builder) {
          * [EntitlementInfo.verification].
          *
          * Default mode is disabled.
+         *
+         * @warning This function is marked as [ExperimentalPreviewRevenueCatPurchasesAPI] and may change in the future.
          */
+        @Deprecated(
+            "Use the new entitlementVerificationMode setter instead.",
+            ReplaceWith("entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)"),
+        )
         @JvmSynthetic
-        fun verificationModeAndDiagnostics(mode: EntitlementVerificationMode) = apply {
-            this.verificationMode = mode
-            this.diagnosticsEnabled = mode.isEnabled
+        @ExperimentalPreviewRevenueCatPurchasesAPI
+        fun informationalVerificationModeAndDiagnosticsEnabled(enabled: Boolean) = apply {
+            if (enabled) {
+                this.verificationMode = EntitlementVerificationMode.INFORMATIONAL
+                this.diagnosticsEnabled = true
+            } else {
+                this.verificationMode = EntitlementVerificationMode.DISABLED
+                this.diagnosticsEnabled = false
+            }
+        }
+
+        /**
+         * Sets the [EntitlementVerificationMode] to perform signature verification of requests to the
+         * RevenueCat backend.
+         *
+         * When changing from [EntitlementVerificationMode.DISABLED] to other modes, the SDK will clear the
+         * CustomerInfo cache.
+         * This means users will need to connect to the internet to get their entitlements back.
+         *
+         * The result of the verification can be obtained from [EntitlementInfos.verification] or
+         * [EntitlementInfo.verification].
+         *
+         * Default mode is disabled.
+         */
+        fun entitlementVerificationMode(verificationMode: EntitlementVerificationMode) = apply {
+            this.verificationMode = verificationMode
         }
 
         /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -7,7 +7,6 @@ package com.revenuecat.purchases.common.caching
 
 import android.content.SharedPreferences
 import com.revenuecat.purchases.CustomerInfo
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.CustomerInfoFactory
 import com.revenuecat.purchases.common.DateProvider

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -136,7 +136,6 @@ internal open class DeviceCache(
     }
 
     @Synchronized
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     fun cacheCustomerInfo(appUserID: String, info: CustomerInfo) {
         val jsonObject = info.rawData.also {
             it.put(CUSTOMER_INFO_SCHEMA_VERSION_KEY, CUSTOMER_INFO_SCHEMA_VERSION)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -142,7 +142,6 @@ internal class IdentityManager(
     }
 
     @Suppress("UnusedPrivateMember", "FunctionOnlyReturningConstant")
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private fun shouldInvalidateCustomerInfoAndETagCache(customerInfo: CustomerInfo?): Boolean {
         return customerInfo != null &&
             customerInfo.entitlements.verification == VerificationResult.NOT_REQUESTED &&

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.identity
 
 import com.revenuecat.purchases.CustomerInfo
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -72,9 +72,8 @@ class PurchasesConfigurationTest {
     }
 
     @Test
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     fun `PurchasesConfiguration sets informational mode and diagnostics correctly`() {
-        val purchasesConfiguration = builder.informationalVerificationModeAndDiagnosticsEnabled(true).build()
+        val purchasesConfiguration = builder.verificationModeAndDiagnostics(EntitlementVerificationMode.INFORMATIONAL).build()
         assertThat(purchasesConfiguration.diagnosticsEnabled).isTrue
         assertThat(purchasesConfiguration.verificationMode).isEqualTo(EntitlementVerificationMode.INFORMATIONAL)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -72,9 +72,10 @@ class PurchasesConfigurationTest {
     }
 
     @Test
-    fun `PurchasesConfiguration sets informational mode and diagnostics correctly`() {
-        val purchasesConfiguration = builder.verificationModeAndDiagnostics(EntitlementVerificationMode.INFORMATIONAL).build()
-        assertThat(purchasesConfiguration.diagnosticsEnabled).isTrue
+    fun `PurchasesConfiguration sets informational mode correctly`() {
+        val purchasesConfiguration = builder.entitlementVerificationMode(
+            EntitlementVerificationMode.INFORMATIONAL
+        ).build()
         assertThat(purchasesConfiguration.verificationMode).isEqualTo(EntitlementVerificationMode.INFORMATIONAL)
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/CustomerInfoFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/CustomerInfoFactoryTest.kt
@@ -34,7 +34,6 @@ class CustomerInfoFactoryTest {
         assertThat(defaultCustomerInfo.requestDate).isEqualTo(Date(1565951442000))
     }
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     @Test
     fun `assigns default verification result correctly`() {
         assertThat(defaultCustomerInfo.entitlements.verification).isEqualTo(VerificationResult.NOT_REQUESTED)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -35,7 +35,6 @@ import kotlin.time.Duration.Companion.minutes
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 class DeviceCacheTest {
 
     private val validCachedCustomerInfo by lazy {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/EntitlementInfosTests.kt
@@ -20,7 +20,6 @@ import kotlin.time.Duration.Companion.days
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 class EntitlementInfosTests {
 
     private var response = JSONObject()

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -574,7 +574,6 @@ class IdentityManagerTests {
 
     // region helper functions
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private fun setupCustomerInfoCacheInvalidationTest(
         userId: String,
         verificationResult: VerificationResult,


### PR DESCRIPTION
This PR brings Trusted entitlements to stable and to java. 

#### Trusted entitlements

This new feature prevents MitM attacks between the SDK and the RevenueCat server.
With verification enabled, the SDK ensures that the response created by the server was not modified by a third-party, and the entitlements received are exactly what was sent.
This is 100% opt-in. EntitlementInfos have a new VerificationResult property, which will indicate the validity of the responses when this feature is enabled.

```
fun configureRevenueCat() {
    val configuration = PurchasesConfiguration.Builder(context, apiKey)
        .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
        .build()
    Purchases.configure(configuration)
}
```