### PR TITLE
Trusted entitlements: Support signing static endpoints

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -142,11 +142,12 @@ internal class HTTPClient(
         val urlPathWithVersion = "/v1$path"
         val connection: HttpURLConnection
         val shouldSignResponse = signingManager.shouldVerifyEndpoint(endpoint)
+        val shouldAddNonce = shouldSignResponse && endpoint.needsNonceToPerformSigning
         val nonce: String?
         try {
             val fullURL = URL(baseURL, urlPathWithVersion)
 
-            nonce = if (shouldSignResponse) signingManager.createRandomNonce() else null
+            nonce = if (shouldAddNonce) signingManager.createRandomNonce() else null
             val headers = getHeaders(requestHeaders, urlPathWithVersion, refreshETag, nonce, shouldSignResponse)
 
             val httpRequest = HTTPRequest(fullURL, headers, jsonBody)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -32,7 +32,7 @@ internal sealed class Endpoint(val pathTemplate: String, val name: String) {
         override fun getPath() = pathTemplate
     }
 
-    val supportsSignatureValidation: Boolean
+    val supportsSignatureVerification: Boolean
         get() = when (this) {
             is GetCustomerInfo,
             LogIn,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -37,6 +37,22 @@ internal sealed class Endpoint(val pathTemplate: String, val name: String) {
             is GetCustomerInfo,
             LogIn,
             PostReceipt,
+            is GetOfferings,
+            GetProductEntitlementMapping,
+            ->
+                true
+            is GetAmazonReceipt,
+            is PostAttributes,
+            PostDiagnostics,
+            ->
+                false
+        }
+
+    val needsNonceToPerformSigning: Boolean
+        get() = when (this) {
+            is GetCustomerInfo,
+            LogIn,
+            PostReceipt,
             ->
                 true
             is GetAmazonReceipt,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -69,7 +69,7 @@ internal class SigningManager(
     }
 
     fun shouldVerifyEndpoint(endpoint: Endpoint): Boolean {
-        return endpoint.supportsSignatureValidation && signatureVerificationMode.shouldVerify
+        return endpoint.supportsSignatureVerification && signatureVerificationMode.shouldVerify
     }
 
     fun createRandomNonce(): String {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.strings.NetworkStrings
 import com.revenuecat.purchases.utils.Result
@@ -141,6 +142,7 @@ internal class SigningManager(
                 )
 
                 return if (verificationResult) {
+                    verboseLog(NetworkStrings.VERIFICATION_SUCCESS.format(urlPath))
                     VerificationResult.VERIFIED
                 } else {
                     errorLog(NetworkStrings.VERIFICATION_ERROR.format(urlPath))

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/NetworkStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/NetworkStrings.kt
@@ -19,4 +19,5 @@ internal object NetworkStrings {
         " but none provided."
     const val VERIFICATION_INVALID_SIZE = "Verification: Request to '%s' has signature with wrong size. '%s'"
     const val VERIFICATION_ERROR = "Verification: Request to '%s' failed verification."
+    const val VERIFICATION_SUCCESS = "Verification: Request to '%s' verified successfully."
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
@@ -60,6 +60,14 @@ internal abstract class BaseBackendIntegrationTest {
 
     @Before
     fun setUp() {
+        setupTest()
+    }
+
+    abstract fun apiKey(): String
+
+    protected fun setupTest(
+        signatureVerificationMode: SignatureVerificationMode = SignatureVerificationMode.Disabled
+    ) {
         appConfig = mockk<AppConfig>().apply {
             every { baseURL } returns URL("https://api.revenuecat.com")
             every { store } returns Store.PLAY_STORE
@@ -82,13 +90,11 @@ internal abstract class BaseBackendIntegrationTest {
             every { edit() } returns sharedPreferencesEditor
         }
         eTagManager = ETagManager(sharedPreferences)
-        signingManager = SigningManager(SignatureVerificationMode.Disabled, appConfig, apiKey())
+        signingManager = SigningManager(signatureVerificationMode, appConfig, apiKey())
         httpClient = HTTPClient(appConfig, eTagManager, diagnosticsTrackerIfEnabled = null, signingManager)
         backendHelper = BackendHelper(apiKey(), dispatcher, appConfig, httpClient)
         backend = Backend(appConfig, dispatcher, diagnosticsDispatcher, httpClient, backendHelper)
     }
-
-    abstract fun apiKey(): String
 
     protected fun ensureBlockFinishes(block: (CountDownLatch) -> Unit) {
         val latch = CountDownLatch(1)

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
@@ -16,6 +16,7 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.spyk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.BeforeClass
@@ -90,7 +91,7 @@ internal abstract class BaseBackendIntegrationTest {
             every { edit() } returns sharedPreferencesEditor
         }
         eTagManager = ETagManager(sharedPreferences)
-        signingManager = SigningManager(signatureVerificationMode, appConfig, apiKey())
+        signingManager = spyk(SigningManager(signatureVerificationMode, appConfig, apiKey()))
         httpClient = HTTPClient(appConfig, eTagManager, diagnosticsTrackerIfEnabled = null, signingManager)
         backendHelper = BackendHelper(apiKey(), dispatcher, appConfig, httpClient)
         backend = Backend(appConfig, dispatcher, diagnosticsDispatcher, httpClient, backendHelper)

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderBackendIntegrationTest.kt
@@ -1,8 +1,12 @@
 package com.revenuecat.purchases.backend_integration_tests
 
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
+import com.revenuecat.purchases.common.verification.SignatureVerificationMode
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 
 internal class LoadShedderBackendIntegrationTest: BaseBackendIntegrationTest() {
@@ -41,5 +45,81 @@ internal class LoadShedderBackendIntegrationTest: BaseBackendIntegrationTest() {
             )
         }
         assertThat(error).isNull()
+    }
+
+    @Test
+    fun `can perform verified product entitlement mapping backend request`() {
+        setupTest(SignatureVerificationMode.Enforced())
+        ensureBlockFinishes { latch ->
+            backend.getProductEntitlementMapping(
+                onSuccessHandler = { productEntitlementMapping ->
+                    assertThat(productEntitlementMapping.mappings).containsOnlyKeys(
+                        "com.revenuecat.loadshedder.monthly",
+                        "com.revenuecat.loadshedder.monthly:monthly"
+                    )
+                    assertThat(productEntitlementMapping.mappings["com.revenuecat.loadshedder.monthly"]).isEqualTo(
+                        ProductEntitlementMapping.Mapping(
+                            productIdentifier = "com.revenuecat.loadshedder.monthly",
+                            basePlanId = "monthly",
+                            entitlements = listOf("premium", "pro")
+                        )
+                    )
+                    assertThat(productEntitlementMapping.mappings["com.revenuecat.loadshedder.monthly:monthly"]).isEqualTo(
+                        ProductEntitlementMapping.Mapping(
+                            productIdentifier = "com.revenuecat.loadshedder.monthly",
+                            basePlanId = "monthly",
+                            entitlements = listOf("premium", "pro")
+                        )
+                    )
+                    latch.countDown()
+                },
+                onErrorHandler = {
+                    fail("Expected success but got error: $it")
+                }
+            )
+        }
+        verify(exactly = 1) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
+    }
+
+    @Test
+    fun `can perform offerings backend request`() {
+        ensureBlockFinishes { latch ->
+            backend.getOfferings(
+                appUserID = "test-user-id",
+                appInBackground = false,
+                onSuccess = { offeringsResponse ->
+                    assertThat(offeringsResponse.getString("current_offering_id")).isEqualTo("default")
+                    latch.countDown()
+                },
+                onError = { _, _ ->
+                    fail("Expected success")
+                }
+            )
+        }
+        verify(exactly = 1) {
+            // Verify we save the backend response in the shared preferences
+            sharedPreferencesEditor.putString("/v1${Endpoint.GetOfferings("test-user-id").getPath()}", any())
+        }
+        verify(exactly = 1) { sharedPreferencesEditor.apply() }
+        verify(exactly = 0) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
+    }
+
+    @Test
+    fun `can perform verified offerings backend request`() {
+        setupTest(SignatureVerificationMode.Enforced())
+        ensureBlockFinishes { latch ->
+            backend.getOfferings(
+                appUserID = "test-user-id",
+                appInBackground = false,
+                onSuccess = { offeringsResponse ->
+                    assertThat(offeringsResponse.getString("current_offering_id")).isEqualTo("default")
+                    latch.countDown()
+                },
+                onError = { error, _ ->
+                    fail("Expected success. Got error: $error")
+                }
+            )
+        }
+        verify(exactly = 1) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -3,8 +3,10 @@ package com.revenuecat.purchases.backend_integration_tests
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
+import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 
 internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
@@ -36,6 +38,51 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
         verify(exactly = 1) {
             // Verify we save the backend response in the shared preferences
             sharedPreferencesEditor.putString("/v1${Endpoint.GetProductEntitlementMapping.getPath()}", any())
+        }
+        verify(exactly = 1) { sharedPreferencesEditor.apply() }
+    }
+
+    @Test
+    fun `can perform offerings backend request`() {
+        ensureBlockFinishes { latch ->
+            backend.getOfferings(
+                appUserID = "test-user-id",
+                appInBackground = false,
+                onSuccess = { offeringsResponse ->
+                    assertThat(offeringsResponse.length()).isPositive
+                    latch.countDown()
+                },
+                onError = { _, _ ->
+                    fail("Expected success")
+                }
+            )
+        }
+        verify(exactly = 1) {
+            // Verify we save the backend response in the shared preferences
+            sharedPreferencesEditor.putString("/v1${Endpoint.GetOfferings("test-user-id").getPath()}", any())
+        }
+        verify(exactly = 1) { sharedPreferencesEditor.apply() }
+    }
+
+    @Test
+    fun `can perform verified offerings backend request`() {
+        setupTest(SignatureVerificationMode.Enforced())
+        ensureBlockFinishes { latch ->
+            backend.getOfferings(
+                appUserID = "test-user-id",
+                appInBackground = false,
+                onSuccess = { offeringsResponse ->
+                    assertThat(offeringsResponse.length()).isPositive
+                    latch.countDown()
+                },
+                onError = { error, _ ->
+                    fail("Expected success. Got error: $error")
+                }
+            )
+        }
+        verify(exactly = 1) {
+            // Verify we save the backend response in the shared preferences
+            sharedPreferencesEditor.putString("/v1${Endpoint.GetOfferings("test-user-id").getPath()}", any())
         }
         verify(exactly = 1) { sharedPreferencesEditor.apply() }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -40,6 +40,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
             sharedPreferencesEditor.putString("/v1${Endpoint.GetProductEntitlementMapping.getPath()}", any())
         }
         verify(exactly = 1) { sharedPreferencesEditor.apply() }
+        verify(exactly = 0) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
     }
 
     @Test
@@ -63,6 +64,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
                 }
             )
         }
+        verify(exactly = 1) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
     }
 
     @Test
@@ -85,6 +87,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
             sharedPreferencesEditor.putString("/v1${Endpoint.GetOfferings("test-user-id").getPath()}", any())
         }
         verify(exactly = 1) { sharedPreferencesEditor.apply() }
+        verify(exactly = 0) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
     }
 
     @Test
@@ -103,5 +106,6 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
                 }
             )
         }
