### PR TITLE
Add purchases.setOnesignalUserID

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -85,6 +85,7 @@ final class PurchasesAPI {
         purchases.setFBAnonymousID("");
         purchases.setMparticleID("");
         purchases.setOnesignalID("");
+        purchases.setOnesignalUserID("");
         purchases.setAirshipChannelID("");
         purchases.setMediaSource("");
         purchases.setCampaign("");

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -120,6 +120,7 @@ private class PurchasesAPI {
             setFBAnonymousID("")
             setMparticleID("")
             setOnesignalID("")
+            setOnesignalUserID("")
             setAirshipChannelID("")
             setMixpanelDistinctID("")
             setFirebaseAppInstanceID("")

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -514,7 +514,7 @@ class Purchases internal constructor(
     fun setMixpanelDistinctID(mixpanelDistinctID: String?) {
         purchasesOrchestrator.setMixpanelDistinctID(mixpanelDistinctID)
     }
-    
+
     /**
      * Subscriber attribute associated with the OneSignal Player Id for the user
      * Required for the RevenueCat OneSignal integration. Deprecated for OneSignal versions above v9.0.

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -514,15 +514,24 @@ class Purchases internal constructor(
     fun setMixpanelDistinctID(mixpanelDistinctID: String?) {
         purchasesOrchestrator.setMixpanelDistinctID(mixpanelDistinctID)
     }
-
     /**
-     * Subscriber attribute associated with the OneSignal Player Id for the user
-     * Required for the RevenueCat OneSignal integration
+     * Subscriber attribute associated with the OneSignal Player Id for the user.
+     * Required for the RevenueCat OneSignal integration. Deprecated for OneSignal versions above v9.0.
      *
      * @param onesignalID null or an empty string will delete the subscriber attribute
      */
     fun setOnesignalID(onesignalID: String?) {
         purchasesOrchestrator.setOnesignalID(onesignalID)
+    }
+
+    /**
+     * Subscriber attribute associated with the OneSignal User ID for the user
+     * Required for the RevenueCat OneSignal integration with versions v11.0 and above.
+     *
+     * @param onesignalUserID null or an empty string will delete the subscriber attribute
+     */
+    fun setOnesignalUserID(onesignalUserID: String?) {
+        purchasesOrchestrator.setOnesignalUserID(onesignalUserID)
     }
 
     /**

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -515,7 +515,7 @@ class Purchases internal constructor(
         purchasesOrchestrator.setMixpanelDistinctID(mixpanelDistinctID)
     }
     /**
-     * Subscriber attribute associated with the OneSignal Player Id for the user.
+     * Subscriber attribute associated with the OneSignal Player Id for the user
      * Required for the RevenueCat OneSignal integration. Deprecated for OneSignal versions above v9.0.
      *
      * @param onesignalID null or an empty string will delete the subscriber attribute

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -514,6 +514,7 @@ class Purchases internal constructor(
     fun setMixpanelDistinctID(mixpanelDistinctID: String?) {
         purchasesOrchestrator.setMixpanelDistinctID(mixpanelDistinctID)
     }
+    
     /**
      * Subscriber attribute associated with the OneSignal Player Id for the user
      * Required for the RevenueCat OneSignal integration. Deprecated for OneSignal versions above v9.0.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -544,6 +544,15 @@ internal class PurchasesOrchestrator constructor(
         )
     }
 
+    fun setOnesignalUserID(onesignalUserID: String?) {
+        log(LogIntent.DEBUG, AttributionStrings.METHOD_CALLED.format("setOnesignalUserID"))
+        subscriberAttributesManager.setAttribute(
+            SubscriberAttributeKey.IntegrationIds.OneSignalUserId,
+            onesignalUserID,
+            appUserID,
+        )
+    }
+
     fun setAirshipChannelID(airshipChannelID: String?) {
         log(LogIntent.DEBUG, AttributionStrings.METHOD_CALLED.format("setAirshipChannelID"))
         subscriberAttributesManager.setAttribute(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
@@ -27,6 +27,7 @@ internal enum class ReservedSubscriberAttribute(val value: String) {
     FB_ANON_ID("\$fbAnonId"),
     MPARTICLE_ID("\$mparticleId"),
     ONESIGNAL_ID("\$onesignalId"),
+    ONESIGNAL_USER_ID("\$onesignalUserId"),
     AIRSHIP_CHANNEL_ID("\$airshipChannelId"),
     CLEVER_TAP_ID("\$clevertapId"),
 
@@ -73,6 +74,7 @@ internal sealed class SubscriberAttributeKey(val backendKey: String) {
     sealed class IntegrationIds(backendKey: ReservedSubscriberAttribute) : SubscriberAttributeKey(backendKey.value) {
         object MixpanelDistinctId : IntegrationIds(ReservedSubscriberAttribute.MIXPANEL_DISTINCT_ID)
         object OneSignal : IntegrationIds(ReservedSubscriberAttribute.ONESIGNAL_ID)
+        object OneSignalUserId : IntegrationIds(ReservedSubscriberAttribute.ONESIGNAL_USER_ID)
         object Airship : IntegrationIds(ReservedSubscriberAttribute.AIRSHIP_CHANNEL_ID)
         object FirebaseAppInstanceId : IntegrationIds(ReservedSubscriberAttribute.FIREBASE_APP_INSTANCE_ID)
     }

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -276,6 +276,13 @@ class SubscriberAttributesPurchasesTests {
     }
 
     @Test
+    fun `setOnesignalUserID`() {
+        integrationIDTest(SubscriberAttributeKey.IntegrationIds.OneSignalUserId) { id ->
+            underTest.setOnesignalUserID(id)
+        }
+    }
+
+    @Test
     fun `setAirshipChannelID`() {
         integrationIDTest(SubscriberAttributeKey.IntegrationIds.Airship) { id ->
             underTest.setAirshipChannelID(id)


### PR DESCRIPTION
### Motivation
OneSignal is migrating to a new User Centric API (v11.0). Adding a new reserved attribute to provide the new OneSignal User Id.

### Description
* Added $onesignalUserId reserved attribute with setter methods 
