### PR TITLE
Debug view: Add offerings section and purchasing capabilities

### DIFF
--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesDebugViewAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesDebugViewAPI.kt
@@ -1,14 +1,26 @@
 package com.revenuecat.apitester.kotlin
 
 import androidx.compose.runtime.Composable
+import com.revenuecat.purchases.PurchasesTransactionException
 import com.revenuecat.purchases.debugview.DebugRevenueCatBottomSheet
 import com.revenuecat.purchases.debugview.DebugRevenueCatScreen
+import com.revenuecat.purchases.models.StoreTransaction
 
 @Suppress("unused")
 private class PurchasesDebugViewAPI {
     @Composable
-    fun CheckDebugView(isVisible: Boolean, onDismissCallback: (() -> Unit)? = null) {
-        DebugRevenueCatScreen()
-        DebugRevenueCatBottomSheet(isVisible = isVisible, onDismissCallback = onDismissCallback)
+    fun CheckDebugView(
+        onPurchaseCompleted: (StoreTransaction) -> Unit,
+        onPurchaseErrored: (PurchasesTransactionException) -> Unit,
+        isVisible: Boolean,
+        onDismissCallback: (() -> Unit)? = null,
+    ) {
+        DebugRevenueCatScreen(onPurchaseCompleted, onPurchaseErrored)
+        DebugRevenueCatBottomSheet(
+            onPurchaseCompleted = onPurchaseCompleted,
+            onPurchaseErrored = onPurchaseErrored,
+            isVisible = isVisible,
+            onDismissCallback = onDismissCallback,
+        )
     }
 }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesDebugViewAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesDebugViewAPI.kt
@@ -15,7 +15,10 @@ private class PurchasesDebugViewAPI {
         isVisible: Boolean,
         onDismissCallback: (() -> Unit)? = null,
     ) {
-        DebugRevenueCatScreen(onPurchaseCompleted, onPurchaseErrored)
+        DebugRevenueCatScreen(
+            onPurchaseCompleted = onPurchaseCompleted,
+            onPurchaseErrored = onPurchaseErrored,
+        )
         DebugRevenueCatBottomSheet(
             onPurchaseCompleted = onPurchaseCompleted,
             onPurchaseErrored = onPurchaseErrored,

--- a/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/ContextExtensions.kt
+++ b/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/ContextExtensions.kt
@@ -10,5 +10,5 @@ fun Context.findActivity(): Activity {
         if (context is Activity) return context
         context = context.baseContext
     }
-    error("no activity")
+    error("RevenueCatDebugView: Could not find activity context from current context.")
 }

--- a/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/ContextExtensions.kt
+++ b/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/ContextExtensions.kt
@@ -1,0 +1,14 @@
+package com.revenuecat.purchases.debugview
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+
+fun Context.findActivity(): Activity {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    error("no activity")
+}

--- a/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/DebugRevenueCatViewModel.kt
+++ b/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/DebugRevenueCatViewModel.kt
@@ -1,8 +1,17 @@
 package com.revenuecat.purchases.debugview
 
+import android.app.Activity
+import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.debugview.models.SettingScreenState
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.SubscriptionOption
 import kotlinx.coroutines.flow.StateFlow
 
 internal interface DebugRevenueCatViewModel {
     val state: StateFlow<SettingScreenState>
+
+    fun toastDisplayed()
+    fun purchasePackage(activity: Activity, rcPackage: Package)
+    fun purchaseProduct(activity: Activity, storeProduct: StoreProduct)
+    fun purchaseSubscriptionOption(activity: Activity, subscriptionOption: SubscriptionOption)
 }

--- a/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/InternalDebugRevenueCatBottomSheet.kt
+++ b/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/InternalDebugRevenueCatBottomSheet.kt
@@ -5,11 +5,15 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
+import com.revenuecat.purchases.PurchasesTransactionException
+import com.revenuecat.purchases.models.StoreTransaction
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun InternalDebugRevenueCatBottomSheet(
+    onPurchaseCompleted: (StoreTransaction) -> Unit,
+    onPurchaseErrored: (PurchasesTransactionException) -> Unit,
     isVisible: Boolean = false,
     onDismissCallback: (() -> Unit)? = null,
 ) {
@@ -29,7 +33,7 @@ internal fun InternalDebugRevenueCatBottomSheet(
                 }
             },
         ) {
-            InternalDebugRevenueCatScreen()
+            InternalDebugRevenueCatScreen(onPurchaseCompleted, onPurchaseErrored)
         }
     }
 }

