### PR TITLE
Fix onDismiss getting called twice in PaywallDialogs

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -39,16 +39,18 @@ fun PaywallDialog(
         }
     }
     if (shouldDisplayDialog) {
-        val dismissRequest = {
-            paywallDialogOptions.dismissRequest?.invoke()
-            shouldDisplayDialog = false
-        }
-
         Dialog(
-            onDismissRequest = dismissRequest,
+            onDismissRequest = {
+                shouldDisplayDialog = false
+                paywallDialogOptions.dismissRequest?.invoke()
+            },
             properties = DialogProperties(usePlatformDefaultWidth = shouldUsePlatformDefaultWidth()),
         ) {
-            DialogScaffold(paywallDialogOptions.toPaywallOptions(dismissRequest))
+            DialogScaffold(
+                paywallDialogOptions.toPaywallOptions(paywallDialogDismissRequest = {
+                    shouldDisplayDialog = false
+                }),
+            )
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -39,18 +39,18 @@ fun PaywallDialog(
         }
     }
     if (shouldDisplayDialog) {
+        val dismissRequest = {
+            shouldDisplayDialog = false
+        }
+
         Dialog(
             onDismissRequest = {
-                shouldDisplayDialog = false
+                dismissRequest()
                 paywallDialogOptions.dismissRequest?.invoke()
             },
             properties = DialogProperties(usePlatformDefaultWidth = shouldUsePlatformDefaultWidth()),
         ) {
-            DialogScaffold(
-                paywallDialogOptions.toPaywallOptions(dismissRequest = {
-                    shouldDisplayDialog = false
-                }),
-            )
+            DialogScaffold(paywallDialogOptions.toPaywallOptions(dismissRequest))
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -47,7 +47,7 @@ fun PaywallDialog(
             properties = DialogProperties(usePlatformDefaultWidth = shouldUsePlatformDefaultWidth()),
         ) {
             DialogScaffold(
-                paywallDialogOptions.toPaywallOptions(paywallDialogDismissRequest = {
+                paywallDialogOptions.toPaywallOptions(dismissRequest = {
                     shouldDisplayDialog = false
                 }),
             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -24,9 +24,9 @@ class PaywallDialogOptions(builder: Builder) {
         this.listener = builder.listener
     }
 
-    internal fun toPaywallOptions(dismissRequest: () -> Unit): PaywallOptions {
+    internal fun toPaywallOptions(paywallDialogDismissRequest: () -> Unit): PaywallOptions {
         return PaywallOptions.Builder {
-            dismissRequest()
+            paywallDialogDismissRequest()
             this.dismissRequest?.invoke()
         }
             .setOffering(offering)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -24,9 +24,9 @@ class PaywallDialogOptions(builder: Builder) {
         this.listener = builder.listener
     }
 
-    internal fun toPaywallOptions(paywallDialogDismissRequest: () -> Unit): PaywallOptions {
+    internal fun toPaywallOptions(dismissRequest: () -> Unit): PaywallOptions {
         return PaywallOptions.Builder {
-            paywallDialogDismissRequest()
+            dismissRequest()
             this.dismissRequest?.invoke()
         }
             .setOffering(offering)


### PR DESCRIPTION
We call `paywallDialogOptions.dismissRequest?.invoke()` inside `toPaywallOptions` so since we were passing 

```
val dismissRequest = {
            paywallDialogOptions.dismissRequest?.invoke()
            shouldDisplayDialog = false
}
```

the `paywallDialogOptions.dismissRequest?.invoke()` piece was getting called twice when calling `paywallDialogOptions.toPaywallOptions(dismissRequest)`