### PR TITLE
`Paywalls`: `PaywallColor` supports RGBA

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallColor.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallColor.kt
@@ -68,10 +68,3 @@ data class PaywallColor(
         },
     )
 }
-
-/**
- * Represents a color scheme.
- */
-enum class ColorScheme {
-    LIGHT, DARK
-}

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallColorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallColorTest.kt
@@ -11,15 +11,34 @@ import java.util.*
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 class PaywallColorTest {
-
     @Test
-    fun `paywall color can be created from a ColorInt`() {
-        val colorInt = Color.parseColor("#FFAABB")
+    fun `paywall color can be created from an RGB ColorInt`() {
+        val stringRepresentation = "#FFAABB"
+        val colorInt = Color.parseColor(stringRepresentation)
         val paywallColor = PaywallColor(colorInt)
 
         assertThat(colorInt).isEqualTo(paywallColor.colorInt)
-        assertThat("#FFAABB").isEqualTo(paywallColor.stringRepresentation)
+        assertThat(stringRepresentation).isEqualTo(paywallColor.stringRepresentation)
         assertThat(Color.valueOf(colorInt)).isEqualTo(paywallColor.underlyingColor)
     }
 
+    @Test
+    fun `paywall color can be created from RGB string`() {
+        val stringRepresentation = "#FFAABB"
+        val paywallColor = PaywallColor(stringRepresentation)
+        val color = Color.valueOf(Color.parseColor(stringRepresentation))
+
+        assertThat(stringRepresentation).isEqualTo(paywallColor.stringRepresentation)
+        assertThat(color).isEqualTo(paywallColor.underlyingColor)
+    }
+
+    @Test
+    fun `paywall color can be created from RGBA string`() {
+        val stringRepresentation = "#FFAABB11"
+        val paywallColor = PaywallColor(stringRepresentation)
+        val color = Color.valueOf(Color.parseColor(stringRepresentation))
+
+        assertThat(stringRepresentation).isEqualTo(paywallColor.stringRepresentation)
+        assertThat(color).isEqualTo(paywallColor.underlyingColor)
+    }
 }


### PR DESCRIPTION
Turns out it already did, so I just wrote some tests.