### PR TITLE
`Paywalls`: new `PaywallActivityLauncher.launchIfNeeded` methods

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -15,11 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.window.core.layout.WindowWidthSizeClass
-import com.revenuecat.purchases.Purchases
-import com.revenuecat.purchases.PurchasesException
-import com.revenuecat.purchases.awaitCustomerInfo
-import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.helpers.computeWindowWidthSizeClass
+import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayPaywall
 import kotlinx.coroutines.launch
 
 /**
@@ -36,17 +33,7 @@ fun PaywallDialog(
     if (shouldDisplayBlock != null) {
         LaunchedEffect(paywallDialogOptions) {
             launch {
-                shouldDisplayDialog = try {
-                    shouldDisplayBlock.invoke(Purchases.sharedInstance.awaitCustomerInfo())
-                } catch (e: PurchasesException) {
-                    Logger.e("Error fetching customer info to display paywall dialog", e)
-                    false
-                }
-                if (shouldDisplayDialog) {
-                    Logger.d("Displaying paywall dialog according to display logic")
-                } else {
-                    Logger.d("Not displaying paywall dialog according to display logic")
-                }
+                shouldDisplayDialog = shouldDisplayPaywall(shouldDisplayBlock)
             }
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui
 
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayBlockForEntitlementIdentifier
 
 class PaywallDialogOptions(builder: Builder) {
 
@@ -47,9 +48,7 @@ class PaywallDialogOptions(builder: Builder) {
          */
         fun setRequiredEntitlementIdentifier(requiredEntitlementIdentifier: String?) = apply {
             requiredEntitlementIdentifier?.let { requiredEntitlementIdentifier ->
-                this.shouldDisplayBlock = { customerInfo ->
-                    customerInfo.entitlements[requiredEntitlementIdentifier]?.isActive != true
-                }
+                this.shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier)
             }
         }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -4,7 +4,10 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.Fragment
+import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayBlockForEntitlementIdentifier
+import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayPaywall
 
 /**
  * Implement this interface to receive the result of the paywall activity.
@@ -40,5 +43,34 @@ class PaywallActivityLauncher {
     @JvmOverloads
     fun launch(offering: Offering? = null) {
         activityResultLauncher.launch(PaywallActivityArgs(offeringId = offering?.identifier))
+    }
+
+    /**
+     * Launch the paywall activity if the current user does not have [requiredEntitlementIdentifier] active.
+     * @param offering The offering to be shown in the paywall. If null, the current offering will be shown.
+     */
+    @JvmOverloads
+    suspend fun launchIfNeeded(
+        offering: Offering? = null,
+        requiredEntitlementIdentifier: String,
+    ) {
+        launchIfNeeded(
+            offering = offering,
+            shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier),
+        )
+    }
+
+    /**
+     * Launch the paywall activity based on whether the result of [shouldDisplayBlock] is true.
+     * @param offering The offering to be shown in the paywall. If null, the current offering will be shown.
+     */
+    @JvmOverloads
+    suspend fun launchIfNeeded(
+        offering: Offering? = null,
+        shouldDisplayBlock: (CustomerInfo) -> Boolean,
+    ) {
+        if (shouldDisplayPaywall(shouldDisplayBlock)) {
+            activityResultLauncher.launch(PaywallActivityArgs(offeringId = offering?.identifier))
+        }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -50,7 +50,7 @@ class PaywallActivityLauncher {
      * @param offering The offering to be shown in the paywall. If null, the current offering will be shown.
      */
     @JvmOverloads
-    suspend fun launchIfNeeded(
+    fun launchIfNeeded(
         offering: Offering? = null,
         requiredEntitlementIdentifier: String,
     ) {
@@ -65,12 +65,14 @@ class PaywallActivityLauncher {
      * @param offering The offering to be shown in the paywall. If null, the current offering will be shown.
      */
     @JvmOverloads
-    suspend fun launchIfNeeded(
+    fun launchIfNeeded(
         offering: Offering? = null,
         shouldDisplayBlock: (CustomerInfo) -> Boolean,
     ) {
-        if (shouldDisplayPaywall(shouldDisplayBlock)) {
-            activityResultLauncher.launch(PaywallActivityArgs(offeringId = offering?.identifier))
+        shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
+            if (shouldDisplay) {
+                activityResultLauncher.launch(PaywallActivityArgs(offeringId = offering?.identifier))
+            }
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -48,6 +48,8 @@ class PaywallActivityLauncher {
     /**
      * Launch the paywall activity if the current user does not have [requiredEntitlementIdentifier] active.
      * @param offering The offering to be shown in the paywall. If null, the current offering will be shown.
+     * @param requiredEntitlementIdentifier the paywall will be displayed only if the current user does not
+     * have this entitlement active.
      */
     @JvmOverloads
     fun launchIfNeeded(
@@ -63,6 +65,7 @@ class PaywallActivityLauncher {
     /**
      * Launch the paywall activity based on whether the result of [shouldDisplayBlock] is true.
      * @param offering The offering to be shown in the paywall. If null, the current offering will be shown.
+     * @param shouldDisplayBlock the paywall will be displayed only if this returns true.
      */
     @JvmOverloads
     fun launchIfNeeded(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/HelperFunctions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/HelperFunctions.kt
@@ -26,7 +26,7 @@ internal suspend fun shouldDisplayPaywall(shouldDisplayBlock: (CustomerInfo) -> 
  */
 internal fun shouldDisplayPaywall(
     shouldDisplayBlock: (CustomerInfo) -> Boolean,
-    result: (shouldDisplay: Boolean) -> Unit
+    result: (shouldDisplay: Boolean) -> Unit,
 ) {
     Purchases.sharedInstance.getCustomerInfoWith(
         onSuccess = {
@@ -42,7 +42,7 @@ internal fun shouldDisplayPaywall(
         onError = {
             Logger.e("Error fetching customer info to display paywall", PurchasesException(it))
             result(false)
-        }
+        },
     )
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/HelperFunctions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/HelperFunctions.kt
@@ -3,7 +3,39 @@ package com.revenuecat.purchases.ui.revenuecatui.helpers
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.platform.LocalInspectionMode
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.awaitCustomerInfo
 
 @Composable
 @ReadOnlyComposable
 internal fun isInPreviewMode() = LocalInspectionMode.current
+
+/**
+ * Evaluates [shouldDisplayBlock] with the current CustomerInfo to determine if a paywall should be displayed.
+ */
+internal suspend fun shouldDisplayPaywall(shouldDisplayBlock: (CustomerInfo) -> Boolean): Boolean {
+    val shouldDisplayDialog = try {
+        shouldDisplayBlock.invoke(Purchases.sharedInstance.awaitCustomerInfo())
+    } catch (e: PurchasesException) {
+        Logger.e("Error fetching customer info to display paywall", e)
+        false
+    }
+    if (shouldDisplayDialog) {
+        Logger.d("Displaying paywall according to display logic")
+    } else {
+        Logger.d("Not displaying paywall according to display logic")
+    }
+
+    return shouldDisplayDialog
+}
+
+/**
+ * Creates a block to determine if a paywall should be displayed based on a CustomerInfo and entitlement identifier.
+ */
+internal fun shouldDisplayBlockForEntitlementIdentifier(entitlement: String): ((CustomerInfo) -> Boolean) {
+    return { customerInfo ->
+        customerInfo.entitlements[entitlement]?.isActive != true
+    }
+}


### PR DESCRIPTION
This mimics the equivalent API in `PaywallDialogOptions` (and like in iOS).