### PR TITLE
Paywalls: Fix purchase button text flashing when changing selected package

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/ConsistentPackageContentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/ConsistentPackageContentView.kt
@@ -31,15 +31,20 @@ internal fun ConsistentPackageContentView(
 internal fun ConsistentPackageContentView(
     packages: List<TemplateConfiguration.PackageInfo>,
     selected: TemplateConfiguration.PackageInfo,
+    shouldAnimate: Boolean = true,
     creator: @Composable (TemplateConfiguration.PackageInfo) -> Unit,
 ) {
     Box {
         packages.forEach { packageItem ->
-            val opacity by animateFloatAsState(
-                targetValue = if (packageItem.rcPackage == selected.rcPackage) 1.0f else 0.0f,
-                animationSpec = UIConstant.defaultAnimation(),
-                label = "ConsistentPackageContentView",
-            )
+            val opacity = if (shouldAnimate) {
+                animateFloatAsState(
+                    targetValue = if (packageItem.rcPackage == selected.rcPackage) 1.0f else 0.0f,
+                    animationSpec = UIConstant.defaultAnimation(),
+                    label = "ConsistentPackageContentView",
+                ).value
+            } else {
+                if (packageItem.rcPackage == selected.rcPackage) 1.0f else 0.0f
+            }
 
             Box(
                 modifier = Modifier

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
@@ -186,15 +186,24 @@ private fun PurchaseButtonPreview() {
 }
 
 private fun TemplateConfiguration.PackageConfiguration.hasDifferentCallToActionText(): Boolean {
-    val firstLocalization = all.first().localization
+    val firstText = with(all.first()) {
+        introEligibilityText(
+            introEligibility,
+            localization.callToAction,
+            localization.callToActionWithIntroOffer,
+            localization.callToActionWithMultipleIntroOffers,
+        )
+    }
+
     all.forEach {
-        with(it.localization) {
-            if (callToAction != firstLocalization.callToAction ||
-                callToActionWithIntroOffer != firstLocalization.callToActionWithIntroOffer ||
-                callToActionWithMultipleIntroOffers != firstLocalization.callToActionWithMultipleIntroOffers
-            ) {
-                return true
-            }
+        if (firstText != introEligibilityText(
+                it.introEligibility,
+                it.localization.callToAction,
+                it.localization.callToActionWithIntroOffer,
+                it.localization.callToActionWithMultipleIntroOffers,
+            )
+        ) {
+            return true
         }
     }
     return false

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
@@ -113,6 +113,7 @@ private fun PurchaseButton(
                 ConsistentPackageContentView(
                     packages = packages.all,
                     selected = selectedPackage.value,
+                    shouldAnimate = packages.hasDifferentCallToActionText(),
                 ) {
                     val localization = it.localization
                     IntroEligibilityStateView(
@@ -182,4 +183,19 @@ private fun PurchaseButtonPreview() {
             viewModel = viewModel,
         )
     }
+}
+
+private fun TemplateConfiguration.PackageConfiguration.hasDifferentCallToActionText(): Boolean {
+    val firstLocalization = all.first().localization
+    all.forEach {
+        with(it.localization) {
+            if (callToAction != firstLocalization.callToAction ||
+                callToActionWithIntroOffer != firstLocalization.callToActionWithIntroOffer ||
+                callToActionWithMultipleIntroOffers != firstLocalization.callToActionWithMultipleIntroOffers
+            ) {
+                return true
+            }
+        }
+    }
+    return false
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
@@ -185,6 +185,7 @@ private fun PurchaseButtonPreview() {
     }
 }
 
+// This checks whether any of the packages has a different call to action text than the others.
 private fun TemplateConfiguration.PackageConfiguration.hasDifferentCallToActionText(): Boolean {
     val firstText = with(all.first()) {
         introEligibilityText(
@@ -195,7 +196,8 @@ private fun TemplateConfiguration.PackageConfiguration.hasDifferentCallToActionT
         )
     }
 
-    all.forEach {
+    // We skip the first element since it will always be true.
+    all.drop(1).forEach {
         if (firstText != introEligibilityText(
                 it.introEligibility,
                 it.localization.callToAction,


### PR DESCRIPTION
### Description
In some cases, the purchase button text doesn't change when selecting different packages. However, we were still animating the text resulting in a small flash in the purchase button when changing the selected package.

This makes it so, if the purchase button text doesn't change between all the packages, we don't animate it.