### PR TITLE
Fix load shedder integration tests

### DIFF
--- a/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestIntegrationTest/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
@@ -91,7 +91,8 @@ class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
                 onSuccess = { offerings ->
                     assertThat(offerings.current).isNotNull
                     assertThat(offerings.current?.availablePackages?.size).isEqualTo(1)
-                    assertThat(offerings.current?.annual?.product?.sku).isEqualTo(Constants.productIdToPurchase)
+                    assertThat(offerings.current?.availablePackages?.get(0)?.product?.sku)
+                        .isEqualTo(Constants.productIdToPurchase)
 
                     assertThat(offerings.current?.metadata).isNotNull
                     assertThat(offerings.current?.metadata?.get("dontdeletethis")).isEqualTo("useforintegrationtesting")
@@ -114,7 +115,8 @@ class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
                 onSuccess = { offerings ->
                     assertThat(offerings.current).isNotNull
                     assertThat(offerings.current?.availablePackages?.size).isEqualTo(1)
-                    assertThat(offerings.current?.annual?.product?.sku).isEqualTo(Constants.productIdToPurchase)
+                    assertThat(offerings.current?.availablePackages?.get(0)?.product?.sku)
+                        .isEqualTo(Constants.productIdToPurchase)
                     latch.countDown()
                 },
             )
@@ -128,7 +130,8 @@ class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
                 onSuccess = { newOfferings ->
                     assertThat(newOfferings.current).isNotNull
                     assertThat(newOfferings.current?.availablePackages?.size).isEqualTo(1)
-                    assertThat(newOfferings.current?.annual?.product?.sku).isEqualTo(Constants.productIdToPurchase)
+                    assertThat(newOfferings.current?.availablePackages?.get(0)?.product?.sku)
+                        .isEqualTo(Constants.productIdToPurchase)
 
                     latch.countDown()
                 },


### PR DESCRIPTION
### Description
After #1123, we fixed the production integration tests but we broke the load shedder integration tests (since the load shedder is using monthly skus and the production app is using annual skus)... This fixes it so it works for both.