### PR TITLE
Trusted entitlements: Support post params hash header

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBackend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBackend.kt
@@ -32,7 +32,8 @@ internal class AmazonBackend(
         val call = {
             backendHelper.performRequest(
                 Endpoint.GetAmazonReceipt(storeUserID, receiptId),
-                null,
+                body = null,
+                postFieldsToSign = null,
                 { error ->
                     synchronized(this@AmazonBackend) {
                         postAmazonReceiptCallbacks.remove(cacheKey)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -67,6 +67,11 @@ internal class Backend(
     private val httpClient: HTTPClient,
     private val backendHelper: BackendHelper,
 ) {
+    private companion object {
+        const val APP_USER_ID = "app_user_id"
+        const val FETCH_TOKEN = "fetch_token"
+        const val NEW_APP_USER_ID = "new_app_user_id"
+    }
 
     val verificationMode: SignatureVerificationMode
         get() = httpClient.signingManager.signatureVerificationMode
@@ -118,7 +123,8 @@ internal class Backend(
                 return httpClient.performRequest(
                     appConfig.baseURL,
                     endpoint,
-                    null,
+                    body = null,
+                    postFieldsToSign = null,
                     backendHelper.authenticationHeaders,
                 )
             }
@@ -183,10 +189,10 @@ internal class Backend(
         )
 
         val body = mapOf(
-            "fetch_token" to purchaseToken,
+            FETCH_TOKEN to purchaseToken,
             "product_ids" to receiptInfo.productIDs,
             "platform_product_ids" to receiptInfo.platformProductIds?.map { it.asMap },
-            "app_user_id" to appUserID,
+            APP_USER_ID to appUserID,
             "is_restore" to isRestore,
             "presented_offering_identifier" to receiptInfo.offeringIdentifier,
             "observer_mode" to observerMode,
@@ -198,6 +204,11 @@ internal class Backend(
             "pricing_phases" to receiptInfo.pricingPhases?.map { it.toMap() },
             "proration_mode" to receiptInfo.prorationMode?.name,
         ).filterNotNullValues()
+
+        val postFieldsToSign = listOf(
+            APP_USER_ID to appUserID,
+            FETCH_TOKEN to purchaseToken,
+        )
 
         val extraHeaders = mapOf(
             "price_string" to receiptInfo.storeProduct?.price?.formatted,
@@ -211,6 +222,7 @@ internal class Backend(
                     appConfig.baseURL,
                     Endpoint.PostReceipt,
                     body,
+                    postFieldsToSign,
                     backendHelper.authenticationHeaders + extraHeaders,
                 )
             }
@@ -274,7 +286,8 @@ internal class Backend(
                 return httpClient.performRequest(
                     appConfig.baseURL,
                     endpoint,
-                    null,
+                    body = null,
+                    postFieldsToSign = null,
                     backendHelper.authenticationHeaders,
                 )
             }
@@ -326,13 +339,19 @@ internal class Backend(
         )
         val call = object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {
+                val body = mapOf(
+                    APP_USER_ID to appUserID,
+                    NEW_APP_USER_ID to newAppUserID,
+                )
+                val postFieldsToSign = listOf(
+                    APP_USER_ID to appUserID,
+                    NEW_APP_USER_ID to newAppUserID,
+                )
                 return httpClient.performRequest(
                     appConfig.baseURL,
                     Endpoint.LogIn,
-                    mapOf(
-                        "new_app_user_id" to newAppUserID,
-                        "app_user_id" to appUserID,
-                    ),
+                    body,
+                    postFieldsToSign,
                     backendHelper.authenticationHeaders,
                 )
             }
@@ -385,6 +404,7 @@ internal class Backend(
                     appConfig.diagnosticsURL,
                     Endpoint.PostDiagnostics,
                     body,
+                    postFieldsToSign = null,
                     backendHelper.authenticationHeaders,
                 )
             }
@@ -434,7 +454,8 @@ internal class Backend(
                 return httpClient.performRequest(
                     appConfig.baseURL,
                     endpoint,
-                    null,
+                    body = null,
+                    postFieldsToSign = null,
                     backendHelper.authenticationHeaders,
                 )
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BackendHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BackendHelper.kt
@@ -17,6 +17,7 @@ internal class BackendHelper(
     fun performRequest(
         endpoint: Endpoint,
         body: Map<String, Any?>?,
+        postFieldsToSign: List<Pair<String, String>>?,
         onError: (PurchasesError) -> Unit,
         onCompleted: (PurchasesError?, Int, JSONObject) -> Unit,
     ) {
@@ -27,6 +28,7 @@ internal class BackendHelper(
                         appConfig.baseURL,
                         endpoint,
                         body,
+                        postFieldsToSign,
                         authenticationHeaders,
                     )
                 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -152,7 +152,7 @@ internal class HTTPClient(
             val fullURL = URL(baseURL, urlPathWithVersion)
 
             nonce = if (shouldAddNonce) signingManager.createRandomNonce() else null
-            postFieldsToSignHeader = postFieldsToSign?.let {
+            postFieldsToSignHeader = postFieldsToSign?.takeIf { shouldSignResponse }?.let {
                 signingManager.getPostParamsForSigningHeaderIfNeeded(endpoint, postFieldsToSign)
             }
             val headers = getHeaders(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -95,11 +95,13 @@ internal class HTTPClient(
      * @throws JSONException Thrown for any JSON errors, not thrown for returned HTTP error codes
      * @throws IOException Thrown for any unexpected errors, not thrown for returned HTTP error codes
      */
+    @Suppress("LongParameterList")
     @Throws(JSONException::class, IOException::class)
     fun performRequest(
         baseURL: URL,
         endpoint: Endpoint,
         body: Map<String, Any?>?,
+        postFieldsToSign: List<Pair<String, String>>?,
         requestHeaders: Map<String, String>,
         refreshETag: Boolean = false,
     ): HTTPResult {
@@ -117,23 +119,24 @@ internal class HTTPClient(
         val requestStartTime = dateProvider.now
         var callResult: HTTPResult? = null
         try {
-            callResult = performCall(baseURL, endpoint, body, requestHeaders, refreshETag)
+            callResult = performCall(baseURL, endpoint, body, postFieldsToSign, requestHeaders, refreshETag)
             callSuccessful = true
         } finally {
             trackHttpRequestPerformedIfNeeded(endpoint, requestStartTime, callSuccessful, callResult)
         }
         if (callResult == null) {
             log(LogIntent.WARNING, NetworkStrings.ETAG_RETRYING_CALL)
-            callResult = performRequest(baseURL, endpoint, body, requestHeaders, refreshETag = true)
+            callResult = performRequest(baseURL, endpoint, body, postFieldsToSign, requestHeaders, refreshETag = true)
         }
         return callResult
     }
 
-    @Suppress("ThrowsCount")
+    @Suppress("ThrowsCount", "LongParameterList", "LongMethod")
     private fun performCall(
         baseURL: URL,
         endpoint: Endpoint,
         body: Map<String, Any?>?,
+        postFieldsToSign: List<Pair<String, String>>?,
         requestHeaders: Map<String, String>,
         refreshETag: Boolean,
     ): HTTPResult? {
@@ -148,7 +151,17 @@ internal class HTTPClient(
             val fullURL = URL(baseURL, urlPathWithVersion)
 
             nonce = if (shouldAddNonce) signingManager.createRandomNonce() else null
-            val headers = getHeaders(requestHeaders, urlPathWithVersion, refreshETag, nonce, shouldSignResponse)
+            val postFieldsToSignHeader = postFieldsToSign?.let {
+                signingManager.getPostParamsForSigningHeaderIfNeeded(endpoint, postFieldsToSign)
+            }
+            val headers = getHeaders(
+                requestHeaders,
+                urlPathWithVersion,
+                refreshETag,
+                nonce,
+                shouldSignResponse,
+                postFieldsToSignHeader,
+            )
 
             val httpRequest = HTTPRequest(fullURL, headers, jsonBody)
 
@@ -233,12 +246,14 @@ internal class HTTPClient(
         eTagManager.clearCaches()
     }
 
+    @Suppress("LongParameterList")
     private fun getHeaders(
         authenticationHeaders: Map<String, String>,
         urlPath: String,
         refreshETag: Boolean,
         nonce: String?,
         shouldSignResponse: Boolean,
+        postFieldsToSignHeader: String?,
     ): Map<String, String> {
         return mapOf(
             "Content-Type" to "application/json",
@@ -252,6 +267,7 @@ internal class HTTPClient(
             "X-Client-Bundle-ID" to appConfig.packageName,
             "X-Observer-Mode-Enabled" to if (appConfig.finishTransactions) "false" else "true",
             "X-Nonce" to nonce,
+            HTTPRequest.POST_PARAMS_HASH to postFieldsToSignHeader,
         )
             .plus(authenticationHeaders)
             .plus(eTagManager.getETagHeaders(urlPath, shouldSignResponse, refreshETag))

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPRequest.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPRequest.kt
@@ -11,5 +11,6 @@ internal data class HTTPRequest(
     companion object {
         const val ETAG_HEADER_NAME = "X-RevenueCat-ETag"
         const val ETAG_LAST_REFRESH_NAME = "X-RC-Last-Refresh-Time"
+        const val POST_PARAMS_HASH = "X-Post-Params-Hash"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -20,6 +20,7 @@ internal class SigningManager(
     private companion object {
         const val NONCE_BYTES_SIZE = 12
         const val POST_PARAMS_ALGORITHM = "sha256"
+        const val POST_PARAMS_SEPARATOR = 0x00.toByte()
     }
 
     private data class Parameters(
@@ -94,7 +95,7 @@ internal class SigningManager(
             val sha256Digest = MessageDigest.getInstance("SHA-256")
             postFieldsToSign.mapIndexed { index, pair ->
                 if (index > 0) {
-                    sha256Digest.update(0x00.toByte())
+                    sha256Digest.update(POST_PARAMS_SEPARATOR)
                 }
                 sha256Digest.update(pair.second.toByteArray())
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -89,8 +89,7 @@ internal class SigningManager(
         postFieldsToSign: List<Pair<String, String>>?,
     ): String? {
         return if (!postFieldsToSign.isNullOrEmpty() &&
-            signatureVerificationMode.shouldVerify &&
-            endpoint.supportsSignatureVerification
+            shouldVerifyEndpoint(endpoint)
         ) {
             val sha256Digest = MessageDigest.getInstance("SHA-256")
             postFieldsToSign.mapIndexed { index, pair ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -81,7 +81,7 @@ internal class SigningManager(
     fun createRandomNonce(): String {
         val bytes = ByteArray(NONCE_BYTES_SIZE)
         SecureRandom().nextBytes(bytes)
-        return String(Base64.encode(bytes, Base64.DEFAULT))
+        return String(Base64.encode(bytes, Base64.DEFAULT)).trim()
     }
 
     fun getPostParamsForSigningHeaderIfNeeded(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SigningManager.kt
@@ -27,6 +27,7 @@ internal class SigningManager(
         val apiKey: String,
         val nonce: String?,
         val urlPath: String,
+        val postParamsHashHeader: String?,
         val requestTime: String,
         val eTag: String?,
         val body: String?,
@@ -41,6 +42,7 @@ internal class SigningManager(
             if (apiKey != other.apiKey) return false
             if (nonce != other.nonce) return false
             if (urlPath != other.urlPath) return false
+            if (postParamsHashHeader != other.postParamsHashHeader) return false
             if (requestTime != other.requestTime) return false
             if (eTag != other.eTag) return false
             if (body != other.body) return false
@@ -53,6 +55,7 @@ internal class SigningManager(
             result = 31 * result + apiKey.hashCode()
             result = 31 * result + (nonce?.hashCode() ?: 0)
             result = 31 * result + urlPath.hashCode()
+            result = 31 * result + (postParamsHashHeader?.hashCode() ?: 0)
             result = 31 * result + requestTime.hashCode()
             result = 31 * result + (eTag?.hashCode() ?: 0)
             result = 31 * result + (body?.hashCode() ?: 0)
@@ -64,6 +67,7 @@ internal class SigningManager(
                 apiKey.toByteArray() +
                 (nonce?.let { Base64.decode(it, Base64.DEFAULT) } ?: byteArrayOf()) +
                 urlPath.toByteArray() +
+                (postParamsHashHeader?.toByteArray() ?: byteArrayOf()) +
                 requestTime.toByteArray() +
                 (eTag?.toByteArray() ?: byteArrayOf()) +
                 (body?.toByteArray() ?: byteArrayOf())
@@ -115,6 +119,7 @@ internal class SigningManager(
         body: String?,
         requestTime: String?,
         eTag: String?,
+        postFieldsToSignHeader: String?,
     ): VerificationResult {
         if (appConfig.forceSigningErrors) {
             warnLog("Forcing signing error for request with path: $urlPath")
@@ -161,6 +166,7 @@ internal class SigningManager(
                     apiKey,
                     nonce,
                     urlPath,
+                    postFieldsToSignHeader,
                     requestTime,
                     eTag,
                     body,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesPoster.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesPoster.kt
@@ -24,6 +24,7 @@ internal class SubscriberAttributesPoster(
         backendHelper.performRequest(
             Endpoint.PostAttributes(appUserID),
             mapOf("attributes" to attributes),
+            postFieldsToSign = null,
             { error ->
                 onErrorHandler(error, false, emptyList())
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
@@ -14,6 +14,7 @@ import com.revenuecat.purchases.utils.SyncDispatcher
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
@@ -162,5 +163,35 @@ class AmazonBackendTest {
 
         assertThat(receivedError!!).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.NetworkError)
+    }
+
+    @Test
+    fun `getAmazonReceiptData does not add post fields to sign`() {
+        every {
+            mockClient.performRequest(
+                baseURL = baseURL,
+                endpoint = Endpoint.GetAmazonReceipt("store_user_id", "receipt_id"),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
+            )
+        } returns successfulResult
+
+        underTest.getAmazonReceiptData(
+            receiptId = "receipt_id",
+            storeUserID = "store_user_id",
+            onSuccess = expectedOnSuccess,
+            onError = unexpectedOnError
+        )
+
+        verify(exactly = 1) {
+            mockClient.performRequest(
+                baseURL = baseURL,
+                endpoint = Endpoint.GetAmazonReceipt("store_user_id", "receipt_id"),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
+            )
+        }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBackendTest.kt
@@ -103,6 +103,7 @@ class AmazonBackendTest {
                 baseURL = baseURL,
                 endpoint = Endpoint.GetAmazonReceipt("store_user_id", "receipt_id"),
                 body = null,
+                postFieldsToSign = null,
                 requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
             )
         } returns successfulResult
@@ -124,6 +125,7 @@ class AmazonBackendTest {
                 baseURL = baseURL,
                 endpoint = Endpoint.GetAmazonReceipt("store_user_id", "receipt_id"),
                 body = null,
+                postFieldsToSign = null,
                 requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
             )
         } returns unsuccessfulResult
@@ -146,6 +148,7 @@ class AmazonBackendTest {
                 baseURL = baseURL,
                 endpoint = Endpoint.GetAmazonReceipt("store_user_id", "receipt_id"),
                 body = null,
+                postFieldsToSign = null,
                 requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
             )
         } throws IOException()

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
@@ -17,6 +17,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.spyk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.BeforeClass
@@ -102,5 +103,13 @@ internal abstract class BaseBackendIntegrationTest {
         block(latch)
         latch.await(TIMEOUT.inWholeSeconds, TimeUnit.SECONDS)
         assertThat(latch.count).isEqualTo(0)
+    }
+
+    protected fun assertSigningPerformed() {
+        verify(exactly = 1) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())  }
+    }
+
+    protected fun assertSigningNotPerformed() {
+        verify(exactly = 0) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())  }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderBackendIntegrationTest.kt
@@ -122,4 +122,51 @@ internal class LoadShedderBackendIntegrationTest: BaseBackendIntegrationTest() {
         }
         assertSigningPerformed()
     }
+
+    @Test
+    fun `can perform login backend request`() {
+        ensureBlockFinishes { latch ->
+            backend.logIn(
+                appUserID = "test-user-id",
+                newAppUserID = "new-test-user-id",
+                onSuccessHandler = { customerInfo, _ ->
+                    assertThat(customerInfo.originalAppUserId).isEqualTo("new-test-user-id")
+                    latch.countDown()
+                },
+                onErrorHandler = {
+                    fail("Expected success")
+                }
+            )
+        }
+        verify(exactly = 1) {
+            // Verify we save the backend response in the shared preferences
+            sharedPreferencesEditor.putString("/v1${Endpoint.LogIn.getPath()}", any())
+        }
+        verify(exactly = 1) { sharedPreferencesEditor.apply() }
+        assertSigningNotPerformed()
+    }
+
+    @Test
+    fun `can perform verified login backend request`() {
+        setupTest(SignatureVerificationMode.Enforced())
+        ensureBlockFinishes { latch ->
+            backend.logIn(
+                appUserID = "test-user-id",
+                newAppUserID = "new-test-user-id",
+                onSuccessHandler = { customerInfo, _ ->
+                    assertThat(customerInfo.originalAppUserId).isEqualTo("new-test-user-id")
+                    latch.countDown()
+                },
+                onErrorHandler = {
+                    fail("Expected success")
+                }
+            )
+        }
+        verify(exactly = 1) {
+            // Verify we save the backend response in the shared preferences
+            sharedPreferencesEditor.putString("/v1${Endpoint.LogIn.getPath()}", any())
+        }
+        verify(exactly = 1) { sharedPreferencesEditor.apply() }
+        assertSigningPerformed()
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderBackendIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.backend_integration_tests
 
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
@@ -155,6 +156,7 @@ internal class LoadShedderBackendIntegrationTest: BaseBackendIntegrationTest() {
                 newAppUserID = "new-test-user-id",
                 onSuccessHandler = { customerInfo, _ ->
                     assertThat(customerInfo.originalAppUserId).isEqualTo("new-test-user-id")
+                    assertThat(customerInfo.entitlements.verification).isEqualTo(VerificationResult.VERIFIED)
                     latch.countDown()
                 },
                 onErrorHandler = {

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/LoadShedderBackendIntegrationTest.kt
@@ -78,7 +78,7 @@ internal class LoadShedderBackendIntegrationTest: BaseBackendIntegrationTest() {
                 }
             )
         }
-        verify(exactly = 1) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
+        assertSigningPerformed()
     }
 
     @Test
@@ -101,7 +101,7 @@ internal class LoadShedderBackendIntegrationTest: BaseBackendIntegrationTest() {
             sharedPreferencesEditor.putString("/v1${Endpoint.GetOfferings("test-user-id").getPath()}", any())
         }
         verify(exactly = 1) { sharedPreferencesEditor.apply() }
-        verify(exactly = 0) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
+        assertSigningNotPerformed()
     }
 
     @Test
@@ -120,6 +120,6 @@ internal class LoadShedderBackendIntegrationTest: BaseBackendIntegrationTest() {
                 }
             )
         }
-        verify(exactly = 1) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
+        assertSigningPerformed()
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -40,7 +40,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
             sharedPreferencesEditor.putString("/v1${Endpoint.GetProductEntitlementMapping.getPath()}", any())
         }
         verify(exactly = 1) { sharedPreferencesEditor.apply() }
-        verify(exactly = 0) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
+        assertSigningNotPerformed()
     }
 
     @Test
@@ -64,7 +64,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
                 }
             )
         }
-        verify(exactly = 1) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
+        assertSigningPerformed()
     }
 
     @Test
@@ -87,7 +87,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
             sharedPreferencesEditor.putString("/v1${Endpoint.GetOfferings("test-user-id").getPath()}", any())
         }
         verify(exactly = 1) { sharedPreferencesEditor.apply() }
-        verify(exactly = 0) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
+        assertSigningNotPerformed()
     }
 
     @Test
@@ -106,6 +106,6 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
                 }
             )
         }
-        verify(exactly = 1) { signingManager.verifyResponse(any(), any(), any(), any(), any(), any())  }
+        assertSigningPerformed()
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.backend_integration_tests
 
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMapping
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
@@ -141,6 +142,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
                 newAppUserID = "new-test-user-id",
                 onSuccessHandler = { customerInfo, _ ->
                     assertThat(customerInfo.originalAppUserId).isEqualTo("new-test-user-id")
+                    assertThat(customerInfo.entitlements.verification).isEqualTo(VerificationResult.VERIFIED)
                     latch.countDown()
                 },
                 onErrorHandler = {

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -108,4 +108,51 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
         }
         assertSigningPerformed()
     }
+
+    @Test
+    fun `can perform login backend request`() {
+        ensureBlockFinishes { latch ->
+            backend.logIn(
+                appUserID = "test-user-id",
+                newAppUserID = "new-test-user-id",
+                onSuccessHandler = { customerInfo, _ ->
+                    assertThat(customerInfo.originalAppUserId).isEqualTo("new-test-user-id")
+                    latch.countDown()
+                },
+                onErrorHandler = {
+                    fail("Expected success")
+                }
+            )
+        }
+        verify(exactly = 1) {
+            // Verify we save the backend response in the shared preferences
+            sharedPreferencesEditor.putString("/v1${Endpoint.LogIn.getPath()}", any())
+        }
+        verify(exactly = 1) { sharedPreferencesEditor.apply() }
+        assertSigningNotPerformed()
+    }
+
+    @Test
+    fun `can perform verified login backend request`() {
+        setupTest(SignatureVerificationMode.Enforced())
+        ensureBlockFinishes { latch ->
+            backend.logIn(
+                appUserID = "test-user-id",
+                newAppUserID = "new-test-user-id",
+                onSuccessHandler = { customerInfo, _ ->
+                    assertThat(customerInfo.originalAppUserId).isEqualTo("new-test-user-id")
+                    latch.countDown()
+                },
+                onErrorHandler = {
+                    fail("Expected success")
+                }
+            )
+        }
+        verify(exactly = 1) {
+            // Verify we save the backend response in the shared preferences
+            sharedPreferencesEditor.putString("/v1${Endpoint.LogIn.getPath()}", any())
+        }
+        verify(exactly = 1) { sharedPreferencesEditor.apply() }
+        assertSigningPerformed()
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -313,7 +313,8 @@ class BackendTest {
             mockClient.performRequest(
                 mockBaseURL,
                 Endpoint.GetCustomerInfo(appUserID),
-                null,
+                body = null,
+                postFieldsToSign = null,
                 any()
             )
         }
@@ -365,6 +366,7 @@ class BackendTest {
             mockClient.performRequest(
                 mockBaseURL,
                 Endpoint.PostReceipt,
+                any(),
                 any(),
                 any()
             )
@@ -615,6 +617,7 @@ class BackendTest {
                 mockBaseURL,
                 Endpoint.PostReceipt,
                 any(),
+                any(),
                 any()
             )
         }
@@ -684,6 +687,7 @@ class BackendTest {
                 mockBaseURL,
                 Endpoint.PostReceipt,
                 any(),
+                any(),
                 any()
             )
         }
@@ -691,7 +695,8 @@ class BackendTest {
             mockClient.performRequest(
                 mockBaseURL,
                 Endpoint.GetCustomerInfo(appUserID),
-                null,
+                body = null,
+                postFieldsToSign = null,
                 any()
             )
         }
@@ -782,6 +787,7 @@ class BackendTest {
                 mockBaseURL,
                 Endpoint.PostReceipt,
                 any() as Map<String, Any?>,
+                any(),
                 any()
             )
         }
@@ -841,6 +847,7 @@ class BackendTest {
                 mockBaseURL,
                 Endpoint.PostReceipt,
                 any() as Map<String, Any?>,
+                any(),
                 any()
             )
         }
@@ -885,6 +892,7 @@ class BackendTest {
             mockClient.performRequest(
                 mockBaseURL,
                 Endpoint.PostReceipt,
+                any(),
                 any(),
                 any()
             )
@@ -932,6 +940,7 @@ class BackendTest {
                 mockBaseURL,
                 Endpoint.PostReceipt,
                 any() as Map<String, Any?>,
+                any(),
                 any()
             )
         }
@@ -993,6 +1002,7 @@ class BackendTest {
             mockClient.performRequest(
                 mockBaseURL,
                 Endpoint.PostReceipt,
+                any(),
                 any(),
                 any()
             )
@@ -1220,7 +1230,8 @@ class BackendTest {
             mockClient.performRequest(
                 mockBaseURL,
                 Endpoint.GetOfferings(appUserID),
-                null,
+                body = null,
+                postFieldsToSign = null,
                 any()
             )
         }
@@ -1249,7 +1260,8 @@ class BackendTest {
             mockClient.performRequest(
                 mockBaseURL,
                 Endpoint.GetOfferings(appUserID),
-                null,
+                body = null,
+                postFieldsToSign = null,
                 any()
             )
         }
@@ -1257,7 +1269,8 @@ class BackendTest {
             mockClient.performRequest(
                 mockBaseURL,
                 Endpoint.GetOfferings("anotherUser"),
-                null,
+                body = null,
+                postFieldsToSign = null,
                 any()
             )
         }
@@ -1309,6 +1322,7 @@ class BackendTest {
                 mockBaseURL,
                 Endpoint.LogIn,
                 body,
+                any(),
                 any()
             )
         }
@@ -1470,6 +1484,7 @@ class BackendTest {
                 mockBaseURL,
                 Endpoint.LogIn,
                 requestBody,
+                any(),
                 any()
             )
         }
@@ -1520,6 +1535,7 @@ class BackendTest {
                 mockBaseURL,
                 Endpoint.LogIn,
                 requestBody,
+                any(),
                 any()
             )
         }
@@ -1570,6 +1586,7 @@ class BackendTest {
                 mockBaseURL,
                 Endpoint.LogIn,
                 requestBody,
+                any(),
                 any()
             )
         }
@@ -1586,6 +1603,7 @@ class BackendTest {
                 baseURL = mockDiagnosticsBaseURL,
                 endpoint = diagnosticsEndpoint,
                 body = mapOf("entries" to JSONArray(diagnosticsList)),
+                postFieldsToSign = null,
                 requestHeaders = mapOf("Authorization" to "Bearer TEST_API_KEY")
             )
         }
@@ -1614,6 +1632,7 @@ class BackendTest {
                 baseURL = mockDiagnosticsBaseURL,
                 endpoint = diagnosticsEndpoint,
                 body = mapOf("entries" to JSONArray(diagnosticsList)),
+                postFieldsToSign = null,
                 requestHeaders = mapOf("Authorization" to "Bearer TEST_API_KEY")
             )
         }
@@ -1644,6 +1663,7 @@ class BackendTest {
                 baseURL = mockDiagnosticsBaseURL,
                 endpoint = diagnosticsEndpoint,
                 body = mapOf("entries" to JSONArray(diagnosticsList)),
+                postFieldsToSign = null,
                 requestHeaders = mapOf("Authorization" to "Bearer TEST_API_KEY")
             )
         }
@@ -1803,6 +1823,7 @@ class BackendTest {
                 baseURL = mockBaseURL,
                 endpoint = productEntitlementMappingEndpoint,
                 body = null,
+                postFieldsToSign = null,
                 requestHeaders = defaultAuthHeaders
             )
         }
@@ -1829,6 +1850,7 @@ class BackendTest {
                 baseURL = mockBaseURL,
                 endpoint = productEntitlementMappingEndpoint,
                 body = null,
+                postFieldsToSign = null,
                 requestHeaders = defaultAuthHeaders
             )
         }
@@ -1860,6 +1882,7 @@ class BackendTest {
                 baseURL = mockBaseURL,
                 endpoint = productEntitlementMappingEndpoint,
                 body = null,
+                postFieldsToSign = null,
                 requestHeaders = defaultAuthHeaders
             )
         }
@@ -2010,6 +2033,7 @@ class BackendTest {
                 eq(baseURL),
                 eq(endpoint),
                 (if (body == null) any() else capture(requestBodySlot)),
+                any(),
                 capture(headersSlot)
             )
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -47,7 +47,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
             expectedResult = HTTPResult.createResult()
         )
 
-        client.performRequest(baseURL, Endpoint.LogIn, null, mapOf("" to ""))
+        client.performRequest(baseURL, Endpoint.LogIn, body = null, postFieldsToSign = null, mapOf("" to ""))
 
         val request = server.takeRequest()
         assertThat(request.method).isEqualTo("GET")
@@ -62,7 +62,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
             expectedResult = HTTPResult.createResult(responseCode = 223)
         )
 
-        val result = client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+        val result = client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
 
         server.takeRequest()
 
@@ -77,7 +77,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
             expectedResult = HTTPResult.createResult(223, "{'response': 'OK'}")
         )
 
-        val result = client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+        val result = client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
 
         server.takeRequest()
 
@@ -95,7 +95,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         )
 
         try {
-            client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+            client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
         } finally {
             server.takeRequest()
         }
@@ -109,7 +109,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
 
         client = createClient(appConfig = createAppConfig(forceServerErrors = true))
 
-        val result = client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+        val result = client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
 
         assertThat(server.requestCount).isEqualTo(0)
         assertThat(result.responseCode).isEqualTo(RCHTTPStatusCodes.ERROR)
@@ -126,7 +126,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         val appConfig = createAppConfig(forceServerErrors = true)
         client = createClient(appConfig = appConfig)
 
-        client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+        client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
 
         assertThat(server.requestCount).isEqualTo(0)
 
@@ -137,7 +137,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
             expectedResult = HTTPResult.createResult(payload = "{}")
         )
 
-        client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+        client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
 
         assertThat(server.requestCount).isEqualTo(1)
     }
