### PR TITLE
Paywalls: Add support for `sub_offer_duration` variable in paywalls

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
@@ -209,7 +209,7 @@ internal object TestData {
                 price = Price(amountMicros = 23_990_000, currencyCode = "USD", formatted = "$23.99"),
                 description = "3 month",
                 period = Period(value = 3, unit = Period.Unit.MONTH, iso8601 = "P3M"),
-                freeTrialPeriod = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
+                freeTrialPeriod = Period(value = 2, unit = Period.Unit.WEEK, iso8601 = "P2W"),
                 introPrice = Price(amountMicros = 3_990_000, currencyCode = "USD", formatted = "$3.99"),
             ),
         )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui.data.processed
 import android.icu.text.MeasureFormat
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.extensions.localizedPeriod
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ApplicationContext
@@ -23,12 +24,8 @@ internal class VariableDataProvider(
         return rcPackage.product.formattedPricePerMonth(locale)
     }
 
-    fun localizedIntroductoryOfferPrice(rcPackage: Package): String {
-        // TODO-PAYWALLS: Decide how this will look like for products that have both a free trial
-        // and a discounted introductory price.
-        val option = rcPackage.product.defaultOption
-        val introductoryPrice = option?.freePhase ?: option?.introPhase ?: return ""
-        return introductoryPrice.price.formatted
+    fun localizedIntroductoryOfferPrice(rcPackage: Package): String? {
+        return getIntroPhaseToApply(rcPackage)?.price?.formatted
     }
 
     fun productName(rcPackage: Package): String {
@@ -50,13 +47,15 @@ internal class VariableDataProvider(
     }
 
     fun subscriptionDuration(rcPackage: Package, locale: Locale): String? {
-        return rcPackage.product.period?.let { period ->
-            period.localizedPeriod(locale, formatWidth = MeasureFormat.FormatWidth.WIDE)
-        } ?: periodName(rcPackage)
+        return rcPackage.product.period?.localizedPeriod(locale, formatWidth = MeasureFormat.FormatWidth.WIDE)
+            ?: periodName(rcPackage)
     }
 
-    fun introductoryOfferDuration(rcPackage: Package): String? {
-        return "INT_OFFER_DURATION"
+    fun introductoryOfferDuration(rcPackage: Package, locale: Locale): String? {
+        return getIntroPhaseToApply(rcPackage)?.billingPeriod?.localizedPeriod(
+            locale,
+            formatWidth = MeasureFormat.FormatWidth.WIDE,
+        )
     }
 
     fun localizedPricePerPeriod(rcPackage: Package, locale: Locale): String {
@@ -72,5 +71,12 @@ internal class VariableDataProvider(
 
     fun localizedPriceAndPerMonth(rcPackage: Package): String {
         return "PRICE_AND_PER_MONTH"
+    }
+
+    private fun getIntroPhaseToApply(rcPackage: Package): PricingPhase? {
+        // TODO-PAYWALLS: Decide how this will look like for products that have both a free trial
+        // and a discounted introductory price.
+        val option = rcPackage.product.defaultOption
+        return option?.freePhase ?: option?.introPhase
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
@@ -50,7 +50,7 @@ internal object VariableProcessor {
                     locale,
                 )
                 VariableName.SUB_DURATION -> variableDataProvider.subscriptionDuration(rcPackage, locale)
-                VariableName.SUB_OFFER_DURATION -> variableDataProvider.introductoryOfferDuration(rcPackage)
+                VariableName.SUB_OFFER_DURATION -> variableDataProvider.introductoryOfferDuration(rcPackage, locale)
                 VariableName.SUB_OFFER_PRICE -> variableDataProvider.localizedIntroductoryOfferPrice(rcPackage)
             } ?: run {
                 Logger.w(

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
@@ -92,13 +92,19 @@ internal class TemplateConfigurationFactoryTest {
             PackageType.WEEKLY -> "Subscribe for $1.99/wk"
             else -> error("Unknown package type ${rcPackage.packageType}")
         }
+        val offerDetailsWithIntroOffer = when(rcPackage.packageType) {
+            PackageType.ANNUAL -> "PRICE_AND_PER_MONTH after 1 month trial"
+            PackageType.MONTHLY -> "PRICE_AND_PER_MONTH after  trial"
+            PackageType.WEEKLY -> "PRICE_AND_PER_MONTH after  trial"
+            else -> error("Unknown package type ${rcPackage.packageType}")
+        }
         val processedLocalization = ProcessedLocalizedConfiguration(
             title = localizedConfiguration.title,
             subtitle = localizedConfiguration.subtitle,
             callToAction = callToAction,
             callToActionWithIntroOffer = null,
             offerDetails = "PRICE_AND_PER_MONTH",
-            offerDetailsWithIntroOffer = "PRICE_AND_PER_MONTH after INT_OFFER_DURATION trial",
+            offerDetailsWithIntroOffer = offerDetailsWithIntroOffer,
             offerName = periodName,
             features = emptyList(),
         )

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
@@ -175,14 +175,14 @@ class VariableProcessorTest {
     fun `process variables processes sub_offer_duration`() {
         expectVariablesResult("{{ sub_offer_duration }}", "1 month")
         expectVariablesResult("{{ sub_offer_duration }}", "1 month", rcPackage = TestData.Packages.bimonthly)
-        expectVariablesResult("{{ sub_offer_duration }}", "1 month", rcPackage = TestData.Packages.quarterly)
+        expectVariablesResult("{{ sub_offer_duration }}", "2 weeks", rcPackage = TestData.Packages.quarterly)
     }
 
     @Test
     fun `process variables processes sub_offer_duration for spanish locale`() {
         expectVariablesResult("{{ sub_offer_duration }}", "1 mes", esLocale)
         expectVariablesResult("{{ sub_offer_duration }}", "1 mes", esLocale, TestData.Packages.bimonthly)
-        expectVariablesResult("{{ sub_offer_duration }}", "1 mes", esLocale, TestData.Packages.quarterly)
+        expectVariablesResult("{{ sub_offer_duration }}", "2 semanas", esLocale, TestData.Packages.quarterly)
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
@@ -173,7 +173,21 @@ class VariableProcessorTest {
 
     @Test
     fun `process variables processes sub_offer_duration`() {
-        expectVariablesResult("{{ sub_offer_duration }}", "INT_OFFER_DURATION")
+        expectVariablesResult("{{ sub_offer_duration }}", "1 month")
+        expectVariablesResult("{{ sub_offer_duration }}", "1 month", rcPackage = TestData.Packages.bimonthly)
+        expectVariablesResult("{{ sub_offer_duration }}", "1 month", rcPackage = TestData.Packages.quarterly)
+    }
+
+    @Test
+    fun `process variables processes sub_offer_duration for spanish locale`() {
+        expectVariablesResult("{{ sub_offer_duration }}", "1 mes", esLocale)
+        expectVariablesResult("{{ sub_offer_duration }}", "1 mes", esLocale, TestData.Packages.bimonthly)
+        expectVariablesResult("{{ sub_offer_duration }}", "1 mes", esLocale, TestData.Packages.quarterly)
+    }
+
+    @Test
+    fun `process variables processes sub_offer_duration as empty string if no offers`() {
+        expectVariablesResult("{{ sub_offer_duration }}", "", rcPackage = TestData.Packages.monthly)
     }
 
     @Test


### PR DESCRIPTION
### Description
Adds support for `sub_offer_duration` variable in paywalls. Makes sure we use the same intro offer than with `sub_offer_price` in case there are multiple (currently we only display one)
