### PR TITLE
Better handling of packages not found for id error

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
@@ -29,7 +29,6 @@ internal object PackageConfigurationFactory {
         if (filteredRCPackages.isEmpty()) {
             return Result.failure(PackageConfigurationError("No packages found for ids $filter"))
         }
-        require(filteredRCPackages.isNotEmpty()) { "No packages found for ids $filter" }
         val packageInfos = filteredRCPackages.map {
             TemplateConfiguration.PackageInfo(
                 rcPackage = it,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PackageConfigurationError.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PackageConfigurationError.kt
@@ -1,0 +1,3 @@
+package com.revenuecat.purchases.ui.revenuecatui.errors
+
+class PackageConfigurationError(override val message: String) : Throwable(message)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -64,8 +64,8 @@ internal fun Offering.toPaywallViewState(
     mode: PaywallViewMode,
     validatedPaywallData: PaywallData,
     template: PaywallTemplate,
-): PaywallViewState.Loaded {
-    val templateConfiguration = TemplateConfigurationFactory.create(
+): PaywallViewState {
+    val createTemplateConfigurationResult = TemplateConfigurationFactory.create(
         variableDataProvider = variableDataProvider,
         mode = mode,
         paywallData = validatedPaywallData,
@@ -73,6 +73,9 @@ internal fun Offering.toPaywallViewState(
         activelySubscribedProductIdentifiers = emptySet(), // TODO-PAYWALLS: Check for active subscriptions
         template,
     )
+    val templateConfiguration = createTemplateConfigurationResult.getOrElse {
+        return PaywallViewState.Error(it.message ?: "Unknown error")
+    }
     return PaywallViewState.Loaded(
         templateConfiguration = templateConfiguration,
         selectedPackage = templateConfiguration.packages.default,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
@@ -25,7 +25,7 @@ internal class TemplateConfigurationFactoryTest {
     @Before
     fun setUp() {
         variableDataProvider = VariableDataProvider(MockApplicationContext())
-        template2Configuration = TemplateConfigurationFactory.create(
+        val result = TemplateConfigurationFactory.create(
             variableDataProvider,
             paywallViewMode,
             TestData.template2,
@@ -33,6 +33,7 @@ internal class TemplateConfigurationFactoryTest {
             emptySet(),
             PaywallTemplate.TEMPLATE_2,
         )
+        template2Configuration = result.getOrNull()!!
     }
 
     @Test


### PR DESCRIPTION
We had a `require` in `createPackageConfiguration` that would throw if the selected package in the template configuration is not available. I changed the error handling with using `Result`