### PR TITLE
Paywalls: Add offer details in template 2 when in condensed form

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/OfferDetails.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/OfferDetails.kt
@@ -13,6 +13,10 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 
+/**
+ * This displays the offer details of the selected package. For templates that allow to select
+ * multiple packages, each package needs its own offer details so we won't use this composable.
+ */
 @Composable
 internal fun OfferDetails(
     state: PaywallState.Loaded,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/OfferDetails.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/OfferDetails.kt
@@ -19,7 +19,7 @@ internal fun OfferDetails(
 ) {
     Box(
         modifier = Modifier
-            .padding(vertical = UIConstant.defaultVerticalSpacing, horizontal = UIConstant.defaultHorizontalPadding),
+            .padding(bottom = UIConstant.defaultVerticalSpacing),
     ) {
         IntroEligibilityStateView(
             textWithNoIntroOffer = state.selectedLocalization.offerDetails,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/OfferDetails.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/OfferDetails.kt
@@ -1,0 +1,36 @@
+package com.revenuecat.purchases.ui.revenuecatui.composables
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import com.revenuecat.purchases.ui.revenuecatui.UIConstant
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
+import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
+
+@Composable
+internal fun OfferDetails(
+    state: PaywallState.Loaded,
+) {
+    Box(
+        modifier = Modifier
+            .padding(vertical = UIConstant.defaultVerticalSpacing, horizontal = UIConstant.defaultHorizontalPadding),
+    ) {
+        IntroEligibilityStateView(
+            textWithNoIntroOffer = state.selectedLocalization.offerDetails,
+            textWithIntroOffer = state.selectedLocalization.offerDetailsWithIntroOffer,
+            textWithMultipleIntroOffers = state.selectedLocalization.offerDetailsWithMultipleIntroOffers,
+            eligibility = state.selectedPackage.value.introEligibility,
+            color = state.templateConfiguration.getCurrentColors().text1,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Normal,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -118,8 +118,6 @@ private fun ColumnScope.Template1MainContent(state: PaywallState.Loaded) {
         }
     }
 
-    Spacer(modifier = Modifier.weight(1f))
-
     OfferDetails(state)
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -39,8 +39,8 @@ import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
-import com.revenuecat.purchases.ui.revenuecatui.composables.IntroEligibilityStateView
 import com.revenuecat.purchases.ui.revenuecatui.composables.Markdown
+import com.revenuecat.purchases.ui.revenuecatui.composables.OfferDetails
 import com.revenuecat.purchases.ui.revenuecatui.composables.PurchaseButton
 import com.revenuecat.purchases.ui.revenuecatui.composables.RemoteImage
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
@@ -50,7 +50,6 @@ import com.revenuecat.purchases.ui.revenuecatui.data.isInFullScreenMode
 import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
-import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 
 @Composable
 internal fun Template1(state: PaywallState.Loaded, viewModel: PaywallViewModel) {
@@ -119,24 +118,9 @@ private fun ColumnScope.Template1MainContent(state: PaywallState.Loaded) {
         }
     }
 
-    Column(
-        modifier = Modifier
-            .padding(bottom = UIConstant.defaultVerticalSpacing)
-            .fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Bottom,
-    ) {
-        IntroEligibilityStateView(
-            textWithNoIntroOffer = localizedConfig.offerDetails,
-            textWithIntroOffer = localizedConfig.offerDetailsWithIntroOffer,
-            textWithMultipleIntroOffers = localizedConfig.offerDetailsWithMultipleIntroOffers,
-            eligibility = state.selectedPackage.value.introEligibility,
-            color = colors.text1,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.Normal,
-            textAlign = TextAlign.Center,
-        )
-    }
+    Spacer(modifier = Modifier.weight(1f))
+
+    OfferDetails(state)
 }
 
 @Composable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -2,6 +2,8 @@ package com.revenuecat.purchases.ui.revenuecatui.templates
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -44,6 +46,7 @@ import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
 import com.revenuecat.purchases.ui.revenuecatui.composables.IconImage
 import com.revenuecat.purchases.ui.revenuecatui.composables.IntroEligibilityStateView
 import com.revenuecat.purchases.ui.revenuecatui.composables.Markdown
+import com.revenuecat.purchases.ui.revenuecatui.composables.OfferDetails
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallBackground
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIcon
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIconName
@@ -145,11 +148,41 @@ private fun ColumnScope.Template2MainContent(
             Spacer(Modifier.weight(1f))
         }
 
+        AnimatedPackages(state, packageSelectionVisible, viewModel, childModifier)
+
+        if (state.isInFullScreenMode) {
+            Spacer(Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun AnimatedPackages(
+    state: PaywallState.Loaded,
+    packageSelectionVisible: Boolean,
+    viewModel: PaywallViewModel,
+    childModifier: Modifier,
+) {
+    val packagesContentAlignment = if (state.isInFullScreenMode) {
+        Alignment.TopStart
+    } else {
+        Alignment.BottomCenter
+    }
+    Box(contentAlignment = packagesContentAlignment) {
+        AnimatedVisibility(
+            visible = !packageSelectionVisible,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            label = "OfferDetailsVisibility",
+        ) {
+            OfferDetails(state)
+        }
+
         AnimatedVisibility(
             visible = packageSelectionVisible,
             enter = expandVertically(expandFrom = Alignment.Bottom),
             exit = shrinkVertically(shrinkTowards = Alignment.Bottom),
-            label = "AllPlansVisibility",
+            label = "SelectPackagesVisibility",
         ) {
             Column(
                 verticalArrangement = Arrangement.spacedBy(
@@ -159,10 +192,6 @@ private fun ColumnScope.Template2MainContent(
             ) {
                 state.templateConfiguration.packages.all.forEach { packageInfo ->
                     SelectPackageButton(state, packageInfo, viewModel, childModifier)
-                }
-
-                if (state.isInFullScreenMode) {
-                    Spacer(Modifier.weight(1f))
                 }
             }
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.templates
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -171,8 +172,8 @@ private fun AnimatedPackages(
     Box(contentAlignment = packagesContentAlignment) {
         AnimatedVisibility(
             visible = !packageSelectionVisible,
-            enter = fadeIn(),
-            exit = fadeOut(),
+            enter = fadeIn(animationSpec = tween(delayMillis = 200)),
+            exit = fadeOut(animationSpec = tween(delayMillis = 200)),
             label = "OfferDetailsVisibility",
         ) {
             OfferDetails(state)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -172,8 +172,8 @@ private fun AnimatedPackages(
     Box(contentAlignment = packagesContentAlignment) {
         AnimatedVisibility(
             visible = !packageSelectionVisible,
-            enter = fadeIn(animationSpec = tween(delayMillis = 200)),
-            exit = fadeOut(animationSpec = tween(delayMillis = 200)),
+            enter = fadeIn(animationSpec = tween(delayMillis = UIConstant.defaultAnimationDurationMillis)),
+            exit = fadeOut(animationSpec = tween(delayMillis = UIConstant.defaultAnimationDurationMillis)),
             label = "OfferDetailsVisibility",
         ) {
             OfferDetails(state)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
@@ -30,8 +30,8 @@ import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.composables.Footer
 import com.revenuecat.purchases.ui.revenuecatui.composables.IconImage
-import com.revenuecat.purchases.ui.revenuecatui.composables.IntroEligibilityStateView
 import com.revenuecat.purchases.ui.revenuecatui.composables.Markdown
+import com.revenuecat.purchases.ui.revenuecatui.composables.OfferDetails
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIcon
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIconName
 import com.revenuecat.purchases.ui.revenuecatui.composables.PurchaseButton
@@ -41,7 +41,6 @@ import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfigura
 import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
-import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 
 private object Template3UIConstants {
     val iconCornerRadius = 8.dp
@@ -72,21 +71,7 @@ internal fun Template3(
         ) {
             Template3MainContent(state)
         }
-        Column(
-            modifier = Modifier
-                .align(Alignment.CenterHorizontally)
-                .padding(bottom = UIConstant.defaultVerticalSpacing),
-        ) {
-            IntroEligibilityStateView(
-                textWithNoIntroOffer = state.selectedLocalization.offerDetails,
-                textWithIntroOffer = state.selectedLocalization.offerDetailsWithIntroOffer,
-                textWithMultipleIntroOffers = state.selectedLocalization.offerDetailsWithMultipleIntroOffers,
-                eligibility = state.selectedPackage.value.introEligibility,
-                color = state.templateConfiguration.getCurrentColors().text1,
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.bodyMedium,
-            )
-        }
+        OfferDetails(state)
         PurchaseButton(state, viewModel)
         Footer(templateConfiguration = state.templateConfiguration, viewModel = viewModel)
     }
@@ -125,7 +110,8 @@ private fun Features(
     if (features.isEmpty()) return
 
     Column(
-        modifier = Modifier.verticalScroll(rememberScrollState())
+        modifier = Modifier
+            .verticalScroll(rememberScrollState())
             .fillMaxHeight(),
         verticalArrangement = Arrangement.spacedBy(Template3UIConstants.featureSpacing, Alignment.Top),
     ) {


### PR DESCRIPTION
### Description
Followup to #1365. This adds the offer details to the template 2 when in condensed form. 

https://github.com/RevenueCat/purchases-android/assets/808417/567fa149-f026-4957-ba1c-28b5db88aec0



