### PR TITLE
Paywalls: Use paywall data in paywall

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
@@ -45,6 +45,7 @@ internal fun InternalPaywallView(
             is PaywallViewState.Loaded -> {
                 val offering = state.offering
                 Text(text = "Paywall for offeringId: ${offering.identifier}")
+                // TODO-PAYWALLS: Use device locale and move logic to view model
                 offering.paywall?.configForLocale(Locale.ENGLISH)?.let { localizedConfiguration ->
                     Text(
                         style = MaterialTheme.typography.h5,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
@@ -10,15 +10,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.Offering
+import java.util.Locale
 
 @Composable
 internal fun InternalPaywallView(
@@ -40,9 +43,23 @@ internal fun InternalPaywallView(
                 Text(text = "Error: ${state.errorMessage}")
             }
             is PaywallViewState.Loaded -> {
-                Text(text = "Paywall for offeringId: ${state.offering.identifier}")
+                val offering = state.offering
+                Text(text = "Paywall for offeringId: ${offering.identifier}")
+                offering.paywall?.configForLocale(Locale.ENGLISH)?.let { localizedConfiguration ->
+                    Text(
+                        style = MaterialTheme.typography.h5,
+                        textAlign = TextAlign.Center,
+                        text = localizedConfiguration.title,
+                    )
+                    Text(
+                        style = MaterialTheme.typography.subtitle1,
+                        textAlign = TextAlign.Center,
+                        text = localizedConfiguration.subtitle ?: "",
+                    )
+                }
                 val activity = LocalContext.current.getActivity() ?: error("Error finding activity")
-                state.offering.availablePackages.forEach { aPackage ->
+                
+                offering.availablePackages.forEach { aPackage ->
                     Button(onClick = { viewModel.purchasePackage(activity, aPackage) }) {
                         Text(text = "Purchase ${aPackage.identifier}. Price: ${aPackage.product.price.formatted}")
                     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
@@ -58,7 +58,7 @@ internal fun InternalPaywallView(
                     )
                 }
                 val activity = LocalContext.current.getActivity() ?: error("Error finding activity")
-                
+
                 offering.availablePackages.forEach { aPackage ->
                     Button(onClick = { viewModel.purchasePackage(activity, aPackage) }) {
                         Text(text = "Purchase ${aPackage.identifier}. Price: ${aPackage.product.price.formatted}")


### PR DESCRIPTION
### Description
This just adds a couple of text views as a PoC of setting a paywall in the dashboard and seeing the data in the UI.
![image](https://github.com/RevenueCat/purchases-android/assets/808417/ec95eef0-63e1-4ece-8432-9b521bcfdbdf)
