### PR TITLE
CustomEntitlementComputation: Generate dokka docs only for defaults flavor

### DIFF
--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -92,7 +92,30 @@ dependencies {
 
 tasks.dokkaHtmlPartial.configure {
     dokkaSourceSets {
-        configureEach {
+        named("customEntitlementComputation") {
+            suppress.set(true)
+        }
+        named("defaults") {
+            dependsOn("main")
+            reportUndocumented.set(true)
+            includeNonPublic.set(false)
+            skipDeprecated.set(true)
+
+            externalDocumentationLink {
+                url.set(uri("https://developer.android.com/reference/package-list").toURL())
+            }
+            sourceLink {
+                localDirectory.set(file("src/main/kotlin"))
+                remoteUrl.set(uri("https://github.com/revenuecat/purchases-android/blob/main/purchases/src/main/kotlin").toURL())
+                remoteLineSuffix.set("#L")
+            }
+            sourceLink {
+                localDirectory.set(file("src/main/java"))
+                remoteUrl.set(uri("https://github.com/revenuecat/purchases-android/blob/main/public/src/main/java").toURL())
+                remoteLineSuffix.set("#L")
+            }
+        }
+        named("main") {
             reportUndocumented.set(true)
             includeNonPublic.set(false)
             skipDeprecated.set(true)


### PR DESCRIPTION
### Description
After #1153, docs were generated with multiple `Purchases` classes and it was very confusing. For the public docs, we only need the defaults flavor, so we can remove docs for the customEntitlementComputation package
