### PR TITLE
Trusted entitlements: Add Signature type to process new signature response format

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/verification/Signature.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/Signature.kt
@@ -1,0 +1,83 @@
+package com.revenuecat.purchases.common.verification
+
+import android.util.Base64
+import androidx.annotation.VisibleForTesting
+
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+internal enum class SignatureComponent(val size: Int) {
+    INTERMEDIATE_KEY(size = 32),
+    INTERMEDIATE_KEY_EXPIRATION(size = 4),
+    INTERMEDIATE_KEY_SIGNATURE(size = 64),
+    SALT(size = 16),
+    PAYLOAD(size = 64),
+    ;
+
+    companion object {
+        val totalSize: Int
+            get() = values().sumOf { it.size }
+    }
+
+    val startByte: Int
+        get() = values().copyOfRange(0, ordinal).sumOf { it.size }
+
+    val endByte: Int
+        get() = startByte + size
+}
+
+private fun ByteArray.copyOf(component: SignatureComponent): ByteArray {
+    return copyOfRange(component.startByte, component.endByte)
+}
+
+data class Signature(
+    val intermediateKey: ByteArray,
+    val intermediateKeyExpiration: ByteArray,
+    val intermediateKeySignature: ByteArray,
+    val salt: ByteArray,
+    val payload: ByteArray,
+) {
+    companion object {
+        internal fun fromString(signature: String): Signature {
+            val signatureBytes = Base64.decode(signature, Base64.DEFAULT)
+            val expectedSize = SignatureComponent.totalSize
+            if (signatureBytes.size != expectedSize) {
+                throw InvalidSignatureSizeException(
+                    "Invalid signature size. Expected $expectedSize, " +
+                        "got ${signatureBytes.size} bytes",
+                )
+            }
+            return Signature(
+                signatureBytes.copyOf(SignatureComponent.INTERMEDIATE_KEY),
+                signatureBytes.copyOf(SignatureComponent.INTERMEDIATE_KEY_EXPIRATION),
+                signatureBytes.copyOf(SignatureComponent.INTERMEDIATE_KEY_SIGNATURE),
+                signatureBytes.copyOf(SignatureComponent.SALT),
+                signatureBytes.copyOf(SignatureComponent.PAYLOAD),
+            )
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Signature
+
+        if (!intermediateKey.contentEquals(other.intermediateKey)) return false
+        if (!intermediateKeyExpiration.contentEquals(other.intermediateKeyExpiration)) return false
+        if (!intermediateKeySignature.contentEquals(other.intermediateKeySignature)) return false
+        if (!salt.contentEquals(other.salt)) return false
+        if (!payload.contentEquals(other.payload)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = intermediateKey.contentHashCode()
+        result = 31 * result + intermediateKeyExpiration.contentHashCode()
+        result = 31 * result + intermediateKeySignature.contentHashCode()
+        result = 31 * result + salt.contentHashCode()
+        result = 31 * result + payload.contentHashCode()
+        return result
+    }
+}
+
+internal class InvalidSignatureSizeException(message: String) : Exception(message)

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/Signature.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/Signature.kt
@@ -3,28 +3,7 @@ package com.revenuecat.purchases.common.verification
 import android.util.Base64
 import androidx.annotation.VisibleForTesting
 
-@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-internal enum class SignatureComponent(val size: Int) {
-    INTERMEDIATE_KEY(size = 32),
-    INTERMEDIATE_KEY_EXPIRATION(size = 4),
-    INTERMEDIATE_KEY_SIGNATURE(size = 64),
-    SALT(size = 16),
-    PAYLOAD(size = 64),
-    ;
-
-    companion object {
-        val totalSize: Int
-            get() = values().sumOf { it.size }
-    }
-
-    val startByte: Int
-        get() = values().copyOfRange(0, ordinal).sumOf { it.size }
-
-    val endByte: Int
-        get() = startByte + size
-}
-
-private fun ByteArray.copyOf(component: SignatureComponent): ByteArray {
+private fun ByteArray.copyOf(component: Signature.Component): ByteArray {
     return copyOfRange(component.startByte, component.endByte)
 }
 
@@ -38,7 +17,7 @@ data class Signature(
     companion object {
         internal fun fromString(signature: String): Signature {
             val signatureBytes = Base64.decode(signature, Base64.DEFAULT)
-            val expectedSize = SignatureComponent.totalSize
+            val expectedSize = Component.totalSize
             if (signatureBytes.size != expectedSize) {
                 throw InvalidSignatureSizeException(
                     "Invalid signature size. Expected $expectedSize, " +
@@ -46,13 +25,34 @@ data class Signature(
                 )
             }
             return Signature(
-                signatureBytes.copyOf(SignatureComponent.INTERMEDIATE_KEY),
-                signatureBytes.copyOf(SignatureComponent.INTERMEDIATE_KEY_EXPIRATION),
-                signatureBytes.copyOf(SignatureComponent.INTERMEDIATE_KEY_SIGNATURE),
-                signatureBytes.copyOf(SignatureComponent.SALT),
-                signatureBytes.copyOf(SignatureComponent.PAYLOAD),
+                signatureBytes.copyOf(Component.INTERMEDIATE_KEY),
+                signatureBytes.copyOf(Component.INTERMEDIATE_KEY_EXPIRATION),
+                signatureBytes.copyOf(Component.INTERMEDIATE_KEY_SIGNATURE),
+                signatureBytes.copyOf(Component.SALT),
+                signatureBytes.copyOf(Component.PAYLOAD),
             )
         }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal enum class Component(val size: Int) {
+        INTERMEDIATE_KEY(size = 32),
+        INTERMEDIATE_KEY_EXPIRATION(size = 4),
+        INTERMEDIATE_KEY_SIGNATURE(size = 64),
+        SALT(size = 16),
+        PAYLOAD(size = 64),
+        ;
+
+        companion object {
+            val totalSize: Int
+                get() = values().sumOf { it.size }
+        }
+
+        val startByte: Int
+            get() = values().copyOfRange(0, ordinal).sumOf { it.size }
+
+        val endByte: Int
+            get() = startByte + size
     }
 
     override fun equals(other: Any?): Boolean {

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SignatureTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SignatureTest.kt
@@ -13,25 +13,25 @@ class SignatureTest {
 
     @Test
     fun `components have correct ranges`() {
-        assertThat(SignatureComponent.INTERMEDIATE_KEY.startByte).isEqualTo(0)
-        assertThat(SignatureComponent.INTERMEDIATE_KEY.endByte).isEqualTo(32)
-        assertThat(SignatureComponent.INTERMEDIATE_KEY_EXPIRATION.startByte).isEqualTo(32)
-        assertThat(SignatureComponent.INTERMEDIATE_KEY_EXPIRATION.endByte).isEqualTo(36)
-        assertThat(SignatureComponent.INTERMEDIATE_KEY_SIGNATURE.startByte).isEqualTo(36)
-        assertThat(SignatureComponent.INTERMEDIATE_KEY_SIGNATURE.endByte).isEqualTo(100)
-        assertThat(SignatureComponent.SALT.startByte).isEqualTo(100)
-        assertThat(SignatureComponent.SALT.endByte).isEqualTo(116)
-        assertThat(SignatureComponent.PAYLOAD.startByte).isEqualTo(116)
-        assertThat(SignatureComponent.PAYLOAD.endByte).isEqualTo(180)
+        assertThat(Signature.Component.INTERMEDIATE_KEY.startByte).isEqualTo(0)
+        assertThat(Signature.Component.INTERMEDIATE_KEY.endByte).isEqualTo(32)
+        assertThat(Signature.Component.INTERMEDIATE_KEY_EXPIRATION.startByte).isEqualTo(32)
+        assertThat(Signature.Component.INTERMEDIATE_KEY_EXPIRATION.endByte).isEqualTo(36)
+        assertThat(Signature.Component.INTERMEDIATE_KEY_SIGNATURE.startByte).isEqualTo(36)
+        assertThat(Signature.Component.INTERMEDIATE_KEY_SIGNATURE.endByte).isEqualTo(100)
+        assertThat(Signature.Component.SALT.startByte).isEqualTo(100)
+        assertThat(Signature.Component.SALT.endByte).isEqualTo(116)
+        assertThat(Signature.Component.PAYLOAD.startByte).isEqualTo(116)
+        assertThat(Signature.Component.PAYLOAD.endByte).isEqualTo(180)
     }
 
     @Test
     fun `fromString parses correctly`() {
-        assertThat(signature.intermediateKey.size).isEqualTo(SignatureComponent.INTERMEDIATE_KEY.size)
-        assertThat(signature.intermediateKeyExpiration.size).isEqualTo(SignatureComponent.INTERMEDIATE_KEY_EXPIRATION.size)
-        assertThat(signature.intermediateKeySignature.size).isEqualTo(SignatureComponent.INTERMEDIATE_KEY_SIGNATURE.size)
-        assertThat(signature.salt.size).isEqualTo(SignatureComponent.SALT.size)
-        assertThat(signature.payload.size).isEqualTo(SignatureComponent.PAYLOAD.size)
+        assertThat(signature.intermediateKey.size).isEqualTo(Signature.Component.INTERMEDIATE_KEY.size)
+        assertThat(signature.intermediateKeyExpiration.size).isEqualTo(Signature.Component.INTERMEDIATE_KEY_EXPIRATION.size)
+        assertThat(signature.intermediateKeySignature.size).isEqualTo(Signature.Component.INTERMEDIATE_KEY_SIGNATURE.size)
+        assertThat(signature.salt.size).isEqualTo(Signature.Component.SALT.size)
+        assertThat(signature.payload.size).isEqualTo(Signature.Component.PAYLOAD.size)
     }
 
     @Test

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SignatureTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SignatureTest.kt
@@ -1,0 +1,42 @@
+package com.revenuecat.purchases.common.verification
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SignatureTest {
+
+    @Test
+    fun `components have correct ranges`() {
+        assertThat(SignatureComponent.INTERMEDIATE_KEY.startByte).isEqualTo(0)
+        assertThat(SignatureComponent.INTERMEDIATE_KEY.endByte).isEqualTo(32)
+        assertThat(SignatureComponent.INTERMEDIATE_KEY_EXPIRATION.startByte).isEqualTo(32)
+        assertThat(SignatureComponent.INTERMEDIATE_KEY_EXPIRATION.endByte).isEqualTo(36)
+        assertThat(SignatureComponent.INTERMEDIATE_KEY_SIGNATURE.startByte).isEqualTo(36)
+        assertThat(SignatureComponent.INTERMEDIATE_KEY_SIGNATURE.endByte).isEqualTo(100)
+        assertThat(SignatureComponent.SALT.startByte).isEqualTo(100)
+        assertThat(SignatureComponent.SALT.endByte).isEqualTo(116)
+        assertThat(SignatureComponent.PAYLOAD.startByte).isEqualTo(116)
+        assertThat(SignatureComponent.PAYLOAD.endByte).isEqualTo(180)
+    }
+
+    @Test
+    fun `fromString parses correctly`() {
+        val signature = Signature.fromString("nVoKJjLhhTNo19Mkjr5DEmgMf361HWxxMyctC10Ob7f/////+GStaG6mLGXfe+T+p6jDqBkuLHfF3VaCOYLwpCfWQBzeTGXB7ntSs4ESiw9sxHy0VTR0P5mSDxkSteR/qAANCFfQSkHeWl4NJ4IDusH1iehUgiku0dMOx5+u53eU3eB45bV7Uttc/AX9bSzpwinw1hqRpuNOyNZOQk0r+vDokRcMlC9XgraztIAO+m0LLtMF")
+        assertThat(signature.intermediateKey.size).isEqualTo(SignatureComponent.INTERMEDIATE_KEY.size)
+        assertThat(signature.intermediateKeyExpiration.size).isEqualTo(SignatureComponent.INTERMEDIATE_KEY_EXPIRATION.size)
+        assertThat(signature.intermediateKeySignature.size).isEqualTo(SignatureComponent.INTERMEDIATE_KEY_SIGNATURE.size)
+        assertThat(signature.salt.size).isEqualTo(SignatureComponent.SALT.size)
+        assertThat(signature.payload.size).isEqualTo(SignatureComponent.PAYLOAD.size)
+    }
+
+    @Test
+    fun `fromString errors if invalid signature size`() {
+        assertThatExceptionOfType(InvalidSignatureSizeException::class.java).isThrownBy {
+            Signature.fromString("nVoKJjLhhTNo19M")
+        }
+    }
+}

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SignatureTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SignatureTest.kt
@@ -9,6 +9,8 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class SignatureTest {
 
+    private val signature = Signature.fromString("nVoKJjLhhTNo19Mkjr5DEmgMf361HWxxMyctC10Ob7f/////+GStaG6mLGXfe+T+p6jDqBkuLHfF3VaCOYLwpCfWQBzeTGXB7ntSs4ESiw9sxHy0VTR0P5mSDxkSteR/qAANCFfQSkHeWl4NJ4IDusH1iehUgiku0dMOx5+u53eU3eB45bV7Uttc/AX9bSzpwinw1hqRpuNOyNZOQk0r+vDokRcMlC9XgraztIAO+m0LLtMF")
+
     @Test
     fun `components have correct ranges`() {
         assertThat(SignatureComponent.INTERMEDIATE_KEY.startByte).isEqualTo(0)
@@ -25,7 +27,6 @@ class SignatureTest {
 
     @Test
     fun `fromString parses correctly`() {
-        val signature = Signature.fromString("nVoKJjLhhTNo19Mkjr5DEmgMf361HWxxMyctC10Ob7f/////+GStaG6mLGXfe+T+p6jDqBkuLHfF3VaCOYLwpCfWQBzeTGXB7ntSs4ESiw9sxHy0VTR0P5mSDxkSteR/qAANCFfQSkHeWl4NJ4IDusH1iehUgiku0dMOx5+u53eU3eB45bV7Uttc/AX9bSzpwinw1hqRpuNOyNZOQk0r+vDokRcMlC9XgraztIAO+m0LLtMF")
         assertThat(signature.intermediateKey.size).isEqualTo(SignatureComponent.INTERMEDIATE_KEY.size)
         assertThat(signature.intermediateKeyExpiration.size).isEqualTo(SignatureComponent.INTERMEDIATE_KEY_EXPIRATION.size)
         assertThat(signature.intermediateKeySignature.size).isEqualTo(SignatureComponent.INTERMEDIATE_KEY_SIGNATURE.size)
@@ -38,5 +39,53 @@ class SignatureTest {
         assertThatExceptionOfType(InvalidSignatureSizeException::class.java).isThrownBy {
             Signature.fromString("nVoKJjLhhTNo19M")
         }
+    }
+
+    @Test
+    fun `equals checks all fields`() {
+        val otherSignature = Signature(
+            intermediateKey = signature.intermediateKey.copyOf(),
+            intermediateKeyExpiration = signature.intermediateKeyExpiration.copyOf(),
+            intermediateKeySignature = signature.intermediateKeySignature.copyOf(),
+            salt = signature.salt.copyOf(),
+            payload = signature.payload.copyOf(),
+        )
+        assertThat(signature).isEqualTo(otherSignature)
+    }
+
+    @Test
+    fun `equals is false if small changes`() {
+        val otherSignature = Signature(
+            intermediateKey = signature.intermediateKey.copyOfRange(0, 1),
+            intermediateKeyExpiration = signature.intermediateKeyExpiration.copyOf(),
+            intermediateKeySignature = signature.intermediateKeySignature.copyOf(),
+            salt = signature.salt.copyOf(),
+            payload = signature.payload.copyOf(),
+        )
+        assertThat(signature).isNotEqualTo(otherSignature)
+    }
+
+    @Test
+    fun `hashCode includes all fields`() {
+        val otherSignature = Signature(
+            intermediateKey = signature.intermediateKey.copyOf(),
+            intermediateKeyExpiration = signature.intermediateKeyExpiration.copyOf(),
+            intermediateKeySignature = signature.intermediateKeySignature.copyOf(),
+            salt = signature.salt.copyOf(),
+            payload = signature.payload.copyOf(),
+        )
+        assertThat(signature.hashCode()).isEqualTo(otherSignature.hashCode())
+    }
+
+    @Test
+    fun `hashCode changes if different`() {
+        val otherSignature = Signature(
+            intermediateKey = signature.intermediateKey.copyOfRange(0, 1),
+            intermediateKeyExpiration = signature.intermediateKeyExpiration.copyOf(),
+            intermediateKeySignature = signature.intermediateKeySignature.copyOf(),
+            salt = signature.salt.copyOf(),
+            payload = signature.payload.copyOf(),
+        )
+        assertThat(signature.hashCode()).isNotEqualTo(otherSignature.hashCode())
     }
 }


### PR DESCRIPTION
### Description
First PR for SDK-3200

This adds the new `Signature` type which will encode the different fields that are part of the new signature format. This is currently unused and will be used in future PRs.