### PR TITLE
`Paywalls`: use `IntroEligibilityStateView`

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
@@ -3,6 +3,9 @@ package com.revenuecat.purchases.ui.revenuecatui.composables
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 
 /**
@@ -14,6 +17,9 @@ internal fun IntroEligibilityStateView(
     textWithIntroOffer: String?,
     eligibility: IntroOfferEligibility,
     color: Color = Color.Unspecified,
+    style: TextStyle = TextStyle.Default,
+    fontWeight: FontWeight? = null,
+    textAlign: TextAlign? = null,
 ) {
     val text: String = if (textWithIntroOffer != null && eligibility == IntroOfferEligibility.ELIGIBLE) {
         textWithIntroOffer
@@ -23,7 +29,13 @@ internal fun IntroEligibilityStateView(
         textWithNoIntroOffer ?: textWithIntroOffer ?: ""
     }
 
-    Text(text, color = color)
+    Text(
+        text,
+        color = color,
+        style = style,
+        fontWeight = fontWeight,
+        textAlign = textAlign,
+    )
 }
 
 internal enum class IntroOfferEligibility {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.tooling.preview.Preview
 /**
  * A composable that can display different data based on intro eligibility status.
  */
+@SuppressWarnings("LongParameterList")
 @Composable
 internal fun IntroEligibilityStateView(
     textWithNoIntroOffer: String?,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.IntSize
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywallView
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
+import com.revenuecat.purchases.ui.revenuecatui.composables.IntroEligibilityStateView
 import com.revenuecat.purchases.ui.revenuecatui.composables.PurchaseButton
 import com.revenuecat.purchases.ui.revenuecatui.composables.RemoteImage
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
@@ -43,6 +44,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.currentColors
 import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 import kotlin.math.roundToInt
 
 @Composable
@@ -111,13 +113,14 @@ private fun ColumnScope.Template1MainContent(state: PaywallViewState.Loaded) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Bottom,
     ) {
-        Text(
+        IntroEligibilityStateView(
+            textWithNoIntroOffer = localizedConfig.offerDetails,
+            textWithIntroOffer = localizedConfig.offerDetailsWithIntroOffer,
+            eligibility = state.selectedPackage.introEligibility,
+            color = colors.text1,
             style = MaterialTheme.typography.bodyLarge,
             fontWeight = FontWeight.Normal,
             textAlign = TextAlign.Center,
-            // TODO-Paywalls: intro offer details
-            text = localizedConfig.offerDetails ?: "",
-            color = colors.text1,
         )
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
@@ -30,6 +30,7 @@ import com.revenuecat.purchases.ui.revenuecatui.InternalPaywallView
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
 import com.revenuecat.purchases.ui.revenuecatui.composables.IconImage
+import com.revenuecat.purchases.ui.revenuecatui.composables.IntroEligibilityStateView
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIcon
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIconName
 import com.revenuecat.purchases.ui.revenuecatui.composables.PurchaseButton
@@ -38,6 +39,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 
 private object Template3UIConstants {
     val iconCornerRadius = 8.dp
@@ -66,6 +68,17 @@ internal fun Template3(
             verticalArrangement = Arrangement.spacedBy(UIConstant.defaultVerticalSpacing, Alignment.CenterVertically),
         ) {
             Template3MainContent(state)
+        }
+        Column(
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            IntroEligibilityStateView(
+                textWithNoIntroOffer = state.selectedLocalization.offerDetails,
+                textWithIntroOffer = state.selectedLocalization.offerDetailsWithIntroOffer,
+                eligibility = state.selectedPackage.introEligibility,
+                color = state.templateConfiguration.getCurrentColors().text1,
+                textAlign = TextAlign.Center,
+            )
         }
         PurchaseButton(state, viewModel)
         Footer(templateConfiguration = state.templateConfiguration, viewModel = viewModel)
@@ -166,8 +179,8 @@ private fun Feature(
     }
 }
 
-@Preview(locale = "en-rUS")
-@Preview(locale = "es-rES")
+@Preview(locale = "en-rUS", showBackground = true)
+@Preview(locale = "es-rES", showBackground = true)
 @Composable
 private fun Template3Preview() {
     InternalPaywallView(offering = TestData.template3Offering)


### PR DESCRIPTION
Also added the missing offer details to template 3:
<img width="316" alt="Screenshot 2023-10-04 at 14 34 58" src="https://github.com/RevenueCat/purchases-android/assets/685609/ce730f89-1076-4d8d-86bb-92780cf050f4">
