### PR TITLE
Fix integration tests and change to a different project

### DIFF
--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -49,10 +49,10 @@ open class BasePurchasesIntegrationTest {
     protected val testUserId = "android-integration-test-$currentTimestamp"
     protected val proxyUrl = Constants.proxyUrl.takeIf { it != "NO_PROXY_URL" }
 
-    protected lateinit var mockBillingAbstract: BillingAbstract
+    internal lateinit var mockBillingAbstract: BillingAbstract
 
-    protected var latestPurchasesUpdatedListener: BillingAbstract.PurchasesUpdatedListener? = null
-    protected var latestStateListener: BillingAbstract.StateListener? = null
+    internal var latestPurchasesUpdatedListener: BillingAbstract.PurchasesUpdatedListener? = null
+    private var latestStateListener: BillingAbstract.StateListener? = null
 
     // We shouldn't cache the whole activity, but considering that these are simple integration tests
     // and we don't perform any configuration changes, it shouldn't cause any leaks.

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
@@ -91,7 +91,7 @@ class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
                 onSuccess = { offerings ->
                     assertThat(offerings.current).isNotNull
                     assertThat(offerings.current?.availablePackages?.size).isEqualTo(1)
-                    assertThat(offerings.current?.monthly?.product?.sku).isEqualTo(Constants.productIdToPurchase)
+                    assertThat(offerings.current?.annual?.product?.sku).isEqualTo(Constants.productIdToPurchase)
 
                     assertThat(offerings.current?.metadata).isNotNull
                     assertThat(offerings.current?.metadata?.get("dontdeletethis")).isEqualTo("useforintegrationtesting")
@@ -114,7 +114,7 @@ class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
                 onSuccess = { offerings ->
                     assertThat(offerings.current).isNotNull
                     assertThat(offerings.current?.availablePackages?.size).isEqualTo(1)
-                    assertThat(offerings.current?.monthly?.product?.sku).isEqualTo(Constants.productIdToPurchase)
+                    assertThat(offerings.current?.annual?.product?.sku).isEqualTo(Constants.productIdToPurchase)
                     latch.countDown()
                 },
             )
@@ -128,7 +128,7 @@ class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
                 onSuccess = { newOfferings ->
                     assertThat(newOfferings.current).isNotNull
                     assertThat(newOfferings.current?.availablePackages?.size).isEqualTo(1)
-                    assertThat(newOfferings.current?.monthly?.product?.sku).isEqualTo(Constants.productIdToPurchase)
+                    assertThat(newOfferings.current?.annual?.product?.sku).isEqualTo(Constants.productIdToPurchase)
 
                     latch.countDown()
                 },

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/helpers/BillingAbstractMockHelper.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/helpers/BillingAbstractMockHelper.kt
@@ -8,7 +8,7 @@ import com.revenuecat.purchases.models.StoreProduct
 import io.mockk.every
 import io.mockk.slot
 
-fun BillingAbstract.mockQueryProductDetails(
+internal fun BillingAbstract.mockQueryProductDetails(
     queryProductDetailsSubsReturn: List<StoreProduct> = listOf(StoreProductFactory.createGoogleStoreProduct()),
     queryProductDetailsInAppReturn: List<StoreProduct> = emptyList(),
 ): BillingAbstract {

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/offlineentitlements/BaseOfflineEntitlementsIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/offlineentitlements/BaseOfflineEntitlementsIntegrationTest.kt
@@ -21,7 +21,7 @@ abstract class BaseOfflineEntitlementsIntegrationTest : BasePurchasesIntegration
     )
 
     // Hack until we get a running token for production API tests. After that, we can just use "entitlementsToVerify"
-    private val expectedEntitlements = entitlementsToVerify.ifEmpty { listOf("pro_cat", "another_pro_4") }
+    private val expectedEntitlements = entitlementsToVerify.ifEmpty { listOf("pro_cat") }
 
     // region helpers
 

--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/purchasesExtensions.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/purchasesExtensions.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases
 import android.annotation.SuppressLint
 import com.revenuecat.purchases.common.BillingAbstract
 
-fun Purchases.Companion.configure(
+internal fun Purchases.Companion.configure(
     configuration: PurchasesConfiguration,
     overrideBillingAbstract: BillingAbstract,
     forceServerErrors: Boolean = false,

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -16,11 +16,11 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
         ensureBlockFinishes { latch ->
             backend.getProductEntitlementMapping(
                 onSuccessHandler = { productEntitlementMapping ->
-                    assertThat(productEntitlementMapping.mappings.size).isEqualTo(36)
-                    assertThat(productEntitlementMapping.mappings["annual_freetrial"]).isEqualTo(
+                    assertThat(productEntitlementMapping.mappings.size).isEqualTo(2)
+                    assertThat(productEntitlementMapping.mappings["cheapest_subs"]).isEqualTo(
                         ProductEntitlementMapping.Mapping(
-                            productIdentifier = "annual_freetrial",
-                            basePlanId = "p1y",
+                            productIdentifier = "cheapest_subs",
+                            basePlanId = "annual",
                             entitlements = listOf("pro_cat")
                         )
                     )


### PR DESCRIPTION
### Description
This fixes a couple of things:
- Fixes integration tests after the changes in #1106. There were some compiler issues
- Changes the project used by production integration tests and production backend integration tests to make it more stable (We were using a shared project before 😬 )
