### PR TITLE
Add header to requests when in custom entitlement computation mode

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -269,6 +269,7 @@ internal class HTTPClient(
             "X-Observer-Mode-Enabled" to if (appConfig.finishTransactions) "false" else "true",
             "X-Nonce" to nonce,
             HTTPRequest.POST_PARAMS_HASH to postFieldsToSignHeader,
+            "X-Custom-Entitlements-Computation" to if (appConfig.customEntitlementsComputation) "true" else null,
         )
             .plus(authenticationHeaders)
             .plus(eTagManager.getETagHeaders(urlPath, shouldSignResponse, refreshETag))

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
@@ -77,6 +77,7 @@ internal abstract class BaseBackendIntegrationTest {
             every { languageTag } returns "en-US"
             every { versionName } returns "test-version-name"
             every { packageName } returns "com.revenuecat.purchases.backend_tests"
+            every { customEntitlementsComputation } returns false
             every { finishTransactions } returns true
             every { forceServerErrors } returns false
             every { forceSigningErrors } returns false

--- a/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common
 
 import android.content.Context
+import com.revenuecat.purchases.DangerousSettings
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
@@ -67,6 +68,7 @@ internal abstract class BaseHTTPClientTest {
         platformInfo: PlatformInfo = expectedPlatformInfo,
         proxyURL: URL? = baseURL,
         store: Store = Store.PLAY_STORE,
+        customEntitlementsComputation: Boolean = false,
         forceServerErrors: Boolean = false,
         forceSigningErrors: Boolean = false,
     ): AppConfig {
@@ -76,6 +78,7 @@ internal abstract class BaseHTTPClientTest {
             platformInfo = platformInfo,
             proxyURL = proxyURL,
             store = store,
+            dangerousSettings = DangerousSettings(customEntitlementsComputation = customEntitlementsComputation),
             runningTests = true,
             forceServerErrors = forceServerErrors,
             forceSigningErrors = forceSigningErrors,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -190,6 +190,39 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
     }
 
     @Test
+    fun `does not add custom entitlement computation header if disabled`() {
+        val expectedResult = HTTPResult.createResult()
+        val endpoint = Endpoint.LogIn
+        enqueue(
+            endpoint,
+            expectedResult
+        )
+
+        client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
+
+        val request = server.takeRequest()
+
+        assertThat(request.headers.names()).doesNotContain("X-Custom-Entitlements-Computation")
+    }
+
+    @Test
+    fun `adds custom entitlement computation header if enabled`() {
+        client = createClient(appConfig = createAppConfig(customEntitlementsComputation = true))
+        val expectedResult = HTTPResult.createResult()
+        val endpoint = Endpoint.LogIn
+        enqueue(
+            endpoint,
+            expectedResult
+        )
+
+        client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
+
+        val request = server.takeRequest()
+
+        assertThat(request.getHeader("X-Custom-Entitlements-Computation")).isEqualTo("true")
+    }
+
+    @Test
     fun addsETagHeadersToRequest() {
         val expectedResult = HTTPResult.createResult()
         val endpoint = Endpoint.LogIn


### PR DESCRIPTION
### Description
This PR adds a new header `X-Custom-Entitlements-Computation` to all requests when custom entitlement computation is enabled.