### PR TITLE
Remove customEntitlementComputation flavor for non-purchases modules

### DIFF
--- a/feature/amazon/build.gradle
+++ b/feature/amazon/build.gradle
@@ -1,13 +1,23 @@
 plugins {
     alias libs.plugins.android.library
     alias libs.plugins.kotlin.android
-    alias libs.plugins.mavenPublish
+}
+
+if (!project.getProperties()["ANDROID_VARIANT_TO_PUBLISH"].contains("customEntitlementComputation")) {
+    apply plugin: "com.vanniktech.maven.publish"
 }
 
 apply from: "$rootProject.projectDir/library.gradle"
 
 android {
     namespace 'com.revenuecat.purchases.amazon'
+
+    flavorDimensions = ["apis"]
+    productFlavors {
+        defaults {
+            dimension "apis"
+        }
+    }
 
     defaultConfig {
         missingDimensionStrategy 'apis', 'defaults'

--- a/library.gradle
+++ b/library.gradle
@@ -2,16 +2,6 @@ android {
     compileSdkVersion compileVersion
     buildToolsVersion buildToolsVersion
 
-    flavorDimensions "apis"
-    productFlavors {
-        defaults {
-            dimension "apis"
-        }
-        customEntitlementComputation {
-            dimension "apis"
-        }
-    }
-
     defaultConfig {
         minSdkVersion obtainMinSdkVersion()
         targetSdkVersion compileVersion

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -15,6 +15,16 @@ android {
         buildConfig true
     }
 
+    flavorDimensions = ["apis"]
+    productFlavors {
+        defaults {
+            dimension "apis"
+        }
+        customEntitlementComputation {
+            dimension "apis"
+        }
+    }
+
     defaultConfig {
         testApplicationId obtainTestApplicationId()
         testBuildType obtainTestBuildType()


### PR DESCRIPTION
### Description
This reverts the changes in #1169, and additionally makes some changes so we only apply the maven publish plugin when using the `defaults` flavor in non-purchases modules. This should avoid having to have extra flavors in those modules and having them support the `customEntitlementComputation` flavor.

This was becoming a bit of a problem as I was working in the debug view #1075. Since some of the functions I'm using aren't in the `customEntitlementComputation` flavor. I could have split the debug view library by flavor to make it compatible, but that seems like unnecessary work.

