### PR TITLE
PaywallTester: Improve AppInfo screen to allow LogIn/LogOut and display debug menu

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
@@ -1,16 +1,123 @@
 package com.revenuecat.paywallstester.ui.screens.main.appinfo
 
+import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.revenuecat.purchases.ui.debugview.DebugRevenueCatBottomSheet
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
-fun AppInfoScreen() {
-    Text(text = "App Info screen")
+fun AppInfoScreen(viewModel: AppInfoScreenViewModel = viewModel<AppInfoScreenViewModelImpl>()) {
+    var isDebugBottomSheetVisible by remember { mutableStateOf(false) }
+    var showLogInDialog by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        val currentUserID = viewModel.state.collectAsState().value ?: "No user logged in"
+        Text(text = "Current user ID: $currentUserID")
+        Button(onClick = { showLogInDialog = true }) {
+            Text(text = "Log in")
+        }
+        Button(onClick = { viewModel.logOut() }) {
+            Text(text = "Log out")
+        }
+        Button(onClick = { isDebugBottomSheetVisible = true }) {
+            Text(text = "Show debug view")
+        }
+    }
+
+    if (showLogInDialog) {
+        LoginDialog(viewModel) { showLogInDialog = false }
+    }
+
+    DebugRevenueCatBottomSheet(
+        onPurchaseCompleted = { isDebugBottomSheetVisible = false },
+        onPurchaseErrored = { Log.e("PaywallTester", "Error purchasing through debug view: $it") },
+        isVisible = isDebugBottomSheetVisible,
+        onDismissCallback = { isDebugBottomSheetVisible = false },
+    )
 }
 
+@Composable
+private fun LoginDialog(viewModel: AppInfoScreenViewModel, onDismissed: () -> Unit) {
+    var userId by remember {
+        mutableStateOf("")
+    }
+    Dialog(onDismissRequest = { onDismissed() }) {
+        Surface(shape = MaterialTheme.shapes.medium) {
+            Column {
+                Column(Modifier.padding(24.dp)) {
+                    Text(text = "Enter user ID")
+                    Spacer(Modifier.size(16.dp))
+                    OutlinedTextField(
+                        value = userId,
+                        onValueChange = { userId = it },
+                        label = { Text("User ID") },
+                    )
+                }
+                Spacer(Modifier.size(4.dp))
+                Row(
+                    Modifier
+                        .padding(8.dp)
+                        .fillMaxWidth(),
+                    Arrangement.spacedBy(8.dp, Alignment.End),
+                ) {
+                    TextButton(
+                        onClick = { onDismissed() },
+                        content = { Text("CANCEL") },
+                    )
+                    TextButton(
+                        onClick = {
+                            viewModel.logIn(userId)
+                            onDismissed()
+                        },
+                        content = { Text("OK") },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Suppress("EmptyFunctionBlock")
 @Preview(showBackground = true)
 @Composable
 fun AppInfoScreenPreview() {
-    AppInfoScreen()
+    AppInfoScreen(
+        viewModel = object : AppInfoScreenViewModel {
+            override val state: StateFlow<String?>
+                get() = MutableStateFlow("test-user-id")
+
+            override fun logIn(newAppUserId: String) { }
+            override fun logOut() { }
+        },
+    )
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreenViewModel.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreenViewModel.kt
@@ -1,0 +1,57 @@
+package com.revenuecat.paywallstester.ui.screens.main.appinfo
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.awaitLogIn
+import com.revenuecat.purchases.awaitLogOut
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+interface AppInfoScreenViewModel {
+    val state: StateFlow<String?>
+
+    fun logIn(newAppUserId: String)
+    fun logOut()
+}
+
+class AppInfoScreenViewModelImpl : ViewModel(), AppInfoScreenViewModel {
+
+    override val state: StateFlow<String?>
+        get() = _state.asStateFlow()
+
+    private val _state = MutableStateFlow<String?>(null)
+
+    init {
+        updateAppUserID()
+    }
+
+    override fun logIn(newAppUserId: String) {
+        viewModelScope.launch {
+            try {
+                Purchases.sharedInstance.awaitLogIn(newAppUserId)
+                updateAppUserID()
+            } catch (e: PurchasesException) {
+                _state.value = "Error logging in: ${e.message}"
+            }
+        }
+    }
+
+    override fun logOut() {
+        viewModelScope.launch {
+            try {
+                Purchases.sharedInstance.awaitLogOut()
+                updateAppUserID()
+            } catch (e: PurchasesException) {
+                _state.value = "Error logging out: ${e.message}"
+            }
+        }
+    }
+
+    private fun updateAppUserID() {
+        _state.value = Purchases.sharedInstance.appUserID
+    }
+}


### PR DESCRIPTION
### Description
This improves PaywallTester so we can logIn/logOut and display the debug menu from the app.
![image](https://github.com/RevenueCat/purchases-android/assets/808417/04b7592a-5c5a-4002-b7fc-eb111e8f44a9)
