### PR TITLE
Debug view: Support deploying both noop and debug version of `debugview` package

### DIFF
--- a/examples/MagicWeatherCompose/settings.gradle
+++ b/examples/MagicWeatherCompose/settings.gradle
@@ -20,6 +20,6 @@ include ':app'
 // Uncomment to use local version of the SDK
 includeBuild("../../") {
     dependencySubstitution {
-        substitute module("com.revenuecat.purchases:debugview") using project(":debugview")
+        substitute module("com.revenuecat.purchases:debugview") using project(":ui:debugview")
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -127,18 +127,33 @@ platform :android do
     )
 
     UI.verbose("Deploying Custom Entitlements Computation version")
+    deploy_specific_package(
+      "customEntitlementComputationRelease",
+      "purchases-custom-entitlement-computation",
+      "purchases"
+    )
 
-    gradleProperties["ANDROID_VARIANT_TO_PUBLISH"] = "customEntitlementComputationRelease"
-    gradleProperties["POM_ARTIFACT_ID"] = "purchases-custom-entitlement-computation"
-
-    gradle(
-      tasks: [
-        "purchases:publish --no-daemon --no-parallel"
-      ],
-      properties: gradleProperties
+    UI.verbose("Deploying Debug view version")
+    deploy_specific_package(
+      "defaultsDebug",
+      "purchases-debug-view",
+      "ui:debugview"
     )
 
     github_release(version: version) unless is_snapshot_version?(version)
+  end
+
+  def deploy_specific_package(variant, artifact_id, module_to_deploy)
+    gradleProperties["ANDROID_VARIANT_TO_PUBLISH"] = "customEntitlementComputationRelease"
+    gradleProperties["POM_ARTIFACT_ID"] = "purchases-custom-entitlement-computation"
+
+    command = module_to_deploy == nil ? "publish" : "#{module_to_deploy}:publish"
+    gradle(
+      tasks: [
+        "#{command} --no-daemon --no-parallel"
+      ],
+      properties: gradleProperties
+    )
   end
 
   desc "Upload a snapshot release"

--- a/ui/debugview/build.gradle
+++ b/ui/debugview/build.gradle
@@ -4,10 +4,9 @@ plugins {
     alias libs.plugins.paparazzi
 }
 
-// TODO Uncomment apply plugin once debugview package is ready to be published.
-//if (!project.getProperties()["ANDROID_VARIANT_TO_PUBLISH"].contains("customEntitlementComputation")) {
-//    apply plugin: "com.vanniktech.maven.publish"
-//}
+if (!project.getProperties()["ANDROID_VARIANT_TO_PUBLISH"].contains("customEntitlementComputation")) {
+    apply plugin: "com.vanniktech.maven.publish"
+}
 
 apply from: "$rootProject.projectDir/library.gradle"
 

--- a/ui/debugview/gradle.properties
+++ b/ui/debugview/gradle.properties
@@ -1,0 +1,4 @@
+POM_NAME=purchases-debug-view
+# We default to deploy the noop version since release is the noop version.
+POM_ARTIFACT_ID=purchases-debug-view-noop
+POM_PACKAGING=aar


### PR DESCRIPTION
### Description
This sets up the project to be able to deploy the `defaultsRelease` variant as `purchases-debug-view-noop` package and `defaultsDebug` variant as `purchases-debug-view`

Hold until #1187 and #1191 are merged.