### PR TITLE
Paywalls: Predownload offering images if paywalls sdk exists

### DIFF
--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -83,6 +83,7 @@ dependencies {
     implementation libs.playServices.ads.identifier
 
     compileOnly libs.amazon.appstore.sdk
+    compileOnly libs.coil.compose
 
     testImplementation libs.bundles.test
     testImplementation libs.billing

--- a/purchases/consumer-rules.pro
+++ b/purchases/consumer-rules.pro
@@ -3,5 +3,6 @@
 -dontwarn com.google.errorprone.annotations.CanIgnoreReturnValue
 -dontwarn com.google.errorprone.annotations.Immutable
 -dontwarn com.amazon.**
+-dontwarn coil.**
 # Adding temporarily to fix issue after adding kotlin serialization
 -dontwarn java.lang.ClassValue

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -37,6 +37,7 @@ import com.revenuecat.purchases.strings.ConfigureStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesPoster
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
+import com.revenuecat.purchases.utils.OfferingImagePreDownloader
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import java.net.URL
 import java.util.concurrent.ExecutorService
@@ -220,6 +221,7 @@ internal class PurchasesFactory(
                 offeringsCache,
                 backend,
                 OfferingsFactory(billing, offeringParser, dispatcher),
+                OfferingImagePreDownloader(application),
             )
 
             log(LogIntent.DEBUG, ConfigureStrings.DEBUG_ENABLED)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -37,6 +37,7 @@ import com.revenuecat.purchases.strings.ConfigureStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesPoster
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
+import com.revenuecat.purchases.utils.CoilImageDownloader
 import com.revenuecat.purchases.utils.OfferingImagePreDownloader
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import java.net.URL
@@ -221,7 +222,7 @@ internal class PurchasesFactory(
                 offeringsCache,
                 backend,
                 OfferingsFactory(billing, offeringParser, dispatcher),
-                OfferingImagePreDownloader(application),
+                OfferingImagePreDownloader(coilImageDownloader = CoilImageDownloader(application)),
             )
 
             log(LogIntent.DEBUG, ConfigureStrings.DEBUG_ENABLED)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -10,12 +10,14 @@ import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.strings.OfferingStrings
+import com.revenuecat.purchases.utils.OfferingImagePreDownloader
 import org.json.JSONObject
 
 internal class OfferingsManager(
     private val offeringsCache: OfferingsCache,
     private val backend: Backend,
     private val offeringsFactory: OfferingsFactory,
+    private val offeringImagePreDownloader: OfferingImagePreDownloader,
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper()),
 ) {
@@ -93,6 +95,9 @@ internal class OfferingsManager(
                 handleErrorFetchingOfferings(error, onError)
             },
             onSuccess = { offerings ->
+                offerings.current?.let {
+                    offeringImagePreDownloader.preDownloadOfferingImages(it)
+                }
                 offeringsCache.cacheOfferings(offerings, offeringsJSON)
                 dispatch {
                     onSuccess?.invoke(offerings)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
@@ -144,7 +144,10 @@ data class PaywallData(
              * Image displayed as an app icon in a template.
              */
             val icon: String? = null,
-        )
+        ) {
+            internal val all: List<String>
+                get() = listOfNotNull(header, background, icon)
+        }
 
         @Serializable
         data class ColorInformation(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CoilImageDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CoilImageDownloader.kt
@@ -6,10 +6,11 @@ import coil.ImageLoader
 import coil.disk.DiskCache
 import coil.request.ImageRequest
 
+// Note: these values have to match those in RemoteImage
 private const val MAX_CACHE_SIZE_BYTES = 25 * 1024 * 1024L // 25 MB
 private const val PAYWALL_IMAGE_CACHE_FOLDER = "revenuecatui_cache"
 
-class CoilImageDownloader(
+internal class CoilImageDownloader(
     private val applicationContext: Context,
 ) {
     fun downloadImage(uri: Uri) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CoilImageDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CoilImageDownloader.kt
@@ -1,0 +1,36 @@
+package com.revenuecat.purchases.utils
+
+import android.content.Context
+import android.net.Uri
+import coil.ImageLoader
+import coil.disk.DiskCache
+import coil.request.ImageRequest
+
+private const val MAX_CACHE_SIZE_BYTES = 25 * 1024 * 1024L // 25 MB
+private const val PAYWALL_IMAGE_CACHE_FOLDER = "revenuecatui_cache"
+
+class CoilImageDownloader(
+    private val applicationContext: Context,
+) {
+    fun downloadImage(uri: Uri) {
+        val request = ImageRequest.Builder(applicationContext)
+            .data(uri)
+            .build()
+        applicationContext.getRevenueCatUIImageLoader().enqueue(request)
+    }
+}
+
+/**
+ * This downloads paywall images in a specific cache for RevenueCat.
+ * If you update this, make sure the version in the [RemoteImage] composable is also updated.
+ */
+private fun Context.getRevenueCatUIImageLoader(): ImageLoader {
+    return ImageLoader.Builder(this)
+        .diskCache {
+            DiskCache.Builder()
+                .directory(cacheDir.resolve(PAYWALL_IMAGE_CACHE_FOLDER))
+                .maxSizeBytes(MAX_CACHE_SIZE_BYTES)
+                .build()
+        }
+        .build()
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
@@ -13,10 +13,14 @@ private const val MAX_CACHE_SIZE_BYTES = 25 * 1024 * 1024L // 25 MB
 internal class OfferingImagePreDownloader(
     private val applicationContext: Context,
 ) {
+    /**
+     * We check for the existance of the paywalls SDK. If so, the Coil SDK should be available to
+     * pre-download the images.
+     */
     private val shouldPredownloadImages: Boolean = try {
         Class.forName("com.revenuecat.purchases.ui.revenuecatui.PaywallKt")
         true
-    } catch (e: ClassNotFoundException) {
+    } catch (_: ClassNotFoundException) {
         false
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
@@ -1,0 +1,53 @@
+package com.revenuecat.purchases.utils
+
+import android.content.Context
+import android.net.Uri
+import coil.ImageLoader
+import coil.disk.DiskCache
+import coil.request.ImageRequest
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.common.debugLog
+
+private const val MAX_CACHE_SIZE_BYTES = 25 * 1024 * 1024L // 25 MB
+
+class OfferingImagePreDownloader(
+    private val applicationContext: Context,
+) {
+    private val shouldPredownloadImages: Boolean = try {
+        Class.forName("com.revenuecat.purchases.ui.revenuecatui.PaywallKt")
+        true
+    } catch (e: ClassNotFoundException) {
+        false
+    }
+
+    fun preDownloadOfferingImages(offering: Offering) {
+        if (!shouldPredownloadImages) return
+        offering.paywall?.let { paywallData ->
+            val imageUris = paywallData.config.images.all.map {
+                Uri.parse(paywallData.assetBaseURL.toString()).buildUpon().path(it).build()
+            }
+            imageUris.forEach {
+                debugLog("Pre-downloading paywall image: $it")
+                val request = ImageRequest.Builder(applicationContext)
+                    .data(it)
+                    .build()
+                applicationContext.getRevenueCatUIImageLoader().enqueue(request)
+            }
+        }
+    }
+}
+
+/**
+ * This downloads paywall images in a specific cache for RevenueCat.
+ * If you update this, make sure the version in the [RemoteImage] composable is also updated.
+ */
+private fun Context.getRevenueCatUIImageLoader(): ImageLoader {
+    return ImageLoader.Builder(this)
+        .diskCache {
+            DiskCache.Builder()
+                .directory(cacheDir.resolve("revenuecatui_cache"))
+                .maxSizeBytes(MAX_CACHE_SIZE_BYTES)
+                .build()
+        }
+        .build()
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.utils
 import android.net.Uri
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.common.verboseLog
 
 internal class OfferingImagePreDownloader(
     /**
@@ -19,7 +20,13 @@ internal class OfferingImagePreDownloader(
 ) {
 
     fun preDownloadOfferingImages(offering: Offering) {
-        if (!shouldPredownloadImages) return
+        if (!shouldPredownloadImages) {
+            verboseLog("OfferingImagePreDownloader won't pre-download images")
+            return
+        }
+
+        debugLog("OfferingImagePreDownloader: starting image download")
+
         offering.paywall?.let { paywallData ->
             val imageUris = paywallData.config.images.all.map {
                 Uri.parse(paywallData.assetBaseURL.toString()).buildUpon().path(it).build()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
@@ -1,18 +1,10 @@
 package com.revenuecat.purchases.utils
 
-import android.content.Context
 import android.net.Uri
-import coil.ImageLoader
-import coil.disk.DiskCache
-import coil.request.ImageRequest
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.common.debugLog
 
-private const val MAX_CACHE_SIZE_BYTES = 25 * 1024 * 1024L // 25 MB
-
 internal class OfferingImagePreDownloader(
-    private val applicationContext: Context,
-) {
     /**
      * We check for the existance of the paywalls SDK. If so, the Coil SDK should be available to
      * pre-download the images.
@@ -22,7 +14,9 @@ internal class OfferingImagePreDownloader(
         true
     } catch (_: ClassNotFoundException) {
         false
-    }
+    },
+    private val coilImageDownloader: CoilImageDownloader,
+) {
 
     fun preDownloadOfferingImages(offering: Offering) {
         if (!shouldPredownloadImages) return
@@ -32,26 +26,8 @@ internal class OfferingImagePreDownloader(
             }
             imageUris.forEach {
                 debugLog("Pre-downloading paywall image: $it")
-                val request = ImageRequest.Builder(applicationContext)
-                    .data(it)
-                    .build()
-                applicationContext.getRevenueCatUIImageLoader().enqueue(request)
+                coilImageDownloader.downloadImage(it)
             }
         }
     }
-}
-
-/**
- * This downloads paywall images in a specific cache for RevenueCat.
- * If you update this, make sure the version in the [RemoteImage] composable is also updated.
- */
-private fun Context.getRevenueCatUIImageLoader(): ImageLoader {
-    return ImageLoader.Builder(this)
-        .diskCache {
-            DiskCache.Builder()
-                .directory(cacheDir.resolve("revenuecatui_cache"))
-                .maxSizeBytes(MAX_CACHE_SIZE_BYTES)
-                .build()
-        }
-        .build()
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
@@ -10,7 +10,7 @@ import com.revenuecat.purchases.common.debugLog
 
 private const val MAX_CACHE_SIZE_BYTES = 25 * 1024 * 1024L // 25 MB
 
-class OfferingImagePreDownloader(
+internal class OfferingImagePreDownloader(
     private val applicationContext: Context,
 ) {
     private val shouldPredownloadImages: Boolean = try {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.utils.ONE_OFFERINGS_RESPONSE
+import com.revenuecat.purchases.utils.OfferingImagePreDownloader
 import com.revenuecat.purchases.utils.STUB_OFFERING_IDENTIFIER
 import com.revenuecat.purchases.utils.STUB_PRODUCT_IDENTIFIER
 import com.revenuecat.purchases.utils.stubOfferings
@@ -34,6 +35,7 @@ class OfferingsManagerTest {
     private lateinit var cache: OfferingsCache
     private lateinit var backend: Backend
     private lateinit var offeringsFactory: OfferingsFactory
+    private lateinit var offeringImagePreDownloader: OfferingImagePreDownloader
 
     private lateinit var offeringsManager: OfferingsManager
 
@@ -42,13 +44,17 @@ class OfferingsManagerTest {
         cache = mockk()
         backend = mockk()
         offeringsFactory = mockk()
+        offeringImagePreDownloader = mockk<OfferingImagePreDownloader>().apply {
+            every { preDownloadOfferingImages(any()) } just Runs
+        }
 
         mockBackendResponseSuccess()
 
         offeringsManager = OfferingsManager(
             cache,
             backend,
-            offeringsFactory
+            offeringsFactory,
+            offeringImagePreDownloader,
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
@@ -1,0 +1,94 @@
+package com.revenuecat.purchases.utils
+
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.paywalls.PaywallData
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyAll
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.URL
+
+@RunWith(AndroidJUnit4::class)
+class OfferingImagePreDownloaderTest {
+
+    private lateinit var coilImageDownloader: CoilImageDownloader
+
+    private lateinit var preDownloader: OfferingImagePreDownloader
+
+    @Before
+    fun setUp() {
+        coilImageDownloader = mockk<CoilImageDownloader>().apply {
+            every { downloadImage(any()) } just Runs
+        }
+
+        preDownloader = OfferingImagePreDownloader(shouldPredownloadImages = true, coilImageDownloader)
+    }
+
+    @Test
+    fun `downloads images from offering paywall data`() {
+        preDownloader.preDownloadOfferingImages(createOfferings())
+
+        verifyAll {
+            coilImageDownloader.downloadImage(Uri.parse("https://www.revenuecat.com/test_header.png"))
+            coilImageDownloader.downloadImage(Uri.parse("https://www.revenuecat.com/test_background.png"))
+            coilImageDownloader.downloadImage(Uri.parse("https://www.revenuecat.com/test_icon.png"))
+        }
+    }
+
+    @Test
+    fun `if no paywall data, it does not download anything`() {
+        preDownloader.preDownloadOfferingImages(mockk<Offering>().apply { every { paywall } returns null })
+
+        verify(exactly = 0) {
+            coilImageDownloader.downloadImage(any())
+        }
+    }
+
+    @Test
+    fun `if no images, it does not download anything`() {
+        preDownloader.preDownloadOfferingImages(createOfferings(null, null, null))
+
+        verify(exactly = 0) {
+            coilImageDownloader.downloadImage(any())
+        }
+    }
+
+    @Test
+    fun `if disabled, it does not download anything`() {
+        preDownloader = OfferingImagePreDownloader(shouldPredownloadImages = false, coilImageDownloader)
+        preDownloader.preDownloadOfferingImages(createOfferings())
+
+        verify(exactly = 0) {
+            coilImageDownloader.downloadImage(any())
+        }
+    }
+
+    private fun createOfferings(
+        header: String? = "test_header.png",
+        background: String? = "test_background.png",
+        icon: String? = "test_icon.png",
+    ): Offering {
+        return mockk<Offering>().apply {
+            every { paywall } returns PaywallData(
+                templateName = "mock-template",
+                config = mockk<PaywallData.Configuration>().apply {
+                    every { images } returns PaywallData.Configuration.Images(
+                        header = header,
+                        background = background,
+                        icon = icon,
+                    )
+                },
+                assetBaseURL = URL("https://www.revenuecat.com/"),
+                revision = 0,
+                localization = mockk(),
+            )
+        }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
@@ -49,6 +49,10 @@ internal fun RemoteImage(
 
 private const val MAX_CACHE_SIZE_BYTES = 25 * 1024 * 1024L // 25 MB
 
+/**
+ * This downloads paywall images in a specific cache for RevenueCat.
+ * If you update this, make sure the version in the [OfferingImagePreDownloader] class is also updated.
+ */
 @Composable
 @ReadOnlyComposable
 private fun Context.getRevenueCatUIImageLoader(): ImageLoader {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
@@ -47,6 +47,7 @@ internal fun RemoteImage(
     )
 }
 
+// Note: these values have to match those in CoilImageDownloader
 private const val MAX_CACHE_SIZE_BYTES = 25 * 1024 * 1024L // 25 MB
 private const val PAYWALL_IMAGE_CACHE_FOLDER = "revenuecatui_cache"
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
@@ -48,10 +48,11 @@ internal fun RemoteImage(
 }
 
 private const val MAX_CACHE_SIZE_BYTES = 25 * 1024 * 1024L // 25 MB
+private const val PAYWALL_IMAGE_CACHE_FOLDER = "revenuecatui_cache"
 
 /**
  * This downloads paywall images in a specific cache for RevenueCat.
- * If you update this, make sure the version in the [OfferingImagePreDownloader] class is also updated.
+ * If you update this, make sure the version in the [CoilImageDownloader] class is also updated.
  */
 @Composable
 @ReadOnlyComposable
@@ -59,7 +60,7 @@ private fun Context.getRevenueCatUIImageLoader(): ImageLoader {
     return ImageLoader.Builder(this)
         .diskCache {
             DiskCache.Builder()
-                .directory(cacheDir.resolve("revenuecatui_cache"))
+                .directory(cacheDir.resolve(PAYWALL_IMAGE_CACHE_FOLDER))
                 .maxSizeBytes(MAX_CACHE_SIZE_BYTES)
                 .build()
         }


### PR DESCRIPTION
### Description
We want to predownload images from offerings early in the app's lifetime so they are ready when the paywalls are displayed. This PR checks if the paywall sdk is part of the path and if so, and there is a `current` paywall, we download the images.
