### PR TITLE
Use real debug view dependencies in magic weather compose

### DIFF
--- a/examples/MagicWeatherCompose/app/build.gradle
+++ b/examples/MagicWeatherCompose/app/build.gradle
@@ -78,5 +78,6 @@ dependencies {
     debugImplementation libs.compose.ui.test.manifest
     implementation libs.revenuecat
     implementation libs.revenuecat.amazon
-    implementation libs.revenuecat.debugview
+    debugImplementation libs.revenuecat.debugview
+    releaseImplementation libs.revenuecat.debugview.noop
 }

--- a/examples/MagicWeatherCompose/gradle/libs.versions.toml
+++ b/examples/MagicWeatherCompose/gradle/libs.versions.toml
@@ -35,4 +35,5 @@ compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 
 revenuecat = { module = "com.revenuecat.purchases:purchases", version.ref = "purchases" }
 revenuecat-amazon = { module = "com.revenuecat.purchases:purchases-store-amazon", version.ref = "purchases" }
-revenuecat-debugview = { module = "com.revenuecat.purchases:debugview", version.ref = "purchases" }
+revenuecat-debugview = { module = "com.revenuecat.purchases:purchases-debug-view", version.ref = "purchases" }
+revenuecat-debugview-noop = { module = "com.revenuecat.purchases:purchases-debug-view-noop", version.ref = "purchases" }

--- a/examples/MagicWeatherCompose/settings.gradle
+++ b/examples/MagicWeatherCompose/settings.gradle
@@ -18,8 +18,14 @@ rootProject.name = "MagicWeatherCompose"
 include ':app'
 
 // Uncomment to use local version of the SDK
-includeBuild("../../") {
-    dependencySubstitution {
-        substitute module("com.revenuecat.purchases:debugview") using project(":ui:debugview")
-    }
-}
+//includeBuild("../../") {
+//    dependencySubstitution {
+//        substitute module("com.revenuecat.purchases:purchases") using project(":purchases")
+//    }
+//    dependencySubstitution {
+//        substitute module("com.revenuecat.purchases:purchases-debug-view") using project(":ui:debugview")
+//    }
+//    dependencySubstitution {
+//        substitute module("com.revenuecat.purchases:purchases-debug-view-noop") using project(":ui:debugview")
+//    }
+//}


### PR DESCRIPTION
### Description
This changes magic weather compose to use the real debug view dependencies instead of pointing to the local version by default.