### PR TITLE
Disable offline entitlements in custom entitlements computation mode

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -114,7 +114,9 @@ internal class OfflineEntitlementsManager(
 
     // We disable offline entitlements in observer mode (finishTransactions = true) since it doesn't
     // provide any value and simplifies operations in that mode.
-    private fun isOfflineEntitlementsEnabled() = appConfig.finishTransactions && appConfig.enableOfflineEntitlements
+    private fun isOfflineEntitlementsEnabled() = appConfig.finishTransactions &&
+        appConfig.enableOfflineEntitlements &&
+        !appConfig.customEntitlementsComputation
 }
 
 private typealias OfflineCustomerInfoCallback = Pair<(CustomerInfo) -> Unit, (PurchasesError) -> Unit>


### PR DESCRIPTION
### Description
Offline entitlements aren't needed in custom entitlements computation mode so this PR disables it in that mode.

