### PR TITLE
Add switchUser

### DIFF
--- a/api-tester/src/customEntitlementComputation/kotlin/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/customEntitlementComputation/kotlin/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -20,4 +20,8 @@ final class PurchasesAPI {
 
         Purchases.configure(build);
     }
+
+    static void check(final Purchases purchases) {
+        purchases.switchUser("newUserID");
+    }
 }

--- a/api-tester/src/customEntitlementComputation/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/customEntitlementComputation/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -22,4 +22,8 @@ private class PurchasesAPI {
 
         Purchases.configure(build)
     }
+
+    fun check(purchases: Purchases) {
+        purchases.switchUser("newUserID")
+    }
 }

--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -27,6 +27,7 @@ import java.net.URL
  * guide to setup your RevenueCat account.
  * @warning Only one instance of Purchases should be instantiated at a time!
  */
+@Suppress("TooManyFunctions")
 class Purchases internal constructor(
     @get:JvmSynthetic internal val purchasesOrchestrator: PurchasesOrchestrator,
 ) {
@@ -128,6 +129,16 @@ class Purchases internal constructor(
         purchasesOrchestrator.removeUpdatedCustomerInfoListener()
     }
 
+    /**
+     * Updates the current appUserID to a new one, without associating the two.
+     *
+     * Important: This method is only available in Custom Entitlements Computation mode.
+     * Tokens posted by the SDK to the RevenueCat backend after calling this method will be sent
+     * with the newAppUserID.
+     */
+    fun switchUser(newAppUserID: String) {
+        purchasesOrchestrator.switchUser(newAppUserID)
+    }
     //endregion
 
     // region Static

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -29,6 +29,7 @@ import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
+import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.google.isSuccessful
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.interfaces.Callback
@@ -49,6 +50,7 @@ import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.strings.AttributionStrings
 import com.revenuecat.purchases.strings.ConfigureStrings
 import com.revenuecat.purchases.strings.CustomerInfoStrings
+import com.revenuecat.purchases.strings.IdentityStrings
 import com.revenuecat.purchases.strings.PurchaseStrings
 import com.revenuecat.purchases.strings.RestoreStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
@@ -399,7 +401,6 @@ internal class PurchasesOrchestrator constructor(
             if (error != null) {
                 callback?.onError(error)
             } else {
-                backend.clearCaches()
                 synchronized(this@PurchasesOrchestrator) {
                     state = state.copy(purchaseCallbacksByProductId = Collections.emptyMap())
                 }
@@ -655,6 +656,20 @@ internal class PurchasesOrchestrator constructor(
 
     //endregion
     //endregion
+
+    // region Custom entitlements computation
+    fun switchUser(newAppUserID: String) {
+        if (identityManager.currentAppUserID == newAppUserID) {
+            warnLog(IdentityStrings.SWITCHING_USER_SAME_APP_USER_ID.format(newAppUserID))
+            return
+        }
+
+        identityManager.switchUser(newAppUserID)
+
+        offeringsManager.fetchAndCacheOfferings(newAppUserID, state.appInBackground)
+    }
+    //endregion
+
     //endregion
 
     // region Private Methods

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/IdentityStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/IdentityStrings.kt
@@ -12,4 +12,7 @@ internal object IdentityStrings {
     const val LOG_OUT_SUCCESSFUL = "Logged out successfully"
     const val INVALIDATING_CACHED_CUSTOMER_INFO = "Detected unverified cached CustomerInfo but verification " +
         "is enabled. Invalidating cache."
+    const val SWITCHING_USER = "Switching to user %s."
+    const val SWITCHING_USER_SAME_APP_USER_ID = "switchUser called with the same appUserID as the current user %s. " +
+        "This has no effect."
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -376,6 +376,19 @@ class IdentityManagerTests {
             )
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
+    }
+
+    @Test
+    fun `logOut clears backend caches`() {
+        val identifiedUserID = "Waldo"
+        every { mockDeviceCache.cleanupOldAttributionData() } just Runs
+        mockIdentifiedUser(identifiedUserID)
+        mockSubscriberAttributesManagerSynchronize(identifiedUserID)
+
+        var error: PurchasesError? = null
+        identityManager.logOut { error = it }
+
+        assertThat(error).isNull()
         verify(exactly = 1) { mockBackend.clearCaches() }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -376,6 +376,7 @@ class IdentityManagerTests {
             )
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
+        verify(exactly = 1) { mockBackend.clearCaches() }
     }
 
     @Test
@@ -572,6 +573,38 @@ class IdentityManagerTests {
         }
     }
 
+    // region switch user
+    @Test
+    fun `switching users clears all caches`() {
+        val oldAppUserID = "cesar"
+        mockIdentifiedUser(oldAppUserID)
+        val newAppUserID = "new"
+        every { mockDeviceCache.cacheCustomerInfo(any(), any()) } just Runs
+        mockSubscriberAttributesManagerSynchronize(newAppUserID)
+        mockSubscriberAttributesManagerCopyAttributes(oldAppUserID, newAppUserID)
+
+        identityManager.switchUser(newAppUserID)
+
+        verify(exactly = 1) { mockDeviceCache.clearCachesForAppUserID(oldAppUserID) }
+        verify(exactly = 1) { mockOfferingsCache.clearCache() }
+        verify(exactly = 1) {
+            mockSubscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
+        }
+        verify(exactly = 1) { mockOfflineEntitlementsManager.resetOfflineCustomerInfoCache() }
+        verify(exactly = 1) { mockBackend.clearCaches() }
+    }
+    @Test
+    fun `switching users saves the new user`() {
+        val oldAppUserID = "cesar"
+        mockIdentifiedUser(oldAppUserID)
+
+        val newAppUserID = "new"
+        identityManager.switchUser(newAppUserID)
+
+        verify(exactly = 1) { mockDeviceCache.cacheAppUserID(newAppUserID) }
+    }
+    // endregion
+
     // region helper functions
 
     private fun setupCustomerInfoCacheInvalidationTest(
@@ -600,6 +633,7 @@ class IdentityManagerTests {
         every { mockDeviceCache.clearCachesForAppUserID(identifiedUserID) } just Runs
         every { mockSubscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(identifiedUserID) } just Runs
         every { mockSubscriberAttributesCache.cleanUpSubscriberAttributeCache(identifiedUserID) } just Runs
+        every { mockBackend.clearCaches() } just Runs
     }
 
     @Suppress("SameParameterValue")
@@ -626,6 +660,7 @@ class IdentityManagerTests {
         every { mockDeviceCache.getLegacyCachedAppUserID() } returns null
         every { mockDeviceCache.clearCachesForAppUserID(stubAnonymousID) } just Runs
         every { mockSubscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(stubAnonymousID) } just Runs
+        every { mockBackend.clearCaches() } just Runs
     }
 
     private fun mockCleanCaches() {

--- a/purchases/src/testCustomEntitlementComputation/kotlin/com/revenuecat/purchases/PurchasesLoginTests.kt
+++ b/purchases/src/testCustomEntitlementComputation/kotlin/com/revenuecat/purchases/PurchasesLoginTests.kt
@@ -1,0 +1,57 @@
+package com.revenuecat.purchases
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+internal class PurchasesLoginTests : BasePurchasesTest() {
+
+    // region Switch user
+    @Test
+    fun `switchUser switches user`() {
+        val newAppUserID = "newUser"
+        every {
+            mockIdentityManager.switchUser(newAppUserID)
+        } just Runs
+        mockOfferingsManagerFetchOfferings(newAppUserID)
+
+        purchases.switchUser(newAppUserID)
+
+        verify { mockIdentityManager.switchUser(newAppUserID) }
+    }
+
+    @Test
+    fun `switchUser refreshes offerings cache`() {
+        val newAppUserID = "newUser"
+        every {
+            mockIdentityManager.switchUser(newAppUserID)
+        } just Runs
+        mockOfferingsManagerFetchOfferings(newAppUserID)
+
+        purchases.switchUser(newAppUserID)
+
+        verify { mockOfferingsManager.fetchAndCacheOfferings(newAppUserID, false, any(), any()) }
+    }
+
+    @Test
+    fun `switchUser no ops if new app user ID is same as current`() {
+        val newAppUserID = appUserId
+        every {
+            mockIdentityManager.switchUser(newAppUserID)
+        } just Runs
+        mockOfferingsManagerFetchOfferings(newAppUserID)
+
+        purchases.switchUser(newAppUserID)
+
+        verify(exactly = 0) { mockIdentityManager.switchUser(newAppUserID) }
+        verify(exactly = 0) { mockOfferingsManager.fetchAndCacheOfferings(newAppUserID, false, any(), any()) }
+    }
+    // endregion
+}

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -552,28 +552,6 @@ internal class PurchasesTest : BasePurchasesTest() {
         }
     }
 
-    @Test
-    fun `logOut clears backend caches when successful`() {
-        setUp()
-
-        every {
-            mockCache.cleanupOldAttributionData()
-        } just Runs
-
-        every {
-            mockBackend.clearCaches()
-        } just Runs
-
-        val mockCompletion = mockk<ReceiveCustomerInfoCallback>(relaxed = true)
-        mockIdentityManagerLogout()
-        mockOfferingsManagerFetchOfferings()
-
-        purchases.logOut(mockCompletion)
-        verify(exactly = 1) {
-            mockBackend.clearCaches()
-        }
-    }
-
     // endregion
 
     // region syncPurchases


### PR DESCRIPTION
This method allows you to change the cached app user id, but it doesn't fetch the customer info afterwards. It does fetch offerings though. 

Here's the iOS equivalent

https://github.com/RevenueCat/purchases-ios/blob/598a76f18d4836573381ebd6a90140e5e24e07c1/Sources/Identity/IdentityManager.swift#L94