### PR TITLE
Paywalls: Support custom fonts through FontProvider

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl
 import com.revenuecat.purchases.ui.revenuecatui.data.isInFullScreenMode
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
+import com.revenuecat.purchases.ui.revenuecatui.fonts.PaywallTheme
 import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toAndroidContext
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template1
@@ -30,19 +31,23 @@ internal fun InternalPaywall(
     options: PaywallOptions,
     viewModel: PaywallViewModel = getPaywallViewModel(options),
 ) {
-    viewModel.refreshStateIfLocaleChanged()
-    val colors = MaterialTheme.colorScheme
-    viewModel.refreshStateIfColorsChanged(colors)
+    PaywallTheme(fontProvider = options.fontProvider) {
+        viewModel.refreshStateIfLocaleChanged()
+        val colors = MaterialTheme.colorScheme
+        viewModel.refreshStateIfColorsChanged(colors)
 
-    when (val state = viewModel.state.collectAsState().value) {
-        is PaywallState.Loading -> {
-            LoadingPaywall(mode = options.mode)
-        }
-        is PaywallState.Error -> {
-            Text(text = "Error: ${state.errorMessage}")
-        }
-        is PaywallState.Loaded -> {
-            LoadedPaywall(state = state, viewModel = viewModel)
+        when (val state = viewModel.state.collectAsState().value) {
+            is PaywallState.Loading -> {
+                LoadingPaywall(mode = options.mode)
+            }
+
+            is PaywallState.Error -> {
+                Text(text = "Error: ${state.errorMessage}")
+            }
+
+            is PaywallState.Loaded -> {
+                LoadedPaywall(state = state, viewModel = viewModel)
+            }
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui
 
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayBlockForEntitlementIdentifier
 
 class PaywallDialogOptions(builder: Builder) {
@@ -10,6 +11,7 @@ class PaywallDialogOptions(builder: Builder) {
     val shouldDisplayBlock: ((CustomerInfo) -> Boolean)?
     val offering: Offering?
     val shouldDisplayDismissButton: Boolean
+    val fontProvider: FontProvider?
     val listener: PaywallListener?
 
     init {
@@ -17,13 +19,15 @@ class PaywallDialogOptions(builder: Builder) {
         this.dismissRequest = builder.dismissRequest
         this.offering = builder.offering
         this.shouldDisplayDismissButton = builder.shouldDisplayDismissButton
+        this.fontProvider = builder.fontProvider
         this.listener = builder.listener
     }
 
-    fun toPaywallOptions(): PaywallOptions {
+    internal fun toPaywallOptions(): PaywallOptions {
         return PaywallOptions.Builder()
             .setOffering(offering)
             .setShouldDisplayDismissButton(shouldDisplayDismissButton)
+            .setFontProvider(fontProvider)
             .setListener(listener)
             .build()
     }
@@ -34,6 +38,7 @@ class PaywallDialogOptions(builder: Builder) {
         internal var shouldDisplayBlock: ((CustomerInfo) -> Boolean)? = null
         internal var offering: Offering? = null
         internal var shouldDisplayDismissButton: Boolean = true
+        internal var fontProvider: FontProvider? = null
         internal var listener: PaywallListener? = null
 
         /**
@@ -58,6 +63,10 @@ class PaywallDialogOptions(builder: Builder) {
 
         fun setShouldDisplayDismissButton(shouldDisplayDismissButton: Boolean) = apply {
             this.shouldDisplayDismissButton = shouldDisplayDismissButton
+        }
+
+        fun setFontProvider(fontProvider: FontProvider?) = apply {
+            this.fontProvider = fontProvider
         }
 
         fun setListener(listener: PaywallListener?) = apply {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui
 
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
 
 internal sealed class OfferingSelection {
     data class OfferingType(val offeringType: Offering) : OfferingSelection()
@@ -26,18 +27,21 @@ class PaywallOptions(builder: Builder) {
 
     internal val offeringSelection: OfferingSelection
     val shouldDisplayDismissButton: Boolean
+    val fontProvider: FontProvider?
     val listener: PaywallListener?
     internal var mode: PaywallMode = PaywallMode.default
 
     init {
         this.offeringSelection = builder.offeringSelection
         this.shouldDisplayDismissButton = builder.shouldDisplayDismissButton
+        this.fontProvider = builder.fontProvider
         this.listener = builder.listener
     }
 
     class Builder {
         internal var offeringSelection: OfferingSelection = OfferingSelection.None
         internal var shouldDisplayDismissButton: Boolean = false
+        internal var fontProvider: FontProvider? = null
         internal var listener: PaywallListener? = null
 
         fun setOffering(offering: Offering?) = apply {
@@ -52,6 +56,10 @@ class PaywallOptions(builder: Builder) {
 
         fun setShouldDisplayDismissButton(shouldDisplayDismissButton: Boolean) = apply {
             this.shouldDisplayDismissButton = shouldDisplayDismissButton
+        }
+
+        fun setFontProvider(fontProvider: FontProvider?) = apply {
+            this.fontProvider = fontProvider
         }
 
         fun setListener(listener: PaywallListener?) = apply {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -42,21 +42,26 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
         }
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        val args = getArgs()
-        val fontProvider = args?.mapFonts?.let { mapFonts ->
+    private fun getFontProvider(): FontProvider? {
+        return getArgs()?.fonts?.let { fonts ->
+            val fontsMap = fonts.mapValues { entry ->
+                entry.value?.let { fontRes ->
+                    ResourcesCompat.getFont(this, fontRes)?.let { FontFamily(it) }
+                }
+            }
             object : FontProvider {
                 override fun getFont(type: TypographyType): FontFamily? {
-                    return mapFonts[type]?.let { fontRes ->
-                        return ResourcesCompat.getFont(this@PaywallActivity, fontRes)?.let { FontFamily(it) }
-                    }
+                    return fontsMap[type]
                 }
             }
         }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         val paywallOptions = PaywallOptions.Builder()
             .setOfferingId(getArgs()?.offeringId)
-            .setFontProvider(fontProvider)
+            .setFontProvider(getFontProvider())
             .setListener(this)
             .build()
         setContent {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.core.content.res.ResourcesCompat
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -18,6 +20,8 @@ import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
+import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
+import com.revenuecat.purchases.ui.revenuecatui.fonts.TypographyType
 
 /**
  * Wrapper activity around [Paywall] that allows using it when you are not using Jetpack Compose directly.
@@ -40,8 +44,19 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val args = getArgs()
+        val fontProvider = args?.mapFonts?.let { mapFonts ->
+            object : FontProvider {
+                override fun getFont(type: TypographyType): FontFamily? {
+                    return mapFonts[type]?.let { fontRes ->
+                        return ResourcesCompat.getFont(this@PaywallActivity, fontRes)?.let { FontFamily(it) }
+                    }
+                }
+            }
+        }
         val paywallOptions = PaywallOptions.Builder()
             .setOfferingId(getArgs()?.offeringId)
+            .setFontProvider(fontProvider)
             .setListener(this)
             .build()
         setContent {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -43,16 +43,14 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
     }
 
     private fun getFontProvider(): FontProvider? {
-        return getArgs()?.fonts?.let { fonts ->
-            val fontsMap = fonts.mapValues { entry ->
-                entry.value?.let { fontRes ->
-                    ResourcesCompat.getFont(this, fontRes)?.let { FontFamily(it) }
-                }
+        val fontsMap = getArgs()?.fonts?.mapValues { entry ->
+            entry.value?.let { fontRes ->
+                ResourcesCompat.getFont(this, fontRes)?.let { FontFamily(it) }
             }
-            object : FontProvider {
-                override fun getFont(type: TypographyType): FontFamily? {
-                    return fontsMap[type]
-                }
+        } ?: return null
+        return object : FontProvider {
+            override fun getFont(type: TypographyType): FontFamily? {
+                return fontsMap[type]
             }
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
@@ -10,8 +10,8 @@ internal data class PaywallActivityArgs(
     val offeringId: String? = null,
     val fonts: Map<TypographyType, Int?>? = null,
 ) : Parcelable {
-    constructor(offeringId: String? = null, provider: FontResourceProvider?) : this(
+    constructor(offeringId: String? = null, fontProvider: FontResourceProvider?) : this(
         offeringId,
-        provider?.let { TypographyType.values().associateBy({ it }, { provider.getFontResourceId(it) }) },
+        fontProvider?.let { TypographyType.values().associateBy({ it }, { fontProvider.getFontResourceId(it) }) },
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
@@ -1,9 +1,11 @@
 package com.revenuecat.purchases.ui.revenuecatui.activity
 
 import android.os.Parcelable
+import com.revenuecat.purchases.ui.revenuecatui.fonts.TypographyType
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class PaywallActivityArgs(
     val offeringId: String? = null,
+    val mapFonts: Map<TypographyType, Int?>? = null,
 ) : Parcelable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
@@ -1,11 +1,17 @@
 package com.revenuecat.purchases.ui.revenuecatui.activity
 
 import android.os.Parcelable
+import com.revenuecat.purchases.ui.revenuecatui.fonts.FontResourceProvider
 import com.revenuecat.purchases.ui.revenuecatui.fonts.TypographyType
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class PaywallActivityArgs(
     val offeringId: String? = null,
-    val mapFonts: Map<TypographyType, Int?>? = null,
-) : Parcelable
+    val fonts: Map<TypographyType, Int?>? = null,
+) : Parcelable {
+    constructor(offeringId: String? = null, provider: FontResourceProvider?) : this(
+        offeringId,
+        provider?.let { TypographyType.values().associateBy({ it }, { provider.getFontResourceId(it) }) },
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -44,7 +44,9 @@ class PaywallActivityLauncher {
      */
     @JvmOverloads
     fun launch(offering: Offering? = null, fontResourceProvider: FontResourceProvider? = null) {
-        val fontMap = TypographyType.values().associateBy({ it }, { fontResourceProvider?.getFontResourceId(it) })
+        val fontMap = fontResourceProvider?.let { provider ->
+            TypographyType.values().associateBy({ it }, { provider.getFontResourceId(it) })
+        }
         activityResultLauncher.launch(
             PaywallActivityArgs(
                 offeringId = offering?.identifier,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -46,7 +46,7 @@ class PaywallActivityLauncher {
         activityResultLauncher.launch(
             PaywallActivityArgs(
                 offeringId = offering?.identifier,
-                provider = fontResourceProvider,
+                fontProvider = fontResourceProvider,
             ),
         )
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -7,7 +7,6 @@ import androidx.fragment.app.Fragment
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontResourceProvider
-import com.revenuecat.purchases.ui.revenuecatui.fonts.TypographyType
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayBlockForEntitlementIdentifier
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayPaywall
 
@@ -44,13 +43,10 @@ class PaywallActivityLauncher {
      */
     @JvmOverloads
     fun launch(offering: Offering? = null, fontResourceProvider: FontResourceProvider? = null) {
-        val fontMap = fontResourceProvider?.let { provider ->
-            TypographyType.values().associateBy({ it }, { provider.getFontResourceId(it) })
-        }
         activityResultLauncher.launch(
             PaywallActivityArgs(
                 offeringId = offering?.identifier,
-                mapFonts = fontMap,
+                provider = fontResourceProvider,
             ),
         )
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -6,6 +6,8 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.Fragment
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.fonts.FontResourceProvider
+import com.revenuecat.purchases.ui.revenuecatui.fonts.TypographyType
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayBlockForEntitlementIdentifier
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayPaywall
 
@@ -41,8 +43,14 @@ class PaywallActivityLauncher {
      * @param offering The offering to be shown in the paywall. If null, the current offering will be shown.
      */
     @JvmOverloads
-    fun launch(offering: Offering? = null) {
-        activityResultLauncher.launch(PaywallActivityArgs(offeringId = offering?.identifier))
+    fun launch(offering: Offering? = null, fontResourceProvider: FontResourceProvider? = null) {
+        val fontMap = TypographyType.values().associateBy({ it }, { fontResourceProvider?.getFontResourceId(it) })
+        activityResultLauncher.launch(
+            PaywallActivityArgs(
+                offeringId = offering?.identifier,
+                mapFonts = fontMap,
+            ),
+        )
     }
 
     /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.composables
 
 import androidx.compose.animation.Crossfade
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,7 +22,7 @@ internal fun IntroEligibilityStateView(
     textWithMultipleIntroOffers: String?,
     eligibility: IntroOfferEligibility,
     color: Color = Color.Unspecified,
-    style: TextStyle = TextStyle.Default,
+    style: TextStyle = LocalTextStyle.current,
     fontWeight: FontWeight? = null,
     textAlign: TextAlign? = null,
     modifier: Modifier = Modifier,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/TypographyExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/TypographyExtensions.kt
@@ -1,0 +1,37 @@
+package com.revenuecat.purchases.ui.revenuecatui.extensions
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
+import com.revenuecat.purchases.ui.revenuecatui.fonts.TypographyType
+
+fun Typography.copyWithFontProvider(fontProvider: FontProvider): Typography {
+    with(this) {
+        return copy(
+            displayLarge = displayLarge.modifyFontIfNeeded(TypographyType.DISPLAY_LARGE, fontProvider),
+            displayMedium = displayMedium.modifyFontIfNeeded(TypographyType.DISPLAY_MEDIUM, fontProvider),
+            displaySmall = displaySmall.modifyFontIfNeeded(TypographyType.DISPLAY_SMALL, fontProvider),
+            headlineLarge = headlineLarge.modifyFontIfNeeded(TypographyType.HEADLINE_LARGE, fontProvider),
+            headlineMedium = headlineMedium.modifyFontIfNeeded(TypographyType.HEADLINE_MEDIUM, fontProvider),
+            headlineSmall = headlineSmall.modifyFontIfNeeded(TypographyType.HEADLINE_SMALL, fontProvider),
+            titleLarge = titleLarge.modifyFontIfNeeded(TypographyType.TITLE_LARGE, fontProvider),
+            titleMedium = titleMedium.modifyFontIfNeeded(TypographyType.TITLE_MEDIUM, fontProvider),
+            titleSmall = titleSmall.modifyFontIfNeeded(TypographyType.TITLE_SMALL, fontProvider),
+            bodyLarge = bodyLarge.modifyFontIfNeeded(TypographyType.BODY_LARGE, fontProvider),
+            bodyMedium = bodyMedium.modifyFontIfNeeded(TypographyType.BODY_MEDIUM, fontProvider),
+            bodySmall = bodySmall.modifyFontIfNeeded(TypographyType.BODY_SMALL, fontProvider),
+            labelLarge = labelLarge.modifyFontIfNeeded(TypographyType.LABEL_LARGE, fontProvider),
+            labelMedium = labelMedium.modifyFontIfNeeded(TypographyType.LABEL_MEDIUM, fontProvider),
+            labelSmall = labelSmall.modifyFontIfNeeded(TypographyType.LABEL_SMALL, fontProvider),
+        )
+    }
+}
+
+private fun TextStyle.modifyFontIfNeeded(typographyType: TypographyType, fontProvider: FontProvider): TextStyle {
+    val font = fontProvider.getFont(typographyType)
+    return if (font == null) {
+        this
+    } else {
+        this.copy(fontFamily = font)
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontProvider.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.fonts
 
 import androidx.compose.ui.text.font.FontFamily
-import com.revenuecat.purchases.ui.revenuecatui.PaywallView
 
 /**
  * Implement this interface to provide custom fonts to the [PaywallView]. If you don't, the current material3 theme

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontProvider.kt
@@ -1,13 +1,12 @@
 package com.revenuecat.purchases.ui.revenuecatui.fonts
 
-import android.os.Parcelable
 import androidx.compose.ui.text.font.FontFamily
 
 /**
  * Implement this interface to provide custom fonts to the PaywallView. If you don't, the current material3 theme
  * typography will be used.
  */
-interface FontProvider : Parcelable {
+interface FontProvider {
     /**
      * Returns the font to be used for the given [TypographyType]. If null is returned, the default font will be used.
      * @param type the [TypographyType] for which the font is being requested.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontProvider.kt
@@ -6,6 +6,8 @@ import com.revenuecat.purchases.ui.revenuecatui.PaywallView
 /**
  * Implement this interface to provide custom fonts to the [PaywallView]. If you don't, the current material3 theme
  * typography will be used.
+ * This can't be used when launching the paywall as an activity since the fonts are not parcelable/serializable.
+ * Use [FontResourceProvider] instead.
  */
 interface FontProvider {
     /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontProvider.kt
@@ -1,9 +1,10 @@
 package com.revenuecat.purchases.ui.revenuecatui.fonts
 
 import androidx.compose.ui.text.font.FontFamily
+import com.revenuecat.purchases.ui.revenuecatui.PaywallView
 
 /**
- * Implement this interface to provide custom fonts to the PaywallView. If you don't, the current material3 theme
+ * Implement this interface to provide custom fonts to the [PaywallView]. If you don't, the current material3 theme
  * typography will be used.
  */
 interface FontProvider {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontProvider.kt
@@ -1,0 +1,17 @@
+package com.revenuecat.purchases.ui.revenuecatui.fonts
+
+import android.os.Parcelable
+import androidx.compose.ui.text.font.FontFamily
+
+/**
+ * Implement this interface to provide custom fonts to the PaywallView. If you don't, the current material3 theme
+ * typography will be used.
+ */
+interface FontProvider : Parcelable {
+    /**
+     * Returns the font to be used for the given [TypographyType]. If null is returned, the default font will be used.
+     * @param type the [TypographyType] for which the font is being requested.
+     * @return the `FontFamily` to be used for the given [TypographyType].
+     */
+    fun getFont(type: TypographyType): FontFamily?
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontResourceProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontResourceProvider.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
 /**
  * Implement this interface to provide custom fonts to the [PaywallActivityLauncher].
  * If you don't, the default material3 theme fonts will be used.
+ * Use [FontProvider] instead if you are using Compose with [PaywallView] or [PaywallDialog].
  */
 interface FontResourceProvider {
     /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontResourceProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontResourceProvider.kt
@@ -1,0 +1,19 @@
+package com.revenuecat.purchases.ui.revenuecatui.fonts
+
+import androidx.annotation.FontRes
+import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
+
+/**
+ * Implement this interface to provide custom fonts to the [PaywallActivityLauncher].
+ * If you don't, the default material3 theme fonts will be used.
+ */
+interface FontResourceProvider {
+    /**
+     * Returns the font resource id to be used for the given [TypographyType]. If null is returned,
+     * the default font will be used.
+     * @param type the [TypographyType] for which the font is being requested.
+     * @return the font resource id to be used for the given [TypographyType].
+     */
+    @FontRes
+    fun getFontResourceId(type: TypographyType): Int?
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/PaywallTheme.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/PaywallTheme.kt
@@ -1,0 +1,56 @@
+package com.revenuecat.purchases.ui.revenuecatui.fonts
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
+
+@Composable
+internal fun PaywallTheme(
+    fontProvider: FontProvider?,
+    content: @Composable () -> Unit,
+) {
+    if (fontProvider == null) {
+        content()
+    } else {
+        val oldTypography = MaterialTheme.typography
+        val typography = oldTypography.copy(
+            displayLarge = oldTypography.displayLarge.modifyFontIfNeeded(TypographyType.DISPLAY_LARGE, fontProvider),
+            displayMedium = oldTypography.displayMedium.modifyFontIfNeeded(TypographyType.DISPLAY_MEDIUM, fontProvider),
+            displaySmall = oldTypography.displaySmall.modifyFontIfNeeded(TypographyType.DISPLAY_SMALL, fontProvider),
+            headlineLarge = oldTypography.headlineLarge.modifyFontIfNeeded(TypographyType.HEADLINE_LARGE, fontProvider),
+            headlineMedium = oldTypography.headlineMedium.modifyFontIfNeeded(
+                TypographyType.HEADLINE_MEDIUM,
+                fontProvider,
+            ),
+            headlineSmall = oldTypography.headlineSmall.modifyFontIfNeeded(TypographyType.HEADLINE_SMALL, fontProvider),
+            titleLarge = oldTypography.titleLarge.modifyFontIfNeeded(TypographyType.TITLE_LARGE, fontProvider),
+            titleMedium = oldTypography.titleMedium.modifyFontIfNeeded(TypographyType.TITLE_MEDIUM, fontProvider),
+            titleSmall = oldTypography.titleSmall.modifyFontIfNeeded(TypographyType.TITLE_SMALL, fontProvider),
+            bodyLarge = oldTypography.bodyLarge.modifyFontIfNeeded(TypographyType.BODY_LARGE, fontProvider),
+            bodyMedium = oldTypography.bodyMedium.modifyFontIfNeeded(TypographyType.BODY_MEDIUM, fontProvider),
+            bodySmall = oldTypography.bodySmall.modifyFontIfNeeded(TypographyType.BODY_SMALL, fontProvider),
+            labelLarge = oldTypography.labelLarge.modifyFontIfNeeded(TypographyType.LABEL_LARGE, fontProvider),
+            labelMedium = oldTypography.labelMedium.modifyFontIfNeeded(TypographyType.LABEL_MEDIUM, fontProvider),
+            labelSmall = oldTypography.labelSmall.modifyFontIfNeeded(TypographyType.LABEL_SMALL, fontProvider),
+        )
+        MaterialTheme(
+            colorScheme = MaterialTheme.colorScheme,
+            typography = typography,
+            shapes = MaterialTheme.shapes,
+            content = content,
+        )
+    }
+}
+
+private fun TextStyle.modifyFontIfNeeded(typographyType: TypographyType, fontProvider: FontProvider?): TextStyle {
+    return if (fontProvider == null) {
+        this
+    } else {
+        val font = fontProvider.getFont(typographyType)
+        if (font == null) {
+            this
+        } else {
+            this.copy(fontFamily = font)
+        }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/PaywallTheme.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/PaywallTheme.kt
@@ -2,7 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui.fonts
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.text.TextStyle
+import com.revenuecat.purchases.ui.revenuecatui.extensions.copyWithFontProvider
 
 @Composable
 internal fun PaywallTheme(
@@ -12,45 +12,11 @@ internal fun PaywallTheme(
     if (fontProvider == null) {
         content()
     } else {
-        val oldTypography = MaterialTheme.typography
-        val typography = oldTypography.copy(
-            displayLarge = oldTypography.displayLarge.modifyFontIfNeeded(TypographyType.DISPLAY_LARGE, fontProvider),
-            displayMedium = oldTypography.displayMedium.modifyFontIfNeeded(TypographyType.DISPLAY_MEDIUM, fontProvider),
-            displaySmall = oldTypography.displaySmall.modifyFontIfNeeded(TypographyType.DISPLAY_SMALL, fontProvider),
-            headlineLarge = oldTypography.headlineLarge.modifyFontIfNeeded(TypographyType.HEADLINE_LARGE, fontProvider),
-            headlineMedium = oldTypography.headlineMedium.modifyFontIfNeeded(
-                TypographyType.HEADLINE_MEDIUM,
-                fontProvider,
-            ),
-            headlineSmall = oldTypography.headlineSmall.modifyFontIfNeeded(TypographyType.HEADLINE_SMALL, fontProvider),
-            titleLarge = oldTypography.titleLarge.modifyFontIfNeeded(TypographyType.TITLE_LARGE, fontProvider),
-            titleMedium = oldTypography.titleMedium.modifyFontIfNeeded(TypographyType.TITLE_MEDIUM, fontProvider),
-            titleSmall = oldTypography.titleSmall.modifyFontIfNeeded(TypographyType.TITLE_SMALL, fontProvider),
-            bodyLarge = oldTypography.bodyLarge.modifyFontIfNeeded(TypographyType.BODY_LARGE, fontProvider),
-            bodyMedium = oldTypography.bodyMedium.modifyFontIfNeeded(TypographyType.BODY_MEDIUM, fontProvider),
-            bodySmall = oldTypography.bodySmall.modifyFontIfNeeded(TypographyType.BODY_SMALL, fontProvider),
-            labelLarge = oldTypography.labelLarge.modifyFontIfNeeded(TypographyType.LABEL_LARGE, fontProvider),
-            labelMedium = oldTypography.labelMedium.modifyFontIfNeeded(TypographyType.LABEL_MEDIUM, fontProvider),
-            labelSmall = oldTypography.labelSmall.modifyFontIfNeeded(TypographyType.LABEL_SMALL, fontProvider),
-        )
         MaterialTheme(
             colorScheme = MaterialTheme.colorScheme,
-            typography = typography,
+            typography = MaterialTheme.typography.copyWithFontProvider(fontProvider),
             shapes = MaterialTheme.shapes,
             content = content,
         )
-    }
-}
-
-private fun TextStyle.modifyFontIfNeeded(typographyType: TypographyType, fontProvider: FontProvider?): TextStyle {
-    return if (fontProvider == null) {
-        this
-    } else {
-        val font = fontProvider.getFont(typographyType)
-        if (font == null) {
-            this
-        } else {
-            this.copy(fontFamily = font)
-        }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/TypographyType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/TypographyType.kt
@@ -1,0 +1,22 @@
+package com.revenuecat.purchases.ui.revenuecatui.fonts
+
+/**
+ * Text styles for which the fonts can be overridden in the paywall.
+ */
+enum class TypographyType {
+    DISPLAY_LARGE,
+    DISPLAY_MEDIUM,
+    DISPLAY_SMALL,
+    HEADLINE_LARGE,
+    HEADLINE_MEDIUM,
+    HEADLINE_SMALL,
+    TITLE_LARGE,
+    TITLE_MEDIUM,
+    TITLE_SMALL,
+    BODY_LARGE,
+    BODY_MEDIUM,
+    BODY_SMALL,
+    LABEL_LARGE,
+    LABEL_MEDIUM,
+    LABEL_SMALL,
+}


### PR DESCRIPTION
### Description
This adds a way for devs to give us a `FontProvider`, which will be used to override the font family in our views when a font family is provided. If it's not provided, the current material3 theme's font will be used.
