### PR TITLE
Trusted entitlements: Do not use etags if cache version not requested and verification enabled

### DIFF
--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -147,7 +147,7 @@ class HTTPClient(
             val fullURL = URL(baseURL, urlPathWithVersion)
 
             nonce = if (shouldSignResponse) signingManager.createRandomNonce() else null
-            val headers = getHeaders(requestHeaders, urlPathWithVersion, refreshETag, nonce)
+            val headers = getHeaders(requestHeaders, urlPathWithVersion, refreshETag, nonce, shouldSignResponse)
 
             val httpRequest = HTTPRequest(fullURL, headers, jsonBody)
 
@@ -237,6 +237,7 @@ class HTTPClient(
         urlPath: String,
         refreshETag: Boolean,
         nonce: String?,
+        shouldSignResponse: Boolean,
     ): Map<String, String> {
         return mapOf(
             "Content-Type" to "application/json",
@@ -252,7 +253,7 @@ class HTTPClient(
             "X-Nonce" to nonce,
         )
             .plus(authenticationHeaders)
-            .plus(eTagManager.getETagHeaders(urlPath, refreshETag))
+            .plus(eTagManager.getETagHeaders(urlPath, shouldSignResponse, refreshETag))
             .filterNotNullValues()
     }
 

--- a/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/HTTPClient.kt
@@ -175,10 +175,9 @@ class HTTPClient(
         }
 
         val verificationResult = if (shouldSignResponse &&
-            nonce != null &&
             RCHTTPStatusCodes.isSuccessful(responseCode)
         ) {
-            verifyResponse(path, responseCode, connection, payload, nonce)
+            verifyResponse(path, connection, payload, nonce)
         } else {
             VerificationResult.NOT_REQUESTED
         }
@@ -278,15 +277,13 @@ class HTTPClient(
 
     private fun verifyResponse(
         urlPath: String,
-        responseCode: Int,
         connection: URLConnection,
         payload: String?,
-        nonce: String,
+        nonce: String?,
     ): VerificationResult {
         return signingManager.verifyResponse(
             urlPath = urlPath,
-            responseCode = responseCode,
-            signature = connection.getHeaderField(HTTPResult.SIGNATURE_HEADER_NAME),
+            signatureString = connection.getHeaderField(HTTPResult.SIGNATURE_HEADER_NAME),
             nonce = nonce,
             body = payload,
             requestTime = getRequestTimeHeader(connection),

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
@@ -19,8 +19,18 @@ sealed class SignatureVerificationMode {
         }
     }
     object Disabled : SignatureVerificationMode()
-    data class Informational(val signatureVerifier: SignatureVerifier) : SignatureVerificationMode()
-    data class Enforced(val signatureVerifier: SignatureVerifier) : SignatureVerificationMode()
+    data class Informational(
+        val signatureVerifier: SignatureVerifier,
+        override val intermediateSignatureHelper: IntermediateSignatureHelper = IntermediateSignatureHelper(
+            signatureVerifier,
+        ),
+    ) : SignatureVerificationMode()
+    data class Enforced(
+        val signatureVerifier: SignatureVerifier,
+        override val intermediateSignatureHelper: IntermediateSignatureHelper = IntermediateSignatureHelper(
+            signatureVerifier,
+        ),
+    ) : SignatureVerificationMode()
 
     val shouldVerify: Boolean
         get() = when (this) {
@@ -32,10 +42,10 @@ sealed class SignatureVerificationMode {
                 true
         }
 
-    val verifier: SignatureVerifier?
+    open val intermediateSignatureHelper: IntermediateSignatureHelper?
         get() = when (this) {
             is Disabled -> null
-            is Informational -> signatureVerifier
-            is Enforced -> signatureVerifier
+            is Informational -> intermediateSignatureHelper
+            is Enforced -> intermediateSignatureHelper
         }
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
@@ -17,17 +17,17 @@ sealed class SignatureVerificationMode {
                 //     Enforced(signatureVerifier ?: DefaultSignatureVerifier())
             }
         }
+
+        private fun createIntermediateSignatureHelper(): IntermediateSignatureHelper {
+            return IntermediateSignatureHelper(DefaultSignatureVerifier())
+        }
     }
     object Disabled : SignatureVerificationMode()
     data class Informational(
-        override val intermediateSignatureHelper: IntermediateSignatureHelper = IntermediateSignatureHelper(
-            DefaultSignatureVerifier(),
-        ),
+        override val intermediateSignatureHelper: IntermediateSignatureHelper = createIntermediateSignatureHelper(),
     ) : SignatureVerificationMode()
     data class Enforced(
-        override val intermediateSignatureHelper: IntermediateSignatureHelper = IntermediateSignatureHelper(
-            DefaultSignatureVerifier(),
-        ),
+        override val intermediateSignatureHelper: IntermediateSignatureHelper = createIntermediateSignatureHelper(),
     ) : SignatureVerificationMode()
 
     val shouldVerify: Boolean
@@ -46,4 +46,6 @@ sealed class SignatureVerificationMode {
             is Informational -> intermediateSignatureHelper
             is Enforced -> intermediateSignatureHelper
         }
+
+
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
@@ -6,12 +6,12 @@ sealed class SignatureVerificationMode {
     companion object {
         fun fromEntitlementVerificationMode(
             verificationMode: EntitlementVerificationMode,
-            signatureVerifier: SignatureVerifier? = null,
+            rootVerifier: SignatureVerifier? = null,
         ): SignatureVerificationMode {
             return when (verificationMode) {
                 EntitlementVerificationMode.DISABLED -> Disabled
                 EntitlementVerificationMode.INFORMATIONAL ->
-                    Informational(signatureVerifier ?: DefaultSignatureVerifier())
+                    Informational(IntermediateSignatureHelper(rootVerifier ?: DefaultSignatureVerifier()))
                 // Hidden ENFORCED mode during feature beta
                 // EntitlementVerificationMode.ENFORCED ->
                 //     Enforced(signatureVerifier ?: DefaultSignatureVerifier())
@@ -20,15 +20,13 @@ sealed class SignatureVerificationMode {
     }
     object Disabled : SignatureVerificationMode()
     data class Informational(
-        val signatureVerifier: SignatureVerifier,
         override val intermediateSignatureHelper: IntermediateSignatureHelper = IntermediateSignatureHelper(
-            signatureVerifier,
+            DefaultSignatureVerifier(),
         ),
     ) : SignatureVerificationMode()
     data class Enforced(
-        val signatureVerifier: SignatureVerifier,
         override val intermediateSignatureHelper: IntermediateSignatureHelper = IntermediateSignatureHelper(
-            signatureVerifier,
+            DefaultSignatureVerifier(),
         ),
     ) : SignatureVerificationMode()
 

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
@@ -46,6 +46,4 @@ sealed class SignatureVerificationMode {
             is Informational -> intermediateSignatureHelper
             is Enforced -> intermediateSignatureHelper
         }
-
-
 }

--- a/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/common/src/main/java/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -5,9 +5,9 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.networking.Endpoint
-import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.strings.NetworkStrings
+import com.revenuecat.purchases.utils.Result
 import java.security.SecureRandom
 
 class SigningManager(
@@ -16,7 +16,6 @@ class SigningManager(
 ) {
     private companion object {
         const val NONCE_BYTES_SIZE = 12
-        const val SALT_BYTES_SIZE = 16
     }
 
     fun shouldVerifyEndpoint(endpoint: Endpoint): Boolean {
@@ -29,12 +28,11 @@ class SigningManager(
         return String(Base64.encode(bytes, Base64.DEFAULT))
     }
 
-    @Suppress("LongParameterList", "ReturnCount")
+    @Suppress("LongParameterList", "ReturnCount", "CyclomaticComplexMethod")
     fun verifyResponse(
         urlPath: String,
-        responseCode: Int,
-        signature: String?,
-        nonce: String,
+        signatureString: String?,
+        nonce: String?,
         body: String?,
         requestTime: String?,
         eTag: String?,
@@ -43,9 +41,10 @@ class SigningManager(
             warnLog("Forcing signing error for request with path: $urlPath")
             return VerificationResult.FAILED
         }
-        val signatureVerifier = signatureVerificationMode.verifier ?: return VerificationResult.NOT_REQUESTED
+        val intermediateSignatureHelper = signatureVerificationMode.intermediateSignatureHelper
+            ?: return VerificationResult.NOT_REQUESTED
 
-        if (signature == null) {
+        if (signatureString == null) {
             errorLog(NetworkStrings.VERIFICATION_MISSING_SIGNATURE.format(urlPath))
             return VerificationResult.FAILED
         }
@@ -53,29 +52,45 @@ class SigningManager(
             errorLog(NetworkStrings.VERIFICATION_MISSING_REQUEST_TIME.format(urlPath))
             return VerificationResult.FAILED
         }
-
-        val signatureMessage = getSignatureMessage(responseCode, body, eTag)
-        if (signatureMessage == null) {
+        if (body == null && eTag == null) {
             errorLog(NetworkStrings.VERIFICATION_MISSING_BODY_OR_ETAG.format(urlPath))
             return VerificationResult.FAILED
         }
 
-        val decodedNonce = Base64.decode(nonce, Base64.DEFAULT)
-        val decodedSignature = Base64.decode(signature, Base64.DEFAULT)
-        val saltBytes = decodedSignature.copyOfRange(0, SALT_BYTES_SIZE)
-        val signatureToVerify = decodedSignature.copyOfRange(SALT_BYTES_SIZE, decodedSignature.size)
-        val messageToVerify = saltBytes + decodedNonce + requestTime.toByteArray() + signatureMessage.toByteArray()
-        val verificationResult = signatureVerifier.verify(signatureToVerify, messageToVerify)
-
-        return if (verificationResult) {
-            VerificationResult.VERIFIED
-        } else {
-            errorLog(NetworkStrings.VERIFICATION_ERROR.format(urlPath))
-            VerificationResult.FAILED
+        val signature: Signature
+        try {
+            signature = Signature.fromString(signatureString)
+        } catch (e: InvalidSignatureSizeException) {
+            errorLog(NetworkStrings.VERIFICATION_INVALID_SIZE.format(urlPath, e.message))
+            return VerificationResult.FAILED
         }
-    }
 
-    private fun getSignatureMessage(responseCode: Int, body: String?, eTag: String?): String? {
-        return if (responseCode == RCHTTPStatusCodes.NOT_MODIFIED) eTag else body
+        when (val result = intermediateSignatureHelper.createIntermediateKeyVerifierIfVerified(signature)) {
+            is Result.Error -> {
+                errorLog(
+                    NetworkStrings.VERIFICATION_INTERMEDIATE_KEY_FAILED.format(
+                        urlPath,
+                        result.value.underlyingErrorMessage,
+                    ),
+                )
+                return VerificationResult.FAILED
+            }
+            is Result.Success -> {
+                val intermediateKeyVerifier = result.value
+                val decodedNonce = nonce?.let { Base64.decode(it, Base64.DEFAULT) } ?: byteArrayOf()
+                val requestTimeBytes = requestTime.toByteArray()
+                val eTagBytes = eTag?.toByteArray() ?: byteArrayOf()
+                val payloadBytes = body?.toByteArray() ?: byteArrayOf()
+                val messageToVerify = signature.salt + decodedNonce + requestTimeBytes + eTagBytes + payloadBytes
+                val verificationResult = intermediateKeyVerifier.verify(signature.payload, messageToVerify)
+
+                return if (verificationResult) {
+                    VerificationResult.VERIFIED
+                } else {
+                    errorLog(NetworkStrings.VERIFICATION_ERROR.format(urlPath))
+                    VerificationResult.FAILED
+                }
+            }
+        }
     }
 }

--- a/common/src/main/java/com/revenuecat/purchases/strings/NetworkStrings.kt
+++ b/common/src/main/java/com/revenuecat/purchases/strings/NetworkStrings.kt
@@ -11,9 +11,12 @@ object NetworkStrings {
     const val SAME_CALL_ALREADY_IN_PROGRESS = "Same call already in progress, adding to callbacks map with key: %s"
     const val PROBLEM_CONNECTING = "Unable to start a network connection due to a network configuration issue: %s"
     const val VERIFICATION_MISSING_SIGNATURE = "Verification: Request to '%s' requires a signature but none provided."
+    const val VERIFICATION_INTERMEDIATE_KEY_FAILED = "Verification: Request to '%s' provided an intermediate key that" +
+        " did not verify correctly. Reason %s"
     const val VERIFICATION_MISSING_REQUEST_TIME = "Verification: Request to '%s' requires a request time" +
         " but none provided."
     const val VERIFICATION_MISSING_BODY_OR_ETAG = "Verification: Request to '%s' requires a body or etag" +
         " but none provided."
+    const val VERIFICATION_INVALID_SIZE = "Verification: Request to '%s' has signature with wrong size. '%s'"
     const val VERIFICATION_ERROR = "Verification: Request to '%s' failed verification."
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -39,7 +39,7 @@ abstract class BaseHTTPClientTest {
 
     protected val mockETagManager = mockk<ETagManager>().also {
         every {
-            it.getETagHeaders(any(), any())
+            it.getETagHeaders(any(), any(), any())
         } answers {
             mapOf(HTTPRequest.ETAG_HEADER_NAME to "")
         }

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -195,7 +195,7 @@ class HTTPClientTest: BaseHTTPClientTest() {
         val endpoint = Endpoint.LogIn
 
         every {
-            mockETagManager.getETagHeaders(any(), any())
+            mockETagManager.getETagHeaders(any(), any(), any())
         } answers {
             mapOf(
                 HTTPRequest.ETAG_HEADER_NAME to "mock-etag",
@@ -222,7 +222,7 @@ class HTTPClientTest: BaseHTTPClientTest() {
         val endpoint = Endpoint.LogIn
 
         every {
-            mockETagManager.getETagHeaders(any(), any())
+            mockETagManager.getETagHeaders(any(), any(), any())
         } answers {
             mapOf(
                 HTTPRequest.ETAG_HEADER_NAME to "mock-etag",
@@ -365,10 +365,10 @@ class HTTPClientTest: BaseHTTPClientTest() {
         server.takeRequest()
 
         verify(exactly = 1) {
-            mockETagManager.getETagHeaders(any(), false)
+            mockETagManager.getETagHeaders(any(), any(), refreshETag = false)
         }
         verify(exactly = 1) {
-            mockETagManager.getETagHeaders(any(), true)
+            mockETagManager.getETagHeaders(any(), any(), refreshETag = true)
         }
         assertThat(result.payload).isEqualTo(expectedResult.payload)
         assertThat(result.responseCode).isEqualTo(expectedResult.responseCode)

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -176,6 +176,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
             .setResponseCode(responseCode)
             .setHeader(HTTPResult.SIGNATURE_HEADER_NAME, "test-signature")
             .setHeader(HTTPResult.REQUEST_TIME_HEADER_NAME, 1234567890L)
+            .setHeader(HTTPResult.ETAG_HEADER_NAME, "test-etag")
         server.enqueue(response)
 
         val result = client.performRequest(
@@ -195,7 +196,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
                 "test-nonce",
                 "{\"test-key\":\"test-value\"}",
                 "1234567890",
-                eTag = null
+                "test-etag"
             )
         }
     }

--- a/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -41,7 +41,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         )
 
         every {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
         } returns VerificationResult.VERIFIED
 
         client.performRequest(
@@ -81,7 +81,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
         assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_REQUESTED)
         verify(exactly = 0) {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
         }
     }
 
@@ -112,7 +112,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
         assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_REQUESTED)
         verify(exactly = 0) {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
         }
     }
 
@@ -143,7 +143,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
         assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_REQUESTED)
         verify(exactly = 0) {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
         }
     }
 
@@ -157,7 +157,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         val responseCode = expectedResult.responseCode
 
         every {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
         } returns VerificationResult.VERIFIED
 
         every {
@@ -176,7 +176,6 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
             .setResponseCode(responseCode)
             .setHeader(HTTPResult.SIGNATURE_HEADER_NAME, "test-signature")
             .setHeader(HTTPResult.REQUEST_TIME_HEADER_NAME, 1234567890L)
-            .setHeader(HTTPResult.ETAG_HEADER_NAME, "test-etag")
         server.enqueue(response)
 
         val result = client.performRequest(
@@ -192,12 +191,11 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         verify(exactly = 1) {
             mockSigningManager.verifyResponse(
                 endpoint.getPath(),
-                responseCode,
                 "test-signature",
                 "test-nonce",
                 "{\"test-key\":\"test-value\"}",
                 "1234567890",
-                "test-etag"
+                eTag = null
             )
         }
     }
@@ -222,7 +220,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         server.takeRequest()
         assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_REQUESTED)
         verify(exactly = 0) {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
         }
     }
 
@@ -236,7 +234,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         )
 
         every {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
         } returns VerificationResult.FAILED
 
         val result = client.performRequest(
@@ -261,7 +259,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         )
 
         every {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
         } returns VerificationResult.FAILED
 
         var thrownCorrectException = false
@@ -292,7 +290,7 @@ class HTTPClientVerificationTest: BaseHTTPClientTest() {
         )
 
         every {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
         } returns VerificationResult.VERIFIED
 
         val result = client.performRequest(

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SignatureVerificationModeTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SignatureVerificationModeTest.kt
@@ -27,20 +27,18 @@ class SignatureVerificationModeTest {
 
     @Test
     fun `shouldVerify has correct values for all the verification modes`() {
-        val signatureVerifier = DefaultSignatureVerifier()
         assertThat(SignatureVerificationMode.Disabled.shouldVerify).isFalse
-        assertThat(SignatureVerificationMode.Informational(signatureVerifier).shouldVerify).isTrue
-        assertThat(SignatureVerificationMode.Enforced(signatureVerifier).shouldVerify).isTrue
+        assertThat(SignatureVerificationMode.Informational().shouldVerify).isTrue
+        assertThat(SignatureVerificationMode.Enforced().shouldVerify).isTrue
     }
 
     @Test
     fun `intermediateSignatureHelper has values in enabled verification modes`() {
-        val signatureVerifier = DefaultSignatureVerifier()
         var verificationMode: SignatureVerificationMode = SignatureVerificationMode.Disabled
         assertThat(verificationMode.intermediateSignatureHelper).isNull()
-        verificationMode = SignatureVerificationMode.Informational(signatureVerifier)
+        verificationMode = SignatureVerificationMode.Informational()
         assertThat(verificationMode.intermediateSignatureHelper).isNotNull
-        verificationMode = SignatureVerificationMode.Enforced(signatureVerifier)
+        verificationMode = SignatureVerificationMode.Enforced()
         assertThat(verificationMode.intermediateSignatureHelper).isNotNull
     }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SignatureVerificationModeTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SignatureVerificationModeTest.kt
@@ -32,4 +32,15 @@ class SignatureVerificationModeTest {
         assertThat(SignatureVerificationMode.Informational(signatureVerifier).shouldVerify).isTrue
         assertThat(SignatureVerificationMode.Enforced(signatureVerifier).shouldVerify).isTrue
     }
+
+    @Test
+    fun `intermediateSignatureHelper has values in enabled verification modes`() {
+        val signatureVerifier = DefaultSignatureVerifier()
+        var verificationMode: SignatureVerificationMode = SignatureVerificationMode.Disabled
+        assertThat(verificationMode.intermediateSignatureHelper).isNull()
+        verificationMode = SignatureVerificationMode.Informational(signatureVerifier)
+        assertThat(verificationMode.intermediateSignatureHelper).isNotNull
+        verificationMode = SignatureVerificationMode.Enforced(signatureVerifier)
+        assertThat(verificationMode.intermediateSignatureHelper).isNotNull
+    }
 }

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.common.verification
 
 import android.util.Base64
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.crypto.tink.subtle.Ed25519Sign
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
@@ -11,10 +12,13 @@ import com.revenuecat.purchases.utils.Result
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
+import org.bouncycastle.util.test.NumberParsing
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.nio.ByteBuffer
+import java.security.SecureRandom
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -181,6 +185,19 @@ class SigningManagerTest {
         val rootVerifier = DefaultSignatureVerifier("yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=")
         val signingManager = SigningManager(SignatureVerificationMode.Informational(rootVerifier), appConfig)
         val verificationResult = callVerifyResponse(signingManager)
+        assertThat(verificationResult).isEqualTo(VerificationResult.VERIFIED)
+    }
+
+    @Test
+    fun `verifyResponse with both payload and etag verifies correctly`() {
+//        createFakeSignature()
+        val rootVerifier = DefaultSignatureVerifier("yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=")
+        val signingManager = SigningManager(SignatureVerificationMode.Informational(rootVerifier), appConfig)
+        val verificationResult = callVerifyResponse(
+            signingManager,
+            signature = "xoDYyUeHnIlSIAeOOzmvdNPOlbNSKK+xE0fE/ufS1fsKCgoKkY+e/hYWiSW5cV6pVpp0i3Ag1p/wH4CcPnDSuG4qzPW8l582Q3gE9j5pIG3XrYxpblHCxBnfcBsxNriK0awxAVBTK1hPk60bAeilLRVB2Qwj2phUfQKOqgKxxUh1XHQlJJqUOiAUdv35dB3tmtPWH//MHO/V7mD72P+kwqecZgDxEZxgbe68VczwjIkSPo4F",
+            eTag = "test-etag",
+        )
         assertThat(verificationResult).isEqualTo(VerificationResult.VERIFIED)
     }
 

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -190,7 +190,6 @@ class SigningManagerTest {
 
     @Test
     fun `verifyResponse with both payload and etag verifies correctly`() {
-//        createFakeSignature()
         val rootVerifier = DefaultSignatureVerifier("yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=")
         val signingManager = SigningManager(SignatureVerificationMode.Informational(rootVerifier), appConfig)
         val verificationResult = callVerifyResponse(

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases.common.verification
 
 import android.util.Base64
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.crypto.tink.subtle.Ed25519Sign
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
@@ -12,13 +11,10 @@ import com.revenuecat.purchases.utils.Result
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
-import org.bouncycastle.util.test.NumberParsing
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import java.nio.ByteBuffer
-import java.security.SecureRandom
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -43,10 +39,10 @@ class SigningManagerTest {
 
         disabledSigningManager = SigningManager(SignatureVerificationMode.Disabled, appConfig)
         informationalSigningManager = SigningManager(
-            SignatureVerificationMode.Informational(mockk(), intermediateSignatureHelper), appConfig
+            SignatureVerificationMode.Informational(intermediateSignatureHelper), appConfig
         )
         enforcedSigningManager = SigningManager(
-            SignatureVerificationMode.Enforced(mockk(), intermediateSignatureHelper), appConfig
+            SignatureVerificationMode.Enforced(intermediateSignatureHelper), appConfig
         )
     }
 
@@ -183,7 +179,10 @@ class SigningManagerTest {
     @Test
     fun `verifyResponse with real data verifies correctly`() {
         val rootVerifier = DefaultSignatureVerifier("yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=")
-        val signingManager = SigningManager(SignatureVerificationMode.Informational(rootVerifier), appConfig)
+        val signingManager = SigningManager(
+            SignatureVerificationMode.Informational(IntermediateSignatureHelper(rootVerifier)),
+            appConfig,
+        )
         val verificationResult = callVerifyResponse(signingManager)
         assertThat(verificationResult).isEqualTo(VerificationResult.VERIFIED)
     }
@@ -191,7 +190,10 @@ class SigningManagerTest {
     @Test
     fun `verifyResponse with both payload and etag verifies correctly`() {
         val rootVerifier = DefaultSignatureVerifier("yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=")
-        val signingManager = SigningManager(SignatureVerificationMode.Informational(rootVerifier), appConfig)
+        val signingManager = SigningManager(
+            SignatureVerificationMode.Informational(IntermediateSignatureHelper(rootVerifier)),
+            appConfig,
+        )
         val verificationResult = callVerifyResponse(
             signingManager,
             signature = "xoDYyUeHnIlSIAeOOzmvdNPOlbNSKK+xE0fE/ufS1fsKCgoKkY+e/hYWiSW5cV6pVpp0i3Ag1p/wH4CcPnDSuG4qzPW8l582Q3gE9j5pIG3XrYxpblHCxBnfcBsxNriK0awxAVBTK1hPk60bAeilLRVB2Qwj2phUfQKOqgKxxUh1XHQlJJqUOiAUdv35dB3tmtPWH//MHO/V7mD72P+kwqecZgDxEZxgbe68VczwjIkSPo4F",
@@ -204,7 +206,10 @@ class SigningManagerTest {
     @Test
     fun `verifyResponse with slightly different data does not verify correctly`() {
         val rootVerifier = DefaultSignatureVerifier("yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=")
-        val signingManager = SigningManager(SignatureVerificationMode.Informational(rootVerifier), appConfig)
+        val signingManager = SigningManager(
+            SignatureVerificationMode.Informational(IntermediateSignatureHelper(rootVerifier)),
+            appConfig,
+        )
         assertThat(
             callVerifyResponse(signingManager, requestTime = "1677005916011") // Wrong request time
         ).isEqualTo(VerificationResult.FAILED)

--- a/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/common/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -206,6 +206,11 @@ class SigningManagerTest {
     private fun callVerifyResponse(
         signingManager: SigningManager,
         requestPath: String = "test-url-path",
+        // Generated signature using test keys:
+        // Test root private key: YMHMQMpepBKamtSzO8KCN2M8Z3AUW5R1JXIFtxUWFUI
+        // Test root public key: yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=
+        // Test intermediate private key: fPBoIjQ7DecE89ATW6PZsqLVQNyEs5fiX3sUyS3U4YI
+        // Test intermediate public key: xoDYyUeHnIlSIAeOOzmvdNPOlbNSKK+xE0fE/ufS1fs=
         signature: String? = "xoDYyUeHnIlSIAeOOzmvdNPOlbNSKK+xE0fE/ufS1fsKCgoKkY+e/hYWiSW5cV6pVpp0i3Ag1p/wH4CcPnDSuG4qzPW8l582Q3gE9j5pIG3XrYxpblHCxBnfcBsxNriK0awxAd8tsYi90CIUqiJXxN+/9Z4xLNME00pcLbsXFO0GqNVPkYgGgSJWEd/xAIiXQBypugaAb17y4u0xpjcyS5JRFXuLJCD4CGMZtmqWewWuuQgC",
         nonce: String = "MTIzNDU2Nzg5MGFi",
         body: String? = "{\"request_date\":\"2023-02-21T18:58:36Z\",\"request_date_ms\":1677005916011,\"subscriber\":{\"entitlements\":{},\"first_seen\":\"2023-02-21T18:58:35Z\",\"last_seen\":\"2023-02-21T18:58:35Z\",\"management_url\":null,\"non_subscriptions\":{},\"original_app_user_id\":\"login\",\"original_application_version\":null,\"original_purchase_date\":null,\"other_purchases\":{},\"subscriptions\":{}}}\n",


### PR DESCRIPTION
### Description
Added additional checks to not use cached etags when cached result is NOT_REQUESTED and verification is enabled. This will be used for other signed requests aside from the customer info/post receipt/login endpoints.
