### PR TITLE
Fix navigation after closing paywall in Paywalls screen

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -38,7 +38,10 @@ fun PaywallDialog(
         }
     }
     if (shouldDisplayDialog) {
-        val dismissRequest = { shouldDisplayDialog = false }
+        val dismissRequest = {
+            paywallDialogOptions.dismissRequest?.invoke()
+            shouldDisplayDialog = false
+        }
 
         Dialog(
             onDismissRequest = dismissRequest,


### PR DESCRIPTION
@aboedo noticed that when navigating to the Template 2 full screen from the Paywalls tab, going back, then navigating again was not working. 

@tonidero took a very quick look and seems that we are not calling the PaywallDialog onDismiss callback when going back, so the PaywallsScreen thinks that there is still a paywall displaying so it doesn't work.

I added the missing call to the `dismissRequest` callback
