### PR TITLE
Make customEntitlementComputation singular

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
@@ -11,7 +11,7 @@ data class DangerousSettings internal constructor(
      */
     val autoSyncPurchases: Boolean = true,
 
-    internal val customEntitlementsComputation: Boolean = false,
+    internal val customEntitlementComputation: Boolean = false,
 ) {
     constructor(autoSyncPurchases: Boolean = true) : this(autoSyncPurchases, false)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
@@ -34,8 +34,8 @@ internal class AppConfig(
         log(LogIntent.INFO, ConfigureStrings.CONFIGURING_PURCHASES_PROXY_URL_SET)
     } ?: URL("https://api.revenuecat.com/")
     val diagnosticsURL = URL("https://api-diagnostics.revenuecat.com/")
-    val customEntitlementsComputation: Boolean
-        get() = dangerousSettings.customEntitlementsComputation
+    val customEntitlementComputation: Boolean
+        get() = dangerousSettings.customEntitlementComputation
 
     val playStoreVersionName = context.playStoreVersionName
     val playServicesVersionName = context.playServicesVersionName

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -269,7 +269,7 @@ internal class HTTPClient(
             "X-Observer-Mode-Enabled" to if (appConfig.finishTransactions) "false" else "true",
             "X-Nonce" to nonce,
             HTTPRequest.POST_PARAMS_HASH to postFieldsToSignHeader,
-            "X-Custom-Entitlements-Computation" to if (appConfig.customEntitlementsComputation) "true" else null,
+            "X-Custom-Entitlements-Computation" to if (appConfig.customEntitlementComputation) "true" else null,
         )
             .plus(authenticationHeaders)
             .plus(eTagManager.getETagHeaders(urlPath, shouldSignResponse, refreshETag))

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -116,7 +116,7 @@ internal class OfflineEntitlementsManager(
     // provide any value and simplifies operations in that mode.
     private fun isOfflineEntitlementsEnabled() = appConfig.finishTransactions &&
         appConfig.enableOfflineEntitlements &&
-        !appConfig.customEntitlementsComputation
+        !appConfig.customEntitlementComputation
 }
 
 private typealias OfflineCustomerInfoCallback = Pair<(CustomerInfo) -> Unit, (PurchasesError) -> Unit>

--- a/purchases/src/test/java/com/revenuecat/purchases/DangerousSettingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/DangerousSettingsTest.kt
@@ -10,7 +10,7 @@ class DangerousSettingsTest {
     @Test
     fun `default customEntitlementComputation is false`() {
         val dangerousSettings = DangerousSettings()
-        assertThat(dangerousSettings.customEntitlementsComputation).isFalse
+        assertThat(dangerousSettings.customEntitlementComputation).isFalse
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
@@ -77,7 +77,7 @@ internal abstract class BaseBackendIntegrationTest {
             every { languageTag } returns "en-US"
             every { versionName } returns "test-version-name"
             every { packageName } returns "com.revenuecat.purchases.backend_tests"
-            every { customEntitlementsComputation } returns false
+            every { customEntitlementComputation } returns false
             every { finishTransactions } returns true
             every { forceServerErrors } returns false
             every { forceSigningErrors } returns false

--- a/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -192,18 +192,18 @@ class AppConfigTest {
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,
-            dangerousSettings = DangerousSettings(customEntitlementsComputation = true)
+            dangerousSettings = DangerousSettings(customEntitlementComputation = true)
         )
-        assertThat(appConfig.customEntitlementsComputation).isTrue
+        assertThat(appConfig.customEntitlementComputation).isTrue
         val appConfig2 = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,
-            dangerousSettings = DangerousSettings(customEntitlementsComputation = false)
+            dangerousSettings = DangerousSettings(customEntitlementComputation = false)
         )
-        assertThat(appConfig2.customEntitlementsComputation).isFalse
+        assertThat(appConfig2.customEntitlementComputation).isFalse
     }
 
     @Test
@@ -309,7 +309,7 @@ class AppConfigTest {
             "AppConfig(" +
                 "platformInfo=PlatformInfo(flavor=native, version=3.2.0), " +
                 "store=PLAY_STORE, " +
-                "dangerousSettings=DangerousSettings(autoSyncPurchases=true, customEntitlementsComputation=false), " +
+                "dangerousSettings=DangerousSettings(autoSyncPurchases=true, customEntitlementComputation=false), " +
                 "languageTag='', " +
                 "versionName='', " +
                 "packageName='', " +

--- a/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -68,7 +68,7 @@ internal abstract class BaseHTTPClientTest {
         platformInfo: PlatformInfo = expectedPlatformInfo,
         proxyURL: URL? = baseURL,
         store: Store = Store.PLAY_STORE,
-        customEntitlementsComputation: Boolean = false,
+        customEntitlementComputation: Boolean = false,
         forceServerErrors: Boolean = false,
         forceSigningErrors: Boolean = false,
     ): AppConfig {
@@ -78,7 +78,7 @@ internal abstract class BaseHTTPClientTest {
             platformInfo = platformInfo,
             proxyURL = proxyURL,
             store = store,
-            dangerousSettings = DangerousSettings(customEntitlementsComputation = customEntitlementsComputation),
+            dangerousSettings = DangerousSettings(customEntitlementComputation = customEntitlementComputation),
             runningTests = true,
             forceServerErrors = forceServerErrors,
             forceSigningErrors = forceSigningErrors,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -207,7 +207,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
 
     @Test
     fun `adds custom entitlement computation header if enabled`() {
-        client = createClient(appConfig = createAppConfig(customEntitlementsComputation = true))
+        client = createClient(appConfig = createAppConfig(customEntitlementComputation = true))
         val expectedResult = HTTPResult.createResult()
         val endpoint = Endpoint.LogIn
         enqueue(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
@@ -61,7 +61,7 @@ class OfflineEntitlementsManagerTest {
             appConfig.finishTransactions
         } returns true
         every {
-            appConfig.customEntitlementsComputation
+            appConfig.customEntitlementComputation
         } returns false
         every {
             appConfig.enableOfflineEntitlements
@@ -148,7 +148,7 @@ class OfflineEntitlementsManagerTest {
     @Test
     fun `shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest returns false if custom entitlement computation`() {
         every { deviceCache.getCachedCustomerInfo(appUserID) } returns null
-        every { appConfig.customEntitlementsComputation } returns true
+        every { appConfig.customEntitlementComputation } returns true
         val isServerError = true
         val result = offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInGetCustomerInfoRequest(
             isServerError,
@@ -189,7 +189,7 @@ class OfflineEntitlementsManagerTest {
 
     @Test
     fun `shouldCalculateOfflineCustomerInfoInPostReceipt returns false if custom entitlements computation mode`() {
-        every { appConfig.customEntitlementsComputation } returns true
+        every { appConfig.customEntitlementComputation } returns true
         val isServerError = true
         assertThat(offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInPostReceipt(isServerError)).isFalse
     }
@@ -428,7 +428,7 @@ class OfflineEntitlementsManagerTest {
 
     @Test
     fun `updateProductEntitlementMappingCacheIfStale does nothing in custom entitlement computation mode`() {
-        every { appConfig.customEntitlementsComputation } returns true
+        every { appConfig.customEntitlementComputation } returns true
         offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         verify(exactly = 0) { backend.getProductEntitlementMapping(any(), any()) }
     }


### PR DESCRIPTION
### Description
In iOS, we are using `customEntitlementComputation` instead of `customEntitlementsComputation`. This makes it consistent in android
