### PR TITLE
Paywalls: Implement `price_per_period` variable support

### DIFF
--- a/examples/paywall-tester/build.gradle
+++ b/examples/paywall-tester/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "com.revenuecat.paywall_tester"
-        minSdk 21
+        minSdk 24
         versionCode paywallTesterVersionCode as Integer
         versionName paywallTesterVersionName
 

--- a/ui/revenuecatui/build.gradle
+++ b/ui/revenuecatui/build.gradle
@@ -22,7 +22,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21 // Compose requires minSdkVersion 21
+        minSdkVersion 24 // MeasureFormat requires API 24
     }
 
     buildFeatures {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
@@ -168,7 +168,7 @@ internal object TestData {
                 title = "Annual",
                 price = Price(amountMicros = 67_990_000, currencyCode = "USD", formatted = "$67.99"),
                 description = "Annual",
-                period = Period(value = 12, unit = Period.Unit.MONTH, iso8601 = "P1Y"),
+                period = Period(value = 1, unit = Period.Unit.YEAR, iso8601 = "P1Y"),
             ),
         )
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
@@ -1,8 +1,10 @@
 package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
+import android.os.Build
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.ui.revenuecatui.R
+import com.revenuecat.purchases.ui.revenuecatui.extensions.localizedPeriod
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ApplicationContext
 import java.util.Locale
 
@@ -51,8 +53,19 @@ internal class VariableDataProvider(
         return "INT_OFFER_DURATION"
     }
 