--- a/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/InternalDebugRevenueCatScreen.kt
+++ b/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/InternalDebugRevenueCatScreen.kt
@@ -1,5 +1,7 @@
 package com.revenuecat.purchases.debugview
 
+import android.app.Activity
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,19 +12,30 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PurchasesTransactionException
 import com.revenuecat.purchases.debugview.models.InternalDebugRevenueCatScreenViewModel
+import com.revenuecat.purchases.debugview.models.InternalDebugRevenueCatScreenViewModelFactory
 import com.revenuecat.purchases.debugview.models.SettingGroupState
 import com.revenuecat.purchases.debugview.models.SettingScreenState
 import com.revenuecat.purchases.debugview.models.SettingState
 import com.revenuecat.purchases.debugview.settings.SettingGroup
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.models.SubscriptionOption
 import kotlinx.coroutines.flow.MutableStateFlow
 
 @Composable
 internal fun InternalDebugRevenueCatScreen(
-    screenViewModel: DebugRevenueCatViewModel = viewModel<InternalDebugRevenueCatScreenViewModel>(),
+    onPurchaseCompleted: (StoreTransaction) -> Unit,
+    onPurchaseErrored: (PurchasesTransactionException) -> Unit,
+    screenViewModel: DebugRevenueCatViewModel = viewModel<InternalDebugRevenueCatScreenViewModel>(
+        factory = InternalDebugRevenueCatScreenViewModelFactory(onPurchaseCompleted, onPurchaseErrored),
+    ),
 ) {
     Column(
         modifier = Modifier
@@ -30,19 +43,35 @@ internal fun InternalDebugRevenueCatScreen(
             .fillMaxWidth()
             .padding(bottom = 16.dp),
     ) {
+        val state = screenViewModel.state.collectAsState().value
+        DisplayToastMessageIfNeeded(screenViewModel, state = state)
         Text(
             text = "RevenueCat Debug Menu",
             style = MaterialTheme.typography.h5,
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
         )
-        screenViewModel.state.collectAsState().value.toSettingGroupStates().forEach { SettingGroup(it) }
+        state.toSettingGroupStates().forEach { SettingGroup(it) }
     }
+}
+
+@Composable
+private fun DisplayToastMessageIfNeeded(viewModel: DebugRevenueCatViewModel, state: SettingScreenState) {
+    state.toastMessage?.let { toastMessage ->
+        Toast.makeText(
+            LocalContext.current,
+            toastMessage,
+            Toast.LENGTH_LONG,
+        ).show()
+    }
+    viewModel.toastDisplayed()
 }
 
 @Preview(showBackground = true)
 @Composable
 private fun InternalDebugRevenueCatScreenPreview() {
     InternalDebugRevenueCatScreen(
+        onPurchaseCompleted = {},
+        onPurchaseErrored = {},
         screenViewModel = object : DebugRevenueCatViewModel {
             override val state = MutableStateFlow<SettingScreenState>(
                 SettingScreenState.Configured(
@@ -69,6 +98,22 @@ private fun InternalDebugRevenueCatScreenPreview() {
                     ),
                 ),
             )
+
+            override fun toastDisplayed() {
+                error("Not implemented")
+            }
+
+            override fun purchasePackage(activity: Activity, rcPackage: Package) {
+                error("Not implemented")
+            }
+
+            override fun purchaseProduct(activity: Activity, storeProduct: StoreProduct) {
+                error("Not implemented")
+            }
+
+            override fun purchaseSubscriptionOption(activity: Activity, subscriptionOption: SubscriptionOption) {
+                error("Not implemented")
+            }
         },
     )
 }

--- a/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/models/InternalDebugRevenueCatScreenViewModelFactory.kt
+++ b/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/models/InternalDebugRevenueCatScreenViewModelFactory.kt
@@ -1,0 +1,17 @@
+package com.revenuecat.purchases.debugview.models
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.revenuecat.purchases.PurchasesTransactionException
+import com.revenuecat.purchases.models.StoreTransaction
+
+class InternalDebugRevenueCatScreenViewModelFactory(
+    private val onPurchaseCompleted: (StoreTransaction) -> Unit,
+    private val onPurchaseErrored: (PurchasesTransactionException) -> Unit,
+) : ViewModelProvider.NewInstanceFactory() {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T = InternalDebugRevenueCatScreenViewModel(
+        onPurchaseCompleted,
+        onPurchaseErrored,
+    ) as T
+}

--- a/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/models/SettingScreenState.kt
+++ b/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/models/SettingScreenState.kt
@@ -1,12 +1,19 @@
 package com.revenuecat.purchases.debugview.models
 
-internal sealed class SettingScreenState(open val configuration: SettingGroupState) {
-    data class NotConfigured(override val configuration: SettingGroupState) : SettingScreenState(configuration)
+internal sealed class SettingScreenState(
+    open val configuration: SettingGroupState,
+    open val toastMessage: String? = null,
+) {
+    data class NotConfigured(
+        override val configuration: SettingGroupState,
+        override val toastMessage: String? = null,
+    ) : SettingScreenState(configuration, toastMessage)
     data class Configured(
         override val configuration: SettingGroupState,
         val customerInfo: SettingGroupState,
         val offerings: SettingGroupState,
-    ) : SettingScreenState(configuration)
+        override val toastMessage: String? = null,
+    ) : SettingScreenState(configuration, toastMessage)
 
     fun toSettingGroupStates(): List<SettingGroupState> {
         return when (this) {

--- a/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/models/SettingState.kt
+++ b/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/models/SettingState.kt
@@ -1,5 +1,8 @@
 package com.revenuecat.purchases.debugview.models
 
+import com.revenuecat.purchases.Offering
+
 internal sealed class SettingState(open val title: String) {
     data class Text(override val title: String, val content: String) : SettingState(title)
+    class OfferingSetting(val offering: Offering) : SettingState(offering.identifier)
 }

--- a/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/settings/SettingGroup.kt
+++ b/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/settings/SettingGroup.kt
@@ -37,7 +37,10 @@ internal fun SettingGroup(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 settingGroupState.settings.forEach { settingState ->
-                    SettingText(settingState)
+                    when (settingState) {
+                        is SettingState.Text -> SettingText(settingState)
+                        is SettingState.OfferingSetting -> SettingOffering(settingState)
+                    }
                     Divider()
                 }
             }

--- a/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/settings/SettingOffering.kt
+++ b/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/settings/SettingOffering.kt
@@ -1,0 +1,273 @@
+package com.revenuecat.purchases.debugview.settings
+
+import android.app.Activity
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.Card
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.debugview.DebugRevenueCatViewModel
+import com.revenuecat.purchases.debugview.findActivity
+import com.revenuecat.purchases.debugview.models.InternalDebugRevenueCatScreenViewModel
+import com.revenuecat.purchases.debugview.models.SettingState
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.PricingPhase
+import com.revenuecat.purchases.models.PurchasingData
+import com.revenuecat.purchases.models.RecurrenceMode
+import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.SubscriptionOption
+import com.revenuecat.purchases.models.SubscriptionOptions
+
+@Composable
+internal fun SettingOffering(
+    settingState: SettingState.OfferingSetting,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 16.dp),
+    ) {
+        Text(text = settingState.title, style = MaterialTheme.typography.h6)
+        Spacer(modifier = Modifier.size(8.dp))
+        settingState.offering.availablePackages.forEach { rcPackage ->
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                border = BorderStroke(2.dp, Color.Gray),
+            ) {
+                SettingPackage(rcPackage)
+            }
+        }
+    }
+}
+
+@Suppress("LongMethod")
+@Composable
+internal fun SettingPackage(
+    rcPackage: Package,
+    screenViewModel: DebugRevenueCatViewModel = viewModel<InternalDebugRevenueCatScreenViewModel>(),
+) {
+    val isSubscription = rcPackage.product.type == ProductType.SUBS
+    val activity = LocalContext.current.findActivity()
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 16.dp),
+    ) {
+        Column(horizontalAlignment = Alignment.End) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(text = "Package ID:", style = MaterialTheme.typography.body1)
+                Text(text = rcPackage.identifier, style = MaterialTheme.typography.body2)
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(text = "Product ID:", style = MaterialTheme.typography.body1)
+                Text(text = rcPackage.product.id, style = MaterialTheme.typography.body2)
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(text = "Product Type:", style = MaterialTheme.typography.body1)
+                Text(text = rcPackage.product.type.toString(), style = MaterialTheme.typography.body2)
+            }
+            if (!isSubscription) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(text = "Price:", style = MaterialTheme.typography.body1)
+                    Text(
+                        text = rcPackage.product.price.formatted,
+                        style = MaterialTheme.typography.body2,
+                    )
+                }
+            }
+            Button(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                onClick = { screenViewModel.purchasePackage(activity, rcPackage) },
+            ) {
+                Text(text = "Buy package", style = MaterialTheme.typography.subtitle2)
+            }
+            Button(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                onClick = { screenViewModel.purchaseProduct(activity, rcPackage.product) },
+            ) {
+                Text(text = "Buy product", style = MaterialTheme.typography.subtitle2)
+            }
+        }
+        if (isSubscription) {
+            Divider()
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = "Subscription Options",
+                style = MaterialTheme.typography.subtitle2,
+            )
+            rcPackage.product.subscriptionOptions?.forEach { subscriptionOption ->
+                SettingSubscriptionOption(
+                    activity = activity,
+                    screenViewModel = screenViewModel,
+                    subscriptionOption = subscriptionOption,
+                    isDefaultOption = subscriptionOption == rcPackage.product.defaultOption,
+                )
+                if (subscriptionOption != rcPackage.product.subscriptionOptions?.last()) {
+                    Divider()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun SettingSubscriptionOption(
+    activity: Activity,
+    screenViewModel: DebugRevenueCatViewModel,
+    subscriptionOption: SubscriptionOption,
+    isDefaultOption: Boolean,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.End,
+    ) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(text = "Subscription Option ID:", style = MaterialTheme.typography.body1)
+            Text(text = subscriptionOption.id, style = MaterialTheme.typography.body2)
+        }
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(text = "Tags:", style = MaterialTheme.typography.body1)
+            Text(
+                text = subscriptionOption.tags.takeIf { it.isNotEmpty() }?.toString() ?: "None",
+                style = MaterialTheme.typography.body2,
+            )
+        }
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(text = "Pricing phases:", style = MaterialTheme.typography.body1)
+            val pricingPhasesString = subscriptionOption.pricingPhases.joinToString("\n") {
+                "- ${it.price.formatted}/${it.billingPeriod.iso8601}"
+            }
+            Text(
+                text = pricingPhasesString,
+                style = MaterialTheme.typography.body2,
+            )
+        }
+        Button(onClick = { screenViewModel.purchaseSubscriptionOption(activity, subscriptionOption) }) {
+            val buttonText = if (isDefaultOption) {
+                "Buy option (default)"
+            } else {
+                "Buy option"
+            }
+            Text(text = buttonText, style = MaterialTheme.typography.subtitle2)
+        }
+    }
+}
+
+@Suppress("MagicNumber")
+private val offering: Offering
+    get() {
+        val price = Price("$9.99", 9990000, "USD")
+        val purchasingData = object : PurchasingData {
+            override val productId: String
+                get() = "product_id"
+            override val productType: ProductType
+                get() = ProductType.SUBS
+        }
+        val subscriptionOption = object : SubscriptionOption {
+            override val id: String
+                get() = "monthly:free_trial"
+            override val pricingPhases: List<PricingPhase>
+                get() = listOf(
+                    PricingPhase(
+                        billingPeriod = Period(1, Period.Unit.MONTH, "P1M"),
+                        recurrenceMode = RecurrenceMode.NON_RECURRING,
+                        billingCycleCount = 0,
+                        price = Price("$0", 0, "USD"),
+                    ),
+                    PricingPhase(
+                        billingPeriod = Period(1, Period.Unit.MONTH, "P1M"),
+                        recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                        billingCycleCount = 0,
+                        price = price,
+                    ),
+                )
+            override val tags: List<String>
+                get() = listOf("tag1", "tag2")
+            override val presentedOfferingIdentifier: String
+                get() = "offering_id"
+            override val purchasingData: PurchasingData
+                get() = purchasingData
+        }
+        val subscriptionOptions = SubscriptionOptions(listOf(subscriptionOption))
+        val storeProduct = object : StoreProduct {
+            override val id: String
+                get() = "product_id"
+            override val type: ProductType
+                get() = ProductType.SUBS
+            override val price: Price
+                get() = price
+            override val title: String
+                get() = "product_title"
+            override val description: String
+                get() = "product_description"
+            override val period: Period
+                get() = Period(1, Period.Unit.YEAR, "P1Y")
+            override val subscriptionOptions: SubscriptionOptions
+                get() = subscriptionOptions
+            override val defaultOption: SubscriptionOption
+                get() = subscriptionOption
+            override val purchasingData: PurchasingData
+                get() = purchasingData
+            override val presentedOfferingIdentifier: String
+                get() = "offering_id"
+
+            @Deprecated("Use sku instead", ReplaceWith("id"))
+            override val sku: String
+                get() = id
+
+            override fun copyWithOfferingId(offeringId: String): StoreProduct {
+                error("Not implemented")
+            }
+        }
+        return Offering(
+            identifier = "offering_id",
+            serverDescription = "server_description",
+            metadata = emptyMap(),
+            availablePackages = listOf(
+                Package("package_id", PackageType.ANNUAL, storeProduct, "offering_id"),
+            ),
+        )
+    }
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingPreview() {
+    SettingOffering(SettingState.OfferingSetting(offering))
+}

