### PR TITLE
Refactor checking for available packages when creating package configuration

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
@@ -10,24 +10,26 @@ internal object PackageConfigurationFactory {
     @Suppress("LongParameterList")
     fun createPackageConfiguration(
         variableDataProvider: VariableDataProvider,
-        packages: List<Package>,
+        availablePackages: List<Package>,
         activelySubscribedProductIdentifiers: Set<String>,
-        filter: List<String>,
+        packageIdsInConfig: List<String>,
         default: String?,
         localization: PaywallData.LocalizedConfiguration,
         configurationType: PackageConfigurationType,
         locale: Locale,
     ): Result<TemplateConfiguration.PackageConfiguration> {
-        val packagesById = packages.associateBy { it.identifier }
-        val filteredRCPackages = filter.mapNotNull {
-            val rcPackage = packagesById[it]
+        val availablePackagesById = availablePackages.associateBy { it.identifier }
+        val filteredRCPackages = packageIdsInConfig.mapNotNull {
+            val rcPackage = availablePackagesById[it]
             if (rcPackage == null) {
                 Logger.d("Package with id $it not found. Ignoring.")
             }
             rcPackage
-        }
+        }.takeUnless { it.isEmpty() } ?: availablePackages
+
         if (filteredRCPackages.isEmpty()) {
-            return Result.failure(PackageConfigurationError("No packages found for ids $filter"))
+            // This wont' happen because availablePackages won't be empty. Offerings can't have empty available packages
+            return Result.failure(PackageConfigurationError("No packages found for ids $packageIdsInConfig"))
         }
         val packageInfos = filteredRCPackages.map {
             TemplateConfiguration.PackageInfo(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
@@ -28,7 +28,7 @@ internal object PackageConfigurationFactory {
         }.takeUnless { it.isEmpty() } ?: availablePackages
 
         if (filteredRCPackages.isEmpty()) {
-            // This wont' happen because availablePackages won't be empty. Offerings can't have empty available packages
+            // This won't happen because availablePackages won't be empty. Offerings can't have empty available packages
             return Result.failure(PackageConfigurationError("No packages found for ids $packageIdsInConfig"))
         }
         val packageInfos = filteredRCPackages.map {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
@@ -11,14 +11,11 @@ internal object TemplateConfigurationFactory {
         variableDataProvider: VariableDataProvider,
         mode: PaywallViewMode,
         paywallData: PaywallData,
-        packages: List<Package>,
+        availablePackages: List<Package>,
         activelySubscribedProductIdentifiers: Set<String>,
         template: PaywallTemplate,
     ): Result<TemplateConfiguration> {
         val (locale, localizedConfiguration) = paywallData.localizedConfiguration
-        val packageIds = paywallData.config.packages.takeUnless {
-            it.isEmpty()
-        } ?: packages.map { it.identifier }
         val images = TemplateConfiguration.Images(
             iconUri = paywallData.getUriFromImage(paywallData.config.images.icon),
             backgroundUri = paywallData.getUriFromImage(paywallData.config.images.background),
@@ -28,9 +25,9 @@ internal object TemplateConfigurationFactory {
         val createPackageResult =
             PackageConfigurationFactory.createPackageConfiguration(
                 variableDataProvider = variableDataProvider,
-                packages = packages,
+                availablePackages = availablePackages,
                 activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers,
-                filter = packageIds,
+                packageIdsInConfig = paywallData.config.packages,
                 default = paywallData.config.defaultPackage,
                 localization = localizedConfiguration,
                 configurationType = template.configurationType,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -69,7 +69,7 @@ internal fun Offering.toPaywallViewState(
         variableDataProvider = variableDataProvider,
         mode = mode,
         paywallData = validatedPaywallData,
-        packages = availablePackages,
+        availablePackages = availablePackages,
         activelySubscribedProductIdentifiers = emptySet(), // TODO-PAYWALLS: Check for active subscriptions
         template,
     )


### PR DESCRIPTION
There shouldn't be any behavior change, but this refactor makes it more clear what happens when none of the configured packages are available.