@@ -157,7 +157,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         val headers = HashMap<String, String>()
         headers["Authentication"] = "Bearer todd"
 
-        client.performRequest(baseURL, endpoint, null, headers)
+        client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, headers)
 
         val request = server.takeRequest()
 
@@ -173,7 +173,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
             expectedResult
         )
 
-        client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+        client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
 
         val request = server.takeRequest()
 
@@ -208,7 +208,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
             expectedResult
         )
 
-        client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+        client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
 
         val request = server.takeRequest()
 
@@ -235,7 +235,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
             expectedResult
         )
 
-        client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+        client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
 
         val request = server.takeRequest()
 
@@ -255,7 +255,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         )
 
         client = createClient(appConfig)
-        client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+        client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
 
         val request = server.takeRequest()
 
@@ -274,12 +274,38 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         val body = HashMap<String, String>()
         body["user_id"] = "jerry"
 
-        client.performRequest(baseURL, endpoint, body, mapOf("" to ""))
+        client.performRequest(baseURL, endpoint, body, postFieldsToSign = null, mapOf("" to ""))
 
         val request = server.takeRequest()
         assertThat(request.method).`as`("method is POST").isEqualTo("POST")
         assertThat(request.body).`as`("body is not null").isNotNull
         assertThat(request.body.size).isGreaterThan(0)
