### PR TITLE
Optimize billing client connection retries

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -93,6 +93,8 @@ internal class BillingWrapper(
     // how long before the data source tries to reconnect to Google play
     private var reconnectMilliseconds = RECONNECT_TIMER_START_MILLISECONDS
 
+    private var reconnectionAlreadyScheduled = false
+
     class ClientFactory(private val context: Context) {
         @UiThread
         fun buildClient(listener: com.android.billingclient.api.PurchasesUpdatedListener): BillingClient {
@@ -121,6 +123,8 @@ internal class BillingWrapper(
             if (billingClient == null) {
                 billingClient = clientFactory.buildClient(this)
             }
+
+            reconnectionAlreadyScheduled = false
 
             billingClient?.let {
                 if (!it.isReady) {
@@ -730,9 +734,7 @@ internal class BillingWrapper(
     }
 
     override fun onBillingServiceDisconnected() {
-        mainHandler.post {
-            log(LogIntent.DEBUG, BillingStrings.BILLING_SERVICE_DISCONNECTED.format(billingClient.toString()))
-        }
+        log(LogIntent.DEBUG, BillingStrings.BILLING_SERVICE_DISCONNECTED.format(billingClient?.toString()))
         retryBillingServiceConnectionWithExponentialBackoff()
     }
 
@@ -743,12 +745,17 @@ internal class BillingWrapper(
      * This prevents ANRs, see https://github.com/android/play-billing-samples/issues/310
      */
     private fun retryBillingServiceConnectionWithExponentialBackoff() {
-        log(LogIntent.DEBUG, BillingStrings.BILLING_CLIENT_RETRY.format(reconnectMilliseconds))
-        startConnectionOnMainThread(reconnectMilliseconds)
-        reconnectMilliseconds = min(
-            reconnectMilliseconds * 2,
-            RECONNECT_TIMER_MAX_TIME_MILLISECONDS,
-        )
+        if (reconnectionAlreadyScheduled) {
+            log(LogIntent.DEBUG, BillingStrings.BILLING_CLIENT_RETRY_ALREADY_SCHEDULED)
+        } else {
+            log(LogIntent.DEBUG, BillingStrings.BILLING_CLIENT_RETRY.format(reconnectMilliseconds))
+            reconnectionAlreadyScheduled = true
+            startConnectionOnMainThread(reconnectMilliseconds)
+            reconnectMilliseconds = min(
+                reconnectMilliseconds * 2,
+                RECONNECT_TIMER_MAX_TIME_MILLISECONDS,
+            )
+        }
     }
 
     override fun isConnected(): Boolean = billingClient?.isReady ?: false

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -734,7 +734,7 @@ internal class BillingWrapper(
     }
 
     override fun onBillingServiceDisconnected() {
-        log(LogIntent.DEBUG, BillingStrings.BILLING_SERVICE_DISCONNECTED.format(billingClient?.toString()))
+        log(LogIntent.WARNING, BillingStrings.BILLING_SERVICE_DISCONNECTED.format(billingClient?.toString()))
         retryBillingServiceConnectionWithExponentialBackoff()
     }
 
@@ -746,9 +746,9 @@ internal class BillingWrapper(
      */
     private fun retryBillingServiceConnectionWithExponentialBackoff() {
         if (reconnectionAlreadyScheduled) {
-            log(LogIntent.DEBUG, BillingStrings.BILLING_CLIENT_RETRY_ALREADY_SCHEDULED)
+            log(LogIntent.WARNING, BillingStrings.BILLING_CLIENT_RETRY_ALREADY_SCHEDULED)
         } else {
-            log(LogIntent.DEBUG, BillingStrings.BILLING_CLIENT_RETRY.format(reconnectMilliseconds))
+            log(LogIntent.WARNING, BillingStrings.BILLING_CLIENT_RETRY.format(reconnectMilliseconds))
             reconnectionAlreadyScheduled = true
             startConnectionOnMainThread(reconnectMilliseconds)
             reconnectMilliseconds = min(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -29,4 +29,5 @@ internal object BillingStrings {
     const val BILLING_INAPP_MESSAGE_UNEXPECTED_CODE = "Unexpected billing code: %s"
     const val BILLING_UNSPECIFIED_INAPP_MESSAGE_TYPES = "Tried to show in-app messages without specifying any types. " +
         "Please add what types of in-app message you want to display."
+    const val BILLING_CLIENT_RETRY_ALREADY_SCHEDULED = "BillingClient connection retry already scheduled. Ignoring"
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -2254,9 +2254,10 @@ class BillingWrapperTest {
     @Test
     fun `if BillingService disconnects, will try to reconnect with exponential backoff`() {
         // ensure delay on first retry
+        val runnableSlot = slot<Runnable>()
         val firstRetryMillisecondsSlot = slot<Long>()
         every {
-            handler.postDelayed(any(), capture(firstRetryMillisecondsSlot))
+            handler.postDelayed(capture(runnableSlot), capture(firstRetryMillisecondsSlot))
         } returns true
 
         wrapper.onBillingServiceDisconnected()
@@ -2264,15 +2265,19 @@ class BillingWrapperTest {
         assertThat(firstRetryMillisecondsSlot.isCaptured).isTrue
         assertThat(firstRetryMillisecondsSlot.captured).isNotEqualTo(0)
 
+        runnableSlot.captured.run()
+
         // ensure 2nd retry has longer delay
         val secondRetryMillisecondsSlot = slot<Long>()
         every {
-            handler.postDelayed(any(), capture(secondRetryMillisecondsSlot))
+            handler.postDelayed(capture(runnableSlot), capture(secondRetryMillisecondsSlot))
         } returns true
         wrapper.onBillingServiceDisconnected()
 
         assertThat(secondRetryMillisecondsSlot.isCaptured).isTrue
         assertThat(secondRetryMillisecondsSlot.captured).isGreaterThan(firstRetryMillisecondsSlot.captured)
+
+        runnableSlot.captured.run()
 
         // ensure milliseconds backoff gets reset to default after successful connection
         wrapper.onBillingSetupFinished(billingClientOKResult)
@@ -2287,9 +2292,26 @@ class BillingWrapperTest {
     }
 
     @Test
-    fun `if billing setup returns recoverable error code, will try to reconnect with exponential backoff`() {
+    fun `if BillingService disconnect callback called multiple times, single retry is done`() {
         every {
             handler.postDelayed(any(), any())
+        } returns true
+
+        wrapper.onBillingServiceDisconnected()
+        wrapper.onBillingServiceDisconnected()
+        wrapper.onBillingServiceDisconnected()
+
+        // One is done during the initial connect attempt. The second one is the retry.
+        verify(exactly = 2) {
+            handler.postDelayed(any(), any())
+        }
+    }
+
+    @Test
+    fun `if billing setup returns recoverable error code, will try to reconnect with exponential backoff`() {
+        val runnableSlot = slot<Runnable>()
+        every {
+            handler.postDelayed(capture(runnableSlot), any())
         } returns true
 
         val errorCodes = listOf(
@@ -2304,6 +2326,7 @@ class BillingWrapperTest {
             currentCallback += 1
             wrapper.onBillingSetupFinished(errorCode.buildResult())
             verify(exactly = currentCallback) { handler.postDelayed(any(), any()) }
+            runnableSlot.captured.run()
         }
     }
 


### PR DESCRIPTION
### Description
This is a possible approach to deal with #1288 
Seems like Google may be calling the `onBillingServiceDisconnected` callback multiple times consecutively. In those cases we are scheduling retries in the future for each of those calls which adds some overheard to that bug in Google's side. In order to minimize that overhead, this PR suggests having only a maximum of 1 retry scheduled, which should reduce the overhead a lot.