### PR TITLE
Trusted entitlements: Improve signature verification error log

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -122,7 +122,7 @@ open class PurchasesConfiguration(builder: Builder) {
          * The result of the verification can be obtained from [EntitlementInfos.verification] or
          * [EntitlementInfo.verification].
          *
-         * Default mode is disabled.
+         * Default mode is disabled. Please see https://rev.cat/trusted-entitlements for more info.
          */
         fun entitlementVerificationMode(verificationMode: EntitlementVerificationMode) = apply {
             this.verificationMode = verificationMode

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
@@ -57,5 +57,6 @@ enum class PurchasesErrorCode(val code: Int, val description: String) {
     ),
     EmptySubscriberAttributesError(25, "A request for subscriber attributes returned none."),
     CustomerInfoError(28, "There was a problem related to the customer info."),
-    SignatureVerificationError(36, "Request failed signature verification."),
+    SignatureVerificationError(36, "Request failed signature verification. " +
+        "Please see https://www.revenuecat.com/docs/trusted-entitlements for more info."),
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
@@ -59,7 +59,6 @@ enum class PurchasesErrorCode(val code: Int, val description: String) {
     CustomerInfoError(28, "There was a problem related to the customer info."),
     SignatureVerificationError(
         36,
-        "Request failed signature verification. " +
-            "Please see https://www.revenuecat.com/docs/trusted-entitlements for more info.",
+        "Request failed signature verification. Please see https://rev.cat/trusted-entitlements for more info.",
     ),
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
@@ -57,6 +57,9 @@ enum class PurchasesErrorCode(val code: Int, val description: String) {
     ),
     EmptySubscriberAttributesError(25, "A request for subscriber attributes returned none."),
     CustomerInfoError(28, "There was a problem related to the customer info."),
-    SignatureVerificationError(36, "Request failed signature verification. " +
-        "Please see https://www.revenuecat.com/docs/trusted-entitlements for more info."),
+    SignatureVerificationError(
+        36,
+        "Request failed signature verification. " +
+            "Please see https://www.revenuecat.com/docs/trusted-entitlements for more info.",
+    ),
 }


### PR DESCRIPTION
### Description
This adds a link to the trusted entitlements page in the docs when there is a signature verification error. This will help users get more data about the issue immediately without having to contact support.
