### PR TITLE
`Paywalls`: implemented `LoadingPaywallView` with `placeholder`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,6 +106,7 @@ coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", ve
 kotlin-bom = "org.jetbrains.kotlin:kotlin-bom:1.8.0"
 compose-bom = "androidx.compose:compose-bom:2023.05.01"
 compose-ui = { module = "androidx.compose.ui:ui" }
+compose-ui-util = { module = "androidx.compose.ui:ui-util" }
 compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-material = { module = "androidx.compose.material:material" }

--- a/ui/revenuecatui/build.gradle
+++ b/ui/revenuecatui/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation libs.androidx.core
     implementation platform(libs.compose.bom)
     implementation libs.compose.ui
+    implementation libs.compose.ui.util
     implementation libs.compose.ui.graphics
     implementation libs.compose.ui.tooling.preview
     implementation libs.compose.material

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywallView.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
@@ -15,6 +16,9 @@ import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.paywalls.PaywallData
+import com.revenuecat.purchases.ui.revenuecatui.composables.Fade
+import com.revenuecat.purchases.ui.revenuecatui.composables.PlaceholderDefaults
+import com.revenuecat.purchases.ui.revenuecatui.composables.placeholder
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
@@ -74,6 +78,15 @@ private fun LoadingPaywallView(state: PaywallViewState.Loaded, viewModel: Paywal
         Template2(
             state = state,
             viewModel = viewModel,
+            childModifier = Modifier
+                .placeholder(
+                    visible = true,
+                    highlight = Fade(
+                        highlightColor = LoadingPaywallConstants.placeholderColor.copy(alpha = 0.5f),
+                        animationSpec = PlaceholderDefaults.fadeAnimationSpec,
+                    ),
+                    color = LoadingPaywallConstants.placeholderColor,
+                ),
         )
 
         // Overlay to capture touches
@@ -93,6 +106,8 @@ private fun LoadingPaywallView(state: PaywallViewState.Loaded, viewModel: Paywal
 
 private object LoadingPaywallConstants {
     const val offeringIdentifier = "loading_offering"
+
+    val placeholderColor = Color.Gray
 
     val template = PaywallTemplate.TEMPLATE_2
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
@@ -41,11 +41,13 @@ import java.net.URL
 internal fun Footer(
     templateConfiguration: TemplateConfiguration,
     viewModel: PaywallViewModel,
+    childModifier: Modifier = Modifier,
 ) {
     Footer(
         configuration = templateConfiguration.configuration,
         colors = templateConfiguration.getCurrentColors(),
         viewModel = viewModel,
+        childModifier = childModifier,
     )
 }
 
@@ -54,11 +56,12 @@ private fun Footer(
     configuration: PaywallData.Configuration,
     colors: TemplateConfiguration.Colors,
     viewModel: PaywallViewModel,
+    childModifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
 
     Row(
-        modifier = Modifier
+        modifier = childModifier
             .fillMaxWidth()
             .height(intrinsicSize = IntrinsicSize.Max)
             .padding(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IconImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IconImage.kt
@@ -31,10 +31,11 @@ internal fun IconImage(
     uri: Uri?,
     maxWidth: Dp,
     iconCornerRadius: Dp,
+    childModifier: Modifier = Modifier,
 ) {
     uri?.let {
         Column(modifier = Modifier.widthIn(max = maxWidth)) {
-            val modifier = Modifier
+            val modifier = childModifier
                 .aspectRatio(ratio = 1f)
                 .widthIn(max = maxWidth)
                 .clip(RoundedCornerShape(iconCornerRadius))

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
@@ -20,9 +20,10 @@ import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 internal fun PurchaseButton(
     state: PaywallViewState.Loaded,
     viewModel: PaywallViewModel,
+    childModifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = Modifier
+        modifier = childModifier
             .fillMaxWidth()
             .padding(horizontal = UIConstant.defaultHorizontalPadding),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/placeholder.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/placeholder.kt
@@ -1,0 +1,326 @@
+package com.revenuecat.purchases.ui.revenuecatui.composables
+
+import androidx.annotation.FloatRange
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.InfiniteRepeatableSpec
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Transition
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.node.Ref
+import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.util.lerp
+import java.lang.Float.max
+
+internal object PlaceholderDefaults {
+    /**
+     * The default [InfiniteRepeatableSpec] to use for [fade].
+     */
+    val fadeAnimationSpec: InfiniteRepeatableSpec<Float> by lazy {
+        infiniteRepeatable(
+            animation = tween(delayMillis = 200, durationMillis = 600),
+            repeatMode = RepeatMode.Reverse,
+        )
+    }
+
+    /**
+     * The default [InfiniteRepeatableSpec] to use for [shimmer].
+     */
+    val shimmerAnimationSpec: InfiniteRepeatableSpec<Float> by lazy {
+        infiniteRepeatable(
+            animation = tween(durationMillis = 1700, delayMillis = 200),
+            repeatMode = RepeatMode.Restart,
+        )
+    }
+}
+
+/**
+ * From https://github.com/google/accompanist/blob/main/placeholder/src/main/java/com/google/accompanist/placeholder/Placeholder.kt
+ * See https://github.com/google/accompanist/pull/1672. That's deprecated, so we're copying it here for now.
+ *
+ * @param visible whether the placeholder should be visible or not.
+ * @param color the color used to draw the placeholder UI.
+ * @param shape desired shape of the placeholder. Defaults to [RectangleShape].
+ * @param highlight optional highlight animation.
+ * @param placeholderFadeTransitionSpec The transition spec to use when fading the placeholder
+ * on/off screen. The boolean parameter defined for the transition is [visible].
+ * @param contentFadeTransitionSpec The transition spec to use when fading the content
+ * on/off screen. The boolean parameter defined for the transition is [visible].
+ */
+@Suppress("LongParameterList")
+internal fun Modifier.placeholder(
+    visible: Boolean,
+    color: Color,
+    shape: Shape = RectangleShape,
+    highlight: PlaceholderHighlight? = null,
+    placeholderFadeTransitionSpec: @Composable Transition.Segment<Boolean>.() -> FiniteAnimationSpec<Float> =
+        { spring() },
+    contentFadeTransitionSpec: @Composable Transition.Segment<Boolean>.() -> FiniteAnimationSpec<Float> = { spring() },
+): Modifier = composed(
+    inspectorInfo = debugInspectorInfo {
+        name = "placeholder"
+        value = visible
+        properties["visible"] = visible
+        properties["color"] = color
+        properties["highlight"] = highlight
+        properties["shape"] = shape
+    },
+) {
+    // Values used for caching purposes
+    val lastSize = remember { Ref<Size>() }
+    val lastLayoutDirection = remember { Ref<LayoutDirection>() }
+    val lastOutline = remember { Ref<Outline>() }
+
+    // The current highlight animation progress
+    var highlightProgress: Float by remember { mutableStateOf(0f) }
+
+    // This is our crossfade transition
+    val transitionState = remember { MutableTransitionState(visible) }.apply {
+        targetState = visible
+    }
+    val transition = updateTransition(transitionState, "placeholder_crossfade")
+
+    val placeholderAlpha by transition.animateFloat(
+        transitionSpec = placeholderFadeTransitionSpec,
+        label = "placeholder_fade",
+        targetValueByState = { placeholderVisible -> if (placeholderVisible) 1f else 0f },
+    )
+    val contentAlpha by transition.animateFloat(
+        transitionSpec = contentFadeTransitionSpec,
+        label = "content_fade",
+        targetValueByState = { placeholderVisible -> if (placeholderVisible) 0f else 1f },
+    )
+
+    // Run the optional animation spec and update the progress if the placeholder is visible
+    val animationSpec = highlight?.animationSpec
+    if (animationSpec != null && (visible || placeholderAlpha >= 0.01f)) {
+        val infiniteTransition = rememberInfiniteTransition(label = "Transition")
+        highlightProgress = infiniteTransition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec = animationSpec,
+            label = "Animation",
+        ).value
+    }
+
+    val paint = remember { Paint() }
+    remember(color, shape, highlight) {
+        drawWithContent {
+            // Draw the composable content first
+            if (contentAlpha in 0.01f..0.99f) {
+                // If the content alpha is between 1% and 99%, draw it in a layer with
+                // the alpha applied
+                paint.alpha = contentAlpha
+                withLayer(paint) {
+                    with(this@drawWithContent) {
+                        drawContent()
+                    }
+                }
+            } else if (contentAlpha >= 0.99f) {
+                // If the content alpha is > 99%, draw it with no alpha
+                drawContent()
+            }
+
+            if (placeholderAlpha in 0.01f..0.99f) {
+                // If the placeholder alpha is between 1% and 99%, draw it in a layer with
+                // the alpha applied
+                paint.alpha = placeholderAlpha
+                withLayer(paint) {
+                    lastOutline.value = drawPlaceholder(
+                        shape = shape,
+                        color = color,
+                        highlight = highlight,
+                        progress = highlightProgress,
+                        lastOutline = lastOutline.value,
+                        lastLayoutDirection = lastLayoutDirection.value,
+                        lastSize = lastSize.value,
+                    )
+                }
+            } else if (placeholderAlpha >= 0.99f) {
+                // If the placeholder alpha is > 99%, draw it with no alpha
+                lastOutline.value = drawPlaceholder(
+                    shape = shape,
+                    color = color,
+                    highlight = highlight,
+                    progress = highlightProgress,
+                    lastOutline = lastOutline.value,
+                    lastLayoutDirection = lastLayoutDirection.value,
+                    lastSize = lastSize.value,
+                )
+            }
+
+            // Keep track of the last size & layout direction
+            lastSize.value = size
+            lastLayoutDirection.value = layoutDirection
+        }
+    }
+}
+
+@Suppress("LongParameterList")
+private fun DrawScope.drawPlaceholder(
+    shape: Shape,
+    color: Color,
+    highlight: PlaceholderHighlight?,
+    progress: Float,
+    lastOutline: Outline?,
+    lastLayoutDirection: LayoutDirection?,
+    lastSize: Size?,
+): Outline? {
+    // shortcut to avoid Outline calculation and allocation
+    if (shape === RectangleShape) {
+        // Draw the initial background color
+        drawRect(color = color)
+
+        if (highlight != null) {
+            drawRect(
+                brush = highlight.brush(progress, size),
+                alpha = highlight.alpha(progress),
+            )
+        }
+        // We didn't create an outline so return null
+        return null
+    }
+
+    // Otherwise we need to create an outline from the shape
+    val outline = lastOutline.takeIf {
+        size == lastSize && layoutDirection == lastLayoutDirection
+    } ?: shape.createOutline(size, layoutDirection, this)
+
+    // Draw the placeholder color
+    drawOutline(outline = outline, color = color)
+
+    if (highlight != null) {
+        drawOutline(
+            outline = outline,
+            brush = highlight.brush(progress, size),
+            alpha = highlight.alpha(progress),
+        )
+    }
+
+    // Return the outline we used
+    return outline
+}
+
+private inline fun DrawScope.withLayer(
+    paint: Paint,
+    drawBlock: DrawScope.() -> Unit,
+) = drawIntoCanvas { canvas ->
+    canvas.saveLayer(size.toRect(), paint)
+    drawBlock()
+    canvas.restore()
+}
+
+// region highlights
+
+internal interface PlaceholderHighlight {
+    /**
+     * The optional animation spec to use when running the animation for this highlight.
+     */
+    val animationSpec: InfiniteRepeatableSpec<Float>?
+
+    /**
+     * Return a [Brush] to draw for the given [progress] and [size].
+     *
+     * @param progress the current animated progress in the range of 0f..1f.
+     * @param size The size of the current layout to draw in.
+     */
+    fun brush(
+        @FloatRange(from = 0.0, to = 1.0) progress: Float,
+        size: Size,
+    ): Brush
+
+    /**
+     * Return the desired alpha value used for drawing the [Brush] returned from [brush].
+     *
+     * @param progress the current animated progress in the range of 0f..1f.
+     */
+    @FloatRange(from = 0.0, to = 1.0)
+    fun alpha(progress: Float): Float
+
+    companion object
+}
+
+private fun PlaceholderHighlight.Companion.shimmer(
+    highlightColor: Color,
+    animationSpec: InfiniteRepeatableSpec<Float> = PlaceholderDefaults.shimmerAnimationSpec,
+    @FloatRange(from = 0.0, to = 1.0) progressForMaxAlpha: Float = 0.6f,
+): PlaceholderHighlight = Shimmer(
+    highlightColor = highlightColor,
+    animationSpec = animationSpec,
+    progressForMaxAlpha = progressForMaxAlpha,
+)
+
+internal data class Fade(
+    private val highlightColor: Color,
+    override val animationSpec: InfiniteRepeatableSpec<Float>,
+) : PlaceholderHighlight {
+    private val brush = SolidColor(highlightColor)
+
+    override fun brush(progress: Float, size: Size): Brush = brush
+    override fun alpha(progress: Float): Float = progress
+}
+
+private data class Shimmer(
+    private val highlightColor: Color,
+    override val animationSpec: InfiniteRepeatableSpec<Float>,
+    private val progressForMaxAlpha: Float = 0.6f,
+) : PlaceholderHighlight {
+    override fun brush(
+        progress: Float,
+        size: Size,
+    ): Brush = Brush.radialGradient(
+        colors = listOf(
+            highlightColor.copy(alpha = 0f),
+            highlightColor,
+            highlightColor.copy(alpha = 0f),
+        ),
+        center = Offset(x = 0f, y = 0f),
+        radius = (max(size.width, size.height) * progress * 2).coerceAtLeast(0.01f),
+    )
+
+    override fun alpha(progress: Float): Float = when {
+        // From 0f...ProgressForOpaqueAlpha we animate from 0..1
+        progress <= progressForMaxAlpha -> {
+            lerp(
+                start = 0f,
+                stop = 1f,
+                fraction = progress / progressForMaxAlpha,
+            )
+        }
+        // From ProgressForOpaqueAlpha..1f we animate from 1..0
+        else -> {
+            lerp(
+                start = 1f,
+                stop = 0f,
+                fraction = (progress - progressForMaxAlpha) / (1f - progressForMaxAlpha),
+            )
+        }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -147,7 +147,7 @@ private fun SelectPackageButton(
     }
     val border = if (isSelected) null else BorderStroke(2.dp, colors.text1)
     Button(
-        modifier = Modifier.fillMaxWidth().then(childModifier),
+        modifier = childModifier.fillMaxWidth(),
         onClick = { viewModel.selectPackage(packageInfo) },
         colors = ButtonDefaults.buttonColors(containerColor = background, contentColor = textColor),
         shape = RoundedCornerShape(15.dp),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -50,8 +50,15 @@ private object Template2UIConstants {
     const val checkmarkUnselectedAlpha = 0.3f
 }
 
+/**
+ * @param childModifier this allows using [Modifier.placeholder].
+ */
 @Composable
-internal fun Template2(state: PaywallViewState.Loaded, viewModel: PaywallViewModel) {
+internal fun Template2(
+    state: PaywallViewState.Loaded,
+    viewModel: PaywallViewModel,
+    childModifier: Modifier = Modifier,
+) {
     Box {
         PaywallBackground(state.templateConfiguration)
 
@@ -67,16 +74,24 @@ internal fun Template2(state: PaywallViewState.Loaded, viewModel: PaywallViewMod
                     ),
                 contentAlignment = Alignment.Center,
             ) {
-                Template2MainContent(state, viewModel)
+                Template2MainContent(state, viewModel, childModifier)
             }
-            PurchaseButton(state, viewModel)
-            Footer(templateConfiguration = state.templateConfiguration, viewModel = viewModel)
+            PurchaseButton(state, viewModel, childModifier)
+            Footer(
+                templateConfiguration = state.templateConfiguration,
+                viewModel = viewModel,
+                childModifier = childModifier,
+            )
         }
     }
 }
 
 @Composable
-private fun Template2MainContent(state: PaywallViewState.Loaded, viewModel: PaywallViewModel) {
+private fun Template2MainContent(
+    state: PaywallViewState.Loaded,
+    viewModel: PaywallViewModel,
+    childModifier: Modifier,
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -89,6 +104,7 @@ private fun Template2MainContent(state: PaywallViewState.Loaded, viewModel: Payw
             uri = state.templateConfiguration.images.iconUri,
             maxWidth = Template2UIConstants.maxIconWidth,
             iconCornerRadius = Template2UIConstants.iconCornerRadius,
+            childModifier = childModifier,
         )
         val localizedConfig = state.selectedLocalization
         val colors = state.templateConfiguration.getCurrentColors()
@@ -98,6 +114,7 @@ private fun Template2MainContent(state: PaywallViewState.Loaded, viewModel: Payw
             textAlign = TextAlign.Center,
             text = localizedConfig.title,
             color = colors.text1,
+            modifier = childModifier,
         )
         Text(
             style = MaterialTheme.typography.titleMedium,
@@ -105,9 +122,10 @@ private fun Template2MainContent(state: PaywallViewState.Loaded, viewModel: Payw
             textAlign = TextAlign.Center,
             text = localizedConfig.subtitle ?: "",
             color = colors.text1,
+            modifier = childModifier,
         )
         state.templateConfiguration.packages.all.forEach { packageInfo ->
-            SelectPackageButton(state, packageInfo, viewModel)
+            SelectPackageButton(state, packageInfo, viewModel, childModifier)
         }
     }
 }
@@ -117,6 +135,7 @@ private fun SelectPackageButton(
     state: PaywallViewState.Loaded,
     packageInfo: TemplateConfiguration.PackageInfo,
     viewModel: PaywallViewModel,
+    childModifier: Modifier,
 ) {
     val colors = state.templateConfiguration.getCurrentColors()
     val isSelected = packageInfo == state.selectedPackage
@@ -128,7 +147,7 @@ private fun SelectPackageButton(
     }
     val border = if (isSelected) null else BorderStroke(2.dp, colors.text1)
     Button(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().then(childModifier),
         onClick = { viewModel.selectPackage(packageInfo) },
         colors = ButtonDefaults.buttonColors(containerColor = background, contentColor = textColor),
         shape = RoundedCornerShape(15.dp),


### PR DESCRIPTION
This uses https://github.com/google/accompanist/blob/main/placeholder/. It's deprecated but might come to Compose itself in the future. This is just a temporary loading screen, we can decide whether to keep it, implement it in another way, or remove it in the future.

![image](https://github.com/RevenueCat/purchases-android/assets/685609/bc9f138e-2d95-478d-9a9a-896c1cdad8a5)
