### PR TITLE
`Paywalls`: improve error handling

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallTesterApp.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallTesterApp.kt
@@ -52,7 +52,7 @@ private fun AppNavHost(
             route = AppScreen.Paywall.route.plus("/{${PaywallScreenViewModel.OFFERING_ID_KEY}}"),
             arguments = listOf(navArgument(PaywallScreenViewModel.OFFERING_ID_KEY) { type = NavType.StringType }),
         ) {
-            PaywallScreen()
+            PaywallScreen(dismissRequest = navController::popBackStack)
         }
         composable(
             route = AppScreen.PaywallFooter.route
@@ -68,7 +68,9 @@ private fun AppNavHost(
                 },
             ),
         ) {
-            PaywallFooterScreen()
+            PaywallFooterScreen(
+                dismissRequest = navController::popBackStack,
+            )
         }
     }
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
@@ -28,13 +28,10 @@ import com.revenuecat.paywallstester.SamplePaywalls
 import com.revenuecat.paywallstester.SamplePaywallsLoader
 import com.revenuecat.paywallstester.ui.screens.paywallfooter.SamplePaywall
 import com.revenuecat.paywallstester.ui.theme.googleFont
-import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
-import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialog
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions
 import com.revenuecat.purchases.ui.revenuecatui.PaywallFooter
