### PR TITLE
`Paywalls`: fixed accessibility across templates

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/AdaptiveComposable.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/AdaptiveComposable.kt
@@ -19,12 +19,15 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.Constraints
 
 @Composable
-internal fun RowScope.AdaptiveComposable(composables: List<@Composable () -> Unit>) {
+internal fun RowScope.AdaptiveComposable(
+    modifier: Modifier = Modifier,
+    composables: List<@Composable () -> Unit>,
+) {
     var maxSize by remember { mutableStateOf(0) }
     val viewSizes = remember { mutableStateListOf<Int>().also { it.addAll(List(composables.size) { 0 }) } }
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .onGloballyPositioned { coordinates ->
                 if (coordinates.size.width != maxSize) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
@@ -27,6 +27,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.text
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -165,6 +169,8 @@ private fun RowScope.Button(
         return first + second
     }
 
+    val firstText = stringResource(texts.first())
+
     Column(
         modifier = Modifier
             .weight(1f)
@@ -173,11 +179,18 @@ private fun RowScope.Button(
         TextButton(
             onClick = action::invoke,
             contentPadding = PaddingValues(4.dp),
-            modifier = Modifier.align(CenterHorizontally),
+            modifier = Modifier
+                .align(CenterHorizontally)
+                .semantics(mergeDescendants = true) {
+                    // Accessibility will see only the largest text
+                    text = AnnotatedString(firstText)
+                },
         ) {
             // Find the first view that fits, starting from the longest text and fitting in one line,
             // ending with the shortest in multiple lines.
             AdaptiveComposable(
+                // Ignore children as accessibility elements
+                modifier = Modifier.clearAndSetSemantics {},
                 merge(
                     texts.map {
                         {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
@@ -27,17 +27,13 @@ internal fun IntroEligibilityStateView(
     textAlign: TextAlign? = null,
     modifier: Modifier = Modifier,
 ) {
-    val text: String = when (eligibility) {
-        IntroOfferEligibility.SINGLE_OFFER_ELIGIBLE -> textWithIntroOffer
-        IntroOfferEligibility.MULTIPLE_OFFERS_ELIGIBLE -> textWithMultipleIntroOffers
-        else -> textWithNoIntroOffer
-    } // Display text with intro offer as a backup to ensure layout does not change when switching states.
-        ?: textWithNoIntroOffer
-        ?: textWithIntroOffer
-        ?: ""
-
     Crossfade(
-        targetState = text,
+        targetState = introEligibilityText(
+            eligibility,
+            textWithIntroOffer,
+            textWithMultipleIntroOffers,
+            textWithNoIntroOffer,
+        ),
         animationSpec = UIConstant.defaultAnimation(),
         label = "IntroEligibilityStateView",
     ) {
@@ -50,6 +46,22 @@ internal fun IntroEligibilityStateView(
             modifier = modifier,
         )
     }
+}
+
+internal fun introEligibilityText(
+    eligibility: IntroOfferEligibility,
+    textWithIntroOffer: String?,
+    textWithMultipleIntroOffers: String?,
+    textWithNoIntroOffer: String?,
+): String {
+    return when (eligibility) {
+        IntroOfferEligibility.SINGLE_OFFER_ELIGIBLE -> textWithIntroOffer
+        IntroOfferEligibility.MULTIPLE_OFFERS_ELIGIBLE -> textWithMultipleIntroOffers
+        else -> textWithNoIntroOffer
+    } // Display text with intro offer as a backup to ensure layout does not change when switching states.
+        ?: textWithNoIntroOffer
+        ?: textWithIntroOffer
+        ?: ""
 }
 
 internal enum class IntroOfferEligibility {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
@@ -58,6 +58,7 @@ internal fun PurchaseButton(
     }
 }
 
+@Suppress("LongMethod")
 @Composable
 private fun PurchaseButton(
     colors: TemplateConfiguration.Colors,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
@@ -26,6 +26,10 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.text
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -80,6 +84,17 @@ private fun PurchaseButton(
         Button(
             modifier = Modifier
                 .fillMaxWidth()
+                .semantics(mergeDescendants = true) {
+                    val p = selectedPackage.value
+                    text = AnnotatedString(
+                        introEligibilityText(
+                            eligibility = p.introEligibility,
+                            textWithIntroOffer = p.localization.callToActionWithIntroOffer,
+                            textWithMultipleIntroOffers = p.localization.callToActionWithMultipleIntroOffers,
+                            textWithNoIntroOffer = p.localization.callToAction,
+                        ),
+                    )
+                }
                 .background(
                     brush = buttonBrush(colors),
                     shape = ButtonDefaults.shape,
@@ -90,7 +105,10 @@ private fun PurchaseButton(
                 contentColor = colors.callToActionForeground,
             ),
         ) {
-            Box {
+            Box(
+                // Ignore children as accessibility elements
+                modifier = Modifier.clearAndSetSemantics {},
+            ) {
                 ConsistentPackageContentView(
                     packages = packages.all,
                     selected = selectedPackage.value,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -249,7 +251,10 @@ private fun ColumnScope.SelectPackageButton(
         modifier = childModifier
             .fillMaxWidth()
             .alpha(buttonAlpha)
-            .align(Alignment.Start),
+            .align(Alignment.Start)
+            .semantics {
+                selected = isSelected
+            },
         onClick = { viewModel.selectPackage(packageInfo) },
         colors = ButtonDefaults.buttonColors(containerColor = background, contentColor = textColor),
         shape = RoundedCornerShape(UIConstant.defaultPackageCornerRadius),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -141,7 +142,8 @@ private fun Feature(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = UIConstant.defaultHorizontalPadding)
-            .padding(top = Template3UIConstants.iconPadding * 2),
+            .padding(top = Template3UIConstants.iconPadding * 2)
+            .semantics(mergeDescendants = true) {},
     ) {
         feature.iconID?.let { PaywallIconName.fromValue(it) }?.let { icon ->
             Box(


### PR DESCRIPTION
### Improvements:
- `PurchaseButton` is now accessible and will only read the relevant text
- `Footer` is fully accessible and will read the largest text even if it's not displayed
- `Template2` provides context on what package is selected
- `Template3` combines feature elements into a single accessibility element

https://github.com/RevenueCat/purchases-android/assets/685609/77bae51f-0f52-4c57-b642-62aefa3fc8b7