### PR TITLE
Paywalls: Add variable processing to paywall strings

### DIFF
--- a/ui/revenuecatui/build.gradle
+++ b/ui/revenuecatui/build.gradle
@@ -50,4 +50,7 @@ dependencies {
     implementation libs.coil.compose
     debugImplementation libs.compose.ui.tooling
     debugImplementation libs.androidx.test.compose.manifest
+
+    testImplementation libs.bundles.test
+    testImplementation libs.coroutines.test
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
@@ -25,11 +25,7 @@ internal fun InternalPaywallView(
     listener: PaywallViewListener? = null,
     viewModel: PaywallViewModel = getPaywallViewModel(offering = offering, listener = listener),
 ) {
-    var locale by remember { mutableStateOf(LocaleListCompat.getDefault()) }
-    if (locale != LocaleListCompat.getDefault()) {
-        locale = LocaleListCompat.getDefault()
-        viewModel.refreshState()
-    }
+    updateStateIfLocaleChanged(viewModel)
 
     when (val state = viewModel.state.collectAsState().value) {
         is PaywallViewState.Loading -> {
@@ -47,6 +43,15 @@ internal fun InternalPaywallView(
                 PaywallTemplate.TEMPLATE_5 -> Text(text = "Error: Template 5 not supported")
             }
         }
+    }
+}
+
+@Composable
+private fun updateStateIfLocaleChanged(viewModel: PaywallViewModel) {
+    var locale by remember { mutableStateOf(LocaleListCompat.getDefault()) }
+    if (locale != LocaleListCompat.getDefault()) {
+        locale = LocaleListCompat.getDefault()
+        viewModel.refreshState()
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
@@ -3,6 +3,12 @@ package com.revenuecat.purchases.ui.revenuecatui
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
@@ -11,6 +17,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template2
+import java.lang.ref.WeakReference
 
 @Composable
 internal fun InternalPaywallView(
@@ -18,6 +25,12 @@ internal fun InternalPaywallView(
     listener: PaywallViewListener? = null,
     viewModel: PaywallViewModel = getPaywallViewModel(offering = offering, listener = listener),
 ) {
+    var locale by remember { mutableStateOf(LocaleListCompat.getDefault()) }
+    if (locale != LocaleListCompat.getDefault()) {
+        locale = LocaleListCompat.getDefault()
+        viewModel.refreshState()
+    }
+
     when (val state = viewModel.state.collectAsState().value) {
         is PaywallViewState.Loading -> {
             Text(text = "Loading...")
@@ -40,6 +53,6 @@ internal fun InternalPaywallView(
 @Composable
 private fun getPaywallViewModel(offering: Offering?, listener: PaywallViewListener?): PaywallViewModel {
     return viewModel<PaywallViewModelImpl>(
-        factory = PaywallViewModelFactory(offering, listener),
+        factory = PaywallViewModelFactory(WeakReference(LocalContext.current.applicationContext), offering, listener),
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
@@ -17,7 +17,6 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template2
-import java.lang.ref.WeakReference
 
 @Composable
 internal fun InternalPaywallView(
@@ -58,6 +57,6 @@ private fun updateStateIfLocaleChanged(viewModel: PaywallViewModel) {
 @Composable
 private fun getPaywallViewModel(offering: Offering?, listener: PaywallViewListener?): PaywallViewModel {
     return viewModel<PaywallViewModelImpl>(
-        factory = PaywallViewModelFactory(WeakReference(LocalContext.current.applicationContext), offering, listener),
+        factory = PaywallViewModelFactory(LocalContext.current.applicationContext, offering, listener),
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
@@ -5,10 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.PaywallViewListener
-import java.lang.ref.WeakReference
 
 internal class PaywallViewModelFactory(
-    private val applicationContext: WeakReference<Context>,
+    private val applicationContext: Context,
     private val offering: Offering?,
     private val listener: PaywallViewListener?,
 ) : ViewModelProvider.NewInstanceFactory() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
@@ -1,15 +1,18 @@
 package com.revenuecat.purchases.ui.revenuecatui.data
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.PaywallViewListener
+import java.lang.ref.WeakReference
 
 internal class PaywallViewModelFactory(
+    private val applicationContext: WeakReference<Context>,
     private val offering: Offering?,
     private val listener: PaywallViewListener?,
 ) : ViewModelProvider.NewInstanceFactory() {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        return PaywallViewModelImpl(offering, listener) as T
+        return PaywallViewModelImpl(applicationContext, offering, listener) as T
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
@@ -64,45 +64,45 @@ internal object TestData {
         paywall = template2,
         serverDescription = "",
     )
-}
 
-private object Packages {
-    val weekly = Package(
-        packageType = PackageType.WEEKLY,
-        identifier = PackageType.WEEKLY.identifier!!,
-        offering = "offering",
-        product = TestStoreProduct(
-            id = "com.revenuecat.weekly_product",
-            title = "Weekly",
-            price = Price(amountMicros = 199, currencyCode = "USA", formatted = "$1.99"),
-            description = "Weekly",
-            period = Period(value = 1, unit = Period.Unit.WEEK, iso8601 = "P1W"),
-        ),
-    )
-    val monthly = Package(
-        packageType = PackageType.MONTHLY,
-        identifier = PackageType.MONTHLY.identifier!!,
-        offering = "offering",
-        product = TestStoreProduct(
-            id = "com.revenuecat.monthly_product",
-            title = "Monthly",
-            price = Price(amountMicros = 799, currencyCode = "USA", formatted = "$7.99"),
-            description = "Monthly",
-            period = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
-        ),
-    )
-    val annual = Package(
-        packageType = PackageType.ANNUAL,
-        identifier = PackageType.ANNUAL.identifier!!,
-        offering = "offering",
-        product = TestStoreProduct(
-            id = "com.revenuecat.annual_product",
-            title = "Annual",
-            price = Price(amountMicros = 6799, currencyCode = "USA", formatted = "$67.99"),
-            description = "Annual",
-            period = Period(value = 12, unit = Period.Unit.MONTH, iso8601 = "P1Y"),
-        ),
-    )
+    object Packages {
+        val weekly = Package(
+            packageType = PackageType.WEEKLY,
+            identifier = PackageType.WEEKLY.identifier!!,
+            offering = "offering",
+            product = TestStoreProduct(
+                id = "com.revenuecat.weekly_product",
+                title = "Weekly",
+                price = Price(amountMicros = 1_990_000, currencyCode = "USD", formatted = "$1.99"),
+                description = "Weekly",
+                period = Period(value = 1, unit = Period.Unit.WEEK, iso8601 = "P1W"),
+            ),
+        )
+        val monthly = Package(
+            packageType = PackageType.MONTHLY,
+            identifier = PackageType.MONTHLY.identifier!!,
+            offering = "offering",
+            product = TestStoreProduct(
+                id = "com.revenuecat.monthly_product",
+                title = "Monthly",
+                price = Price(amountMicros = 7_990_000, currencyCode = "USD", formatted = "$7.99"),
+                description = "Monthly",
+                period = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
+            ),
+        )
+        val annual = Package(
+            packageType = PackageType.ANNUAL,
+            identifier = PackageType.ANNUAL.identifier!!,
+            offering = "offering",
+            product = TestStoreProduct(
+                id = "com.revenuecat.annual_product",
+                title = "Annual",
+                price = Price(amountMicros = 67_990_000, currencyCode = "USD", formatted = "$67.99"),
+                description = "Annual",
+                period = Period(value = 12, unit = Period.Unit.MONTH, iso8601 = "P1Y"),
+            ),
+        )
+    }
 }
 
 private object Constants {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
@@ -13,7 +13,6 @@ import com.revenuecat.purchases.models.SubscriptionOptions
 import com.revenuecat.purchases.paywalls.PaywallColor
 import com.revenuecat.purchases.paywalls.PaywallData
 import java.net.URL
-import java.util.Locale
 
 internal object TestData {
     val template2 = PaywallData(
@@ -142,9 +141,5 @@ private data class TestStoreProduct(
 
     override fun copyWithOfferingId(offeringId: String): StoreProduct {
         return this
-    }
-
-    override fun formattedPricePerMonth(locale: Locale): String {
-        return "test_formatted_price_per_month"
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
-import android.content.Context
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
@@ -9,7 +8,7 @@ import java.util.Locale
 internal object PackageConfigurationFactory {
     @Suppress("LongParameterList")
     fun createPackageConfiguration(
-        context: Context,
+        variableDataProvider: VariableDataProvider,
         packages: List<Package>,
         activelySubscribedProductIdentifiers: Set<String>,
         filter: List<String>,
@@ -30,7 +29,7 @@ internal object PackageConfigurationFactory {
         val packageInfos = filteredRCPackages.map {
             TemplateConfiguration.PackageInfo(
                 rcPackage = it,
-                localization = ProcessedLocalizedConfiguration.create(context, localization, it, locale),
+                localization = ProcessedLocalizedConfiguration.create(variableDataProvider, localization, it, locale),
                 currentlySubscribed = activelySubscribedProductIdentifiers.contains(it.product.id),
                 discountRelativeToMostExpensivePerMonth = null, // TODO-PAYWALLS: Support discount UI
             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
+import android.content.Context
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
@@ -8,6 +9,7 @@ import java.util.Locale
 internal object PackageConfigurationFactory {
     @Suppress("LongParameterList")
     fun createPackageConfiguration(
+        context: Context,
         packages: List<Package>,
         activelySubscribedProductIdentifiers: Set<String>,
         filter: List<String>,
@@ -28,7 +30,7 @@ internal object PackageConfigurationFactory {
         val packageInfos = filteredRCPackages.map {
             TemplateConfiguration.PackageInfo(
                 rcPackage = it,
-                localization = ProcessedLocalizedConfiguration.create(localization, it, locale),
+                localization = ProcessedLocalizedConfiguration.create(context, localization, it, locale),
                 currentlySubscribed = activelySubscribedProductIdentifiers.contains(it.product.id),
                 discountRelativeToMostExpensivePerMonth = null, // TODO-PAYWALLS: Support discount UI
             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/ProcessedLocalizedConfiguration.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/ProcessedLocalizedConfiguration.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
-import android.content.Context
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallData
 import java.util.Locale
@@ -17,14 +16,14 @@ internal data class ProcessedLocalizedConfiguration(
 ) {
     companion object {
         fun create(
-            context: Context,
+            variableDataProvider: VariableDataProvider,
             localizedConfiguration: PaywallData.LocalizedConfiguration,
             rcPackage: Package,
             locale: Locale,
         ): ProcessedLocalizedConfiguration {
             fun String.processVariables(): String {
                 return VariableProcessor.processVariables(
-                    context,
+                    variableDataProvider,
                     this,
                     rcPackage,
                     locale,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/ProcessedLocalizedConfiguration.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/ProcessedLocalizedConfiguration.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
+import android.content.Context
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallData
 import java.util.Locale
@@ -16,36 +17,34 @@ internal data class ProcessedLocalizedConfiguration(
 ) {
     companion object {
         fun create(
+            context: Context,
             localizedConfiguration: PaywallData.LocalizedConfiguration,
             rcPackage: Package,
             locale: Locale,
         ): ProcessedLocalizedConfiguration {
+            fun String.processVariables(): String {
+                return VariableProcessor.processVariables(
+                    context,
+                    this,
+                    rcPackage,
+                    locale,
+                )
+            }
             return ProcessedLocalizedConfiguration(
-                title = localizedConfiguration.title.processVariables(rcPackage, locale),
-                subtitle = localizedConfiguration.subtitle?.processVariables(rcPackage, locale),
-                callToAction = localizedConfiguration.callToAction.processVariables(rcPackage, locale),
-                callToActionWithIntroOffer = localizedConfiguration.callToActionWithIntroOffer?.processVariables(
-                    rcPackage,
-                    locale,
-                ),
-                offerDetails = localizedConfiguration.offerDetails?.processVariables(rcPackage, locale),
-                offerDetailsWithIntroOffer = localizedConfiguration.offerDetailsWithIntroOffer?.processVariables(
-                    rcPackage,
-                    locale,
-                ),
-                offerName = localizedConfiguration.offerName?.processVariables(rcPackage, locale),
+                title = localizedConfiguration.title.processVariables(),
+                subtitle = localizedConfiguration.subtitle?.processVariables(),
+                callToAction = localizedConfiguration.callToAction.processVariables(),
+                callToActionWithIntroOffer = localizedConfiguration.callToActionWithIntroOffer?.processVariables(),
+                offerDetails = localizedConfiguration.offerDetails?.processVariables(),
+                offerDetailsWithIntroOffer = localizedConfiguration.offerDetailsWithIntroOffer?.processVariables(),
+                offerName = localizedConfiguration.offerName?.processVariables(),
                 features = localizedConfiguration.features.map { feature ->
                     feature.copy(
-                        title = feature.title.processVariables(rcPackage, locale),
-                        content = feature.content?.processVariables(rcPackage, locale),
+                        title = feature.title.processVariables(),
+                        content = feature.content?.processVariables(),
                     )
                 },
             )
-        }
-
-        @Suppress("UnusedParameter")
-        private fun String.processVariables(rcPackage: Package, locale: Locale): String {
-            return this // TODO-PAYWALLS: Process variables
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
-import android.content.Context
 import android.net.Uri
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallData
@@ -10,7 +9,7 @@ import java.util.Locale
 internal object TemplateConfigurationFactory {
     @Suppress("LongParameterList", "ThrowsCount")
     fun create(
-        context: Context,
+        variableDataProvider: VariableDataProvider,
         mode: PaywallViewMode,
         paywallData: PaywallData,
         packages: List<Package>,
@@ -31,7 +30,7 @@ internal object TemplateConfigurationFactory {
             headerUri = paywallData.getUriFromImage(paywallData.config.images.header),
         )
         val packageConfiguration = PackageConfigurationFactory.createPackageConfiguration(
-            context = context,
+            variableDataProvider = variableDataProvider,
             packages = packages,
             activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers,
             filter = packageIds,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
+import android.content.Context
 import android.net.Uri
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallData
@@ -9,6 +10,7 @@ import java.util.Locale
 internal object TemplateConfigurationFactory {
     @Suppress("LongParameterList", "ThrowsCount")
     fun create(
+        context: Context,
         mode: PaywallViewMode,
         paywallData: PaywallData,
         packages: List<Package>,
@@ -29,6 +31,7 @@ internal object TemplateConfigurationFactory {
             headerUri = paywallData.getUriFromImage(paywallData.config.images.header),
         )
         val packageConfiguration = PackageConfigurationFactory.createPackageConfiguration(
+            context = context,
             packages = packages,
             activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers,
             filter = packageIds,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
@@ -1,0 +1,57 @@
+package com.revenuecat.purchases.ui.revenuecatui.data.processed
+
+import android.content.Context
+import com.revenuecat.purchases.Package
+import java.text.NumberFormat
+import java.util.Currency
+import java.util.Locale
+
+@Suppress("UnusedParameter", "FunctionOnlyReturningConstant")
+internal object VariableDataProvider {
+    private const val MICRO_MULTIPLIER = 1000000.0
+
+    fun applicationName(context: Context): String {
+        return context.applicationInfo.loadLabel(context.packageManager).toString()
+    }
+
+    fun localizedPrice(rcPackage: Package): String {
+        return rcPackage.product.price.formatted
+    }
+
+    fun localizedPricePerMonth(rcPackage: Package, locale: Locale): String {
+        val price = rcPackage.product.price.amountMicros / MICRO_MULTIPLIER
+        val periodMonths = rcPackage.product.period?.valueInMonths ?: 1.0
+        val currencyCode = rcPackage.product.price.currencyCode
+        val numberFormat = NumberFormat.getCurrencyInstance(locale)
+        numberFormat.currency = Currency.getInstance(currencyCode)
+        return numberFormat.format(price / periodMonths)
+    }
+
+    fun localizedIntroductoryOfferPrice(rcPackage: Package): String? {
+        return "INTRO_OFFER_PRICE"
+    }
+
+    fun productName(rcPackage: Package): String {
+        return "PRODUCT_NAME"
+    }
+
+    fun periodName(rcPackage: Package): String {
+        return "PERIOD_NAME"
+    }
+
+    fun subscriptionDuration(rcPackage: Package): String? {
+        return "SUBS_DURATION"
+    }
+
+    fun introductoryOfferDuration(rcPackage: Package): String? {
+        return "INT_OFFER_DURATION"
+    }
+
+    fun localizedPricePerPeriod(rcPackage: Package): String {
+        return "PRICE_PER_PERIOD"
+    }
+
+    fun localizedPriceAndPerMonth(rcPackage: Package): String {
+        return "PRICE_AND_PER_MONTH"
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
@@ -2,18 +2,12 @@ package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
 import android.content.Context
 import com.revenuecat.purchases.Package
-import java.text.NumberFormat
-import java.util.Currency
 import java.util.Locale
 
 @Suppress("UnusedParameter", "FunctionOnlyReturningConstant")
 internal class VariableDataProvider(
     private val applicationContext: Context,
 ) {
-    companion object {
-        private const val MICRO_MULTIPLIER = 1000000.0
-    }
-
     val applicationName: String
         get() = applicationContext.applicationInfo.loadLabel(applicationContext.packageManager).toString()
 
@@ -22,12 +16,7 @@ internal class VariableDataProvider(
     }
 
     fun localizedPricePerMonth(rcPackage: Package, locale: Locale): String {
-        val price = rcPackage.product.price.amountMicros / MICRO_MULTIPLIER
-        val periodMonths = rcPackage.product.period?.valueInMonths ?: 1.0
-        val currencyCode = rcPackage.product.price.currencyCode
-        val numberFormat = NumberFormat.getCurrencyInstance(locale)
-        numberFormat.currency = Currency.getInstance(currencyCode)
-        return numberFormat.format(price / periodMonths)
+        return rcPackage.product.formattedPricePerMonth(locale) ?: ""
     }
 
     fun localizedIntroductoryOfferPrice(rcPackage: Package): String? {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
@@ -7,12 +7,15 @@ import java.util.Currency
 import java.util.Locale
 
 @Suppress("UnusedParameter", "FunctionOnlyReturningConstant")
-internal object VariableDataProvider {
-    private const val MICRO_MULTIPLIER = 1000000.0
-
-    fun applicationName(context: Context): String {
-        return context.applicationInfo.loadLabel(context.packageManager).toString()
+internal class VariableDataProvider(
+    private val applicationContext: Context,
+) {
+    companion object {
+        private const val MICRO_MULTIPLIER = 1000000.0
     }
+
+    val applicationName: String
+        get() = applicationContext.applicationInfo.loadLabel(applicationContext.packageManager).toString()
 
     fun localizedPrice(rcPackage: Package): String {
         return rcPackage.product.price.formatted

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
@@ -1,0 +1,51 @@
+package com.revenuecat.purchases.ui.revenuecatui.data.processed
+
+import android.content.Context
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import java.util.Locale
+
+internal object VariableProcessor {
+    private val REGEX = Regex("\\{\\{\\s[a-zA-Z0-9_]+\\s\\}\\}")
+
+    fun processVariables(
+        context: Context,
+        originalString: String,
+        rcPackage: Package,
+        locale: Locale,
+    ): String {
+        var resultString = originalString
+        REGEX.findAll(originalString).toList().reversed().forEach { matchResult ->
+            val newValue = variableValue(context, matchResult, rcPackage, locale)
+            newValue?.let {
+                resultString = resultString.replaceRange(matchResult.range, it)
+            }
+        }
+        return resultString
+    }
+
+    private fun variableValue(
+        context: Context,
+        matchResult: MatchResult,
+        rcPackage: Package,
+        locale: Locale,
+    ): String? {
+        val variableString = matchResult.value
+        return when (val variableWithoutBraces = variableString.substring(2, variableString.length - 2).trim()) {
+            "app_name" -> VariableDataProvider.applicationName(context)
+            "price" -> VariableDataProvider.localizedPrice(rcPackage)
+            "price_per_period" -> VariableDataProvider.localizedPricePerPeriod(rcPackage)
+            "total_price_and_per_month" -> VariableDataProvider.localizedPriceAndPerMonth(rcPackage)
+            "product_name" -> VariableDataProvider.productName(rcPackage)
+            "sub_period" -> VariableDataProvider.periodName(rcPackage)
+            "sub_price_per_month" -> VariableDataProvider.localizedPricePerMonth(rcPackage, locale)
+            "sub_duration" -> VariableDataProvider.subscriptionDuration(rcPackage)
+            "sub_offer_duration" -> VariableDataProvider.introductoryOfferDuration(rcPackage)
+            "sub_offer_price" -> VariableDataProvider.localizedIntroductoryOfferPrice(rcPackage)
+            else -> {
+                Logger.e("Unknown variable: $variableWithoutBraces")
+                null
+            }
+        }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
@@ -15,7 +15,9 @@ internal object VariableProcessor {
     ): String {
         var resultString = originalString
         REGEX.findAll(originalString).toList().reversed().forEach { matchResult ->
-            val newValue = variableValue(variableDataProvider, matchResult, rcPackage, locale)
+            val variableString = matchResult.value
+            val variableWithoutBraces = variableString.substring(2, variableString.length - 2).trim()
+            val newValue = variableValue(variableDataProvider, variableWithoutBraces, rcPackage, locale)
             newValue?.let {
                 resultString = resultString.replaceRange(matchResult.range, it)
             }
@@ -25,12 +27,11 @@ internal object VariableProcessor {
 
     private fun variableValue(
         variableDataProvider: VariableDataProvider,
-        matchResult: MatchResult,
+        variableName: String,
         rcPackage: Package,
         locale: Locale,
     ): String? {
-        val variableString = matchResult.value
-        return when (val variableWithoutBraces = variableString.substring(2, variableString.length - 2).trim()) {
+        return when (variableName) {
             "app_name" -> variableDataProvider.applicationName
             "price" -> variableDataProvider.localizedPrice(rcPackage)
             "price_per_period" -> variableDataProvider.localizedPricePerPeriod(rcPackage)
@@ -42,7 +43,7 @@ internal object VariableProcessor {
             "sub_offer_duration" -> variableDataProvider.introductoryOfferDuration(rcPackage)
             "sub_offer_price" -> variableDataProvider.localizedIntroductoryOfferPrice(rcPackage)
             else -> {
-                Logger.e("Unknown variable: $variableWithoutBraces")
+                Logger.e("Unknown variable: $variableName")
                 null
             }
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
-import android.content.Context
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import java.util.Locale
@@ -9,14 +8,14 @@ internal object VariableProcessor {
     private val REGEX = Regex("\\{\\{\\s[a-zA-Z0-9_]+\\s\\}\\}")
 
     fun processVariables(
-        context: Context,
+        variableDataProvider: VariableDataProvider,
         originalString: String,
         rcPackage: Package,
         locale: Locale,
     ): String {
         var resultString = originalString
         REGEX.findAll(originalString).toList().reversed().forEach { matchResult ->
-            val newValue = variableValue(context, matchResult, rcPackage, locale)
+            val newValue = variableValue(variableDataProvider, matchResult, rcPackage, locale)
             newValue?.let {
                 resultString = resultString.replaceRange(matchResult.range, it)
             }
@@ -25,23 +24,23 @@ internal object VariableProcessor {
     }
 
     private fun variableValue(
-        context: Context,
+        variableDataProvider: VariableDataProvider,
         matchResult: MatchResult,
         rcPackage: Package,
         locale: Locale,
     ): String? {
         val variableString = matchResult.value
         return when (val variableWithoutBraces = variableString.substring(2, variableString.length - 2).trim()) {
-            "app_name" -> VariableDataProvider.applicationName(context)
-            "price" -> VariableDataProvider.localizedPrice(rcPackage)
-            "price_per_period" -> VariableDataProvider.localizedPricePerPeriod(rcPackage)
-            "total_price_and_per_month" -> VariableDataProvider.localizedPriceAndPerMonth(rcPackage)
-            "product_name" -> VariableDataProvider.productName(rcPackage)
-            "sub_period" -> VariableDataProvider.periodName(rcPackage)
-            "sub_price_per_month" -> VariableDataProvider.localizedPricePerMonth(rcPackage, locale)
-            "sub_duration" -> VariableDataProvider.subscriptionDuration(rcPackage)
-            "sub_offer_duration" -> VariableDataProvider.introductoryOfferDuration(rcPackage)
-            "sub_offer_price" -> VariableDataProvider.localizedIntroductoryOfferPrice(rcPackage)
+            "app_name" -> variableDataProvider.applicationName
+            "price" -> variableDataProvider.localizedPrice(rcPackage)
+            "price_per_period" -> variableDataProvider.localizedPricePerPeriod(rcPackage)
+            "total_price_and_per_month" -> variableDataProvider.localizedPriceAndPerMonth(rcPackage)
+            "product_name" -> variableDataProvider.productName(rcPackage)
+            "sub_period" -> variableDataProvider.periodName(rcPackage)
+            "sub_price_per_month" -> variableDataProvider.localizedPricePerMonth(rcPackage, locale)
+            "sub_duration" -> variableDataProvider.subscriptionDuration(rcPackage)
+            "sub_offer_duration" -> variableDataProvider.introductoryOfferDuration(rcPackage)
+            "sub_offer_price" -> variableDataProvider.localizedIntroductoryOfferPrice(rcPackage)
             else -> {
                 Logger.e("Unknown variable: $variableWithoutBraces")
                 null

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.helpers
 
+import android.content.Context
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
@@ -7,11 +8,12 @@ import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfigura
 import java.util.Locale
 
 @Suppress("ReturnCount", "TooGenericExceptionCaught")
-internal fun Offering.toPaywallViewState(): PaywallViewState {
+internal fun Offering.toPaywallViewState(applicationContext: Context): PaywallViewState {
     val paywallData = this.paywall
         ?: return PaywallViewState.Error("No paywall data for offering: $identifier")
     return try {
         val templateConfiguration = TemplateConfigurationFactory.create(
+            context = applicationContext,
             mode = PaywallViewMode.FULL_SCREEN,
             paywallData = paywallData,
             packages = availablePackages,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -1,19 +1,19 @@
 package com.revenuecat.purchases.ui.revenuecatui.helpers
 
-import android.content.Context
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfigurationFactory
+import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
 import java.util.Locale
 
 @Suppress("ReturnCount", "TooGenericExceptionCaught")
-internal fun Offering.toPaywallViewState(applicationContext: Context): PaywallViewState {
+internal fun Offering.toPaywallViewState(variableDataProvider: VariableDataProvider): PaywallViewState {
     val paywallData = this.paywall
         ?: return PaywallViewState.Error("No paywall data for offering: $identifier")
     return try {
         val templateConfiguration = TemplateConfigurationFactory.create(
-            context = applicationContext,
+            variableDataProvider = variableDataProvider,
             mode = PaywallViewMode.FULL_SCREEN,
             paywallData = paywallData,
             packages = availablePackages,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProviderTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProviderTest.kt
@@ -1,0 +1,56 @@
+package com.revenuecat.purchases.ui.revenuecatui.data.processed
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ui.revenuecatui.data.TestData
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+
+@RunWith(AndroidJUnit4::class)
+class VariableDataProviderTest {
+
+    private lateinit var applicationContext: Context
+    private lateinit var variableDataProvider: VariableDataProvider
+
+    @Before
+    fun setUp() {
+        applicationContext = mockk()
+        variableDataProvider = VariableDataProvider(applicationContext)
+    }
+
+    @Test
+    fun `applicationName processes app name correctly`() {
+        val testAppName = "test app name"
+        val packageManager = mockk<PackageManager>()
+        every { applicationContext.packageManager } returns packageManager
+        every { applicationContext.applicationInfo } returns mockk<ApplicationInfo>().apply {
+            every { loadLabel(packageManager) } returns testAppName
+        }
+        assertThat(variableDataProvider.applicationName).isEqualTo(testAppName)
+    }
+
+    @Test
+    fun `localizedPrice provides correct price`() {
+        val rcPackage = TestData.Packages.annual
+        assertThat(variableDataProvider.localizedPrice(rcPackage)).isEqualTo("$67.99")
+    }
+
+    @Test
+    fun `localizedPricePerMonth provides correct price`() {
+        val rcPackage = TestData.Packages.annual
+        assertThat(variableDataProvider.localizedPricePerMonth(rcPackage, Locale.US)).isEqualTo("$5.67")
+    }
+
+    @Test
+    fun `localizedPricePerMonth provides correct price in other locales`() {
+        val rcPackage = TestData.Packages.annual
+        assertThat(variableDataProvider.localizedPricePerMonth(rcPackage, Locale("es", "ES"))).isEqualTo("5,67 US\$")
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
@@ -1,0 +1,57 @@
+package com.revenuecat.purchases.ui.revenuecatui.data.processed
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.Package
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+
+@RunWith(AndroidJUnit4::class)
+class VariableProcessorTest {
+
+    private lateinit var variableDataProvider: VariableDataProvider
+    private lateinit var rcPackage: Package
+    private lateinit var locale: Locale
+
+    @Before
+    fun setUp() {
+        variableDataProvider = mockk()
+        rcPackage = mockk()
+        locale = Locale.ITALY
+    }
+
+    @Test
+    fun `process variables returns original text if no variables`() {
+        val originalText = "text without any variables"
+        val resultText = VariableProcessor.processVariables(variableDataProvider, originalText, rcPackage, locale)
+        assertThat(resultText).isEqualTo(originalText)
+    }
+
+    @Test
+    fun `process variables returns processed text with single variable`() {
+        val originalText = "text with {{ app_name }} one variable"
+        every { variableDataProvider.applicationName } returns "app name"
+        val resultText = VariableProcessor.processVariables(variableDataProvider, originalText, rcPackage, locale)
+        assertThat(resultText).isEqualTo("text with app name one variable")
+    }
+
+    @Test
+    fun `process variables returns processed text with multiple variable`() {
+        val originalText = "text with {{ app_name }} and {{ sub_price_per_month }} multiple variables"
+        every { variableDataProvider.applicationName } returns "app name"
+        every { variableDataProvider.localizedPricePerMonth(rcPackage, locale) } returns "$9.99"
+        val resultText = VariableProcessor.processVariables(variableDataProvider, originalText, rcPackage, locale)
+        assertThat(resultText).isEqualTo("text with app name and $9.99 multiple variables")
+    }
+
+    @Test
+    fun `process variables does not modify unknown variables`() {
+        val originalText = "text with {{ unknown_variable }}"
+        val resultText = VariableProcessor.processVariables(variableDataProvider, originalText, rcPackage, locale)
+        assertThat(resultText).isEqualTo(originalText)
+    }
+}


### PR DESCRIPTION
### Description
This adds an initial implementation for processing paywall strings variables.

Considering some of the variables require access to the context/resources (like to get application name or to access some string resources), we have to keep a reference to the application context in the viewModel, which is not ideal...

The alternative discussed was to delay processing the strings (including locales and variables) until the last moment and use the activity context, but that seems to make a more complex architecture.
![image](https://github.com/RevenueCat/purchases-android/assets/808417/fb19badb-cf73-4003-961c-146adfa3b4b2)
