### PR TITLE
Paywalls: Enable footer modes in paywall tester paywalls tab

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.paywallstester.ui.screens.main.paywalls
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,6 +11,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -20,15 +22,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.revenuecat.paywallstester.SamplePaywalls
 import com.revenuecat.paywallstester.SamplePaywallsLoader
+import com.revenuecat.paywallstester.ui.screens.paywallfooter.SamplePaywall
 import com.revenuecat.paywallstester.ui.theme.googleFont
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialog
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions
+import com.revenuecat.purchases.ui.revenuecatui.PaywallFooter
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
 
@@ -40,6 +47,7 @@ fun PaywallsScreen(
 
     LazyColumn {
         items(SamplePaywalls.SampleTemplate.values()) { template ->
+            val offering = samplePaywallsLoader.offeringForTemplate(template)
             Column(modifier = Modifier.fillMaxWidth()) {
                 Text(
                     text = template.displayableName,
@@ -48,27 +56,27 @@ fun PaywallsScreen(
                 )
                 ButtonWithEmoji(
                     onClick = {
-                        val offering = samplePaywallsLoader.offeringForTemplate(template)
                         displayPaywallState = DisplayPaywallState.FullScreen(offering)
                     },
                     emoji = "\uD83D\uDCF1",
                     label = "Full screen",
                 )
                 ButtonWithEmoji(
-                    onClick = { },
+                    onClick = {
+                        displayPaywallState = DisplayPaywallState.Footer(offering)
+                    },
                     emoji = "\uD83D\uDD3D",
-                    label = "Footer (coming soon)",
-                    enabled = false,
-                )
-                ButtonWithEmoji(
-                    onClick = { },
-                    emoji = "\uD83D\uDDDC️",
-                    label = "Condenser footer (coming soon)",
-                    enabled = false,
+                    label = "Footer",
                 )
                 ButtonWithEmoji(
                     onClick = {
-                        val offering = samplePaywallsLoader.offeringForTemplate(template)
+                        displayPaywallState = DisplayPaywallState.Footer(offering, condensed = true)
+                    },
+                    emoji = "\uD83D\uDDDC️",
+                    label = "Condenser footer",
+                )
+                ButtonWithEmoji(
+                    onClick = {
                         displayPaywallState = DisplayPaywallState.FullScreen(offering, CustomFontProvider(googleFont))
                     },
                     emoji = "\uD83C\uDD70️",
@@ -79,19 +87,57 @@ fun PaywallsScreen(
     }
     val currentState = displayPaywallState
     if (currentState is DisplayPaywallState.FullScreen) {
-        PaywallDialog(
-            PaywallDialogOptions.Builder(dismissRequest = {
-                displayPaywallState = DisplayPaywallState.None
+        FullScreenDialog(currentState) {
+            displayPaywallState = DisplayPaywallState.None
+        }
+    } else if (currentState is DisplayPaywallState.Footer) {
+        FooterDialog(currentState) {
+            displayPaywallState = DisplayPaywallState.None
+        }
+    }
+}
+
+@Composable
+private fun FullScreenDialog(currentState: DisplayPaywallState.FullScreen, onDismiss: () -> Unit) {
+    PaywallDialog(
+        PaywallDialogOptions.Builder(dismissRequest = onDismiss)
+            .setOffering(currentState.offering)
+            .setListener(object : PaywallListener {
+                override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
+                    onDismiss()
+                }
             })
-                .setOffering(currentState.offering)
-                .setListener(object : PaywallListener {
-                    override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
-                        displayPaywallState = DisplayPaywallState.None
-                    }
-                })
-                .setFontProvider(currentState.fontProvider)
-                .build(),
-        )
+            .setFontProvider(currentState.fontProvider)
+            .build(),
+    )
+}
+
+@Composable
+private fun FooterDialog(currentState: DisplayPaywallState.Footer, onDismiss: () -> Unit) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Scaffold { scaffoldPadding ->
+            Box(modifier = Modifier.padding(scaffoldPadding)) {
+                PaywallFooter(
+                    options = PaywallOptions.Builder()
+                        .setOffering(currentState.offering)
+                        .setListener(object : PaywallListener {
+                            override fun onPurchaseCompleted(
+                                customerInfo: CustomerInfo,
+                                storeTransaction: StoreTransaction,
+                            ) {
+                                onDismiss()
+                            }
+                        })
+                        .build(),
+                    condensed = currentState.condensed,
+                ) { footerPadding ->
+                    SamplePaywall(paddingValues = footerPadding)
+                }
+            }
+        }
     }
 }
 
@@ -100,6 +146,10 @@ private sealed class DisplayPaywallState {
     data class FullScreen(
         val offering: Offering? = null,
         val fontProvider: FontProvider? = null,
+    ) : DisplayPaywallState()
+    data class Footer(
+        val offering: Offering? = null,
+        val condensed: Boolean = false,
     ) : DisplayPaywallState()
 }
 

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
@@ -63,7 +63,7 @@ fun PaywallsScreen(
                 )
                 ButtonWithEmoji(
                     onClick = {
-                        displayPaywallState = DisplayPaywallState.Footer(offering)
+                        displayPaywallState = DisplayPaywallState.Footer(offering, condensed = false)
                     },
                     emoji = "\uD83D\uDD3D",
                     label = "Footer",
@@ -102,11 +102,7 @@ private fun FullScreenDialog(currentState: DisplayPaywallState.FullScreen, onDis
     PaywallDialog(
         PaywallDialogOptions.Builder(dismissRequest = onDismiss)
             .setOffering(currentState.offering)
-            .setListener(object : PaywallListener {
-                override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
-                    onDismiss()
-                }
-            })
+            .setListener(PaywallListenerImpl(onDismiss))
             .setFontProvider(currentState.fontProvider)
             .build(),
     )
@@ -123,14 +119,7 @@ private fun FooterDialog(currentState: DisplayPaywallState.Footer, onDismiss: ()
                 PaywallFooter(
                     options = PaywallOptions.Builder()
                         .setOffering(currentState.offering)
-                        .setListener(object : PaywallListener {
-                            override fun onPurchaseCompleted(
-                                customerInfo: CustomerInfo,
-                                storeTransaction: StoreTransaction,
-                            ) {
-                                onDismiss()
-                            }
-                        })
+                        .setListener(PaywallListenerImpl(onDismiss))
                         .build(),
                     condensed = currentState.condensed,
                 ) { footerPadding ->
@@ -151,6 +140,12 @@ private sealed class DisplayPaywallState {
         val offering: Offering? = null,
         val condensed: Boolean = false,
     ) : DisplayPaywallState()
+}
+
+private class PaywallListenerImpl(private val onDismiss: () -> Unit) : PaywallListener {
+    override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
+        onDismiss()
+    }
 }
 
 @Composable

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywallfooter/PaywallFooterScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywallfooter/PaywallFooterScreen.kt
@@ -58,7 +58,7 @@ fun PaywallFooterScreen(
 
 @Suppress("MagicNumber")
 @Composable
-private fun SamplePaywall(paddingValues: PaddingValues) {
+internal fun SamplePaywall(paddingValues: PaddingValues) {
     Column(
         modifier = Modifier
             .fillMaxWidth()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -95,7 +95,7 @@ private fun getPaywallViewModel(
     return viewModel<PaywallViewModelImpl>(
         // We need to pass the key in order to create different view models for different offerings when
         // trying to load different paywalls for the same view model store owner.
-        key = options.offeringSelection.offeringIdentifier,
+        key = options.offeringSelection.offeringIdentifier + options.mode,
         factory = PaywallViewModelFactory(
             applicationContext.toAndroidContext(),
             options,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -26,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
+import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
@@ -37,6 +37,7 @@ import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIconName
 import com.revenuecat.purchases.ui.revenuecatui.composables.PurchaseButton
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
+import com.revenuecat.purchases.ui.revenuecatui.data.isInFullScreenMode
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
@@ -56,20 +57,22 @@ internal fun Template3(
     viewModel: PaywallViewModel,
 ) {
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxWidth(),
     ) {
-        Column(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .padding(
-                    horizontal = UIConstant.defaultHorizontalPadding,
-                    vertical = UIConstant.defaultVerticalSpacing,
-                ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(UIConstant.defaultVerticalSpacing, Alignment.Top),
-        ) {
-            Template3MainContent(state)
+        if (state.isInFullScreenMode) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = UIConstant.defaultHorizontalPadding,
+                        vertical = UIConstant.defaultVerticalSpacing,
+                    ),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(UIConstant.defaultVerticalSpacing, Alignment.Top),
+            ) {
+                Template3MainContent(state)
+            }
         }
         OfferDetails(state)
         PurchaseButton(state, viewModel)
@@ -181,5 +184,23 @@ private fun Template3Preview() {
     InternalPaywall(
         options = PaywallOptions.Builder().build(),
         viewModel = MockViewModel(offering = TestData.template3Offering),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun Template3FooterPreview() {
+    InternalPaywall(
+        options = PaywallOptions.Builder().build(),
+        viewModel = MockViewModel(mode = PaywallMode.FOOTER, offering = TestData.template3Offering),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun Template3CondensedFooterPreview() {
+    InternalPaywall(
+        options = PaywallOptions.Builder().build(),
+        viewModel = MockViewModel(mode = PaywallMode.FOOTER_CONDENSED, offering = TestData.template3Offering),
     )
 }


### PR DESCRIPTION
### Description
Now that footer is supported in all templates, this enables them in the paywalls tab of purchase tester.