-import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
@@ -102,7 +99,6 @@ private fun FullScreenDialog(currentState: DisplayPaywallState.FullScreen, onDis
     PaywallDialog(
         PaywallDialogOptions.Builder(dismissRequest = onDismiss)
             .setOffering(currentState.offering)
-            .setListener(PaywallListenerImpl(onDismiss))
             .setFontProvider(currentState.fontProvider)
             .build(),
     )
@@ -119,7 +115,6 @@ private fun FooterDialog(currentState: DisplayPaywallState.Footer, onDismiss: ()
                 PaywallFooter(
                     options = PaywallOptions.Builder(dismissRequest = onDismiss)
                         .setOffering(currentState.offering)
-                        .setListener(PaywallListenerImpl(onDismiss))
                         .build(),
                     condensed = currentState.condensed,
                 ) { footerPadding ->
@@ -140,12 +135,6 @@ private sealed class DisplayPaywallState {
         val offering: Offering? = null,
         val condensed: Boolean = false,
     ) : DisplayPaywallState()
-}
-
-private class PaywallListenerImpl(private val onDismiss: () -> Unit) : PaywallListener {
-    override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
-        onDismiss()
-    }
 }
 
 @Composable

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
@@ -117,7 +117,7 @@ private fun FooterDialog(currentState: DisplayPaywallState.Footer, onDismiss: ()
         Scaffold { scaffoldPadding ->
             Box(modifier = Modifier.padding(scaffoldPadding)) {
                 PaywallFooter(
-                    options = PaywallOptions.Builder()
+                    options = PaywallOptions.Builder(dismissRequest = onDismiss)
                         .setOffering(currentState.offering)
                         .setListener(PaywallListenerImpl(onDismiss))
                         .build(),

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreen.kt
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 @Composable
 fun PaywallScreen(
     viewModel: PaywallScreenViewModel = viewModel<PaywallScreenViewModelImpl>(),
+    dismissRequest: () -> Unit,
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -32,7 +33,7 @@ fun PaywallScreen(
             }
             is PaywallScreenState.Loaded -> {
                 Paywall(
-                    PaywallOptions.Builder()
+                    PaywallOptions.Builder(dismissRequest)
                         .setOffering(state.offering)
                         .setListener(viewModel)
                         .build(),

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywallfooter/PaywallFooterScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywallfooter/PaywallFooterScreen.kt
@@ -25,6 +25,7 @@ import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 @Composable
 fun PaywallFooterScreen(
     viewModel: PaywallScreenViewModel = viewModel<PaywallScreenViewModelImpl>(),
+    dismissRequest: () -> Unit,
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -40,7 +41,7 @@ fun PaywallFooterScreen(
             }
             is PaywallScreenState.Loaded -> {
                 PaywallFooter(
-                    options = PaywallOptions.Builder()
+                    options = PaywallOptions.Builder(dismissRequest)
                         .setOffering(state.offering)
                         .setListener(viewModel)
                         .build(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -3,13 +3,19 @@ package com.revenuecat.purchases.ui.revenuecatui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
@@ -32,8 +38,7 @@ internal fun InternalPaywall(
 ) {
     PaywallTheme(fontProvider = options.fontProvider) {
         viewModel.refreshStateIfLocaleChanged()
-        val colors = MaterialTheme.colorScheme
-        viewModel.refreshStateIfColorsChanged(colors)
+        viewModel.refreshStateIfColorsChanged(MaterialTheme.colorScheme)
 
         when (val state = viewModel.state.collectAsState().value) {
             is PaywallState.Loading -> {
@@ -41,7 +46,12 @@ internal fun InternalPaywall(
             }
 
             is PaywallState.Error -> {
-                Text(text = "Error: ${state.errorMessage}")
+                LoadingPaywall(mode = options.mode)
+
+                ErrorDialog(
+                    dismissRequest = options.dismissRequest,
+                    error = state.errorMessage,
+                )
             }
 
             is PaywallState.Loaded -> {
@@ -100,5 +110,29 @@ private fun getPaywallViewModel(
             MaterialTheme.colorScheme,
             preview = isInPreviewMode(),
         ),
+    )
+}
+
+@Composable
+private fun ErrorDialog(
+    dismissRequest: () -> Unit,
+    error: String,
+) {
+    AlertDialog(
+        onDismissRequest = dismissRequest,
+        confirmButton = {
+            TextButton(
+                onClick = dismissRequest,
+            ) {
+                Text(
+                    text = stringResource(id = R.string.OK),
+                    textAlign = TextAlign.Center,
+                )
+            }
+        },
+        icon = { Icon(painter = painterResource(id = R.drawable.error), contentDescription = null) },
+        text = {
+            Text(text = error)
+        },
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/Paywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/Paywall.kt
@@ -6,10 +6,7 @@ import androidx.compose.runtime.Composable
  * Composable offering a full screen Paywall UI configured from the RevenueCat dashboard.
  * @param options The options to configure the [Paywall] if needed.
  */
-@Suppress("unused")
 @Composable
-fun Paywall(
-    options: PaywallOptions = PaywallOptions.Builder().build(),
-) {
+fun Paywall(options: PaywallOptions) {
     InternalPaywall(options)
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -24,7 +24,7 @@ class PaywallDialogOptions(builder: Builder) {
     }
 
     internal fun toPaywallOptions(): PaywallOptions {
-        return PaywallOptions.Builder()
+        return PaywallOptions.Builder(dismissRequest)
             .setOffering(offering)
             .setShouldDisplayDismissButton(shouldDisplayDismissButton)
             .setFontProvider(fontProvider)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
  */
 @Composable
 fun PaywallFooter(
-    options: PaywallOptions = PaywallOptions.Builder().build(),
+    options: PaywallOptions,
     condensed: Boolean = false,
     mainContent: @Composable (PaddingValues) -> Unit,
 ) {
@@ -52,7 +52,9 @@ fun PaywallFooter(
 @Preview(showBackground = true)
 @Composable
 private fun PaywallFooterPreview() {
-    PaywallFooter {
+    PaywallFooter(
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
@@ -12,5 +12,4 @@ interface PaywallListener {
     fun onRestoreStarted() {}
     fun onRestoreCompleted(customerInfo: CustomerInfo) {}
     fun onRestoreError(error: PurchasesError) {}
-    fun onCloseButtonPressed() {}
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -26,19 +26,23 @@ internal sealed class OfferingSelection {
 class PaywallOptions(builder: Builder) {
 
     internal val offeringSelection: OfferingSelection
-    val shouldDisplayDismissButton: Boolean
+    private val shouldDisplayDismissButton: Boolean
     val fontProvider: FontProvider?
     val listener: PaywallListener?
     internal var mode: PaywallMode = PaywallMode.default
+    val dismissRequest: () -> Unit
 
     init {
         this.offeringSelection = builder.offeringSelection
         this.shouldDisplayDismissButton = builder.shouldDisplayDismissButton
         this.fontProvider = builder.fontProvider
         this.listener = builder.listener
+        this.dismissRequest = builder.dismissRequest
     }
 
-    class Builder {
+    class Builder(
+        internal val dismissRequest: () -> Unit,
+    ) {
         internal var offeringSelection: OfferingSelection = OfferingSelection.None
         internal var shouldDisplayDismissButton: Boolean = false
         internal var fontProvider: FontProvider? = null

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -74,7 +74,7 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val paywallOptions = PaywallOptions.Builder()
+        val paywallOptions = PaywallOptions.Builder(dismissRequest = ::finish)
             .setOfferingId(getArgs()?.offeringId)
             .setFontProvider(getFontProvider())
             .setListener(this)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -159,6 +159,7 @@ internal class PaywallViewModelImpl(
                     PurchaseParams.Builder(activity, packageToPurchase),
                 )
                 listener?.onPurchaseCompleted(purchaseResult.customerInfo, purchaseResult.storeTransaction)
+                options.dismissRequest()
             } catch (e: PurchasesException) {
                 listener?.onPurchaseError(e.error)
             }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
@@ -141,7 +141,7 @@ internal fun DefaultPaywallPreview() {
         serverDescription = "",
     )
     InternalPaywall(
-        options = PaywallOptions.Builder().build(),
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
         viewModel = MockViewModel(offering = template2Offering),
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -177,34 +177,34 @@ private object Template1UIConstants {
 
 @Preview(showBackground = true)
 @Composable
-internal fun Template1PaywallPreview() {
+private fun Template1PaywallPreview() {
     InternalPaywall(
-        options = PaywallOptions.Builder().build(),
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
         viewModel = MockViewModel(offering = TestData.template1Offering),
     )
 }
 
 @Preview(showBackground = true)
 @Composable
-internal fun Template1FooterPaywallPreview() {
+private fun Template1FooterPaywallPreview() {
     InternalPaywall(
-        options = PaywallOptions.Builder().build(),
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
         viewModel = MockViewModel(mode = PaywallMode.FOOTER, offering = TestData.template1Offering),
     )
 }
 
 @Preview(showBackground = true)
 @Composable
-internal fun Template1CondensedFooterPaywallPreview() {
+private fun Template1CondensedFooterPaywallPreview() {
     InternalPaywall(
-        options = PaywallOptions.Builder().build(),
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
         viewModel = MockViewModel(mode = PaywallMode.FOOTER_CONDENSED, offering = TestData.template1Offering),
     )
 }
 
 @Preview(heightDp = 700, widthDp = 400)
 @Composable
-internal fun CircleMaskPreview() {
+private fun CircleMaskPreview() {
     Box {
         Box(
             modifier = Modifier

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -305,7 +305,7 @@ private fun CheckmarkBox(isSelected: Boolean, colors: TemplateConfiguration.Colo
 @Composable
 private fun Template2PaywallPreview() {
     InternalPaywall(
-        options = PaywallOptions.Builder().build(),
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
         viewModel = MockViewModel(offering = TestData.template2Offering),
     )
 }
@@ -315,7 +315,7 @@ private fun Template2PaywallPreview() {
 @Composable
 private fun Template2PaywallFooterPreview() {
     InternalPaywall(
-        options = PaywallOptions.Builder().build(),
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
         viewModel = MockViewModel(mode = PaywallMode.FOOTER, offering = TestData.template2Offering),
     )
 }
@@ -325,7 +325,7 @@ private fun Template2PaywallFooterPreview() {
 @Composable
 private fun Template2PaywallFooterCondensedPreview() {
     InternalPaywall(
-        options = PaywallOptions.Builder().build(),
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
         viewModel = MockViewModel(mode = PaywallMode.FOOTER_CONDENSED, offering = TestData.template2Offering),
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
@@ -186,7 +186,7 @@ private fun Feature(
 @Composable
 private fun Template3Preview() {
     InternalPaywall(
-        options = PaywallOptions.Builder().build(),
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
         viewModel = MockViewModel(offering = TestData.template3Offering),
     )
 }
@@ -195,7 +195,7 @@ private fun Template3Preview() {
 @Composable
 private fun Template3FooterPreview() {
     InternalPaywall(
-        options = PaywallOptions.Builder().build(),
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
         viewModel = MockViewModel(mode = PaywallMode.FOOTER, offering = TestData.template3Offering),
     )
 }
@@ -204,7 +204,7 @@ private fun Template3FooterPreview() {
 @Composable
 private fun Template3CondensedFooterPreview() {
     InternalPaywall(
-        options = PaywallOptions.Builder().build(),
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
         viewModel = MockViewModel(mode = PaywallMode.FOOTER_CONDENSED, offering = TestData.template3Offering),
     )
 }

--- a/ui/revenuecatui/src/main/res/values-ar/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ar/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">نعم</string>
     <string name="all_plans">كل الاشتراكات</string>
     <string name="privacy">خصوصية</string>
     <string name="privacy_policy">سياسة الخصوصية</string>

--- a/ui/revenuecatui/src/main/res/values-bg/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-bg/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">Добре</string>
     <string name="all_plans">Всички абонаменти</string>
     <string name="privacy">поверителност</string>
     <string name="privacy_policy">Политика за поверителност</string>

--- a/ui/revenuecatui/src/main/res/values-ca/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ca/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">D\'acord</string>
     <string name="all_plans">Totes les subscripcions</string>
     <string name="privacy">Privadesa</string>
     <string name="privacy_policy">Política de privacitat</string>

--- a/ui/revenuecatui/src/main/res/values-cs/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-cs/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">OK</string>
     <string name="all_plans">Všechna předplatná</string>
     <string name="privacy">Soukromí</string>
     <string name="privacy_policy">Zásady ochrany osobních údajů</string>

--- a/ui/revenuecatui/src/main/res/values-da/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-da/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">Okay</string>
     <string name="all_plans">Alle abonnementer</string>
     <string name="privacy">Privatliv</string>
     <string name="privacy_policy">Fortrolighedspolitik</string>

--- a/ui/revenuecatui/src/main/res/values-de/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-de/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">OK</string>
     <string name="all_plans">Alle Abonnements</string>
     <string name="privacy">Privatsphäre</string>
     <string name="privacy_policy">Datenschutzrichtlinie</string>

--- a/ui/revenuecatui/src/main/res/values-el/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-el/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">Εντάξει</string>
     <string name="all_plans">Όλες οι συνδρομές</string>
     <string name="privacy">Μυστικότητα</string>
     <string name="privacy_policy">Πολιτική απορρήτου</string>

--- a/ui/revenuecatui/src/main/res/values-es/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-es/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">OK</string>
     <string name="restore_purchases">Restaurar las compras</string>
     <string name="restore">Restaurar</string>
     <string name="terms_and_conditions">Términos y condiciones</string>

--- a/ui/revenuecatui/src/main/res/values-fi/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-fi/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">OK</string>
     <string name="all_plans">Kaikki tilaukset</string>
     <string name="privacy">Yksityisyys</string>
     <string name="privacy_policy">Tietosuojakäytäntö</string>

--- a/ui/revenuecatui/src/main/res/values-fr/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-fr/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">D\'ACCORD</string>
     <string name="privacy">Confidentialité</string>
     <string name="privacy_policy">Politique de confidentialité</string>
     <string name="restore">Restaurer</string>

--- a/ui/revenuecatui/src/main/res/values-he/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-he/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">בסדר</string>
     <string name="all_plans">כל המנויים</string>
     <string name="privacy">פְּרָטִיוּת</string>
     <string name="privacy_policy">מדיניות הפרטיות</string>

--- a/ui/revenuecatui/src/main/res/values-hi/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-hi/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">ठीक है</string>
     <string name="all_plans">सभी सदस्यताएँ</string>
     <string name="privacy">गोपनीयता</string>
     <string name="privacy_policy">गोपनीयता नीति</string>

--- a/ui/revenuecatui/src/main/res/values-hr/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-hr/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">u redu</string>
     <string name="all_plans">Sve pretplate</string>
     <string name="privacy">Privatnost</string>
     <string name="privacy_policy">Politika privatnosti</string>

--- a/ui/revenuecatui/src/main/res/values-hu/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-hu/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">rendben</string>
     <string name="all_plans">Minden előfizetés</string>
     <string name="privacy">Magánélet</string>
     <string name="privacy_policy">Adatvédelmi irányelvek</string>

--- a/ui/revenuecatui/src/main/res/values-id/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-id/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">OKE</string>
     <string name="all_plans">Semua langganan</string>
     <string name="privacy">Pribadi</string>
     <string name="privacy_policy">Kebijakan pribadi</string>

--- a/ui/revenuecatui/src/main/res/values-it/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-it/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">OK</string>
     <string name="all_plans">Tutti gli abbonamenti</string>
     <string name="privacy">Riservatezza</string>
     <string name="privacy_policy">Politica sulla riservatezza</string>

--- a/ui/revenuecatui/src/main/res/values-ja/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ja/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">わかりました</string>
     <string name="all_plans">すべてのサブスクリプション</string>
     <string name="privacy">プライバシー</string>
     <string name="privacy_policy">プライバシーポリシー</string>

--- a/ui/revenuecatui/src/main/res/values-kk/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-kk/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">ЖАРАЙДЫ МА</string>
     <string name="all_plans">Барлық жазылымдар</string>
     <string name="privacy">Құпиялық</string>
     <string name="privacy_policy">Құпиялылық саясаты</string>

--- a/ui/revenuecatui/src/main/res/values-ko/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ko/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">좋아요</string>
     <string name="all_plans">모든 구독</string>
     <string name="privacy">은둔</string>
     <string name="privacy_policy">개인 정보 정책</string>

--- a/ui/revenuecatui/src/main/res/values-ms/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ms/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">okey</string>
     <string name="all_plans">Semua langganan</string>
     <string name="privacy">Privasi</string>
     <string name="privacy_policy">Dasar privasi</string>

--- a/ui/revenuecatui/src/main/res/values-nl/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-nl/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">OK</string>
     <string name="all_plans">Alle abonnementen</string>
     <string name="privacy">Privacy</string>
     <string name="privacy_policy">Privacybeleid</string>

--- a/ui/revenuecatui/src/main/res/values-no/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-no/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">OK</string>
     <string name="all_plans">Alle abonnementer</string>
     <string name="privacy">Personvern</string>
     <string name="privacy_policy">Personvernerklæring</string>

--- a/ui/revenuecatui/src/main/res/values-pl/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-pl/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">OK</string>
     <string name="all_plans">Wszystkie subskrypcje</string>
     <string name="privacy">Prywatność</string>
     <string name="privacy_policy">Polityka prywatności</string>

--- a/ui/revenuecatui/src/main/res/values-pt/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-pt/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">OK</string>
     <string name="privacy">Privacidade</string>
     <string name="privacy_policy">Política de Privacidade</string>
     <string name="restore">Restaurar</string>

--- a/ui/revenuecatui/src/main/res/values-ro/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ro/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">Bine</string>
     <string name="all_plans">Toate abonamentele</string>
     <string name="privacy">Confidențialitate</string>
     <string name="privacy_policy">Politica de confidențialitate</string>

--- a/ui/revenuecatui/src/main/res/values-ru/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ru/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">ХОРОШО</string>
     <string name="all_plans">Все подписки</string>
     <string name="privacy">Конфиденциальность</string>
     <string name="privacy_policy">Политика конфиденциальности</string>

--- a/ui/revenuecatui/src/main/res/values-sk/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-sk/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">OK</string>
     <string name="all_plans">Všetky odbery</string>
     <string name="privacy">Ochrana osobných údajov</string>
     <string name="privacy_policy">Zásady ochrany osobných údajov</string>

--- a/ui/revenuecatui/src/main/res/values-sv/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-sv/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">OK</string>
     <string name="all_plans">Alla prenumerationer</string>
     <string name="privacy">Integritet</string>
     <string name="privacy_policy">Integritetspolicy</string>

--- a/ui/revenuecatui/src/main/res/values-th/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-th/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">ตกลง</string>
     <string name="all_plans">การสมัครทั้งหมด</string>
     <string name="privacy">ความเป็นส่วนตัว</string>
     <string name="privacy_policy">นโยบายความเป็นส่วนตัว</string>

--- a/ui/revenuecatui/src/main/res/values-tr/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-tr/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">TAMAM</string>
     <string name="all_plans">Tüm abonelikler</string>
     <string name="privacy">Mahremiyet</string>
     <string name="privacy_policy">Gizlilik Politikası</string>

--- a/ui/revenuecatui/src/main/res/values-uk/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-uk/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">в порядку</string>
     <string name="all_plans">Всі підписки</string>
     <string name="privacy">Конфіденційність</string>
     <string name="privacy_policy">Політика конфіденційності</string>

--- a/ui/revenuecatui/src/main/res/values-vi/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-vi/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">ĐƯỢC RỒI</string>
     <string name="all_plans">Tất cả đăng ký</string>
     <string name="privacy">Sự riêng tư</string>
     <string name="privacy_policy">Chính sách bảo mật</string>

--- a/ui/revenuecatui/src/main/res/values-zh-rHK/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-zh-rHK/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">好的</string>
     <string name="privacy">隱私</string>
     <string name="privacy_policy">隱私政策</string>
     <string name="restore">恢復</string>

--- a/ui/revenuecatui/src/main/res/values-zh-rTW/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-zh-rTW/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">好的</string>
     <string name="privacy">隱私</string>
     <string name="privacy_policy">隱私政策</string>
     <string name="restore">恢復</string>

--- a/ui/revenuecatui/src/main/res/values/strings.xml
+++ b/ui/revenuecatui/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="OK">OK</string>
     <string name="restore_purchases">Restore purchases</string>
     <string name="restore">Restore</string>
     <string name="terms_and_conditions">Terms and conditions</string>

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -50,6 +50,8 @@ class PaywallViewModelTest {
     private lateinit var activity: Activity
     private lateinit var listener: PaywallListener
 
+    private var dismissInvoked = false
+
     private val offerings = Offerings(
         defaultOffering,
         mapOf(
@@ -70,6 +72,8 @@ class PaywallViewModelTest {
         context = mockk()
 
         listener = mockk()
+
+        dismissInvoked = false
 
         // Allows mocking Context.getActivity
         mockkStatic("com.revenuecat.purchases.ui.revenuecatui.extensions.ContextExtensionsKt")
@@ -110,13 +114,14 @@ class PaywallViewModelTest {
         }
 
         assertThat(model.actionInProgress.value).isFalse
+        assertThat(dismissInvoked).isFalse
     }
 
     @Test
     fun `Should load default offering`() {
         val model = create(
             activeSubscriptions = setOf(TestData.Packages.monthly.product.id),
-            nonSubscriptionTransactionProductIdentifiers = setOf(TestData.Packages.lifetime.product.id),
+            nonSubscriptionTransactionProductIdentifiers = setOf(TestData.Packages.lifetime.product.id)
         )
 
         coVerify { purchases.awaitOfferings() }
@@ -190,6 +195,8 @@ class PaywallViewModelTest {
             purchases.awaitPurchase(any())
         } returns PurchaseResult(transaction, customerInfo)
 
+        assertThat(dismissInvoked).isFalse
+
         model.purchaseSelectedPackage(context)
 
         coVerify {
@@ -202,6 +209,7 @@ class PaywallViewModelTest {
         }
 
         assertThat(model.actionInProgress.value).isFalse
+        assertThat(dismissInvoked).isTrue
     }
 
     @Test
@@ -230,6 +238,7 @@ class PaywallViewModelTest {
         }
 
         assertThat(model.actionInProgress.value).isFalse
+        assertThat(dismissInvoked).isFalse
     }
 
     private fun create(
@@ -243,7 +252,7 @@ class PaywallViewModelTest {
         return PaywallViewModelImpl(
             MockApplicationContext(),
             purchases,
-            PaywallOptions.Builder(dismissRequest = {})
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
                 .setListener(listener)
                 .setOffering(offering)
                 .build(),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -243,7 +243,7 @@ class PaywallViewModelTest {
         return PaywallViewModelImpl(
             MockApplicationContext(),
             purchases,
-            PaywallOptions.Builder()
+            PaywallOptions.Builder(dismissRequest = {})
                 .setListener(listener)
                 .setOffering(offering)
                 .build(),


### PR DESCRIPTION
This makes `PaywallOptions.Builder` require a `dismissRequest`.
We can get away with not requiring it in iOS because we rely on `@Environment(\.dismiss)`.

This allows us to handle errors in an uniform way and always dismiss the paywall when something fails.

Note that this is only when `PaywallViewModel.state` becomes `Error`. Paywall validation simply logs errors and displays the default template.