+        verify(exactly = 1) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -49,11 +49,11 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
         ensureBlockFinishes { latch ->
             backend.getProductEntitlementMapping(
                 onSuccessHandler = { productEntitlementMapping ->
-                    assertThat(productEntitlementMapping.mappings.size).isEqualTo(36)
-                    assertThat(productEntitlementMapping.mappings["annual_freetrial"]).isEqualTo(
+                    assertThat(productEntitlementMapping.mappings.size).isEqualTo(2)
+                    assertThat(productEntitlementMapping.mappings["cheapest_subs"]).isEqualTo(
                         ProductEntitlementMapping.Mapping(
-                            productIdentifier = "annual_freetrial",
-                            basePlanId = "p1y",
+                            productIdentifier = "cheapest_subs",
+                            basePlanId = "annual",
                             entitlements = listOf("pro_cat")
                         )
                     )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -13,7 +13,6 @@ import io.mockk.verify
 import okhttp3.mockwebserver.MockResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -251,7 +251,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
     }
 
     @Test
-    fun `performRequest on informational client without nonce does not throw on verification error`() {
+    fun `performRequest on informational client without nonce does not throw verification error`() {
         val endpoint = Endpoint.GetOfferings("test-user-id")
         enqueue(
             endpoint = endpoint,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -12,6 +12,8 @@ import io.mockk.mockk
 import io.mockk.verify
 import okhttp3.mockwebserver.MockResponse
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -250,6 +252,30 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
     }
 
     @Test
+    fun `performRequest on informational client without nonce does not throw on verification error`() {
+        val endpoint = Endpoint.GetOfferings("test-user-id")
+        enqueue(
+            endpoint = endpoint,
+            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.FAILED),
+            verificationResult = VerificationResult.FAILED
+        )
+
+        every {
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
+        } returns VerificationResult.FAILED
+
+        val result = client.performRequest(
+            baseURL,
+            endpoint,
+            body = null,
+            requestHeaders = emptyMap()
+        )
+
+        server.takeRequest()
+        assertThat(result.verificationResult).isEqualTo(VerificationResult.FAILED)
+    }
+
+    @Test
     fun `performRequest on enforced client throws verification error`() {
         every { mockSigningManager.signatureVerificationMode } returns mockk<SignatureVerificationMode.Enforced>()
         val endpoint = Endpoint.GetCustomerInfo("test-user-id")
@@ -276,6 +302,34 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
         }
 
         assertThat(thrownCorrectException).isTrue
+        verify(exactly = 0) {
+            mockETagManager.getHTTPResultFromCacheOrBackend(any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `performRequest on enforced client in request without nonce throws verification error`() {
+        every { mockSigningManager.signatureVerificationMode } returns mockk<SignatureVerificationMode.Enforced>()
+        val endpoint = Endpoint.GetOfferings("test-user-id")
+        enqueue(
+            endpoint = endpoint,
+            expectedResult = HTTPResult.createResult(verificationResult = VerificationResult.FAILED),
+            verificationResult = VerificationResult.FAILED
+        )
+
+        every {
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
+        } returns VerificationResult.FAILED
+
+        assertThatExceptionOfType(SignatureVerificationException::class.java).isThrownBy {
+            client.performRequest(
+                baseURL,
+                endpoint,
+                body = null,
+                requestHeaders = emptyMap()
+            )
+        }
+
         verify(exactly = 0) {
             mockETagManager.getHTTPResultFromCacheOrBackend(any(), any(), any(), any(), any(), any(), any())
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -10,6 +10,17 @@ import org.robolectric.annotation.Config
 @Config(manifest = Config.NONE)
 class EndpointTest {
 
+    private val allEndpoints = listOf(
+        Endpoint.GetCustomerInfo("test-user-id"),
+        Endpoint.LogIn,
+        Endpoint.PostReceipt,
+        Endpoint.GetOfferings("test-user-id"),
+        Endpoint.GetProductEntitlementMapping,
+        Endpoint.GetAmazonReceipt("test-user-id", "test-receipt-id"),
+        Endpoint.PostAttributes("test-user-id"),
+        Endpoint.PostDiagnostics,
+    )
+
     @Test
     fun `GetCustomerInfo has correct path`() {
         val endpoint = Endpoint.GetCustomerInfo("test user-id")
@@ -71,7 +82,9 @@ class EndpointTest {
         val expectedSupportsValidationEndpoints = listOf(
             Endpoint.GetCustomerInfo("test-user-id"),
             Endpoint.LogIn,
-            Endpoint.PostReceipt
+            Endpoint.PostReceipt,
+            Endpoint.GetOfferings("test-user-id"),
+            Endpoint.GetProductEntitlementMapping,
         )
         for (endpoint in expectedSupportsValidationEndpoints) {
             assertThat(endpoint.supportsSignatureValidation).isTrue
@@ -82,13 +95,46 @@ class EndpointTest {
     fun `supportsSignatureValidation returns false for expected values`() {
         val expectedNotSupportsValidationEndpoints = listOf(
             Endpoint.GetAmazonReceipt("test-user-id", "test-receipt-id"),
-            Endpoint.GetOfferings("test-user-id"),
             Endpoint.PostAttributes("test-user-id"),
             Endpoint.PostDiagnostics,
-            Endpoint.GetProductEntitlementMapping
         )
         for (endpoint in expectedNotSupportsValidationEndpoints) {
             assertThat(endpoint.supportsSignatureValidation).isFalse
+        }
+    }
+
+    @Test
+    fun `verify needsNonceToPerformSigning is true only if supportsSignatureValidation is true`() {
+        for (endpoint in allEndpoints) {
+            if (!endpoint.supportsSignatureValidation) {
+                assertThat(endpoint.needsNonceToPerformSigning).isFalse
+            }
+        }
+    }
+
+    @Test
+    fun `needsNonceToPerformSigning is true for expected values`() {
+        val expectedEndpoints = listOf(
+            Endpoint.GetCustomerInfo("test-user-id"),
+            Endpoint.LogIn,
+            Endpoint.PostReceipt,
+        )
+        for (endpoint in expectedEndpoints) {
+            assertThat(endpoint.needsNonceToPerformSigning).isTrue
+        }
+    }
+
+    @Test
+    fun `needsNonceToPerformSigning is false for expected values`() {
+        val expectedEndpoints = listOf(
+            Endpoint.GetOfferings("test-user-id"),
+            Endpoint.GetProductEntitlementMapping,
+            Endpoint.GetAmazonReceipt("test-user-id", "test-receipt-id"),
+            Endpoint.PostAttributes("test-user-id"),
+            Endpoint.PostDiagnostics,
+        )
+        for (endpoint in expectedEndpoints) {
+            assertThat(endpoint.needsNonceToPerformSigning).isFalse
         }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -78,7 +78,7 @@ class EndpointTest {
     }
 
     @Test
-    fun `supportsSignatureValidation returns true for expected values`() {
+    fun `supportsSignatureVerification returns true for expected values`() {
         val expectedSupportsValidationEndpoints = listOf(
             Endpoint.GetCustomerInfo("test-user-id"),
             Endpoint.LogIn,
@@ -87,27 +87,33 @@ class EndpointTest {
             Endpoint.GetProductEntitlementMapping,
         )
         for (endpoint in expectedSupportsValidationEndpoints) {
-            assertThat(endpoint.supportsSignatureValidation).isTrue
+            assertThat(endpoint.supportsSignatureVerification)
+                .withFailMessage { "Endpoint $endpoint expected to support signature validation" }
+                .isTrue
         }
     }
 
     @Test
-    fun `supportsSignatureValidation returns false for expected values`() {
+    fun `supportsSignatureVerification returns false for expected values`() {
         val expectedNotSupportsValidationEndpoints = listOf(
             Endpoint.GetAmazonReceipt("test-user-id", "test-receipt-id"),
             Endpoint.PostAttributes("test-user-id"),
             Endpoint.PostDiagnostics,
         )
         for (endpoint in expectedNotSupportsValidationEndpoints) {
-            assertThat(endpoint.supportsSignatureValidation).isFalse
+            assertThat(endpoint.supportsSignatureVerification)
+                .withFailMessage { "Endpoint $endpoint expected to not support signature validation" }
+                .isFalse
         }
     }
 
     @Test
-    fun `verify needsNonceToPerformSigning is true only if supportsSignatureValidation is true`() {
+    fun `verify needsNonceToPerformSigning is true only if supportsSignatureVerification is true`() {
         for (endpoint in allEndpoints) {
-            if (!endpoint.supportsSignatureValidation) {
-                assertThat(endpoint.needsNonceToPerformSigning).isFalse
+            if (!endpoint.supportsSignatureVerification) {
+                assertThat(endpoint.needsNonceToPerformSigning)
+                    .withFailMessage { "Endpoint $endpoint requires nonce but does not support signature validation" }
+                    .isFalse
             }
         }
     }
@@ -120,7 +126,9 @@ class EndpointTest {
             Endpoint.PostReceipt,
         )
         for (endpoint in expectedEndpoints) {
-            assertThat(endpoint.needsNonceToPerformSigning).isTrue
+            assertThat(endpoint.needsNonceToPerformSigning)
+                .withFailMessage { "Endpoint $endpoint expected to require nonce for signing" }
+                .isTrue
         }
     }
 
@@ -134,7 +142,9 @@ class EndpointTest {
             Endpoint.PostDiagnostics,
         )
         for (endpoint in expectedEndpoints) {
-            assertThat(endpoint.needsNonceToPerformSigning).isFalse
+            assertThat(endpoint.needsNonceToPerformSigning)
+                .withFailMessage { "Endpoint $endpoint expected to not require nonce for signing" }
+                .isFalse
         }
     }
 }


### PR DESCRIPTION
### Description
This is based on #1119. Looks like the merge commit for that PR was lost in a rebase in the base PR #1117 😬.
 
This adds support for static endpoint signing. Currently, that would be the offerings and product-entitlement mapping endpoints.