### PR TITLE
`Paywalls`: fixed incorrect background on footer

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases.ui.revenuecatui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -69,7 +68,6 @@ private fun LoadedPaywall(state: PaywallState.Loaded, viewModel: PaywallViewMode
                         ),
                     )
                     .background(backgroundColor)
-                    .padding(top = UIConstant.footerRoundedBorderHeight)
             },
     ) {
         TemplatePaywall(state = state, viewModel = viewModel)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -116,6 +117,8 @@ private fun ColumnScope.Template1MainContent(state: PaywallState.Loaded) {
 
             Spacer(modifier = Modifier.weight(2f))
         }
+    } else {
+        Spacer(modifier = Modifier.height(UIConstant.defaultVerticalSpacing))
     }
 
     OfferDetails(state)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -89,7 +90,18 @@ internal fun Template2(
                 mutableStateOf(state.templateConfiguration.mode != PaywallMode.FOOTER_CONDENSED)
             }
             Template2MainContent(state, viewModel, packageSelectorVisible, childModifier)
+
+            AnimatedVisibility(
+                visible = packageSelectorVisible,
+                enter = fadeIn(animationSpec = UIConstant.defaultAnimation()),
+                exit = fadeOut(animationSpec = UIConstant.defaultAnimation()),
+                label = "Template2.packageSpacig",
+            ) {
+                Spacer(modifier = Modifier.height(UIConstant.defaultVerticalSpacing))
+            }
+
             PurchaseButton(state, viewModel, childModifier)
+
             Footer(
                 templateConfiguration = state.templateConfiguration,
                 viewModel = viewModel,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -89,6 +89,9 @@ internal fun Template2(
             var packageSelectorVisible by remember {
                 mutableStateOf(state.templateConfiguration.mode != PaywallMode.FOOTER_CONDENSED)
             }
+
+            Spacer(modifier = Modifier.height(UIConstant.defaultVerticalSpacing))
+
             Template2MainContent(state, viewModel, packageSelectorVisible, childModifier)
 
             AnimatedVisibility(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -74,6 +75,9 @@ internal fun Template3(
                 Template3MainContent(state)
             }
         }
+
+        Spacer(modifier = Modifier.height(UIConstant.defaultVerticalSpacing))
+
         OfferDetails(state)
         PurchaseButton(state, viewModel)
         Footer(templateConfiguration = state.templateConfiguration, viewModel = viewModel)


### PR DESCRIPTION
### Before:
![Screenshot 2023-10-20 at 14 06 30](https://github.com/RevenueCat/purchases-android/assets/685609/78d386f1-fc52-4417-b3fc-e0ab74403d27)

### After:
![Rounded corner after](https://github.com/RevenueCat/purchases-android/assets/685609/d16a3cd3-672c-4771-83b2-9bc495077e3b)
