### PR TITLE
Paywalls: Add PaywallFooter composable to present a minified paywall UI that allows for custom paywalls

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
@@ -1,17 +1,24 @@
 package com.revenuecat.purchases.ui.revenuecatui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelFactory
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
+import com.revenuecat.purchases.ui.revenuecatui.data.isInFullScreenMode
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
+import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toAndroidContext
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template1
@@ -20,10 +27,8 @@ import com.revenuecat.purchases.ui.revenuecatui.templates.Template3
 
 @Composable
 internal fun InternalPaywallView(
-    mode: PaywallViewMode = PaywallViewMode.default,
-    offering: Offering? = null,
-    listener: PaywallViewListener? = null,
-    viewModel: PaywallViewModel = getPaywallViewModel(offering = offering, listener = listener, mode = mode),
+    options: PaywallViewOptions,
+    viewModel: PaywallViewModel = getPaywallViewModel(options),
 ) {
     viewModel.refreshStateIfLocaleChanged()
     val colors = MaterialTheme.colorScheme
@@ -31,18 +36,37 @@ internal fun InternalPaywallView(
 
     when (val state = viewModel.state.collectAsState().value) {
         is PaywallViewState.Loading -> {
-            LoadingPaywallView(mode = mode)
+            LoadingPaywallView(mode = options.mode)
         }
         is PaywallViewState.Error -> {
             Text(text = "Error: ${state.errorMessage}")
         }
         is PaywallViewState.Loaded -> {
-            when (state.templateConfiguration.template) {
-                PaywallTemplate.TEMPLATE_1 -> Template1(state = state, viewModel = viewModel)
-                PaywallTemplate.TEMPLATE_2 -> Template2(state = state, viewModel = viewModel)
-                PaywallTemplate.TEMPLATE_3 -> Template3(state = state, viewModel = viewModel)
-                PaywallTemplate.TEMPLATE_4 -> Text(text = "Error: Template 4 not supported")
-                PaywallTemplate.TEMPLATE_5 -> Text(text = "Error: Template 5 not supported")
+            val backgroundColor = state.templateConfiguration.getCurrentColors().background
+            Box(
+                modifier = Modifier
+                    .conditional(state.isInFullScreenMode) {
+                        Modifier.background(backgroundColor)
+                    }
+                    .conditional(!state.isInFullScreenMode) {
+                        Modifier
+                            .clip(
+                                RoundedCornerShape(
+                                    topStart = footerRoundedBorderHeight,
+                                    topEnd = footerRoundedBorderHeight,
+                                ),
+                            )
+                            .background(backgroundColor)
+                            .padding(top = footerRoundedBorderHeight)
+                    },
+            ) {
+                when (state.templateConfiguration.template) {
+                    PaywallTemplate.TEMPLATE_1 -> Template1(state = state, viewModel = viewModel)
+                    PaywallTemplate.TEMPLATE_2 -> Template2(state = state, viewModel = viewModel)
+                    PaywallTemplate.TEMPLATE_3 -> Template3(state = state, viewModel = viewModel)
+                    PaywallTemplate.TEMPLATE_4 -> Text(text = "Error: Template 4 not supported")
+                    PaywallTemplate.TEMPLATE_5 -> Text(text = "Error: Template 5 not supported")
+                }
             }
         }
     }
@@ -50,20 +74,16 @@ internal fun InternalPaywallView(
 
 @Composable
 private fun getPaywallViewModel(
-    mode: PaywallViewMode,
-    offering: Offering?,
-    listener: PaywallViewListener?,
+    options: PaywallViewOptions,
 ): PaywallViewModel {
     val applicationContext = LocalContext.current.applicationContext
     return viewModel<PaywallViewModelImpl>(
         // We need to pass the key in order to create different view models for different offerings when
         // trying to load different paywalls for the same view model store owner.
-        key = offering?.identifier,
+        key = options.offering?.identifier,
         factory = PaywallViewModelFactory(
             applicationContext.toAndroidContext(),
-            mode,
-            offering,
-            listener,
+            options,
             MaterialTheme.colorScheme,
             preview = isInPreviewMode(),
         ),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallView.kt
@@ -42,33 +42,43 @@ internal fun InternalPaywallView(
             Text(text = "Error: ${state.errorMessage}")
         }
         is PaywallViewState.Loaded -> {
-            val backgroundColor = state.templateConfiguration.getCurrentColors().background
-            Box(
-                modifier = Modifier
-                    .conditional(state.isInFullScreenMode) {
-                        Modifier.background(backgroundColor)
-                    }
-                    .conditional(!state.isInFullScreenMode) {
-                        Modifier
-                            .clip(
-                                RoundedCornerShape(
-                                    topStart = footerRoundedBorderHeight,
-                                    topEnd = footerRoundedBorderHeight,
-                                ),
-                            )
-                            .background(backgroundColor)
-                            .padding(top = footerRoundedBorderHeight)
-                    },
-            ) {
-                when (state.templateConfiguration.template) {
-                    PaywallTemplate.TEMPLATE_1 -> Template1(state = state, viewModel = viewModel)
-                    PaywallTemplate.TEMPLATE_2 -> Template2(state = state, viewModel = viewModel)
-                    PaywallTemplate.TEMPLATE_3 -> Template3(state = state, viewModel = viewModel)
-                    PaywallTemplate.TEMPLATE_4 -> Text(text = "Error: Template 4 not supported")
-                    PaywallTemplate.TEMPLATE_5 -> Text(text = "Error: Template 5 not supported")
-                }
-            }
+            LoadedPaywallView(state = state, viewModel = viewModel)
         }
+    }
+}
+
+@Composable
+private fun LoadedPaywallView(state: PaywallViewState.Loaded, viewModel: PaywallViewModel) {
+    val backgroundColor = state.templateConfiguration.getCurrentColors().background
+    Box(
+        modifier = Modifier
+            .conditional(state.isInFullScreenMode) {
+                Modifier.background(backgroundColor)
+            }
+            .conditional(!state.isInFullScreenMode) {
+                Modifier
+                    .clip(
+                        RoundedCornerShape(
+                            topStart = UIConstant.footerRoundedBorderHeight,
+                            topEnd = UIConstant.footerRoundedBorderHeight,
+                        ),
+                    )
+                    .background(backgroundColor)
+                    .padding(top = UIConstant.footerRoundedBorderHeight)
+            },
+    ) {
+        TemplatePaywallView(state = state, viewModel = viewModel)
+    }
+}
+
+@Composable
+private fun TemplatePaywallView(state: PaywallViewState.Loaded, viewModel: PaywallViewModel) {
+    when (state.templateConfiguration.template) {
+        PaywallTemplate.TEMPLATE_1 -> Template1(state = state, viewModel = viewModel)
+        PaywallTemplate.TEMPLATE_2 -> Template2(state = state, viewModel = viewModel)
+        PaywallTemplate.TEMPLATE_3 -> Template3(state = state, viewModel = viewModel)
+        PaywallTemplate.TEMPLATE_4 -> Text(text = "Error: Template 4 not supported")
+        PaywallTemplate.TEMPLATE_5 -> Text(text = "Error: Template 5 not supported")
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
@@ -1,0 +1,74 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
+
+internal val footerRoundedBorderHeight = 12.dp
+
+@Composable
+fun PaywallFooter(
+    paywallViewOptions: PaywallViewOptions = PaywallViewOptions.Builder().build(),
+    condensed: Boolean = false,
+    mainContent: @Composable (PaddingValues) -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        // This is a workaround to make the main content be able to go below the footer, so it's visible through
+        // the rounded corners. We pass this padding back to the developer so they can add this padding to their content
+        verticalArrangement = Arrangement.spacedBy(-footerRoundedBorderHeight),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+        ) {
+            mainContent(PaddingValues(bottom = footerRoundedBorderHeight))
+        }
+        val mode = if (condensed) PaywallViewMode.FOOTER_CONDENSED else PaywallViewMode.FOOTER
+        if (isInPreviewMode()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp)
+                    .background(Color.Blue),
+            )
+        } else {
+            PaywallView(paywallViewOptions.changeMode(mode))
+        }
+    }
+}
+
+@Suppress("MagicNumber")
+@Preview(showBackground = true)
+@Composable
+private fun PaywallFooterPreview() {
+    PaywallFooter {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(it),
+        ) {
+            // TODO-PAYWALLS: Implement an actual sample paywall
+            for (i in 1..50) {
+                Text(text = "Main content $i")
+            }
+        }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
@@ -21,9 +21,19 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
 
 internal val footerRoundedBorderHeight = 12.dp
 
+/**
+ * Composable offering a minified screen Paywall UI configured from the RevenueCat dashboard.
+ * You can pass in your own Composables to be displayed in the main content area.
+ *
+ * @param options The options to configure the PaywallView if needed.
+ * @param condensed Whether to condense the composable even more.
+ * @param mainContent The content to display in the main area of the PaywallView. We give a [PaddingValues] so you can
+ * add that padding to your own content. This padding corresponds to the height of the rounded corner area of
+ * the paywall.
+ */
 @Composable
 fun PaywallFooter(
-    paywallViewOptions: PaywallViewOptions = PaywallViewOptions.Builder().build(),
+    options: PaywallViewOptions = PaywallViewOptions.Builder().build(),
     condensed: Boolean = false,
     mainContent: @Composable (PaddingValues) -> Unit,
 ) {
@@ -49,7 +59,7 @@ fun PaywallFooter(
                     .background(Color.Blue),
             )
         } else {
-            PaywallView(paywallViewOptions.changeMode(mode))
+            PaywallView(options.changeMode(mode))
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
@@ -59,7 +59,8 @@ fun PaywallFooter(
                     .background(Color.Blue),
             )
         } else {
-            PaywallView(options.changeMode(mode))
+            options.mode = mode
+            PaywallView(options)
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
@@ -1,25 +1,18 @@
 package com.revenuecat.purchases.ui.revenuecatui
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
-
-internal val footerRoundedBorderHeight = 12.dp
 
 /**
  * Composable offering a minified screen Paywall UI configured from the RevenueCat dashboard.
@@ -41,27 +34,17 @@ fun PaywallFooter(
         modifier = Modifier.fillMaxSize(),
         // This is a workaround to make the main content be able to go below the footer, so it's visible through
         // the rounded corners. We pass this padding back to the developer so they can add this padding to their content
-        verticalArrangement = Arrangement.spacedBy(-footerRoundedBorderHeight),
+        verticalArrangement = Arrangement.spacedBy(-UIConstant.footerRoundedBorderHeight),
     ) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f),
         ) {
-            mainContent(PaddingValues(bottom = footerRoundedBorderHeight))
+            mainContent(PaddingValues(bottom = UIConstant.footerRoundedBorderHeight))
         }
-        val mode = if (condensed) PaywallViewMode.FOOTER_CONDENSED else PaywallViewMode.FOOTER
-        if (isInPreviewMode()) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(200.dp)
-                    .background(Color.Blue),
-            )
-        } else {
-            options.mode = mode
-            PaywallView(options)
-        }
+        options.mode = PaywallViewMode.footerMode(condensed)
+        PaywallView(options)
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallView.kt
@@ -11,8 +11,5 @@ import androidx.compose.runtime.Composable
 fun PaywallView(
     options: PaywallViewOptions = PaywallViewOptions.Builder().build(),
 ) {
-    InternalPaywallView(
-        offering = options.offering,
-        listener = options.listener,
-    )
+    InternalPaywallView(options)
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewMode.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewMode.kt
@@ -9,10 +9,4 @@ internal enum class PaywallViewMode {
     companion object {
         val default = FULL_SCREEN
     }
-
-    val isFullScreen: Boolean
-        get() = when (this) {
-            FULL_SCREEN -> true
-            FOOTER, FOOTER_CONDENSED -> false
-        }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewMode.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewMode.kt
@@ -9,4 +9,10 @@ internal enum class PaywallViewMode {
     companion object {
         val default = FULL_SCREEN
     }
+
+    val isFullScreen: Boolean
+        get() = when (this) {
+            FULL_SCREEN -> true
+            FOOTER, FOOTER_CONDENSED -> false
+        }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewMode.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewMode.kt
@@ -8,5 +8,9 @@ internal enum class PaywallViewMode {
 
     companion object {
         val default = FULL_SCREEN
+
+        fun footerMode(condensed: Boolean): PaywallViewMode {
+            return if (condensed) FOOTER_CONDENSED else FOOTER
+        }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewOptions.kt
@@ -7,17 +7,29 @@ class PaywallViewOptions(builder: Builder) {
     val offering: Offering?
     val shouldDisplayDismissButton: Boolean
     val listener: PaywallViewListener?
+    internal val mode: PaywallViewMode
 
     init {
         this.offering = builder.offering
         this.shouldDisplayDismissButton = builder.shouldDisplayDismissButton
         this.listener = builder.listener
+        this.mode = builder.mode
+    }
+
+    internal fun changeMode(mode: PaywallViewMode): PaywallViewOptions {
+        return Builder()
+            .setOffering(offering)
+            .setListener(listener)
+            .setShouldDisplayDismissButton(shouldDisplayDismissButton)
+            .setMode(mode)
+            .build()
     }
 
     class Builder {
         internal var offering: Offering? = null
         internal var shouldDisplayDismissButton: Boolean = false
         internal var listener: PaywallViewListener? = null
+        internal var mode: PaywallViewMode = PaywallViewMode.default
 
         fun setOffering(offering: Offering?) = apply {
             this.offering = offering
@@ -29,6 +41,10 @@ class PaywallViewOptions(builder: Builder) {
 
         fun setListener(listener: PaywallViewListener?) = apply {
             this.listener = listener
+        }
+
+        internal fun setMode(mode: PaywallViewMode) = apply {
+            this.mode = mode
         }
 
         fun build(): PaywallViewOptions {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallViewOptions.kt
@@ -7,29 +7,18 @@ class PaywallViewOptions(builder: Builder) {
     val offering: Offering?
     val shouldDisplayDismissButton: Boolean
     val listener: PaywallViewListener?
-    internal val mode: PaywallViewMode
+    internal var mode: PaywallViewMode = PaywallViewMode.default
 
     init {
         this.offering = builder.offering
         this.shouldDisplayDismissButton = builder.shouldDisplayDismissButton
         this.listener = builder.listener
-        this.mode = builder.mode
-    }
-
-    internal fun changeMode(mode: PaywallViewMode): PaywallViewOptions {
-        return Builder()
-            .setOffering(offering)
-            .setListener(listener)
-            .setShouldDisplayDismissButton(shouldDisplayDismissButton)
-            .setMode(mode)
-            .build()
     }
 
     class Builder {
         internal var offering: Offering? = null
         internal var shouldDisplayDismissButton: Boolean = false
         internal var listener: PaywallViewListener? = null
-        internal var mode: PaywallViewMode = PaywallViewMode.default
 
         fun setOffering(offering: Offering?) = apply {
             this.offering = offering
@@ -41,10 +30,6 @@ class PaywallViewOptions(builder: Builder) {
 
         fun setListener(listener: PaywallViewListener?) = apply {
             this.listener = listener
-        }
-
-        internal fun setMode(mode: PaywallViewMode) = apply {
-            this.mode = mode
         }
 
         fun build(): PaywallViewOptions {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/UIConstant.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/UIConstant.kt
@@ -6,5 +6,7 @@ internal object UIConstant {
     val defaultHorizontalPadding = 12.dp
     val defaultVerticalSpacing = 12.dp
 
+    val footerRoundedBorderHeight = 12.dp
+
     const val defaultAnimationDurationMillis = 200
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IconImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IconImage.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -43,7 +43,7 @@ internal fun IconImage(
                 Box(
                     modifier = modifier
                         .background(color = MaterialTheme.colorScheme.primary)
-                        .fillMaxSize(),
+                        .size(maxWidth),
                 )
             } else if (uri.toString().contains(PaywallData.defaultAppIconPlaceholder)) {
                 AppIcon(modifier = modifier)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PaywallBackground.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PaywallBackground.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.composables
 
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.BlurredEdgeTreatment
@@ -12,12 +12,12 @@ import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfigura
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 
 @Composable
-internal fun PaywallBackground(templateConfiguration: TemplateConfiguration) {
+internal fun BoxScope.PaywallBackground(templateConfiguration: TemplateConfiguration) {
     templateConfiguration.images.backgroundUri?.let {
         RemoteImage(
             urlString = it.toString(),
             modifier = Modifier
-                .fillMaxSize()
+                .matchParentSize()
                 .conditional(templateConfiguration.configuration.blurredBackgroundImage) {
                     // TODO-PAYWALLS: backwards compatibility for blurring
                     blur(BackgroundUIConstants.blurSize, edgeTreatment = BlurredEdgeTreatment.Unbounded)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -18,6 +18,7 @@ import com.revenuecat.purchases.awaitPurchase
 import com.revenuecat.purchases.awaitRestore
 import com.revenuecat.purchases.ui.revenuecatui.PaywallViewListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
+import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
 import com.revenuecat.purchases.ui.revenuecatui.extensions.getActivity
@@ -52,9 +53,7 @@ internal interface PaywallViewModel {
 @Suppress("TooManyFunctions")
 internal class PaywallViewModelImpl(
     applicationContext: ApplicationContext,
-    private val mode: PaywallViewMode,
-    private val offering: Offering?,
-    private val listener: PaywallViewListener?,
+    private val options: PaywallViewOptions,
     colorScheme: ColorScheme,
     preview: Boolean = false,
 ) : ViewModel(), PaywallViewModel {
@@ -66,6 +65,15 @@ internal class PaywallViewModelImpl(
     private val _state: MutableStateFlow<PaywallViewState>
     private val _lastLocaleList = MutableStateFlow(getCurrentLocaleList())
     private val _colorScheme = MutableStateFlow(colorScheme)
+
+    private val offering: Offering?
+        get() = options.offering
+
+    private val listener: PaywallViewListener?
+        get() = options.listener
+
+    private val mode: PaywallViewMode
+        get() = options.mode
 
     init {
         _state = MutableStateFlow(offering?.calculateState() ?: PaywallViewState.Loading)
@@ -131,10 +139,11 @@ internal class PaywallViewModelImpl(
     }
 
     private fun refreshState() {
-        if (offering == null) {
+        val currentOffering = offering
+        if (currentOffering == null) {
             updateOffering()
         } else {
-            _state.value = offering.calculateState()
+            _state.value = currentOffering.calculateState()
         }
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
@@ -3,20 +3,16 @@ package com.revenuecat.purchases.ui.revenuecatui.data
 import androidx.compose.material3.ColorScheme
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.revenuecat.purchases.Offering
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewListener
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
+import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ApplicationContext
 
 internal class PaywallViewModelFactory(
     private val applicationContext: ApplicationContext,
-    private val mode: PaywallViewMode,
-    private val offering: Offering?,
-    private val listener: PaywallViewListener?,
+    private val options: PaywallViewOptions,
     private val colorScheme: ColorScheme,
     private val preview: Boolean = false,
 ) : ViewModelProvider.NewInstanceFactory() {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        return PaywallViewModelImpl(applicationContext, mode, offering, listener, colorScheme, preview) as T
+        return PaywallViewModelImpl(applicationContext, options, colorScheme, preview) as T
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewState.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui.data
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
+import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.ProcessedLocalizedConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 
@@ -20,3 +21,6 @@ internal val PaywallViewState.Loaded.selectedLocalization: ProcessedLocalizedCon
 internal val PaywallViewState.Loaded.currentColors: TemplateConfiguration.Colors
     @Composable @ReadOnlyComposable
     get() = templateConfiguration.getCurrentColors()
+
+internal val PaywallViewState.Loaded.isInFullScreenMode: Boolean
+    get() = templateConfiguration.mode == PaywallViewMode.FULL_SCREEN

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallColor
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywallView
+import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import java.net.URL
@@ -125,5 +126,5 @@ internal fun Template2PaywallPreview() {
         paywall = paywallData,
         serverDescription = "",
     )
-    InternalPaywallView(offering = template2Offering)
+    InternalPaywallView(options = PaywallViewOptions.Builder().setOffering(template2Offering).build())
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntSize
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywallView
+import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
 import com.revenuecat.purchases.ui.revenuecatui.composables.PurchaseButton
@@ -167,7 +168,7 @@ private object Template1UIConstants {
 @Preview(showBackground = true)
 @Composable
 internal fun Template1PaywallPreview() {
-    InternalPaywallView(offering = TestData.template1Offering)
+    InternalPaywallView(options = PaywallViewOptions.Builder().setOffering(TestData.template1Offering).build())
 }
 
 @Preview(heightDp = 700, widthDp = 400)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -199,10 +199,9 @@ private fun Template2PaywallPreview() {
 @Preview(showBackground = true, locale = "es-rES")
 @Composable
 private fun Template2PaywallFooterPreview() {
-    InternalPaywallView(
-        options = PaywallViewOptions.Builder()
-            .setMode(PaywallViewMode.FOOTER)
-            .setOffering(TestData.template2Offering)
-            .build(),
-    )
+    val options = PaywallViewOptions.Builder()
+        .setOffering(TestData.template2Offering)
+        .build()
+    options.mode = PaywallViewMode.FOOTER
+    InternalPaywallView(options)
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -5,8 +5,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -27,6 +27,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywallView
+import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
+import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
 import com.revenuecat.purchases.ui.revenuecatui.composables.IconImage
@@ -38,9 +40,11 @@ import com.revenuecat.purchases.ui.revenuecatui.composables.PurchaseButton
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.currentColors
+import com.revenuecat.purchases.ui.revenuecatui.data.isInFullScreenMode
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 
 private object Template2UIConstants {
@@ -62,20 +66,8 @@ internal fun Template2(
     Box {
         PaywallBackground(state.templateConfiguration)
 
-        Column(
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(
-                        horizontal = UIConstant.defaultHorizontalPadding,
-                        vertical = UIConstant.defaultVerticalSpacing,
-                    ),
-                contentAlignment = Alignment.Center,
-            ) {
-                Template2MainContent(state, viewModel, childModifier)
-            }
+        Column {
+            Template2MainContent(state, viewModel, childModifier)
             PurchaseButton(state, viewModel, childModifier)
             Footer(
                 templateConfiguration = state.templateConfiguration,
@@ -87,43 +79,47 @@ internal fun Template2(
 }
 
 @Composable
-private fun Template2MainContent(
+private fun ColumnScope.Template2MainContent(
     state: PaywallViewState.Loaded,
     viewModel: PaywallViewModel,
     childModifier: Modifier,
 ) {
     Column(
         modifier = Modifier
-            .fillMaxWidth()
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = UIConstant.defaultHorizontalPadding),
+            .conditional(state.isInFullScreenMode) {
+                Modifier.weight(1f)
+            }
+            .padding(horizontal = UIConstant.defaultHorizontalPadding, vertical = UIConstant.defaultVerticalSpacing),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(UIConstant.defaultVerticalSpacing, Alignment.CenterVertically),
     ) {
-        IconImage(
-            uri = state.templateConfiguration.images.iconUri,
-            maxWidth = Template2UIConstants.maxIconWidth,
-            iconCornerRadius = Template2UIConstants.iconCornerRadius,
-            childModifier = childModifier,
-        )
-        val localizedConfig = state.selectedLocalization
-        val colors = state.templateConfiguration.getCurrentColors()
-        Text(
-            style = MaterialTheme.typography.displaySmall,
-            fontWeight = FontWeight.Black,
-            textAlign = TextAlign.Center,
-            text = localizedConfig.title,
-            color = colors.text1,
-            modifier = childModifier,
-        )
-        Text(
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Medium,
-            textAlign = TextAlign.Center,
-            text = localizedConfig.subtitle ?: "",
-            color = colors.text1,
-            modifier = childModifier,
-        )
+        if (state.isInFullScreenMode) {
+            IconImage(
+                uri = state.templateConfiguration.images.iconUri,
+                maxWidth = Template2UIConstants.maxIconWidth,
+                iconCornerRadius = Template2UIConstants.iconCornerRadius,
+                childModifier = childModifier,
+            )
+            val localizedConfig = state.selectedLocalization
+            val colors = state.templateConfiguration.getCurrentColors()
+            Text(
+                style = MaterialTheme.typography.displaySmall,
+                fontWeight = FontWeight.Black,
+                textAlign = TextAlign.Center,
+                text = localizedConfig.title,
+                color = colors.text1,
+                modifier = childModifier,
+            )
+            Text(
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium,
+                textAlign = TextAlign.Center,
+                text = localizedConfig.subtitle ?: "",
+                color = colors.text1,
+                modifier = childModifier,
+            )
+        }
         state.templateConfiguration.packages.all.forEach { packageInfo ->
             SelectPackageButton(state, packageInfo, viewModel, childModifier)
         }
@@ -155,7 +151,7 @@ private fun SelectPackageButton(
     ) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxWidth()
                 .padding(4.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
@@ -191,6 +187,22 @@ private fun CheckmarkBox(isSelected: Boolean, colors: TemplateConfiguration.Colo
 @Preview(showBackground = true, locale = "en-rUS")
 @Preview(showBackground = true, locale = "es-rES")
 @Composable
-internal fun Template2PaywallPreview() {
-    InternalPaywallView(offering = TestData.template2Offering)
+private fun Template2PaywallPreview() {
+    InternalPaywallView(
+        options = PaywallViewOptions.Builder()
+            .setOffering(TestData.template2Offering)
+            .build(),
+    )
+}
+
+@Preview(showBackground = true, locale = "en-rUS")
+@Preview(showBackground = true, locale = "es-rES")
+@Composable
+private fun Template2PaywallFooterPreview() {
+    InternalPaywallView(
+        options = PaywallViewOptions.Builder()
+            .setMode(PaywallViewMode.FOOTER)
+            .setOffering(TestData.template2Offering)
+            .build(),
+    )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywallView
+import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
 import com.revenuecat.purchases.ui.revenuecatui.composables.IconImage
@@ -170,5 +171,5 @@ private fun Feature(
 @Preview(locale = "es-rES")
 @Composable
 private fun Template3Preview() {
-    InternalPaywallView(offering = TestData.template3Offering)
+    InternalPaywallView(options = PaywallViewOptions.Builder().setOffering(TestData.template3Offering).build())
 }


### PR DESCRIPTION
### Description
This provides a new `PaywallFooter` composable in the API that allows to display a minified paywall UI overlaying the user's custom paywall.
![image](https://github.com/RevenueCat/purchases-android/assets/808417/254dd230-080a-4352-96f5-3f3e3680c72f)

