### PR TITLE
R8: Do not warn about amazon classes in purchases module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,6 +468,11 @@ workflows:
       - assemble-sample-app
       - build-magic-weather-compose
       - run-backend-integration-tests
+      - integration-tests-build
+      - run-firebase-tests:
+          requires:
+            - integration-tests-build
+
 
   deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,11 +468,6 @@ workflows:
       - assemble-sample-app
       - build-magic-weather-compose
       - run-backend-integration-tests
-      - integration-tests-build
-      - run-firebase-tests:
-          requires:
-            - integration-tests-build
-
 
   deploy:
     when:

--- a/purchases/consumer-rules.pro
+++ b/purchases/consumer-rules.pro
@@ -2,3 +2,4 @@
 -keep class androidx.lifecycle.DefaultLifecycleObserver
 -dontwarn com.google.errorprone.annotations.CanIgnoreReturnValue
 -dontwarn com.google.errorprone.annotations.Immutable
+-dontwarn com.amazon.**


### PR DESCRIPTION
### Description
Looks like integration tests from the integration tests module failed to build after the module refactor https://circleci.com/gh/RevenueCat/purchases-android/20341. 

After investigating, looks like it's complaining when minifying the purchases module since it can't find the amazon classes. This makes sense since we don't have the amazon sdk there (it's compile only). The solution is to make those classes not warn. If people use the amazon dependency, they would get its own set of rules which keeps the amazon classes