### PR TITLE
`Paywalls`: extracted `ApplicationContext` interface and `MockViewModel`

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelFactory
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
+import com.revenuecat.purchases.ui.revenuecatui.helpers.toAndroidContext
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template2
 
 @Composable
@@ -57,6 +58,10 @@ private fun updateStateIfLocaleChanged(viewModel: PaywallViewModel) {
 @Composable
 private fun getPaywallViewModel(offering: Offering?, listener: PaywallViewListener?): PaywallViewModel {
     return viewModel<PaywallViewModelImpl>(
-        factory = PaywallViewModelFactory(LocalContext.current.applicationContext, offering, listener),
+        factory = PaywallViewModelFactory(
+            LocalContext.current.applicationContext.toAndroidContext(),
+            offering,
+            listener,
+        ),
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.ui.revenuecatui.PaywallViewListener
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
 import com.revenuecat.purchases.ui.revenuecatui.extensions.getActivity
+import com.revenuecat.purchases.ui.revenuecatui.helpers.ApplicationContext
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toPaywallViewState
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,7 +40,7 @@ internal interface PaywallViewModel {
 }
 
 internal class PaywallViewModelImpl(
-    applicationContext: Context,
+    applicationContext: ApplicationContext,
     private val offering: Offering?,
     private val listener: PaywallViewListener?,
 ) : ViewModel(), PaywallViewModel {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
@@ -1,13 +1,13 @@
 package com.revenuecat.purchases.ui.revenuecatui.data
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.PaywallViewListener
+import com.revenuecat.purchases.ui.revenuecatui.helpers.ApplicationContext
 
 internal class PaywallViewModelFactory(
-    private val applicationContext: Context,
+    private val applicationContext: ApplicationContext,
     private val offering: Offering?,
     private val listener: PaywallViewListener?,
 ) : ViewModelProvider.NewInstanceFactory() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
@@ -17,7 +17,6 @@ import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ApplicationContext
-import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toPaywallViewState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -130,15 +129,7 @@ internal class MockViewModel(
     override fun refreshState() {}
 
     override fun selectPackage(packageToSelect: TemplateConfiguration.PackageInfo) {
-        _state.value = when (val currentState = _state.value) {
-            is PaywallViewState.Loaded -> {
-                currentState.copy(selectedPackage = packageToSelect)
-            }
-            else -> {
-                Logger.e("Unexpected state trying to select package: $currentState")
-                currentState
-            }
-        }
+        error("Not supported")
     }
 
     override fun purchaseSelectedPackage(context: Context) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
@@ -126,7 +126,7 @@ internal class MockViewModel(
         get() = _state.asStateFlow()
     private val _state = MutableStateFlow(offering.toPaywallViewState(VariableDataProvider(MockApplicationContext())))
 
-    override fun refreshState() {}
+    override fun refreshState() = Unit
 
     override fun selectPackage(packageToSelect: TemplateConfiguration.PackageInfo) {
         error("Not supported")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
@@ -1,15 +1,15 @@
 package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
-import android.content.Context
 import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.ui.revenuecatui.helpers.ApplicationContext
 import java.util.Locale
 
 @Suppress("UnusedParameter", "FunctionOnlyReturningConstant")
 internal class VariableDataProvider(
-    private val applicationContext: Context,
+    private val applicationContext: ApplicationContext,
 ) {
     val applicationName: String
-        get() = applicationContext.applicationInfo.loadLabel(applicationContext.packageManager).toString()
+        get() = applicationContext.getApplicationName()
 
     fun localizedPrice(rcPackage: Package): String {
         return rcPackage.product.price.formatted

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/AndroidApplicationContext.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/AndroidApplicationContext.kt
@@ -1,0 +1,20 @@
+package com.revenuecat.purchases.ui.revenuecatui.helpers
+
+import android.content.Context
+
+/**
+ * Abstraction around [Context]
+ */
+internal interface ApplicationContext {
+    fun getApplicationName(): String
+}
+
+internal class AndroidApplicationContext(private val applicationContext: Context) : ApplicationContext {
+    override fun getApplicationName(): String {
+        return applicationContext.applicationInfo.loadLabel(applicationContext.packageManager).toString()
+    }
+}
+
+internal fun Context.toAndroidContext(): ApplicationContext {
+    return AndroidApplicationContext(this)
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/AndroidApplicationContext.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/AndroidApplicationContext.kt
@@ -16,5 +16,5 @@ internal class AndroidApplicationContext(private val applicationContext: Context
 }
 
 internal fun Context.toAndroidContext(): ApplicationContext {
-    return AndroidApplicationContext(this)
+    return AndroidApplicationContext(applicationContext)
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProviderTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProviderTest.kt
@@ -1,10 +1,8 @@
 package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
-import android.content.Context
-import android.content.pm.ApplicationInfo
-import android.content.pm.PackageManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.ui.revenuecatui.data.TestData
+import com.revenuecat.purchases.ui.revenuecatui.helpers.ApplicationContext
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -16,7 +14,7 @@ import java.util.Locale
 @RunWith(AndroidJUnit4::class)
 class VariableDataProviderTest {
 
-    private lateinit var applicationContext: Context
+    private lateinit var applicationContext: ApplicationContext
     private lateinit var variableDataProvider: VariableDataProvider
 
     @Before
@@ -28,11 +26,7 @@ class VariableDataProviderTest {
     @Test
     fun `applicationName processes app name correctly`() {
         val testAppName = "test app name"
-        val packageManager = mockk<PackageManager>()
-        every { applicationContext.packageManager } returns packageManager
-        every { applicationContext.applicationInfo } returns mockk<ApplicationInfo>().apply {
-            every { loadLabel(packageManager) } returns testAppName
-        }
+        every { applicationContext.getApplicationName() } returns testAppName
         assertThat(variableDataProvider.applicationName).isEqualTo(testAppName)
     }
 


### PR DESCRIPTION
Follow up to #1251. This allows us to create a fake `ViewModel` for previews and snapshots.