### PR TITLE
Paywalls: Small optimization purchase button

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
@@ -1,8 +1,11 @@
 package com.revenuecat.purchases.ui.revenuecatui.composables
 
-import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -15,7 +18,6 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -62,17 +64,6 @@ private fun PurchaseButton(
     ) {
         val context = LocalContext.current
 
-        val labelOpacity by animateFloatAsState(
-            targetValue = if (viewModel.actionInProgress.value) 0.0f else 1.0f,
-            animationSpec = UIConstant.defaultAnimation(),
-            label = "PurchaseButton.label",
-        )
-        val progressIndicatorOpacity by animateFloatAsState(
-            targetValue = if (viewModel.actionInProgress.value) 1.0f else 0.0f,
-            animationSpec = UIConstant.defaultAnimation(),
-            label = "PurchaseButton.progressIndicator",
-        )
-
         Button(
             modifier = Modifier.fillMaxWidth(),
             onClick = { viewModel.purchaseSelectedPackage(context) },
@@ -86,30 +77,56 @@ private fun PurchaseButton(
                     packages = packages.all,
                     selected = selectedPackage.value,
                 ) {
-                    val localization = it.localization
-                    IntroEligibilityStateView(
-                        textWithNoIntroOffer = localization.callToAction,
-                        textWithIntroOffer = localization.callToActionWithIntroOffer,
-                        textWithMultipleIntroOffers = localization.callToActionWithMultipleIntroOffers,
-                        eligibility = it.introEligibility,
-                        color = colors.callToActionForeground,
-                        textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        modifier = Modifier
-                            .padding(vertical = UIConstant.defaultVerticalSpacing / 3)
-                            .alpha(labelOpacity),
-                    )
+                    ButtonLabel(shouldShow = !viewModel.actionInProgress.value, selectedPackage = it, colors = colors)
                 }
 
-                CircularProgressIndicator(
-                    color = colors.callToActionForeground,
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .alpha(progressIndicatorOpacity),
-                )
+                LoadingSpinner(shouldShow = viewModel.actionInProgress.value, colors = colors)
             }
         }
+    }
+}
+
+@Composable
+private fun ButtonLabel(
+    shouldShow: Boolean,
+    selectedPackage: TemplateConfiguration.PackageInfo,
+    colors: TemplateConfiguration.Colors,
+) {
+    val localization = selectedPackage.localization
+    AnimatedVisibility(
+        visible = shouldShow,
+        enter = fadeIn(animationSpec = UIConstant.defaultAnimation()),
+        exit = fadeOut(animationSpec = UIConstant.defaultAnimation()),
+        label = "PurchaseButton.label",
+    ) {
+        IntroEligibilityStateView(
+            textWithNoIntroOffer = localization.callToAction,
+            textWithIntroOffer = localization.callToActionWithIntroOffer,
+            textWithMultipleIntroOffers = localization.callToActionWithMultipleIntroOffers,
+            eligibility = selectedPackage.introEligibility,
+            color = colors.callToActionForeground,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier
+                .padding(vertical = UIConstant.defaultVerticalSpacing / 3),
+        )
+    }
+}
+
+@Composable
+private fun BoxScope.LoadingSpinner(shouldShow: Boolean, colors: TemplateConfiguration.Colors) {
+    AnimatedVisibility(
+        visible = shouldShow,
+        modifier = Modifier.align(Alignment.Center),
+        enter = fadeIn(animationSpec = UIConstant.defaultAnimation()),
+        exit = fadeOut(animationSpec = UIConstant.defaultAnimation()),
+        label = "PurchaseButton.LoadingSpinner",
+    ) {
+        CircularProgressIndicator(
+            color = colors.callToActionForeground,
+            modifier = Modifier.align(Alignment.Center),
+        )
     }
 }
 


### PR DESCRIPTION
### Description
This changes the animations for the purchase button to use `AnimatedVisibility` which actually removes the composable when the animation ends, making sure the progress indicator is not rendered without need, causing CPU usage
