### PR TITLE
Paywalls: Add close button option

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -13,8 +13,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
@@ -23,6 +21,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant.defaultAnimation
+import com.revenuecat.purchases.ui.revenuecatui.composables.CloseButton
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelFactory
@@ -55,7 +54,11 @@ internal fun InternalPaywall(
             enter = fadeIn(animationSpec = defaultAnimation()),
             exit = fadeOut(animationSpec = defaultAnimation()),
         ) {
-            LoadingPaywall(mode = options.mode)
+            LoadingPaywall(
+                mode = options.mode,
+                shouldDisplayDismissButton = options.shouldDisplayDismissButton,
+                onDismiss = viewModel::closeButtonPressed,
+            )
         }
 
         AnimatedVisibility(
@@ -108,6 +111,7 @@ private fun LoadedPaywall(state: PaywallState.Loaded, viewModel: PaywallViewMode
             },
     ) {
         TemplatePaywall(state = state, viewModel = viewModel)
+        CloseButton(state.shouldDisplayDismissButton, viewModel::closeButtonPressed)
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.TestStoreProduct
 import com.revenuecat.purchases.paywalls.PaywallData
+import com.revenuecat.purchases.ui.revenuecatui.composables.CloseButton
 import com.revenuecat.purchases.ui.revenuecatui.composables.DisableTouchesComposable
 import com.revenuecat.purchases.ui.revenuecatui.composables.Fade
 import com.revenuecat.purchases.ui.revenuecatui.composables.PlaceholderDefaults
@@ -39,7 +40,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 @Composable
-internal fun LoadingPaywall(mode: PaywallMode) {
+internal fun LoadingPaywall(
+    mode: PaywallMode,
+    shouldDisplayDismissButton: Boolean,
+    onDismiss: () -> Unit,
+) {
     val applicationContext = LocalContext.current.applicationContext.toAndroidContext()
 
     val paywallData: PaywallData = PaywallData.createDefault(
@@ -66,6 +71,7 @@ internal fun LoadingPaywall(mode: PaywallMode) {
         mode = mode,
         validatedPaywallData = paywallData,
         template = LoadingPaywallConstants.template,
+        shouldDisplayDismissButton = shouldDisplayDismissButton,
     )
 
     when (state) {
@@ -75,28 +81,35 @@ internal fun LoadingPaywall(mode: PaywallMode) {
         is PaywallState.Loading,
         -> Box {}
 
-        is PaywallState.Loaded -> LoadingPaywall(state, LoadingViewModel(state))
+        is PaywallState.Loaded -> LoadingPaywall(state, LoadingViewModel(state), onDismiss)
     }
 }
 
 @Composable
-private fun LoadingPaywall(state: PaywallState.Loaded, viewModel: PaywallViewModel) {
-    DisableTouchesComposable {
-        // Template
-        Template2(
-            state = state,
-            viewModel = viewModel,
-            childModifier = Modifier
-                .placeholder(
-                    visible = true,
-                    shape = RoundedCornerShape(UIConstant.defaultPackageCornerRadius),
-                    highlight = Fade(
-                        highlightColor = LoadingPaywallConstants.placeholderColor,
-                        animationSpec = PlaceholderDefaults.fadeAnimationSpec,
+private fun LoadingPaywall(
+    state: PaywallState.Loaded,
+    viewModel: PaywallViewModel,
+    onDismiss: () -> Unit,
+) {
+    Box {
+        DisableTouchesComposable {
+            // Template
+            Template2(
+                state = state,
+                viewModel = viewModel,
+                childModifier = Modifier
+                    .placeholder(
+                        visible = true,
+                        shape = RoundedCornerShape(UIConstant.defaultPackageCornerRadius),
+                        highlight = Fade(
+                            highlightColor = LoadingPaywallConstants.placeholderColor,
+                            animationSpec = PlaceholderDefaults.fadeAnimationSpec,
+                        ),
+                        color = LoadingPaywallConstants.placeholderColor,
                     ),
-                    color = LoadingPaywallConstants.placeholderColor,
-                ),
-        )
+            )
+        }
+        CloseButton(state.shouldDisplayDismissButton, onDismiss)
     }
 }
 
@@ -166,6 +179,10 @@ private class LoadingViewModel(
         error("Not supported")
     }
 
+    override fun closeButtonPressed() {
+        error("Not supported")
+    }
+
     override fun purchaseSelectedPackage(context: Context) {
         error("Can't purchase loading view model")
     }
@@ -180,5 +197,9 @@ private class LoadingViewModel(
 @Preview(showBackground = true)
 @Composable
 internal fun LoadingPaywallPreview() {
-    LoadingPaywall(mode = PaywallMode.FULL_SCREEN)
+    LoadingPaywall(
+        mode = PaywallMode.FULL_SCREEN,
+        shouldDisplayDismissButton = false,
+        onDismiss = {},
+    )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -68,6 +68,9 @@ class PaywallDialogOptions(builder: Builder) {
             this.offering = offering
         }
 
+        /**
+         * Sets whether to display a close button on the paywall screen. Defaults to true.
+         */
         fun setShouldDisplayDismissButton(shouldDisplayDismissButton: Boolean) = apply {
             this.shouldDisplayDismissButton = shouldDisplayDismissButton
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
@@ -44,8 +44,12 @@ fun PaywallFooter(
         ) {
             mainContent(PaddingValues(bottom = UIConstant.defaultCornerRadius))
         }
-        options.mode = PaywallMode.footerMode(condensed)
-        Paywall(options)
+        Paywall(
+            options.copy(
+                mode = PaywallMode.footerMode(condensed),
+                shouldDisplayDismissButton = false,
+            ),
+        )
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -27,7 +27,7 @@ internal sealed class OfferingSelection {
 class PaywallOptions(builder: Builder) {
 
     internal val offeringSelection: OfferingSelection
-    private val shouldDisplayDismissButton: Boolean
+    internal val shouldDisplayDismissButton: Boolean
     val fontProvider: FontProvider?
     val listener: PaywallListener?
     internal var mode: PaywallMode = PaywallMode.default
@@ -59,6 +59,10 @@ class PaywallOptions(builder: Builder) {
                 ?: OfferingSelection.None
         }
 
+        /**
+         * Sets whether to display a close button on the paywall screen. Only available when using
+         * [Paywall], not [PaywallFooter]. Defaults to false.
+         */
         fun setShouldDisplayDismissButton(shouldDisplayDismissButton: Boolean) = apply {
             this.shouldDisplayDismissButton = shouldDisplayDismissButton
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -30,7 +30,7 @@ class PaywallOptions(builder: Builder) {
     internal val shouldDisplayDismissButton: Boolean
     val fontProvider: FontProvider?
     val listener: PaywallListener?
-    internal var mode: PaywallMode = PaywallMode.default
+    internal val mode: PaywallMode
     val dismissRequest: () -> Unit
 
     init {
@@ -38,7 +38,33 @@ class PaywallOptions(builder: Builder) {
         this.shouldDisplayDismissButton = builder.shouldDisplayDismissButton
         this.fontProvider = builder.fontProvider
         this.listener = builder.listener
+        this.mode = builder.mode
         this.dismissRequest = builder.dismissRequest
+    }
+
+    @Suppress("LongParameterList")
+    internal fun copy(
+        offeringSelection: OfferingSelection? = null,
+        shouldDisplayDismissButton: Boolean? = null,
+        fontProvider: FontProvider? = null,
+        listener: PaywallListener? = null,
+        mode: PaywallMode? = null,
+        dismissRequest: (() -> Unit)? = null,
+    ): PaywallOptions {
+        return Builder(dismissRequest ?: this.dismissRequest)
+            .apply {
+                when (offeringSelection) {
+                    is OfferingSelection.OfferingId -> setOfferingId(offeringSelection.offeringId)
+                    is OfferingSelection.OfferingType -> setOffering(offeringSelection.offeringType)
+                    is OfferingSelection.None -> OfferingSelection.None
+                    null -> this.offeringSelection
+                }
+            }
+            .setShouldDisplayDismissButton(shouldDisplayDismissButton ?: this.shouldDisplayDismissButton)
+            .setFontProvider(fontProvider ?: this.fontProvider)
+            .setListener(listener ?: this.listener)
+            .setMode(mode ?: this.mode)
+            .build()
     }
 
     class Builder(
@@ -48,6 +74,7 @@ class PaywallOptions(builder: Builder) {
         internal var shouldDisplayDismissButton: Boolean = false
         internal var fontProvider: FontProvider? = null
         internal var listener: PaywallListener? = null
+        internal var mode: PaywallMode = PaywallMode.default
 
         fun setOffering(offering: Offering?) = apply {
             this.offeringSelection = offering?.let { OfferingSelection.OfferingType(it) }
@@ -61,7 +88,7 @@ class PaywallOptions(builder: Builder) {
 
         /**
          * Sets whether to display a close button on the paywall screen. Only available when using
-         * [Paywall], not [PaywallFooter]. Defaults to false.
+         * [Paywall]. Ignored when using [PaywallFooter]. Defaults to false.
          */
         fun setShouldDisplayDismissButton(shouldDisplayDismissButton: Boolean) = apply {
             this.shouldDisplayDismissButton = shouldDisplayDismissButton
@@ -73,6 +100,10 @@ class PaywallOptions(builder: Builder) {
 
         fun setListener(listener: PaywallListener?) = apply {
             this.listener = listener
+        }
+
+        internal fun setMode(mode: PaywallMode) = apply {
+            this.mode = mode
         }
 
         fun build(): PaywallOptions {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -44,25 +44,19 @@ class PaywallOptions(builder: Builder) {
 
     @Suppress("LongParameterList")
     internal fun copy(
-        offeringSelection: OfferingSelection? = null,
-        shouldDisplayDismissButton: Boolean? = null,
-        fontProvider: FontProvider? = null,
-        listener: PaywallListener? = null,
-        mode: PaywallMode? = null,
-        dismissRequest: (() -> Unit)? = null,
+        offeringSelection: OfferingSelection = this.offeringSelection,
+        shouldDisplayDismissButton: Boolean = this.shouldDisplayDismissButton,
+        fontProvider: FontProvider? = this.fontProvider,
+        listener: PaywallListener? = this.listener,
+        mode: PaywallMode = this.mode,
+        dismissRequest: () -> Unit = this.dismissRequest,
     ): PaywallOptions {
-        return Builder(dismissRequest ?: this.dismissRequest)
-            .apply {
-                when (val offeringSelectionToCheck = offeringSelection ?: this@PaywallOptions.offeringSelection) {
-                    is OfferingSelection.OfferingId -> setOfferingId(offeringSelectionToCheck.offeringId)
-                    is OfferingSelection.OfferingType -> setOffering(offeringSelectionToCheck.offeringType)
-                    is OfferingSelection.None -> { /* Do nothing */ }
-                }
-            }
-            .setShouldDisplayDismissButton(shouldDisplayDismissButton ?: this.shouldDisplayDismissButton)
-            .setFontProvider(fontProvider ?: this.fontProvider)
-            .setListener(listener ?: this.listener)
-            .setMode(mode ?: this.mode)
+        return Builder(dismissRequest)
+            .setOfferingSelection(offeringSelection)
+            .setShouldDisplayDismissButton(shouldDisplayDismissButton)
+            .setFontProvider(fontProvider)
+            .setListener(listener)
+            .setMode(mode)
             .build()
     }
 
@@ -78,6 +72,10 @@ class PaywallOptions(builder: Builder) {
         fun setOffering(offering: Offering?) = apply {
             this.offeringSelection = offering?.let { OfferingSelection.OfferingType(it) }
                 ?: OfferingSelection.None
+        }
+
+        internal fun setOfferingSelection(offeringSelection: OfferingSelection?) = apply {
+            this.offeringSelection = offeringSelection ?: OfferingSelection.None
         }
 
         internal fun setOfferingId(offeringId: String?) = apply {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -53,11 +53,10 @@ class PaywallOptions(builder: Builder) {
     ): PaywallOptions {
         return Builder(dismissRequest ?: this.dismissRequest)
             .apply {
-                when (offeringSelection) {
-                    is OfferingSelection.OfferingId -> setOfferingId(offeringSelection.offeringId)
-                    is OfferingSelection.OfferingType -> setOffering(offeringSelection.offeringType)
-                    is OfferingSelection.None -> OfferingSelection.None
-                    null -> this.offeringSelection
+                when (val offeringSelectionToCheck = offeringSelection ?: this@PaywallOptions.offeringSelection) {
+                    is OfferingSelection.OfferingId -> setOfferingId(offeringSelectionToCheck.offeringId)
+                    is OfferingSelection.OfferingType -> setOffering(offeringSelectionToCheck.offeringType)
+                    is OfferingSelection.None -> { /* Do nothing */ }
                 }
             }
             .setShouldDisplayDismissButton(shouldDisplayDismissButton ?: this.shouldDisplayDismissButton)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -76,9 +76,11 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val args = getArgs()
         val paywallOptions = PaywallOptions.Builder(dismissRequest = ::finish)
-            .setOfferingId(getArgs()?.offeringId)
+            .setOfferingId(args?.offeringId)
             .setFontProvider(getFontProvider())
+            .setShouldDisplayDismissButton(args?.shouldDisplayDismissButton ?: DEFAULT_DISPLAY_DISMISS_BUTTON)
             .setListener(this)
             .build()
         setContent {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
@@ -7,14 +7,22 @@ import com.revenuecat.purchases.ui.revenuecatui.fonts.PaywallFontFamily
 import com.revenuecat.purchases.ui.revenuecatui.fonts.TypographyType
 import kotlinx.parcelize.Parcelize
 
+internal const val DEFAULT_DISPLAY_DISMISS_BUTTON = true
+
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Parcelize
 internal data class PaywallActivityArgs(
     val offeringId: String? = null,
     val fonts: Map<TypographyType, PaywallFontFamily?>? = null,
+    val shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
 ) : Parcelable {
-    constructor(offeringId: String? = null, fontProvider: ParcelizableFontProvider?) : this(
+    constructor(
+        offeringId: String? = null,
+        fontProvider: ParcelizableFontProvider?,
+        shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
+    ) : this(
         offeringId,
         fontProvider?.let { TypographyType.values().associateBy({ it }, { fontProvider.getFont(it) }) },
+        shouldDisplayDismissButton,
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -45,13 +45,19 @@ class PaywallActivityLauncher {
      * @param offering The offering to be shown in the paywall. If null, the current offering will be shown.
      * @param fontProvider The [ParcelizableFontProvider] to be used in the paywall. If null, the default fonts
      * will be used.
+     * @param shouldDisplayDismissButton Whether to display the dismiss button in the paywall.
      */
     @JvmOverloads
-    fun launch(offering: Offering? = null, fontProvider: ParcelizableFontProvider? = null) {
+    fun launch(
+        offering: Offering? = null,
+        fontProvider: ParcelizableFontProvider? = null,
+        shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
+    ) {
         activityResultLauncher.launch(
             PaywallActivityArgs(
                 offeringId = offering?.identifier,
                 fontProvider = fontProvider,
+                shouldDisplayDismissButton = shouldDisplayDismissButton,
             ),
         )
     }
@@ -63,17 +69,20 @@ class PaywallActivityLauncher {
      * will be used.
      * @param requiredEntitlementIdentifier the paywall will be displayed only if the current user does not
      * have this entitlement active.
+     * @param shouldDisplayDismissButton Whether to display the dismiss button in the paywall.
      */
     @JvmOverloads
     fun launchIfNeeded(
         offering: Offering? = null,
         fontProvider: ParcelizableFontProvider? = null,
         requiredEntitlementIdentifier: String,
+        shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
     ) {
         launchIfNeeded(
             offering = offering,
             fontProvider = fontProvider,
             shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier),
+            shouldDisplayDismissButton = shouldDisplayDismissButton,
         )
     }
 
@@ -82,12 +91,14 @@ class PaywallActivityLauncher {
      * @param offering The offering to be shown in the paywall. If null, the current offering will be shown.
      * @param fontProvider The [ParcelizableFontProvider] to be used in the paywall. If null, the default fonts
      * will be used.
+     * @param shouldDisplayDismissButton Whether to display the dismiss button in the paywall.
      * @param shouldDisplayBlock the paywall will be displayed only if this returns true.
      */
     @JvmOverloads
     fun launchIfNeeded(
         offering: Offering? = null,
         fontProvider: ParcelizableFontProvider? = null,
+        shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
         shouldDisplayBlock: (CustomerInfo) -> Boolean,
     ) {
         shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
@@ -96,6 +107,7 @@ class PaywallActivityLauncher {
                     PaywallActivityArgs(
                         offeringId = offering?.identifier,
                         fontProvider = fontProvider,
+                        shouldDisplayDismissButton = shouldDisplayDismissButton,
                     ),
                 )
             }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/CloseButton.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/CloseButton.kt
@@ -1,0 +1,22 @@
+package com.revenuecat.purchases.ui.revenuecatui.composables
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import com.revenuecat.purchases.ui.revenuecatui.R
+
+@Composable
+fun BoxScope.CloseButton(shouldDisplayDismissButton: Boolean, onClick: () -> Unit) {
+    if (shouldDisplayDismissButton) {
+        IconButton(
+            onClick = onClick,
+            modifier = Modifier.align(Alignment.TopStart),
+        ) {
+            Icon(painter = painterResource(id = R.drawable.close), contentDescription = null)
+        }
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -16,9 +16,14 @@ internal sealed class PaywallState {
     data class Loaded(
         val templateConfiguration: TemplateConfiguration,
         val selectedPackage: MutableState<TemplateConfiguration.PackageInfo>,
+        val shouldDisplayDismissButton: Boolean,
     ) : PaywallState() {
-        constructor(templateConfiguration: TemplateConfiguration, selectedPackage: TemplateConfiguration.PackageInfo) :
-            this(templateConfiguration, mutableStateOf(selectedPackage))
+        constructor(
+            templateConfiguration: TemplateConfiguration,
+            selectedPackage: TemplateConfiguration.PackageInfo,
+            shouldDisplayDismissButton: Boolean,
+        ) :
+            this(templateConfiguration, mutableStateOf(selectedPackage), shouldDisplayDismissButton)
 
         fun selectPackage(packageInfo: TemplateConfiguration.PackageInfo) {
             selectedPackage.value = packageInfo

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -40,6 +40,7 @@ internal interface PaywallViewModel {
     fun refreshStateIfLocaleChanged()
     fun refreshStateIfColorsChanged(colorScheme: ColorScheme)
     fun selectPackage(packageToSelect: TemplateConfiguration.PackageInfo)
+    fun closeButtonPressed()
 
     /**
      * Purchase the selected package
@@ -110,6 +111,11 @@ internal class PaywallViewModelImpl(
                 Logger.e("Unexpected state trying to select package: $currentState")
             }
         }
+    }
+
+    override fun closeButtonPressed() {
+        Logger.d("Paywalls: Close button pressed.")
+        options.dismissRequest()
     }
 
     override fun purchaseSelectedPackage(context: Context) {
@@ -229,6 +235,7 @@ internal class PaywallViewModelImpl(
             mode = mode,
             validatedPaywallData = displayablePaywall,
             template = template,
+            shouldDisplayDismissButton = options.shouldDisplayDismissButton,
         )
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -296,6 +296,7 @@ internal class MockViewModel(
             mode = mode,
             validatedPaywallData = offering.paywall!!,
             template = PaywallTemplate.fromId(offering.paywall!!.templateName)!!,
+            shouldDisplayDismissButton = false,
         ),
     )
 
@@ -306,6 +307,10 @@ internal class MockViewModel(
     override fun refreshStateIfColorsChanged(colorScheme: ColorScheme) = Unit
 
     override fun selectPackage(packageToSelect: TemplateConfiguration.PackageInfo) {
+        error("Not supported")
+    }
+
+    override fun closeButtonPressed() {
         error("Not supported")
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -75,6 +75,7 @@ internal fun Offering.toPaywallState(
     mode: PaywallMode,
     validatedPaywallData: PaywallData,
     template: PaywallTemplate,
+    shouldDisplayDismissButton: Boolean,
 ): PaywallState {
     val createTemplateConfigurationResult = TemplateConfigurationFactory.create(
         variableDataProvider = variableDataProvider,
@@ -91,6 +92,7 @@ internal fun Offering.toPaywallState(
     return PaywallState.Loaded(
         templateConfiguration = templateConfiguration,
         selectedPackage = templateConfiguration.packages.default,
+        shouldDisplayDismissButton = shouldDisplayDismissButton,
     )
 }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptionsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptionsTest.kt
@@ -1,0 +1,29 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import androidx.compose.ui.text.font.FontFamily
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PaywallOptionsTest {
+
+    @Test
+    fun `copy copies the same options but with the overwritten parameters`() {
+        val options = PaywallOptions.Builder { }
+            .setOfferingId("offeringId")
+            .setShouldDisplayDismissButton(true)
+            .setListener(object : PaywallListener {})
+            .setFontProvider(CustomFontProvider(FontFamily.Default))
+            .setMode(PaywallMode.footerMode(true))
+            .build()
+        val copy = options.copy(shouldDisplayDismissButton = false)
+        assertThat(copy.offeringSelection).isEqualTo(options.offeringSelection)
+        assertThat(copy.fontProvider).isEqualTo(options.fontProvider)
+        assertThat(copy.listener).isEqualTo(options.listener)
+        assertThat(copy.mode).isEqualTo(options.mode)
+        assertThat(copy.shouldDisplayDismissButton).isFalse
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptionsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptionsTest.kt
@@ -7,6 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @RunWith(AndroidJUnit4::class)
 class PaywallOptionsTest {
 
@@ -25,5 +26,18 @@ class PaywallOptionsTest {
         assertThat(copy.listener).isEqualTo(options.listener)
         assertThat(copy.mode).isEqualTo(options.mode)
         assertThat(copy.shouldDisplayDismissButton).isFalse
+    }
+
+    @Test
+    fun `copy assigns null value to copy if copying with null value`() {
+        val options = PaywallOptions.Builder { }
+            .setOfferingId("offeringId")
+            .setShouldDisplayDismissButton(true)
+            .setListener(object : PaywallListener {})
+            .setFontProvider(CustomFontProvider(FontFamily.Default))
+            .setMode(PaywallMode.footerMode(true))
+            .build()
+        val copy = options.copy(listener = null)
+        assertThat(copy.listener).isNull()
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -330,6 +330,15 @@ class PaywallViewModelTest {
         assertThat(model.actionError.value).isNull()
     }
 
+    @Test
+    fun `close button pressed`() {
+        val model = create()
+
+        assertThat(dismissInvoked).isFalse
+        model.closeButtonPressed()
+        assertThat(dismissInvoked).isTrue
+    }
+
     private fun create(
         offering: Offering? = null,
         activeSubscriptions: Set<String> = setOf(),


### PR DESCRIPTION
### Description
This adds a close button to the paywall that can be displayed when using the `Paywall` composable, the `PaywallDialog` or the `PaywallActivityLauncher`.
![image](https://github.com/RevenueCat/purchases-android/assets/808417/8bb00201-6d1f-45a5-a6cd-8d8cbb241a03)

