### PR TITLE
Paywalls: Organize files into packages

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
@@ -5,6 +5,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelFactory
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template2
 
 @Composable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
@@ -1,4 +1,4 @@
-package com.revenuecat.purchases.ui.revenuecatui
+package com.revenuecat.purchases.ui.revenuecatui.composables
 
 import android.content.Context
 import androidx.compose.runtime.Composable
@@ -11,7 +11,7 @@ import coil.compose.AsyncImage
 import coil.disk.DiskCache
 
 @Composable
-fun RemoteImage(
+internal fun RemoteImage(
     urlString: String,
     modifier: Modifier = Modifier,
     contentScale: ContentScale = ContentScale.Fit,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -1,4 +1,4 @@
-package com.revenuecat.purchases.ui.revenuecatui
+package com.revenuecat.purchases.ui.revenuecatui.data
 
 import android.app.Activity
 import androidx.lifecycle.ViewModel
@@ -11,6 +11,8 @@ import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.awaitOfferings
 import com.revenuecat.purchases.awaitPurchase
 import com.revenuecat.purchases.awaitRestore
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import com.revenuecat.purchases.ui.revenuecatui.helpers.toPaywallViewState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
@@ -1,4 +1,4 @@
-package com.revenuecat.purchases.ui.revenuecatui
+package com.revenuecat.purchases.ui.revenuecatui.data
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewState.kt
@@ -1,4 +1,4 @@
-package com.revenuecat.purchases.ui.revenuecatui
+package com.revenuecat.purchases.ui.revenuecatui.data
 
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallData

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ContextExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ContextExtensions.kt
@@ -1,4 +1,4 @@
-package com.revenuecat.purchases.ui.revenuecatui
+package com.revenuecat.purchases.ui.revenuecatui.extensions
 
 import android.app.Activity
 import android.content.Context

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
@@ -1,4 +1,4 @@
-package com.revenuecat.purchases.ui.revenuecatui
+package com.revenuecat.purchases.ui.revenuecatui.extensions
 
 import android.net.Uri
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.core.os.ConfigurationCompat
 import androidx.core.os.LocaleListCompat
 import com.revenuecat.purchases.paywalls.PaywallData
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import java.util.Locale
 
 @Composable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/Logger.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/Logger.kt
@@ -1,8 +1,8 @@
-package com.revenuecat.purchases.ui.revenuecatui
+package com.revenuecat.purchases.ui.revenuecatui.helpers
 
 import android.util.Log
 
-object Logger {
+internal object Logger {
     private const val TAG = "RevenueCatUI"
 
     // TODO-PAYWALLS, allow hooking up a custom log handler

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -1,6 +1,7 @@
-package com.revenuecat.purchases.ui.revenuecatui
+package com.revenuecat.purchases.ui.revenuecatui.helpers
 
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 
 @Suppress("ReturnCount")
 internal fun Offering.toPaywallViewState(): PaywallViewState {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -30,21 +30,21 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallData
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewModel
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewState
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.R
-import com.revenuecat.purchases.ui.revenuecatui.RemoteImage
+import com.revenuecat.purchases.ui.revenuecatui.composables.RemoteImage
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
-import com.revenuecat.purchases.ui.revenuecatui.accent1Color
-import com.revenuecat.purchases.ui.revenuecatui.accent2Color
-import com.revenuecat.purchases.ui.revenuecatui.backgroundColor
-import com.revenuecat.purchases.ui.revenuecatui.callToActionBackgroundColor
-import com.revenuecat.purchases.ui.revenuecatui.callToActionForegroundColor
-import com.revenuecat.purchases.ui.revenuecatui.getActivity
-import com.revenuecat.purchases.ui.revenuecatui.getColors
-import com.revenuecat.purchases.ui.revenuecatui.iconUrlString
-import com.revenuecat.purchases.ui.revenuecatui.localizedConfig
-import com.revenuecat.purchases.ui.revenuecatui.text1Color
+import com.revenuecat.purchases.ui.revenuecatui.extensions.accent1Color
+import com.revenuecat.purchases.ui.revenuecatui.extensions.accent2Color
+import com.revenuecat.purchases.ui.revenuecatui.extensions.backgroundColor
+import com.revenuecat.purchases.ui.revenuecatui.extensions.callToActionBackgroundColor
+import com.revenuecat.purchases.ui.revenuecatui.extensions.callToActionForegroundColor
+import com.revenuecat.purchases.ui.revenuecatui.extensions.getActivity
+import com.revenuecat.purchases.ui.revenuecatui.extensions.getColors
+import com.revenuecat.purchases.ui.revenuecatui.extensions.iconUrlString
+import com.revenuecat.purchases.ui.revenuecatui.extensions.localizedConfig
+import com.revenuecat.purchases.ui.revenuecatui.extensions.text1Color
 
 private object Template2UIConstants {
     val maxIconWidth = 140.dp

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -30,11 +30,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallData
+import com.revenuecat.purchases.ui.revenuecatui.R
+import com.revenuecat.purchases.ui.revenuecatui.UIConstant
+import com.revenuecat.purchases.ui.revenuecatui.composables.RemoteImage
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
-import com.revenuecat.purchases.ui.revenuecatui.R
-import com.revenuecat.purchases.ui.revenuecatui.composables.RemoteImage
-import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.extensions.accent1Color
 import com.revenuecat.purchases.ui.revenuecatui.extensions.accent2Color
 import com.revenuecat.purchases.ui.revenuecatui.extensions.backgroundColor


### PR DESCRIPTION
### Description
This PR reorganizes the the new RevenueCatUI module files. The packages are:
- `composables`: For generic composables used in multiple UI locations
- `helpers`: Generic helpers
- `extensions`: Extensions for existing classes
- `data`: Data used to drive the UI and view model
