### PR TITLE
Fix NoSuchElementException by using poll when accessing serviceRequests

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -98,7 +98,11 @@ internal class BillingWrapper(
     private fun executePendingRequests() {
         synchronized(this@BillingWrapper) {
             while (billingClient?.isReady == true && !serviceRequests.isEmpty()) {
-                serviceRequests.remove().let { mainHandler.post { it(null) } }
+                try {
+                    serviceRequests.remove().let { mainHandler.post { it(null) } }
+                } catch (e: NoSuchElementException) {
+                    errorLog("Got NoSuchElementException while executing pending requests", e)
+                }
             }
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -101,6 +101,8 @@ internal class BillingWrapper(
                 try {
                     serviceRequests.remove().let { mainHandler.post { it(null) } }
                 } catch (e: NoSuchElementException) {
+                    // We got reports of this exception in Android 12. Access to the queue is synchronized
+                    // so we don't really know how it can happen. We are going to catch it and log it
                     errorLog("Got NoSuchElementException while executing pending requests", e)
                 }
             }


### PR DESCRIPTION
We are getting reports of this exception

```
Exception java.util.NoSuchElementException:
  at java.util.AbstractQueue.remove (AbstractQueue.java:117)
  at com.revenuecat.purchases.google.BillingWrapper.executePendingRequests$lambda-2$lambda-1$lambda-0 (BillingWrapper.kt:101)
  at com.revenuecat.purchases.google.BillingWrapper.executePendingRequests (BillingWrapper.kt:101)
  at com.revenuecat.purchases.google.BillingWrapper.onBillingSetupFinished$lambda-25 (BillingWrapper.kt:672)
  at <private>
```

In this piece of code

```
private fun executePendingRequests() {
        synchronized(this@BillingWrapper) {
            while (billingClient?.isReady == true && !serviceRequests.isEmpty()) {
                serviceRequests.remove().let { mainHandler.post { it(null) } }
            }
        }
    }
```

I can't think of a way that's possible since the access to `serviceRequests` is synchronized. But reports of the exception come only from Android 12, so I am thinking there could be an issue in Android itself

Anyways, I changed the implementation to use `poll` instead, which instead of throwing a exception, returns null if the queue is empty