### PR TITLE
Paywalls: Created AsyncImage to load images asynchronously

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/AsyncImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/AsyncImage.kt
@@ -1,0 +1,43 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import kotlinx.coroutines.launch
+import java.net.URL
+
+@Composable
+internal fun AsyncImage(
+    url: URL,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Fit,
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val bitmapToDisplay = remember { mutableStateOf<Bitmap?>(null) }
+
+    LaunchedEffect(url) {
+        coroutineScope.launch {
+            val result = url.toImageBitmap()
+            result.getOrNull()?.let { bitmap -> bitmapToDisplay.value = bitmap }
+        }
+    }
+
+    bitmapToDisplay.value?.let {
+        Image(
+            it.asImageBitmap(),
+            contentDescription = null,
+            modifier = modifier,
+            contentScale = contentScale,
+        )
+    } ?: Box(modifier = modifier.background(Color.Gray.copy(alpha = 0.5f)))
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/IconImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/IconImage.kt
@@ -1,0 +1,32 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import android.net.Uri
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import com.revenuecat.purchases.paywalls.PaywallData
+import java.net.URL
+
+@Composable
+internal fun IconImage(paywallData: PaywallData) {
+    Column(modifier = Modifier.widthIn(max = UIConstant.maxIconWidth)) {
+        AsyncImage(
+            // TODO-PAYWALLS: Extract to paywall data building code
+            url = URL(
+                Uri.parse(paywallData.assetBaseURL.toString()).buildUpon().path(
+                    paywallData.config.images.icon ?: "",
+                ).build().toString(),
+            ),
+            modifier = Modifier
+                .aspectRatio(ratio = 1f)
+                .widthIn(max = UIConstant.maxIconWidth)
+                .clip(RoundedCornerShape(UIConstant.iconCornerRadius)),
+            contentScale = ContentScale.Crop,
+        )
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.Offering
-import com.revenuecat.purchases.ui.revenuecatui.templates.template2.Template2
+import com.revenuecat.purchases.ui.revenuecatui.templates.Template2
 
 @Composable
 internal fun InternalPaywallView(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/UIConstant.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/UIConstant.kt
@@ -5,4 +5,6 @@ import androidx.compose.ui.unit.dp
 internal object UIConstant {
     val defaultHorizontalPadding = 16.dp
     val defaultButtonVerticalSpacing = 5.dp
+    val maxIconWidth = 140.dp
+    val iconCornerRadius = 16.dp
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/URLExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/URLExtensions.kt
@@ -1,0 +1,30 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import java.net.URL
+
+internal suspend fun URL.toImageBitmap(): Result<Bitmap> {
+    return withContext(Dispatchers.IO) {
+        try {
+            val connection = openConnection()
+            connection.doInput = true
+            connection.connect()
+            val input = connection.inputStream
+            val bitmap = BitmapFactory.decodeStream(input)
+            if (bitmap == null) {
+                val exception = IOException("Image could not be decoded from url $this")
+                Logger.e("Error decoding image from $this", exception)
+                Result.failure(exception)
+            } else {
+                Result.success(bitmap)
+            }
+        } catch (e: IOException) {
+            Logger.e("Error downloading image from $this", e)
+            Result.failure(e)
+        }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -1,8 +1,6 @@
-package com.revenuecat.purchases.ui.revenuecatui.templates.template2
+package com.revenuecat.purchases.ui.revenuecatui.templates
 
-import android.graphics.Bitmap
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -21,14 +19,13 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.drawable.toBitmap
 import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.ui.revenuecatui.IconImage
 import com.revenuecat.purchases.ui.revenuecatui.PaywallViewModel
 import com.revenuecat.purchases.ui.revenuecatui.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.R
@@ -77,10 +74,7 @@ private fun Template2MainContent(state: PaywallViewState.Template2, viewModel: P
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(UIConstant.defaultButtonVerticalSpacing, Alignment.CenterVertically),
     ) {
-        // TODO-PAYWALLS: Replace with correct image
-        val drawable = LocalContext.current.packageManager.getApplicationIcon(LocalContext.current.packageName)
-        Image(drawable.toBitmap(config = Bitmap.Config.ARGB_8888).asImageBitmap(), contentDescription = "")
-
+        IconImage(paywallData = state.paywallData)
         val localizedConfig = state.paywallData.localizedConfig()
         Text(
             style = MaterialTheme.typography.displaySmall,


### PR DESCRIPTION
### Description
This adds a simple `AsyncImage` composable that allows to load an image from a URL. Currently that's loading from internet every time. In the future, we would need to add caching and improve it in general.
![image](https://github.com/RevenueCat/purchases-android/assets/808417/abd89c75-b2dc-4a8a-8eb5-2ad372c0963c)
