### PR TITLE
Remove unnecessary buildToolsVersion config

### DIFF
--- a/base-application.gradle
+++ b/base-application.gradle
@@ -1,6 +1,5 @@
 android {
     compileSdkVersion compileVersion
-    buildToolsVersion buildToolsVersion
 
     defaultConfig {
         minSdkVersion minVersion

--- a/examples/MagicWeather/app/build.gradle
+++ b/examples/MagicWeather/app/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 android {
     compileSdkVersion compileVersion
-    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.revenuecat.purchases_sample"

--- a/library.gradle
+++ b/library.gradle
@@ -1,6 +1,5 @@
 android {
     compileSdkVersion compileVersion
-    buildToolsVersion buildToolsVersion
 
     flavorDimensions "apis"
     productFlavors {


### PR DESCRIPTION
### Description
It's not necessary to specify the `buildToolsVersion` anymore. That will be determined by the AGP plugin. This removes some old references we had to that. https://developer.android.com/tools/releases/build-tools

<img width="874" alt="image" src="https://github.com/RevenueCat/purchases-android/assets/808417/6a2bc98a-b242-4fd8-a9ab-0d6abe48d8cd">
