### PR TITLE
Fix material theme references to use Material3 versions

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/MainScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/MainScreen.kt
@@ -3,7 +3,7 @@ package com.revenuecat.paywallstester.ui.screens.main
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
-import androidx.compose.material.Icon
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -10,9 +10,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Divider
-import androidx.compose.material.Text
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreen.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.AlertDialog
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Markdown.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Markdown.kt
@@ -5,8 +5,8 @@ package com.revenuecat.purchases.ui.revenuecatui.composables
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,7 +47,7 @@ import org.commonmark.parser.Parser
 // Inspired by https://github.com/ErikHellman/MarkdownComposer/blob/master/app/src/main/java/se/hellsoft/markdowncomposer/MarkdownComposer.kt
 
 private const val TAG_URL = "url"
-private val PARSER = Parser.builder()
+private val parser = Parser.builder()
     .extensions(listOf(StrikethroughExtension.create()))
     .build()
 
@@ -55,13 +55,13 @@ private val PARSER = Parser.builder()
 @Composable
 internal fun Markdown(
     text: String,
+    modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
     style: TextStyle = TextStyle.Default,
     fontWeight: FontWeight? = null,
     textAlign: TextAlign? = null,
-    modifier: Modifier = Modifier,
 ) {
-    val root = PARSER.parse(text) as Document
+    val root = parser.parse(text) as Document
 
     Column {
         MDDocument(root, color, style, fontWeight, textAlign, modifier)
@@ -92,12 +92,12 @@ private fun MDHeading(
     modifier: Modifier = Modifier,
 ) {
     val overriddenStyle = when (heading.level) {
-        1 -> MaterialTheme.typography.h1
-        2 -> MaterialTheme.typography.h2
-        3 -> MaterialTheme.typography.h3
-        4 -> MaterialTheme.typography.h4
-        5 -> MaterialTheme.typography.h5
-        6 -> MaterialTheme.typography.h6
+        1 -> MaterialTheme.typography.headlineLarge
+        2 -> MaterialTheme.typography.headlineMedium
+        3 -> MaterialTheme.typography.headlineSmall
+        4 -> MaterialTheme.typography.titleLarge
+        5 -> MaterialTheme.typography.titleMedium
+        6 -> MaterialTheme.typography.titleSmall
         else -> {
             // Invalid header...
             MDBlockChildren(heading, color, style, fontWeight, textAlign, modifier)
@@ -158,7 +158,7 @@ private fun MDBulletList(
         modifier = modifier,
     ) {
         val text = buildAnnotatedString {
-            pushStyle(MaterialTheme.typography.body1.toSpanStyle())
+            pushStyle(MaterialTheme.typography.bodyLarge.toSpanStyle())
             append("$marker ")
             appendMarkdownChildren(it, color)
             pop()
@@ -243,7 +243,7 @@ private fun MDBlockQuote(blockQuote: BlockQuote, color: Color, modifier: Modifie
     ) {
         val text = buildAnnotatedString {
             pushStyle(
-                MaterialTheme.typography.body1.toSpanStyle()
+                MaterialTheme.typography.bodyLarge.toSpanStyle()
                     .plus(SpanStyle(fontStyle = FontStyle.Italic)),
             )
             appendMarkdownChildren(blockQuote, color)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PaywallIcon.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PaywallIcon.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.material.Icon
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -14,10 +14,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier


### PR DESCRIPTION
### Description
Make sure we use material3 all accross the paywall tester app and the revenuecatui library. Also some linter fixes in `Markdown`