### PR TITLE
Paywalls: Fix proguard rules kotlinx serialization

### DIFF
--- a/purchases/consumer-rules.pro
+++ b/purchases/consumer-rules.pro
@@ -3,3 +3,5 @@
 -dontwarn com.google.errorprone.annotations.CanIgnoreReturnValue
 -dontwarn com.google.errorprone.annotations.Immutable
 -dontwarn com.amazon.**
+# Adding temporarily to fix issue after adding kotlin serialization
+-dontwarn java.lang.ClassValue


### PR DESCRIPTION
### Description
After adding kotlin serialization in the paywalls branch, looks like the integration tests started failing to compile with the error:
```
R8: Missing class java.lang.ClassValue (referenced from: void kotlinx.serialization.internal.ClassValueCache$initClassValue$1.<init>(kotlinx.serialization.internal.ClassValueCache) and 3 other contexts)
```
In order to fix this issue, we are adding a `dontwarn` instruction to the proguard rules of the library temporarily so it can compile. 

After investigating why this is needed, I noticed https://github.com/Kotlin/kotlinx.serialization/blob/ba38b7099e502c16efd30386d18174e3a7aefb3a/rules/common.pro#L32 and https://github.com/Kotlin/kotlinx.serialization/issues/2119. But I believe this shouldn't be needed from those comments... However, I believe it should be safe to add it temporarily.