### PR TITLE
Relax consumer rules to allow for better minifying and obfuscation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,18 +505,6 @@ workflows:
       - detekt
       - assemble-purchase-tester
       - run-backend-integration-tests
-      - integration-tests-build
-      - purchases-integration-tests-build
-      - run-firebase-tests-purchases-custom-entitlement-computation-integration-test
-      - run-firebase-tests-purchases-integration-test:
-          requires:
-            - purchases-integration-tests-build
-      - run-firebase-tests-purchases-load-shedder-integration-test:
-          context:
-            - slack-secrets
-      - run-firebase-tests:
-          requires:
-            - integration-tests-build
 
   snapshot-deploy-sample-app-tests:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,10 +505,6 @@ workflows:
       - detekt
       - assemble-purchase-tester
       - run-backend-integration-tests
-      - integration-tests-build
-      - run-firebase-tests:
-          requires:
-            - integration-tests-build
 
   snapshot-deploy-sample-app-tests:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,6 +505,10 @@ workflows:
       - detekt
       - assemble-purchase-tester
       - run-backend-integration-tests
+      - integration-tests-build
+      - run-firebase-tests:
+          requires:
+            - integration-tests-build
 
   snapshot-deploy-sample-app-tests:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,6 +505,18 @@ workflows:
       - detekt
       - assemble-purchase-tester
       - run-backend-integration-tests
+      - integration-tests-build
+      - purchases-integration-tests-build
+      - run-firebase-tests-purchases-custom-entitlement-computation-integration-test
+      - run-firebase-tests-purchases-integration-test:
+          requires:
+            - purchases-integration-tests-build
+      - run-firebase-tests-purchases-load-shedder-integration-test:
+          context:
+            - slack-secrets
+      - run-firebase-tests:
+          requires:
+            - integration-tests-build
 
   snapshot-deploy-sample-app-tests:
     when:

--- a/examples/MagicWeather/app/proguard-rules.pro
+++ b/examples/MagicWeather/app/proguard-rules.pro
@@ -19,5 +19,3 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
-
--keep class com.revenuecat.purchases.** { *; }

--- a/examples/purchase-tester/proguard-rules.pro
+++ b/examples/purchase-tester/proguard-rules.pro
@@ -20,4 +20,3 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 -keepnames class androidx.navigation.fragment.NavHostFragment
--keepnames class com.revenuecat.purchases.Offering

--- a/feature/amazon/consumer-rules.pro
+++ b/feature/amazon/consumer-rules.pro
@@ -1,5 +1,4 @@
 -dontwarn com.amazon.**
 -keep class com.amazon.** {*;}
--keep class com.revenuecat.purchases.amazon.** {*;}
 -keepattributes *Annotation*
 -dontoptimize

--- a/feature/amazon/consumer-rules.pro
+++ b/feature/amazon/consumer-rules.pro
@@ -1,4 +1,5 @@
 -dontwarn com.amazon.**
 -keep class com.amazon.** {*;}
+-keep class com.revenuecat.purchases.amazon.** {*;}
 -keepattributes *Annotation*
 -dontoptimize

--- a/integration-tests/proguard-rules.pro
+++ b/integration-tests/proguard-rules.pro
@@ -19,4 +19,3 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
--keep class com.revenuecat.purchases.** { *; }

--- a/integration-tests/proguard-rules.pro
+++ b/integration-tests/proguard-rules.pro
@@ -19,3 +19,4 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-keep class com.revenuecat.purchases.** { *; }

--- a/purchases/consumer-rules.pro
+++ b/purchases/consumer-rules.pro
@@ -1,4 +1,4 @@
--keep class com.revenuecat.** { *; }
+-keep class com.revenuecat.purchases.amazon.** {*;}
 -keep class androidx.lifecycle.DefaultLifecycleObserver
 -dontwarn com.google.errorprone.annotations.CanIgnoreReturnValue
 -dontwarn com.google.errorprone.annotations.Immutable

--- a/purchases/consumer-rules.pro
+++ b/purchases/consumer-rules.pro
@@ -1,4 +1,3 @@
--keep class com.revenuecat.purchases.amazon.** {*;}
 -keep class androidx.lifecycle.DefaultLifecycleObserver
 -dontwarn com.google.errorprone.annotations.CanIgnoreReturnValue
 -dontwarn com.google.errorprone.annotations.Immutable


### PR DESCRIPTION
### Description
This PR relaxes the rules in our `consumer-rules.pro` files. This allows to obfuscate and minify more code from our SDK. Note that this means that stack traces will be obfuscated moving forward and will need the mapping file in order to deobfuscate. 
