### PR TITLE
Optimize diagnostics file management

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -74,6 +74,8 @@ open class PurchasesConfiguration(builder: Builder) {
          * Examples of this information include response times, cache hits or error codes.
          * This information will be anonymized so it can't be traced back to the end-user.
          * The default value is false.
+         *
+         * Diagnostics is only available in Android API 24+
          */
         fun diagnosticsEnabled(diagnosticsEnabled: Boolean) = apply {
             this.diagnosticsEnabled = diagnosticsEnabled

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -31,11 +31,13 @@ import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsMa
 import com.revenuecat.purchases.common.offlineentitlements.PurchasedProductsFetcher
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
+import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.strings.ConfigureStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesPoster
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
+import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import java.net.URL
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -81,7 +83,7 @@ internal class PurchasesFactory(
 
             var diagnosticsFileHelper: DiagnosticsFileHelper? = null
             var diagnosticsTracker: DiagnosticsTracker? = null
-            if (diagnosticsEnabled) {
+            if (diagnosticsEnabled && isAndroidNOrNewer()) {
                 diagnosticsFileHelper = DiagnosticsFileHelper(FileHelper(context))
                 diagnosticsTracker = DiagnosticsTracker(
                     appConfig,
@@ -89,6 +91,8 @@ internal class PurchasesFactory(
                     DiagnosticsAnonymizer(Anonymizer()),
                     diagnosticsDispatcher,
                 )
+            } else if (diagnosticsEnabled) {
+                warnLog("Diagnostics are only supported on Android N or newer.")
             }
 
             val signatureVerificationMode = SignatureVerificationMode.fromEntitlementVerificationMode(
@@ -193,7 +197,7 @@ internal class PurchasesFactory(
             val offeringParser = OfferingParserFactory.createOfferingParser(store)
 
             var diagnosticsSynchronizer: DiagnosticsSynchronizer? = null
-            if (diagnosticsFileHelper != null && diagnosticsTracker != null) {
+            if (diagnosticsFileHelper != null && diagnosticsTracker != null && isAndroidNOrNewer()) {
                 diagnosticsSynchronizer = DiagnosticsSynchronizer(
                     diagnosticsFileHelper,
                     diagnosticsTracker,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -149,6 +149,7 @@ internal class PurchasesOrchestrator constructor(
             log(LogIntent.WARNING, ConfigureStrings.AUTO_SYNC_PURCHASES_DISABLED)
         }
 
+        diagnosticsSynchronizer?.clearDiagnosticsFileIfTooBig()
         diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -55,6 +55,7 @@ import com.revenuecat.purchases.strings.IdentityStrings
 import com.revenuecat.purchases.strings.PurchaseStrings
 import com.revenuecat.purchases.strings.RestoreStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
+import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import java.net.URL
 import java.util.Collections
 
@@ -149,8 +150,10 @@ internal class PurchasesOrchestrator constructor(
             log(LogIntent.WARNING, ConfigureStrings.AUTO_SYNC_PURCHASES_DISABLED)
         }
 
-        diagnosticsSynchronizer?.clearDiagnosticsFileIfTooBig()
-        diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
+        if (isAndroidNOrNewer()) {
+            diagnosticsSynchronizer?.clearDiagnosticsFileIfTooBig()
+            diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
+        }
     }
 
     /** @suppress */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/FileHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/FileHelper.kt
@@ -1,13 +1,15 @@
 package com.revenuecat.purchases.common
 
 import android.content.Context
-import com.revenuecat.purchases.utils.DataListener
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.revenuecat.purchases.utils.sizeInKB
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.InputStreamReader
+import java.util.stream.Stream
 
 internal class FileHelper(
     private val applicationContext: Context,
@@ -32,36 +34,26 @@ internal class FileHelper(
         return file.delete()
     }
 
-    fun readFilePerLines(filePath: String, dataListener: DataListener<Pair<String, Int>>) {
+    // This is using a lambda with a Stream instead of returning the Stream itself. This is so we keep
+    // the responsibility of closing the bufferedReader to this class. Note that the Stream should
+    // be used synchronously, otherwise the bufferedReader will be closed before the stream is used.
+    @RequiresApi(Build.VERSION_CODES.N)
+    fun readFilePerLines(filePath: String, streamBlock: ((Stream<String>) -> Unit)) {
         openBufferedReader(filePath) { bufferedReader ->
-            var nextLine: String? = bufferedReader.readLine()
-            var lineNumber = 0
-            while (nextLine != null) {
-                dataListener.onData(Pair(nextLine, lineNumber))
-                nextLine = bufferedReader.readLine()
-                lineNumber++
-            }
+            streamBlock(bufferedReader.lines())
         }
-        dataListener.onComplete()
     }
 
+    @RequiresApi(Build.VERSION_CODES.N)
     fun removeFirstLinesFromFile(filePath: String, numberOfLinesToRemove: Int) {
         val textToAppend = StringBuilder()
-        readFilePerLines(
-            filePath,
-            object : DataListener<Pair<String, Int>> {
-                override fun onData(data: Pair<String, Int>) {
-                    if (data.second >= numberOfLinesToRemove) {
-                        textToAppend.append(data.first).append("\n")
-                    }
-                }
-
-                override fun onComplete() {
-                    deleteFile(filePath)
-                    appendToFile(filePath, textToAppend.toString())
-                }
-            },
-        )
+        readFilePerLines(filePath) { stream ->
+            stream.skip(numberOfLinesToRemove.toLong()).forEach { line ->
+                textToAppend.append(line).append("\n")
+            }
+        }
+        deleteFile(filePath)
+        appendToFile(filePath, textToAppend.toString())
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.verboseLog
+import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import java.io.IOException
 import kotlin.time.Duration
 
@@ -161,12 +162,14 @@ internal class DiagnosticsTracker(
     }
 
     internal fun trackEventInCurrentThread(diagnosticsEntry: DiagnosticsEntry) {
-        val anonymizedEvent = diagnosticsAnonymizer.anonymizeEntryIfNeeded(diagnosticsEntry)
-        verboseLog("Tracking diagnostics event: $anonymizedEvent")
-        try {
-            diagnosticsFileHelper.appendEntryToDiagnosticsFile(anonymizedEvent)
-        } catch (e: IOException) {
-            verboseLog("Error tracking diagnostics event: $e")
+        if (isAndroidNOrNewer()) {
+            val anonymizedEvent = diagnosticsAnonymizer.anonymizeEntryIfNeeded(diagnosticsEntry)
+            verboseLog("Tracking diagnostics event: $anonymizedEvent")
+            try {
+                diagnosticsFileHelper.appendEntryToDiagnosticsFile(anonymizedEvent)
+            } catch (e: IOException) {
+                verboseLog("Error tracking diagnostics event: $e")
+            }
         }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -125,13 +125,10 @@ internal class DiagnosticsTracker(
         )
     }
 
-    fun trackMaxEventsStoredLimitReached(totalEventsStored: Int, eventsRemoved: Int, useCurrentThread: Boolean = true) {
+    fun trackMaxEventsStoredLimitReached(useCurrentThread: Boolean = true) {
         val event = DiagnosticsEntry.Event(
             name = DiagnosticsEventName.MAX_EVENTS_STORED_LIMIT_REACHED,
-            properties = mapOf(
-                "total_number_events_stored" to totalEventsStored,
-                "events_removed" to eventsRemoved,
-            ),
+            properties = mapOf(),
         )
         if (useCurrentThread) {
             trackEventInCurrentThread(event)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/AndroidVersionUtils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/AndroidVersionUtils.kt
@@ -1,0 +1,5 @@
+package com.revenuecat.purchases.utils
+
+import android.os.Build
+
+fun isAndroidNOrNewer() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/DataListener.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/DataListener.kt
@@ -1,0 +1,6 @@
+package com.revenuecat.purchases.utils
+
+interface DataListener<T> {
+    fun onData(data: T)
+    fun onComplete()
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/DataListener.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/DataListener.kt
@@ -1,6 +1,0 @@
-package com.revenuecat.purchases.utils
-
-interface DataListener<T> {
-    fun onData(data: T)
-    fun onComplete()
-}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/FileExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/FileExtensions.kt
@@ -1,0 +1,10 @@
+package com.revenuecat.purchases.utils
+
+import java.io.File
+
+private const val BYTE_UNIT_CONVERSION: Double = 1024.0
+
+val File.sizeInBytes: Long
+    get() = length()
+val File.sizeInKB: Double
+    get() = sizeInBytes / BYTE_UNIT_CONVERSION

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -100,6 +100,9 @@ internal open class BasePurchasesTest {
             mockIdentityManager.configure(any())
         } just Runs
         every {
+            mockDiagnosticsSynchronizer.clearDiagnosticsFileIfTooBig()
+        } just Runs
+        every {
             mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
         } just Runs
         every {

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -83,6 +83,11 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     @Test
+    fun `diagnostics is cleared if diagnostics file too big on constructor`() {
+        verify(exactly = 1) { mockDiagnosticsSynchronizer.clearDiagnosticsFileIfTooBig() }
+    }
+
+    @Test
     fun `diagnostics is synced if needed on constructor`() {
         verify(exactly = 1) { mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded() }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
@@ -62,7 +62,7 @@ class DiagnosticsFileHelperTest {
     fun `isDiagnosticsFileTooBig is false if file smaller than limit`() {
         every { fileHelper.fileSizeInKB(diagnosticsFilePath) } returns
             DiagnosticsFileHelper.DIAGNOSTICS_FILE_LIMIT_IN_KB - 1.0
-        assertThat(diagnosticsFileHelper.isDiagnosticsFileTooBig()).isTrue
+        assertThat(diagnosticsFileHelper.isDiagnosticsFileTooBig()).isFalse
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerFunctionalTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerFunctionalTest.kt
@@ -1,0 +1,95 @@
+package com.revenuecat.purchases.common.diagnostics
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.FileHelper
+import com.revenuecat.purchases.common.SyncDispatcher
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import kotlin.random.Random
+
+@RunWith(AndroidJUnit4::class)
+class DiagnosticsSynchronizerFunctionalTest {
+
+    private val testFolder = "temp_test_folder"
+
+    private lateinit var applicationContext: Context
+    private lateinit var diagnosticsTracker: DiagnosticsTracker
+
+    private lateinit var diagnosticsSynchronizer: DiagnosticsSynchronizer
+
+    @Before
+    fun setup() {
+        val tempTestFolder = File(testFolder)
+        if (tempTestFolder.exists()) {
+            error("Temp test folder should not exist before starting tests")
+        }
+        tempTestFolder.mkdirs()
+
+        applicationContext = mockk()
+        every { applicationContext.filesDir } returns tempTestFolder
+        diagnosticsTracker = mockk()
+        every { diagnosticsTracker.trackMaxEventsStoredLimitReached() } just Runs
+
+        diagnosticsSynchronizer = DiagnosticsSynchronizer(
+            DiagnosticsFileHelper(FileHelper(applicationContext)),
+            diagnosticsTracker = diagnosticsTracker,
+            backend = mockk(),
+            diagnosticsDispatcher = SyncDispatcher(),
+            sharedPreferences = mockk(relaxed = true),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        val tempTestFolder = File(testFolder)
+        tempTestFolder.deleteRecursively()
+    }
+
+    @Test
+    fun `diagnostics synchronizer file is not cleared if not too big`() {
+        createDiagnosticsFile(1000)
+        diagnosticsSynchronizer.clearDiagnosticsFileIfTooBig()
+        verify(exactly = 0) { diagnosticsTracker.trackMaxEventsStoredLimitReached() }
+    }
+
+    @Test
+    fun `diagnostics synchronizer file is cleared if too big`() {
+        createDiagnosticsFile(3000)
+        diagnosticsSynchronizer.clearDiagnosticsFileIfTooBig()
+        verify(exactly = 1) { diagnosticsTracker.trackMaxEventsStoredLimitReached() }
+    }
+
+    private fun createDiagnosticsFile(numberOfEvents: Int) {
+        val contents = (1..numberOfEvents).joinToString("\n") { createDiagnosticsEntry().toString() }
+        createTestFileWithContents(contents)
+    }
+
+    private fun createDiagnosticsEntry(): DiagnosticsEntry {
+        return DiagnosticsEntry.Event(
+            DiagnosticsEventName.GOOGLE_QUERY_PURCHASES_REQUEST,
+            mapOf(
+                "test_key_1" to "test_value_1",
+                "test_key_2" to Random.nextBoolean(),
+                "test_key_3" to Random.nextInt(),
+                "test_key_4" to "test_value_${Random.nextInt()}",
+                "test_key_5" to "test_value_5",
+            )
+        )
+    }
+
+    private fun createTestFileWithContents(contents: String) {
+        val file = File(testFolder, DiagnosticsFileHelper.DIAGNOSTICS_FILE_PATH)
+        file.parentFile?.mkdirs()
+        file.createNewFile()
+        file.writeText(contents)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
@@ -7,7 +7,6 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.SyncDispatcher
-import com.revenuecat.purchases.utils.DataListener
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -21,6 +20,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.IOException
+import java.util.stream.Stream
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -277,10 +277,9 @@ class DiagnosticsSynchronizerTest {
     }
 
     private fun mockReadDiagnosticsFile(jsons: List<JSONObject>) {
-        val slot = slot<DataListener<JSONObject>>()
+        val slot = slot<((Stream<JSONObject>) -> Unit)>()
         every { diagnosticsFileHelper.readDiagnosticsFile(capture(slot)) } answers {
-            jsons.forEach { slot.captured.onData(it) }
-            slot.captured.onComplete()
+            slot.captured(jsons.stream())
         }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
@@ -231,48 +231,6 @@ class DiagnosticsSynchronizerTest {
         diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
     }
 
-//    @Test
-//    fun `syncDiagnosticsFileIfNeeded removes old events if exceeding limit`() {
-//        val eventsOverLimit = 10
-//        val eventsToRemove = eventsOverLimit + 1 // Leaves space for tracking event
-//        val eventsInFile = (0 until DiagnosticsSynchronizer.MAX_NUMBER_EVENTS + eventsOverLimit).map {
-//            JSONObject(mapOf("test-key-$it" to "value-$it"))
-//        }
-//        val eventsAfterRemovingOlder = eventsInFile.subList(eventsOverLimit, eventsInFile.size)
-//        every { diagnosticsFileHelper.readDiagnosticsFile() } returnsMany listOf(eventsInFile, eventsAfterRemovingOlder)
-//        every { diagnosticsTracker.trackEventInCurrentThread(any()) } just Runs
-//        every { diagnosticsFileHelper.deleteOlderDiagnostics(eventsToRemove) } just Runs
-//        every { diagnosticsTracker.trackMaxEventsStoredLimitReached(any(), any()) } just Runs
-//        mockBackendResponse(eventsAfterRemovingOlder)
-//        diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
-//        verify(exactly = 1) { diagnosticsFileHelper.deleteOlderDiagnostics(eventsToRemove) }
-//    }
-
-//    @Test
-//    fun `syncDiagnosticsFileIfNeeded tracks max elements stored reached if syncing more than limit`() {
-//        val eventsOverLimit = 10
-//        val eventsToRemove = eventsOverLimit + 1 // Leaves space for tracking event
-//        val totalNumberOfEventsInFile = DiagnosticsSynchronizer.MAX_NUMBER_EVENTS + eventsOverLimit
-//        val eventsInFile = (0 until totalNumberOfEventsInFile).map {
-//            JSONObject(mapOf("test-key-$it" to "value-$it"))
-//        }
-//        val eventsAfterRemovingOlder = eventsInFile.subList(eventsOverLimit, eventsInFile.size)
-//        every { diagnosticsFileHelper.readDiagnosticsFile() } returnsMany listOf(eventsInFile, eventsAfterRemovingOlder)
-//        every { diagnosticsFileHelper.deleteOlderDiagnostics(eventsToRemove) } just Runs
-//        every {
-//            diagnosticsTracker.trackMaxEventsStoredLimitReached(totalNumberOfEventsInFile, eventsToRemove)
-//        } just Runs
-//        mockBackendResponse(eventsAfterRemovingOlder)
-//        diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
-//        verify(exactly = 1) {
-//            diagnosticsTracker.trackMaxEventsStoredLimitReached(
-//                totalNumberOfEventsInFile,
-//                eventsToRemove,
-//                useCurrentThread = true
-//            )
-//        }
-//    }
-
     // endregion
 
     private fun mockSharedPreferences() {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
@@ -13,7 +13,6 @@ import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.playServicesVersionName
 import com.revenuecat.purchases.common.playStoreVersionName
 import io.mockk.Runs
-import io.mockk.clearStaticMockk
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -194,17 +193,13 @@ class DiagnosticsTrackerTest {
 
     @Test
     fun `trackMaxEventsStoredLimitReached tracks correct event`() {
-        val expectedProperties = mapOf(
-            "total_number_events_stored" to 1234,
-            "events_removed" to 234
-        )
         every { diagnosticsFileHelper.appendEntryToDiagnosticsFile(any()) } just Runs
-        diagnosticsTracker.trackMaxEventsStoredLimitReached(totalEventsStored = 1234, eventsRemoved = 234)
+        diagnosticsTracker.trackMaxEventsStoredLimitReached()
         verify(exactly = 1) {
             diagnosticsFileHelper.appendEntryToDiagnosticsFile(match { event ->
                 event is DiagnosticsEntry.Event &&
                     event.name == DiagnosticsEventName.MAX_EVENTS_STORED_LIMIT_REACHED &&
-                    event.properties == expectedProperties
+                    event.properties == emptyMap<String, Any>()
             })
         }
     }


### PR DESCRIPTION
### Description
This PR is the first part of a possible approach to avoid loading huge files in memory in diagnostics at once. Basically, in here we change to reading the file per lines instead of reading everything in one go.

#### Behavior changes
- Diagnostics will be Android 24+ only.
- An important change in behavior is that, instead of using the number of events in the diagnostics file to set a limit, we use the file size. So if on SDK configuration we detect that it's reached X size, we would clear the whole file and start over. 
- When we reach the file size limit, we remove the whole file, instead of just the oldest events.
- We remove the properties from the `MAX_EVENTS_STORED_LIMIT_REACHED` event since they don't make sense with the new approach. (This will require backend changes)
- Now we will have a limit to the max number of diagnostics events in memory and per request.
