### PR TITLE
Trusted entitlements: Add IntermediateSignatureHelper to handle intermediate signature verification process

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/IntExtensions.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/IntExtensions.kt
@@ -1,0 +1,8 @@
+package com.revenuecat.purchases.common
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+fun Int.Companion.fromLittleEndianBytes(byteArray: ByteArray): Int {
+    return ByteBuffer.wrap(byteArray).order(ByteOrder.LITTLE_ENDIAN).int
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/IntermediateSignatureHelper.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/IntermediateSignatureHelper.kt
@@ -1,0 +1,40 @@
+package com.revenuecat.purchases.common.verification
+
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.common.fromLittleEndianBytes
+import com.revenuecat.purchases.utils.Result
+import java.util.Date
+import kotlin.time.Duration.Companion.days
+
+class IntermediateSignatureHelper(
+    private val rootSignatureVerifier: SignatureVerifier,
+) {
+
+    @Suppress("ReturnCount")
+    fun createIntermediateKeyVerifierIfVerified(
+        signature: Signature,
+    ): Result<SignatureVerifier, PurchasesError> {
+        val intermediateKeyMessageToVerify = signature.intermediateKeyExpiration + signature.intermediateKey
+        if (!rootSignatureVerifier.verify(signature.intermediateKeySignature, intermediateKeyMessageToVerify)) {
+            return Result.Error(
+                PurchasesError(PurchasesErrorCode.SignatureVerificationError, "Error verifying intermediate key."),
+            )
+        }
+        val intermediateKeyExpirationDate = getIntermediateKeyExpirationDate(signature.intermediateKeyExpiration)
+        if (intermediateKeyExpirationDate.before(Date())) {
+            return Result.Error(
+                PurchasesError(
+                    PurchasesErrorCode.SignatureVerificationError,
+                    "Intermediate key expired at $intermediateKeyExpirationDate",
+                ),
+            )
+        }
+        return Result.Success(DefaultSignatureVerifier(signature.intermediateKey))
+    }
+
+    private fun getIntermediateKeyExpirationDate(intermediateKeyExpirationBytes: ByteArray): Date {
+        val daysSince1970 = Int.fromLittleEndianBytes(intermediateKeyExpirationBytes).days
+        return Date(daysSince1970.inWholeMilliseconds)
+    }
+}

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerifier.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerifier.kt
@@ -8,12 +8,14 @@ interface SignatureVerifier {
     fun verify(signatureToVerify: ByteArray, messageToVerify: ByteArray): Boolean
 }
 
-class DefaultSignatureVerifier(publicKey: String = DEFAULT_PUBLIC_KEY) : SignatureVerifier {
+class DefaultSignatureVerifier(
+    publicKeyBytes: ByteArray,
+) : SignatureVerifier {
     companion object {
         private const val DEFAULT_PUBLIC_KEY = "UC1upXWg5QVmyOSwozp755xLqquBKjjU+di6U8QhMlM="
     }
 
-    private val publicKeyBytes = Base64.decode(publicKey, Base64.DEFAULT)
+    constructor(publicKey: String = DEFAULT_PUBLIC_KEY) : this(Base64.decode(publicKey, Base64.DEFAULT))
 
     private val verifier = Ed25519Verify(publicKeyBytes)
 

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/IntermediateSignatureHelperTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/IntermediateSignatureHelperTest.kt
@@ -1,0 +1,59 @@
+package com.revenuecat.purchases.common.verification
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.utils.Result
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class IntermediateSignatureHelperTest {
+
+    private val validSignature = Signature.fromString("xoDYyUeHnIlSIAeOOzmvdNPOlbNSKK+xE0fE/ufS1fsK4PUFrNz9mRS0v/InK81CwXmtbGoTy1bD8d+PValEX9dY+8zon/CM8Bx4oA2pUFgtHSaedPJfqnTjNPh0l0O62iWADAwrsih4z//uQoruUD3T5WXa2w7s7LFMnRFuRQY3uKz0StgC/qkPAufCtqzZqQZR1zDu9MxDzmG6eNAqcM3fsIV5sQIMmI3P0dEMDK5cM/YG")
+
+    private lateinit var intermediateSignatureHelper: IntermediateSignatureHelper
+
+    @Before
+    fun setUp() {
+        intermediateSignatureHelper = IntermediateSignatureHelper(
+            DefaultSignatureVerifier("yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=")
+        )
+    }
+
+    @Test
+    fun `if fails to verify intermediate signature, returns error`() {
+        val incorrectSignature = validSignature.copy(intermediateKey = "incorrect".toByteArray())
+        when (val result = intermediateSignatureHelper.createIntermediateKeyVerifierIfVerified(incorrectSignature)) {
+            is Result.Success -> fail("Expected error")
+            is Result.Error -> {
+                assertThat(result.value.code).isEqualTo(PurchasesErrorCode.SignatureVerificationError)
+                assertThat(result.value.underlyingErrorMessage).startsWith("Error verifying intermediate key.")
+            }
+        }
+    }
+
+    @Test
+    fun `if intermediate signature is expired, returns error`() {
+        val expiredIntermediateKeySignature = Signature.fromString("xoDYyUeHnIlSIAeOOzmvdNPOlbNSKK+xE0fE/ufS1fsKAAAAJMOXT1iHMIJlcZ0KNSvIHu+PE5DfETod7ix/ggbABphqbzt7t8p+ZwFpqc7K+1n6lzcsWAyKCWU7ofXoOLF8D0Cfn6wrs56pEGFLZxBvv9m46nIAJz8zmn+LmHo6kRellbweWMo8fbrb08mReRxdqB++3GyQWyHbvOS7yQW/od193UracSQNMH+4wXbcjCwG")
+        when (val result = intermediateSignatureHelper.createIntermediateKeyVerifierIfVerified(expiredIntermediateKeySignature)) {
+            is Result.Success -> fail("Expected error")
+            is Result.Error -> {
+                assertThat(result.value.code).isEqualTo(PurchasesErrorCode.SignatureVerificationError)
+                assertThat(result.value.underlyingErrorMessage).startsWith("Intermediate key expired")
+            }
+        }
+    }
+
+    @Test
+    fun `if intermediate signature is valid, returns verifier`() {
+        when (val result = intermediateSignatureHelper.createIntermediateKeyVerifierIfVerified(validSignature)) {
+            is Result.Success -> {
+                assertThat(result.value).isInstanceOf(DefaultSignatureVerifier::class.java)
+            }
+            is Result.Error -> fail("Expected success")
+        }
+    }
+}


### PR DESCRIPTION
### Description
Second PR to implement SDK-3200

This PR creates the new `IntermediateSignatureHelper` class to handle the logic related to verifying intermediate keys. This is not currently used and will be used in future PRs