-    fun localizedPricePerPeriod(rcPackage: Package): String {
-        return "PRICE_PER_PERIOD"
+    fun localizedPricePerPeriod(rcPackage: Package, locale: Locale): String {
+        val localizedPrice = localizedPrice(rcPackage)
+        return rcPackage.product.period?.let { period ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                var formattedPeriod = period.localizedPeriod(locale)
+                if (period.value == 1 && formattedPeriod.startsWith("1")) {
+                    formattedPeriod = formattedPeriod.substring(startIndex = 1).trim()
+                }
+                "$localizedPrice/$formattedPeriod"
+            } else {
+                localizedPrice
+            }
+        } ?: localizedPrice
     }
 
     fun localizedPriceAndPerMonth(rcPackage: Package): String {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
-import android.os.Build
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.ui.revenuecatui.R
@@ -56,15 +55,11 @@ internal class VariableDataProvider(
     fun localizedPricePerPeriod(rcPackage: Package, locale: Locale): String {
         val localizedPrice = localizedPrice(rcPackage)
         return rcPackage.product.period?.let { period ->
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                var formattedPeriod = period.localizedPeriod(locale)
-                if (period.value == 1 && formattedPeriod.startsWith("1")) {
-                    formattedPeriod = formattedPeriod.substring(startIndex = 1).trim()
-                }
-                "$localizedPrice/$formattedPeriod"
-            } else {
-                localizedPrice
+            var formattedPeriod = period.localizedPeriod(locale)
+            if (period.value == 1 && formattedPeriod.startsWith("1")) {
+                formattedPeriod = formattedPeriod.substring(startIndex = 1).trim()
             }
+            "$localizedPrice/$formattedPeriod"
         } ?: localizedPrice
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
@@ -34,7 +34,7 @@ internal object VariableProcessor {
         return when (variableName) {
             "app_name" -> variableDataProvider.applicationName
             "price" -> variableDataProvider.localizedPrice(rcPackage)
-            "price_per_period" -> variableDataProvider.localizedPricePerPeriod(rcPackage)
+            "price_per_period" -> variableDataProvider.localizedPricePerPeriod(rcPackage, locale)
             "total_price_and_per_month" -> variableDataProvider.localizedPriceAndPerMonth(rcPackage)
             "product_name" -> variableDataProvider.productName(rcPackage)
             "sub_period" -> variableDataProvider.periodName(rcPackage)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PeriodExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PeriodExtensions.kt
@@ -1,0 +1,26 @@
+package com.revenuecat.purchases.ui.revenuecatui.extensions
+
+import android.icu.text.MeasureFormat
+import android.icu.util.Measure
+import android.icu.util.MeasureUnit
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.revenuecat.purchases.models.Period
+import java.util.Locale
+
+@RequiresApi(Build.VERSION_CODES.N)
+internal fun Period.localizedPeriod(locale: Locale): String {
+    return MeasureFormat.getInstance(locale, MeasureFormat.FormatWidth.SHORT).format(
+        Measure(value, unit.measureUnit),
+    )
+}
+
+private val Period.Unit.measureUnit: MeasureUnit?
+    @RequiresApi(Build.VERSION_CODES.N)
+    get() = when (this) {
+        Period.Unit.DAY -> MeasureUnit.DAY
+        Period.Unit.WEEK -> MeasureUnit.WEEK
+        Period.Unit.MONTH -> MeasureUnit.MONTH
+        Period.Unit.YEAR -> MeasureUnit.YEAR
+        Period.Unit.UNKNOWN -> null
+    }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PeriodExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PeriodExtensions.kt
@@ -3,12 +3,9 @@ package com.revenuecat.purchases.ui.revenuecatui.extensions
 import android.icu.text.MeasureFormat
 import android.icu.util.Measure
 import android.icu.util.MeasureUnit
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.revenuecat.purchases.models.Period
 import java.util.Locale
 
-@RequiresApi(Build.VERSION_CODES.N)
 internal fun Period.localizedPeriod(locale: Locale): String {
     return MeasureFormat.getInstance(locale, MeasureFormat.FormatWidth.SHORT).format(
         Measure(value, unit.measureUnit),
@@ -16,7 +13,6 @@ internal fun Period.localizedPeriod(locale: Locale): String {
 }
 
 private val Period.Unit.measureUnit: MeasureUnit?
-    @RequiresApi(Build.VERSION_CODES.N)
     get() = when (this) {
         Period.Unit.DAY -> MeasureUnit.DAY
         Period.Unit.WEEK -> MeasureUnit.WEEK

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
@@ -86,10 +86,16 @@ internal class TemplateConfigurationFactoryTest {
             PackageType.WEEKLY -> "Weekly"
             else -> error("Unknown package type ${rcPackage.packageType}")
         }
+        val callToAction = when(rcPackage.packageType) {
+            PackageType.ANNUAL -> "Subscribe for $67.99/yr"
+            PackageType.MONTHLY -> "Subscribe for $7.99/mth"
+            PackageType.WEEKLY -> "Subscribe for $1.99/wk"
+            else -> error("Unknown package type ${rcPackage.packageType}")
+        }
         val processedLocalization = ProcessedLocalizedConfiguration(
             title = localizedConfiguration.title,
             subtitle = localizedConfiguration.subtitle,
-            callToAction = "Subscribe for PRICE_PER_PERIOD",
+            callToAction = callToAction,
             callToActionWithIntroOffer = null,
             offerDetails = "PRICE_AND_PER_MONTH",
             offerDetailsWithIntroOffer = "PRICE_AND_PER_MONTH after INT_OFFER_DURATION trial",

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
@@ -81,7 +81,12 @@ class VariableProcessorTest {
 
     @Test
     fun `process variables processes price_per_period`() {
-        expectVariablesResult("{{ price_per_period }}", "PRICE_PER_PERIOD")
+        expectVariablesResult("{{ price_per_period }}", "$67.99/yr")
+    }
+
+    @Test
+    fun `process variables processes price_per_period localized in spanish`() {
+        expectVariablesResult("{{ price_per_period }}", "$67.99/a", esLocale)
     }
 
     @Test


### PR DESCRIPTION
### Description
This PR adds support for the `price_per_period` variable in the paywalls. The period is calculated using a `MeasureFormat` which is only available in Android API 24+ so we've increased the min sdk version for now.