### PR TITLE
Support receiving productId with basePlanId in upgrades/downgrades

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
@@ -84,7 +84,9 @@ data class PurchaseParams(val builder: Builder) {
         }
 
         /*
-         * The product ID of the product to change from when initiating a product change.
+         * The product ID of the product to change from when initiating a product change. We expect the subscriptionId
+         * only. If a string including `:` is passed in, we will assume the string is in the form
+         * `productId:basePlanId` and anything after the `:` will be ignored.
          *
          * Product changes are only available in the Play Store. Ignored for Amazon Appstore purchases.
          */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -1024,12 +1024,22 @@ internal class PurchasesOrchestrator constructor(
             return
         }
 
+        var previousProductId = oldProductId
+
+        if (oldProductId.contains(":")) {
+            previousProductId = oldProductId.substringBefore(":")
+            warnLog(
+                "Using incorrect oldProductId: $oldProductId. The productId should not contain the basePlanId. " +
+                    "Using productId: $previousProductId.",
+            )
+        }
+
         billing.findPurchaseInPurchaseHistory(
             appUserID,
             ProductType.SUBS,
-            oldProductId,
+            previousProductId,
             onCompletion = { purchaseRecord ->
-                log(LogIntent.PURCHASE, PurchaseStrings.FOUND_EXISTING_PURCHASE.format(oldProductId))
+                log(LogIntent.PURCHASE, PurchaseStrings.FOUND_EXISTING_PURCHASE.format(previousProductId))
 
                 billing.makePurchaseAsync(
                     activity,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -15,6 +15,7 @@ import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.Config
+import com.revenuecat.purchases.common.Constants
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.ReceiptInfo
@@ -1026,8 +1027,8 @@ internal class PurchasesOrchestrator constructor(
 
         var previousProductId = oldProductId
 
-        if (oldProductId.contains(":")) {
-            previousProductId = oldProductId.substringBefore(":")
+        if (oldProductId.contains(Constants.SUBS_ID_BASE_PLAN_ID_SEPARATOR)) {
+            previousProductId = oldProductId.substringBefore(Constants.SUBS_ID_BASE_PLAN_ID_SEPARATOR)
             warnLog(
                 "Using incorrect oldProductId: $oldProductId. The productId should not contain the basePlanId. " +
                     "Using productId: $previousProductId.",

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Constants.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Constants.kt
@@ -2,4 +2,5 @@ package com.revenuecat.purchases.common
 
 internal object Constants {
     const val GOOGLE_PLAY_MANAGEMENT_URL = "https://play.google.com/store/account/subscriptions"
+    const val SUBS_ID_BASE_PLAN_ID_SEPARATOR = ":"
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/CustomerInfoFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/CustomerInfoFactory.kt
@@ -121,7 +121,7 @@ internal object CustomerInfoFactory {
 
             val expirationObject = getJSONObject(productId)
 
-            val key = basePlanId?.let { "$productId:$it" } ?: productId
+            val key = basePlanId?.let { "$productId${Constants.SUBS_ID_BASE_PLAN_ID_SEPARATOR}$it" } ?: productId
             expirationDates[key] = expirationObject.optDate(jsonKey)
         }
 


### PR DESCRIPTION
### Description
This is a possible approach to some issues we've had with developers passing the wrong productId to the purchase methods on upgrades/downgrades. We expect them to pass the productId, but some are passing the `productId:basePlanId` form.

This PR supports both forms, by just picking the `productId` when given in the incorrect form.
