### PR TITLE
Add revision and remove default_locale

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -17,7 +17,7 @@ internal abstract class OfferingParser {
 
     // TODO-PAYWALLS: uncomment after testing
     private val json = Json {
-//        ignoreUnknownKeys = true
+        ignoreUnknownKeys = true
     }
 
     protected abstract fun findMatchingProduct(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
@@ -26,8 +26,11 @@ data class PaywallData(
      * The base remote URL where assets for this paywall are stored.
      */
     @SerialName("asset_base_url") @Serializable(with = URLSerializer::class) val assetBaseURL: URL,
-    // TODO-PAYWALLS: do we need this one?
-    @SerialName("default_locale") val defaultLocale: String,
+
+    /**
+     * The revision identifier for this paywall.
+     */
+    val revision: Int = 0,
     @SerialName("localized_strings") internal val localization: Map<String, LocalizedConfiguration>,
 ) {
     /**


### PR DESCRIPTION
- Set `ignoreUnknownKeys` to `true`, so there are no exceptions if new fields are added
- Removed `default_locale` since it's deprecated
- Added `revision` https://github.com/RevenueCat/purchases-ios/pull/3155/files