### PR TITLE
`Paywalls`: display purchase/restore errors

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreenViewModel.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreenViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.viewModelScope
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
-import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.awaitOfferings
 import com.revenuecat.purchases.models.StoreTransaction
@@ -66,16 +65,7 @@ class PaywallScreenViewModelImpl(
         }
     }
 
-    override fun onRestoreError(error: PurchasesError) {
-        val value = _state.value
-        if (value is PaywallScreenState.Loaded) {
-            _state.update {
-                value.copy(
-                    dialogText = "There was an error restoring purchases:\n${error.message}",
-                )
-            }
-        }
-    }
+    override fun onRestoreError(error: PurchasesError) = Unit
 
     override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
         val value = _state.value
@@ -88,18 +78,7 @@ class PaywallScreenViewModelImpl(
         }
     }
 
-    override fun onPurchaseError(error: PurchasesError) {
-        val value = _state.value
-        if (value is PaywallScreenState.Loaded) {
-            if (error.code != PurchasesErrorCode.PurchaseCancelledError) {
-                _state.update {
-                    value.copy(
-                        dialogText = "There was an error purchasing:\n${error.message}",
-                    )
-                }
-            }
-        }
-    }
+    override fun onPurchaseError(error: PurchasesError) = Unit
 
     override fun onDialogDismissed() {
         val value = _state.value

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -56,6 +56,13 @@ internal fun InternalPaywall(
 
             is PaywallState.Loaded -> {
                 LoadedPaywall(state = state, viewModel = viewModel)
+
+                viewModel.actionError.value?.let {
+                    ErrorDialog(
+                        dismissRequest = viewModel::clearActionError,
+                        error = it.message,
+                    )
+                }
             }
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.TestStoreProduct
@@ -155,6 +156,7 @@ private class LoadingViewModel(
         get() = _state.asStateFlow()
 
     override val actionInProgress: State<Boolean> = mutableStateOf(false)
+    override val actionError: State<PurchasesError?> = mutableStateOf(null)
 
     override fun refreshStateIfLocaleChanged() = Unit
     override fun refreshStateIfColorsChanged(colorScheme: ColorScheme) = Unit
@@ -176,6 +178,8 @@ private class LoadingViewModel(
     override fun openURL(url: URL, context: Context) {
         error("Can't open URL")
     }
+
+    override fun clearActionError() = Unit
 }
 
 @Preview(showBackground = true)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -3,7 +3,6 @@ package com.revenuecat.purchases.ui.revenuecatui.data.testdata
 import android.content.Context
 import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.State
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
@@ -11,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.TestStoreProduct
@@ -261,7 +261,9 @@ internal class MockViewModel(
     override val state: StateFlow<PaywallState>
         get() = _state.asStateFlow()
     override val actionInProgress: State<Boolean>
-        get() = derivedStateOf { _actionInProgress.value }
+        get() = _actionInProgress
+    override val actionError: State<PurchasesError?>
+        get() = _actionError
 
     fun loadedState(): PaywallState.Loaded? {
         return when (val state = state.value) {
@@ -283,6 +285,7 @@ internal class MockViewModel(
     )
 
     private val _actionInProgress = mutableStateOf(false)
+    private val _actionError = mutableStateOf<PurchasesError?>(null)
 
     override fun refreshStateIfLocaleChanged() = Unit
     override fun refreshStateIfColorsChanged(colorScheme: ColorScheme) = Unit
@@ -310,6 +313,8 @@ internal class MockViewModel(
     override fun openURL(url: URL, context: Context) {
         error("Can't open URL")
     }
+
+    override fun clearActionError() = Unit
 
     private fun simulateActionInProgress() {
         viewModelScope.launch {


### PR DESCRIPTION
![image](https://github.com/RevenueCat/purchases-android/assets/685609/e3252302-9c78-4b07-819a-c24b950d7ed3)