+        assertThat(request.getHeader(HTTPRequest.POST_PARAMS_HASH)).isNull()
+    }
+
+    @Test
+    fun `adds post params hash header`() {
+        val expectedResult = HTTPResult.createResult()
+        val expectedPostParamsHash = "test-post-params-hash"
+        val endpoint = Endpoint.LogIn
+        every {
+            mockSigningManager.getPostParamsForSigningHeaderIfNeeded(endpoint, any())
+        } returns expectedPostParamsHash
+        enqueue(
+            endpoint,
+            expectedResult
+        )
+
+        val body = HashMap<String, String>()
+        body["user_id"] = "jerry"
+        body["new_user_id"] = "john"
+        val postFieldsToSign = listOf(("user_id" to "jerry"), ("new_user_id" to "john"))
+
+        client.performRequest(baseURL, endpoint, body, postFieldsToSign = postFieldsToSign, mapOf("" to ""))
+
+        val request = server.takeRequest()
+        assertThat(request.getHeader(HTTPRequest.POST_PARAMS_HASH)).isNotNull
+        assertThat(request.getHeader(HTTPRequest.POST_PARAMS_HASH)).isEqualTo(expectedPostParamsHash)
     }
 
     @Test
@@ -296,7 +322,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
             expectedResult
         )
 
