### PR TITLE
Clear coroutines scope after each integration test to fix flakyness

### DIFF
--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -10,6 +10,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import org.assertj.core.api.Assertions
 import org.junit.After
@@ -70,6 +71,7 @@ open class BasePurchasesIntegrationTest {
 
     @After
     fun tearDown() {
+        _activity?.lifecycleScope?.cancel()
         _activity = null
         Purchases.resetSingleton()
     }


### PR DESCRIPTION
### Description
Seems that integration tests started failing after #1107/ #1077 

Looks like we were leaking the scope between tests. This was causing integration tests to randomly fail. Cancelling the scope after each test fixed the tests for me. 
