### PR TITLE
`PaywallsTester`: added template name to offerings list

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -96,7 +96,15 @@ private fun OfferingsListScreen(
                             .clickable { dropdownExpandedOffering = offering }
                             .padding(16.dp),
                     ) {
-                        Text(text = offering.identifier)
+                        Column {
+                            Text(text = offering.identifier)
+
+                            offering.paywall?.let {
+                                Text("Template ${it.templateName}")
+                            } ?: run {
+                                Text("No paywall")
+                            }
+                        }
                     }
                     Divider()
                 }


### PR DESCRIPTION
<img width="399" alt="Screenshot 2023-10-05 at 12 27 09" src="https://github.com/RevenueCat/purchases-android/assets/685609/15f540d1-388a-4033-924c-b97a73a3be5a">
