### PR TITLE
Auto-update sample apps SDK versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ commands:
 
 jobs:
 
-  build-magic-weather-compose:
+  assemble-magic-weather-compose-sample-app:
     <<: *android-executor
     shell: /bin/bash --login -o pipefail
     steps:
@@ -140,7 +140,7 @@ jobs:
           command: bundle exec fastlane android build_magic_weather_compose
       - android/save-build-cache
 
-  build-custom-entitlement-computation:
+  assemble-custom-entitlement-computation-sample-app:
     <<: *android-executor
     shell: /bin/bash --login -o pipefail
     steps:
@@ -512,11 +512,11 @@ workflows:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - deploy-snapshot: *only-main-branch
-      - build-magic-weather-compose:
+      - assemble-magic-weather-compose-sample-app:
           <<: *only-main-branch
           requires:
             - deploy-snapshot
-      - build-custom-entitlement-computation:
+      - assemble-custom-entitlement-computation-sample-app:
           <<: *only-main-branch
           requires:
             - deploy-snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,22 @@ jobs:
           command: bundle exec fastlane android build_magic_weather_compose
       - android/save-build-cache
 
+  build-custom-entitlement-computation:
+    <<: *android-executor
+    shell: /bin/bash --login -o pipefail
+    steps:
+      - checkout
+      - install-sdkman
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
+      - android/accept-licenses
+      - android-dependencies
+      - android/restore-build-cache
+      - run:
+          name: Build sample app
+          command: bundle exec fastlane android build_custom_entitlement_computation_sample
+      - android/save-build-cache
+
   test:
     <<: *android-executor
     shell: /bin/bash --login -o pipefail
@@ -270,7 +286,7 @@ jobs:
       - android/save-build-cache:
           cache-prefix: v1a
 
-  assemble-sample-app:
+  assemble-purchase-tester:
     <<: *android-executor
     steps:
       - checkout
@@ -487,9 +503,21 @@ workflows:
     jobs:
       - test
       - detekt
-      - assemble-sample-app
-      - build-magic-weather-compose
+      - assemble-purchase-tester
       - run-backend-integration-tests
+
+  snapshot-deploy:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    jobs:
+      - deploy-snapshot: *only-main-branch
+      - build-magic-weather-compose:
+          requires:
+            - deploy-snapshot
+      - build-custom-entitlement-computation:
+          requires:
+            - deploy-snapshot
 
   deploy:
     when:
@@ -523,7 +551,6 @@ workflows:
             - hold
           <<: *release-branches
       - deploy: *release-tags
-      - deploy-snapshot: *only-main-branch
       - docs-deploy: *release-tags
       - publish-purchase-tester-release:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,16 +506,18 @@ workflows:
       - assemble-purchase-tester
       - run-backend-integration-tests
 
-  snapshot-deploy:
+  snapshot-deploy-sample-app-tests:
     when:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - deploy-snapshot: *only-main-branch
       - build-magic-weather-compose:
+          <<: *only-main-branch
           requires:
             - deploy-snapshot
       - build-custom-entitlement-computation:
+          <<: *only-main-branch
           requires:
             - deploy-snapshot
 

--- a/examples/CustomEntitlementComputationSample/gradle/libs.versions.toml
+++ b/examples/CustomEntitlementComputationSample/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.0.2"
 androidxNavigation = "2.5.3"
 kotlin = "1.7.20"
-purchases = "6.8.0"
+purchases = "6.9.0-SNAPSHOT"
 lifecycle = "2.5.0"
 androidxCore = "1.10.1"
 

--- a/examples/MagicWeather/gradle/libs.versions.toml
+++ b/examples/MagicWeather/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.0.2"
 androidxNavigation = "2.6.0"
 kotlin = "1.9.0"
-purchases = "6.5.2"
+purchases = "6.8.0"
 lifecycle = "2.6.1"
 androidxCore = "1.10.1"
 

--- a/examples/MagicWeather/gradle/libs.versions.toml
+++ b/examples/MagicWeather/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.0.2"
 androidxNavigation = "2.6.0"
 kotlin = "1.9.0"
-purchases = "6.8.0"
+purchases = "6.9.0-SNAPSHOT"
 lifecycle = "2.6.1"
 androidxCore = "1.10.1"
 

--- a/examples/MagicWeatherCompose/gradle/libs.versions.toml
+++ b/examples/MagicWeatherCompose/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.0.2"
 androidxNavigation = "2.5.3"
 kotlin = "1.7.20"
-purchases = "6.5.0"
+purchases = "6.8.0"
 lifecycle = "2.5.0"
 androidxCore = "1.10.1"
 

--- a/examples/MagicWeatherCompose/gradle/libs.versions.toml
+++ b/examples/MagicWeatherCompose/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.0.2"
 androidxNavigation = "2.5.3"
 kotlin = "1.7.20"
-purchases = "6.8.0"
+purchases = "6.9.0-SNAPSHOT"
 lifecycle = "2.5.0"
 androidxCore = "1.10.1"
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -329,6 +329,16 @@ platform :android do
     )
   end
 
+  desc "Builds a Magic Weather Compose APK"
+  lane :build_custom_entitlement_computation_sample do |options|
+    project_dir = "examples/CustomEntitlementComputationSample"
+    task = "assembleDebug"
+    gradle(
+      project_dir: project_dir,
+      task: task,
+    )
+  end
+
   desc <<-DESC
 Builds a Magic Weather APK and prompts for:
 * Gradle task

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,9 @@ files_with_version_number = {
   './docs/index.html' => ['url=https://sdk.revenuecat.com/android/{x}/index.html'],
   './gradle.properties' => ['VERSION_NAME={x}'],
   './.version' => ['{x}'],
+  './examples/MagicWeather/gradle/libs.versions.toml' => ['purchases = "{x}"'],
+  './examples/MagicWeatherCompose/gradle/libs.versions.toml' => ['purchases = "{x}"'],
+  './examples/CustomEntitlementComputationSample/gradle/libs.versions.toml' => ['purchases = "{x}"'],
 }
 
 repo_name = 'purchases-android'

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -139,6 +139,14 @@ Publish purchase tester to test track in Play Console
 
 Builds a Magic Weather Compose APK
 
+### android build_custom_entitlement_computation_sample
+
+```sh
+[bundle exec] fastlane android build_custom_entitlement_computation_sample
+```
+
+Builds a Magic Weather Compose APK
+
 ### android build_magic_weather
 
 ```sh


### PR DESCRIPTION
### Description
Our sample apps are usually pretty behind to the latest version of the SDK. This PR adds them to the automation mechanisms so the version of the SDK is auto-updated.

- [ ] Add assemble-purchase-tester job as required to merge to main branch (assemble-sample-app was renamed)