### PR TITLE
`Paywalls`: improve handling of lifetime/custom packages

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -57,14 +57,15 @@ internal fun LoadingPaywall(mode: PaywallMode) {
     )
 
     val state = offering.toPaywallState(
-        VariableDataProvider(
+        variableDataProvider = VariableDataProvider(
             applicationContext,
             isInPreviewMode(),
         ),
-        setOf(),
-        mode,
-        paywallData,
-        LoadingPaywallConstants.template,
+        activelySubscribedProductIdentifiers = setOf(),
+        nonSubscriptionProductIdentifiers = setOf(),
+        mode = mode,
+        validatedPaywallData = paywallData,
+        template = LoadingPaywallConstants.template,
     )
 
     when (state) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -214,11 +214,14 @@ internal class PaywallViewModelImpl(
             Logger.w(PaywallValidationErrorStrings.DISPLAYING_DEFAULT)
         }
         return offering.toPaywallState(
-            variableDataProvider,
-            customerInfo.activeSubscriptions,
-            mode,
-            displayablePaywall,
-            template,
+            variableDataProvider = variableDataProvider,
+            activelySubscribedProductIdentifiers = customerInfo.activeSubscriptions,
+            nonSubscriptionProductIdentifiers = customerInfo.nonSubscriptionTransactions
+                .map { it.productIdentifier }
+                .toSet(),
+            mode = mode,
+            validatedPaywallData = displayablePaywall,
+            template = template,
         )
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
@@ -42,8 +42,11 @@ internal object PackageConfigurationFactory {
                 PackageType.MONTHLY,
                 PackageType.WEEKLY,
                 -> activelySubscribedProductIdentifiers.contains(it.product.id)
-                PackageType.LIFETIME -> nonSubscriptionProductIdentifiers.contains(it.product.id)
-                PackageType.UNKNOWN, PackageType.CUSTOM -> false
+
+                PackageType.LIFETIME, PackageType.CUSTOM,
+                -> nonSubscriptionProductIdentifiers.contains(it.product.id)
+
+                PackageType.UNKNOWN -> false
             }
 
             TemplateConfiguration.PackageInfo(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
@@ -13,6 +13,7 @@ internal object TemplateConfigurationFactory {
         paywallData: PaywallData,
         availablePackages: List<Package>,
         activelySubscribedProductIdentifiers: Set<String>,
+        nonSubscriptionProductIdentifiers: Set<String>,
         template: PaywallTemplate,
     ): Result<TemplateConfiguration> {
         val (locale, localizedConfiguration) = paywallData.localizedConfiguration
@@ -27,6 +28,7 @@ internal object TemplateConfigurationFactory {
                 variableDataProvider = variableDataProvider,
                 availablePackages = availablePackages,
                 activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers,
+                nonSubscriptionProductIdentifiers = nonSubscriptionProductIdentifiers,
                 packageIdsInConfig = paywallData.config.packageIds,
                 default = paywallData.config.defaultPackage,
                 localization = localizedConfiguration,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -272,11 +272,12 @@ internal class MockViewModel(
 
     private val _state = MutableStateFlow(
         offering.toPaywallState(
-            VariableDataProvider(MockApplicationContext()),
-            setOf(),
-            mode,
-            offering.paywall!!,
-            PaywallTemplate.fromId(offering.paywall!!.templateName)!!,
+            variableDataProvider = VariableDataProvider(MockApplicationContext()),
+            activelySubscribedProductIdentifiers = setOf(),
+            nonSubscriptionProductIdentifiers = setOf(),
+            mode = mode,
+            validatedPaywallData = offering.paywall!!,
+            template = PaywallTemplate.fromId(offering.paywall!!.templateName)!!,
         ),
     )
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -114,6 +114,7 @@ internal object TestData {
             Packages.weekly,
             Packages.monthly,
             Packages.annual,
+            Packages.lifetime,
         ),
         metadata = mapOf(),
         paywall = template2,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/templates/Template2TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/templates/Template2TestData.kt
@@ -14,6 +14,7 @@ internal val TestData.template2: PaywallData
             packageIds = listOf(
                 PackageType.ANNUAL.identifier!!,
                 PackageType.MONTHLY.identifier!!,
+                PackageType.LIFETIME.identifier!!,
             ),
             defaultPackage = PackageType.MONTHLY.identifier!!,
             images = TestData.Constants.images,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -67,10 +67,11 @@ private fun PaywallData.validate(): Result<PaywallTemplate> {
     return Result.success(template)
 }
 
-@Suppress("ReturnCount", "TooGenericExceptionCaught")
+@Suppress("ReturnCount", "TooGenericExceptionCaught", "LongParameterList")
 internal fun Offering.toPaywallState(
     variableDataProvider: VariableDataProvider,
     activelySubscribedProductIdentifiers: Set<String>,
+    nonSubscriptionProductIdentifiers: Set<String>,
     mode: PaywallMode,
     validatedPaywallData: PaywallData,
     template: PaywallTemplate,
@@ -81,6 +82,7 @@ internal fun Offering.toPaywallState(
         paywallData = validatedPaywallData,
         availablePackages = availablePackages,
         activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers,
+        nonSubscriptionProductIdentifiers = nonSubscriptionProductIdentifiers,
         template,
     )
     val templateConfiguration = createTemplateConfigurationResult.getOrElse {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
@@ -27,14 +27,22 @@ internal class TemplateConfigurationFactoryTest {
     fun setUp() {
         variableDataProvider = VariableDataProvider(MockApplicationContext())
         val result = TemplateConfigurationFactory.create(
-            variableDataProvider,
-            paywallMode,
-            TestData.template2,
-            listOf(TestData.Packages.weekly, TestData.Packages.monthly, TestData.Packages.annual),
-            setOf(
-                TestData.Packages.monthly.product.id
+            variableDataProvider = variableDataProvider,
+            mode = paywallMode,
+            paywallData = TestData.template2,
+            availablePackages = listOf(
+                TestData.Packages.weekly,
+                TestData.Packages.monthly,
+                TestData.Packages.annual,
+                TestData.Packages.lifetime,
             ),
-            PaywallTemplate.TEMPLATE_2,
+            activelySubscribedProductIdentifiers = setOf(
+                TestData.Packages.monthly.product.id,
+            ),
+            nonSubscriptionProductIdentifiers = setOf(
+                TestData.Packages.lifetime.product.id
+            ),
+            template = PaywallTemplate.TEMPLATE_2,
         )
         template2Configuration = result.getOrNull()!!
     }
@@ -63,6 +71,7 @@ internal class TemplateConfigurationFactoryTest {
 
         val annualPackage = getPackageInfo(TestData.Packages.annual, currentlySubscribed = false)
         val monthlyPackage = getPackageInfo(TestData.Packages.monthly, currentlySubscribed = true)
+        val lifetime = getPackageInfo(TestData.Packages.lifetime, currentlySubscribed = true)
 
         val expectedConfiguration = TemplateConfiguration.PackageConfiguration.Multiple(
             first = annualPackage,
@@ -70,6 +79,7 @@ internal class TemplateConfigurationFactoryTest {
             all = listOf(
                 annualPackage,
                 monthlyPackage,
+                lifetime
             ),
         )
 
@@ -97,24 +107,28 @@ internal class TemplateConfigurationFactoryTest {
             PackageType.ANNUAL -> "Annual"
             PackageType.MONTHLY -> "Monthly"
             PackageType.WEEKLY -> "Weekly"
+            PackageType.LIFETIME -> "Lifetime"
             else -> error("Unknown package type ${rcPackage.packageType}")
         }
         val callToAction = when(rcPackage.packageType) {
             PackageType.ANNUAL -> "Subscribe for $67.99/yr"
             PackageType.MONTHLY -> "Subscribe for $7.99/mth"
             PackageType.WEEKLY -> "Subscribe for $1.99/wk"
+            PackageType.LIFETIME -> "Subscribe for $1,000"
             else -> error("Unknown package type ${rcPackage.packageType}")
         }
         val offerDetails = when(rcPackage.packageType) {
             PackageType.ANNUAL -> "$67.99/yr ($5.67/mth)"
             PackageType.MONTHLY -> "$7.99/mth"
             PackageType.WEEKLY -> "$1.99/wk ($7.96/mth)"
+            PackageType.LIFETIME -> "$1,000"
             else -> error("Unknown package type ${rcPackage.packageType}")
         }
         val offerDetailsWithIntroOffer = when(rcPackage.packageType) {
             PackageType.ANNUAL -> "$67.99/yr ($5.67/mth) after 1 month trial"
             PackageType.MONTHLY -> "$7.99/mth after  trial"
             PackageType.WEEKLY -> "$1.99/wk ($7.96/mth) after  trial"
+            PackageType.LIFETIME -> "$1,000 after  trial"
             else -> error("Unknown package type ${rcPackage.packageType}")
         }
         val processedLocalization = ProcessedLocalizedConfiguration(

--- a/ui/revenuecatui/src/test/resources/default_template.json
+++ b/ui/revenuecatui/src/test/resources/default_template.json
@@ -28,7 +28,8 @@
     },
     "packages" : [
       "$rc_annual",
-      "$rc_monthly"
+      "$rc_monthly",
+      "$rc_lifetime"
     ],
     "privacy_url" : null,
     "tos_url" : null


### PR DESCRIPTION
This uses the existing `TemplateConfiguration.PackageInfo.currentlySubscribed` to prevent users from subscribing to a lifetime subscription they already own.

Better consumable support will come in the future.