### PR TITLE
Future-proof in-app message APIs in case new types are added

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/InAppMessageTypeAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/InAppMessageTypeAPI.java
@@ -1,0 +1,12 @@
+package com.revenuecat.apitester.java;
+
+import com.revenuecat.purchases.models.InAppMessageType;
+
+@SuppressWarnings({"unused", "SpellCheckingInspection"})
+final class InAppMessageTypeAPI {
+    static void check(final InAppMessageType inAppMessageType) {
+        switch (inAppMessageType) {
+            case BILLING_ISSUES:
+        }
+    }
+}

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
@@ -23,6 +23,7 @@ import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback;
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener;
 import com.revenuecat.purchases.models.BillingFeature;
 import com.revenuecat.purchases.models.GoogleProrationMode;
+import com.revenuecat.purchases.models.InAppMessageType;
 import com.revenuecat.purchases.models.StoreProduct;
 import com.revenuecat.purchases.models.StoreTransaction;
 import com.revenuecat.purchases.models.SubscriptionOption;
@@ -35,7 +36,7 @@ import java.util.concurrent.ExecutorService;
 
 @SuppressWarnings({"unused"})
 final class PurchasesCommonAPI {
-    static void check(final Purchases purchases) {
+    static void check(final Purchases purchases, final Activity activity) {
         final ArrayList<String> productIds = new ArrayList<>();
 
         final ReceiveOfferingsCallback receiveOfferingsListener = new ReceiveOfferingsCallback() {
@@ -68,6 +69,10 @@ final class PurchasesCommonAPI {
         final UpdatedCustomerInfoListener updatedCustomerInfoListener = purchases.getUpdatedCustomerInfoListener();
         purchases.setUpdatedCustomerInfoListener((CustomerInfo customerInfo) -> {
         });
+
+        final List<InAppMessageType> inAppMessageTypeList = new ArrayList<>();
+        purchases.showInAppMessagesIfNeeded(activity);
+        purchases.showInAppMessagesIfNeeded(activity, inAppMessageTypeList);
     }
 
     static void checkPurchasing(final Purchases purchases,
@@ -132,10 +137,10 @@ final class PurchasesCommonAPI {
                 .service(executorService)
                 .diagnosticsEnabled(true)
                 .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
-                .showDeclinedPaymentMessagesAutomatically(true)
+                .showInAppMessagesAutomatically(true)
                 .build();
 
-        final Boolean showDeclinedPaymentMessagesAutomatically = build.getShowDeclinedPaymentMessagesAutomatically();
+        final Boolean showInAppMessagesAutomatically = build.getShowInAppMessagesAutomatically();
 
         final Purchases instance = Purchases.getSharedInstance();
     }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/InAppMesageTypeAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/InAppMesageTypeAPI.kt
@@ -1,0 +1,14 @@
+package com.revenuecat.apitester.kotlin
+
+import com.revenuecat.purchases.models.InAppMessageType
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class InAppMesageTypeAPI {
+    fun check(inAppMessageType: InAppMessageType) {
+        when (inAppMessageType) {
+            InAppMessageType.BILLING_ISSUES,
+            -> {
+            }
+        }.exhaustive
+    }
+}

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
@@ -27,6 +27,7 @@ import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.BillingFeature
 import com.revenuecat.purchases.models.GoogleProrationMode
+import com.revenuecat.purchases.models.InAppMessageType
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.SubscriptionOption
@@ -40,6 +41,7 @@ private class PurchasesCommonAPI {
     @SuppressWarnings("LongParameterList")
     fun check(
         purchases: Purchases,
+        activity: Activity,
     ) {
         val productIds = ArrayList<String>()
         val receiveCustomerInfoCallback = object : ReceiveCustomerInfoCallback {
@@ -69,6 +71,10 @@ private class PurchasesCommonAPI {
 
         val updatedCustomerInfoListener: UpdatedCustomerInfoListener? = purchases.updatedCustomerInfoListener
         purchases.updatedCustomerInfoListener = UpdatedCustomerInfoListener { _: CustomerInfo? -> }
+
+        val inAppMessageTypeList = listOf<InAppMessageType>()
+        purchases.showInAppMessagesIfNeeded(activity)
+        purchases.showInAppMessagesIfNeeded(activity, inAppMessageTypeList)
     }
 
     @SuppressWarnings("LongParameterList", "EmptyFunctionBlock")
@@ -170,14 +176,14 @@ private class PurchasesCommonAPI {
             .appUserID("")
             .observerMode(true)
             .observerMode(false)
-            .showDeclinedPaymentMessagesAutomatically(true)
+            .showInAppMessagesAutomatically(true)
             .service(executorService)
             .diagnosticsEnabled(true)
             .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
             .informationalVerificationModeAndDiagnosticsEnabled(true)
             .build()
 
-        val showDeclinedPaymentMessagesAutomatically: Boolean = build.showDeclinedPaymentMessagesAutomatically
+        val showInAppMessagesAutomatically: Boolean = build.showInAppMessagesAutomatically
 
         val instance: Purchases = Purchases.sharedInstance
     }

--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -15,6 +15,7 @@ import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.BillingFeature
+import com.revenuecat.purchases.models.InAppMessageType
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.strings.ConfigureStrings
@@ -132,15 +133,18 @@ class Purchases internal constructor(
 
     /**
      * Google Play only, no-op for Amazon.
-     * If the user has had a payment declined, this will show a toast notification notifying them and
-     * providing instructions for recovery of the subscription.
-     * If [PurchasesConfiguration.showDeclinedPaymentMessagesAutomatically] is enabled, this will be done
+     * Displays the specified in-app message types to the user as a snackbar if there are any available to be shown.
+     * If [PurchasesConfiguration.showInAppMessagesAutomatically] is enabled, this will be done
      * automatically on each Activity's onStart.
      *
      * For more info: https://rev.cat/googleplayinappmessaging
      */
-    fun showDeclinedPaymentMessageIfNeeded(activity: Activity) {
-        purchasesOrchestrator.showDeclinedPaymentMessageIfNeeded(activity)
+    @JvmOverloads
+    fun showInAppMessagesIfNeeded(
+        activity: Activity,
+        inAppMessageTypes: List<InAppMessageType> = listOf(InAppMessageType.BILLING_ISSUES),
+    ) {
+        purchasesOrchestrator.showInAppMessagesIfNeeded(activity, inAppMessageTypes)
     }
 
     /**

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.interfaces.SyncPurchasesCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.BillingFeature
 import com.revenuecat.purchases.models.GoogleProrationMode
+import com.revenuecat.purchases.models.InAppMessageType
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.strings.ConfigureStrings
@@ -421,15 +422,18 @@ class Purchases internal constructor(
 
     /**
      * Google Play only, no-op for Amazon.
-     * If the user has had a payment declined, this will show a toast notification notifying them and
-     * providing instructions for recovery of the subscription.
-     * If [PurchasesConfiguration.showDeclinedPaymentMessagesAutomatically] is enabled, this will be done
+     * Displays the specified in-app message types to the user as a snackbar if there are any available to be shown.
+     * If [PurchasesConfiguration.showInAppMessagesAutomatically] is enabled, this will be done
      * automatically on each Activity's onStart.
      *
      * For more info: https://rev.cat/googleplayinappmessaging
      */
-    fun showDeclinedPaymentMessageIfNeeded(activity: Activity) {
-        purchasesOrchestrator.showDeclinedPaymentMessageIfNeeded(activity)
+    @JvmOverloads
+    fun showInAppMessagesIfNeeded(
+        activity: Activity,
+        inAppMessageTypes: List<InAppMessageType> = listOf(InAppMessageType.BILLING_ISSUES),
+    ) {
+        purchasesOrchestrator.showInAppMessagesIfNeeded(activity, inAppMessageTypes)
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -9,7 +9,7 @@ open class PurchasesConfiguration(builder: Builder) {
     val apiKey: String
     val appUserID: String?
     val observerMode: Boolean
-    val showDeclinedPaymentMessagesAutomatically: Boolean
+    val showInAppMessagesAutomatically: Boolean
     val service: ExecutorService?
     val store: Store
     val diagnosticsEnabled: Boolean
@@ -26,7 +26,7 @@ open class PurchasesConfiguration(builder: Builder) {
         this.diagnosticsEnabled = builder.diagnosticsEnabled
         this.verificationMode = builder.verificationMode
         this.dangerousSettings = builder.dangerousSettings
-        this.showDeclinedPaymentMessagesAutomatically = builder.showDeclinedPaymentMessagesAutomatically
+        this.showInAppMessagesAutomatically = builder.showInAppMessagesAutomatically
     }
 
     open class Builder(
@@ -41,7 +41,7 @@ open class PurchasesConfiguration(builder: Builder) {
         internal var observerMode: Boolean = false
 
         @set:JvmSynthetic @get:JvmSynthetic
-        internal var showDeclinedPaymentMessagesAutomatically: Boolean = true
+        internal var showInAppMessagesAutomatically: Boolean = true
 
         @set:JvmSynthetic @get:JvmSynthetic
         internal var service: ExecutorService? = null
@@ -63,15 +63,14 @@ open class PurchasesConfiguration(builder: Builder) {
         }
 
         /**
-         * Enable this setting to show a toast with recovery options for users who have had a declined payment
-         * automatically. Default is enabled.
+         * Enable this setting to show in-app messages from Google Play automatically. Default is enabled.
          * For more info: https://rev.cat/googleplayinappmessaging
          *
          * If this setting is disabled, you can show the snackbar by calling
-         * [Purchases.showDeclinedPaymentMessageIfNeeded]
+         * [Purchases.showInAppMessagesIfNeeded]
          */
-        fun showDeclinedPaymentMessagesAutomatically(showDeclinedPaymentMessagesAutomatically: Boolean) = apply {
-            this.showDeclinedPaymentMessagesAutomatically = showDeclinedPaymentMessagesAutomatically
+        fun showInAppMessagesAutomatically(showInAppMessagesAutomatically: Boolean) = apply {
+            this.showInAppMessagesAutomatically = showInAppMessagesAutomatically
         }
 
         fun observerMode(observerMode: Boolean) = apply {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -64,7 +64,7 @@ internal class PurchasesFactory(
             val appConfig = AppConfig(
                 context,
                 observerMode,
-                showDeclinedPaymentMessagesAutomatically,
+                showInAppMessagesAutomatically,
                 platformInfo,
                 proxyURL,
                 store,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -45,6 +45,7 @@ import com.revenuecat.purchases.interfaces.SyncPurchasesCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.BillingFeature
 import com.revenuecat.purchases.models.GoogleProrationMode
+import com.revenuecat.purchases.models.InAppMessageType
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
@@ -191,8 +192,8 @@ internal class PurchasesOrchestrator constructor(
     }
 
     override fun onActivityStarted(activity: Activity) {
-        if (appConfig.showDeclinedPaymentMessagesAutomatically) {
-            showDeclinedPaymentMessageIfNeeded(activity)
+        if (appConfig.showInAppMessagesAutomatically) {
+            showInAppMessagesIfNeeded(activity, InAppMessageType.values().toList())
         }
     }
 
@@ -462,8 +463,8 @@ internal class PurchasesOrchestrator constructor(
         this.updatedCustomerInfoListener = null
     }
 
-    fun showDeclinedPaymentMessageIfNeeded(activity: Activity) {
-        billing.showInAppMessagesIfNeeded(activity) {
+    fun showInAppMessagesIfNeeded(activity: Activity, inAppMessageTypes: List<InAppMessageType>) {
+        billing.showInAppMessagesIfNeeded(activity, inAppMessageTypes) {
             syncPurchases()
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -34,6 +34,7 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.sha1
+import com.revenuecat.purchases.models.InAppMessageType
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreProduct
@@ -289,7 +290,11 @@ internal class AmazonBilling constructor(
         )
     }
 
-    override fun showInAppMessagesIfNeeded(activity: Activity, subscriptionStatusChange: () -> Unit) {
+    override fun showInAppMessagesIfNeeded(
+        activity: Activity,
+        inAppMessageTypes: List<InAppMessageType>,
+        subscriptionStatusChange: () -> Unit,
+    ) {
         // No-op: Amazon doesn't have in-app messages
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
@@ -10,7 +10,7 @@ import java.net.URL
 internal class AppConfig(
     context: Context,
     observerMode: Boolean,
-    val showDeclinedPaymentMessagesAutomatically: Boolean,
+    val showInAppMessagesAutomatically: Boolean,
     val platformInfo: PlatformInfo,
     proxyURL: URL?,
     val store: Store,
@@ -57,7 +57,7 @@ internal class AppConfig(
         if (forceServerErrors != other.forceServerErrors) return false
         if (forceSigningErrors != other.forceSigningErrors) return false
         if (baseURL != other.baseURL) return false
-        if (showDeclinedPaymentMessagesAutomatically != other.showDeclinedPaymentMessagesAutomatically) return false
+        if (showInAppMessagesAutomatically != other.showInAppMessagesAutomatically) return false
 
         return true
     }
@@ -73,7 +73,7 @@ internal class AppConfig(
         result = 31 * result + forceServerErrors.hashCode()
         result = 31 * result + forceSigningErrors.hashCode()
         result = 31 * result + baseURL.hashCode()
-        result = 31 * result + showDeclinedPaymentMessagesAutomatically.hashCode()
+        result = 31 * result + showInAppMessagesAutomatically.hashCode()
         return result
     }
 
@@ -86,7 +86,7 @@ internal class AppConfig(
             "versionName='$versionName', " +
             "packageName='$packageName', " +
             "finishTransactions=$finishTransactions, " +
-            "showDeclinedPaymentMessagesAutomatically=$showDeclinedPaymentMessagesAutomatically, " +
+            "showInAppMessagesAutomatically=$showInAppMessagesAutomatically, " +
             "baseURL=$baseURL)"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCallback
+import com.revenuecat.purchases.models.InAppMessageType
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
@@ -106,7 +107,11 @@ internal abstract class BillingAbstract {
         onSuccess(productID)
     }
 
-    abstract fun showInAppMessagesIfNeeded(activity: Activity, subscriptionStatusChange: () -> Unit)
+    abstract fun showInAppMessagesIfNeeded(
+        activity: Activity,
+        inAppMessageTypes: List<InAppMessageType>,
+        subscriptionStatusChange: () -> Unit,
+    )
 
     interface PurchasesUpdatedListener {
         fun onPurchasesUpdated(purchases: List<StoreTransaction>)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -50,6 +50,7 @@ import com.revenuecat.purchases.common.toHumanReadableDescription
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.GooglePurchasingData
+import com.revenuecat.purchases.models.InAppMessageType
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreTransaction
@@ -757,10 +758,21 @@ internal class BillingWrapper(
 
     override fun isConnected(): Boolean = billingClient?.isReady ?: false
 
-    override fun showInAppMessagesIfNeeded(activity: Activity, subscriptionStatusChange: () -> Unit) {
-        val inAppMessageParams = InAppMessageParams.newBuilder()
-            .addInAppMessageCategoryToShow(InAppMessageParams.InAppMessageCategoryId.TRANSACTIONAL)
-            .build()
+    override fun showInAppMessagesIfNeeded(
+        activity: Activity,
+        inAppMessageTypes: List<InAppMessageType>,
+        subscriptionStatusChange: () -> Unit,
+    ) {
+        if (inAppMessageTypes.isEmpty()) {
+            errorLog(BillingStrings.BILLING_UNSPECIFIED_INAPP_MESSAGE_TYPES)
+            return
+        }
+
+        val inAppMessageParamsBuilder = InAppMessageParams.newBuilder()
+        for (inAppMessageType in inAppMessageTypes) {
+            inAppMessageParamsBuilder.addInAppMessageCategoryToShow(inAppMessageType.inAppMessageCategoryId)
+        }
+        val inAppMessageParams = inAppMessageParamsBuilder.build()
         val weakActivity = WeakReference(activity)
 
         executeRequestOnUIThread { error ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/InAppMessageType.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/InAppMessageType.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.purchases.models
+
+import com.android.billingclient.api.InAppMessageParams
+
+/**
+ * Enum mapping in-app message types
+ */
+enum class InAppMessageType(@InAppMessageParams.InAppMessageCategoryId internal val inAppMessageCategoryId: Int) {
+    /**
+     * In-app messages for billing issues.
+     * If the user has had a payment declined, this will show a toast notification notifying them and
+     * providing instructions for recovery of the subscription.
+     */
+    BILLING_ISSUES(InAppMessageParams.InAppMessageCategoryId.TRANSACTIONAL),
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -27,4 +27,6 @@ internal object BillingStrings {
     const val BILLING_INAPP_MESSAGE_NONE = "No Google Play in-app message was available."
     const val BILLING_INAPP_MESSAGE_UPDATE = "Subscription status was updated from in-app message."
     const val BILLING_INAPP_MESSAGE_UNEXPECTED_CODE = "Unexpected billing code: %s"
+    const val BILLING_UNSPECIFIED_INAPP_MESSAGE_TYPES = "Tried to show in-app messages without specifying any types. " +
+        "Please add what types of in-app message you want to display."
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -332,12 +332,12 @@ internal open class BasePurchasesTest {
         anonymous: Boolean,
         autoSync: Boolean = true,
         customEntitlementComputation: Boolean = false,
-        showDeclinedPaymentMessagesAutomatically: Boolean = false,
+        showInAppMessagesAutomatically: Boolean = false,
     ) {
         val appConfig = AppConfig(
             context = mockContext,
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = showDeclinedPaymentMessagesAutomatically,
+            showInAppMessagesAutomatically = showInAppMessagesAutomatically,
             platformInfo = PlatformInfo("native", "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -37,7 +37,7 @@ class PurchasesConfigurationTest {
         assertThat(purchasesConfiguration.diagnosticsEnabled).isFalse
         assertThat(purchasesConfiguration.verificationMode).isEqualTo(EntitlementVerificationMode.DISABLED)
         assertThat(purchasesConfiguration.dangerousSettings).isEqualTo(DangerousSettings(autoSyncPurchases = true))
-        assertThat(purchasesConfiguration.showDeclinedPaymentMessagesAutomatically).isTrue
+        assertThat(purchasesConfiguration.showInAppMessagesAutomatically).isTrue
     }
 
     @Test
@@ -54,9 +54,9 @@ class PurchasesConfigurationTest {
     }
 
     @Test
-    fun `PurchasesConfiguration sets showDeclinedPaymentMessagesAutomatically correctly`() {
-        val purchasesConfiguration = builder.showDeclinedPaymentMessagesAutomatically(false).build()
-        assertThat(purchasesConfiguration.showDeclinedPaymentMessagesAutomatically).isFalse
+    fun `PurchasesConfiguration sets showInAppMessagesAutomatically correctly`() {
+        val purchasesConfiguration = builder.showInAppMessagesAutomatically(false).build()
+        assertThat(purchasesConfiguration.showInAppMessagesAutomatically).isFalse
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -33,7 +33,7 @@ class AppConfigTest {
         val appConfig = AppConfig(
             context = mockContext,
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -52,7 +52,7 @@ class AppConfigTest {
         val appConfig = AppConfig(
             context = mockContext,
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -73,7 +73,7 @@ class AppConfigTest {
         val appConfig = AppConfig(
             context = mockContext,
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -93,7 +93,7 @@ class AppConfigTest {
         val appConfig = AppConfig(
             context = mockContext,
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -114,7 +114,7 @@ class AppConfigTest {
         val appConfig = AppConfig(
             context = mockContext,
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -123,25 +123,25 @@ class AppConfigTest {
     }
 
     @Test
-    fun `showDeclinedPaymentMessagesAutomatically is set correctly`() {
+    fun `showInAppMessagesAutomatically is set correctly`() {
         val appConfig = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
         )
-        assertThat(appConfig.showDeclinedPaymentMessagesAutomatically).isFalse
+        assertThat(appConfig.showInAppMessagesAutomatically).isFalse
         val appConfig2 = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = true,
+            showInAppMessagesAutomatically = true,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
         )
-        assertThat(appConfig2.showDeclinedPaymentMessagesAutomatically).isTrue
+        assertThat(appConfig2.showInAppMessagesAutomatically).isTrue
     }
 
     @Test
@@ -149,7 +149,7 @@ class AppConfigTest {
         val appConfig = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -162,7 +162,7 @@ class AppConfigTest {
         val appConfig = AppConfig(
             context = mockk(relaxed = true),
             observerMode = true,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -176,7 +176,7 @@ class AppConfigTest {
         val appConfig = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = expected,
             store = Store.PLAY_STORE
@@ -190,7 +190,7 @@ class AppConfigTest {
         val appConfig = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -203,7 +203,7 @@ class AppConfigTest {
         val appConfig = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -216,7 +216,7 @@ class AppConfigTest {
         val appConfig = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -229,7 +229,7 @@ class AppConfigTest {
         val appConfig = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,
@@ -239,7 +239,7 @@ class AppConfigTest {
         val appConfig2 = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,
@@ -253,7 +253,7 @@ class AppConfigTest {
         val x = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -261,7 +261,7 @@ class AppConfigTest {
         val y = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -275,7 +275,7 @@ class AppConfigTest {
         val x = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -283,7 +283,7 @@ class AppConfigTest {
         var y = AppConfig(
             context = mockk(relaxed = true),
             observerMode = true,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -294,7 +294,7 @@ class AppConfigTest {
         y = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.1.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -305,7 +305,7 @@ class AppConfigTest {
         y = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = URL("https://a.com"),
             store = Store.PLAY_STORE
@@ -316,7 +316,7 @@ class AppConfigTest {
         y = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,
@@ -331,7 +331,7 @@ class AppConfigTest {
         val x = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -339,7 +339,7 @@ class AppConfigTest {
         val y = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -352,7 +352,7 @@ class AppConfigTest {
         val x = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE
@@ -366,7 +366,7 @@ class AppConfigTest {
                 "versionName='', " +
                 "packageName='', " +
                 "finishTransactions=true, " +
-                "showDeclinedPaymentMessagesAutomatically=false, " +
+                "showInAppMessagesAutomatically=false, " +
                 "baseURL=https://api.revenuecat.com/)")
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -65,7 +65,7 @@ internal abstract class BaseHTTPClientTest {
     protected fun createAppConfig(
         context: Context = createContext(),
         observerMode: Boolean = false,
-        showDeclinedPaymentMessagesAutomatically: Boolean = false,
+        showInAppMessagesAutomatically: Boolean = false,
         platformInfo: PlatformInfo = expectedPlatformInfo,
         proxyURL: URL? = baseURL,
         store: Store = Store.PLAY_STORE,
@@ -76,7 +76,7 @@ internal abstract class BaseHTTPClientTest {
         return AppConfig(
             context = context,
             observerMode = observerMode,
-            showDeclinedPaymentMessagesAutomatically = showDeclinedPaymentMessagesAutomatically,
+            showInAppMessagesAutomatically = showInAppMessagesAutomatically,
             platformInfo = platformInfo,
             proxyURL = proxyURL,
             store = store,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
@@ -60,7 +60,7 @@ class DiagnosticsTrackerTest {
         appConfig = AppConfig(
             context = context,
             observerMode = true,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -60,7 +60,7 @@ class SubscriberAttributesPurchasesTests {
         val appConfig = AppConfig(
             context = mockk(relaxed = true),
             observerMode = false,
-            showDeclinedPaymentMessagesAutomatically = false,
+            showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,


### PR DESCRIPTION
### Description
Followup to #1290.

This improves the API to future-proof them in case Google adds new in-app message types in the future. This is not a breaking change since the previous APIs haven't been released yet.

