### PR TITLE
`Paywalls`: created `PaywallBackground`

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PaywallBackground.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PaywallBackground.kt
@@ -1,0 +1,35 @@
+package com.revenuecat.purchases.ui.revenuecatui.composables
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.BlurredEdgeTreatment
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.paywalls.PaywallData
+import com.revenuecat.purchases.ui.revenuecatui.extensions.backgroundUrlString
+import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
+
+@Composable
+internal fun PaywallBackground(data: PaywallData) {
+    data.backgroundUrlString?.let {
+        RemoteImage(
+            urlString = it,
+            modifier = Modifier
+                .fillMaxSize()
+                .conditional(data.config.blurredBackgroundImage) {
+                    // TODO-PAYWALLS: backwards compatibility for blurring
+                    blur(BackgroundUIConstants.blurSize, edgeTreatment = BlurredEdgeTreatment.Unbounded)
+                        .alpha(BackgroundUIConstants.blurAlpha)
+                },
+            contentScale = ContentScale.Crop,
+        )
+    }
+}
+
+private object BackgroundUIConstants {
+    val blurSize = 40.dp
+    const val blurAlpha = 0.7f
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
@@ -1,0 +1,11 @@
+package com.revenuecat.purchases.ui.revenuecatui.extensions
+
+import androidx.compose.ui.Modifier
+
+fun Modifier.conditional(condition: Boolean, modifier: Modifier.() -> Modifier): Modifier {
+    return if (condition) {
+        then(modifier(Modifier))
+    } else {
+        this
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
@@ -51,9 +51,14 @@ val PaywallData.Configuration.Colors.accent1Color: Color
 val PaywallData.Configuration.Colors.accent2Color: Color
     get() = accent2?.let { Color(it.colorInt) } ?: accent1Color
 
-val PaywallData.iconUrlString: String
+val PaywallData.iconUrlString: String?
     get() = getUrlStringFromImage(config.images.icon)
 
-private fun PaywallData.getUrlStringFromImage(image: String?): String {
-    return Uri.parse(assetBaseURL.toString()).buildUpon().path(image ?: "").build().toString()
+val PaywallData.backgroundUrlString: String?
+    get() = getUrlStringFromImage(config.images.background)
+
+private fun PaywallData.getUrlStringFromImage(image: String?): String? {
+    return image?.let {
+        Uri.parse(assetBaseURL.toString()).buildUpon().path(it).build().toString()
+    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui.templates
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -32,6 +33,7 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
+import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallBackground
 import com.revenuecat.purchases.ui.revenuecatui.composables.RemoteImage
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
@@ -53,24 +55,28 @@ private object Template2UIConstants {
 
 @Composable
 internal fun Template2(state: PaywallViewState.Template2, viewModel: PaywallViewModel) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-    ) {
-        Spacer(modifier = Modifier.weight(1f))
-        Template2MainContent(state, viewModel)
-        Spacer(modifier = Modifier.weight(1f))
-        PurchaseButton(state, viewModel)
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    start = UIConstant.defaultHorizontalPadding,
-                    end = UIConstant.defaultHorizontalPadding,
-                    bottom = UIConstant.defaultButtonVerticalSpacing,
-                ),
-            horizontalArrangement = Arrangement.Center,
+    Box {
+        PaywallBackground(data = state.paywallData)
+
+        Column(
+            modifier = Modifier.fillMaxSize(),
         ) {
-            RestorePurchasesButton(viewModel)
+            Spacer(modifier = Modifier.weight(1f))
+            Template2MainContent(state, viewModel)
+            Spacer(modifier = Modifier.weight(1f))
+            PurchaseButton(state, viewModel)
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        start = UIConstant.defaultHorizontalPadding,
+                        end = UIConstant.defaultHorizontalPadding,
+                        bottom = UIConstant.defaultButtonVerticalSpacing,
+                    ),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                RestorePurchasesButton(viewModel)
+            }
         }
     }
 }
@@ -133,15 +139,17 @@ private fun PurchaseButton(state: PaywallViewState.Template2, viewModel: Paywall
 
 @Composable
 private fun IconImage(paywallData: PaywallData) {
-    Column(modifier = Modifier.widthIn(max = Template2UIConstants.maxIconWidth)) {
-        RemoteImage(
-            urlString = paywallData.iconUrlString,
-            modifier = Modifier
-                .aspectRatio(ratio = 1f)
-                .widthIn(max = Template2UIConstants.maxIconWidth)
-                .clip(RoundedCornerShape(Template2UIConstants.iconCornerRadius)),
-            contentScale = ContentScale.Crop,
-        )
+    paywallData.iconUrlString?.let {
+        Column(modifier = Modifier.widthIn(max = Template2UIConstants.maxIconWidth)) {
+            RemoteImage(
+                urlString = it,
+                modifier = Modifier
+                    .aspectRatio(ratio = 1f)
+                    .widthIn(max = Template2UIConstants.maxIconWidth)
+                    .clip(RoundedCornerShape(Template2UIConstants.iconCornerRadius)),
+                contentScale = ContentScale.Crop,
+            )
+        }
     }
 }
 


### PR DESCRIPTION
This creates a generic `PaywallBackground` that can be used in any template.

![image](https://github.com/RevenueCat/purchases-android/assets/685609/9b800c1c-705a-4b72-9ba7-153b18ab9b4c)

### Other changes:
- Created `Modifier.conditional`
- Changed `PaywallData.getUrlStringFromImage` to return `String?` (images are optional)
- Added `PaywallBackground` to `Template2`