### PR TITLE
Paywalls: Add experimental annotation to all public APIs in RevenueCat UI

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
@@ -10,10 +10,12 @@ import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import com.revenuecat.paywallstester.ui.theme.PaywallTesterAndroidTheme
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResultHandler
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 class MainActivity : ComponentActivity(), PaywallResultHandler {
     private lateinit var paywallActivityLauncher: PaywallActivityLauncher
 

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.paywallstester.MainActivity
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialog
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -73,6 +74,7 @@ private fun LoadingOfferingsScreen() {
     }
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Composable
 private fun OfferingsListScreen(
     offeringsState: OfferingsState.Loaded,

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
@@ -130,10 +130,10 @@ private fun FooterDialog(currentState: DisplayPaywallState.Footer, onDismiss: ()
     }
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 private sealed class DisplayPaywallState {
     object None : DisplayPaywallState()
     data class FullScreen
-    @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
     constructor(
         val offering: Offering? = null,
         val fontProvider: FontProvider? = null,

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
@@ -29,6 +29,7 @@ import com.revenuecat.paywallstester.SamplePaywallsLoader
 import com.revenuecat.paywallstester.ui.screens.paywallfooter.SamplePaywall
 import com.revenuecat.paywallstester.ui.theme.googleFont
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialog
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions
 import com.revenuecat.purchases.ui.revenuecatui.PaywallFooter
@@ -36,6 +37,7 @@ import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Composable
 fun PaywallsScreen(
     samplePaywallsLoader: SamplePaywallsLoader = SamplePaywallsLoader(),
@@ -94,6 +96,7 @@ fun PaywallsScreen(
     }
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Composable
 private fun FullScreenDialog(currentState: DisplayPaywallState.FullScreen, onDismiss: () -> Unit) {
     PaywallDialog(
@@ -105,6 +108,7 @@ private fun FullScreenDialog(currentState: DisplayPaywallState.FullScreen, onDis
     )
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Composable
 private fun FooterDialog(currentState: DisplayPaywallState.Footer, onDismiss: () -> Unit) {
     Dialog(
@@ -128,7 +132,9 @@ private fun FooterDialog(currentState: DisplayPaywallState.Footer, onDismiss: ()
 
 private sealed class DisplayPaywallState {
     object None : DisplayPaywallState()
-    data class FullScreen(
+    data class FullScreen
+    @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+    constructor(
         val offering: Offering? = null,
         val fontProvider: FontProvider? = null,
     ) : DisplayPaywallState()

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreen.kt
@@ -11,9 +11,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Composable
 fun PaywallScreen(
     viewModel: PaywallScreenViewModel = viewModel<PaywallScreenViewModelImpl>(),

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreenViewModel.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreenViewModel.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.awaitOfferings
 import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,6 +18,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 interface PaywallScreenViewModel : PaywallListener {
     companion object {
         const val OFFERING_ID_KEY = "offering_id"

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywallfooter/PaywallFooterScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywallfooter/PaywallFooterScreen.kt
@@ -19,9 +19,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.paywallstester.ui.screens.paywall.PaywallScreenState
 import com.revenuecat.paywallstester.ui.screens.paywall.PaywallScreenViewModel
 import com.revenuecat.paywallstester.ui.screens.paywall.PaywallScreenViewModelImpl
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallFooter
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Composable
 fun PaywallFooterScreen(
     viewModel: PaywallScreenViewModel = viewModel<PaywallScreenViewModelImpl>(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ExperimentalPreviewRevenueCatUIPurchasesAPI.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ExperimentalPreviewRevenueCatUIPurchasesAPI.kt
@@ -2,7 +2,9 @@ package com.revenuecat.purchases.ui.revenuecatui
 
 /**
  * This annotation marks the experimental preview of the RevenueCat UI Purchases API.
- * This API is in a preview state and has a very high chance of being changed in the future.
+ * This API is in a preview state and has a very high chance of being changed in the near future.
+ 
+ Once RevenueCat UI is stable, this annotation will be removed.
  *
  * Any usage of a declaration annotated with `@ExperimentalPreviewRevenueCatUIPurchasesAPI` must be
  * accepted either by annotating that usage with the [OptIn] annotation,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ExperimentalPreviewRevenueCatUIPurchasesAPI.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ExperimentalPreviewRevenueCatUIPurchasesAPI.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui
 /**
  * This annotation marks the experimental preview of the RevenueCat UI Purchases API.
  * This API is in a preview state and has a very high chance of being changed in the near future.
- 
+
  Once RevenueCat UI is stable, this annotation will be removed.
  *
  * Any usage of a declaration annotated with `@ExperimentalPreviewRevenueCatUIPurchasesAPI` must be

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ExperimentalPreviewRevenueCatUIPurchasesAPI.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ExperimentalPreviewRevenueCatUIPurchasesAPI.kt
@@ -1,0 +1,19 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+/**
+ * This annotation marks the experimental preview of the RevenueCat UI Purchases API.
+ * This API is in a preview state and has a very high chance of being changed in the future.
+ *
+ * Any usage of a declaration annotated with `@ExperimentalPreviewRevenueCatUIPurchasesAPI` must be
+ * accepted either by annotating that usage with the [OptIn] annotation,
+ * e.g. `@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)`, or by using the compiler argument
+ * `-Xopt-in=kotlin.time.ExperimentalPreviewRevenueCatUIPurchasesAPI`.
+ */
+@Retention(value = AnnotationRetention.BINARY)
+@RequiresOptIn(level = RequiresOptIn.Level.ERROR)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+)
+annotation class ExperimentalPreviewRevenueCatUIPurchasesAPI

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -34,6 +34,7 @@ import com.revenuecat.purchases.ui.revenuecatui.templates.Template2
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template3
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template4
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Composable
 internal fun InternalPaywall(
     options: PaywallOptions,
@@ -105,6 +106,7 @@ private fun TemplatePaywall(state: PaywallState.Loaded, viewModel: PaywallViewMo
     }
 }
 
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 @Composable
 private fun getPaywallViewModel(
     options: PaywallOptions,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/Paywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/Paywall.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
  * Composable offering a full screen Paywall UI configured from the RevenueCat dashboard.
  * @param options The options to configure the [Paywall] if needed.
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 @Composable
 fun Paywall(options: PaywallOptions) {
     InternalPaywall(options)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.launch
  * This dialog will be shown as a full screen dialog in compact devices and a normal dialog otherwise.
  * @param paywallDialogOptions The options to configure the PaywallDialog and what to do on dismissal.
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 @Composable
 fun PaywallDialog(
     paywallDialogOptions: PaywallDialogOptions,
@@ -49,6 +50,7 @@ fun PaywallDialog(
     }
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Composable
 private fun DialogScaffold(paywallOptions: PaywallOptions) {
     Scaffold(modifier = Modifier.fillMaxSize()) { paddingValues ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayBlockForEntitlementIdentifier
 
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 class PaywallDialogOptions(builder: Builder) {
 
     val shouldDisplayBlock: ((CustomerInfo) -> Boolean)?

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
  * add that padding to your own content. This padding corresponds to the height of the rounded corner area of
  * the paywall.
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 @Composable
 fun PaywallFooter(
     options: PaywallOptions,
@@ -49,6 +50,7 @@ fun PaywallFooter(
 }
 
 @Suppress("MagicNumber")
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 @Preview(showBackground = true)
 @Composable
 private fun PaywallFooterPreview() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.models.StoreTransaction
 
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 interface PaywallListener {
     fun onPurchaseStarted(rcPackage: Package) {}
     fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -23,6 +23,7 @@ internal sealed class OfferingSelection {
         }
 }
 
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 class PaywallOptions(builder: Builder) {
 
     internal val offeringSelection: OfferingSelection

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -31,6 +32,7 @@ import com.revenuecat.purchases.ui.revenuecatui.fonts.TypographyType
  * Wrapper activity around [Paywall] that allows using it when you are not using Jetpack Compose directly.
  * It receives the [PaywallActivityArgs] as an extra and returns the [PaywallResult] as a result.
  */
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 internal class PaywallActivity : ComponentActivity(), PaywallListener {
     companion object {
         const val ARGS_EXTRA = "paywall_args"

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
@@ -1,11 +1,13 @@
 package com.revenuecat.purchases.ui.revenuecatui.activity
 
 import android.os.Parcelable
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.fonts.ParcelizableFontProvider
 import com.revenuecat.purchases.ui.revenuecatui.fonts.PaywallFontFamily
 import com.revenuecat.purchases.ui.revenuecatui.fonts.TypographyType
 import kotlinx.parcelize.Parcelize
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Parcelize
 internal data class PaywallActivityArgs(
     val offeringId: String? = null,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.Fragment
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.fonts.ParcelizableFontProvider
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayBlockForEntitlementIdentifier
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayPaywall
@@ -13,12 +14,14 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayPaywall
 /**
  * Implement this interface to receive the result of the paywall activity.
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 interface PaywallResultHandler : ActivityResultCallback<PaywallResult>
 
 /**
  * Launches the paywall activity. You need to create this object during the activity's onCreate.
  * Then launch the activity at your moment of choice
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 class PaywallActivityLauncher {
 
     private var activityResultLauncher: ActivityResultLauncher<PaywallActivityArgs>

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallContract.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallContract.kt
@@ -7,11 +7,13 @@ import android.os.Build
 import androidx.activity.result.contract.ActivityResultContract
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 
 /**
  * Contract that specifies how to launch the paywall activity and how to parse its result, abstracting
  * that logic from the caller.
  */
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 internal class PaywallContract : ActivityResultContract<PaywallActivityArgs, PaywallResult>() {
     override fun createIntent(context: Context, args: PaywallActivityArgs): Intent {
         return Intent(context, PaywallActivity::class.java).apply {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallResult.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallResult.kt
@@ -3,11 +3,13 @@ package com.revenuecat.purchases.ui.revenuecatui.activity
 import android.os.Parcelable
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import kotlinx.parcelize.Parcelize
 
 /**
  * Result of the paywall activity.
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 sealed class PaywallResult : Parcelable {
     /**
      * The user cancelled the paywall without purchasing.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -15,6 +15,7 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PurchaseParams
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -51,6 +52,7 @@ internal interface PaywallViewModel {
     fun clearActionError()
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Suppress("TooManyFunctions")
 internal class PaywallViewModelImpl(
     private val applicationContext: ApplicationContext,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
@@ -3,9 +3,11 @@ package com.revenuecat.purchases.ui.revenuecatui.data
 import androidx.compose.material3.ColorScheme
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ApplicationContext
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 internal class PaywallViewModelFactory(
     private val applicationContext: ApplicationContext,
     private val options: PaywallOptions,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PackageConfigurationError.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PackageConfigurationError.kt
@@ -1,3 +1,3 @@
 package com.revenuecat.purchases.ui.revenuecatui.errors
 
-class PackageConfigurationError(override val message: String) : Throwable(message)
+internal class PackageConfigurationError(override val message: String) : Throwable(message)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui.errors
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorStrings
 
-sealed class PaywallValidationError : Throwable() {
+internal sealed class PaywallValidationError : Throwable() {
 
     fun associatedErrorString(offering: Offering): String {
         return when (this) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallColor
 import com.revenuecat.purchases.paywalls.PaywallData
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.R
@@ -119,6 +120,7 @@ private fun getThemeColors(currentColorScheme: ColorScheme): PaywallData.Configu
 
 private fun Color.asPaywallColor(): PaywallColor = PaywallColor(colorInt = this.toArgb())
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Preview(showBackground = true, locale = "en-rUS")
 @Preview(showBackground = true, locale = "es-rES")
 @Composable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/TypographyExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/TypographyExtensions.kt
@@ -2,9 +2,11 @@ package com.revenuecat.purchases.ui.revenuecatui.extensions
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
 import com.revenuecat.purchases.ui.revenuecatui.fonts.TypographyType
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 fun Typography.copyWithFontProvider(fontProvider: FontProvider): Typography {
     with(this) {
         return copy(
@@ -27,6 +29,7 @@ fun Typography.copyWithFontProvider(fontProvider: FontProvider): Typography {
     }
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 private fun TextStyle.modifyFontIfNeeded(typographyType: TypographyType, fontProvider: FontProvider): TextStyle {
     val font = fontProvider.getFont(typographyType)
     return if (font == null) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/CustomFontProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/CustomFontProvider.kt
@@ -1,11 +1,13 @@
 package com.revenuecat.purchases.ui.revenuecatui.fonts
 
 import androidx.compose.ui.text.font.FontFamily
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 
 /**
  * Class that allows to provide a font family for all text styles.
  * @param fontFamily the [FontFamily] to be used for all text styles.
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 class CustomFontProvider(private val fontFamily: FontFamily) : FontProvider {
     override fun getFont(type: TypographyType) = fontFamily
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/CustomParcelizableFontProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/CustomParcelizableFontProvider.kt
@@ -1,9 +1,12 @@
 package com.revenuecat.purchases.ui.revenuecatui.fonts
 
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+
 /**
  * Class that allows to provide a font family for all text styles.
  * @param fontFamily the [PaywallFontFamily] to be used for all text styles.
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 class CustomParcelizableFontProvider(
     private val fontFamily: PaywallFontFamily,
 ) : ParcelizableFontProvider {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/FontProvider.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.fonts
 
 import androidx.compose.ui.text.font.FontFamily
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 
 /**
  * Implement this interface to provide custom fonts to the [PaywallView]. If you don't, the current material3 theme
@@ -9,6 +10,7 @@ import androidx.compose.ui.text.font.FontFamily
  * This can't be used when launching the paywall as an activity since the fonts are not parcelable/serializable.
  * Use [FontResourceProvider] instead.
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 interface FontProvider {
     /**
      * Returns the font to be used for the given [TypographyType]. If null is returned, the default font will be used.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/GoogleFontProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/GoogleFontProvider.kt
@@ -3,11 +3,13 @@ package com.revenuecat.purchases.ui.revenuecatui.fonts
 import android.os.Parcelable
 import androidx.annotation.ArrayRes
 import androidx.compose.ui.text.googlefonts.GoogleFont
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import kotlinx.parcelize.Parcelize
 
 /**
  * Represents a Google font provider.
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 @Parcelize
 data class GoogleFontProvider(
     /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/ParcelizableFontProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/ParcelizableFontProvider.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.fonts
 
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
 
 /**
@@ -8,6 +9,7 @@ import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
  * If you only want to use a single [PaywallFontFamily] for all text styles use [CustomParcelizableFontProvider].
  * Use [FontProvider] instead if you are using Compose with [PaywallView] or [PaywallDialog].
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 interface ParcelizableFontProvider {
     /**
      * Returns the [PaywallFontFamily] to be used for the given [TypographyType]. If null is returned,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/PaywallFont.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/PaywallFont.kt
@@ -4,12 +4,14 @@ import android.os.Parcelable
 import androidx.annotation.FontRes
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
 
 /**
  * Represents a font. You can create either a [GoogleFont] or a [ResourceFont].
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 sealed class PaywallFont : Parcelable {
     /**
      * Represents a downloadable Google Font.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/PaywallFontFamily.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/PaywallFontFamily.kt
@@ -1,10 +1,12 @@
 package com.revenuecat.purchases.ui.revenuecatui.fonts
 
 import android.os.Parcelable
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import kotlinx.parcelize.Parcelize
 
 /**
  * Represents a font family. You can add one ore more [PaywallFont] with different weights and font styles.
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 @Parcelize
 data class PaywallFontFamily(val fonts: List<PaywallFont>) : Parcelable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/PaywallTheme.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/PaywallTheme.kt
@@ -2,8 +2,10 @@ package com.revenuecat.purchases.ui.revenuecatui.fonts
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.extensions.copyWithFontProvider
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Composable
 internal fun PaywallTheme(
     fontProvider: FontProvider?,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/TypographyType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fonts/TypographyType.kt
@@ -1,8 +1,11 @@
 package com.revenuecat.purchases.ui.revenuecatui.fonts
 
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+
 /**
  * Text styles for which the fonts can be overridden in the paywall.
  */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
 enum class TypographyType {
     DISPLAY_LARGE,
     DISPLAY_MEDIUM,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -175,6 +176,7 @@ private object Template1UIConstants {
     const val circleScale = 3.0f
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Preview(showBackground = true)
 @Composable
 private fun Template1PaywallPreview() {
@@ -184,6 +186,7 @@ private fun Template1PaywallPreview() {
     )
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Preview(showBackground = true)
 @Composable
 private fun Template1FooterPaywallPreview() {
@@ -193,6 +196,7 @@ private fun Template1FooterPaywallPreview() {
     )
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Preview(showBackground = true)
 @Composable
 private fun Template1CondensedFooterPaywallPreview() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -306,6 +307,7 @@ private fun CheckmarkBox(isSelected: Boolean, colors: TemplateConfiguration.Colo
     }
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Preview(showBackground = true, locale = "en-rUS")
 @Preview(showBackground = true, locale = "es-rES")
 @Composable
@@ -316,6 +318,7 @@ private fun Template2PaywallPreview() {
     )
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Preview(showBackground = true, locale = "en-rUS")
 @Preview(showBackground = true, locale = "es-rES")
 @Composable
@@ -326,6 +329,7 @@ private fun Template2PaywallFooterPreview() {
     )
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Preview(showBackground = true, locale = "en-rUS")
 @Preview(showBackground = true, locale = "es-rES")
 @Composable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.paywalls.PaywallData
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -183,6 +184,7 @@ private fun Feature(
     }
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Preview(locale = "en-rUS", showBackground = true)
 @Preview(locale = "es-rES", showBackground = true)
 @Composable
@@ -193,6 +195,7 @@ private fun Template3Preview() {
     )
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Preview(showBackground = true)
 @Composable
 private fun Template3FooterPreview() {
@@ -202,6 +205,7 @@ private fun Template3FooterPreview() {
     )
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Preview(showBackground = true)
 @Composable
 private fun Template3CondensedFooterPreview() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template4.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template4.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
@@ -379,6 +380,7 @@ private fun CheckmarkBox(
     }
 }
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Preview(showBackground = true, locale = "en-rUS")
 @Preview(showBackground = true, locale = "es-rES")
 @Composable

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -15,6 +15,7 @@ import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.Transaction
 import com.revenuecat.purchases.paywalls.PaywallData
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -42,6 +43,7 @@ import org.junit.runner.RunWith
 import java.util.Date
 import java.util.UUID
 
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @RunWith(AndroidJUnit4::class)
 class PaywallViewModelTest {
     private val defaultOffering = TestData.template2Offering


### PR DESCRIPTION
### Description
This adds a new `ExperimentalPreviewRevenueCatUIPurchasesAPI` annotation for `RevenueCatUI` experimental APIs, and marks all current public APIs in this library as experimental. We plan to move from using a beta version of the package to using these experimental APIs until we're ready for stable release.
