### PR TITLE
Update Kotlin from 1.6.21 to 1.7.21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.0.2"
-kotlin = "1.6.21"
+kotlin = "1.7.21"
 buildTools = "33.0.2"
 billing = "5.2.1"
 lifecycle = "2.5.0"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/logUtils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/logUtils.kt
@@ -61,6 +61,7 @@ internal fun errorLog(error: PurchasesError) {
         PurchasesErrorCode.UnsupportedError,
         PurchasesErrorCode.EmptySubscriberAttributesError,
         PurchasesErrorCode.CustomerInfoError,
+        PurchasesErrorCode.SignatureVerificationError,
         PurchasesErrorCode.InvalidSubscriberAttributesError,
         -> log(LogIntent.RC_ERROR, error.toString())
         PurchasesErrorCode.PurchaseCancelledError,


### PR DESCRIPTION
### Description
Originally I tried to update to newer versions, but that breaks compatibility with kotlin 1.6. I was able to update to 1.7.21 without breaking a sample app using kotlin 1.6.20 without issues.