### PR TITLE
Paywalls: Make DialogScaffold private

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -61,7 +61,7 @@ fun PaywallDialog(
 }
 
 @Composable
-fun DialogScaffold(paywallDialogOptions: PaywallDialogOptions) {
+private fun DialogScaffold(paywallDialogOptions: PaywallDialogOptions) {
     Scaffold(modifier = Modifier.fillMaxSize()) { paddingValues ->
         Box(
             modifier = Modifier


### PR DESCRIPTION
### Description
I noticed this while looking at the paywall dialog. We shouldn't be exposing the `DialogScaffold`
