### PR TITLE
Log errors when displaying default paywall

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.ApplicationContext
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toPaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.validatedPaywall
+import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorStrings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -182,8 +183,12 @@ internal class PaywallViewModelImpl(
         if (availablePackages.isEmpty()) {
             return PaywallViewState.Error("No packages available")
         }
-        val (displayablePaywall, template, _) = validatedPaywall(_colorScheme.value)
-        // TODO-PAYWALLS: display error
+        val (displayablePaywall, template, error) = validatedPaywall(_colorScheme.value)
+
+        error?.let { validationError ->
+            Logger.w(validationError.associatedErrorString(this))
+            Logger.w(PaywallValidationErrorStrings.DISPLAYING_DEFAULT)
+        }
         return toPaywallViewState(variableDataProvider, mode, displayablePaywall, template)
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
@@ -1,8 +1,35 @@
 package com.revenuecat.purchases.ui.revenuecatui.errors
 
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorStrings
+
 sealed class PaywallValidationError : Throwable() {
-    object MissingPaywall : PaywallValidationError()
-    data class InvalidTemplate(val templateName: String) : PaywallValidationError()
-    data class InvalidVariables(val unrecognizedVariables: Set<String>) : PaywallValidationError()
-    data class InvalidIcons(val invalidIcons: Set<String>) : PaywallValidationError()
+
+    abstract fun associatedErrorString(offering: Offering): String
+
+    object MissingPaywall : PaywallValidationError() {
+        override fun associatedErrorString(offering: Offering): String {
+            return PaywallValidationErrorStrings.MISSING_PAYWALL.format(offering.identifier)
+        }
+    }
+
+    data class InvalidTemplate(val templateName: String) : PaywallValidationError() {
+        override fun associatedErrorString(offering: Offering): String {
+            return PaywallValidationErrorStrings.INVALID_TEMPLATE_NAME.format(templateName)
+        }
+    }
+
+    data class InvalidVariables(val unrecognizedVariables: Set<String>) : PaywallValidationError() {
+        override fun associatedErrorString(offering: Offering): String {
+            val joinedUnrecognizedVariables = this.unrecognizedVariables.joinToString()
+            return PaywallValidationErrorStrings.INVALID_VARIABLES.format(joinedUnrecognizedVariables)
+        }
+    }
+
+    data class InvalidIcons(val invalidIcons: Set<String>) : PaywallValidationError() {
+        override fun associatedErrorString(offering: Offering): String {
+            val joinedInvalidIcons = this.invalidIcons.joinToString()
+            return PaywallValidationErrorStrings.INVALID_ICONS.format(joinedInvalidIcons)
+        }
+    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
@@ -5,31 +5,23 @@ import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorSt
 
 sealed class PaywallValidationError : Throwable() {
 
-    abstract fun associatedErrorString(offering: Offering): String
-
-    object MissingPaywall : PaywallValidationError() {
-        override fun associatedErrorString(offering: Offering): String {
-            return PaywallValidationErrorStrings.MISSING_PAYWALL.format(offering.identifier)
+    fun associatedErrorString(offering: Offering): String {
+        return when (this) {
+            is InvalidIcons -> {
+                val joinedInvalidIcons = this.invalidIcons.joinToString()
+                PaywallValidationErrorStrings.INVALID_ICONS.format(joinedInvalidIcons)
+            }
+            is InvalidTemplate -> PaywallValidationErrorStrings.INVALID_TEMPLATE_NAME.format(templateName)
+            is InvalidVariables -> {
+                val joinedUnrecognizedVariables = this.unrecognizedVariables.joinToString()
+                PaywallValidationErrorStrings.INVALID_VARIABLES.format(joinedUnrecognizedVariables)
+            }
+            MissingPaywall -> PaywallValidationErrorStrings.MISSING_PAYWALL.format(offering.identifier)
         }
     }
 
-    data class InvalidTemplate(val templateName: String) : PaywallValidationError() {
-        override fun associatedErrorString(offering: Offering): String {
-            return PaywallValidationErrorStrings.INVALID_TEMPLATE_NAME.format(templateName)
-        }
-    }
-
-    data class InvalidVariables(val unrecognizedVariables: Set<String>) : PaywallValidationError() {
-        override fun associatedErrorString(offering: Offering): String {
-            val joinedUnrecognizedVariables = this.unrecognizedVariables.joinToString()
-            return PaywallValidationErrorStrings.INVALID_VARIABLES.format(joinedUnrecognizedVariables)
-        }
-    }
-
-    data class InvalidIcons(val invalidIcons: Set<String>) : PaywallValidationError() {
-        override fun associatedErrorString(offering: Offering): String {
-            val joinedInvalidIcons = this.invalidIcons.joinToString()
-            return PaywallValidationErrorStrings.INVALID_ICONS.format(joinedInvalidIcons)
-        }
-    }
+    object MissingPaywall : PaywallValidationError()
+    data class InvalidTemplate(val templateName: String) : PaywallValidationError()
+    data class InvalidVariables(val unrecognizedVariables: Set<String>) : PaywallValidationError()
+    data class InvalidIcons(val invalidIcons: Set<String>) : PaywallValidationError()
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -26,7 +26,7 @@ internal fun Offering.validatedPaywall(
             PaywallData.defaultTemplate,
             PaywallValidationError.MissingPaywall,
         ).also {
-            Logger.d(PaywallValidationErrorStrings.MISSING_PAYWALL.format(this.identifier))
+            Logger.w(PaywallValidationErrorStrings.MISSING_PAYWALL.format(this.identifier))
         }
 
     val template = paywallData.validate().getOrElse {
@@ -35,7 +35,7 @@ internal fun Offering.validatedPaywall(
             PaywallData.defaultTemplate,
             it as PaywallValidationError,
         ).also {
-            Logger.d(PaywallValidationErrorStrings.DISPLAYING_DEFAULT)
+            Logger.w(PaywallValidationErrorStrings.DISPLAYING_DEFAULT)
         }
     }
     return PaywallValidationResult(
@@ -52,20 +52,20 @@ private fun PaywallData.validate(): Result<PaywallTemplate> {
     if (invalidVariablesError != null) {
         return Result.failure<PaywallTemplate>(invalidVariablesError).also {
             val joinedUnrecognizedVariables = invalidVariablesError.unrecognizedVariables.joinToString()
-            Logger.d(PaywallValidationErrorStrings.INVALID_VARIABLES.format(joinedUnrecognizedVariables))
+            Logger.w(PaywallValidationErrorStrings.INVALID_VARIABLES.format(joinedUnrecognizedVariables))
         }
     }
 
     val template = validateTemplate()
         ?: return Result.failure<PaywallTemplate>(PaywallValidationError.InvalidTemplate(templateName)).also {
-            Logger.d(PaywallValidationErrorStrings.INVALID_TEMPLATE_NAME.format(templateName))
+            Logger.w(PaywallValidationErrorStrings.INVALID_TEMPLATE_NAME.format(templateName))
         }
 
     val invalidIconsError = localizedConfiguration.validateIcons()
     if (invalidIconsError != null) {
         return Result.failure<PaywallTemplate>(invalidIconsError).also {
             val joinedInvalidIcons = invalidIconsError.invalidIcons.joinToString()
-            Logger.d(PaywallValidationErrorStrings.INVALID_ICONS.format(joinedInvalidIcons))
+            Logger.w(PaywallValidationErrorStrings.INVALID_ICONS.format(joinedInvalidIcons))
         }
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -14,7 +14,6 @@ import com.revenuecat.purchases.ui.revenuecatui.errors.PaywallValidationError
 import com.revenuecat.purchases.ui.revenuecatui.extensions.createDefault
 import com.revenuecat.purchases.ui.revenuecatui.extensions.createDefaultForIdentifiers
 import com.revenuecat.purchases.ui.revenuecatui.extensions.defaultTemplate
-import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorStrings
 
 @Suppress("ReturnCount")
 internal fun Offering.validatedPaywall(
@@ -25,18 +24,14 @@ internal fun Offering.validatedPaywall(
             PaywallData.createDefault(packages = availablePackages, currentColorScheme),
             PaywallData.defaultTemplate,
             PaywallValidationError.MissingPaywall,
-        ).also {
-            Logger.w(PaywallValidationErrorStrings.MISSING_PAYWALL.format(this.identifier))
-        }
+        )
 
     val template = paywallData.validate().getOrElse {
         return PaywallValidationResult(
             PaywallData.createDefaultForIdentifiers(paywallData.config.packages, currentColorScheme),
             PaywallData.defaultTemplate,
             it as PaywallValidationError,
-        ).also {
-            Logger.w(PaywallValidationErrorStrings.DISPLAYING_DEFAULT)
-        }
+        )
     }
     return PaywallValidationResult(
         paywallData,
@@ -50,23 +45,14 @@ private fun PaywallData.validate(): Result<PaywallTemplate> {
 
     val invalidVariablesError = localizedConfiguration.validateVariables()
     if (invalidVariablesError != null) {
-        return Result.failure<PaywallTemplate>(invalidVariablesError).also {
-            val joinedUnrecognizedVariables = invalidVariablesError.unrecognizedVariables.joinToString()
-            Logger.w(PaywallValidationErrorStrings.INVALID_VARIABLES.format(joinedUnrecognizedVariables))
-        }
+        return Result.failure(invalidVariablesError)
     }
 
-    val template = validateTemplate()
-        ?: return Result.failure<PaywallTemplate>(PaywallValidationError.InvalidTemplate(templateName)).also {
-            Logger.w(PaywallValidationErrorStrings.INVALID_TEMPLATE_NAME.format(templateName))
-        }
+    val template = validateTemplate() ?: return Result.failure(PaywallValidationError.InvalidTemplate(templateName))
 
     val invalidIconsError = localizedConfiguration.validateIcons()
     if (invalidIconsError != null) {
-        return Result.failure<PaywallTemplate>(invalidIconsError).also {
-            val joinedInvalidIcons = invalidIconsError.invalidIcons.joinToString()
-            Logger.w(PaywallValidationErrorStrings.INVALID_ICONS.format(joinedInvalidIcons))
-        }
+        return Result.failure(invalidIconsError)
     }
 
     return Result.success(template)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/strings/PaywallValidationErrorStrings.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/strings/PaywallValidationErrorStrings.kt
@@ -1,0 +1,10 @@
+package com.revenuecat.purchases.ui.revenuecatui.strings
+
+internal object PaywallValidationErrorStrings {
+    const val DISPLAYING_DEFAULT = "Displaying default template due to validation errors."
+    const val MISSING_PAYWALL = "Displaying default template because paywall is missing for offering '%s'."
+    const val INVALID_VARIABLES = "There were some errors validating variables in the paywall strings. " +
+        "The unrecognized variables are: %s"
+    const val INVALID_TEMPLATE_NAME = "Template name is not recognized: %s"
+    const val INVALID_ICONS = "One or more icons were not recognized: %s"
+}


### PR DESCRIPTION
We can't really detect debug builds like we do in iOS, so this PR just adds some debug logs for validation errors that create the default template.