### PR TITLE
`Paywalls`: ignore URL deserialization errors

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
@@ -116,12 +116,16 @@ data class PaywallData(
         /**
          * If set, the paywall will display a terms of service link.
          */
-        @SerialName("tos_url") @Serializable(with = URLSerializer::class) val termsOfServiceURL: URL? = null,
+        @SerialName("tos_url")
+        @Serializable(with = OptionalURLSerializer::class)
+        val termsOfServiceURL: URL? = null,
 
         /**
          * If set, the paywall will display a privacy policy link.
          */
-        @SerialName("privacy_url") @Serializable(with = URLSerializer::class) val privacyURL: URL? = null,
+        @SerialName("privacy_url")
+        @Serializable(with = OptionalURLSerializer::class)
+        val privacyURL: URL? = null,
 
         /**
          * The set of colors used.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/URLSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/URLSerializer.kt
@@ -1,13 +1,15 @@
 package com.revenuecat.purchases.paywalls
 
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import java.net.MalformedURLException
 import java.net.URL
 
-object URLSerializer : KSerializer<URL> {
+internal object URLSerializer : KSerializer<URL> {
     override val descriptor = PrimitiveSerialDescriptor("URL", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): URL {
@@ -16,5 +18,28 @@ object URLSerializer : KSerializer<URL> {
 
     override fun serialize(encoder: Encoder, value: URL) {
         encoder.encodeString(value.toString())
+    }
+}
+
+/**
+ * Equivalent to URLSerializer but allows empty or invalid URLs.
+ */
+internal object OptionalURLSerializer : KSerializer<URL?> {
+    private val delegate = URLSerializer.nullable
+    override val descriptor = PrimitiveSerialDescriptor("URL?", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): URL? {
+        return try {
+            delegate.deserialize(decoder)
+        } catch (e: MalformedURLException) {
+            null
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: URL?) {
+        when (value) {
+            null -> encoder.encodeString("")
+            else -> delegate.serialize(encoder, value)
+        }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallDataTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallDataTest.kt
@@ -113,6 +113,14 @@ class PaywallDataTest {
     }
 
     @Test
+    fun `does not fail to decode invalid URLs`() {
+        val paywall: PaywallData = decode(PAYWALLDATA_EMPTY_IMAGES)
+
+        assertThat(paywall.config.privacyURL).isNull()
+        assertThat(paywall.config.termsOfServiceURL).isNull()
+    }
+
+    @Test
     fun `paywall color can be created from a ColorInt`() {
         val colorInt = Color.parseColor("#FFAABB")
         val paywallColor = PaywallColor(colorInt)

--- a/purchases/src/test/resources/paywalldata-empty-images.json
+++ b/purchases/src/test/resources/paywalldata-empty-images.json
@@ -17,6 +17,8 @@
       "background": " ",
       "icon": null
     },
+    "privacy_url": "invalid url",
+    "tos_url": "unrecognized:?/2 URL",
     "colors": {
       "light": {
         "background": "#FFFFFF",


### PR DESCRIPTION
Note that this is only for the optional URLs, `assetBaseURL` is still required, but I'll handle errors there in a separate PR.