### PR TITLE
`Paywalls`: `PaywallDialogOptions` no longer requires `dismissRequest`

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -26,13 +26,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.paywallstester.MainActivity
-import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
-import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialog
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions
-import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -124,17 +121,9 @@ private fun OfferingsListScreen(
 
     if (displayPaywallDialogOffering != null) {
         PaywallDialog(
-            PaywallDialogOptions.Builder(
-                dismissRequest = {
-                    displayPaywallDialogOffering = null
-                },
-            )
+            PaywallDialogOptions.Builder()
+                .setDismissRequest { displayPaywallDialogOffering = null }
                 .setOffering(displayPaywallDialogOffering)
-                .setListener(object : PaywallListener {
-                    override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
-                        displayPaywallDialogOffering = null
-                    }
-                })
                 .build(),
         )
     }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
@@ -97,7 +97,8 @@ fun PaywallsScreen(
 @Composable
 private fun FullScreenDialog(currentState: DisplayPaywallState.FullScreen, onDismiss: () -> Unit) {
     PaywallDialog(
-        PaywallDialogOptions.Builder(dismissRequest = onDismiss)
+        PaywallDialogOptions.Builder()
+            .setDismissRequest(onDismiss)
             .setOffering(currentState.offering)
             .setFontProvider(currentState.fontProvider)
             .build(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.Dialog
@@ -29,7 +29,7 @@ fun PaywallDialog(
     paywallDialogOptions: PaywallDialogOptions,
 ) {
     val shouldDisplayBlock = paywallDialogOptions.shouldDisplayBlock
-    var shouldDisplayDialog by remember { mutableStateOf(shouldDisplayBlock == null) }
+    var shouldDisplayDialog by rememberSaveable { mutableStateOf(shouldDisplayBlock == null) }
     if (shouldDisplayBlock != null) {
         LaunchedEffect(paywallDialogOptions) {
             launch {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -38,24 +38,26 @@ fun PaywallDialog(
         }
     }
     if (shouldDisplayDialog) {
+        val dismissRequest = { shouldDisplayDialog = false }
+
         Dialog(
-            onDismissRequest = paywallDialogOptions.dismissRequest,
+            onDismissRequest = dismissRequest,
             properties = DialogProperties(usePlatformDefaultWidth = shouldUsePlatformDefaultWidth()),
         ) {
-            DialogScaffold(paywallDialogOptions)
+            DialogScaffold(paywallDialogOptions.toPaywallOptions(dismissRequest))
         }
     }
 }
 
 @Composable
-private fun DialogScaffold(paywallDialogOptions: PaywallDialogOptions) {
+private fun DialogScaffold(paywallOptions: PaywallOptions) {
     Scaffold(modifier = Modifier.fillMaxSize()) { paddingValues ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues),
         ) {
-            Paywall(paywallDialogOptions.toPaywallOptions())
+            Paywall(paywallOptions)
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -7,8 +7,8 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayBlockForEnt
 
 class PaywallDialogOptions(builder: Builder) {
 
-    val dismissRequest: () -> Unit
     val shouldDisplayBlock: ((CustomerInfo) -> Boolean)?
+    val dismissRequest: (() -> Unit)?
     val offering: Offering?
     val shouldDisplayDismissButton: Boolean
     val fontProvider: FontProvider?
@@ -23,8 +23,11 @@ class PaywallDialogOptions(builder: Builder) {
         this.listener = builder.listener
     }
 
-    internal fun toPaywallOptions(): PaywallOptions {
-        return PaywallOptions.Builder(dismissRequest)
+    internal fun toPaywallOptions(dismissRequest: () -> Unit): PaywallOptions {
+        return PaywallOptions.Builder {
+            dismissRequest()
+            this.dismissRequest?.invoke()
+        }
             .setOffering(offering)
             .setShouldDisplayDismissButton(shouldDisplayDismissButton)
             .setFontProvider(fontProvider)
@@ -32,10 +35,9 @@ class PaywallDialogOptions(builder: Builder) {
             .build()
     }
 
-    class Builder(
-        val dismissRequest: () -> Unit,
-    ) {
+    class Builder {
         internal var shouldDisplayBlock: ((CustomerInfo) -> Boolean)? = null
+        internal var dismissRequest: (() -> Unit)? = null
         internal var offering: Offering? = null
         internal var shouldDisplayDismissButton: Boolean = true
         internal var fontProvider: FontProvider? = null
@@ -55,6 +57,10 @@ class PaywallDialogOptions(builder: Builder) {
             requiredEntitlementIdentifier?.let { requiredEntitlementIdentifier ->
                 this.shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier)
             }
+        }
+
+        fun setDismissRequest(dismissRequest: () -> Unit) = apply {
+            this.dismissRequest = dismissRequest
         }
 
         fun setOffering(offering: Offering?) = apply {


### PR DESCRIPTION
`PaywallDialog` works by presenting paywalls automatically based on a provided condition. Because of this, it should also know how to dismiss itself. I changed it to implement this automatically, but also provide a way to optionally pass a block for it.

Also updated the docs to reflect the new APIs: https://github.com/RevenueCat/revenuecat-docs/pull/450