### PR TITLE
`Paywalls`: footer view should not render background image

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallMode.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallMode.kt
@@ -14,3 +14,6 @@ internal enum class PaywallMode {
         }
     }
 }
+
+internal val PaywallMode.isFullScreen: Boolean
+    get() = this == PaywallMode.FULL_SCREEN

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PaywallBackground.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PaywallBackground.kt
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.extensions.defaultBackgroundPlaceholder
+import com.revenuecat.purchases.ui.revenuecatui.isFullScreen
 
 // Current implementation uses a transformation on API level < 31, modifier on > 31.
 @Composable
@@ -49,13 +50,16 @@ internal fun BoxScope.PaywallBackground(templateConfiguration: TemplateConfigura
             alpha = imageAlpha,
         )
     } else if (templateConfiguration.images.backgroundUri != null) {
-        RemoteImage(
-            urlString = templateConfiguration.images.backgroundUri.toString(),
-            modifier = modifier,
-            contentScale = BackgroundUIConstants.contentScale,
-            transformation = backwardsCompatibleTransformation,
-            alpha = imageAlpha,
-        )
+        // Don't display background images on footer unless it's blurred
+        if (shouldBlur || templateConfiguration.mode.isFullScreen) {
+            RemoteImage(
+                urlString = templateConfiguration.images.backgroundUri.toString(),
+                modifier = modifier,
+                contentScale = BackgroundUIConstants.contentScale,
+                transformation = backwardsCompatibleTransformation,
+                alpha = imageAlpha,
+            )
+        }
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -4,9 +4,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.mutableStateOf
-import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.ProcessedLocalizedConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
+import com.revenuecat.purchases.ui.revenuecatui.isFullScreen
 
 internal sealed class PaywallState {
     object Loading : PaywallState()
@@ -34,4 +34,4 @@ internal val PaywallState.Loaded.currentColors: TemplateConfiguration.Colors
     get() = templateConfiguration.getCurrentColors()
 
 internal val PaywallState.Loaded.isInFullScreenMode: Boolean
-    get() = templateConfiguration.mode == PaywallMode.FULL_SCREEN
+    get() = templateConfiguration.mode.isFullScreen


### PR DESCRIPTION
Unless it needs to be blur, to match iOS behavior.

Thanks to @lburdock for finding this discrepancy!