### PR TITLE
`Paywalls`: optimize backwards compatible blurring

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/BlurTransformation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/BlurTransformation.kt
@@ -4,9 +4,11 @@ import android.renderscript.Allocation
 import android.renderscript.Element
 import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicBlur
+import androidx.annotation.VisibleForTesting
 import coil.size.Size
 import coil.transform.Transformation
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 /**
  * BlurTransformation class applies a blur on a given Bitmap image.
@@ -33,14 +35,17 @@ internal class BlurTransformation(
 // max radius supported by RenderScript
 private const val MAX_SUPPORTED_RADIUS = 25f
 
-internal fun Bitmap.blur(context: Context, radius: Float = MAX_SUPPORTED_RADIUS): Bitmap {
+@VisibleForTesting
+internal fun Bitmap.blur(context: Context, radius: Float, scaleDown: Boolean = true): Bitmap {
     if (radius < 1f) {
         return this@blur
     }
     val updatedRadius = min(radius.toDouble(), MAX_SUPPORTED_RADIUS.toDouble())
 
+    val bitmap = if (scaleDown) this.scaledDown() else this
+
     val rs = RenderScript.create(context)
-    val input = Allocation.createFromBitmap(rs, this)
+    val input = Allocation.createFromBitmap(rs, bitmap)
     val output = Allocation.createTyped(rs, input.type)
     val script = ScriptIntrinsicBlur.create(rs, Element.U8_4(rs))
 
@@ -48,7 +53,7 @@ internal fun Bitmap.blur(context: Context, radius: Float = MAX_SUPPORTED_RADIUS)
     script.setInput(input)
     script.forEach(output)
 
-    val blurredBitmap = Bitmap.createBitmap(width, height, config)
+    val blurredBitmap = Bitmap.createBitmap(bitmap.width, bitmap.height, config)
     output.copyTo(blurredBitmap)
 
     input.destroy()
@@ -57,4 +62,14 @@ internal fun Bitmap.blur(context: Context, radius: Float = MAX_SUPPORTED_RADIUS)
     rs.destroy()
 
     return blurredBitmap
+}
+
+private fun Bitmap.scaledDown(): Bitmap {
+    val maxImageSize = 400
+
+    val ratio = min(maxImageSize.toFloat() / width, maxImageSize.toFloat() / height)
+    val width = (ratio * width).roundToInt()
+    val height = (ratio * height).roundToInt()
+
+    return Bitmap.createScaledBitmap(this, width, height, true)
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/BlurTransformation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/BlurTransformation.kt
@@ -32,15 +32,18 @@ internal class BlurTransformation(
     }
 }
 
-// max radius supported by RenderScript
-private const val MAX_SUPPORTED_RADIUS = 25f
+private object BlurConstants {
+    // max radius supported by RenderScript
+    const val maxSupportedRadius = 25f
+    const val maxImageSize = 400
+}
 
 @VisibleForTesting
 internal fun Bitmap.blur(context: Context, radius: Float, scaleDown: Boolean = true): Bitmap {
     if (radius < 1f) {
         return this@blur
     }
-    val updatedRadius = min(radius.toDouble(), MAX_SUPPORTED_RADIUS.toDouble())
+    val updatedRadius = min(radius.toDouble(), BlurConstants.maxSupportedRadius.toDouble())
 
     val bitmap = if (scaleDown) this.scaledDown() else this
 
@@ -65,9 +68,10 @@ internal fun Bitmap.blur(context: Context, radius: Float, scaleDown: Boolean = t
 }
 
 private fun Bitmap.scaledDown(): Bitmap {
-    val maxImageSize = 400
-
-    val ratio = min(maxImageSize.toFloat() / width, maxImageSize.toFloat() / height)
+    val ratio = min(
+        BlurConstants.maxImageSize.toFloat() / width,
+        BlurConstants.maxImageSize.toFloat() / height,
+    )
     val width = (ratio * width).roundToInt()
     val height = (ratio * height).roundToInt()
 


### PR DESCRIPTION
This accomplishes 2 things:
- Optimizes blurring algorithm by only blurring a smaller version of the image
- Fixes the blur not having a large enough radius (because of the `25` limit by `RenderScript`

### Before:
![Blur before](https://github.com/RevenueCat/purchases-android/assets/685609/27592e91-f926-4178-8ff1-6822789f8e3d)

### After:
![Blur after](https://github.com/RevenueCat/purchases-android/assets/685609/d5e4b900-3c46-48d8-84a5-ed399f7b6062)