-        client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+        client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
 
         val request = server.takeRequest()
 
@@ -359,7 +385,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
             )
         } returns expectedResult
 
-        val result = client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+        val result = client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
 
         server.takeRequest()
         server.takeRequest()
@@ -386,6 +412,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
             baseURL,
             endpoint,
             body = null,
+            postFieldsToSign = null,
             requestHeaders = emptyMap()
         )
 
@@ -406,6 +433,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
             baseURL,
             endpoint,
             body = null,
+            postFieldsToSign = null,
             requestHeaders = emptyMap()
         )
 
@@ -431,7 +459,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
             expectedResult = HTTPResult.createResult(payload = "{}\n")
         )
 
-        val result = client.performRequest(baseURL, Endpoint.LogIn, null, emptyMap())
+        val result = client.performRequest(baseURL, Endpoint.LogIn, body = null, postFieldsToSign = null, emptyMap())
 
         server.takeRequest()
 
@@ -461,7 +489,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
 
         every { dateProvider.now } returnsMany listOf(Date(requestStartTime), Date(requestEndTime))
 
-        client.performRequest(baseURL, Endpoint.LogIn, null, mapOf("" to ""))
+        client.performRequest(baseURL, Endpoint.LogIn, body = null, postFieldsToSign = null, mapOf("" to ""))
         server.takeRequest()
 
         verify(exactly = 1) {
@@ -490,7 +518,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
 
         every { dateProvider.now } returnsMany listOf(Date(requestStartTime), Date(requestEndTime))
 
-        client.performRequest(baseURL, Endpoint.LogIn, null, mapOf("" to ""))
+        client.performRequest(baseURL, Endpoint.LogIn, body = null, postFieldsToSign = null, mapOf("" to ""))
         server.takeRequest()
 
         verify(exactly = 1) {
@@ -524,7 +552,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         server.enqueue(response)
 
         try {
-            client.performRequest(baseURL, endpoint, null, mapOf("" to ""))
+            client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
         } catch (e: JSONException) {
             verify(exactly = 1) {
                 diagnosticsTracker.trackHttpRequestPerformed(endpoint, any(), false, HTTPClient.NO_STATUS_CODE, null, VerificationResult.NOT_REQUESTED)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -284,31 +284,6 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
     }
 
     @Test
-    fun `adds post params hash header`() {
-        val expectedResult = HTTPResult.createResult()
-        val expectedPostParamsHash = "test-post-params-hash"
-        val endpoint = Endpoint.LogIn
-        every {
-            mockSigningManager.getPostParamsForSigningHeaderIfNeeded(endpoint, any())
-        } returns expectedPostParamsHash
-        enqueue(
-            endpoint,
-            expectedResult
-        )
-
-        val body = HashMap<String, String>()
-        body["user_id"] = "jerry"
-        body["new_user_id"] = "john"
-        val postFieldsToSign = listOf(("user_id" to "jerry"), ("new_user_id" to "john"))
-
-        client.performRequest(baseURL, endpoint, body, postFieldsToSign = postFieldsToSign, mapOf("" to ""))
-
-        val request = server.takeRequest()
-        assertThat(request.getHeader(HTTPRequest.POST_PARAMS_HASH)).isNotNull
-        assertThat(request.getHeader(HTTPRequest.POST_PARAMS_HASH)).isEqualTo(expectedPostParamsHash)
-    }
-
-    @Test
     fun `given observer mode is enabled, observer mode header is sent`() {
         val appConfig = createAppConfig()
         appConfig.finishTransactions = false

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -49,6 +49,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             baseURL,
             endpoint,
             body = null,
+            postFieldsToSign = null,
             requestHeaders = emptyMap()
         )
 
@@ -75,6 +76,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             baseURL,
             endpoint,
             body = null,
+            postFieldsToSign = null,
             requestHeaders = emptyMap()
         )
 
@@ -106,6 +108,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             baseURL,
             endpoint,
             body = null,
+            postFieldsToSign = null,
             requestHeaders = emptyMap()
         )
 
@@ -137,6 +140,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             baseURL,
             endpoint,
             body = null,
+            postFieldsToSign = null,
             requestHeaders = emptyMap()
         )
 
