### PR TITLE
Add internal customEntitlementsComputation mode to app config

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
@@ -3,11 +3,15 @@ package com.revenuecat.purchases
 /**
  * Only use a Dangerous Setting if suggested by RevenueCat support team.
  */
-data class DangerousSettings(
+data class DangerousSettings internal constructor(
     /**
      * Disable or enable syncing purchases automatically. If this is disabled, RevenueCat will not sync any purchase
      * automatically, and you will have to call syncPurchases whenever a new purchase is completed in order to send it
      * to the RevenueCat's backend. Auto syncing of purchases is enabled by default.
      */
     val autoSyncPurchases: Boolean = true,
-)
+
+    internal val customEntitlementsComputation: Boolean = false,
+) {
+    constructor(autoSyncPurchases: Boolean = true) : this(autoSyncPurchases, false)
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
@@ -34,6 +34,8 @@ internal class AppConfig(
         log(LogIntent.INFO, ConfigureStrings.CONFIGURING_PURCHASES_PROXY_URL_SET)
     } ?: URL("https://api.revenuecat.com/")
     val diagnosticsURL = URL("https://api-diagnostics.revenuecat.com/")
+    val customEntitlementsComputation: Boolean
+        get() = dangerousSettings.customEntitlementsComputation
 
     val playStoreVersionName = context.playStoreVersionName
     val playServicesVersionName = context.playServicesVersionName

--- a/purchases/src/test/java/com/revenuecat/purchases/DangerousSettingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/DangerousSettingsTest.kt
@@ -1,0 +1,21 @@
+package com.revenuecat.purchases
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DangerousSettingsTest {
+    @Test
+    fun `default customEntitlementComputation is false`() {
+        val dangerousSettings = DangerousSettings()
+        assertThat(dangerousSettings.customEntitlementsComputation).isFalse
+    }
+
+    @Test
+    fun `default autoSyncPurchases is true`() {
+        val dangerousSettings = DangerousSettings()
+        assertThat(dangerousSettings.autoSyncPurchases).isTrue
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -185,6 +185,28 @@ class AppConfigTest {
     }
 
     @Test
+    fun `customEntitlementComputation matches version from dangerous settings`() {
+        val appConfig = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null,
+            store = Store.PLAY_STORE,
+            dangerousSettings = DangerousSettings(customEntitlementsComputation = true)
+        )
+        assertThat(appConfig.customEntitlementsComputation).isTrue
+        val appConfig2 = AppConfig(
+            context = mockk(relaxed = true),
+            observerMode = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null,
+            store = Store.PLAY_STORE,
+            dangerousSettings = DangerousSettings(customEntitlementsComputation = false)
+        )
+        assertThat(appConfig2.customEntitlementsComputation).isFalse
+    }
+
+    @Test
     fun `Given two app configs with same data, both are equal`() {
         val x = AppConfig(
             context = mockk(relaxed = true),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -309,7 +309,7 @@ class AppConfigTest {
             "AppConfig(" +
                 "platformInfo=PlatformInfo(flavor=native, version=3.2.0), " +
                 "store=PLAY_STORE, " +
-                "dangerousSettings=DangerousSettings(autoSyncPurchases=true), " +
+                "dangerousSettings=DangerousSettings(autoSyncPurchases=true, customEntitlementsComputation=false), " +
                 "languageTag='', " +
                 "versionName='', " +
                 "packageName='', " +


### PR DESCRIPTION
### Description
This PR adds an internal `customEntitlementsComputation` property to `DangerousSettings` and `AppConfig` so it can be used in the following PRs
