### PR TITLE
Paywalls: Add initial Template2 UI and using colors and texts in paywall

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallColor.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallColor.kt
@@ -26,7 +26,7 @@ data class PaywallColor(
     val underlyingColor: Color?,
 ) {
     /**
-     * The color converted to a ColorInt
+     * The color converted to a @ColorInt representation
      */
     @ColorInt
     val colorInt: Int = Color.parseColor(stringRepresentation)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallColor.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallColor.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.paywalls
 
 import android.graphics.Color
 import android.os.Build
+import androidx.annotation.ColorInt
 import androidx.annotation.RequiresApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -24,6 +25,12 @@ data class PaywallColor(
     @RequiresApi(Build.VERSION_CODES.O)
     val underlyingColor: Color?,
 ) {
+    /**
+     * The color converted to a ColorInt
+     */
+    @ColorInt
+    val colorInt: Int = Color.parseColor(stringRepresentation)
+
     object Serializer : KSerializer<PaywallColor> {
         override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("PaywallColor", PrimitiveKind.STRING)
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ContextExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ContextExtensions.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.content.ContextWrapper
 
 /**
- * This function gets the activity from a given context. Most times, the context itself will be
+ * Returns the activity from a given context. Most times, the context itself will be
  * an activity, but in the case it's not, it will iterate through the context wrappers until it
  * finds one that is an activity.
  */

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ContextExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ContextExtensions.kt
@@ -4,6 +4,11 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 
+/**
+ * This function gets the activity from a given context. Most times, the context itself will be
+ * an activity, but in the case it's not, it will iterate through the context wrappers until it
+ * finds one that is an activity.
+ */
 internal fun Context.getActivity(): Activity? {
     var currentContext = this
     while (currentContext is ContextWrapper) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ContextExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ContextExtensions.kt
@@ -1,0 +1,16 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+
+internal fun Context.getActivity(): Activity? {
+    var currentContext = this
+    while (currentContext is ContextWrapper) {
+        if (currentContext is Activity) {
+            return currentContext
+        }
+        currentContext = currentContext.baseContext
+    }
+    return null
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
@@ -1,83 +1,33 @@
 package com.revenuecat.purchases.ui.revenuecatui
 
-import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Button
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.Offering
-import java.util.Locale
+import com.revenuecat.purchases.ui.revenuecatui.templates.template2.Template2
 
 @Composable
 internal fun InternalPaywallView(
     offering: Offering? = null,
-    viewModel: PaywallViewModel = viewModel<PaywallViewModelImpl>(factory = PaywallViewModelFactory(offering)),
+    viewModel: PaywallViewModel = getPaywallViewModel(offering = offering),
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        when (val state = viewModel.state.collectAsState().value) {
-            is PaywallViewState.Loading -> {
-                Text(text = "Loading...")
-            }
-            is PaywallViewState.Error -> {
-                Text(text = "Error: ${state.errorMessage}")
-            }
-            is PaywallViewState.Loaded -> {
-                val offering = state.offering
-                Text(text = "Paywall for offeringId: ${offering.identifier}")
-                // TODO-PAYWALLS: Use device locale and move logic to view model
-                offering.paywall?.configForLocale(Locale.ENGLISH)?.let { localizedConfiguration ->
-                    Text(
-                        style = MaterialTheme.typography.h5,
-                        textAlign = TextAlign.Center,
-                        text = localizedConfiguration.title,
-                    )
-                    Text(
-                        style = MaterialTheme.typography.subtitle1,
-                        textAlign = TextAlign.Center,
-                        text = localizedConfiguration.subtitle ?: "",
-                    )
-                }
-                val activity = LocalContext.current.getActivity() ?: error("Error finding activity")
-
-                offering.availablePackages.forEach { aPackage ->
-                    Button(onClick = { viewModel.purchasePackage(activity, aPackage) }) {
-                        Text(text = "Purchase ${aPackage.identifier}. Price: ${aPackage.product.price.formatted}")
-                    }
-                    Spacer(modifier = Modifier.height(8.dp))
-                }
-            }
+    when (val state = viewModel.state.collectAsState().value) {
+        is PaywallViewState.Loading -> {
+            Text(text = "Loading...")
+        }
+        is PaywallViewState.Error -> {
+            Text(text = "Error: ${state.errorMessage}")
+        }
+        is PaywallViewState.Template2 -> {
+            Template2(state = state, viewModel = viewModel)
         }
     }
 }
 
-internal fun Context.getActivity(): Activity? {
-    var currentContext = this
-    while (currentContext is ContextWrapper) {
-        if (currentContext is Activity) {
-            return currentContext
-        }
-        currentContext = currentContext.baseContext
-    }
-    return null
+@Composable
+private fun getPaywallViewModel(offering: Offering?): PaywallViewModel {
+    return viewModel<PaywallViewModelImpl>(
+        factory = PaywallViewModelFactory(offering),
+    )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/OfferingToStateMapper.kt
@@ -1,0 +1,21 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import com.revenuecat.purchases.Offering
+
+@Suppress("ReturnCount")
+internal fun Offering.toPaywallViewState(): PaywallViewState {
+    val paywallData = this.paywall
+        ?: return PaywallViewState.Error("No paywall data for offering: $identifier")
+    val packageById = this.availablePackages.associateBy { it.identifier }
+    val packages = paywallData.config.packages.map { packageId ->
+        packageById[packageId] ?: return PaywallViewState.Error("No package $packageId in offering $identifier")
+    }
+    return PaywallViewState.Template2(
+        paywallData = paywallData,
+        packages = packages,
+        selectedPackage = packages.first(), // TODO-PAYWALLS: Use correct default package
+        shouldShowRestorePurchasesButton = paywallData.config.displayRestorePurchases,
+        shouldShowTermsButton = paywallData.config.termsOfServiceURL != null,
+        shouldShowPrivacyPolicyButton = paywallData.config.privacyURL != null,
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDataExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDataExtensions.kt
@@ -1,0 +1,50 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import android.util.Log
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.core.os.ConfigurationCompat
+import androidx.core.os.LocaleListCompat
+import com.revenuecat.purchases.paywalls.PaywallData
+import java.util.Locale
+
+@Composable
+@ReadOnlyComposable
+internal fun PaywallData.getColors(): PaywallData.Configuration.Colors {
+    return config.colors.dark?.takeIf { isSystemInDarkTheme() } ?: config.colors.light
+}
+
+@Composable
+internal fun PaywallData.localizedConfig(): PaywallData.LocalizedConfiguration? {
+    val locale = getLocale()
+    val configForLocale = configForLocale(locale)
+    if (configForLocale == null) {
+        Log.e("RevenueCatUI", "No configuration found for locale $locale")
+    }
+    return configForLocale
+}
+
+@Composable
+@ReadOnlyComposable
+private fun getLocale(): Locale {
+    val configuration = LocalConfiguration.current
+    return ConfigurationCompat.getLocales(configuration).get(0) ?: LocaleListCompat.getDefault()[0] ?: Locale.ENGLISH
+}
+
+val PaywallData.Configuration.Colors.backgroundColor: Color
+    get() = Color(background.colorInt)
+val PaywallData.Configuration.Colors.text1Color: Color
+    get() = Color(text1.colorInt)
+val PaywallData.Configuration.Colors.text2Color: Color
+    get() = text2?.let { Color(it.colorInt) } ?: text1Color
+val PaywallData.Configuration.Colors.callToActionBackgroundColor: Color
+    get() = Color(callToActionBackground.colorInt)
+val PaywallData.Configuration.Colors.callToActionForegroundColor: Color
+    get() = Color(callToActionForeground.colorInt)
+val PaywallData.Configuration.Colors.accent1Color: Color
+    get() = accent1?.let { Color(it.colorInt) } ?: callToActionForegroundColor
+val PaywallData.Configuration.Colors.accent2Color: Color
+    get() = accent2?.let { Color(it.colorInt) } ?: accent1Color

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDataExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDataExtensions.kt
@@ -18,6 +18,7 @@ internal fun PaywallData.getColors(): PaywallData.Configuration.Colors {
 }
 
 @Composable
+@ReadOnlyComposable
 internal fun PaywallData.localizedConfig(): PaywallData.LocalizedConfiguration? {
     val locale = getLocale()
     val configForLocale = configForLocale(locale)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewModel.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.awaitOfferings
 import com.revenuecat.purchases.awaitPurchase
+import com.revenuecat.purchases.awaitRestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,14 +20,22 @@ import kotlinx.coroutines.launch
 internal interface PaywallViewModel {
     val state: StateFlow<PaywallViewState>
 
-    fun purchasePackage(activity: Activity, packageToPurchase: Package)
+    fun selectPackage(packageToSelect: Package)
+    fun purchaseSelectedPackage(activity: Activity)
+    fun restorePurchases()
 }
 
-internal class PaywallViewModelImpl(offering: Offering?) : ViewModel(), PaywallViewModel {
+internal class PaywallViewModelImpl(
+    offering: Offering?,
+) : ViewModel(), PaywallViewModel {
+    companion object {
+        const val TAG = "RevenueCatUI"
+    }
+
     override val state: StateFlow<PaywallViewState>
         get() = _state.asStateFlow()
     private val initialState: PaywallViewState = offering?.let {
-        PaywallViewState.Loaded(it)
+        it.toPaywallViewState()
     } ?: PaywallViewState.Loading
     private val _state = MutableStateFlow(initialState)
 
@@ -36,15 +45,49 @@ internal class PaywallViewModelImpl(offering: Offering?) : ViewModel(), PaywallV
         }
     }
 
-    override fun purchasePackage(activity: Activity, packageToPurchase: Package) {
+    override fun selectPackage(packageToSelect: Package) {
+        _state.value = when (val currentState = _state.value) {
+            is PaywallViewState.Template2 -> {
+                currentState.copy(selectedPackage = packageToSelect)
+            }
+            else -> {
+                Log.e(TAG, "Unexpected state trying to select package: $currentState")
+                currentState
+            }
+        }
+    }
+
+    override fun purchaseSelectedPackage(activity: Activity) {
+        when (val currentState = _state.value) {
+            is PaywallViewState.Template2 -> {
+                purchasePackage(activity, currentState.selectedPackage)
+            }
+            else -> {
+                Log.e(TAG, "Unexpected state trying to purchase package: $currentState")
+            }
+        }
+    }
+
+    override fun restorePurchases() {
+        viewModelScope.launch {
+            try {
+                val customerInfo = Purchases.sharedInstance.awaitRestore()
+                Log.i(TAG, "Restore purchases successful: $customerInfo")
+            } catch (e: PurchasesException) {
+                Log.e(TAG, "Error restoring purchases: $e")
+            }
+        }
+    }
+
+    private fun purchasePackage(activity: Activity, packageToPurchase: Package) {
         viewModelScope.launch {
             try {
                 val purchaseResult = Purchases.sharedInstance.awaitPurchase(
                     PurchaseParams.Builder(activity, packageToPurchase).build(),
                 )
-                Log.i("PaywallTester", "Purchased package: ${purchaseResult.storeTransaction}")
+                Log.i(TAG, "Purchased package: ${purchaseResult.storeTransaction}")
             } catch (e: PurchasesException) {
-                Log.e("PaywallTester", "Error purchasing package: $e")
+                Log.e(TAG, "Error purchasing package: $e")
             }
         }
     }
@@ -57,7 +100,7 @@ internal class PaywallViewModelImpl(offering: Offering?) : ViewModel(), PaywallV
                 if (currentOffering == null) {
                     _state.value = PaywallViewState.Error("No offering or current offering")
                 } else {
-                    _state.value = PaywallViewState.Loaded(currentOffering)
+                    _state.value = currentOffering.toPaywallViewState()
                 }
             } catch (e: PurchasesException) {
                 _state.value = PaywallViewState.Error(e.toString())

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewModelFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewModelFactory.kt
@@ -4,7 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.revenuecat.purchases.Offering
 
-class PaywallViewModelFactory(private val offering: Offering?) : ViewModelProvider.NewInstanceFactory() {
+internal class PaywallViewModelFactory(
+    private val offering: Offering?,
+) : ViewModelProvider.NewInstanceFactory() {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return PaywallViewModelImpl(offering) as T
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewState.kt
@@ -1,9 +1,17 @@
 package com.revenuecat.purchases.ui.revenuecatui
 
-import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.paywalls.PaywallData
 
-sealed class PaywallViewState {
+internal sealed class PaywallViewState {
     object Loading : PaywallViewState()
     data class Error(val errorMessage: String) : PaywallViewState()
-    data class Loaded(val offering: Offering) : PaywallViewState()
+    data class Template2(
+        val paywallData: PaywallData,
+        val packages: List<Package>,
+        val selectedPackage: Package,
+        val shouldShowRestorePurchasesButton: Boolean,
+        val shouldShowTermsButton: Boolean,
+        val shouldShowPrivacyPolicyButton: Boolean,
+    ) : PaywallViewState()
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/UIConstant.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/UIConstant.kt
@@ -1,0 +1,8 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import androidx.compose.ui.unit.dp
+
+internal object UIConstant {
+    val defaultHorizontalPadding = 16.dp
+    val defaultButtonVerticalSpacing = 5.dp
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/template2/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/template2/Template2.kt
@@ -1,0 +1,160 @@
+package com.revenuecat.purchases.ui.revenuecatui.templates.template2
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.drawable.toBitmap
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.ui.revenuecatui.PaywallViewModel
+import com.revenuecat.purchases.ui.revenuecatui.PaywallViewState
+import com.revenuecat.purchases.ui.revenuecatui.R
+import com.revenuecat.purchases.ui.revenuecatui.UIConstant
+import com.revenuecat.purchases.ui.revenuecatui.accent1Color
+import com.revenuecat.purchases.ui.revenuecatui.accent2Color
+import com.revenuecat.purchases.ui.revenuecatui.backgroundColor
+import com.revenuecat.purchases.ui.revenuecatui.callToActionBackgroundColor
+import com.revenuecat.purchases.ui.revenuecatui.callToActionForegroundColor
+import com.revenuecat.purchases.ui.revenuecatui.getActivity
+import com.revenuecat.purchases.ui.revenuecatui.getColors
+import com.revenuecat.purchases.ui.revenuecatui.localizedConfig
+import com.revenuecat.purchases.ui.revenuecatui.text1Color
+
+@Composable
+internal fun Template2(state: PaywallViewState.Template2, viewModel: PaywallViewModel) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Spacer(modifier = Modifier.weight(1f))
+        Template2MainContent(state, viewModel)
+        Spacer(modifier = Modifier.weight(1f))
+        PurchaseButton(state, viewModel)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    start = UIConstant.defaultHorizontalPadding,
+                    end = UIConstant.defaultHorizontalPadding,
+                    bottom = UIConstant.defaultButtonVerticalSpacing,
+                ),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            RestorePurchasesButton(viewModel)
+        }
+    }
+}
+
+@Composable
+private fun Template2MainContent(state: PaywallViewState.Template2, viewModel: PaywallViewModel) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = UIConstant.defaultHorizontalPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(UIConstant.defaultButtonVerticalSpacing, Alignment.CenterVertically),
+    ) {
+        // TODO-PAYWALLS: Replace with correct image
+        val drawable = LocalContext.current.packageManager.getApplicationIcon(LocalContext.current.packageName)
+        Image(drawable.toBitmap(config = Bitmap.Config.ARGB_8888).asImageBitmap(), contentDescription = "")
+
+        val localizedConfig = state.paywallData.localizedConfig()
+        Text(
+            style = MaterialTheme.typography.displaySmall,
+            fontWeight = FontWeight.Black,
+            textAlign = TextAlign.Center,
+            text = localizedConfig?.title ?: "",
+            color = state.paywallData.getColors().text1Color,
+        )
+        Text(
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            text = localizedConfig?.subtitle ?: "",
+            color = state.paywallData.getColors().text1Color,
+        )
+        state.packages.forEach { aPackage ->
+            SelectPackageButton(state, aPackage, viewModel)
+        }
+    }
+}
+
+@Composable
+private fun PurchaseButton(state: PaywallViewState.Template2, viewModel: PaywallViewModel) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = UIConstant.defaultHorizontalPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        val activity = LocalContext.current.getActivity() ?: error("Error finding activity")
+        val colors = state.paywallData.getColors()
+        Button(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = { viewModel.purchaseSelectedPackage(activity) },
+            colors = ButtonDefaults.buttonColors(
+                containerColor = colors.callToActionBackgroundColor,
+                contentColor = colors.callToActionForegroundColor,
+            ),
+        ) {
+            Text(text = state.paywallData.localizedConfig()?.callToAction ?: "")
+        }
+    }
+}
+
+@Composable
+private fun RestorePurchasesButton(viewModel: PaywallViewModel) {
+    TextButton(onClick = { viewModel.restorePurchases() }) {
+        Text(text = stringResource(id = R.string.restore_purchases))
+    }
+}
+
+@Composable
+private fun SelectPackageButton(
+    state: PaywallViewState.Template2,
+    aPackage: Package,
+    viewModel: PaywallViewModel,
+) {
+    val colors = state.paywallData.getColors()
+    val isSelected = aPackage == state.selectedPackage
+    val (background, textColor) = if (isSelected) {
+        colors.accent2Color to colors.accent1Color
+    } else {
+        // TODO-PAYWALLS: Find correct background unselected color
+        colors.backgroundColor to colors.text1Color
+    }
+    val border = if (isSelected) null else BorderStroke(2.dp, colors.text1Color)
+    Button(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = { viewModel.selectPackage(aPackage) },
+        colors = ButtonDefaults.buttonColors(containerColor = background, contentColor = textColor),
+        shape = RoundedCornerShape(15.dp),
+        border = border,
+    ) {
+        Text(text = "Purchase ${aPackage.identifier}. Price: ${aPackage.product.price.formatted}")
+    }
+}

--- a/ui/revenuecatui/src/main/res/values/strings.xml
+++ b/ui/revenuecatui/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="restore_purchases">Restore purchases</string>
+</resources>


### PR DESCRIPTION
### Description
Mostly a bunch of cleanup and improving the UI in this PR.
- Start using colors for texts and buttons.
- Start using device locale
- Move code to extensions for reusability
- Move paywall view UI to `Template2`. First template we're working on
- Improve Template2 to look closer to actual UI.
- Extract conversion from `Offering` to `PaywallViewState` for easier testing and reusability
- Make sure visibility of elements is correct.
![image](https://github.com/RevenueCat/purchases-android/assets/808417/b6b06544-5e53-4e46-b1e0-e14e6fe62694)
