### PR TITLE
Trusted entitlements: Add isVerified propety to VerificationResult enum

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/VerificationResultAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/VerificationResultAPI.java
@@ -11,5 +11,6 @@ final class VerificationResultAPI {
             case VERIFIED:
             case FAILED:
         }
+        boolean isVerified = verificationResult.isVerified();
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VerificationResultAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VerificationResultAPI.kt
@@ -13,5 +13,7 @@ private class VerificationResultAPI {
             VerificationResult.FAILED,
             -> {}
         }.exhaustive
+
+        val isVerified: Boolean = verificationResult.isVerified
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/VerificationResult.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/VerificationResult.kt
@@ -32,4 +32,17 @@ enum class VerificationResult {
      * Verification was performed on device.
      */
     VERIFIED_ON_DEVICE,
+
+    ;
+
+    /**
+     * Whether the result is [VerificationResult.VERIFIED] or [VerificationResult.VERIFIED_ON_DEVICE].
+     */
+    val isVerified: Boolean
+        get() {
+            return when (this) {
+                VERIFIED, VERIFIED_ON_DEVICE -> true
+                NOT_REQUESTED, FAILED -> false
+            }
+        }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/VerificationResultTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/VerificationResultTest.kt
@@ -1,0 +1,18 @@
+package com.revenuecat.purchases
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class VerificationResultTest {
+
+    @Test
+    fun `isVerified returns expected values`() {
+        assertThat(VerificationResult.VERIFIED.isVerified).isTrue
+        assertThat(VerificationResult.VERIFIED_ON_DEVICE.isVerified).isTrue
+        assertThat(VerificationResult.NOT_REQUESTED.isVerified).isFalse
+        assertThat(VerificationResult.FAILED.isVerified).isFalse
+    }
+}


### PR DESCRIPTION
### Description
This adds a `isVerified` property to the `VerificationResult` enum for convenience when dealing with the verification results. Android version of: https://github.com/RevenueCat/purchases-ios/pull/2788
