### PR TITLE
`Paywalls`: Intro Eligibility dependent composable

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
@@ -1,9 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.composables
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 
@@ -35,27 +33,32 @@ internal fun IntroEligibilityStateView(
 
 @Preview(showBackground = true)
 @Composable
-private fun IntroEligibilityPreview() {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        IntroEligibilityStateView(
-            textWithNoIntroOffer = "$3.99/mo",
-            textWithIntroOffer = null,
-            eligibility = IntroOfferEligibility.ELIGIBLE,
-            color = Color.Black,
-        )
+private fun IntroEligibilityPreviewNoOffer() {
+    IntroEligibilityStateView(
+        textWithNoIntroOffer = "$3.99/mo",
+        textWithIntroOffer = null,
+        eligibility = IntroOfferEligibility.ELIGIBLE,
+        color = Color.Black,
+    )
+}
+@Preview(showBackground = true)
+@Composable
+private fun IntroEligibilityPreviewBothTextsIneligible() {
+    IntroEligibilityStateView(
+        textWithNoIntroOffer = "$3.99/mo",
+        textWithIntroOffer = "7 day trial, then $3.99/mo",
+        eligibility = IntroOfferEligibility.INELIGIBLE,
+        color = Color.Black,
+    )
+}
 
-        IntroEligibilityStateView(
-            textWithNoIntroOffer = "$3.99/mo",
-            textWithIntroOffer = "7 day trial, then $3.99/mo",
-            eligibility = IntroOfferEligibility.INELIGIBLE,
-            color = Color.Black,
-        )
-
-        IntroEligibilityStateView(
-            textWithNoIntroOffer = "$3.99/mo",
-            textWithIntroOffer = "7 day trial, then $3.99/mo",
-            eligibility = IntroOfferEligibility.ELIGIBLE,
-            color = Color.Black,
-        )
-    }
+@Preview(showBackground = true)
+@Composable
+private fun IntroEligibilityPreviewBothTextsEligible() {
+    IntroEligibilityStateView(
+        textWithNoIntroOffer = "$3.99/mo",
+        textWithIntroOffer = "7 day trial, then $3.99/mo",
+        eligibility = IntroOfferEligibility.ELIGIBLE,
+        color = Color.Black,
+    )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
@@ -5,11 +5,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 
-internal enum class IntroOfferEligibility {
-    INELIGIBLE,
-    ELIGIBLE,
-}
-
 /**
  * A composable that can display different data based on intro eligibility status.
  */
@@ -31,6 +26,11 @@ internal fun IntroEligibilityStateView(
     Text(text, color = color)
 }
 
+internal enum class IntroOfferEligibility {
+    INELIGIBLE,
+    ELIGIBLE,
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun IntroEligibilityPreviewNoOffer() {
@@ -41,6 +41,7 @@ private fun IntroEligibilityPreviewNoOffer() {
         color = Color.Black,
     )
 }
+
 @Preview(showBackground = true)
 @Composable
 private fun IntroEligibilityPreviewBothTextsIneligible() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
@@ -1,0 +1,61 @@
+package com.revenuecat.purchases.ui.revenuecatui.composables
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+
+internal enum class IntroOfferEligibility {
+    INELIGIBLE,
+    ELIGIBLE,
+}
+
+/**
+ * A composable that can display different data based on intro eligibility status.
+ */
+@Composable
+internal fun IntroEligibilityStateView(
+    textWithNoIntroOffer: String?,
+    textWithIntroOffer: String?,
+    eligibility: IntroOfferEligibility,
+    color: Color,
+) {
+    val text: String = if (textWithIntroOffer != null && eligibility == IntroOfferEligibility.ELIGIBLE) {
+        textWithIntroOffer
+    } else {
+        // Display text with intro offer as a backup to ensure layout does not change
+        // when switching states.
+        textWithNoIntroOffer ?: textWithIntroOffer ?: ""
+    }
+
+    Text(text, color = color)
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun IntroEligibilityPreview() {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        IntroEligibilityStateView(
+            textWithNoIntroOffer = "$3.99/mo",
+            textWithIntroOffer = null,
+            eligibility = IntroOfferEligibility.ELIGIBLE,
+            color = Color.Black,
+        )
+
+        IntroEligibilityStateView(
+            textWithNoIntroOffer = "$3.99/mo",
+            textWithIntroOffer = "7 day trial, then $3.99/mo",
+            eligibility = IntroOfferEligibility.INELIGIBLE,
+            color = Color.Black,
+        )
+
+        IntroEligibilityStateView(
+            textWithNoIntroOffer = "$3.99/mo",
+            textWithIntroOffer = "7 day trial, then $3.99/mo",
+            eligibility = IntroOfferEligibility.ELIGIBLE,
+            color = Color.Black,
+        )
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
@@ -10,7 +10,3 @@ internal fun Modifier.conditional(condition: Boolean, modifier: Modifier.() -> M
         this
     }
 }
-
-internal fun Modifier.hidden(condition: Boolean): Modifier {
-    return this.then(Modifier.alpha(if (condition) 0f else 1f))
-}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.extensions
 
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 
 internal fun Modifier.conditional(condition: Boolean, modifier: Modifier.() -> Modifier): Modifier {
     return if (condition) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/ModifierExtensions.kt
@@ -1,11 +1,16 @@
 package com.revenuecat.purchases.ui.revenuecatui.extensions
 
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 
-fun Modifier.conditional(condition: Boolean, modifier: Modifier.() -> Modifier): Modifier {
+internal fun Modifier.conditional(condition: Boolean, modifier: Modifier.() -> Modifier): Modifier {
     return if (condition) {
         then(modifier(Modifier))
     } else {
         this
     }
+}
+
+internal fun Modifier.hidden(condition: Boolean): Modifier {
+    return this.then(Modifier.alpha(if (condition) 0f else 1f))
 }


### PR DESCRIPTION
This is equivalent to https://github.com/RevenueCat/purchases-ios/blob/main/RevenueCatUI/Views/IntroEligibilityStateView.swift.

It allows us to display different text depending on:
- Whether there is a special `_with_intro_offer` version of the text
- Has eligible offers

This will be used when displaying `call_to_action` and `offer_details`. And later on we can expand this to support multiple phases.