### PR TITLE
Add revenuecatui gradle.properties to specify name of dependency

### DIFF
--- a/ui/revenuecatui/gradle.properties
+++ b/ui/revenuecatui/gradle.properties
@@ -1,0 +1,4 @@
+POM_NAME=revenuecat-ui
+# We default to deploy the noop version since release is the noop version.
+POM_ARTIFACT_ID=revenuecat-ui
+POM_PACKAGING=aar

--- a/ui/revenuecatui/gradle.properties
+++ b/ui/revenuecatui/gradle.properties
@@ -1,4 +1,4 @@
-POM_NAME=revenuecat-ui
+POM_NAME=purchases-ui
 # We default to deploy the noop version since release is the noop version.
-POM_ARTIFACT_ID=revenuecat-ui
+POM_ARTIFACT_ID=purchases-ui
 POM_PACKAGING=aar


### PR DESCRIPTION
### Description
Adding a `gradle.properties` file to the `ui:revenuecatui` module to specify the name of the dependency. With this, developers will need to add the dependency like: `implementation "com.revenuecat.purchases:purchases-ui:VERSION_NUMBER"`