### PR TITLE
Add `valueInMonths` helper to `Period` class

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PeriodAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PeriodAPI.java
@@ -8,6 +8,7 @@ final class PeriodAPI {
         int val = period.getValue();
         Period.Unit unit = period.getUnit();
         String iso8601 = period.getIso8601();
+        Double valueInMonths = period.getValueInMonths();
 
         switch (unit) {
             case DAY:

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PricingPhaseAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PricingPhaseAPI.java
@@ -16,4 +16,10 @@ final class PricingPhaseAPI {
 
         OfferPaymentMode offerPaymentMode = pricingPhase.getOfferPaymentMode();
     }
+
+    static void checkPrice(Price price) {
+        String formatted = price.getFormatted();
+        Long amount = price.getAmountMicros();
+        String currencyCode = price.getCurrencyCode();
+    }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PeriodAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PeriodAPI.kt
@@ -9,6 +9,7 @@ private class PeriodAPI {
             val value: Int = value
             val unit: Period.Unit = unit
             val iso8601: String = iso8601
+            val valueInMonths: Double = valueInMonths
 
             when (unit) {
                 Period.Unit.DAY,

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PricingPhaseAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PricingPhaseAPI.kt
@@ -16,4 +16,10 @@ private class PricingPhaseAPI {
 
         val offerPaymentMode: OfferPaymentMode? = pricingPhase.offerPaymentMode
     }
+
+    fun checkingPrice(price: Price) {
+        val formatted: String = price.formatted
+        val amountMicros: Long = price.amountMicros
+        val currencyCode: String = price.currencyCode
+    }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/Period.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/Period.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.models
 
 import android.os.Parcelable
+import com.revenuecat.purchases.common.errorLog
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -27,6 +28,10 @@ data class Period(
 ) : Parcelable {
 
     companion object Factory {
+        private const val DAYS_PER_MONTH = 30.0
+        private const val WEEKS_PER_MONTH = 4.0
+        private const val MONTHS_PER_YEAR = 12.0
+
         fun create(iso8601: String): Period {
             val pair = iso8601.toPeriod()
             return Period(pair.first, pair.second, iso8601)
@@ -41,6 +46,18 @@ data class Period(
         YEAR,
         UNKNOWN,
     }
+
+    val valueInMonths: Double
+        get() = when (unit) {
+            Unit.DAY -> value / DAYS_PER_MONTH
+            Unit.WEEK -> value / WEEKS_PER_MONTH
+            Unit.MONTH -> value.toDouble()
+            Unit.YEAR -> value * MONTHS_PER_YEAR
+            Unit.UNKNOWN -> {
+                errorLog("Unknown period unit trying to get value in months: $unit")
+                0.0
+            }
+        }
 }
 
 // Would use Duration.parse but only available API 26 and up

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/Period.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/Period.kt
@@ -47,6 +47,9 @@ data class Period(
         UNKNOWN,
     }
 
+    /**
+     * The period value in month units. This is an approximated value.
+     */
     val valueInMonths: Double
         get() = when (unit) {
             Unit.DAY -> value / DAYS_PER_MONTH

--- a/purchases/src/test/java/com/revenuecat/purchases/models/PeriodTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/models/PeriodTest.kt
@@ -1,0 +1,84 @@
+package com.revenuecat.purchases.models
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PeriodTest {
+    companion object {
+        private val MAX_OFFSET = Offset.offset(0.0000001)
+    }
+
+    @Test
+    fun `create period creates expected period class for months`() {
+        val period = Period.create("P1M")
+        assertThat(period.value).isEqualTo(1)
+        assertThat(period.unit).isEqualTo(Period.Unit.MONTH)
+        assertThat(period.iso8601).isEqualTo("P1M")
+    }
+
+    @Test
+    fun `create period creates expected period class for years`() {
+        val period = Period.create("P1Y")
+        assertThat(period.value).isEqualTo(1)
+        assertThat(period.unit).isEqualTo(Period.Unit.YEAR)
+        assertThat(period.iso8601).isEqualTo("P1Y")
+    }
+
+    @Test
+    fun `create period creates expected period class for weeks`() {
+        val period = Period.create("P1W")
+        assertThat(period.value).isEqualTo(1)
+        assertThat(period.unit).isEqualTo(Period.Unit.WEEK)
+        assertThat(period.iso8601).isEqualTo("P1W")
+    }
+
+    @Test
+    fun `create period creates expected period class for days`() {
+        val period = Period.create("P1D")
+        assertThat(period.value).isEqualTo(1)
+        assertThat(period.unit).isEqualTo(Period.Unit.DAY)
+        assertThat(period.iso8601).isEqualTo("P1D")
+    }
+
+    @Test
+    fun `create period creates expected period class for multiple units`() {
+        val period = Period.create("P3M")
+        assertThat(period.value).isEqualTo(3)
+        assertThat(period.unit).isEqualTo(Period.Unit.MONTH)
+        assertThat(period.iso8601).isEqualTo("P3M")
+    }
+
+    @Test
+    fun `valueInMonths is correct for days`() {
+        val period = Period.create("P3D")
+        assertThat(period.valueInMonths).isCloseTo(0.1, MAX_OFFSET)
+    }
+
+    @Test
+    fun `valueInMonths is correct for weeks`() {
+        val period = Period.create("P2W")
+        assertThat(period.valueInMonths).isCloseTo(0.5, MAX_OFFSET)
+    }
+
+    @Test
+    fun `valueInMonths is correct for months`() {
+        val period = Period.create("P1M")
+        assertThat(period.valueInMonths).isEqualTo(1.0, MAX_OFFSET)
+    }
+
+    @Test
+    fun `valueInMonths is correct for years`() {
+        val period = Period.create("P1Y")
+        assertThat(period.valueInMonths).isCloseTo(12.0, MAX_OFFSET)
+    }
+
+    @Test
+    fun `valueInMonths is 0 for unknown`() {
+        val period = Period(value = 1, unit = Period.Unit.UNKNOWN, iso8601 = "P1W")
+        assertThat(period.valueInMonths).isCloseTo(0.0, MAX_OFFSET)
+    }
+}


### PR DESCRIPTION
### Description
To help with the variables work needed for paywalls, this adds a helper function `valueInMonths` for the `Period` class. This will be used to calculate the price per month.