@@ -184,6 +188,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             baseURL,
             endpoint,
             body = null,
+            postFieldsToSign = null,
             requestHeaders = emptyMap()
         )
 
@@ -216,6 +221,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             baseURL,
             endpoint,
             body = null,
+            postFieldsToSign = null,
             requestHeaders = emptyMap()
         )
 
@@ -243,6 +249,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             baseURL,
             endpoint,
             body = null,
+            postFieldsToSign = null,
             requestHeaders = emptyMap()
         )
 
@@ -267,6 +274,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             baseURL,
             endpoint,
             body = null,
+            postFieldsToSign = null,
             requestHeaders = emptyMap()
         )
 
@@ -294,6 +302,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
                 baseURL,
                 endpoint,
                 body = null,
+                postFieldsToSign = null,
                 requestHeaders = emptyMap()
             )
         } catch (_: SignatureVerificationException) {
@@ -325,6 +334,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
                 baseURL,
                 endpoint,
                 body = null,
+                postFieldsToSign = null,
                 requestHeaders = emptyMap()
             )
         }
@@ -351,6 +361,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             baseURL,
             endpoint,
             body = null,
+            postFieldsToSign = null,
             requestHeaders = emptyMap()
         )
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientVerificationTest.kt
@@ -41,9 +41,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             verificationResult = VerificationResult.VERIFIED
         )
 
