### PR TITLE
Paywalls: Add multiple offers fields to the paywall response and processing

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
@@ -238,6 +238,14 @@ data class PaywallData(
         @SerialName("call_to_action_with_intro_offer") val callToActionWithIntroOffer: String? = null,
 
         /**
+         * The content of the main action button for purchasing a subscription when multiple intro offer are available.
+         * This may happen in Google Play, if you have an offer with both a free trial and a discounted price.
+         * If `null`, no information regarding trial eligibility will be displayed.
+         */
+        @SerialName("call_to_action_with_multiple_intro_offers")
+        val callToActionWithMultipleIntroOffers: String? = null,
+
+        /**
          * Description for the offer to be purchased.
          */
         @SerialName("offer_details") val offerDetails: String? = null,
@@ -247,6 +255,13 @@ data class PaywallData(
          * If `null`, no information regarding trial eligibility will be displayed.
          */
         @SerialName("offer_details_with_intro_offer") val offerDetailsWithIntroOffer: String? = null,
+
+        /**
+         * Description for the offer to be purchased when multiple intro offers are available.
+         * This may happen in Google Play, if you have an offer with both a free trial and a discounted price.
+         * If `null`, no information regarding trial eligibility will be displayed.
+         */
+        @SerialName("offer_details_with_multiple_intro_offers") val offerDetailsWithMultipleIntroOffers: String? = null,
 
         /**
          * The name representing each of the packages, most commonly a variable.

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallDataTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallDataTest.kt
@@ -61,8 +61,18 @@ class PaywallDataTest {
             assertThat(darkColors.accent2?.stringRepresentation).isEqualTo("#FF00FF")
         }
 
-        val requiredLocale = "gl_ES".toLocale()
-        assertThat(paywall.configForLocale(requiredLocale)).isNull()
+        val unknownLocale = "gl_ES".toLocale()
+        assertThat(paywall.configForLocale(unknownLocale)).isNull()
+
+        val validLocale = "en_US".toLocale()
+        val localizedConfiguration = paywall.configForLocale(validLocale)
+        assertThat(localizedConfiguration).isNotNull
+        assertThat(localizedConfiguration?.callToActionWithMultipleIntroOffers).isEqualTo(
+            "Purchase now with multiple offers"
+        )
+        assertThat(localizedConfiguration?.offerDetailsWithMultipleIntroOffers).isEqualTo(
+            "Start your {{ sub_offer_duration }} trial, then {{ sub_offer_duration_2 }} discount, then {{ sub_price_per_month }} per month"
+        )
     }
 
     @Test

--- a/purchases/src/test/resources/paywalldata-sample1.json
+++ b/purchases/src/test/resources/paywalldata-sample1.json
@@ -6,8 +6,10 @@
       "subtitle": "Description",
       "call_to_action": "Purchase now",
       "call_to_action_with_intro_offer": "Purchase now",
+      "call_to_action_with_multiple_intro_offers": "Purchase now with multiple offers",
       "offer_details": "{{ sub_price_per_month }} per month",
       "offer_details_with_intro_offer": "Start your {{ sub_offer_duration }} trial, then {{ sub_price_per_month }} per month",
+      "offer_details_with_multiple_intro_offers": "Start your {{ sub_offer_duration }} trial, then {{ sub_offer_duration_2 }} discount, then {{ sub_price_per_month }} per month",
       "offer_name": "{{ period }}",
       "features": [
         {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/ProcessedLocalizedConfiguration.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/ProcessedLocalizedConfiguration.kt
@@ -9,8 +9,10 @@ internal data class ProcessedLocalizedConfiguration(
     val subtitle: String?,
     val callToAction: String,
     val callToActionWithIntroOffer: String?,
+    val callToActionWithMultipleIntroOffers: String?,
     val offerDetails: String?,
     val offerDetailsWithIntroOffer: String?,
+    val offerDetailsWithMultipleIntroOffers: String?,
     val offerName: String?,
     val features: List<PaywallData.LocalizedConfiguration.Feature> = emptyList(),
 ) {
@@ -29,21 +31,25 @@ internal data class ProcessedLocalizedConfiguration(
                     locale,
                 )
             }
-            return ProcessedLocalizedConfiguration(
-                title = localizedConfiguration.title.processVariables(),
-                subtitle = localizedConfiguration.subtitle?.processVariables(),
-                callToAction = localizedConfiguration.callToAction.processVariables(),
-                callToActionWithIntroOffer = localizedConfiguration.callToActionWithIntroOffer?.processVariables(),
-                offerDetails = localizedConfiguration.offerDetails?.processVariables(),
-                offerDetailsWithIntroOffer = localizedConfiguration.offerDetailsWithIntroOffer?.processVariables(),
-                offerName = localizedConfiguration.offerName?.processVariables(),
-                features = localizedConfiguration.features.map { feature ->
-                    feature.copy(
-                        title = feature.title.processVariables(),
-                        content = feature.content?.processVariables(),
-                    )
-                },
-            )
+            with(localizedConfiguration) {
+                return ProcessedLocalizedConfiguration(
+                    title = title.processVariables(),
+                    subtitle = subtitle?.processVariables(),
+                    callToAction = callToAction.processVariables(),
+                    callToActionWithIntroOffer = callToActionWithIntroOffer?.processVariables(),
+                    callToActionWithMultipleIntroOffers = callToActionWithMultipleIntroOffers?.processVariables(),
+                    offerDetails = offerDetails?.processVariables(),
+                    offerDetailsWithIntroOffer = offerDetailsWithIntroOffer?.processVariables(),
+                    offerDetailsWithMultipleIntroOffers = offerDetailsWithMultipleIntroOffers?.processVariables(),
+                    offerName = offerName?.processVariables(),
+                    features = features.map { feature ->
+                        feature.copy(
+                            title = feature.title.processVariables(),
+                            content = feature.content?.processVariables(),
+                        )
+                    },
+                )
+            }
         }
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
@@ -111,8 +111,10 @@ internal class TemplateConfigurationFactoryTest {
             subtitle = localizedConfiguration.subtitle,
             callToAction = callToAction,
             callToActionWithIntroOffer = null,
+            callToActionWithMultipleIntroOffers = null,
             offerDetails = offerDetails,
             offerDetailsWithIntroOffer = offerDetailsWithIntroOffer,
+            offerDetailsWithMultipleIntroOffers = null,
             offerName = periodName,
             features = emptyList(),
         )


### PR DESCRIPTION
### Description
Adds parsing of `call_to_action_with_multiple_intro_offers` and `offer_details_with_multiple_intro_offers` to paywall data. Also adds those fields to the processed localization fields. This will be used with products that have multiple offers (free trial + discount)
