### PR TITLE
Fix issue updating customer info on app open

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -160,16 +160,17 @@ class Purchases internal constructor(
     init {
         identityManager.configure(backingFieldAppUserID)
 
-        dispatch {
-            ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleHandler)
-        }
-
         billing.stateListener = object : BillingAbstract.StateListener {
             override fun onConnected() {
                 postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount)
             }
         }
         billing.purchasesUpdatedListener = getPurchasesUpdatedListener()
+
+        dispatch {
+            ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleHandler)
+        }
+
         if (!appConfig.dangerousSettings.autoSyncPurchases) {
             log(LogIntent.WARNING, AUTO_SYNC_PURCHASES_DISABLED)
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -168,6 +168,8 @@ class Purchases internal constructor(
         billing.purchasesUpdatedListener = getPurchasesUpdatedListener()
 
         dispatch {
+            // This needs to happen after the billing client listeners have been set. This is because
+            // we perform operations with the billing client in the lifecycle observer methods.
             ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleHandler)
         }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -146,6 +146,9 @@ internal class BillingWrapper(
             } else {
                 executePendingRequests()
             }
+        } else {
+            // This shouldn't happen, but if it does, we want to propagate an error instead of hanging.
+            request(PurchasesError(PurchasesErrorCode.UnknownError, "BillingWrapper is not attached to a listener"))
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -198,6 +198,25 @@ class BillingWrapperTest {
     }
 
     @Test
+    fun `if no listener is set, we fail`() {
+        wrapper.purchasesUpdatedListener = null
+
+        var error: PurchasesError? = null
+        wrapper.queryPurchaseHistoryAsync(
+            ProductType.SUBS.toGoogleProductType()!!,
+            {
+                fail("call should not succeed")
+            },
+            {
+                error = it
+            }
+        )
+        assertThat(error).isNotNull
+        assertThat(error?.code).isEqualTo(PurchasesErrorCode.UnknownError)
+        assertThat(error?.underlyingErrorMessage).isEqualTo("BillingWrapper is not attached to a listener")
+    }
+
+    @Test
     fun defersCallUntilConnected() {
         every { mockClient.isReady } returns false
 


### PR DESCRIPTION
### Description
In some situations, we weren't refreshing the customer info on app open. This was caused by #1073. In that PR we changed to fetch current purchases before getting customer info, so we would sync purchases before getting customer info. However, when we fetch customer info during the app open's `onAppForeground` callback, the `billing.purchasesUpdatedListener` was not set. Currently, if that listener isn't set, we would just [skip the query](https://github.com/RevenueCat/purchases-android/blob/ef34062996a17aa6a47d6eb2ca0903d66a51ab5e/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt#L142) altogether so we would never get a response. 

Thanks @joshdholtz  for bringing it up!