-        every {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
-        } returns VerificationResult.VERIFIED
+        mockSigningResult(VerificationResult.VERIFIED)
 
         client.performRequest(
             baseURL,
@@ -83,9 +81,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
         server.takeRequest()
 
         assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_REQUESTED)
-        verify(exactly = 0) {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
-        }
+        assertSigningNotPerformed()
     }
 
     @Test
@@ -115,9 +111,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
         server.takeRequest()
 
         assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_REQUESTED)
-        verify(exactly = 0) {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
-        }
+        assertSigningNotPerformed()
     }
 
     @Test
@@ -147,9 +141,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
         server.takeRequest()
 
         assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_REQUESTED)
-        verify(exactly = 0) {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
-        }
+        assertSigningNotPerformed()
     }
 
     @Test
@@ -161,9 +153,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
         )
         val responseCode = expectedResult.responseCode
 
-        every {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
-        } returns VerificationResult.VERIFIED
+        mockSigningResult(VerificationResult.VERIFIED)
 
         every {
             mockETagManager.getHTTPResultFromCacheOrBackend(
@@ -202,7 +192,8 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
                 "test-nonce",
                 "{\"test-key\":\"test-value\"}",
                 "1234567890",
-                "test-etag"
+                "test-etag",
+                postFieldsToSignHeader = null
             )
         }
     }
@@ -227,9 +218,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
         server.takeRequest()
         assertThat(result.verificationResult).isEqualTo(VerificationResult.NOT_REQUESTED)
-        verify(exactly = 0) {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
-        }
+        assertSigningNotPerformed()
     }
 
     @Test
@@ -241,9 +230,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             verificationResult = VerificationResult.FAILED
         )
 
