### PR TITLE
Improve offerings start log

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -42,7 +42,6 @@ internal class OfferingsManager(
                     } else OfferingStrings.OFFERINGS_STALE_UPDATING_IN_FOREGROUND,
                 )
                 fetchAndCacheOfferings(appUserID, appInBackground)
-                log(LogIntent.RC_SUCCESS, OfferingStrings.OFFERINGS_UPDATED_FROM_NETWORK)
             }
         }
     }
@@ -51,7 +50,6 @@ internal class OfferingsManager(
         if (offeringsCache.isOfferingsCacheStale(appInBackground = false)) {
             log(LogIntent.DEBUG, OfferingStrings.OFFERINGS_STALE_UPDATING_IN_FOREGROUND)
             fetchAndCacheOfferings(appUserID, appInBackground = false)
-            log(LogIntent.RC_SUCCESS, OfferingStrings.OFFERINGS_UPDATED_FROM_NETWORK)
         }
     }
 
@@ -61,6 +59,7 @@ internal class OfferingsManager(
         onError: ((PurchasesError) -> Unit)? = null,
         onSuccess: ((Offerings) -> Unit)? = null,
     ) {
+        log(LogIntent.RC_SUCCESS, OfferingStrings.OFFERINGS_START_UPDATE_FROM_NETWORK)
         backend.getOfferings(
             appUserID,
             appInBackground,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -15,7 +15,7 @@ internal object OfferingStrings {
     const val NO_CACHED_OFFERINGS_FETCHING_NETWORK = "No cached Offerings, fetching from network"
     const val OFFERINGS_STALE_UPDATING_IN_BACKGROUND = "Offerings cache is stale, updating from network in background"
     const val OFFERINGS_STALE_UPDATING_IN_FOREGROUND = "Offerings cache is stale, updating from network in foreground"
-    const val OFFERINGS_UPDATED_FROM_NETWORK = "Offerings updated from network."
+    const val OFFERINGS_START_UPDATE_FROM_NETWORK = "Start Offerings update from network."
     const val RETRIEVED_PRODUCTS = "Retrieved productDetailsList: %s"
     const val VENDING_OFFERINGS_CACHE = "Vending Offerings from cache"
     const val EMPTY_PRODUCT_ID_LIST = "productId list is empty, skipping queryProductDetailsAsync call"


### PR DESCRIPTION
### Description
I noticed we had a very misleading log `Offerings updated from network.`. It seemed to indicate that that offerings had finished updating but it actually indicated that offerings started to be updated from network. I changed it to `Start Offerings update from network.` and also changed the location of the log so it happens in all places where offerings are actually fetched from network.
