### PR TITLE
Add `StoreProduct.pricePerMonth`

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
@@ -27,7 +27,8 @@ final class StoreProductAPI {
         final String title = product.getTitle();
         final String description = product.getDescription();
         final Period period = product.getPeriod();
-        final String pricePerMonth = product.formattedPricePerMonth(locale);
+        final String formattedPricePerMonth = product.formattedPricePerMonth(locale);
+        final Price pricePerMonth = product.pricePerMonth(locale);
 
         SubscriptionOptions subscriptionOptions = product.getSubscriptionOptions();
         SubscriptionOption defaultOption = product.getDefaultOption();

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
@@ -23,8 +23,10 @@ private class StoreProductAPI {
             val sku: String = sku
             val type: ProductType = type
             val price: Price? = price
-            val pricePerMonth: String? = formattedPricePerMonth(locale)
-            val pricePerMonthNoLocale: String? = formattedPricePerMonth()
+            val formattedPricePerMonth: String? = formattedPricePerMonth(locale)
+            val formattedPricePerMonthNoLocale: String? = formattedPricePerMonth()
+            val pricePerMonth: Price? = pricePerMonth(locale)
+            val pricePerMonthNoLocale: Price? = pricePerMonth()
             val title: String = title
             val description: String = description
             val period: Period? = period

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/PricingPhase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/PricingPhase.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases.models
 
 import android.os.Parcelable
-import com.revenuecat.purchases.utils.formattedPricePerMonth
+import com.revenuecat.purchases.utils.pricePerMonth
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
@@ -62,6 +62,6 @@ data class PricingPhase(
      */
     @JvmOverloads
     fun formattedPriceInMonths(locale: Locale = Locale.getDefault()): String {
-        return price.formattedPricePerMonth(billingPeriod, locale)
+        return price.pricePerMonth(billingPeriod, locale).formatted
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases.models
 
 import com.revenuecat.purchases.ProductType
-import com.revenuecat.purchases.utils.formattedPricePerMonth
+import com.revenuecat.purchases.utils.pricePerMonth
 import java.util.Locale
 
 /**
@@ -99,7 +99,19 @@ interface StoreProduct {
      * For Google subscriptions, this value will use the basePlan to calculate the value.
      * @param locale Locale to use for formatting the price. Default is the system default locale.
      */
+    fun pricePerMonth(locale: Locale = Locale.getDefault()): Price? {
+        return period?.let { price.pricePerMonth(it, locale) }
+    }
+
+    /**
+     * Null for INAPP products. The price of the [StoreProduct] in the given locale in a monthly recurrence.
+     * This means that, for example, if the period is annual, the price will be divided by 12.
+     * It uses a currency formatter to format the price in the given locale.
+     * Note that this value may be an approximation.
+     * For Google subscriptions, this value will use the basePlan to calculate the value.
+     * @param locale Locale to use for formatting the price. Default is the system default locale.
+     */
     fun formattedPricePerMonth(locale: Locale = Locale.getDefault()): String? {
-        return period?.let { price.formattedPricePerMonth(it, locale) }
+        return pricePerMonth(locale)?.formatted
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PriceExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PriceExtensions.kt
@@ -8,11 +8,13 @@ import java.util.Locale
 
 private const val MICRO_MULTIPLIER = 1_000_000.0
 
-internal fun Price.formattedPricePerMonth(billingPeriod: Period, locale: Locale): String {
+internal fun Price.pricePerMonth(billingPeriod: Period, locale: Locale): Price {
     val periodMonths = billingPeriod.valueInMonths
-    val currencyCode = currencyCode
-    val priceDecimal = amountMicros / MICRO_MULTIPLIER
     val numberFormat = NumberFormat.getCurrencyInstance(locale)
     numberFormat.currency = Currency.getInstance(currencyCode)
-    return numberFormat.format(priceDecimal / periodMonths)
+
+    val value = amountMicros / periodMonths
+    val formatted = numberFormat.format(value / MICRO_MULTIPLIER)
+
+    return Price(formatted, (value).toLong(), currencyCode)
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -320,18 +320,29 @@ class StoreProductTest {
             productDetails = mockProductDetails(),
             presentedOfferingIdentifier = "originalOfferingId"
         )
+        assertThat(storeProduct.pricePerMonth(Locale.US)).isNull()
         assertThat(storeProduct.formattedPricePerMonth(Locale.US)).isNull()
     }
 
     @Test
     fun `formattedPricePerMonth is correct for SUBS monthly product with free trial`() {
         val product = createSubscriptionStoreProduct(Period.create("P1M"))
+        assertThat(product.pricePerMonth(Locale.US)).isEqualTo(Price(
+            "$1.00",
+            1_000_000,
+            product.price.currencyCode,
+        ))
         assertThat(product.formattedPricePerMonth(Locale.US)).isEqualTo("$1.00")
     }
 
     @Test
     fun `formattedPricePerMonth is correct for SUBS annual product with free trial`() {
         val product = createSubscriptionStoreProduct(Period.create("P1Y"))
+        assertThat(product.pricePerMonth(Locale.US)).isEqualTo(Price(
+            "$0.08",
+            83_333,
+            product.price.currencyCode,
+        ))
         assertThat(product.formattedPricePerMonth(Locale.US)).isEqualTo("$0.08")
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsTest.kt
@@ -15,7 +15,11 @@ class PriceExtensionsTest {
         val price = Price("$59.99", 59_990_000, "USD")
         val billingPeriod = Period.create("P1Y")
         val locale = Locale.US
-        assertThat(price.formattedPricePerMonth(billingPeriod, locale)).isEqualTo("$5.00")
+        val pricePerMonth = price.pricePerMonth(billingPeriod, locale)
+
+        assertThat(pricePerMonth.formatted).isEqualTo("$5.00")
+        assertThat(pricePerMonth.currencyCode).isEqualTo(price.currencyCode)
+        assertThat(pricePerMonth.amountMicros).isEqualTo(price.amountMicros / 12)
     }
 
     @Test
@@ -23,7 +27,11 @@ class PriceExtensionsTest {
         val price = Price("$59.99", 59_990_000, "USD")
         val billingPeriod = Period.create("P1Y")
         val locale = Locale("es", "ES")
-        assertThat(price.formattedPricePerMonth(billingPeriod, locale)).isEqualTo("5,00 US$")
+        val pricePerMonth = price.pricePerMonth(billingPeriod, locale)
+
+        assertThat(pricePerMonth.formatted).isEqualTo("5,00 US$")
+        assertThat(pricePerMonth.currencyCode).isEqualTo("USD")
+        assertThat(pricePerMonth.amountMicros).isEqualTo(price.amountMicros / 12)
     }
 
     @Test
@@ -31,7 +39,11 @@ class PriceExtensionsTest {
         val price = Price("59.99€", 59_990_000, "EUR")
         val billingPeriod = Period.create("P1Y")
         val locale = Locale("es", "ES")
-        assertThat(price.formattedPricePerMonth(billingPeriod, locale)).isEqualTo("5,00 €")
+        val pricePerMonth = price.pricePerMonth(billingPeriod, locale)
+
+        assertThat(pricePerMonth.formatted).isEqualTo("5,00 €")
+        assertThat(pricePerMonth.currencyCode).isEqualTo("EUR")
+        assertThat(pricePerMonth.amountMicros).isEqualTo(price.amountMicros / 12)
     }
 
     @Test
@@ -39,7 +51,11 @@ class PriceExtensionsTest {
         val price = Price("59.99€", 59_990_000, "EUR")
         val billingPeriod = Period.create("P1Y")
         val locale = Locale.US
-        assertThat(price.formattedPricePerMonth(billingPeriod, locale)).isEqualTo("€5.00")
+        val pricePerMonth = price.pricePerMonth(billingPeriod, locale)
+
+        assertThat(pricePerMonth.formatted).isEqualTo("€5.00")
+        assertThat(pricePerMonth.currencyCode).isEqualTo("EUR")
+        assertThat(pricePerMonth.amountMicros).isEqualTo(price.amountMicros / 12)
     }
 
     @Test
@@ -47,6 +63,10 @@ class PriceExtensionsTest {
         val price = Price("9.99€", 9_990_000, "USD")
         val billingPeriod = Period.create("P1M")
         val locale = Locale.US
-        assertThat(price.formattedPricePerMonth(billingPeriod, locale)).isEqualTo("$9.99")
+        val pricePerMonth = price.pricePerMonth(billingPeriod, locale)
+
+        assertThat(pricePerMonth.formatted).isEqualTo("$9.99")
+        assertThat(pricePerMonth.currencyCode).isEqualTo("USD")
+        assertThat(pricePerMonth.amountMicros).isEqualTo(price.amountMicros)
     }
 }


### PR DESCRIPTION
This is a counterpart to the existing `formattedPricePerMonth`. It becomes the canonical implementation returning a `Price` instead.

This will be used for Paywalls to calculate discounts between packages.