### PR TITLE
`Paywalls`: improve `LoadingPaywall`

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui
 
 import android.content.Context
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -84,8 +85,9 @@ private fun LoadingPaywall(state: PaywallState.Loaded, viewModel: PaywallViewMod
             childModifier = Modifier
                 .placeholder(
                     visible = true,
+                    shape = RoundedCornerShape(UIConstant.defaultPackageCornerRadius),
                     highlight = Fade(
-                        highlightColor = LoadingPaywallConstants.placeholderColor.copy(alpha = 0.5f),
+                        highlightColor = LoadingPaywallConstants.placeholderColor,
                         animationSpec = PlaceholderDefaults.fadeAnimationSpec,
                     ),
                     color = LoadingPaywallConstants.placeholderColor,
@@ -97,7 +99,8 @@ private fun LoadingPaywall(state: PaywallState.Loaded, viewModel: PaywallViewMod
 private object LoadingPaywallConstants {
     const val offeringIdentifier = "loading_offering"
 
-    val placeholderColor = Color.Gray
+    const val placeholderAlpha = 0.5f
+    val placeholderColor = Color.Gray.copy(alpha = placeholderAlpha)
 
     val template = PaywallTemplate.TEMPLATE_2
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
@@ -67,7 +67,7 @@ private fun Footer(
     val context = LocalContext.current
 
     Row(
-        modifier = childModifier
+        modifier = Modifier
             .fillMaxWidth()
             .height(intrinsicSize = IntrinsicSize.Min)
             .padding(horizontal = UIConstant.defaultHorizontalPadding)
@@ -80,6 +80,7 @@ private fun Footer(
         if (configuration.displayRestorePurchases) {
             Button(
                 color = color,
+                childModifier = childModifier,
                 R.string.restore_purchases,
                 R.string.restore,
             ) { viewModel.restorePurchases() }
@@ -92,6 +93,7 @@ private fun Footer(
         configuration.termsOfServiceURL?.let {
             Button(
                 color = color,
+                childModifier = childModifier,
                 R.string.terms_and_conditions,
                 R.string.terms,
             ) { viewModel.openURL(it, context) }
@@ -104,6 +106,7 @@ private fun Footer(
         configuration.privacyURL?.let {
             Button(
                 color = color,
+                childModifier = childModifier,
                 R.string.privacy_policy,
                 R.string.privacy,
             ) { viewModel.openURL(it, context) }
@@ -132,6 +135,7 @@ private fun RowScope.Separator(color: Color) {
 @Composable
 private fun RowScope.Button(
     color: Color,
+    childModifier: Modifier,
     @StringRes vararg texts: Int,
     action: () -> Unit,
 ) {
@@ -162,6 +166,7 @@ private fun RowScope.Button(
                                 style = FooterConstants.style(),
                                 softWrap = false,
                                 maxLines = 1,
+                                modifier = childModifier
                             )
                         }
                     },
@@ -173,6 +178,7 @@ private fun RowScope.Button(
                                 textAlign = TextAlign.Center,
                                 style = FooterConstants.style(),
                                 softWrap = true,
+                                modifier = childModifier
                             )
                         }
                     },

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
@@ -166,7 +166,7 @@ private fun RowScope.Button(
                                 style = FooterConstants.style(),
                                 softWrap = false,
                                 maxLines = 1,
-                                modifier = childModifier
+                                modifier = childModifier,
                             )
                         }
                     },
@@ -178,7 +178,7 @@ private fun RowScope.Button(
                                 textAlign = TextAlign.Center,
                                 style = FooterConstants.style(),
                                 softWrap = true,
-                                modifier = childModifier
+                                modifier = childModifier,
                             )
                         }
                     },


### PR DESCRIPTION
Added alpha and corner radius to the placeholder items. Also changed how `Footer` is implemented to only make the `Text` a placeholder.

![Screenshot 2023-10-18 at 15 12 42](https://github.com/RevenueCat/purchases-android/assets/685609/24325262-1abc-4ef0-8940-15e7334a750e)


