### PR TITLE
`Paywalls`: decode empty images as `null`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -15,9 +15,11 @@ import org.json.JSONObject
 
 internal abstract class OfferingParser {
 
-    // TODO-PAYWALLS: uncomment after testing
-    private val json = Json {
-        ignoreUnknownKeys = true
+    companion object {
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal val json = Json {
+            ignoreUnknownKeys = true
+        }
     }
 
     protected abstract fun findMatchingProduct(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/EmptyStringToNullSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/EmptyStringToNullSerializer.kt
@@ -1,0 +1,33 @@
+package com.revenuecat.purchases.paywalls
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Decodes empty or blank strings as null
+ */
+internal object EmptyStringToNullSerializer : KSerializer<String?> {
+    private val delegate = String.serializer().nullable
+
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(
+        "EmptyStringToNullSerializer",
+        PrimitiveKind.STRING,
+    )
+
+    override fun deserialize(decoder: Decoder): String? {
+        return delegate.deserialize(decoder)?.takeIf(String::isNotBlank)
+    }
+
+    override fun serialize(encoder: Encoder, value: String?) {
+        when (value) {
+            null -> encoder.encodeString("")
+            else -> encoder.encodeString(value)
+        }
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
@@ -133,16 +133,19 @@ data class PaywallData(
             /**
              * Image displayed as a header in a template.
              */
+            @Serializable(with = EmptyStringToNullSerializer::class)
             val header: String? = null,
 
             /**
              * Image displayed as a background in a template.
              */
+            @Serializable(with = EmptyStringToNullSerializer::class)
             val background: String? = null,
 
             /**
              * Image displayed as an app icon in a template.
              */
+            @Serializable(with = EmptyStringToNullSerializer::class)
             val icon: String? = null,
         ) {
             internal val all: List<String>

--- a/purchases/src/test/resources/paywalldata-empty-images.json
+++ b/purchases/src/test/resources/paywalldata-empty-images.json
@@ -1,0 +1,32 @@
+{
+  "template_name": "1",
+  "localized_strings": {
+    "en_US": {
+      "title": "Paywall",
+      "subtitle": "Description",
+      "call_to_action": "Purchase now",
+      "call_to_action_with_intro_offer": "Purchase now",
+      "offer_details": "{{ sub_price_per_month }} per month",
+      "offer_details_with_intro_offer": "Start your {{ sub_offer_duration }} trial, then {{ sub_price_per_month }} per month"
+    }
+  },
+  "config": {
+    "packages": ["$rc_monthly", "$rc_annual"],
+    "images": {
+      "header": "",
+      "background": " ",
+      "icon": null
+    },
+    "colors": {
+      "light": {
+        "background": "#FFFFFF",
+        "text_1": "#FFFFFF",
+        "call_to_action_background": "#FFFFFF",
+        "call_to_action_foreground": "#FFFFFF",
+        "accent_1": "#FFFFFF"
+      },
+      "dark": null
+    }
+  },
+  "asset_base_url": "https://rc-paywalls.s3.amazonaws.com"
+}


### PR DESCRIPTION
Equivalent to https://github.com/RevenueCat/purchases-ios/pull/3195

This fixes issues with paywalls in the backend sending `""` as images and the SDK trying to render an empty image and taking space:
![Screenshot 2023-10-26 at 12 11 34](https://github.com/RevenueCat/purchases-android/assets/685609/637bbf74-2915-4651-99b3-e0c8b40ff0be)