--- a/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/settings/SettingOffering.kt
+++ b/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/settings/SettingOffering.kt
@@ -29,6 +29,7 @@ import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.debugview.DebugRevenueCatViewModel
 import com.revenuecat.purchases.debugview.findActivity
 import com.revenuecat.purchases.debugview.models.InternalDebugRevenueCatScreenViewModel
+import com.revenuecat.purchases.debugview.models.SettingScreenState
 import com.revenuecat.purchases.debugview.models.SettingState
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
@@ -38,10 +39,13 @@ import com.revenuecat.purchases.models.RecurrenceMode
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.SubscriptionOptions
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 internal fun SettingOffering(
     settingState: SettingState.OfferingSetting,
+    activity: Activity = LocalContext.current.findActivity(),
+    screenViewModel: DebugRevenueCatViewModel = viewModel<InternalDebugRevenueCatScreenViewModel>(),
 ) {
     Column(
         modifier = Modifier
@@ -57,7 +61,7 @@ internal fun SettingOffering(
                     .padding(vertical = 8.dp),
                 border = BorderStroke(2.dp, Color.Gray),
             ) {
-                SettingPackage(rcPackage)
+                SettingPackage(rcPackage, activity, screenViewModel)
             }
         }
     }
@@ -67,10 +71,10 @@ internal fun SettingOffering(
 @Composable
 internal fun SettingPackage(
     rcPackage: Package,
+    activity: Activity = LocalContext.current.findActivity(),
     screenViewModel: DebugRevenueCatViewModel = viewModel<InternalDebugRevenueCatScreenViewModel>(),
 ) {
     val isSubscription = rcPackage.product.type == ProductType.SUBS
-    val activity = LocalContext.current.findActivity()
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -269,5 +273,25 @@ private val offering: Offering
 @Preview(showBackground = true)
 @Composable
 private fun SettingPreview() {
-    SettingOffering(SettingState.OfferingSetting(offering))
+    val viewModel = object : DebugRevenueCatViewModel {
+        override val state: StateFlow<SettingScreenState>
+            get() = error("Not implemented")
+
+        override fun toastDisplayed() {
+            error("Not implemented")
+        }
+
+        override fun purchasePackage(activity: Activity, rcPackage: Package) {
+            error("Not implemented")
+        }
+
+        override fun purchaseProduct(activity: Activity, storeProduct: StoreProduct) {
+            error("Not implemented")
+        }
+
+        override fun purchaseSubscriptionOption(activity: Activity, subscriptionOption: SubscriptionOption) {
+            error("Not implemented")
+        }
+    }
+    SettingOffering(SettingState.OfferingSetting(offering), activity = Activity(), viewModel)
 }

--- a/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/settings/SettingText.kt
+++ b/debugview/src/debug/kotlin/com/revenuecat/purchases/debugview/settings/SettingText.kt
@@ -18,7 +18,7 @@ import com.revenuecat.purchases.debugview.models.SettingState
 
 @Composable
 internal fun SettingText(
-    settingState: SettingState,
+    settingState: SettingState.Text,
 ) {
     Row(
         modifier = Modifier
@@ -33,18 +33,16 @@ internal fun SettingText(
         )
         Spacer(modifier = Modifier.size(16.dp))
         Box {
-            when (settingState) {
-                is SettingState.Text -> Text(
-                    text = settingState.content,
-                    style = MaterialTheme.typography.subtitle2,
-                )
-            }
+            Text(
+                text = settingState.content,
+                style = MaterialTheme.typography.subtitle2,
+            )
         }
     }
 }
 
 @Preview
 @Composable
-private fun SettingTextPreview() {
+private fun SettingPreview() {
     SettingText(SettingState.Text("Settings title", "Settings content"))
 }

--- a/debugview/src/main/kotlin/com/revenuecat/purchases/debugview/DebugRevenueCatBottomSheet.kt
+++ b/debugview/src/main/kotlin/com/revenuecat/purchases/debugview/DebugRevenueCatBottomSheet.kt
@@ -4,6 +4,14 @@ import androidx.compose.runtime.Composable
 import com.revenuecat.purchases.PurchasesTransactionException
 import com.revenuecat.purchases.models.StoreTransaction
 
+/**
+ * Composable function that allows to display the debug screen as a bottom sheet.
+ *
+ * @param onPurchaseCompleted Callback that will be called when a purchase is completed within the debug screen.
+ * @param onPurchaseErrored Callback that will be called when a purchase fails or is cancelled within the debug screen.
+ * @param isVisible Whether the bottom sheet should be visible or not.
+ * @param onDismissCallback Callback that will be called when the bottom sheet is dismissed.
+ */
 @Composable
 fun DebugRevenueCatBottomSheet(
     onPurchaseCompleted: (StoreTransaction) -> Unit,

--- a/debugview/src/main/kotlin/com/revenuecat/purchases/debugview/DebugRevenueCatBottomSheet.kt
+++ b/debugview/src/main/kotlin/com/revenuecat/purchases/debugview/DebugRevenueCatBottomSheet.kt
@@ -1,13 +1,19 @@
 package com.revenuecat.purchases.debugview
 
 import androidx.compose.runtime.Composable
+import com.revenuecat.purchases.PurchasesTransactionException
+import com.revenuecat.purchases.models.StoreTransaction
 
 @Composable
 fun DebugRevenueCatBottomSheet(
+    onPurchaseCompleted: (StoreTransaction) -> Unit,
+    onPurchaseErrored: (PurchasesTransactionException) -> Unit,
     isVisible: Boolean = false,
     onDismissCallback: (() -> Unit)? = null,
 ) {
     InternalDebugRevenueCatBottomSheet(
+        onPurchaseCompleted,
+        onPurchaseErrored,
         isVisible,
         onDismissCallback,
     )

--- a/debugview/src/main/kotlin/com/revenuecat/purchases/debugview/DebugRevenueCatScreen.kt
+++ b/debugview/src/main/kotlin/com/revenuecat/purchases/debugview/DebugRevenueCatScreen.kt
@@ -4,6 +4,12 @@ import androidx.compose.runtime.Composable
 import com.revenuecat.purchases.PurchasesTransactionException
 import com.revenuecat.purchases.models.StoreTransaction
 
+/**
+ * Composable function that allows to display the debug screen as any part of the screen in your composable tree.
+ *
+ * @param onPurchaseCompleted Callback that will be called when a purchase is completed within the debug screen.
+ * @param onPurchaseErrored Callback that will be called when a purchase fails or is cancelled within the debug screen.
+ */
 @Composable
 fun DebugRevenueCatScreen(
     onPurchaseCompleted: (StoreTransaction) -> Unit,

--- a/debugview/src/main/kotlin/com/revenuecat/purchases/debugview/DebugRevenueCatScreen.kt
+++ b/debugview/src/main/kotlin/com/revenuecat/purchases/debugview/DebugRevenueCatScreen.kt
@@ -1,8 +1,13 @@
 package com.revenuecat.purchases.debugview
 
 import androidx.compose.runtime.Composable
+import com.revenuecat.purchases.PurchasesTransactionException
+import com.revenuecat.purchases.models.StoreTransaction
 
 @Composable
-fun DebugRevenueCatScreen() {
-    InternalDebugRevenueCatScreen()
+fun DebugRevenueCatScreen(
+    onPurchaseCompleted: (StoreTransaction) -> Unit,
+    onPurchaseErrored: (PurchasesTransactionException) -> Unit,
+) {
+    InternalDebugRevenueCatScreen(onPurchaseCompleted, onPurchaseErrored)
 }

--- a/debugview/src/release/kotlin/com/revenuecat/purchases/debugview/InternalDebugRevenueCatBottomSheet.kt
+++ b/debugview/src/release/kotlin/com/revenuecat/purchases/debugview/InternalDebugRevenueCatBottomSheet.kt
@@ -1,10 +1,14 @@
 package com.revenuecat.purchases.debugview
 
 import androidx.compose.runtime.Composable
+import com.revenuecat.purchases.PurchasesTransactionException
+import com.revenuecat.purchases.models.StoreTransaction
 
 @Suppress("EmptyFunctionBlock", "UnusedParameter")
 @Composable
 internal fun InternalDebugRevenueCatBottomSheet(
+    onPurchaseCompleted: (StoreTransaction) -> Unit,
+    onPurchaseErrored: (PurchasesTransactionException) -> Unit,
     isVisible: Boolean = false,
     onDismissCallback: (() -> Unit)? = null,
 ) {}

--- a/debugview/src/release/kotlin/com/revenuecat/purchases/debugview/InternalDebugRevenueCatScreen.kt
+++ b/debugview/src/release/kotlin/com/revenuecat/purchases/debugview/InternalDebugRevenueCatScreen.kt
@@ -1,7 +1,12 @@
 package com.revenuecat.purchases.debugview
 
 import androidx.compose.runtime.Composable
+import com.revenuecat.purchases.PurchasesTransactionException
+import com.revenuecat.purchases.models.StoreTransaction
 
 @Suppress("EmptyFunctionBlock")
 @Composable
-internal fun InternalDebugRevenueCatScreen() {}
+internal fun InternalDebugRevenueCatScreen(
+    onPurchaseCompleted: (StoreTransaction) -> Unit,
+    onPurchaseErrored: (PurchasesTransactionException) -> Unit,
+) {}

--- a/debugview/src/release/kotlin/com/revenuecat/purchases/debugview/InternalDebugRevenueCatScreen.kt
+++ b/debugview/src/release/kotlin/com/revenuecat/purchases/debugview/InternalDebugRevenueCatScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import com.revenuecat.purchases.PurchasesTransactionException
 import com.revenuecat.purchases.models.StoreTransaction
 
-@Suppress("EmptyFunctionBlock")
+@Suppress("EmptyFunctionBlock", "UnusedParameter")
 @Composable
 internal fun InternalDebugRevenueCatScreen(
     onPurchaseCompleted: (StoreTransaction) -> Unit,

--- a/examples/MagicWeatherCompose/app/src/main/java/com/revenuecat/sample/main/MainScreen.kt
+++ b/examples/MagicWeatherCompose/app/src/main/java/com/revenuecat/sample/main/MainScreen.kt
@@ -71,7 +71,13 @@ fun MainScreen(
         bottomBar = { BottomBarNavigation(navController) },
     ) {
         MainNavHost(navController, changeScreenCallback, Modifier.padding(it))
-        DebugRevenueCatBottomSheet(displayRCDebugMenu) {
+        DebugRevenueCatBottomSheet(
+            onPurchaseCompleted = { scope.launch { displayRCDebugMenu = false } },
+            onPurchaseErrored = { error ->
+                if (!error.userCancelled) scope.launch { displayRCDebugMenu = false }
+            },
+            displayRCDebugMenu,
+        ) {
             displayRCDebugMenu = false
         }
     }


### PR DESCRIPTION
### Description
This PR adds the offerings section to the debug menu and allows to purchase packages, products and subscription options for those offerings.

https://github.com/RevenueCat/purchases-android/assets/808417/6431e038-b4ca-446e-a83c-990960d71831

