### PR TITLE
Fix loading another template in Paywalls screen

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/SamplePaywalls.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/SamplePaywalls.kt
@@ -13,7 +13,7 @@ import java.net.URL
 class SamplePaywallsLoader {
     fun offeringForTemplate(template: SamplePaywalls.SampleTemplate): Offering {
         return Offering(
-            SamplePaywalls.offeringIdentifier,
+            "$SamplePaywalls.offeringIdentifier_${template.id}",
             SamplePaywalls.offeringIdentifier,
             emptyMap(),
             SamplePaywalls.packages,


### PR DESCRIPTION
There was a bug when loading a different template after dismissing a paywall. The offering would not change and would always load the first offering loaded

It took me a bit to realize what's going on, but we have this piece of code in the InternalPaywallView

```
@Composable
private fun getPaywallViewModel(
    options: PaywallViewOptions,
): PaywallViewModel {
    val applicationContext = LocalContext.current.applicationContext
    return viewModel<PaywallViewModelImpl>(
        // We need to pass the key in order to create different view models for different offerings when
        // trying to load different paywalls for the same view model store owner.
        key = options.offeringSelection.offeringIdentifier,
        factory = PaywallViewModelFactory(
            applicationContext.toAndroidContext(),
            options,
            MaterialTheme.colorScheme,
            preview = isInPreviewMode(),
        ),
    )
}
```

The key used to identify the viewmodel is the offering identifier, and for the offerings we create in the SamplePaywalls class, the offering identifier is always the same: `offering`

This was causing the InternalPaywallView to always load the same ViewModel, the first one that was created.

I updated the code to create a unique identifier for every sample offering.