-        every {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
-        } returns VerificationResult.FAILED
+        mockSigningResult(VerificationResult.FAILED)
 
         val result = client.performRequest(
             baseURL,
@@ -266,9 +253,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             verificationResult = VerificationResult.FAILED
         )
 
-        every {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
-        } returns VerificationResult.FAILED
+        mockSigningResult(VerificationResult.FAILED)
 
         val result = client.performRequest(
             baseURL,
@@ -292,9 +277,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             verificationResult = VerificationResult.FAILED
         )
 
-        every {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
-        } returns VerificationResult.FAILED
+        mockSigningResult(VerificationResult.FAILED)
 
         var thrownCorrectException = false
         try {
@@ -325,9 +308,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             verificationResult = VerificationResult.FAILED
         )
 
-        every {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
-        } returns VerificationResult.FAILED
+        mockSigningResult(VerificationResult.FAILED)
 
         assertThatExceptionOfType(SignatureVerificationException::class.java).isThrownBy {
             client.performRequest(
@@ -353,9 +334,7 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
             verificationResult = VerificationResult.VERIFIED
         )
 
-        every {
-            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any())
-        } returns VerificationResult.VERIFIED
+        mockSigningResult(VerificationResult.VERIFIED)
 
         val result = client.performRequest(
             baseURL,
@@ -367,5 +346,17 @@ internal class HTTPClientVerificationTest: BaseHTTPClientTest() {
 
         server.takeRequest()
         assertThat(result.verificationResult).isEqualTo(VerificationResult.VERIFIED)
+    }
+
+    private fun mockSigningResult(result: VerificationResult) {
+        every {
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+        } returns result
+    }
+
+    private fun assertSigningNotPerformed() {
+        verify(exactly = 0) {
+            mockSigningManager.verifyResponse(any(), any(), any(), any(), any(), any(), any())
+        }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -269,8 +269,9 @@ class SigningManagerTest {
         nonce: String = "MTIzNDU2Nzg5MGFi",
         body: String? = "{\"request_date\":\"2023-02-21T18:58:36Z\",\"request_date_ms\":1677005916011,\"subscriber\":{\"entitlements\":{},\"first_seen\":\"2023-02-21T18:58:35Z\",\"last_seen\":\"2023-02-21T18:58:35Z\",\"management_url\":null,\"non_subscriptions\":{},\"original_app_user_id\":\"login\",\"original_application_version\":null,\"original_purchase_date\":null,\"other_purchases\":{},\"subscriptions\":{}}}\n",
         requestTime: String? = "1677005916012",
-        eTag: String? = null
-    ) = signingManager.verifyResponse(requestPath, signature, nonce, body, requestTime, eTag)
+        eTag: String? = null,
+        postParamsHeader: String? = null,
+    ) = signingManager.verifyResponse(requestPath, signature, nonce, body, requestTime, eTag, postParamsHeader)
 
     // endregion
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.common.verification
 
 import android.util.Base64
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.crypto.tink.subtle.Ed25519Sign
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
@@ -15,6 +16,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.SecureRandom
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -29,6 +33,11 @@ class SigningManagerTest {
     private lateinit var disabledSigningManager: SigningManager
     private lateinit var informationalSigningManager: SigningManager
     private lateinit var enforcedSigningManager: SigningManager
+
+    private val testFieldsToSign = listOf(
+        "test-field-1" to "test-value-1",
+        "test-field-2" to "test-value-2",
+    )
 
     @Before
     fun setUp() {
@@ -95,6 +104,44 @@ class SigningManagerTest {
     }
 
     // endregion
+
+    // region getPostParamsForSigningHeaderIfNeeded
+
+    @Test
+    fun `getPostParamsForSigningHeaderIfNeeded returns null if null fields passed`() {
+        val header = informationalSigningManager.getPostParamsForSigningHeaderIfNeeded(Endpoint.LogIn, null)
+        assertThat(header).isNull()
+    }
+
+    @Test
+    fun `getPostParamsForSigningHeaderIfNeeded returns null if empty fields passed`() {
+        val header = informationalSigningManager.getPostParamsForSigningHeaderIfNeeded(Endpoint.LogIn, emptyList())
+        assertThat(header).isNull()
+    }
+
+    @Test
+    fun `getPostParamsForSigningHeaderIfNeeded returns null if endpoint does not support signing`() {
+        val header = informationalSigningManager.getPostParamsForSigningHeaderIfNeeded(Endpoint.PostDiagnostics, testFieldsToSign)
+        assertThat(header).isNull()
+    }
+
+    @Test
+    fun `getPostParamsForSigningHeaderIfNeeded returns null if signing disabled`() {
+        val header = disabledSigningManager.getPostParamsForSigningHeaderIfNeeded(Endpoint.LogIn, testFieldsToSign)
+        assertThat(header).isNull()
+    }
+
+    @Test
+    fun `getPostParamsForSigningHeaderIfNeeded returns header with correct value in informational`() {
+        val header = informationalSigningManager.getPostParamsForSigningHeaderIfNeeded(Endpoint.LogIn, testFieldsToSign)
+        assertThat(header).isEqualTo("test-field-1,test-field-2:sha256:0a1d806f908079361fc0d18073dfcfcacb730afe4ace3d0478602479892e81d3")
+    }
+
+    @Test
+    fun `getPostParamsForSigningHeaderIfNeeded returns header with correct value in enforced`() {
+        val header = enforcedSigningManager.getPostParamsForSigningHeaderIfNeeded(Endpoint.LogIn, testFieldsToSign)
+        assertThat(header).isEqualTo("test-field-1,test-field-2:sha256:0a1d806f908079361fc0d18073dfcfcacb730afe4ace3d0478602479892e81d3")
+    }
 
     // region verifyResponse
 
@@ -253,6 +300,23 @@ class SigningManagerTest {
         assertThat(verificationResult).isEqualTo(VerificationResult.VERIFIED)
     }
 
+    @Test
+    fun `verifyResponse with post fields to sign verifies correctly`() {
+        val rootVerifier = DefaultSignatureVerifier("yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=")
+        val signingManager = SigningManager(
+            SignatureVerificationMode.Informational(IntermediateSignatureHelper(rootVerifier)),
+            appConfig,
+            apiKey,
+        )
+        val postParamsHeader = "test-field-1,test-field-2:sha256:0a1d806f908079361fc0d18073dfcfcacb730afe4ace3d0478602479892e81d3"
+        val verificationResult = callVerifyResponse(
+            signingManager,
+            signature = "xoDYyUeHnIlSIAeOOzmvdNPOlbNSKK+xE0fE/ufS1fsAAMNQ1HiPDL34Vx0Uy74KPV5mztuk3DHBpucT/rSYVlkxIa3ModYmPfYZ20lnlbSB1UiP6oJHwAA2pXlS6AQ5eLSuAr6y+BuXlXXhZybxIJRFiToh3gs+X7IVmtCZwtkNu0rM0CGZ6FbQFAutF+Y5dGM8Q4HUAdy8pb639Zv9Lf7eZZ/Td9XuWqd+TA98M2MfL6ED",
+            postParamsHeader = postParamsHeader,
+        )
+        assertThat(verificationResult).isEqualTo(VerificationResult.VERIFIED)
+    }
+
     // endregion
 
     // region Helpers
@@ -272,6 +336,43 @@ class SigningManagerTest {
         eTag: String? = null,
         postParamsHeader: String? = null,
     ) = signingManager.verifyResponse(requestPath, signature, nonce, body, requestTime, eTag, postParamsHeader)
+
+    // We can use this function to create new signatures if we need to change the test data
+    @Suppress("Unused")
+    private fun createFakeSignature(
+        rootPrivateKeyEncoded: String = "YMHMQMpepBKamtSzO8KCN2M8Z3AUW5R1JXIFtxUWFUI",
+        rootPublicKeyEncoded: String = "yg2wZGAr8Af+Unt9RImQDbL7qA81txk+ga0I+ylmcyo=",
+        intermediatePrivateKeyEncoded: String = "fPBoIjQ7DecE89ATW6PZsqLVQNyEs5fiX3sUyS3U4YI",
+        intermediatePublicKeyEncoded: String = "xoDYyUeHnIlSIAeOOzmvdNPOlbNSKK+xE0fE/ufS1fs=",
+        intermediateKeyExpirationDaysBytes: ByteArray = ByteBuffer.allocate(Int.SIZE_BYTES).putInt(50_000).order(ByteOrder.LITTLE_ENDIAN).array(),
+        requestPath: String = "test-url-path",
+        postParamsHeader: String = "test-field-1,test-field-2:sha256:0a1d806f908079361fc0d18073dfcfcacb730afe4ace3d0478602479892e81d3",
+        apiKey: String = this.apiKey,
+        body: String? = "{\"request_date\":\"2023-02-21T18:58:36Z\",\"request_date_ms\":1677005916011,\"subscriber\":{\"entitlements\":{},\"first_seen\":\"2023-02-21T18:58:35Z\",\"last_seen\":\"2023-02-21T18:58:35Z\",\"management_url\":null,\"non_subscriptions\":{},\"original_app_user_id\":\"login\",\"original_application_version\":null,\"original_purchase_date\":null,\"other_purchases\":{},\"subscriptions\":{}}}\n",
+        requestTime: String? = "1677005916012",
+        eTag: String? = null,
+        nonce: String? = "MTIzNDU2Nzg5MGFi",
+        salt: ByteArray = ByteArray(16).apply { SecureRandom().nextBytes(this) }
+    ): String {
+        val rootSigner = Ed25519Sign(Base64.decode(rootPrivateKeyEncoded, Base64.DEFAULT))
+        val intermediatePublicKey = Base64.decode(intermediatePublicKeyEncoded, Base64.DEFAULT)
+        val intermediatePublicKeySignature = rootSigner.sign(intermediateKeyExpirationDaysBytes + intermediatePublicKey)
+        val intermediateSigner = Ed25519Sign(Base64.decode(intermediatePrivateKeyEncoded, Base64.DEFAULT))
+        val payloadToSign = salt +
+            apiKey.toByteArray() +
+            (nonce?.let { Base64.decode(it, Base64.DEFAULT) } ?: byteArrayOf()) +
+            requestPath.toByteArray() +
+            postParamsHeader.toByteArray() +
+            (requestTime?.toByteArray() ?: byteArrayOf()) +
+            (eTag?.toByteArray() ?: byteArrayOf()) +
+            (body?.toByteArray() ?: byteArrayOf())
+        val signature =  intermediatePublicKey +
+            intermediateKeyExpirationDaysBytes +
+            intermediatePublicKeySignature +
+            salt +
+            intermediateSigner.sign(payloadToSign)
+        return Base64.encodeToString(signature, Base64.DEFAULT)
+    }
 
     // endregion
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/verification/SigningManagerTest.kt
@@ -97,6 +97,12 @@ class SigningManagerTest {
     }
 
     @Test
+    fun `createRandomNonce does not end with new line`() {
+        val nonce = disabledSigningManager.createRandomNonce()
+        assertThat(nonce.endsWith('\n')).isFalse
+    }
+
+    @Test
     fun `createRandomNonce returns different nonce on each call`() {
         val nonce1 = disabledSigningManager.createRandomNonce()
         val nonce2 = disabledSigningManager.createRandomNonce()

--- a/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -23,6 +23,7 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.unmockkObject
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.json.JSONObject
@@ -140,6 +141,28 @@ class SubscriberAttributesPosterTests {
             unexpectedOnError
         )
         assertThat(receivedOnSuccess).isTrue()
+    }
+
+    @Test
+    fun `postSubscriberAttributes does not add post fields to sign`() {
+        mockResponse(200)
+
+        subscriberAttributesPoster.postSubscriberAttributes(
+            mapOf("email" to SubscriberAttribute("email", "un@email.com").toBackendMap()),
+            appUserID,
+            expectedOnSuccess,
+            unexpectedOnError
+        )
+
+        verify(exactly = 1) {
+            mockClient.performRequest(
+                mockBaseURL,
+                Endpoint.PostAttributes(appUserID),
+                any(),
+                postFieldsToSign = null,
+                requestHeaders = mapOf("Authorization" to "Bearer $API_KEY")
+            )
+        }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -412,6 +412,7 @@ class SubscriberAttributesPosterTests {
                 mockBaseURL,
                 Endpoint.PostAttributes(appUserID),
                 (expectedBody ?: any()),
+                postFieldsToSign = null,
                 mapOf("Authorization" to "Bearer $API_KEY")
             )
         }
@@ -428,13 +429,14 @@ class SubscriberAttributesPosterTests {
     private val actualPostReceiptBodySlot = slot<Map<String, Any?>>()
     private fun mockPostReceiptResponse(
         responseCode: Int = 200,
-        responseBody: String = "{}"
+        responseBody: String = "{}",
     ) {
         every {
             mockClient.performRequest(
                 mockBaseURL,
                 Endpoint.PostReceipt,
                 capture(actualPostReceiptBodySlot),
+                any(),
                 mapOf("Authorization" to "Bearer $API_KEY")
             )
         } answers {


### PR DESCRIPTION
### Description
As an additional security measure we will add a new header to the request that will be part of the data to verify as part of the signature.

Depends on https://github.com/RevenueCat/khepri/pull/6246
