### PR TITLE
Optimize SDK initialization when requests executed before any activity starts

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBackend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBackend.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.amazon
 
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.BackendHelper
+import com.revenuecat.purchases.common.Delay
 import com.revenuecat.purchases.common.networking.Endpoint
 import org.json.JSONObject
 
@@ -34,6 +35,7 @@ internal class AmazonBackend(
                 Endpoint.GetAmazonReceipt(storeUserID, receiptId),
                 body = null,
                 postFieldsToSign = null,
+                delay = Delay.NONE,
                 { error ->
                     synchronized(this@AmazonBackend) {
                         postAmazonReceiptCallbacks.remove(cacheKey)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -523,17 +523,18 @@ internal class Backend(
         val foregroundCacheKey = cacheKey.copy(appInBackground = false)
         val foregroundCallAlreadyInPlace = containsKey(foregroundCacheKey)
         val cacheKeyToUse = if (cacheKey.appInBackground && foregroundCallAlreadyInPlace) {
+            warnLog(NetworkStrings.SAME_CALL_SCHEDULED_WITHOUT_JITTER.format(foregroundCacheKey))
             foregroundCacheKey
         } else {
             cacheKey
         }
         addCallback(call, dispatcher, cacheKeyToUse, functions, delay)
         // In case we have a request with a jittered delay queued, and we perform the same request without
-        // delay, we want to call the callback using the unjittered request
+        // jittered delay, we want to call the callback using the unjittered request
         val backgroundedCacheKey = cacheKey.copy(appInBackground = true)
         val backgroundCallAlreadyInPlace = containsKey(foregroundCacheKey)
         if (!cacheKey.appInBackground && backgroundCallAlreadyInPlace) {
-            warnLog(NetworkStrings.SAME_CALL_SCHEDULED_FOR_THE_FUTURE.format(cacheKey))
+            warnLog(NetworkStrings.SAME_CALL_SCHEDULED_WITH_JITTER.format(foregroundCacheKey))
             remove(backgroundedCacheKey)?.takeIf { it.isNotEmpty() }?.let { backgroundedCallbacks ->
                 if (containsKey(cacheKey)) {
                     this[cacheKey]?.addAll(backgroundedCallbacks)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BackendHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BackendHelper.kt
@@ -14,10 +14,12 @@ internal class BackendHelper(
 ) {
     internal val authenticationHeaders = mapOf("Authorization" to "Bearer ${this.apiKey}")
 
+    @Suppress("LongParameterList")
     fun performRequest(
         endpoint: Endpoint,
         body: Map<String, Any?>?,
         postFieldsToSign: List<Pair<String, String>>?,
+        delay: Delay,
         onError: (PurchasesError) -> Unit,
         onCompleted: (PurchasesError?, Int, JSONObject) -> Unit,
     ) {
@@ -47,6 +49,7 @@ internal class BackendHelper(
                 }
             },
             dispatcher,
+            delay,
         )
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -61,11 +61,12 @@ internal class OfferingsManager(
         onError: ((PurchasesError) -> Unit)? = null,
         onSuccess: ((Offerings) -> Unit)? = null,
     ) {
-        offeringsCache.setOfferingsCacheTimestampToNow()
         backend.getOfferings(
             appUserID,
             appInBackground,
-            { createAndCacheOfferings(it, onError, onSuccess) },
+            {
+                createAndCacheOfferings(it, onError, onSuccess)
+            },
             { backendError, isServerError ->
                 if (isServerError) {
                     val cachedOfferingsResponse = offeringsCache.cachedOfferingsResponse
@@ -94,6 +95,7 @@ internal class OfferingsManager(
             },
             onSuccess = { offerings ->
                 offeringsCache.cacheOfferings(offerings, offeringsJSON)
+                offeringsCache.setOfferingsCacheTimestampToNow()
                 dispatch {
                     onSuccess?.invoke(offerings)
                 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/NetworkStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/NetworkStrings.kt
@@ -8,6 +8,8 @@ internal object NetworkStrings {
         "Retrying call with a new ETag"
     const val ETAG_CALL_ALREADY_RETRIED = "We can't find the cached response, but call has already been retried. " +
         "Returning result from backend: %s"
+    const val SAME_CALL_SCHEDULED_FOR_THE_FUTURE = "Same call already scheduled with jitter delay, adding existing " +
+        "callbacks to unjittered request with key: %s"
     const val SAME_CALL_ALREADY_IN_PROGRESS = "Same call already in progress, adding to callbacks map with key: %s"
     const val PROBLEM_CONNECTING = "Unable to start a network connection due to a network configuration issue: %s"
     const val VERIFICATION_MISSING_SIGNATURE = "Verification: Request to '%s' requires a signature but none provided."

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/NetworkStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/NetworkStrings.kt
@@ -8,7 +8,9 @@ internal object NetworkStrings {
         "Retrying call with a new ETag"
     const val ETAG_CALL_ALREADY_RETRIED = "We can't find the cached response, but call has already been retried. " +
         "Returning result from backend: %s"
-    const val SAME_CALL_SCHEDULED_FOR_THE_FUTURE = "Same call already scheduled with jitter delay, adding existing " +
+    const val SAME_CALL_SCHEDULED_WITHOUT_JITTER = "Request already scheduled without jitter delay, adding " +
+        "callbacks to unjittered request with key: %s"
+    const val SAME_CALL_SCHEDULED_WITH_JITTER = "Request already scheduled with jitter delay, adding existing " +
         "callbacks to unjittered request with key: %s"
     const val SAME_CALL_ALREADY_IN_PROGRESS = "Same call already in progress, adding to callbacks map with key: %s"
     const val PROBLEM_CONNECTING = "Unable to start a network connection due to a network configuration issue: %s"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesPoster.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesPoster.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.subscriberattributes
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.BackendHelper
+import com.revenuecat.purchases.common.Delay
 import com.revenuecat.purchases.common.SubscriberAttributeError
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
@@ -25,6 +26,7 @@ internal class SubscriberAttributesPoster(
             Endpoint.PostAttributes(appUserID),
             mapOf("attributes" to attributes),
             postFieldsToSign = null,
+            delay = Delay.DEFAULT,
             { error ->
                 onErrorHandler(error, false, emptyList())
             },


### PR DESCRIPTION
### Description
We discovered that the SDK might take a while to respond to offerings/customer info operations if they are started before any `Activity` has had the chance to start. This is because the SDK considers the app to be in the background, and we have some optimizations in place where we add some jittering to backend requests performed in the background

The approach in this PR is to make it so:
- If a request without a jitter delay is started after a request with jitter (but before it's completed), we move the callbacks to use the response from the request without jittering.
- If a request with jittering is started after a request without jitter (but before it's completed), we will not add the request with jitter but just reuse the existing request without jittering.

Note that with this approach, we might be duplicating requests in these situations... But I think it should be ok, lmk if you think otherwise
