### PR TITLE
CustomEntitlementsComputation: disable first listener callback when set

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoUpdateHandler.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoUpdateHandler.kt
@@ -19,8 +19,8 @@ internal class CustomerInfoUpdateHandler(
     private val deviceCache: DeviceCache,
     private val identityManager: IdentityManager,
     private val offlineEntitlementsManager: OfflineEntitlementsManager,
-    private val handler: Handler = Handler(Looper.getMainLooper()),
     private val appConfig: AppConfig,
+    private val handler: Handler = Handler(Looper.getMainLooper()),
 ) {
 
     var updatedCustomerInfoListener: UpdatedCustomerInfoListener? = null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoUpdateHandler.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoUpdateHandler.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases
 
 import android.os.Handler
 import android.os.Looper
+import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.log
@@ -19,6 +20,7 @@ internal class CustomerInfoUpdateHandler(
     private val identityManager: IdentityManager,
     private val offlineEntitlementsManager: OfflineEntitlementsManager,
     private val handler: Handler = Handler(Looper.getMainLooper()),
+    private val appConfig: AppConfig,
 ) {
 
     var updatedCustomerInfoListener: UpdatedCustomerInfoListener? = null
@@ -57,8 +59,10 @@ internal class CustomerInfoUpdateHandler(
     private fun afterSetListener(listener: UpdatedCustomerInfoListener?) {
         if (listener != null) {
             log(LogIntent.DEBUG, ConfigureStrings.LISTENER_SET)
-            getCachedCustomerInfo(identityManager.currentAppUserID)?.let {
-                notifyListeners(it)
+            if (!appConfig.customEntitlementComputation) {
+                getCachedCustomerInfo(identityManager.currentAppUserID)?.let {
+                    notifyListeners(it)
+                }
             }
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -156,6 +156,7 @@ internal class PurchasesFactory(
                 cache,
                 identityManager,
                 offlineEntitlementsManager,
+                appConfig = appConfig,
             )
 
             val postReceiptHelper = PostReceiptHelper(

--- a/purchases/src/test/java/com/revenuecat/purchases/CustomerInfoUpdateHandlerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/CustomerInfoUpdateHandlerTest.kt
@@ -59,6 +59,7 @@ class CustomerInfoUpdateHandlerTest {
 
         verify(exactly = 1) { listenerMock.onReceived(mockInfo) }
     }
+
     @Test
     fun `setting listener doesn't send cached value if custom entitlements computation enabled`() {
         every { appConfig.customEntitlementComputation } returns true

--- a/purchases/src/test/java/com/revenuecat/purchases/CustomerInfoUpdateHandlerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/CustomerInfoUpdateHandlerTest.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.identity.IdentityManager
@@ -20,6 +21,7 @@ class CustomerInfoUpdateHandlerTest {
     private lateinit var deviceCache: DeviceCache
     private lateinit var identityManager: IdentityManager
     private lateinit var offlineEntitlementsManager: OfflineEntitlementsManager
+    private lateinit var appConfig: AppConfig
 
     private lateinit var customerInfoUpdateHandler: CustomerInfoUpdateHandler
 
@@ -31,16 +33,19 @@ class CustomerInfoUpdateHandlerTest {
         deviceCache = mockk()
         identityManager = mockk()
         offlineEntitlementsManager = mockk()
+        appConfig = mockk()
 
         every { identityManager.currentAppUserID } returns appUserId
         every { deviceCache.getCachedCustomerInfo(appUserId) } returns mockInfo
         every { deviceCache.cacheCustomerInfo(appUserId, mockInfo) } just Runs
         every { offlineEntitlementsManager.offlineCustomerInfo } returns null
+        every { appConfig.customEntitlementComputation } returns false
 
         customerInfoUpdateHandler = CustomerInfoUpdateHandler(
             deviceCache,
             identityManager,
             offlineEntitlementsManager,
+            appConfig = appConfig,
         )
     }
 
@@ -54,6 +59,14 @@ class CustomerInfoUpdateHandlerTest {
 
         verify(exactly = 1) { listenerMock.onReceived(mockInfo) }
     }
+    @Test
+    fun `setting listener doesn't send cached value if custom entitlements computation enabled`() {
+        every { appConfig.customEntitlementComputation } returns true
+        val listenerMock = mockk<UpdatedCustomerInfoListener>(relaxed = true)
+        customerInfoUpdateHandler.updatedCustomerInfoListener = listenerMock
+
+        verify(exactly = 0) { listenerMock.onReceived(mockInfo) }
+    }
 
     @Test
     fun `setting listener sends offline customer info cached value if it exists over cached value`() {
@@ -66,7 +79,7 @@ class CustomerInfoUpdateHandlerTest {
     }
 
     @Test
-    fun `setting listener does not send cached value if it does not exists`() {
+    fun `setting listener does not send cached value if it does not exist`() {
         val listenerMock = mockk<UpdatedCustomerInfoListener>(relaxed = true)
         every { deviceCache.getCachedCustomerInfo(any()) } returns null
         customerInfoUpdateHandler.updatedCustomerInfoListener = listenerMock


### PR DESCRIPTION
Disables the first fire of the Customer Info listener when it's set initially. 