### PR TITLE
`Paywalls`: fixed `Footer` padding

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
@@ -70,10 +70,8 @@ private fun Footer(
         modifier = childModifier
             .fillMaxWidth()
             .height(intrinsicSize = IntrinsicSize.Min)
-            .padding(
-                horizontal = UIConstant.defaultHorizontalPadding,
-                vertical = UIConstant.defaultVerticalSpacing,
-            ),
+            .padding(horizontal = UIConstant.defaultHorizontalPadding)
+            .padding(bottom = UIConstant.defaultVerticalSpacing),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
     ) {


### PR DESCRIPTION
This padding was duplicated in all templates.

### Before:
![Screenshot 2023-10-16 at 10 28 15](https://github.com/RevenueCat/purchases-android/assets/685609/15bffb0a-a5e2-4e41-8b93-747fa523eaa7)

### After:
![Screenshot 2023-10-16 at 10 28 32](https://github.com/RevenueCat/purchases-android/assets/685609/68b5c54f-b192-4cfb-8cd7-5589c12a227e)
