### PR TITLE
Paywalls: Rename `PaywallView` to `Paywall`

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -32,7 +32,7 @@ import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialog
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewListener
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -126,7 +126,7 @@ private fun OfferingsListScreen(
                 },
             )
                 .setOffering(displayPaywallDialogOffering)
-                .setListener(object : PaywallViewListener {
+                .setListener(object : PaywallListener {
                     override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
                         displayPaywallDialogOffering = null
                     }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
@@ -27,7 +27,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialog
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewListener
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 
 @Composable
 fun PaywallsScreen(
@@ -80,7 +80,7 @@ fun PaywallsScreen(
                 },
             )
                 .setOffering(displayPaywallDialogOffering)
-                .setListener(object : PaywallViewListener {
+                .setListener(object : PaywallListener {
                     override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
                         displayPaywallDialogOffering = null
                     }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreen.kt
@@ -11,8 +11,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.revenuecat.purchases.ui.revenuecatui.PaywallView
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
+import com.revenuecat.purchases.ui.revenuecatui.Paywall
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 
 @Composable
 fun PaywallScreen(
@@ -31,8 +31,8 @@ fun PaywallScreen(
                 Text(text = "Error: ${state.errorMessage}")
             }
             is PaywallScreenState.Loaded -> {
-                PaywallView(
-                    PaywallViewOptions.Builder()
+                Paywall(
+                    PaywallOptions.Builder()
                         .setOffering(state.offering)
                         .setListener(viewModel)
                         .build(),

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreenViewModel.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreenViewModel.kt
@@ -11,14 +11,14 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.awaitOfferings
 import com.revenuecat.purchases.models.StoreTransaction
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewListener
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-interface PaywallScreenViewModel : PaywallViewListener {
+interface PaywallScreenViewModel : PaywallListener {
     companion object {
         const val OFFERING_ID_KEY = "offering_id"
     }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywallfooter/PaywallFooterScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywallfooter/PaywallFooterScreen.kt
@@ -20,7 +20,7 @@ import com.revenuecat.paywallstester.ui.screens.paywall.PaywallScreenState
 import com.revenuecat.paywallstester.ui.screens.paywall.PaywallScreenViewModel
 import com.revenuecat.paywallstester.ui.screens.paywall.PaywallScreenViewModelImpl
 import com.revenuecat.purchases.ui.revenuecatui.PaywallFooter
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 
 @Composable
 fun PaywallFooterScreen(
@@ -40,7 +40,7 @@ fun PaywallFooterScreen(
             }
             is PaywallScreenState.Loaded -> {
                 PaywallFooter(
-                    options = PaywallViewOptions.Builder()
+                    options = PaywallOptions.Builder()
                         .setOffering(state.offering)
                         .setListener(viewModel)
                         .build(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -12,10 +12,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelFactory
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl
-import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.isInFullScreenMode
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
@@ -26,8 +26,8 @@ import com.revenuecat.purchases.ui.revenuecatui.templates.Template2
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template3
 
 @Composable
-internal fun InternalPaywallView(
-    options: PaywallViewOptions,
+internal fun InternalPaywall(
+    options: PaywallOptions,
     viewModel: PaywallViewModel = getPaywallViewModel(options),
 ) {
     viewModel.refreshStateIfLocaleChanged()
@@ -35,20 +35,20 @@ internal fun InternalPaywallView(
     viewModel.refreshStateIfColorsChanged(colors)
 
     when (val state = viewModel.state.collectAsState().value) {
-        is PaywallViewState.Loading -> {
-            LoadingPaywallView(mode = options.mode)
+        is PaywallState.Loading -> {
+            LoadingPaywall(mode = options.mode)
         }
-        is PaywallViewState.Error -> {
+        is PaywallState.Error -> {
             Text(text = "Error: ${state.errorMessage}")
         }
-        is PaywallViewState.Loaded -> {
-            LoadedPaywallView(state = state, viewModel = viewModel)
+        is PaywallState.Loaded -> {
+            LoadedPaywall(state = state, viewModel = viewModel)
         }
     }
 }
 
 @Composable
-private fun LoadedPaywallView(state: PaywallViewState.Loaded, viewModel: PaywallViewModel) {
+private fun LoadedPaywall(state: PaywallState.Loaded, viewModel: PaywallViewModel) {
     val backgroundColor = state.templateConfiguration.getCurrentColors().background
     Box(
         modifier = Modifier
@@ -67,12 +67,12 @@ private fun LoadedPaywallView(state: PaywallViewState.Loaded, viewModel: Paywall
                     .padding(top = UIConstant.footerRoundedBorderHeight)
             },
     ) {
-        TemplatePaywallView(state = state, viewModel = viewModel)
+        TemplatePaywall(state = state, viewModel = viewModel)
     }
 }
 
 @Composable
-private fun TemplatePaywallView(state: PaywallViewState.Loaded, viewModel: PaywallViewModel) {
+private fun TemplatePaywall(state: PaywallState.Loaded, viewModel: PaywallViewModel) {
     when (state.templateConfiguration.template) {
         PaywallTemplate.TEMPLATE_1 -> Template1(state = state, viewModel = viewModel)
         PaywallTemplate.TEMPLATE_2 -> Template2(state = state, viewModel = viewModel)
@@ -84,7 +84,7 @@ private fun TemplatePaywallView(state: PaywallViewState.Loaded, viewModel: Paywa
 
 @Composable
 private fun getPaywallViewModel(
-    options: PaywallViewOptions,
+    options: PaywallOptions,
 ): PaywallViewModel {
     val applicationContext = LocalContext.current.applicationContext
     return viewModel<PaywallViewModelImpl>(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -22,15 +22,15 @@ import com.revenuecat.purchases.ui.revenuecatui.composables.DisableTouchesCompos
 import com.revenuecat.purchases.ui.revenuecatui.composables.Fade
 import com.revenuecat.purchases.ui.revenuecatui.composables.PlaceholderDefaults
 import com.revenuecat.purchases.ui.revenuecatui.composables.placeholder
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
-import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
 import com.revenuecat.purchases.ui.revenuecatui.extensions.createDefault
 import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toAndroidContext
-import com.revenuecat.purchases.ui.revenuecatui.helpers.toPaywallViewState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.toPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template2
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -38,7 +38,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import java.net.URL
 
 @Composable
-internal fun LoadingPaywallView(mode: PaywallViewMode) {
+internal fun LoadingPaywall(mode: PaywallMode) {
     val paywallData: PaywallData = PaywallData.createDefault(
         LoadingPaywallConstants.packages,
         MaterialTheme.colorScheme,
@@ -52,7 +52,7 @@ internal fun LoadingPaywallView(mode: PaywallViewMode) {
         paywall = paywallData,
     )
 
-    val state = offering.toPaywallViewState(
+    val state = offering.toPaywallState(
         VariableDataProvider(
             LocalContext.current.applicationContext.toAndroidContext(),
             isInPreviewMode(),
@@ -66,16 +66,16 @@ internal fun LoadingPaywallView(mode: PaywallViewMode) {
     when (state) {
         // The loading PaywallData is known at compile time
         // and snapshots ensure that these 2 states are impossible.
-        is PaywallViewState.Error,
-        is PaywallViewState.Loading,
+        is PaywallState.Error,
+        is PaywallState.Loading,
         -> Box {}
 
-        is PaywallViewState.Loaded -> LoadingPaywallView(state, LoadingViewModel(state))
+        is PaywallState.Loaded -> LoadingPaywall(state, LoadingViewModel(state))
     }
 }
 
 @Composable
-private fun LoadingPaywallView(state: PaywallViewState.Loaded, viewModel: PaywallViewModel) {
+private fun LoadingPaywall(state: PaywallState.Loaded, viewModel: PaywallViewModel) {
     DisableTouchesComposable {
         // Template
         Template2(
@@ -142,9 +142,9 @@ private object LoadingPaywallConstants {
 }
 
 private class LoadingViewModel(
-    state: PaywallViewState,
+    state: PaywallState,
 ) : PaywallViewModel {
-    override val state: StateFlow<PaywallViewState>
+    override val state: StateFlow<PaywallState>
         get() = _state.asStateFlow()
 
     override val actionInProgress: State<Boolean> = mutableStateOf(false)
@@ -173,6 +173,6 @@ private class LoadingViewModel(
 
 @Preview(showBackground = true)
 @Composable
-internal fun LoadingPaywallViewPreview() {
-    LoadingPaywallView(mode = PaywallViewMode.FULL_SCREEN)
+internal fun LoadingPaywallPreview() {
+    LoadingPaywall(mode = PaywallMode.FULL_SCREEN)
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/Paywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/Paywall.kt
@@ -4,12 +4,12 @@ import androidx.compose.runtime.Composable
 
 /**
  * Composable offering a full screen Paywall UI configured from the RevenueCat dashboard.
- * @param options The options to configure the PaywallView if needed.
+ * @param options The options to configure the [Paywall] if needed.
  */
 @Suppress("unused")
 @Composable
-fun PaywallView(
-    options: PaywallViewOptions = PaywallViewOptions.Builder().build(),
+fun Paywall(
+    options: PaywallOptions = PaywallOptions.Builder().build(),
 ) {
-    InternalPaywallView(options)
+    InternalPaywall(options)
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -55,7 +55,7 @@ private fun DialogScaffold(paywallDialogOptions: PaywallDialogOptions) {
                 .fillMaxSize()
                 .padding(paddingValues),
         ) {
-            PaywallView(paywallDialogOptions.toPaywallViewOptions())
+            Paywall(paywallDialogOptions.toPaywallOptions())
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -10,7 +10,7 @@ class PaywallDialogOptions(builder: Builder) {
     val shouldDisplayBlock: ((CustomerInfo) -> Boolean)?
     val offering: Offering?
     val shouldDisplayDismissButton: Boolean
-    val listener: PaywallViewListener?
+    val listener: PaywallListener?
 
     init {
         this.shouldDisplayBlock = builder.shouldDisplayBlock
@@ -20,8 +20,8 @@ class PaywallDialogOptions(builder: Builder) {
         this.listener = builder.listener
     }
 
-    fun toPaywallViewOptions(): PaywallViewOptions {
-        return PaywallViewOptions.Builder()
+    fun toPaywallOptions(): PaywallOptions {
+        return PaywallOptions.Builder()
             .setOffering(offering)
             .setShouldDisplayDismissButton(shouldDisplayDismissButton)
             .setListener(listener)
@@ -34,7 +34,7 @@ class PaywallDialogOptions(builder: Builder) {
         internal var shouldDisplayBlock: ((CustomerInfo) -> Boolean)? = null
         internal var offering: Offering? = null
         internal var shouldDisplayDismissButton: Boolean = true
-        internal var listener: PaywallViewListener? = null
+        internal var listener: PaywallListener? = null
 
         /**
          * Allows to configure whether to display the paywall dialog depending on operations on the CustomerInfo
@@ -60,7 +60,7 @@ class PaywallDialogOptions(builder: Builder) {
             this.shouldDisplayDismissButton = shouldDisplayDismissButton
         }
 
-        fun setListener(listener: PaywallViewListener?) = apply {
+        fun setListener(listener: PaywallListener?) = apply {
             this.listener = listener
         }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
@@ -18,15 +18,15 @@ import androidx.compose.ui.tooling.preview.Preview
  * Composable offering a minified screen Paywall UI configured from the RevenueCat dashboard.
  * You can pass in your own Composables to be displayed in the main content area.
  *
- * @param options The options to configure the PaywallView if needed.
+ * @param options The options to configure the [Paywall] if needed.
  * @param condensed Whether to condense the composable even more.
- * @param mainContent The content to display in the main area of the PaywallView. We give a [PaddingValues] so you can
+ * @param mainContent The content to display in the main area of the [Paywall]. We give a [PaddingValues] so you can
  * add that padding to your own content. This padding corresponds to the height of the rounded corner area of
  * the paywall.
  */
 @Composable
 fun PaywallFooter(
-    options: PaywallViewOptions = PaywallViewOptions.Builder().build(),
+    options: PaywallOptions = PaywallOptions.Builder().build(),
     condensed: Boolean = false,
     mainContent: @Composable (PaddingValues) -> Unit,
 ) {
@@ -43,8 +43,8 @@ fun PaywallFooter(
         ) {
             mainContent(PaddingValues(bottom = UIConstant.footerRoundedBorderHeight))
         }
-        options.mode = PaywallViewMode.footerMode(condensed)
-        PaywallView(options)
+        options.mode = PaywallMode.footerMode(condensed)
+        Paywall(options)
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
@@ -5,7 +5,7 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.models.StoreTransaction
 
-interface PaywallViewListener {
+interface PaywallListener {
     fun onPurchaseStarted(rcPackage: Package) {}
     fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {}
     fun onPurchaseError(error: PurchasesError) {}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallMode.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallMode.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui
 
-internal enum class PaywallViewMode {
+internal enum class PaywallMode {
     FULL_SCREEN,
     FOOTER,
     FOOTER_CONDENSED,
@@ -9,7 +9,7 @@ internal enum class PaywallViewMode {
     companion object {
         val default = FULL_SCREEN
 
-        fun footerMode(condensed: Boolean): PaywallViewMode {
+        fun footerMode(condensed: Boolean): PaywallMode {
             return if (condensed) FOOTER_CONDENSED else FOOTER
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -22,12 +22,12 @@ internal sealed class OfferingSelection {
         }
 }
 
-class PaywallViewOptions(builder: Builder) {
+class PaywallOptions(builder: Builder) {
 
     internal val offeringSelection: OfferingSelection
     val shouldDisplayDismissButton: Boolean
-    val listener: PaywallViewListener?
-    internal var mode: PaywallViewMode = PaywallViewMode.default
+    val listener: PaywallListener?
+    internal var mode: PaywallMode = PaywallMode.default
 
     init {
         this.offeringSelection = builder.offeringSelection
@@ -38,7 +38,7 @@ class PaywallViewOptions(builder: Builder) {
     class Builder {
         internal var offeringSelection: OfferingSelection = OfferingSelection.None
         internal var shouldDisplayDismissButton: Boolean = false
-        internal var listener: PaywallViewListener? = null
+        internal var listener: PaywallListener? = null
 
         fun setOffering(offering: Offering?) = apply {
             this.offeringSelection = offering?.let { OfferingSelection.OfferingType(it) }
@@ -54,12 +54,12 @@ class PaywallViewOptions(builder: Builder) {
             this.shouldDisplayDismissButton = shouldDisplayDismissButton
         }
 
-        fun setListener(listener: PaywallViewListener?) = apply {
+        fun setListener(listener: PaywallListener?) = apply {
             this.listener = listener
         }
 
-        fun build(): PaywallViewOptions {
-            return PaywallViewOptions(this)
+        fun build(): PaywallOptions {
+            return PaywallOptions(this)
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -15,15 +15,15 @@ import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.models.StoreTransaction
-import com.revenuecat.purchases.ui.revenuecatui.PaywallView
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewListener
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
+import com.revenuecat.purchases.ui.revenuecatui.Paywall
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 
 /**
- * Wrapper activity around [PaywallView] that allows using it when you are not using Jetpack Compose directly.
+ * Wrapper activity around [Paywall] that allows using it when you are not using Jetpack Compose directly.
  * It receives the [PaywallActivityArgs] as an extra and returns the [PaywallResult] as a result.
  */
-internal class PaywallActivity : ComponentActivity(), PaywallViewListener {
+internal class PaywallActivity : ComponentActivity(), PaywallListener {
     companion object {
         const val ARGS_EXTRA = "paywall_args"
 
@@ -40,7 +40,7 @@ internal class PaywallActivity : ComponentActivity(), PaywallViewListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val paywallOptions = PaywallViewOptions.Builder()
+        val paywallOptions = PaywallOptions.Builder()
             .setOfferingId(getArgs()?.offeringId)
             .setListener(this)
             .build()
@@ -48,7 +48,7 @@ internal class PaywallActivity : ComponentActivity(), PaywallViewListener {
             MaterialTheme {
                 Scaffold { paddingValues ->
                     Box(Modifier.fillMaxSize().padding(paddingValues)) {
-                        PaywallView(paywallOptions)
+                        Paywall(paywallOptions)
                     }
                 }
             }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.paywalls.PaywallData
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
+import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
@@ -204,6 +204,6 @@ private fun FooterPreview() {
             defaultPackage = null,
         ),
         colors = ColorsFactory.create(paywallDataColors = TestData.template2.config.colors.light),
-        viewModel = MockViewModel(PaywallViewMode.FULL_SCREEN, TestData.template2Offering),
+        viewModel = MockViewModel(PaywallMode.FULL_SCREEN, TestData.template2Offering),
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
@@ -21,8 +21,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
-import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
@@ -30,7 +30,7 @@ import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 
 @Composable
 internal fun PurchaseButton(
-    state: PaywallViewState.Loaded,
+    state: PaywallState.Loaded,
     viewModel: PaywallViewModel,
     childModifier: Modifier = Modifier,
 ) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -4,19 +4,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.mutableStateOf
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
+import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.ProcessedLocalizedConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 
-internal sealed class PaywallViewState {
-    object Loading : PaywallViewState()
+internal sealed class PaywallState {
+    object Loading : PaywallState()
 
-    data class Error(val errorMessage: String) : PaywallViewState()
+    data class Error(val errorMessage: String) : PaywallState()
 
     data class Loaded(
         val templateConfiguration: TemplateConfiguration,
         val selectedPackage: MutableState<TemplateConfiguration.PackageInfo>,
-    ) : PaywallViewState() {
+    ) : PaywallState() {
         constructor(templateConfiguration: TemplateConfiguration, selectedPackage: TemplateConfiguration.PackageInfo) :
             this(templateConfiguration, mutableStateOf(selectedPackage))
 
@@ -26,12 +26,12 @@ internal sealed class PaywallViewState {
     }
 }
 
-internal val PaywallViewState.Loaded.selectedLocalization: ProcessedLocalizedConfiguration
+internal val PaywallState.Loaded.selectedLocalization: ProcessedLocalizedConfiguration
     get() = selectedPackage.value.localization
 
-internal val PaywallViewState.Loaded.currentColors: TemplateConfiguration.Colors
+internal val PaywallState.Loaded.currentColors: TemplateConfiguration.Colors
     @Composable @ReadOnlyComposable
     get() = templateConfiguration.getCurrentColors()
 
-internal val PaywallViewState.Loaded.isInFullScreenMode: Boolean
-    get() = templateConfiguration.mode == PaywallViewMode.FULL_SCREEN
+internal val PaywallState.Loaded.isInFullScreenMode: Boolean
+    get() = templateConfiguration.mode == PaywallMode.FULL_SCREEN

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
@@ -3,12 +3,12 @@ package com.revenuecat.purchases.ui.revenuecatui.data
 import androidx.compose.material3.ColorScheme
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ApplicationContext
 
 internal class PaywallViewModelFactory(
     private val applicationContext: ApplicationContext,
-    private val options: PaywallViewOptions,
+    private val options: PaywallOptions,
     private val colorScheme: ColorScheme,
     private val preview: Boolean = false,
 ) : ViewModelProvider.NewInstanceFactory() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfiguration.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfiguration.kt
@@ -7,11 +7,11 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallData
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
+import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 
 internal data class TemplateConfiguration(
     val template: PaywallTemplate,
-    val mode: PaywallViewMode,
+    val mode: PaywallMode,
     val packages: PackageConfiguration,
     val configuration: PaywallData.Configuration,
     val images: Images,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
@@ -3,13 +3,13 @@ package com.revenuecat.purchases.ui.revenuecatui.data.processed
 import android.net.Uri
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallData
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
+import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 
 internal object TemplateConfigurationFactory {
     @Suppress("LongParameterList", "ThrowsCount")
     fun create(
         variableDataProvider: VariableDataProvider,
-        mode: PaywallViewMode,
+        mode: PaywallMode,
         paywallData: PaywallData,
         availablePackages: List<Package>,
         activelySubscribedProductIdentifiers: Set<String>,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -15,10 +15,10 @@ import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.TestStoreProduct
 import com.revenuecat.purchases.paywalls.PaywallData
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
+import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.R
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
-import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
@@ -26,7 +26,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.testdata.templates.template
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.templates.template2
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.templates.template3
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ApplicationContext
-import com.revenuecat.purchases.ui.revenuecatui.helpers.toPaywallViewState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.toPaywallState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -244,25 +244,25 @@ internal class MockApplicationContext : ApplicationContext {
 }
 
 internal class MockViewModel(
-    mode: PaywallViewMode = PaywallViewMode.default,
+    mode: PaywallMode = PaywallMode.default,
     offering: Offering,
     private val allowsPurchases: Boolean = false,
 ) : ViewModel(), PaywallViewModel {
-    override val state: StateFlow<PaywallViewState>
+    override val state: StateFlow<PaywallState>
         get() = _state.asStateFlow()
     override val actionInProgress: State<Boolean>
         get() = derivedStateOf { _actionInProgress.value }
 
-    fun loadedState(): PaywallViewState.Loaded? {
+    fun loadedState(): PaywallState.Loaded? {
         return when (val state = state.value) {
-            is PaywallViewState.Error -> null
-            is PaywallViewState.Loaded -> state
-            is PaywallViewState.Loading -> null
+            is PaywallState.Error -> null
+            is PaywallState.Loaded -> state
+            is PaywallState.Loading -> null
         }
     }
 
     private val _state = MutableStateFlow(
-        offering.toPaywallViewState(
+        offering.toPaywallState(
             VariableDataProvider(MockApplicationContext()),
             setOf(),
             mode,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/Animations.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/Animations.kt
@@ -6,8 +6,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
-import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 
 @Composable
@@ -22,7 +22,7 @@ internal fun PaywallViewModel.packageButtonActionInProgressOpacityAnimation(): F
 }
 
 @Composable
-internal fun PaywallViewState.Loaded.packageButtonColorAnimation(
+internal fun PaywallState.Loaded.packageButtonColorAnimation(
     packageInfo: TemplateConfiguration.PackageInfo,
     selectedColor: Color,
     unselectedColor: Color,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
@@ -10,15 +10,15 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallColor
 import com.revenuecat.purchases.paywalls.PaywallData
-import com.revenuecat.purchases.ui.revenuecatui.InternalPaywallView
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
+import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import java.net.URL
 import java.util.Locale
 
 /***
- * Default [PaywallData] to display when attempting to present a PaywallView with an offering that has no paywall
+ * Default [PaywallData] to display when attempting to present a Paywall with an offering that has no paywall
  * configuration, or when that configuration is invalid.
  */
 internal fun PaywallData.Companion.createDefault(
@@ -124,5 +124,5 @@ internal fun Template2PaywallPreview() {
         paywall = paywallData,
         serverDescription = "",
     )
-    InternalPaywallView(options = PaywallViewOptions.Builder().setOffering(template2Offering).build())
+    InternalPaywall(options = PaywallOptions.Builder().setOffering(template2Offering).build())
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -3,9 +3,9 @@ package com.revenuecat.purchases.ui.revenuecatui.helpers
 import androidx.compose.material3.ColorScheme
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.paywalls.PaywallData
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
+import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIconName
-import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfigurationFactory
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
@@ -59,13 +59,13 @@ private fun PaywallData.validate(): Result<PaywallTemplate> {
 }
 
 @Suppress("ReturnCount", "TooGenericExceptionCaught")
-internal fun Offering.toPaywallViewState(
+internal fun Offering.toPaywallState(
     variableDataProvider: VariableDataProvider,
     activelySubscribedProductIdentifiers: Set<String>,
-    mode: PaywallViewMode,
+    mode: PaywallMode,
     validatedPaywallData: PaywallData,
     template: PaywallTemplate,
-): PaywallViewState {
+): PaywallState {
     val createTemplateConfigurationResult = TemplateConfigurationFactory.create(
         variableDataProvider = variableDataProvider,
         mode = mode,
@@ -75,9 +75,9 @@ internal fun Offering.toPaywallViewState(
         template,
     )
     val templateConfiguration = createTemplateConfigurationResult.getOrElse {
-        return PaywallViewState.Error(it.message ?: "Unknown error")
+        return PaywallState.Error(it.message ?: "Unknown error")
     }
-    return PaywallViewState.Loaded(
+    return PaywallState.Loaded(
         templateConfiguration = templateConfiguration,
         selectedPackage = templateConfiguration.packages.default,
     )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -34,23 +34,23 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
-import com.revenuecat.purchases.ui.revenuecatui.InternalPaywallView
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
+import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
 import com.revenuecat.purchases.ui.revenuecatui.composables.IntroEligibilityStateView
 import com.revenuecat.purchases.ui.revenuecatui.composables.Markdown
 import com.revenuecat.purchases.ui.revenuecatui.composables.PurchaseButton
 import com.revenuecat.purchases.ui.revenuecatui.composables.RemoteImage
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
-import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.currentColors
 import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 
 @Composable
-internal fun Template1(state: PaywallViewState.Loaded, viewModel: PaywallViewModel) {
+internal fun Template1(state: PaywallState.Loaded, viewModel: PaywallViewModel) {
     Column(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -65,7 +65,7 @@ internal fun Template1(state: PaywallViewState.Loaded, viewModel: PaywallViewMod
 
 @SuppressWarnings("LongMethod")
 @Composable
-private fun ColumnScope.Template1MainContent(state: PaywallViewState.Loaded) {
+private fun ColumnScope.Template1MainContent(state: PaywallState.Loaded) {
     val localizedConfig = state.selectedLocalization
     val colors = state.currentColors
 
@@ -189,7 +189,7 @@ private object Template1UIConstants {
 @Preview(showBackground = true)
 @Composable
 internal fun Template1PaywallPreview() {
-    InternalPaywallView(options = PaywallViewOptions.Builder().setOffering(TestData.template1Offering).build())
+    InternalPaywall(options = PaywallOptions.Builder().setOffering(TestData.template1Offering).build())
 }
 
 @Preview(heightDp = 700, widthDp = 400)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -29,9 +29,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.revenuecat.purchases.ui.revenuecatui.InternalPaywallView
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
+import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
+import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
 import com.revenuecat.purchases.ui.revenuecatui.composables.IconImage
@@ -41,8 +41,8 @@ import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallBackground
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIcon
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIconName
 import com.revenuecat.purchases.ui.revenuecatui.composables.PurchaseButton
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
-import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.currentColors
 import com.revenuecat.purchases.ui.revenuecatui.data.isInFullScreenMode
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
@@ -65,7 +65,7 @@ private object Template2UIConstants {
  */
 @Composable
 internal fun Template2(
-    state: PaywallViewState.Loaded,
+    state: PaywallState.Loaded,
     viewModel: PaywallViewModel,
     childModifier: Modifier = Modifier,
 ) {
@@ -86,7 +86,7 @@ internal fun Template2(
 
 @Composable
 private fun ColumnScope.Template2MainContent(
-    state: PaywallViewState.Loaded,
+    state: PaywallState.Loaded,
     viewModel: PaywallViewModel,
     childModifier: Modifier,
 ) {
@@ -144,7 +144,7 @@ private fun ColumnScope.Template2MainContent(
 @SuppressWarnings("LongMethod")
 @Composable
 private fun ColumnScope.SelectPackageButton(
-    state: PaywallViewState.Loaded,
+    state: PaywallState.Loaded,
     packageInfo: TemplateConfiguration.PackageInfo,
     viewModel: PaywallViewModel,
     childModifier: Modifier,
@@ -231,8 +231,8 @@ private fun CheckmarkBox(isSelected: Boolean, colors: TemplateConfiguration.Colo
 @Preview(showBackground = true, locale = "es-rES")
 @Composable
 private fun Template2PaywallPreview() {
-    InternalPaywallView(
-        options = PaywallViewOptions.Builder()
+    InternalPaywall(
+        options = PaywallOptions.Builder()
             .setOffering(TestData.template2Offering)
             .build(),
     )
@@ -242,9 +242,9 @@ private fun Template2PaywallPreview() {
 @Preview(showBackground = true, locale = "es-rES")
 @Composable
 private fun Template2PaywallFooterPreview() {
-    val options = PaywallViewOptions.Builder()
+    val options = PaywallOptions.Builder()
         .setOffering(TestData.template2Offering)
         .build()
-    options.mode = PaywallViewMode.FOOTER
-    InternalPaywallView(options)
+    options.mode = PaywallMode.FOOTER
+    InternalPaywall(options)
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
@@ -25,8 +25,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.paywalls.PaywallData
-import com.revenuecat.purchases.ui.revenuecatui.InternalPaywallView
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewOptions
+import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
 import com.revenuecat.purchases.ui.revenuecatui.composables.IconImage
@@ -35,8 +35,8 @@ import com.revenuecat.purchases.ui.revenuecatui.composables.Markdown
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIcon
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIconName
 import com.revenuecat.purchases.ui.revenuecatui.composables.PurchaseButton
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
-import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
@@ -52,7 +52,7 @@ private object Template3UIConstants {
 
 @Composable
 internal fun Template3(
-    state: PaywallViewState.Loaded,
+    state: PaywallState.Loaded,
     viewModel: PaywallViewModel,
 ) {
     Column(
@@ -92,7 +92,7 @@ internal fun Template3(
 }
 
 @Composable
-private fun ColumnScope.Template3MainContent(state: PaywallViewState.Loaded) {
+private fun ColumnScope.Template3MainContent(state: PaywallState.Loaded) {
     IconImage(
         uri = state.templateConfiguration.images.iconUri,
         maxWidth = Template3UIConstants.iconSize,
@@ -191,5 +191,5 @@ private fun Feature(
 @Preview(locale = "es-rES", showBackground = true)
 @Composable
 private fun Template3Preview() {
-    InternalPaywallView(options = PaywallViewOptions.Builder().setOffering(TestData.template3Offering).build())
+    InternalPaywall(options = PaywallOptions.Builder().setOffering(TestData.template3Offering).build())
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
@@ -4,7 +4,7 @@ import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
-import com.revenuecat.purchases.ui.revenuecatui.PaywallViewMode
+import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockApplicationContext
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.templates.template2
@@ -17,7 +17,7 @@ import java.util.Locale
 @RunWith(AndroidJUnit4::class)
 internal class TemplateConfigurationFactoryTest {
 
-    private val paywallViewMode = PaywallViewMode.FULL_SCREEN
+    private val paywallMode = PaywallMode.FULL_SCREEN
 
     private lateinit var variableDataProvider: VariableDataProvider
 
@@ -28,7 +28,7 @@ internal class TemplateConfigurationFactoryTest {
         variableDataProvider = VariableDataProvider(MockApplicationContext())
         val result = TemplateConfigurationFactory.create(
             variableDataProvider,
-            paywallViewMode,
+            paywallMode,
             TestData.template2,
             listOf(TestData.Packages.weekly, TestData.Packages.monthly, TestData.Packages.annual),
             setOf(
@@ -46,7 +46,7 @@ internal class TemplateConfigurationFactoryTest {
 
     @Test
     fun `template configuration has correct view mode`() {
-        assertThat(template2Configuration.mode).isEqualTo(paywallViewMode)
+        assertThat(template2Configuration.mode).isEqualTo(paywallMode)
     }
 
     @Test


### PR DESCRIPTION
### Description
This renames a few elements of our public API:
- `PaywallView` to `Paywall`
- `PaywallViewOptions` to `PaywallOptions`
- `PaywallViewListener` to `PaywallListener`

And internal names:
- `InternalPaywallView` to `InternalPaywall`
- `PaywallViewState` to `PaywallState`
- `LoadingPaywallView` to `LoadingPaywall`
- `PaywallViewMode` to `PaywallMode`
- Some other private composables.

