### PR TITLE
Add limit to how many diagnostics events to sync per request (part 2)

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/FileHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/FileHelper.kt
@@ -32,11 +32,11 @@ internal class FileHelper(
         return file.delete()
     }
 
-    fun readFilePerLines(filePath: String, dataListener: DataListener<Pair<String, Int>>) {
+    fun readFilePerLines(filePath: String, dataListener: DataListener<Pair<String, Int>>, maxLines: Int? = null) {
         openBufferedReader(filePath) { bufferedReader ->
             var nextLine: String? = bufferedReader.readLine()
             var lineNumber = 0
-            while (nextLine != null) {
+            while (nextLine != null && (maxLines == null || lineNumber < maxLines)) {
                 dataListener.onData(Pair(nextLine, lineNumber))
                 nextLine = bufferedReader.readLine()
                 lineNumber++

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
@@ -39,7 +39,7 @@ internal class DiagnosticsFileHelper(
     }
 
     @Synchronized
-    fun readDiagnosticsFile(listener: DataListener<JSONObject>) {
+    fun readDiagnosticsFile(listener: DataListener<JSONObject>, maxEntries: Int? = null) {
         if (fileHelper.fileIsEmpty(DIAGNOSTICS_FILE_PATH)) {
             listener.onComplete()
         } else {
@@ -54,6 +54,7 @@ internal class DiagnosticsFileHelper(
                         listener.onComplete()
                     }
                 },
+                maxLines = maxEntries,
             )
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/FileHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/FileHelperTest.kt
@@ -162,6 +162,33 @@ class FileHelperTest {
         assertThat(onCompleteCallCount).isEqualTo(1)
     }
 
+    @Test
+    fun `readFilePerLines with max lines returns correct content`() {
+        createTestFileWithContents("first line\nsecond line\nthird line\nfourth line")
+        val receivedValues = mutableListOf<Pair<String, Int>>()
+        var onCompleteCallCount = 0
+        fileHelper.readFilePerLines(
+            testFilePath,
+            object : DataListener<Pair<String, Int>> {
+                override fun onData(data: Pair<String, Int>) {
+                    receivedValues.add(data)
+                }
+
+                override fun onComplete() {
+                    onCompleteCallCount++
+                }
+            },
+            maxLines = 2,
+        )
+        assertThat(receivedValues).isEqualTo(
+            listOf(
+                Pair("first line", 0),
+                Pair("second line", 1),
+            )
+        )
+        assertThat(onCompleteCallCount).isEqualTo(1)
+    }
+
     private fun verifyFileDoesNotExist() {
         val file = File(testFolder, testFilePath)
         if (file.exists()) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
@@ -112,4 +112,18 @@ class DiagnosticsFileHelperTest {
         assertThat(dataListenerCallParams[1]["test_key"]).isEqualTo("test_value")
         assertThat(dataListenerOnCompleteCallCount).isEqualTo(1)
     }
+
+    @Test
+    fun `readDiagnosticsFile passes maxLines requirement to fileHelper as expected`() {
+        every { fileHelper.fileIsEmpty(diagnosticsFilePath) } returns false
+        val dataListenerSlot = slot<DataListener<Pair<String, Int>>>()
+        val maxLines = 2
+        every { fileHelper.readFilePerLines(diagnosticsFilePath, capture(dataListenerSlot), maxLines) } answers {
+            dataListenerSlot.captured.onData(Pair("{}", 0))
+            dataListenerSlot.captured.onData(Pair("{\"test_key\": \"test_value\"}", 1))
+            dataListenerSlot.captured.onComplete()
+        }
+        diagnosticsFileHelper.readDiagnosticsFile(dataListener, maxLines)
+        verify(exactly = 1) { fileHelper.readFilePerLines(diagnosticsFilePath, any(), maxLines) }
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
@@ -101,7 +101,9 @@ class DiagnosticsSynchronizerTest {
 
         diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
 
-        verify(exactly = 1) { diagnosticsFileHelper.readDiagnosticsFile(any()) }
+        verify(exactly = 1) {
+            diagnosticsFileHelper.readDiagnosticsFile(any(), DiagnosticsSynchronizer.MAX_EVENTS_TO_SYNC_PER_REQUEST)
+        }
         verify(exactly = 0) { backend.postDiagnostics(any(), any(), any()) }
     }
 
@@ -111,7 +113,9 @@ class DiagnosticsSynchronizerTest {
 
         diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
 
-        verify(exactly = 1) { diagnosticsFileHelper.readDiagnosticsFile(any()) }
+        verify(exactly = 1) {
+            diagnosticsFileHelper.readDiagnosticsFile(any(), DiagnosticsSynchronizer.MAX_EVENTS_TO_SYNC_PER_REQUEST)
+        }
         verify(exactly = 1) { backend.postDiagnostics(testDiagnosticsEntryJSONs, any(), any()) }
     }
 
@@ -278,7 +282,12 @@ class DiagnosticsSynchronizerTest {
 
     private fun mockReadDiagnosticsFile(jsons: List<JSONObject>) {
         val slot = slot<DataListener<JSONObject>>()
-        every { diagnosticsFileHelper.readDiagnosticsFile(capture(slot)) } answers {
+        every {
+            diagnosticsFileHelper.readDiagnosticsFile(
+                capture(slot),
+                DiagnosticsSynchronizer.MAX_EVENTS_TO_SYNC_PER_REQUEST,
+            )
+        } answers {
             jsons.forEach { slot.captured.onData(it) }
             slot.captured.onComplete()
         }


### PR DESCRIPTION
### Description
This is a followup to #1194 

In this PR, we add a limit to how many diagnostics entries to sync per request. It also prevents loading the whole diagnostics file in memory at any point in time.
