### PR TITLE
Fix flaky integration tests: Wait for coroutines to finish before continuing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,9 +468,7 @@ workflows:
       - assemble-sample-app
       - build-magic-weather-compose
       - run-backend-integration-tests
-      - run-firebase-tests-purchases-load-shedder-integration-test:
-          context:
-            - slack-secrets
+
   deploy:
     when:
       not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,7 +468,9 @@ workflows:
       - assemble-sample-app
       - build-magic-weather-compose
       - run-backend-integration-tests
-
+      - run-firebase-tests-purchases-load-shedder-integration-test:
+          context:
+            - slack-secrets
   deploy:
     when:
       not:

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -10,7 +10,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.After
 import org.junit.BeforeClass
@@ -172,7 +172,7 @@ open class BasePurchasesIntegrationTest {
     protected fun runTestActivityLifecycleScope(
         testBody: suspend CoroutineScope.() -> Unit,
     ) {
-        activity.lifecycleScope.launch {
+        runBlocking(activity.lifecycleScope.coroutineContext) {
             testBody()
         }
     }


### PR DESCRIPTION
### Description
Looks like our new coroutine test infrastructure added in #1077 / #1107 wasn't waiting for the code to be executed before continuing. In some cases the `@After` code was actually executed before the test, in those cases, the test was failing. In this PR I change it to a blocking method so the test finishes before continuing.
