### PR TITLE
`Paywalls`: Markdown support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ viewmodelCompose = "2.4.0"
 paparrazzi = "1.3.1"
 coil = "2.4.0"
 window = "1.1.0"
+commonmark = "0.21.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -119,6 +120,9 @@ window-core = { module = "androidx.window:window-core", version.ref = "window" }
 
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coil" }
+
+commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
+commonmark-strikethrough = { module = "org.commonmark:commonmark-ext-gfm-strikethrough", version.ref = "commonmark" }
 
 navigation-compose = "androidx.navigation:navigation-compose:2.5.3"
 

--- a/ui/revenuecatui/build.gradle
+++ b/ui/revenuecatui/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     implementation libs.androidx.lifecycle.viewmodel.compose
     implementation libs.coil.compose
     implementation libs.coil.svg
+    implementation libs.commonmark
+    implementation libs.commonmark.strikethrough
     debugImplementation libs.compose.ui.tooling
     debugImplementation libs.androidx.test.compose.manifest
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.ui.revenuecatui.composables
 
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
@@ -30,7 +29,7 @@ internal fun IntroEligibilityStateView(
         textWithNoIntroOffer ?: textWithIntroOffer ?: ""
     }
 
-    Text(
+    Markdown(
         text,
         color = color,
         style = style,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Markdown.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Markdown.kt
@@ -1,0 +1,358 @@
+@file:Suppress("TooManyFunctions")
+
+package com.revenuecat.purchases.ui.revenuecatui.composables
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import org.commonmark.ext.gfm.strikethrough.Strikethrough
+import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension
+import org.commonmark.node.BlockQuote
+import org.commonmark.node.BulletList
+import org.commonmark.node.Code
+import org.commonmark.node.Document
+import org.commonmark.node.Emphasis
+import org.commonmark.node.FencedCodeBlock
+import org.commonmark.node.HardLineBreak
+import org.commonmark.node.Heading
+import org.commonmark.node.Link
+import org.commonmark.node.ListBlock
+import org.commonmark.node.Node
+import org.commonmark.node.OrderedList
+import org.commonmark.node.Paragraph
+import org.commonmark.node.StrongEmphasis
+import org.commonmark.node.Text
+import org.commonmark.parser.Parser
+
+// Inspired by https://github.com/ErikHellman/MarkdownComposer/blob/master/app/src/main/java/se/hellsoft/markdowncomposer/MarkdownComposer.kt
+
+private const val TAG_URL = "url"
+private val PARSER = Parser.builder()
+    .extensions(listOf(StrikethroughExtension.create()))
+    .build()
+
+@SuppressWarnings("LongParameterList")
+@Composable
+internal fun Markdown(
+    text: String,
+    color: Color = Color.Unspecified,
+    style: TextStyle = TextStyle.Default,
+    fontWeight: FontWeight? = null,
+    textAlign: TextAlign? = null,
+    modifier: Modifier = Modifier,
+) {
+    val root = PARSER.parse(text) as Document
+
+    Column {
+        MDDocument(root, color, style, fontWeight, textAlign, modifier)
+    }
+}
+
+@SuppressWarnings("LongParameterList")
+@Composable
+private fun MDDocument(
+    document: Document,
+    color: Color,
+    style: TextStyle,
+    fontWeight: FontWeight?,
+    textAlign: TextAlign?,
+    modifier: Modifier,
+) {
+    MDBlockChildren(document, color, style, fontWeight, textAlign, modifier)
+}
+
+@SuppressWarnings("LongParameterList", "MagicNumber")
+@Composable
+private fun MDHeading(
+    heading: Heading,
+    color: Color,
+    style: TextStyle,
+    fontWeight: FontWeight?,
+    textAlign: TextAlign?,
+    modifier: Modifier = Modifier,
+) {
+    val overriddenStyle = when (heading.level) {
+        1 -> MaterialTheme.typography.h1
+        2 -> MaterialTheme.typography.h2
+        3 -> MaterialTheme.typography.h3
+        4 -> MaterialTheme.typography.h4
+        5 -> MaterialTheme.typography.h5
+        6 -> MaterialTheme.typography.h6
+        else -> {
+            // Invalid header...
+            MDBlockChildren(heading, color, style, fontWeight, textAlign, modifier)
+            return
+        }
+    }
+
+    val padding = if (heading.parent is Document) 8.dp else 0.dp
+    Box(modifier = modifier.padding(bottom = padding)) {
+        val text = buildAnnotatedString {
+            appendMarkdownChildren(heading, color)
+        }
+        MarkdownText(text, color, overriddenStyle, fontWeight, textAlign, modifier)
+    }
+}
+
+@SuppressWarnings("LongParameterList")
+@Composable
+private fun MDParagraph(
+    paragraph: Paragraph,
+    color: Color,
+    style: TextStyle,
+    fontWeight: FontWeight?,
+    textAlign: TextAlign?,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        val styledText = buildAnnotatedString {
+            pushStyle(
+                style
+                    .copy(fontWeight = fontWeight)
+                    .toSpanStyle(),
+            )
+            appendMarkdownChildren(paragraph as Node, color)
+            pop()
+        }
+        MarkdownText(styledText, color, style, fontWeight, textAlign, modifier)
+    }
+}
+
+@SuppressWarnings("LongParameterList")
+@Composable
+private fun MDBulletList(
+    bulletList: BulletList,
+    color: Color,
+    style: TextStyle,
+    fontWeight: FontWeight?,
+    textAlign: TextAlign?,
+    modifier: Modifier = Modifier,
+) {
+    val marker = bulletList.bulletMarker
+    MDListItems(
+        bulletList,
+        color = color,
+        style = style,
+        fontWeight = fontWeight,
+        textAlign = textAlign,
+        modifier = modifier,
+    ) {
+        val text = buildAnnotatedString {
+            pushStyle(MaterialTheme.typography.body1.toSpanStyle())
+            append("$marker ")
+            appendMarkdownChildren(it, color)
+            pop()
+        }
+        MarkdownText(text, color, style, fontWeight, textAlign, modifier)
+    }
+}
+
+@SuppressWarnings("LongParameterList")
+@Composable
+private fun MDOrderedList(
+    orderedList: OrderedList,
+    color: Color,
+    style: TextStyle,
+    fontWeight: FontWeight?,
+    textAlign: TextAlign?,
+    modifier: Modifier = Modifier,
+) {
+    var number = orderedList.startNumber
+    val delimiter = orderedList.delimiter
+    MDListItems(
+        orderedList,
+        color = color,
+        style = style,
+        fontWeight = fontWeight,
+        textAlign = textAlign,
+        modifier = modifier,
+    ) {
+        val text = buildAnnotatedString {
+            pushStyle(style.toSpanStyle())
+            append("${number++}$delimiter ")
+            appendMarkdownChildren(it, color)
+            pop()
+        }
+        MarkdownText(text, color, style, fontWeight, textAlign, modifier)
+    }
+}
+
+@SuppressWarnings("LongParameterList")
+@Composable
+private fun MDListItems(
+    listBlock: ListBlock,
+    color: Color,
+    style: TextStyle,
+    fontWeight: FontWeight?,
+    textAlign: TextAlign?,
+    modifier: Modifier = Modifier,
+    item: @Composable (node: Node) -> Unit,
+) {
+    val bottom = if (listBlock.parent is Document) 8.dp else 0.dp
+    val start = if (listBlock.parent is Document) 0.dp else 8.dp
+    Column(modifier = modifier.padding(start = start, bottom = bottom)) {
+        var listItem = listBlock.firstChild
+        while (listItem != null) {
+            var child = listItem.firstChild
+            while (child != null) {
+                when (child) {
+                    is BulletList -> MDBulletList(child, color, style, fontWeight, textAlign, modifier)
+                    is OrderedList -> MDOrderedList(child, color, style, fontWeight, textAlign, modifier)
+                    else -> item(child)
+                }
+                child = child.next
+            }
+            listItem = listItem.next
+        }
+    }
+}
+
+@Composable
+private fun MDBlockQuote(blockQuote: BlockQuote, color: Color, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .drawBehind {
+                drawLine(
+                    color = color,
+                    strokeWidth = 2f,
+                    start = Offset(12.dp.value, 0f),
+                    end = Offset(12.dp.value, size.height),
+                )
+            }
+            .padding(start = 16.dp, top = 4.dp, bottom = 4.dp),
+    ) {
+        val text = buildAnnotatedString {
+            pushStyle(
+                MaterialTheme.typography.body1.toSpanStyle()
+                    .plus(SpanStyle(fontStyle = FontStyle.Italic)),
+            )
+            appendMarkdownChildren(blockQuote, color)
+            pop()
+        }
+        Text(text, modifier)
+    }
+}
+
+@Composable
+private fun MDFencedCodeBlock(fencedCodeBlock: FencedCodeBlock, modifier: Modifier = Modifier) {
+    val padding = if (fencedCodeBlock.parent is Document) 8.dp else 0.dp
+    Box(modifier = modifier.padding(start = 8.dp, bottom = padding)) {
+        Text(
+            text = fencedCodeBlock.literal,
+            style = TextStyle(fontFamily = FontFamily.Monospace),
+            modifier = modifier,
+        )
+    }
+}
+
+@SuppressWarnings("LongParameterList")
+@Composable
+private fun MDBlockChildren(
+    parent: Node,
+    color: Color,
+    style: TextStyle,
+    fontWeight: FontWeight?,
+    textAlign: TextAlign?,
+    modifier: Modifier,
+) {
+    var child = parent.firstChild
+    while (child != null) {
+        when (child) {
+            is BlockQuote -> MDBlockQuote(child, color, modifier)
+            is Heading -> MDHeading(child, color, style, fontWeight, textAlign, modifier)
+            is Paragraph -> MDParagraph(child, color, style, fontWeight, textAlign, modifier)
+            is FencedCodeBlock -> MDFencedCodeBlock(child, modifier)
+            is BulletList -> MDBulletList(child, color, style, fontWeight, textAlign, modifier)
+            is OrderedList -> MDOrderedList(child, color, style, fontWeight, textAlign, modifier)
+        }
+        child = child.next
+    }
+}
+
+private fun AnnotatedString.Builder.appendMarkdownChildren(
+    parent: Node,
+    color: Color,
+) {
+    var child = parent.firstChild
+    while (child != null) {
+        when (child) {
+            is Paragraph -> appendMarkdownChildren(child, color)
+            is Text -> append(child.literal)
+            is Emphasis -> {
+                pushStyle(SpanStyle(fontStyle = FontStyle.Italic))
+                appendMarkdownChildren(child, color)
+                pop()
+            }
+            is StrongEmphasis -> {
+                pushStyle(SpanStyle(fontWeight = FontWeight.Bold))
+                appendMarkdownChildren(child, color)
+                pop()
+            }
+            is Code -> {
+                pushStyle(TextStyle(fontFamily = FontFamily.Monospace).toSpanStyle())
+                append(child.literal)
+                pop()
+            }
+            is HardLineBreak -> {
+                append("\n")
+            }
+            is Link -> {
+                val underline = SpanStyle(color, textDecoration = TextDecoration.Underline)
+                pushStyle(underline)
+                pushStringAnnotation(TAG_URL, child.destination)
+                appendMarkdownChildren(child, color)
+                pop()
+                pop()
+            }
+            is Strikethrough -> {
+                pushStyle(TextStyle(textDecoration = TextDecoration.LineThrough).toSpanStyle())
+                appendMarkdownChildren(child, color)
+                pop()
+            }
+        }
+        child = child.next
+    }
+}
+
+@SuppressWarnings("LongParameterList")
+@Composable
+private fun MarkdownText(
+    text: AnnotatedString,
+    color: Color,
+    style: TextStyle,
+    fontWeight: FontWeight?,
+    textAlign: TextAlign?,
+    modifier: Modifier = Modifier,
+) {
+    val layoutResult = remember { mutableStateOf<TextLayoutResult?>(null) }
+
+    Text(
+        text = text,
+        color = color,
+        style = style,
+        fontWeight = fontWeight,
+        textAlign = textAlign,
+        modifier = modifier,
+        onTextLayout = { layoutResult.value = it },
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
@@ -43,6 +43,7 @@ internal fun PurchaseButton(
                 textWithNoIntroOffer = state.selectedLocalization.callToAction,
                 textWithIntroOffer = state.selectedLocalization.callToActionWithIntroOffer,
                 eligibility = state.selectedPackage.introEligibility,
+                color = colors.callToActionForeground,
             )
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/templates/Template1TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/templates/Template1TestData.kt
@@ -38,11 +38,11 @@ internal val TestData.template1: PaywallData
         ),
         localization = mapOf(
             "en_US" to PaywallData.LocalizedConfiguration(
-                title = "Ignite your child's curiosity",
-                subtitle = "Get access to all our educational content trusted by thousands of parents.",
-                callToAction = "Subscribe for {{ sub_price_per_month }}",
-                callToActionWithIntroOffer = "Purchase for {{ sub_price_per_month }} per month",
-                offerDetails = "{{ sub_price_per_month }} per month",
+                title = "Ignite your _child_'s curiosity",
+                subtitle = "Get access to **all our educational content** trusted by thousands of parents.",
+                callToAction = "Subscribe for _only_ {{ sub_price_per_month }}",
+                callToActionWithIntroOffer = "Purchase for _only_ {{ sub_price_per_month }} per month",
+                offerDetails = "*Just* {{ sub_price_per_month }} per month",
                 offerDetailsWithIntroOffer = "Start your {{ sub_offer_duration }} trial, " +
                     "then {{ sub_price_per_month }} per month",
             ),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/templates/Template2TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/templates/Template2TestData.kt
@@ -34,10 +34,10 @@ internal val TestData.template2: PaywallData
         ),
         localization = mapOf(
             "en_US" to PaywallData.LocalizedConfiguration(
-                title = "Call to action for better conversion.",
-                subtitle = "Lorem ipsum is simply dummy text of the printing and typesetting industry.",
+                title = "Call to **action** for _better_ conversion.",
+                subtitle = "**Lorem ipsum** is simply ~dummy~ text of the _printing_ and *typesetting* industry.",
                 callToAction = "Subscribe for {{ price_per_period }}",
-                offerDetails = "{{ total_price_and_per_month }}",
+                offerDetails = "_Just_ {{ total_price_and_per_month }}",
                 offerDetailsWithIntroOffer = "{{ total_price_and_per_month }} after {{ sub_offer_duration }} trial",
                 offerName = "{{ sub_period }}",
             ),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/templates/Template3TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/templates/Template3TestData.kt
@@ -48,7 +48,7 @@ internal val TestData.template3: PaywallData
                 features = listOf(
                     PaywallData.LocalizedConfiguration.Feature(
                         title = "Today",
-                        content = "Full access to 1000+ workouts plus free meal plan worth {{ price }}.",
+                        content = "**Full** access to ~~100~~ 1000+ workouts plus free meal plan worth _{{ price }}_.",
                         iconID = "tick",
                     ),
                     PaywallData.LocalizedConfiguration.Feature(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -38,6 +37,7 @@ import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
 import com.revenuecat.purchases.ui.revenuecatui.composables.IntroEligibilityStateView
+import com.revenuecat.purchases.ui.revenuecatui.composables.Markdown
 import com.revenuecat.purchases.ui.revenuecatui.composables.PurchaseButton
 import com.revenuecat.purchases.ui.revenuecatui.composables.RemoteImage
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
@@ -62,6 +62,7 @@ internal fun Template1(state: PaywallViewState.Loaded, viewModel: PaywallViewMod
     }
 }
 
+@SuppressWarnings("LongMethod")
 @Composable
 private fun ColumnScope.Template1MainContent(state: PaywallViewState.Loaded) {
     val localizedConfig = state.selectedLocalization
@@ -79,11 +80,11 @@ private fun ColumnScope.Template1MainContent(state: PaywallViewState.Loaded) {
 
         Spacer(modifier = Modifier.weight(1f))
 
-        Text(
+        Markdown(
+            text = localizedConfig.title,
             style = MaterialTheme.typography.displaySmall,
             fontWeight = FontWeight.Black,
             textAlign = TextAlign.Center,
-            text = localizedConfig.title,
             color = colors.text1,
             modifier = Modifier
                 .padding(
@@ -96,11 +97,16 @@ private fun ColumnScope.Template1MainContent(state: PaywallViewState.Loaded) {
             modifier = Modifier
                 .padding(horizontal = UIConstant.defaultHorizontalPadding),
         ) {
-            Text(
+            Markdown(
+                text = localizedConfig.subtitle ?: "",
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.Normal,
                 textAlign = TextAlign.Center,
-                text = localizedConfig.subtitle ?: "",
+                modifier = Modifier
+                    .padding(
+                        horizontal = UIConstant.defaultHorizontalPadding,
+                        vertical = UIConstant.defaultVerticalSpacing,
+                    ),
                 color = colors.text1,
             )
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -14,10 +14,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,6 +33,7 @@ import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
 import com.revenuecat.purchases.ui.revenuecatui.composables.IconImage
 import com.revenuecat.purchases.ui.revenuecatui.composables.IntroEligibilityStateView
+import com.revenuecat.purchases.ui.revenuecatui.composables.Markdown
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallBackground
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIcon
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIconName
@@ -103,7 +104,7 @@ private fun ColumnScope.Template2MainContent(
             )
             val localizedConfig = state.selectedLocalization
             val colors = state.templateConfiguration.getCurrentColors()
-            Text(
+            Markdown(
                 style = MaterialTheme.typography.displaySmall,
                 fontWeight = FontWeight.Black,
                 textAlign = TextAlign.Center,
@@ -111,7 +112,7 @@ private fun ColumnScope.Template2MainContent(
                 color = colors.text1,
                 modifier = childModifier,
             )
-            Text(
+            Markdown(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Medium,
                 textAlign = TextAlign.Center,
@@ -159,12 +160,14 @@ private fun SelectPackageButton(
                 CheckmarkBox(isSelected = isSelected, colors = state.currentColors)
                 Text(
                     text = packageInfo.localization.offerName ?: packageInfo.rcPackage.product.title,
+                    color = textColor,
                 )
             }
             IntroEligibilityStateView(
                 textWithNoIntroOffer = packageInfo.localization.offerDetails,
                 textWithIntroOffer = packageInfo.localization.offerDetailsWithIntroOffer,
                 eligibility = packageInfo.introEligibility,
+                color = textColor,
             )
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,6 +31,7 @@ import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
 import com.revenuecat.purchases.ui.revenuecatui.composables.IconImage
 import com.revenuecat.purchases.ui.revenuecatui.composables.IntroEligibilityStateView
+import com.revenuecat.purchases.ui.revenuecatui.composables.Markdown
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIcon
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIconName
 import com.revenuecat.purchases.ui.revenuecatui.composables.PurchaseButton
@@ -95,7 +95,7 @@ private fun Template3MainContent(state: PaywallViewState.Loaded) {
     )
     val localizedConfig = state.selectedLocalization
     val colors = state.templateConfiguration.getCurrentColors()
-    Text(
+    Markdown(
         style = MaterialTheme.typography.headlineSmall,
         fontWeight = FontWeight.Black,
         textAlign = TextAlign.Center,
@@ -139,7 +139,8 @@ private fun Feature(
         verticalAlignment = Alignment.Top,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = UIConstant.defaultHorizontalPadding),
+            .padding(horizontal = UIConstant.defaultHorizontalPadding)
+            .padding(top = Template3UIConstants.iconPadding * 2),
     ) {
         feature.iconID?.let { PaywallIconName.fromValue(it) }?.let { icon ->
             Box(
@@ -159,7 +160,7 @@ private fun Feature(
             modifier = Modifier
                 .padding(start = UIConstant.defaultHorizontalPadding),
         ) {
-            Text(
+            Markdown(
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Start,
@@ -167,8 +168,7 @@ private fun Feature(
                 color = colors.text1,
             )
             feature.content?.let { content ->
-                Text(
-                    modifier = Modifier.padding(top = Template3UIConstants.iconPadding * 2),
+                Markdown(
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Normal,
                     textAlign = TextAlign.Start,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
@@ -98,9 +98,9 @@ internal class TemplateConfigurationFactoryTest {
             else -> error("Unknown package type ${rcPackage.packageType}")
         }
         val offerDetails = when(rcPackage.packageType) {
-            PackageType.ANNUAL -> "$67.99/yr ($5.67/mth)"
-            PackageType.MONTHLY -> "$7.99/mth"
-            PackageType.WEEKLY -> "$1.99/wk ($7.96/mth)"
+            PackageType.ANNUAL -> "_Just_ $67.99/yr ($5.67/mth)"
+            PackageType.MONTHLY -> "_Just_ $7.99/mth"
+            PackageType.WEEKLY -> "_Just_ $1.99/wk ($7.96/mth)"
             else -> error("Unknown package type ${rcPackage.packageType}")
         }
         val offerDetailsWithIntroOffer = when(rcPackage.packageType) {


### PR DESCRIPTION
This uses https://github.com/commonmark/commonmark-java for parsing, and the rendering implementation is derived from https://github.com/ErikHellman/MarkdownComposer/blob/master/app/src/main/java/se/hellsoft/markdowncomposer/MarkdownComposer.kt with a lot changes to be able to use `Markdown()` in the same way we use `Text()`, therefore being able to replace our usages everywhere.

<img width="352" alt="Screenshot 2023-10-05 at 12 27 37" src="https://github.com/RevenueCat/purchases-android/assets/685609/08b05cf2-9c63-46bf-9f9f-b86f0225c34a">