### PR TITLE
Rename `queue` initiation source to `unsynced_active_purchases`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostPendingTransactionsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostPendingTransactionsHelper.kt
@@ -77,7 +77,7 @@ internal class PostPendingTransactionsHelper(
                 transactionsToSync,
                 allowSharingPlayStoreAccount,
                 appUserID,
-                PostReceiptInitiationSource.QUEUE,
+                PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
                 transactionPostSuccess = { _, customerInfo ->
                     results.add(Result.Success(customerInfo))
                     callCompletionFromResults(transactionsToSync, results, onError, onSuccess)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptInitiationSource.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptInitiationSource.kt
@@ -3,13 +3,13 @@ package com.revenuecat.purchases
 internal enum class PostReceiptInitiationSource {
     RESTORE,
     PURCHASE,
-    QUEUE,
+    UNSYNCED_ACTIVE_PURCHASES,
     ;
 
     val postReceiptFieldValue: String
         get() = when (this) {
             RESTORE -> "restore"
             PURCHASE -> "purchase"
-            QUEUE -> "queue"
+            UNSYNCED_ACTIVE_PURCHASES -> "unsynced_active_purchases"
         }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
@@ -29,7 +29,7 @@ class PostPendingTransactionsHelperTest {
 
     private val allowSharingPlayStoreAccount = true
     private val appUserId = "test-app-user-id"
-    private val initiationSource = PostReceiptInitiationSource.QUEUE
+    private val initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES
 
     private lateinit var appConfig: AppConfig
     private lateinit var deviceCache: DeviceCache

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptInitiationSourceTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptInitiationSourceTest.kt
@@ -12,6 +12,7 @@ class PostReceiptInitiationSourceTest {
     fun `initiation source have correct postReceiptFieldValue`() {
         assertThat(PostReceiptInitiationSource.PURCHASE.postReceiptFieldValue).isEqualTo("purchase")
         assertThat(PostReceiptInitiationSource.RESTORE.postReceiptFieldValue).isEqualTo("restore")
-        assertThat(PostReceiptInitiationSource.QUEUE.postReceiptFieldValue).isEqualTo("queue")
+        assertThat(PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES.postReceiptFieldValue)
+            .isEqualTo("unsynced_active_purchases")
     }
 }


### PR DESCRIPTION
### Description
We talked about renaming `queue` initiation source, which is more of an iOS term, to `unsynced_active_purchases` to match more what we do in android.