### PR TITLE
Unify caching offerings and updating update timestamp

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
@@ -26,6 +26,7 @@ internal class OfferingsCache(
     fun cacheOfferings(offerings: Offerings, offeringsResponse: JSONObject) {
         offeringsCachedObject.cacheInstance(offerings)
         deviceCache.cacheOfferingsResponse(offeringsResponse)
+        offeringsCachedObject.updateCacheTimestamp(dateProvider.now)
     }
 
     // region Offerings cache
@@ -42,11 +43,6 @@ internal class OfferingsCache(
     @Synchronized
     fun clearOfferingsCacheTimestamp() {
         offeringsCachedObject.clearCacheTimestamp()
-    }
-
-    @Synchronized
-    fun setOfferingsCacheTimestampToNow() {
-        offeringsCachedObject.updateCacheTimestamp(dateProvider.now)
     }
 
     // endregion Offerings cache

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -95,7 +95,6 @@ internal class OfferingsManager(
             },
             onSuccess = { offerings ->
                 offeringsCache.cacheOfferings(offerings, offeringsJSON)
-                offeringsCache.setOfferingsCacheTimestampToNow()
                 dispatch {
                     onSuccess?.invoke(offerings)
                 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -407,62 +407,6 @@ class OfferingsManagerTest {
         verify(exactly = 1) { cache.clearOfferingsCacheTimestamp() }
     }
 
-    @Test
-    fun `getOfferings marks offerings cache timestamp upon success`() {
-        every {
-            cache.cachedOfferings
-        } returns null
-        every {
-            cache.cacheOfferings(any(), any())
-        } just Runs
-        mockDeviceCache()
-        val (_, offerings) = stubOfferings(productId)
-        mockOfferingsFactory(offerings)
-
-        var offeringsReceived = false
-        offeringsManager.getOfferings(
-            appUserId,
-            appInBackground = false,
-            onError = { Assert.fail("should be a success") },
-            onSuccess = { offeringsReceived = true }
-        )
-
-        verify(exactly = 1) {
-            cache.setOfferingsCacheTimestampToNow()
-        }
-        assertThat(offeringsReceived).isTrue
-    }
-
-    @Test
-    fun `getOfferings does not mark offerings cache timestamp upon error`() {
-        every {
-            cache.cachedOfferings
-        } returns null
-        every {
-            cache.cacheOfferings(any(), any())
-        } just Runs
-        mockDeviceCache()
-        val (_, offerings) = stubOfferings(productId)
-        mockOfferingsFactory(offerings)
-
-        val expectedError = PurchasesError(PurchasesErrorCode.NetworkError)
-        mockBackendResponseError(error = expectedError, isServerError = false)
-        every { cache.clearOfferingsCacheTimestamp() } just Runs
-
-        var errorReceived = false
-        offeringsManager.getOfferings(
-            appUserId,
-            appInBackground = false,
-            onError = { errorReceived = true },
-            onSuccess = { Assert.fail("should be an error") }
-        )
-
-        verify(exactly = 0) {
-            cache.setOfferingsCacheTimestampToNow()
-        }
-        assertThat(errorReceived).isTrue
-    }
-
     // endregion getOfferings
 
     // region helpers
@@ -515,7 +459,6 @@ class OfferingsManagerTest {
     }
 
     private fun mockDeviceCache(wasSuccessful: Boolean = true) {
-        every { cache.setOfferingsCacheTimestampToNow() } just Runs
         if (wasSuccessful) {
             every { cache.cacheOfferings(any(), any()) } just Runs
         } else {


### PR DESCRIPTION
### Description
Unifies caching offerings and updating the offerings cache timestamp to simplify things, as suggested in https://github.com/RevenueCat/purchases-android/pull/1204#discussion_r1303095501