### PR TITLE
Make coroutines APIs stable

### DIFF
--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -2,7 +2,6 @@ package com.revenuecat.apitester.kotlin
 
 import com.revenuecat.purchases.CacheFetchPolicy
 import com.revenuecat.purchases.CustomerInfo
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.PurchasesError
@@ -23,7 +22,6 @@ import com.revenuecat.purchases.models.BillingFeature
 import com.revenuecat.purchases.restorePurchasesWith
 import com.revenuecat.purchases.syncPurchasesWith
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Suppress("unused", "UNUSED_VARIABLE", "EmptyFunctionBlock", "DEPRECATION")
 private class PurchasesAPI {
     @SuppressWarnings("LongParameterList")

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
@@ -33,7 +33,6 @@ import com.revenuecat.purchases.purchaseWith
 import java.net.URL
 import java.util.concurrent.ExecutorService
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Suppress("unused", "UNUSED_VARIABLE", "EmptyFunctionBlock")
 private class PurchasesCommonAPI {
     @SuppressWarnings("LongParameterList")
@@ -140,6 +139,7 @@ private class PurchasesCommonAPI {
         val getProductsResult: List<StoreProduct> = purchases.awaitGetProducts(listOf("product"))
     }
 
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     @Suppress("ForbiddenComment")
     fun checkConfiguration(context: Context, executorService: ExecutorService) {
         val features: List<BillingFeature> = ArrayList()

--- a/examples/CustomEntitlementComputationSample/app/src/main/java/com/revenuecat/sample/main/MainViewModel.kt
+++ b/examples/CustomEntitlementComputationSample/app/src/main/java/com/revenuecat/sample/main/MainViewModel.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.revenuecat.purchases.CustomerInfo
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PurchaseParams
 import com.revenuecat.purchases.Purchases
@@ -22,7 +21,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 class MainViewModel : ViewModel() {
     private val previewMode = false // change this to true to be able to preview in Android Studio
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingFragment.kt
@@ -13,7 +13,6 @@ import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.transition.MaterialContainerTransform
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PurchaseParams
@@ -35,7 +34,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 @SuppressWarnings("TooManyFunctions")
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 class OfferingFragment : Fragment(), PackageCardAdapter.PackageCardAdapterListener {
 
     lateinit var binding: FragmentOfferingBinding

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewViewModel.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.EntitlementInfo
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesException
@@ -17,7 +16,6 @@ import com.revenuecat.purchases.awaitCustomerInfo
 import com.revenuecat.purchases.restorePurchasesWith
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 class OverviewViewModel(private val interactionHandler: OverviewInteractionHandler) : ViewModel() {
 
     val customerInfo: MutableLiveData<CustomerInfo?> by lazy {

--- a/purchases/src/androidTestCustomEntitlementComputation/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestCustomEntitlementComputation/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
@@ -14,7 +14,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @RunWith(AndroidJUnit4::class)
 class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
 

--- a/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/trustedentitlements/TrustedEntitlementsInformationalModeIntegrationTest.kt
+++ b/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/trustedentitlements/TrustedEntitlementsInformationalModeIntegrationTest.kt
@@ -5,7 +5,6 @@ import com.revenuecat.purchases.BasePurchasesIntegrationTest
 import com.revenuecat.purchases.CacheFetchPolicy
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.EntitlementVerificationMode
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.PurchaseParams
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.VerificationResult
@@ -21,7 +20,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @RunWith(AndroidJUnit4::class)
 class TrustedEntitlementsInformationalModeIntegrationTest : BasePurchasesIntegrationTest() {
 

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -184,8 +184,9 @@ class Purchases internal constructor(
      * Initiate a purchase with the given [PurchaseParams].
      * Initialized with an [Activity] either a [Package], [StoreProduct], or [SubscriptionOption].
      *
-     * If a [Package] or [StoreProduct] is used to build the [PurchaseParams], the [defaultOption] will be purchased.
-     * [defaultOption] is selected via the following logic:
+     * If a [Package] or [StoreProduct] is used to build the [PurchaseParams], the [StoreProduct.defaultOption] will
+     * be purchased.
+     * [StoreProduct.defaultOption] is selected via the following logic:
      *   - Filters out offers with "rc-ignore-offer" tag
      *   - Uses [SubscriptionOption] with the longest free trial or cheapest first phase
      *   - Falls back to use base plan

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
@@ -10,9 +10,6 @@ import kotlin.coroutines.suspendCoroutine
  * Get latest available customer info.
  * Coroutine friendly version of [Purchases.getCustomerInfo].
  *
- * @warning This function is marked as [ExperimentalPreviewRevenueCatPurchasesAPI] and may change in the future.
- * Only available in Kotlin.
- *
  * @param fetchPolicy Specifies cache behavior for customer info retrieval (optional).
  * Defaults to [CacheFetchPolicy.default]: [CACHED_OR_FETCHED].
  *
@@ -20,7 +17,6 @@ import kotlin.coroutines.suspendCoroutine
  * @return The [CustomerInfo] associated to the current user.
  */
 @JvmSynthetic
-@ExperimentalPreviewRevenueCatPurchasesAPI
 @Throws(PurchasesException::class)
 suspend fun Purchases.awaitCustomerInfo(
     fetchPolicy: CacheFetchPolicy = CacheFetchPolicy.default(),
@@ -40,15 +36,11 @@ suspend fun Purchases.awaitCustomerInfo(
  *
  * Coroutine friendly version of [Purchases.logIn].
  *
- * @warning This function is marked as [ExperimentalPreviewRevenueCatPurchasesAPI] and may change in the future.
- * Only available in Kotlin.
- *
  * @param appUserID The new appUserID that should be linked to the currently user
  * @throws [PurchasesException] with a [PurchasesError] if there's an error login the customer info.
  * @return The [CustomerInfo] associated to the current user.
  */
 @JvmSynthetic
-@ExperimentalPreviewRevenueCatPurchasesAPI
 @Throws(PurchasesTransactionException::class)
 suspend fun Purchases.awaitLogIn(appUserID: String): LogInResult {
     return suspendCoroutine { continuation ->
@@ -68,14 +60,10 @@ suspend fun Purchases.awaitLogIn(appUserID: String): LogInResult {
  *
  * Coroutine friendly version of [Purchases.logOut].
  *
- * @warning This function is marked as [ExperimentalPreviewRevenueCatPurchasesAPI] and may change in the future.
- * Only available in Kotlin.
- *
  * @throws [PurchasesException] with a [PurchasesError] if there's an error login out the user.
  * @return The [CustomerInfo] associated to the current user.
  */
 @JvmSynthetic
-@ExperimentalPreviewRevenueCatPurchasesAPI
 @Throws(PurchasesTransactionException::class)
 suspend fun Purchases.awaitLogOut(): CustomerInfo {
     return suspendCoroutine { continuation ->
@@ -99,14 +87,10 @@ suspend fun Purchases.awaitLogOut(): CustomerInfo {
  *
  * Coroutine friendly version of [Purchases.restorePurchases].
  *
- * @warning This function is marked as [ExperimentalPreviewRevenueCatPurchasesAPI] and may change in the future.
- * Only available in Kotlin.
- *
  * @throws [PurchasesException] with a [PurchasesError] if there's an error login out the user.
  * @return The [CustomerInfo] with the restored purchases.
  */
 @JvmSynthetic
-@ExperimentalPreviewRevenueCatPurchasesAPI
 @Throws(PurchasesTransactionException::class)
 suspend fun Purchases.awaitRestore(): CustomerInfo {
     return suspendCoroutine { continuation ->
@@ -123,15 +107,11 @@ suspend fun Purchases.awaitRestore(): CustomerInfo {
  *
  * Coroutine friendly version of [Purchases.syncPurchases].
  *
- * @warning This function is marked as [ExperimentalPreviewRevenueCatPurchasesAPI] and may change in the future.
- * Only available in Kotlin.
- *
  * @throws [PurchasesException] with the first [PurchasesError] found while syncing the purchases.
  * @return The [CustomerInfo] associated to the user, after all purchases have been successfully synced. If there are no
  * purchases to sync, the customer info will be returned without any changes.
  */
 @JvmSynthetic
-@ExperimentalPreviewRevenueCatPurchasesAPI
 @Throws(PurchasesException::class)
 suspend fun Purchases.awaitSyncPurchases(): CustomerInfo {
     return suspendCoroutine { continuation ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CoroutinesExtensionsCommon.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CoroutinesExtensionsCommon.kt
@@ -16,14 +16,10 @@ import kotlin.coroutines.suspendCoroutine
  *
  * Coroutine friendly version of [Purchases.getOfferings].
  *
- * @warning This function is marked as [ExperimentalPreviewRevenueCatPurchasesAPI] and may change in the future.
- * Only available in Kotlin.
- *
  * @throws [PurchasesException] with a [PurchasesError] if there's an error retrieving the offerings.
  * @return The [Offerings] available to this user.
  */
 @JvmSynthetic
-@ExperimentalPreviewRevenueCatPurchasesAPI
 @Throws(PurchasesException::class)
 suspend fun Purchases.awaitOfferings(): Offerings {
     return suspendCoroutine { continuation ->
@@ -38,8 +34,9 @@ suspend fun Purchases.awaitOfferings(): Offerings {
  * Initiate a purchase with the given [PurchaseParams].
  * Initialized with an [Activity] either a [Package], [StoreProduct], or [SubscriptionOption].
  *
- * If a [Package] or [StoreProduct] is used to build the [PurchaseParams], the [defaultOption] will be purchased.
- * [defaultOption] is selected via the following logic:
+ * If a [Package] or [StoreProduct] is used to build the [PurchaseParams], the [StoreProduct.defaultOption] will
+ * be purchased.
+ * [StoreProduct.defaultOption] is selected via the following logic:
  *   - Filters out offers with "rc-ignore-offer" tag
  *   - Uses [SubscriptionOption] with the longest free trial or cheapest first phase
  *   - Falls back to use base plan
@@ -48,12 +45,8 @@ suspend fun Purchases.awaitOfferings(): Offerings {
  * @throws [PurchasesTransactionException] with a [PurchasesTransactionException] if there's an error when purchasing
  * and a userCancelled boolean that indicates if the user cancelled the purchase flow.
  * @return The [StoreTransaction] for this purchase and the updated [CustomerInfo] for this user.
- *
- * @warning This function is marked as [ExperimentalPreviewRevenueCatPurchasesAPI] and may change in the future.
- * Only available in Kotlin.
  */
 @JvmSynthetic
-@ExperimentalPreviewRevenueCatPurchasesAPI
 @Throws(PurchasesTransactionException::class)
 suspend fun Purchases.awaitPurchase(purchaseParams: PurchaseParams): PurchaseResult {
     return suspendCoroutine { continuation ->
@@ -79,15 +72,11 @@ suspend fun Purchases.awaitPurchase(purchaseParams: PurchaseParams): PurchaseRes
  * @param [productIds] List of productIds
  * @param [type] A product type to filter by
  *
- * @warning This function is marked as [ExperimentalPreviewRevenueCatPurchasesAPI] and may change in the future.
- * Only available in Kotlin.
- *
  * @throws [PurchasesException] with a [PurchasesError] if there's an error retrieving the products.
  * @return A list of [StoreProduct] with the products that have been able to be fetched from the store successfully.
  * Not found products will be ignored.
  */
 @JvmSynthetic
-@ExperimentalPreviewRevenueCatPurchasesAPI
 @Throws(PurchasesTransactionException::class)
 suspend fun Purchases.awaitGetProducts(
     productIds: List<String>,

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesCommonTest.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesCoroutinesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesCoroutinesTest.kt
@@ -14,7 +14,7 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import kotlin.random.Random
 
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 internal class PurchasesCoroutinesTest : BasePurchasesTest() {


### PR DESCRIPTION
### Description
Make coroutine APIs stable. This is removing the `@ExperimentalPreviewRevenueCatPurchasesAPI` annotations from the new coroutine APIs.
