### PR TITLE
Send `initiation_source` in post receipt requests

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostPendingTransactionsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostPendingTransactionsHelper.kt
@@ -77,6 +77,7 @@ internal class PostPendingTransactionsHelper(
                 transactionsToSync,
                 allowSharingPlayStoreAccount,
                 appUserID,
+                PostReceiptInitiationSource.QUEUE,
                 transactionPostSuccess = { _, customerInfo ->
                     results.add(Result.Success(customerInfo))
                     callCompletionFromResults(transactionsToSync, results, onError, onSuccess)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -38,6 +38,7 @@ internal class PostReceiptHelper(
         isRestore: Boolean,
         appUserID: String,
         marketplace: String?,
+        initiationSource: PostReceiptInitiationSource,
         onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -48,6 +49,7 @@ internal class PostReceiptHelper(
             receiptInfo,
             storeUserID,
             marketplace,
+            initiationSource,
             onSuccess = {
                 deviceCache.addSuccessfullyPostedToken(purchaseToken)
                 onSuccess(it)
@@ -79,6 +81,7 @@ internal class PostReceiptHelper(
         storeProduct: StoreProduct?,
         isRestore: Boolean,
         appUserID: String,
+        initiationSource: PostReceiptInitiationSource,
         onSuccess: (SuccessfulPurchaseCallback)? = null,
         onError: (ErrorPurchaseCallback)? = null,
     ) {
@@ -96,6 +99,7 @@ internal class PostReceiptHelper(
             receiptInfo = receiptInfo,
             storeUserID = purchase.storeUserID,
             marketplace = purchase.marketplace,
+            initiationSource = initiationSource,
             onSuccess = { info ->
                 billing.consumeAndSave(finishTransactions, purchase)
                 onSuccess?.let { it(purchase, info) }
@@ -125,6 +129,7 @@ internal class PostReceiptHelper(
         receiptInfo: ReceiptInfo,
         storeUserID: String?,
         marketplace: String?,
+        initiationSource: PostReceiptInitiationSource,
         onSuccess: (CustomerInfo) -> Unit,
         onError: PostReceiptDataErrorCallback,
     ) {
@@ -138,6 +143,7 @@ internal class PostReceiptHelper(
                 receiptInfo = receiptInfo,
                 storeAppUserID = storeUserID,
                 marketplace = marketplace,
+                initiationSource = initiationSource,
                 onSuccess = { customerInfo, responseBody ->
                     offlineEntitlementsManager.resetOfflineCustomerInfoCache()
                     subscriberAttributesManager.markAsSynced(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptInitiationSource.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptInitiationSource.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.purchases
+
+internal enum class PostReceiptInitiationSource {
+    RESTORE,
+    PURCHASE,
+    QUEUE,
+    ;
+
+    val postReceiptFieldValue: String
+        get() = when (this) {
+            RESTORE -> "restore"
+            PURCHASE -> "purchase"
+            QUEUE -> "queue"
+        }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostTransactionWithProductDetailsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostTransactionWithProductDetailsHelper.kt
@@ -16,10 +16,12 @@ internal class PostTransactionWithProductDetailsHelper(
     /**
      * The callbacks in this method are called for each transaction in the list.
      */
+    @Suppress("LongParameterList")
     fun postTransactions(
         transactions: List<StoreTransaction>,
         allowSharingPlayStoreAccount: Boolean,
         appUserID: String,
+        initiationSource: PostReceiptInitiationSource,
         transactionPostSuccess: (SuccessfulPurchaseCallback)? = null,
         transactionPostError: (ErrorPurchaseCallback)? = null,
     ) {
@@ -46,6 +48,7 @@ internal class PostTransactionWithProductDetailsHelper(
                             storeProduct = purchasedStoreProduct,
                             isRestore = allowSharingPlayStoreAccount,
                             appUserID = appUserID,
+                            initiationSource = initiationSource,
                             onSuccess = transactionPostSuccess,
                             onError = transactionPostError,
                         )
@@ -56,6 +59,7 @@ internal class PostTransactionWithProductDetailsHelper(
                             storeProduct = null,
                             isRestore = allowSharingPlayStoreAccount,
                             appUserID = appUserID,
+                            initiationSource = initiationSource,
                             onSuccess = transactionPostSuccess,
                             onError = transactionPostError,
                         )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -234,6 +234,7 @@ internal class PurchasesOrchestrator constructor(
                     this.allowSharingPlayStoreAccount,
                     appUserID,
                     marketplace = null,
+                    PostReceiptInitiationSource.RESTORE,
                     {
                         val logMessage = PurchaseStrings.PURCHASE_SYNCED_USER_ID.format(receiptID, amazonUserID)
                         log(LogIntent.PURCHASE, logMessage)
@@ -339,6 +340,7 @@ internal class PurchasesOrchestrator constructor(
                                 storeProduct = null,
                                 isRestore = true,
                                 appUserID = appUserID,
+                                initiationSource = PostReceiptInitiationSource.RESTORE,
                                 onSuccess = { _, info ->
                                     log(LogIntent.DEBUG, RestoreStrings.PURCHASE_RESTORED.format(purchase))
                                     if (sortedByTime.last() == purchase) {
@@ -779,6 +781,7 @@ internal class PurchasesOrchestrator constructor(
                     purchases,
                     allowSharingPlayStoreAccount,
                     appUserID,
+                    PostReceiptInitiationSource.PURCHASE,
                     transactionPostSuccess = callbackPair.first,
                     transactionPostError = callbackPair.second,
                 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
@@ -53,6 +53,7 @@ internal class SyncPurchasesHelper(
                             isRestore,
                             appUserID,
                             purchase.marketplace,
+                            PostReceiptInitiationSource.RESTORE,
                             {
                                 log(LogIntent.PURCHASE, PurchaseStrings.PURCHASE_SYNCED.format(purchase))
                                 handleLastPurchase(purchase, lastPurchase)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -6,6 +6,7 @@
 package com.revenuecat.purchases.common
 
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.networking.Endpoint
@@ -176,6 +177,7 @@ internal class Backend(
         storeAppUserID: String?,
         @SuppressWarnings("UnusedPrivateMember")
         marketplace: String? = null,
+        initiationSource: PostReceiptInitiationSource,
         onSuccess: PostReceiptDataSuccessCallback,
         onError: PostReceiptDataErrorCallback,
     ) {
@@ -204,6 +206,7 @@ internal class Backend(
             "store_user_id" to storeAppUserID,
             "pricing_phases" to receiptInfo.pricingPhases?.map { it.toMap() },
             "proration_mode" to receiptInfo.prorationMode?.name,
+            "initiation_source" to initiationSource.postReceiptFieldValue,
         ).filterNotNullValues()
 
         val postFieldsToSign = listOf(

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -169,7 +169,7 @@ internal open class BasePurchasesTest {
     private fun mockPostReceiptHelper() {
         with(mockPostReceiptHelper) {
             every {
-                postTransactionAndConsumeIfNeeded(any(), any(), any(), any(), captureLambda(), any())
+                postTransactionAndConsumeIfNeeded(any(), any(), any(), any(), any(), captureLambda(), any())
             } answers {
                 lambda<SuccessfulPurchaseCallback>().captured.invoke(
                     firstArg(),
@@ -177,7 +177,7 @@ internal open class BasePurchasesTest {
                 )
             }
             every {
-                postTokenWithoutConsuming(any(), any(), any(), any(), any(), any(), captureLambda(), any())
+                postTokenWithoutConsuming(any(), any(), any(), any(), any(), any(), any(), captureLambda(), any())
             } answers {
                 lambda<(CustomerInfo) -> Unit>().captured.invoke(mockInfo)
             }

--- a/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
@@ -29,6 +29,7 @@ class PostPendingTransactionsHelperTest {
 
     private val allowSharingPlayStoreAccount = true
     private val appUserId = "test-app-user-id"
+    private val initiationSource = PostReceiptInitiationSource.QUEUE
 
     private lateinit var appConfig: AppConfig
     private lateinit var deviceCache: DeviceCache
@@ -73,7 +74,7 @@ class PostPendingTransactionsHelperTest {
             billing.queryPurchases(any(), any(), any())
         }
         verify(exactly = 0) {
-            postTransactionWithProductDetailsHelper.postTransactions(any(), any(), any(), any(), any())
+            postTransactionWithProductDetailsHelper.postTransactions(any(), any(), any(), any(), any(), any())
         }
     }
 
@@ -121,6 +122,7 @@ class PostPendingTransactionsHelperTest {
                 listOf(activePurchase),
                 allowSharingPlayStoreAccount,
                 appUserId,
+                initiationSource,
                 any(),
                 any()
             )
@@ -178,7 +180,7 @@ class PostPendingTransactionsHelperTest {
         syncAndAssertSuccessful(null)
 
         verify(exactly = 0) {
-            postTransactionWithProductDetailsHelper.postTransactions(any(), any(), any(), any(), any())
+            postTransactionWithProductDetailsHelper.postTransactions(any(), any(), any(), any(), any(), any())
         }
     }
 
@@ -195,7 +197,7 @@ class PostPendingTransactionsHelperTest {
 
         verify(exactly = 0) { deviceCache.cleanPreviouslySentTokens(any()) }
         verify(exactly = 0) {
-            postTransactionWithProductDetailsHelper.postTransactions(any(), any(), any(), any(), any())
+            postTransactionWithProductDetailsHelper.postTransactions(any(), any(), any(), any(), any(), any())
         }
     }
 
@@ -242,6 +244,7 @@ class PostPendingTransactionsHelperTest {
                 allPurchases,
                 allowSharingPlayStoreAccount,
                 appUserId,
+                initiationSource,
                 captureLambda(),
                 any()
             )
@@ -291,6 +294,7 @@ class PostPendingTransactionsHelperTest {
                 allPurchases,
                 allowSharingPlayStoreAccount,
                 appUserId,
+                initiationSource,
                 capture(successSlot),
                 capture(errorSlot)
             )
@@ -314,6 +318,7 @@ class PostPendingTransactionsHelperTest {
                 transactions ?: any(),
                 allowSharingPlayStoreAccount,
                 appUserId,
+                initiationSource,
                 captureLambda(),
                 any()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -49,6 +49,7 @@ class PostReceiptHelperTest {
     private val subscriptionOptionId = "mock-base-plan-id:mock-offer-id"
     private val postToken = "test-post-token"
     private val storeUserId = "test-store-user-id"
+    private val initiationSource = PostReceiptInitiationSource.PURCHASE
     private val marketplace = "test-marketplace"
     private val mockStoreTransaction = mockGooglePurchase.toStoreTransaction(
         ProductType.SUBS,
@@ -122,6 +123,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = allowSharingPlayStoreAccount,
             appUserID = appUserID,
+            initiationSource = PostReceiptInitiationSource.PURCHASE,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -143,6 +145,7 @@ class PostReceiptHelperTest {
                 receiptInfo = expectedReceiptInfo,
                 storeAppUserID = mockStoreTransaction.storeUserID,
                 marketplace = mockStoreTransaction.marketplace,
+                initiationSource = PostReceiptInitiationSource.PURCHASE,
                 onSuccess = any(),
                 onError = any()
             )
@@ -159,6 +162,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -173,6 +177,7 @@ class PostReceiptHelperTest {
                 receiptInfo = any(),
                 storeAppUserID = any(),
                 marketplace = any(),
+                initiationSource = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -189,6 +194,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -211,6 +217,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -232,6 +239,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -253,6 +261,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -273,6 +282,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { transaction, customerInfo ->
                 successTransaction = transaction
                 successCustomerInfo = customerInfo
@@ -294,6 +304,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -317,6 +328,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -340,6 +352,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -359,6 +372,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -377,6 +391,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -397,6 +412,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { transaction, error ->
                 errorTransaction = transaction
@@ -419,6 +435,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -437,6 +454,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -456,6 +474,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -485,6 +504,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, customerInfo -> receivedCustomerInfo = customerInfo },
             onError = { _, _ -> fail("Expected success") }
         )
@@ -511,6 +531,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->  },
             onError = { _, _ -> fail("Expected success") }
         )
@@ -537,6 +558,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->  },
             onError = { _, _ -> fail("Expected success") }
         )
@@ -564,6 +586,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->  },
             onError = { _, _ -> fail("Expected success") }
         )
@@ -582,6 +605,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -598,6 +622,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -614,6 +639,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -631,6 +657,7 @@ class PostReceiptHelperTest {
             storeProduct = mockInAppProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -647,6 +674,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -671,6 +699,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -687,6 +716,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -703,6 +733,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -724,6 +755,7 @@ class PostReceiptHelperTest {
             storeProduct = mockStoreProduct,
             isRestore = true,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -743,7 +775,10 @@ class PostReceiptHelperTest {
 
     @Test
     fun `postTokenWithoutConsuming posts with expected default parameters`() {
-        mockPostReceiptSuccess(postType = PostType.TOKEN_WITHOUT_CONSUMING)
+        mockPostReceiptSuccess(
+            postType = PostType.TOKEN_WITHOUT_CONSUMING,
+            postReceiptInitiationSource = PostReceiptInitiationSource.RESTORE,
+        )
 
         val allowSharingPlayStoreAccount = true
 
@@ -754,6 +789,7 @@ class PostReceiptHelperTest {
             isRestore = allowSharingPlayStoreAccount,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = PostReceiptInitiationSource.RESTORE,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -768,6 +804,7 @@ class PostReceiptHelperTest {
                 receiptInfo = testReceiptInfo,
                 storeAppUserID = storeUserId,
                 marketplace = marketplace,
+                initiationSource = PostReceiptInitiationSource.RESTORE,
                 onSuccess = any(),
                 onError = any()
             )
@@ -786,6 +823,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = PostReceiptInitiationSource.PURCHASE,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -800,6 +838,7 @@ class PostReceiptHelperTest {
                 receiptInfo = any(),
                 storeAppUserID = any(),
                 marketplace = any(),
+                initiationSource = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -818,6 +857,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -842,6 +882,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -863,6 +904,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should succeed") }
         )
@@ -884,6 +926,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -905,6 +948,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { successCalledCount++ },
             onError = { fail("Should succeed") }
         )
@@ -927,6 +971,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { fail("Should fail") },
             onError = { }
         )
@@ -955,6 +1000,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { fail("Should fail") },
             onError = { }
         )
@@ -982,6 +1028,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { fail("Should fail") },
             onError = { }
         )
@@ -1005,6 +1052,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { fail("Should fail") },
             onError = { }
         )
@@ -1029,6 +1077,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { fail("Should fail") },
             onError = { purchasesError = it }
         )
@@ -1047,6 +1096,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -1070,6 +1120,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { fail("Should fail") },
             onError = { }
         )
@@ -1092,6 +1143,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -1115,6 +1167,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { fail("Expected error") },
             onError = { }
         )
@@ -1139,6 +1192,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { fail("Expected error") },
             onError = { }
         )
@@ -1173,6 +1227,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { successCallCount++ },
             onError = { fail("Should succeed") }
         )
@@ -1204,6 +1259,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -1235,6 +1291,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -1267,6 +1324,7 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -1296,7 +1354,8 @@ class PostReceiptHelperTest {
     private fun mockPostReceiptSuccess(
         customerInfo: CustomerInfo = defaultCustomerInfo,
         jsonBody: JSONObject = JSONObject(Responses.validFullPurchaserResponse),
-        postType: PostType = PostType.TRANSACTION_AND_CONSUME
+        postType: PostType = PostType.TRANSACTION_AND_CONSUME,
+        postReceiptInitiationSource: PostReceiptInitiationSource = initiationSource,
     ) {
         every {
             backend.postReceiptData(
@@ -1308,6 +1367,7 @@ class PostReceiptHelperTest {
                 receiptInfo = capture(postedReceiptInfoSlot),
                 storeAppUserID = any(),
                 marketplace = any(),
+                initiationSource = postReceiptInitiationSource,
                 onSuccess = captureLambda(),
                 onError = any()
             )
@@ -1339,6 +1399,7 @@ class PostReceiptHelperTest {
                 receiptInfo = capture(postedReceiptInfoSlot),
                 storeAppUserID = any(),
                 marketplace = any(),
+                initiationSource = initiationSource,
                 onSuccess = any(),
                 onError = captureLambda()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptInitiationSourceTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptInitiationSourceTest.kt
@@ -1,0 +1,17 @@
+package com.revenuecat.purchases
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PostReceiptInitiationSourceTest {
+
+    @Test
+    fun `initiation source have correct postReceiptFieldValue`() {
+        assertThat(PostReceiptInitiationSource.PURCHASE.postReceiptFieldValue).isEqualTo("purchase")
+        assertThat(PostReceiptInitiationSource.RESTORE.postReceiptFieldValue).isEqualTo("restore")
+        assertThat(PostReceiptInitiationSource.QUEUE.postReceiptFieldValue).isEqualTo("queue")
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/PostTransactionWithProductDetailsHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostTransactionWithProductDetailsHelperTest.kt
@@ -25,6 +25,7 @@ class PostTransactionWithProductDetailsHelperTest {
     private val appUserID = "appUserID"
     private val productID = "productID"
     private val subscriptionOptionId = "monthly_base_plan"
+    private val initiationSource = PostReceiptInitiationSource.PURCHASE
     private val mockStoreProduct = stubStoreProduct(productID)
 
     private val mockSubsTransaction = createTransaction(ProductType.SUBS)
@@ -51,7 +52,8 @@ class PostTransactionWithProductDetailsHelperTest {
         postTransactionWithProductDetailsHelper.postTransactions(
             transactions = emptyList(),
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
-            appUserID = "appUserID",
+            appUserID = appUserID,
+            initiationSource = initiationSource,
             transactionPostSuccess = { _, _ -> fail("Should not be called") },
             transactionPostError = { _, _ -> fail("Should not be called") },
         )
@@ -66,7 +68,8 @@ class PostTransactionWithProductDetailsHelperTest {
         postTransactionWithProductDetailsHelper.postTransactions(
             transactions = transactions,
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
-            appUserID = "appUserID",
+            appUserID = appUserID,
+            initiationSource = initiationSource,
             transactionPostSuccess = { _, _ -> fail("Should not be called") },
             transactionPostError = { _, error -> receivedError = error },
         )
@@ -86,6 +89,7 @@ class PostTransactionWithProductDetailsHelperTest {
             transactions = transactions,
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             transactionPostSuccess = { _, _ -> fail("Should not be called") },
             transactionPostError = { _, _ -> errorCallCount++ },
         )
@@ -93,7 +97,7 @@ class PostTransactionWithProductDetailsHelperTest {
         assertThat(errorCallCount).isEqualTo(1)
         verify(exactly = 0) {
             postReceiptHelper.postTransactionAndConsumeIfNeeded(
-                any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
             )
         }
     }
@@ -107,6 +111,7 @@ class PostTransactionWithProductDetailsHelperTest {
             transactions = listOf(mockSubsTransaction),
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             transactionPostSuccess = { _, _ ->  },
             transactionPostError = { _, _ -> fail("Should be success") },
         )
@@ -117,6 +122,7 @@ class PostTransactionWithProductDetailsHelperTest {
                 null,
                 allowSharingPlayStoreAccount,
                 appUserID,
+                initiationSource,
                 any(),
                 any(),
             )
@@ -132,6 +138,7 @@ class PostTransactionWithProductDetailsHelperTest {
             transactions = listOf(mockInAppTransaction),
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             transactionPostSuccess = { _, _ ->  },
             transactionPostError = { _, _ -> fail("Should be success") },
         )
@@ -142,6 +149,7 @@ class PostTransactionWithProductDetailsHelperTest {
                 mockStoreProduct,
                 allowSharingPlayStoreAccount,
                 appUserID,
+                initiationSource,
                 any(),
                 any(),
             )
@@ -157,6 +165,7 @@ class PostTransactionWithProductDetailsHelperTest {
             transactions = listOf(mockSubsTransaction),
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             transactionPostSuccess = { _, _ ->  },
             transactionPostError = { _, _ -> fail("Should be success") },
         )
@@ -167,6 +176,7 @@ class PostTransactionWithProductDetailsHelperTest {
                 mockStoreProduct,
                 allowSharingPlayStoreAccount,
                 appUserID,
+                initiationSource,
                 any(),
                 any(),
             )
@@ -185,6 +195,7 @@ class PostTransactionWithProductDetailsHelperTest {
             transactions = listOf(mockSubsTransaction),
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
             appUserID = appUserID,
+            initiationSource = initiationSource,
             transactionPostSuccess = { storeTransaction, customerInfo ->
                 receivedStoreTransaction = storeTransaction
                 receivedCustomerInfo = customerInfo
@@ -252,6 +263,7 @@ class PostTransactionWithProductDetailsHelperTest {
                 storeProduct,
                 allowSharingPlayStoreAccount,
                 appUserID,
+                initiationSource,
                 captureLambda(),
                 any()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -66,6 +66,8 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     private val subProductId = "sub"
     private val subPurchaseToken = "token_sub"
 
+    private val initiationSource = PostReceiptInitiationSource.PURCHASE
+
     private val mockLifecycle = mockk<Lifecycle>()
     private val mockLifecycleOwner = mockk<LifecycleOwner>()
 
@@ -261,7 +263,9 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         val oldPurchase = mockPurchaseFound()
         mockQueryingProductDetails(oldPurchase.productIds.first(), ProductType.SUBS, null)
         every {
-            mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(oldPurchase, any(), false, appUserId, captureLambda(), any())
+            mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(
+                oldPurchase, any(), isRestore = false, appUserId, initiationSource, captureLambda(), any(),
+            )
         } answers {
             lambda<SuccessfulPurchaseCallback>().captured.invoke(oldPurchase, mockk())
         }
@@ -289,6 +293,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 storeProduct = any(),
                 isRestore = false,
                 appUserID = appUserId,
+                initiationSource = initiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -571,7 +576,9 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
 
         allPurchases.forEach { transaction ->
             every {
-                mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(transaction, any(), false, appUserId, captureLambda(), any())
+                mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(
+                    transaction, any(), isRestore = false, appUserId, initiationSource, captureLambda(), any(),
+                )
             } answers {
                 lambda<SuccessfulPurchaseCallback>().captured.invoke(transaction, mockk())
             }
@@ -585,6 +592,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 storeProduct = match { it.purchasingData.productId == inAppProductId },
                 isRestore = false,
                 appUserID = appUserId,
+                initiationSource = initiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -593,6 +601,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 storeProduct = match { it.purchasingData.productId == subProductId },
                 isRestore = false,
                 appUserID = appUserId,
+                initiationSource = initiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -609,6 +618,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 storeProduct = any(),
                 isRestore = any(),
                 appUserID = any(),
+                initiationSource = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -1114,16 +1124,13 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         )
 
         capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(transactions)
-        val productInfo = ReceiptInfo(
-            productIDs = listOf(productId),
-            offeringIdentifier = "offering_a"
-        )
         verify(exactly = 1) {
             mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(
                 purchase = transactions[0],
                 storeProduct = null,
                 isRestore = false,
                 appUserID = appUserId,
+                initiationSource = initiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -1382,6 +1389,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 storeProduct = any(),
                 isRestore = true,
                 appUserID = randomAppUserId,
+                initiationSource = initiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -1404,6 +1412,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 storeProduct = any(),
                 isRestore = false,
                 appUserID = appUserId,
+                initiationSource = initiationSource,
                 onSuccess = any(),
                 onError = any()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith
 class SyncPurchasesHelperTest {
 
     private val appUserID = "test-app-user-id"
+    private val initiationSource = PostReceiptInitiationSource.RESTORE
     private val testError = PurchasesError(PurchasesErrorCode.CustomerInfoError)
     private val customerInfoMock = mockk<CustomerInfo>()
     private val appInBackground = false
@@ -66,7 +67,7 @@ class SyncPurchasesHelperTest {
         assertThat(receivedCustomerInfo).isEqualTo(customerInfoMock)
         verify(exactly = 0) {
             postReceiptHelper.postTokenWithoutConsuming(
-                any(), any(), any(), any(), any(), any(), any(), any()
+                any(), any(), any(), any(), any(), any(), any(), any(), any(),
             )
         }
     }
@@ -102,7 +103,7 @@ class SyncPurchasesHelperTest {
         assertThat(error).isNotNull
         verify(exactly = 0) {
             postReceiptHelper.postTokenWithoutConsuming(
-                any(), any(), any(), any(), any(), any(), any(), any()
+                any(), any(), any(), any(), any(), any(), any(), any(), any(),
             )
         }
     }
@@ -124,7 +125,9 @@ class SyncPurchasesHelperTest {
         mockBillingQueryAllPurchasesSuccess(listOf(purchase1, purchase2))
 
         every {
-            postReceiptHelper.postTokenWithoutConsuming(any(), any(), any(), any(), any(), any(), captureLambda(), any())
+            postReceiptHelper.postTokenWithoutConsuming(
+                any(), any(), any(), any(), any(), any(), any(), captureLambda(), any(),
+            )
         } answers {
             lambda<(CustomerInfo) -> Unit>().captured.invoke(mockk())
         }
@@ -146,6 +149,7 @@ class SyncPurchasesHelperTest {
                 isRestore = isRestore,
                 appUserID = appUserID,
                 marketplace = null,
+                initiationSource = initiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -156,6 +160,7 @@ class SyncPurchasesHelperTest {
                 isRestore = isRestore,
                 appUserID = appUserID,
                 marketplace = "test-marketplace",
+                initiationSource = initiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -179,7 +184,9 @@ class SyncPurchasesHelperTest {
         mockBillingQueryAllPurchasesSuccess(listOf(purchase1, purchase2))
 
         every {
-            postReceiptHelper.postTokenWithoutConsuming(any(), any(), any(), any(), any(), any(), any(), captureLambda())
+            postReceiptHelper.postTokenWithoutConsuming(
+                any(), any(), any(), any(), any(), any(), any(), any(), captureLambda(),
+            )
         } answers {
             lambda<(PurchasesError) -> Unit>().captured.invoke(testError)
         }
@@ -201,6 +208,7 @@ class SyncPurchasesHelperTest {
                 isRestore = isRestore,
                 appUserID = appUserID,
                 marketplace = null,
+                initiationSource = initiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -211,6 +219,7 @@ class SyncPurchasesHelperTest {
                 isRestore = isRestore,
                 appUserID = appUserID,
                 marketplace = "test-marketplace",
+                initiationSource = initiationSource,
                 onSuccess = any(),
                 onError = any()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/BackendTest.kt
@@ -7,6 +7,7 @@ package com.revenuecat.purchases.common
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -130,6 +131,7 @@ class BackendTest {
         offeringIdentifier = "offering_a"
     )
     private val fetchToken = "fetch_token"
+    private val initiationSource = PostReceiptInitiationSource.PURCHASE
     private val defaultTimeout = 2000L
 
     private var receivedCustomerInfo: CustomerInfo? = null
@@ -415,7 +417,8 @@ class BackendTest {
             resultBody = null,
             observerMode = false,
             receiptInfo = basicReceiptInfo,
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         assertThat(receivedCustomerInfo).`as`("Received info is not null").isNotNull
@@ -429,7 +432,8 @@ class BackendTest {
             isRestore = false,
             observerMode = false,
             receiptInfo = basicReceiptInfo,
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         verify(exactly = 1) {
@@ -458,7 +462,8 @@ class BackendTest {
             isRestore = false,
             observerMode = false,
             receiptInfo = receiptInfo,
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         val expectedPricingPhases = receiptInfo.pricingPhases
@@ -534,7 +539,8 @@ class BackendTest {
             isRestore = false,
             observerMode = false,
             receiptInfo = receiptInfo,
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         assertThat(requestBodySlot.isCaptured).isTrue
@@ -577,7 +583,8 @@ class BackendTest {
             isRestore = false,
             observerMode = false,
             receiptInfo = receiptInfo,
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         assertThat(requestBodySlot.isCaptured).isTrue
@@ -602,6 +609,7 @@ class BackendTest {
             observerMode = true,
             receiptInfo = receiptInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         assertThat(requestBodySlot.isCaptured).isTrue
@@ -627,11 +635,31 @@ class BackendTest {
             observerMode = true,
             receiptInfo = receiptInfo,
             storeAppUserID = expectedStoreUserId,
+            initiationSource = initiationSource,
         )
 
         assertThat(requestBodySlot.isCaptured).isTrue
         assertThat(requestBodySlot.captured.keys).contains("store_user_id")
         assertThat(requestBodySlot.captured["store_user_id"]).isEqualTo(expectedStoreUserId)
+    }
+
+    @Test
+    fun `postReceipt posts initiationSource`() {
+        mockPostReceiptResponseAndPost(
+            backend,
+            responseCode = 200,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            observerMode = true,
+            receiptInfo = ReceiptInfo(productIDs = productIDs, storeProduct = storeProduct),
+            storeAppUserID = null,
+            initiationSource = initiationSource,
+        )
+
+        assertThat(requestBodySlot.isCaptured).isTrue
+        assertThat(requestBodySlot.captured.keys).contains("initiation_source")
+        assertThat(requestBodySlot.captured["initiation_source"]).isEqualTo(initiationSource.postReceiptFieldValue)
     }
 
     @Test
@@ -644,7 +672,8 @@ class BackendTest {
             resultBody = null,
             observerMode = false,
             receiptInfo = basicReceiptInfo,
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         assertThat(receivedCustomerInfo).`as`("Received info is null").isNull()
@@ -662,6 +691,7 @@ class BackendTest {
             delayed = true,
             receiptInfo = basicReceiptInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->
                 lock.countDown()
             },
@@ -674,6 +704,7 @@ class BackendTest {
             delayed = true,
             receiptInfo = basicReceiptInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->
                 lock.countDown()
             },
@@ -728,6 +759,7 @@ class BackendTest {
             observerMode = false,
             receiptInfo = basicReceiptInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->
                 mockResponse(
                     Endpoint.GetCustomerInfo(appUserID),
@@ -782,7 +814,8 @@ class BackendTest {
             resultBody = null,
             observerMode = true,
             receiptInfo = ReceiptInfo(productIDs),
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         assertThat(receivedCustomerInfo).`as`("Received info is not null").isNotNull
@@ -802,7 +835,8 @@ class BackendTest {
                 productIDs,
                 storeProduct = storeProduct
             ),
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         assertThat(receivedCustomerInfo).`as`("Received info is not null").isNotNull
@@ -833,6 +867,7 @@ class BackendTest {
             observerMode = false,
             receiptInfo = receiptInfo1,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->
                 lock.countDown()
             },
@@ -845,6 +880,7 @@ class BackendTest {
             observerMode = false,
             receiptInfo = receiptInfo2,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->
                 lock.countDown()
             },
@@ -893,6 +929,7 @@ class BackendTest {
             observerMode = false,
             receiptInfo = receiptInfo1,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->
                 lock.countDown()
             },
@@ -905,6 +942,7 @@ class BackendTest {
             observerMode = false,
             receiptInfo = receiptInfo2,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->
                 lock.countDown()
             },
@@ -933,6 +971,7 @@ class BackendTest {
             observerMode = false,
             receiptInfo = basicReceiptInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->
                 lock.countDown()
             },
@@ -951,6 +990,7 @@ class BackendTest {
             observerMode = false,
             receiptInfo = receiptInfo2,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->
                 lock.countDown()
             },
@@ -985,6 +1025,7 @@ class BackendTest {
             observerMode = false,
             receiptInfo = receiptInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->
                 lock.countDown()
             },
@@ -998,6 +1039,7 @@ class BackendTest {
             observerMode = false,
             receiptInfo = receiptInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = { _, _ ->
                 lock.countDown()
             },
@@ -1030,6 +1072,7 @@ class BackendTest {
                 storeProduct = storeProduct
             ),
             storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         assertThat(receivedCustomerInfo).`as`("Received purchaser info is not null").isNotNull
@@ -1047,6 +1090,7 @@ class BackendTest {
             observerMode = false,
             receiptInfo = receiptInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             delayed = true,
             onSuccess = { _, _ ->
                 lock.countDown()
@@ -1059,6 +1103,7 @@ class BackendTest {
             isRestore = false,
             observerMode = false,
             receiptInfo = receiptInfo,
+            initiationSource = initiationSource,
             delayed = true,
             storeAppUserID = "store_app_user_id",
             onSuccess = { _, _ ->
@@ -1092,7 +1137,8 @@ class BackendTest {
                 }""".trimIndent(),
             observerMode = false,
             receiptInfo = ReceiptInfo(productIDs),
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         assertThat(receivedCustomerInfo).`as`("Received info is null").isNull()
@@ -1116,7 +1162,8 @@ class BackendTest {
                 }""".trimIndent(),
             observerMode = false,
             receiptInfo = ReceiptInfo(productIDs),
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         assertThat(receivedPostReceiptErrorHandlingBehavior).isEqualTo(PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED)
@@ -1135,7 +1182,8 @@ class BackendTest {
                 }""".trimIndent(),
             observerMode = false,
             receiptInfo = ReceiptInfo(productIDs),
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         assertThat(receivedPostReceiptErrorHandlingBehavior).isEqualTo(PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
@@ -1154,7 +1202,8 @@ class BackendTest {
                 }""".trimIndent(),
             observerMode = false,
             receiptInfo = ReceiptInfo(productIDs),
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         assertThat(receivedPostReceiptErrorHandlingBehavior).isEqualTo(PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
@@ -1173,7 +1222,8 @@ class BackendTest {
                 productIDs,
                 storeProduct = storeProduct
             ),
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         assertThat(headersSlot.isCaptured).isTrue
@@ -1195,6 +1245,7 @@ class BackendTest {
                 storeProduct = storeProduct
             ),
             storeAppUserID = null,
+            initiationSource = initiationSource,
             marketplace = "DE"
         )
 
@@ -1217,6 +1268,7 @@ class BackendTest {
                 storeProduct = storeProduct
             ),
             storeAppUserID = null,
+            initiationSource = initiationSource,
             marketplace = "US"
         )
 
@@ -1240,7 +1292,8 @@ class BackendTest {
                 productIDs,
                 storeProduct = storeProduct
             ),
-            storeAppUserID = null
+            storeAppUserID = null,
+            initiationSource = initiationSource,
         )
 
         val expectedPostFieldsToSign = listOf(
@@ -2276,6 +2329,7 @@ class BackendTest {
         observerMode: Boolean,
         receiptInfo: ReceiptInfo,
         storeAppUserID: String?,
+        initiationSource: PostReceiptInitiationSource,
         delayed: Boolean = false,
         marketplace: String? = null,
         onSuccess: (CustomerInfo, JSONObject?) -> Unit = onReceivePostReceiptSuccessHandler,
@@ -2301,6 +2355,7 @@ class BackendTest {
             receiptInfo = receiptInfo,
             storeAppUserID = storeAppUserID,
             marketplace = marketplace,
+            initiationSource = initiationSource,
             onSuccess = onSuccess,
             onError = onError
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.subscriberattributes
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.VerificationResult
@@ -291,6 +292,7 @@ class SubscriberAttributesPosterTests {
     ).toBackendMap()
     private val fetchToken = "fetch_token"
     private val productID = "product_id"
+    private val initiationSource = PostReceiptInitiationSource.PURCHASE
 
     @Test
     fun `posting receipt with attributes works`() {
@@ -307,6 +309,7 @@ class SubscriberAttributesPosterTests {
             subscriberAttributes = mapOfSubscriberAttributes,
             receiptInfo = productInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = expectedOnSuccessPostReceipt,
             onError = unexpectedOnErrorPostReceipt
         )
@@ -333,6 +336,7 @@ class SubscriberAttributesPosterTests {
             subscriberAttributes = mapOfSubscriberAttributes,
             receiptInfo = productInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = expectedOnSuccessPostReceipt,
             onError = unexpectedOnErrorPostReceipt
         )
@@ -358,6 +362,7 @@ class SubscriberAttributesPosterTests {
             subscriberAttributes = emptyMap(),
             receiptInfo = productInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = expectedOnSuccessPostReceipt,
             onError = unexpectedOnErrorPostReceipt
         )
@@ -386,6 +391,7 @@ class SubscriberAttributesPosterTests {
             subscriberAttributes = emptyMap(),
             receiptInfo = productInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = expectedOnSuccessPostReceipt,
             onError = unexpectedOnErrorPostReceipt
         )
@@ -413,6 +419,7 @@ class SubscriberAttributesPosterTests {
             subscriberAttributes = emptyMap(),
             receiptInfo = productInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = unexpectedOnSuccessPostReceipt,
             onError = expectedOnErrorPostReceipt
         )
@@ -440,6 +447,7 @@ class SubscriberAttributesPosterTests {
             subscriberAttributes = emptyMap(),
             receiptInfo = productInfo,
             storeAppUserID = null,
+            initiationSource = initiationSource,
             onSuccess = unexpectedOnSuccessPostReceipt,
             onError = expectedOnErrorPostReceipt
         )

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesCoroutinesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesCoroutinesTest.kt
@@ -283,6 +283,7 @@ internal class PurchasesCoroutinesTest : BasePurchasesTest() {
                 any(),
                 true,
                 appUserId,
+                PostReceiptInitiationSource.RESTORE,
                 onSuccess = captureLambda(),
                 any()
             )

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -52,6 +52,8 @@ internal class PurchasesTest : BasePurchasesTest() {
     private val inAppPurchaseToken = "token_inapp"
     private val subProductId = "sub"
     private val subPurchaseToken = "token_sub"
+    private val initiationSource = PostReceiptInitiationSource.PURCHASE
+    private val restoreInitiationSource = PostReceiptInitiationSource.RESTORE
     private var receivedProducts: List<StoreProduct>? = null
 
     @Test
@@ -94,6 +96,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 storeProduct = any(),
                 isRestore = true,
                 appUserID = appUserId,
+                initiationSource = initiationSource,
                 onSuccess = any(),
                 onError = any(),
             )
@@ -135,6 +138,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 storeProduct = any(),
                 isRestore = false,
                 appUserID = appUserId,
+                initiationSource = initiationSource,
                 onSuccess = any(),
                 onError = any(),
             )
@@ -717,6 +721,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 marketplace = null,
+                initiationSource = PostReceiptInitiationSource.RESTORE,
                 onSuccess = any(),
                 onError = any()
             )
@@ -773,6 +778,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 marketplace = null,
+                initiationSource = PostReceiptInitiationSource.RESTORE,
                 onSuccess = any(),
                 onError = any()
             )
@@ -798,6 +804,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 marketplace = null,
+                initiationSource = PostReceiptInitiationSource.RESTORE,
                 onSuccess = any(),
                 onError = any()
             )
@@ -848,6 +855,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 marketplace = null,
+                initiationSource = PostReceiptInitiationSource.RESTORE,
                 onSuccess = any(),
                 onError = any()
             )
@@ -902,6 +910,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 marketplace = null,
+                initiationSource = PostReceiptInitiationSource.RESTORE,
                 onSuccess = any(),
                 onError = any()
             )
@@ -982,6 +991,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = true,
                 appUserID = appUserId,
                 marketplace = null,
+                initiationSource = PostReceiptInitiationSource.RESTORE,
                 onSuccess = any(),
                 onError = any(),
             )
@@ -1040,6 +1050,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = true,
                 appUserID = appUserId,
                 marketplace = null,
+                initiationSource = PostReceiptInitiationSource.RESTORE,
                 onSuccess = any(),
                 onError = any(),
             )
@@ -1111,6 +1122,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 storeProduct = null,
                 isRestore = true,
                 appUserID = appUserId,
+                initiationSource = restoreInitiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -1119,6 +1131,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 storeProduct = null,
                 isRestore = true,
                 appUserID = appUserId,
+                initiationSource = restoreInitiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -1174,7 +1187,9 @@ internal class PurchasesTest : BasePurchasesTest() {
             VerificationResult.NOT_REQUESTED
         )
         every {
-            mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(any(), any(), any(), any(), captureLambda(), any())
+            mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(
+                any(), any(), any(), any(), any(), captureLambda(), any(),
+            )
         } answers {
             lambda<SuccessfulPurchaseCallback>().captured.invoke(firstArg(), mockInfo)
         }

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -721,7 +721,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 marketplace = null,
-                initiationSource = PostReceiptInitiationSource.RESTORE,
+                initiationSource = restoreInitiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -778,7 +778,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 marketplace = null,
-                initiationSource = PostReceiptInitiationSource.RESTORE,
+                initiationSource = restoreInitiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -804,7 +804,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 marketplace = null,
-                initiationSource = PostReceiptInitiationSource.RESTORE,
+                initiationSource = restoreInitiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -855,7 +855,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 marketplace = null,
-                initiationSource = PostReceiptInitiationSource.RESTORE,
+                initiationSource = restoreInitiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -910,7 +910,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 marketplace = null,
-                initiationSource = PostReceiptInitiationSource.RESTORE,
+                initiationSource = restoreInitiationSource,
                 onSuccess = any(),
                 onError = any()
             )
@@ -991,7 +991,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = true,
                 appUserID = appUserId,
                 marketplace = null,
-                initiationSource = PostReceiptInitiationSource.RESTORE,
+                initiationSource = restoreInitiationSource,
                 onSuccess = any(),
                 onError = any(),
             )
@@ -1050,7 +1050,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = true,
                 appUserID = appUserId,
                 marketplace = null,
-                initiationSource = PostReceiptInitiationSource.RESTORE,
+                initiationSource = restoreInitiationSource,
                 onSuccess = any(),
                 onError = any(),
             )


### PR DESCRIPTION
### Description
This PR adds a new `initiation_source` field to the post receipt body that indicates where the receipt was originated from. This is already done in iOS.
