### PR TITLE
Catch IllegalStateException and forward StoreProblemError

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -56,6 +56,7 @@ import com.revenuecat.purchases.strings.RestoreStrings
 import com.revenuecat.purchases.utils.Result
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.lang.IllegalStateException
 import java.util.Date
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.math.min
@@ -129,11 +130,18 @@ internal class BillingWrapper(
                     log(LogIntent.DEBUG, BillingStrings.BILLING_CLIENT_STARTING.format(it))
                     if (startConnectionAttempts < MAX_RECONNECTION_ATTEMPTS) {
                         startConnectionAttempts++
-                        it.startConnection(this)
+                        try {
+                            it.startConnection(this)
+                        } catch (e: IllegalStateException) {
+                            log(
+                                LogIntent.GOOGLE_ERROR,
+                                BillingStrings.ILLEGAL_STATE_EXCEPTION_WHEN_CONNECTING.format(e),
+                            )
+                        }
                     } else {
                         // There's an IllegalStateException on Samsung devices that try to bind to the service more
                         // than 999 times. This is a workaround to avoid that.
-                        log(LogIntent.DEBUG, BillingStrings.BILLING_CLIENT_TOO_MANY_RETRIES.format(it))
+                        log(LogIntent.DEBUG, BillingStrings.BILLING_CLIENT_TOO_MANY_RETRIES)
                         it.endConnection()
                     }
                 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -20,7 +20,6 @@ internal object BillingStrings {
     const val NULL_ACTIVITY_INTENT = "Activity passed into launchBillingFlow has a null intent, which may cause " +
         "a crash. See https://github.com/RevenueCat/purchases-android/issues/381 for more information."
     const val BILLING_CLIENT_RETRY = "Retrying BillingClient connection after backoff of %s milliseconds."
-    const val BILLING_CLIENT_TOO_MANY_RETRIES = "There were too many attempts to start connection. Ending connection."
     const val ILLEGAL_STATE_EXCEPTION_WHEN_CONNECTING = "There was an IllegalStateException when connecting to " +
         "BillingClient. This has been reported to occur on Samsung devices on unknown circumstances.\nException: %s"
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -20,4 +20,5 @@ internal object BillingStrings {
     const val NULL_ACTIVITY_INTENT = "Activity passed into launchBillingFlow has a null intent, which may cause " +
         "a crash. See https://github.com/RevenueCat/purchases-android/issues/381 for more information."
     const val BILLING_CLIENT_RETRY = "Retrying BillingClient connection after backoff of %s milliseconds."
+    const val BILLING_CLIENT_TOO_MANY_RETRIES = "Ending connection for %s"
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -20,5 +20,7 @@ internal object BillingStrings {
     const val NULL_ACTIVITY_INTENT = "Activity passed into launchBillingFlow has a null intent, which may cause " +
         "a crash. See https://github.com/RevenueCat/purchases-android/issues/381 for more information."
     const val BILLING_CLIENT_RETRY = "Retrying BillingClient connection after backoff of %s milliseconds."
-    const val BILLING_CLIENT_TOO_MANY_RETRIES = "Ending connection for %s"
+    const val BILLING_CLIENT_TOO_MANY_RETRIES = "There were too many attempts to start connection. Ending connection."
+    const val ILLEGAL_STATE_EXCEPTION_WHEN_CONNECTING = "There was an IllegalStateException when connecting to " +
+        "BillingClient. This has been reported to occur on Samsung devices on unknown circumstances.\nException: %s"
 }


### PR DESCRIPTION
Hopefully this fix the following stacktrace on Samsung devices

```
Fatal Exception: java.lang.IllegalStateException: Too many bind requests(999+) for service Intent { act=com.android.vending.billing.InAppBillingService.BIND pkg=com.android.vending cmp=com.android.vending/com.google.android.finsky.billing.iab.InAppBillingService (has extras) }
       at android.app.ContextImpl.bindServiceCommon(ContextImpl.java:2115)
       at android.app.ContextImpl.bindService(ContextImpl.java:2024)
       at android.content.ContextWrapper.bindService(ContextWrapper.java:870)
       at com.android.billingclient.api.BillingClientImpl.launchBillingFlow(com.android.billingclient:billing@@5.1.0:52)
       at com.revenuecat.purchases.google.BillingWrapper.startConnection(BillingWrapper.kt:122)
       at com.revenuecat.purchases.google.BillingWrapper.startConnectionOnMainThread$lambda-3(BillingWrapper.kt:108)
       at com.revenuecat.purchases.google.BillingWrapper.$r8$lambda$hLiSTu2HCHKyRrb-HVFlJFdt_lQ(BillingWrapper.kt)
       at com.revenuecat.purchases.google.BillingWrapper$$ExternalSyntheticLambda9.run(D8$$SyntheticClass:2)
       at android.os.Handler.handleCallback(Handler.java:942)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8757)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
 ```
 
 Related issues I found:
 
 https://github.com/Automattic/simplenote-android/pull/1601
 
 https://github.com/brave/brave-core/pull/16795/ (although it looks like they took a similar approach and the problem didn't get fixed https://github.com/brave/brave-browser/issues/27751#issuecomment-1419374952)

https://github.com/brave/brave-browser/issues/28946
 
 
 I added a max for attempting to reconnect and also a try/catch in case that doesn't fix it.
 