### PR TITLE
DENG-494: Fix offering metadata not fulling expanding

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JSONArrayExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JSONArrayExtensions.kt
@@ -8,7 +8,7 @@ internal fun <T> JSONArray.toList(): List<T>? {
 
     for (i in 0 until this.length()) {
         val value = when (val rawValue = this.get(i)) {
-            is JSONObject -> rawValue.toMap<T>()
+            is JSONObject -> rawValue.toMap<T>(deep = true)
             is JSONArray -> rawValue.toList<T>()
             else -> rawValue
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JSONObjectExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JSONObjectExtensions.kt
@@ -16,7 +16,7 @@ internal fun <T> JSONObject.toMap(deep: Boolean = false): Map<String, T>? {
     return this.keys()?.asSequence()?.map { jsonKey ->
         if (deep) {
             val value = when (val rawValue = this[jsonKey]) {
-                is JSONObject -> rawValue.toMap<T>()
+                is JSONObject -> rawValue.toMap<T>(deep = true)
                 is JSONArray -> rawValue.toList<T>()
                 else -> rawValue
             }

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
@@ -240,7 +240,10 @@ class OfferingsTest {
             "string" to "five",
             "array" to listOf("five"),
             "dictionary" to mapOf(
-                "string" to "five"
+                "string" to "five",
+                "more_dictionary" to mapOf(
+                    "map" to "deep"
+                ),
             )
         )
         val offeringJSON = getOfferingJSON(

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
@@ -238,7 +238,12 @@ class OfferingsTest {
             "double" to 5.5,
             "boolean" to true,
             "string" to "five",
-            "array" to listOf("five"),
+            "array" to listOf(
+                "five",
+                mapOf(
+                    "map" to "deep"
+                ),
+            ),
             "dictionary" to mapOf(
                 "string" to "five",
                 "more_dictionary" to mapOf(

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/JSONArrayExtensionsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/JSONArrayExtensionsTest.kt
@@ -11,12 +11,18 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 class JSONArrayExtensionsTest {
-    val fromList = listOf(
+    private val fromList = listOf(
         5,
         5.5,
         true,
         "five",
-        listOf("six", "seven"),
+        listOf(
+            "six",
+            "seven",
+            mapOf(
+                "map" to "deep"
+            ),
+        ),
         mapOf(
             "string" to "five",
             "more_dictionary" to mapOf(
@@ -37,7 +43,13 @@ class JSONArrayExtensionsTest {
         assertThat(toList[3]).isEqualTo("five")
 
         assertThat(toList[4]).isEqualTo(
-            listOf("six", "seven")
+            listOf(
+                "six",
+                "seven",
+                mapOf(
+                    "map" to "deep"
+                ),
+            )
         )
         assertThat(toList[5]).isEqualTo(
             mapOf(

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/JSONArrayExtensionsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/JSONArrayExtensionsTest.kt
@@ -17,7 +17,12 @@ class JSONArrayExtensionsTest {
         true,
         "five",
         listOf("six", "seven"),
-        mapOf("string" to "five")
+        mapOf(
+            "string" to "five",
+            "more_dictionary" to mapOf(
+                "map" to "deep"
+            ),
+        )
     )
 
     @Test
@@ -35,7 +40,12 @@ class JSONArrayExtensionsTest {
             listOf("six", "seven")
         )
         assertThat(toList[5]).isEqualTo(
-            mapOf("string" to "five")
+            mapOf(
+                "string" to "five",
+                "more_dictionary" to mapOf(
+                    "map" to "deep"
+                ),
+            )
         )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/JSONObjectExtensionsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/JSONObjectExtensionsTest.kt
@@ -18,7 +18,10 @@ class JSONObjectExtensionsTest {
         "string" to "five",
         "array" to listOf("five"),
         "dictionary" to mapOf(
-            "string" to "five"
+            "string" to "five",
+            "more_dictionary" to mapOf(
+                "map" to "deep"
+            )
         )
     )
 
@@ -52,7 +55,12 @@ class JSONObjectExtensionsTest {
             listOf("five")
         )
         assertThat(toMap["dictionary"]).isEqualTo(
-            mapOf("string" to "five")
+            mapOf(
+                "string" to "five",
+                "more_dictionary" to mapOf(
+                    "map" to "deep",
+                ),
+            ),
         )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/JSONObjectExtensionsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/JSONObjectExtensionsTest.kt
@@ -11,12 +11,17 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 class JSONObjectExtensionsTest {
-    val fromMap = mapOf(
+    private val fromMap = mapOf(
         "int" to 5,
         "double" to 5.5,
         "boolean" to true,
         "string" to "five",
-        "array" to listOf("five"),
+        "array" to listOf(
+            "five",
+            mapOf(
+                "map" to "deep"
+            ),
+        ),
         "dictionary" to mapOf(
             "string" to "five",
             "more_dictionary" to mapOf(
@@ -52,7 +57,12 @@ class JSONObjectExtensionsTest {
         assertThat(toMap["string"]).isEqualTo("five")
 
         assertThat(toMap["array"]).isEqualTo(
-            listOf("five")
+            listOf(
+                "five",
+                mapOf(
+                    "map" to "deep"
+                ),
+            )
         )
         assertThat(toMap["dictionary"]).isEqualTo(
             mapOf(


### PR DESCRIPTION
### Motivation

Fixes [DENG-494](https://linear.app/revenuecat/issue/DENG-494/offering-metadata-not-being-set-properly-with-nested-information)

Metadata not fully expanding on native Android and hybrids.

### Description

- Added `.toMap(deep=true)` within `JSONObject.toMap()` to keep expanding nested objects
- Added `.toMap(deep=true)` within `JSONArray.toList()` to keep expanding nested objects
- More and deeper nested tests for `JSONObject`, `JSONArray`, and offering
