### PR TITLE
Paywalls: Fix state update upon locale changes

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
@@ -3,12 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
@@ -27,7 +22,7 @@ internal fun InternalPaywallView(
     listener: PaywallViewListener? = null,
     viewModel: PaywallViewModel = getPaywallViewModel(offering = offering, listener = listener, mode = mode),
 ) {
-    updateStateIfLocaleChanged(viewModel)
+    viewModel.refreshStateIfLocaleChanged()
 
     when (val state = viewModel.state.collectAsState().value) {
         is PaywallViewState.Loading -> {
@@ -45,15 +40,6 @@ internal fun InternalPaywallView(
                 PaywallTemplate.TEMPLATE_5 -> Text(text = "Error: Template 5 not supported")
             }
         }
-    }
-}
-
-@Composable
-private fun updateStateIfLocaleChanged(viewModel: PaywallViewModel) {
-    var locale by remember { mutableStateOf(LocaleListCompat.getDefault()) }
-    if (locale != LocaleListCompat.getDefault()) {
-        locale = LocaleListCompat.getDefault()
-        viewModel.refreshState()
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -58,10 +58,9 @@ internal class PaywallViewModelImpl(
     override val state: StateFlow<PaywallViewState>
         get() = _state.asStateFlow()
     private val _state: MutableStateFlow<PaywallViewState>
-    private val _lastLocaleList = MutableStateFlow(LocaleListCompat.getDefault())
+    private val _lastLocaleList = MutableStateFlow(getCurrentLocaleList())
 
     init {
-        Logger.e("TEST: INITIALIZING PAYWALL VIEW MODEL")
         _state = MutableStateFlow(offering?.calculateState() ?: PaywallViewState.Loading)
         if (offering == null) {
             updateOffering()
@@ -69,8 +68,8 @@ internal class PaywallViewModelImpl(
     }
 
     override fun refreshStateIfLocaleChanged() {
-        if (_lastLocaleList.value != LocaleListCompat.getDefault()) {
-            _lastLocaleList.value = LocaleListCompat.getDefault()
+        if (_lastLocaleList.value != getCurrentLocaleList()) {
+            _lastLocaleList.value = getCurrentLocaleList()
             if (offering == null) {
                 updateOffering()
             } else {
@@ -151,5 +150,9 @@ internal class PaywallViewModelImpl(
 
     private fun Offering.calculateState(): PaywallViewState {
         return toPaywallViewState(variableDataProvider, mode)
+    }
+
+    private fun getCurrentLocaleList(): LocaleListCompat {
+        return LocaleListCompat.getDefault()
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.revenuecat.purchases.Offering
@@ -31,7 +32,7 @@ import java.net.URL
 internal interface PaywallViewModel {
     val state: StateFlow<PaywallViewState>
 
-    fun refreshState()
+    fun refreshStateIfLocaleChanged()
     fun selectPackage(packageToSelect: TemplateConfiguration.PackageInfo)
 
     /**
@@ -57,19 +58,24 @@ internal class PaywallViewModelImpl(
     override val state: StateFlow<PaywallViewState>
         get() = _state.asStateFlow()
     private val _state: MutableStateFlow<PaywallViewState>
+    private val _lastLocaleList = MutableStateFlow(LocaleListCompat.getDefault())
 
     init {
+        Logger.e("TEST: INITIALIZING PAYWALL VIEW MODEL")
         _state = MutableStateFlow(offering?.calculateState() ?: PaywallViewState.Loading)
         if (offering == null) {
             updateOffering()
         }
     }
 
-    override fun refreshState() {
-        if (offering == null) {
-            updateOffering()
-        } else {
-            _state.value = offering.calculateState()
+    override fun refreshStateIfLocaleChanged() {
+        if (_lastLocaleList.value != LocaleListCompat.getDefault()) {
+            _lastLocaleList.value = LocaleListCompat.getDefault()
+            if (offering == null) {
+                updateOffering()
+            } else {
+                _state.value = offering.calculateState()
+            }
         }
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/TestData.kt
@@ -260,7 +260,7 @@ internal class MockViewModel(
     private val _state =
         MutableStateFlow(offering.toPaywallViewState(VariableDataProvider(MockApplicationContext()), mode))
 
-    override fun refreshState() = Unit
+    override fun refreshStateIfLocaleChanged() = Unit
 
     override fun selectPackage(packageToSelect: TemplateConfiguration.PackageInfo) {
         error("Not supported")


### PR DESCRIPTION
### Description
I noticed the locale changes weren't working as expected. It changed the system driven locales but not our computed strings. This was because the code that was meant to update the state upon locale changes was wrong. We were using `remember` to store the last locales, but that doesn't survive configuration changes like the view model does. So I moved the logic to the view model.