### PR TITLE
`Paywalls`: increase `PaywallBackground` blur radius to match iOS

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PaywallBackground.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PaywallBackground.kt
@@ -60,7 +60,7 @@ internal fun BoxScope.PaywallBackground(templateConfiguration: TemplateConfigura
 }
 
 private object BackgroundUIConstants {
-    val blurSize = 40.dp
+    val blurSize = 60.dp
     val contentScale = ContentScale.Crop
     const val blurAlpha = 0.7f
     const val minSDKVersionSupportingBlur = 31


### PR DESCRIPTION
### Before:
![Screenshot 2023-10-25 at 17 09 35](https://github.com/RevenueCat/purchases-android/assets/685609/47dcb4d4-f5f6-4d4d-8baa-d1676ca18472)

### After:

![Screenshot 2023-10-25 at 17 07 24](https://github.com/RevenueCat/purchases-android/assets/685609/35e367d6-c1b8-4a7b-b422-c8203d2db1e6)
