### PR TITLE
`Paywalls`: convert empty strings to `null`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
@@ -234,18 +234,22 @@ data class PaywallData(
         /**
          * The subtitle of the paywall screen.
          */
+        @Serializable(with = EmptyStringToNullSerializer::class)
         val subtitle: String? = null,
 
         /**
          * The content of the main action button for purchasing a subscription.
          */
-        @SerialName("call_to_action") val callToAction: String,
+        @SerialName("call_to_action")
+        val callToAction: String,
 
         /**
          * The content of the main action button for purchasing a subscription when an intro offer is available.
          * If `null`, no information regarding trial eligibility will be displayed.
          */
-        @SerialName("call_to_action_with_intro_offer") val callToActionWithIntroOffer: String? = null,
+        @SerialName("call_to_action_with_intro_offer")
+        @Serializable(with = EmptyStringToNullSerializer::class)
+        val callToActionWithIntroOffer: String? = null,
 
         /**
          * The content of the main action button for purchasing a subscription when multiple intro offer are available.
@@ -253,30 +257,39 @@ data class PaywallData(
          * If `null`, no information regarding trial eligibility will be displayed.
          */
         @SerialName("call_to_action_with_multiple_intro_offers")
+        @Serializable(with = EmptyStringToNullSerializer::class)
         val callToActionWithMultipleIntroOffers: String? = null,
 
         /**
          * Description for the offer to be purchased.
          */
-        @SerialName("offer_details") val offerDetails: String? = null,
+        @SerialName("offer_details")
+        @Serializable(with = EmptyStringToNullSerializer::class)
+        val offerDetails: String? = null,
 
         /**
          * Description for the offer to be purchased when an intro offer is available.
          * If `null`, no information regarding trial eligibility will be displayed.
          */
-        @SerialName("offer_details_with_intro_offer") val offerDetailsWithIntroOffer: String? = null,
+        @SerialName("offer_details_with_intro_offer")
+        @Serializable(with = EmptyStringToNullSerializer::class)
+        val offerDetailsWithIntroOffer: String? = null,
 
         /**
          * Description for the offer to be purchased when multiple intro offers are available.
          * This may happen in Google Play, if you have an offer with both a free trial and a discounted price.
          * If `null`, no information regarding trial eligibility will be displayed.
          */
-        @SerialName("offer_details_with_multiple_intro_offers") val offerDetailsWithMultipleIntroOffers: String? = null,
+        @SerialName("offer_details_with_multiple_intro_offers")
+        @Serializable(with = EmptyStringToNullSerializer::class)
+        val offerDetailsWithMultipleIntroOffers: String? = null,
 
         /**
          * The name representing each of the packages, most commonly a variable.
          */
-        @SerialName("offer_name") val offerName: String? = null,
+        @SerialName("offer_name")
+        @Serializable(with = EmptyStringToNullSerializer::class)
+        val offerName: String? = null,
 
         /**
          * An optional list of features that describe this paywall.

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallDataTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallDataTest.kt
@@ -62,16 +62,42 @@ class PaywallDataTest {
         val unknownLocale = "gl_ES".toLocale()
         assertThat(paywall.configForLocale(unknownLocale)).isNull()
 
-        val validLocale = "en_US".toLocale()
-        val localizedConfiguration = paywall.configForLocale(validLocale)
-        assertThat(localizedConfiguration).isNotNull
-        assertThat(localizedConfiguration?.callToActionWithMultipleIntroOffers).isEqualTo(
-            "Purchase now with multiple offers"
-        )
-        assertThat(localizedConfiguration?.offerDetailsWithMultipleIntroOffers).isEqualTo(
-            "Try {{ sub_offer_duration }} for free, then {{ sub_offer_price_2 }} for your first " +
-                "{{ sub_offer_duration_2 }}, and just {{ sub_price_per_month }} thereafter."
-        )
+        val english = paywall.configForLocale("en_US".toLocale())
+        assertThat(english).isNotNull
+        english?.apply {
+            assertThat(title).isEqualTo("Paywall")
+            assertThat(subtitle).isEqualTo("Description")
+
+            assertThat(callToAction).isEqualTo("Purchase now")
+            assertThat(callToActionWithIntroOffer).isEqualTo("Purchase now")
+            assertThat(callToActionWithMultipleIntroOffers).isEqualTo("Purchase now with multiple offers")
+
+            assertThat(offerDetails).isEqualTo("{{ sub_price_per_month }} per month")
+            assertThat(offerDetailsWithIntroOffer).isEqualTo(
+                "Start your {{ sub_offer_duration }} trial, " +
+                    "then {{ sub_price_per_month }} per month"
+            )
+            assertThat(offerDetailsWithMultipleIntroOffers).isEqualTo(
+                "Try {{ sub_offer_duration }} for free, " +
+                    "then {{ sub_offer_price_2 }} for your first {{ sub_offer_duration_2 }}, " +
+                    "and just {{ sub_price_per_month }} thereafter."
+            )
+        }
+
+        val spanish = paywall.configForLocale("es".toLocale())
+        assertThat(spanish).isNotNull
+        spanish?.apply {
+            assertThat(title).isEqualTo("Tienda")
+            assertThat(subtitle).isNull()
+
+            assertThat(callToAction).isEqualTo("Comprar")
+            assertThat(callToActionWithIntroOffer).isNull()
+            assertThat(callToActionWithMultipleIntroOffers).isNull()
+
+            assertThat(offerDetails).isNull()
+            assertThat(offerDetailsWithIntroOffer).isNull()
+            assertThat(offerDetailsWithMultipleIntroOffers).isNull()
+        }
     }
 
     @Test

--- a/purchases/src/test/resources/paywalldata-sample1.json
+++ b/purchases/src/test/resources/paywalldata-sample1.json
@@ -27,7 +27,9 @@
     "es_ES": {
       "title": "Tienda",
       "call_to_action": "Comprar",
+      "call_to_action_with_multiple_intro_offers": " ",
       "offer_details_with_intro_offer": " ",
+      "offer_details_with_multiple_intro_offers": "",
       "offer_name": "{{ period }}",
       "features": [
         {


### PR DESCRIPTION
Equivalent to https://github.com/RevenueCat/purchases-ios/pull/2818

`IntroEligibilityStateView` relies on strings being `null` to determine what string is available, therefore we need to make sure we don't have empty strings in `PaywallData`.