### PR TITLE
Trusted entitlements: Remove decoding of url to verify signatures

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.common.verification
 
-import android.net.Uri
 import android.util.Base64
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.AppConfig
@@ -61,7 +60,7 @@ internal class SigningManager(
             return salt +
                 apiKey.toByteArray() +
                 (nonce?.let { Base64.decode(it, Base64.DEFAULT) } ?: byteArrayOf()) +
-                Uri.decode(urlPath).toByteArray() +
+                urlPath.toByteArray() +
                 requestTime.toByteArray() +
                 (eTag?.toByteArray() ?: byteArrayOf()) +
                 (body?.toByteArray() ?: byteArrayOf())

--- a/purchases/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -192,6 +192,22 @@ class SigningManagerTest {
     }
 
     @Test
+    fun `verifyResponse with encoded url verifies correctly`() {
+        val rootVerifier = DefaultSignatureVerifier("yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=")
+        val signingManager = SigningManager(
+            SignatureVerificationMode.Informational(IntermediateSignatureHelper(rootVerifier)),
+            appConfig,
+            apiKey,
+        )
+        val verificationResult = callVerifyResponse(
+            signingManager,
+            requestPath = "/v1/subscribers/\$RCAnonymousID%3A1af512a3b9c848899fe427f39dd69f2b",
+            signature = "xoDYyUeHnIlSIAeOOzmvdNPOlbNSKK+xE0fE/ufS1fsAAMNQ1HiPDL34Vx0Uy74KPV5mztuk3DHBpucT/rSYVlkxIa3ModYmPfYZ20lnlbSB1UiP6oJHwAA2pXlS6AQ5eLSuAmm2UIYPrDGEEC8Lgj1sAn2fGMRMx2eaPNzDPBGTxxZROfjkI1wtsyJC0w0I7d8TkLeXjUTlWNafmc4GVMleE/tQZZGIoNrnar0HqICUnB8B",
+        )
+        assertThat(verificationResult).isEqualTo(VerificationResult.VERIFIED)
+    }
+
+    @Test
     fun `verifyResponse with both payload and etag verifies correctly`() {
         val rootVerifier = DefaultSignatureVerifier("yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=")
         val signingManager = SigningManager(


### PR DESCRIPTION
### Description
We made one more change to the signature verification. Now we don't need to decode the url in order to verify the signature.