### PR TITLE
Paywalls: Improve PaywallDialog look on tablets

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -1,7 +1,10 @@
 package com.revenuecat.purchases.ui.revenuecatui
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -12,12 +15,17 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.window.core.layout.WindowWidthSizeClass
 import com.revenuecat.purchases.ui.revenuecatui.helpers.computeWindowWidthSizeClass
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayPaywall
 import kotlinx.coroutines.launch
+
+private object UIDialogConstants {
+    const val MAX_HEIGHT_PERCENTAGE_TABLET = 0.85f
+}
 
 /**
  * Composable offering a dialog screen Paywall UI configured from the RevenueCat dashboard.
@@ -58,13 +66,32 @@ fun PaywallDialog(
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Composable
 private fun DialogScaffold(paywallOptions: PaywallOptions) {
-    Scaffold(modifier = Modifier.fillMaxSize()) { paddingValues ->
+    Scaffold(
+        modifier = Modifier
+            .fillMaxWidth()
+            .fillMaxHeight(getDialogMaxHeightPercentage()),
+    ) { paddingValues ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues),
         ) {
             Paywall(paywallOptions)
+        }
+    }
+}
+
+@Composable
+@ReadOnlyComposable
+private fun getDialogMaxHeightPercentage(): Float {
+    val orientation = LocalConfiguration.current.orientation
+    if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+        return 1f
+    }
+    return computeWindowWidthSizeClass().let {
+        when (it) {
+            WindowWidthSizeClass.MEDIUM, WindowWidthSizeClass.EXPANDED -> UIDialogConstants.MAX_HEIGHT_PERCENTAGE_TABLET
+            else -> 1f
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.ui.revenuecatui
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -25,6 +24,7 @@ import kotlinx.coroutines.launch
 
 private object UIDialogConstants {
     const val MAX_HEIGHT_PERCENTAGE_TABLET = 0.85f
+    const val MAX_ASPECT_RATIO_TO_APPLY_MAX_HEIGHT = 1.5f
 }
 
 /**
@@ -84,8 +84,8 @@ private fun DialogScaffold(paywallOptions: PaywallOptions) {
 @Composable
 @ReadOnlyComposable
 private fun getDialogMaxHeightPercentage(): Float {
-    val orientation = LocalConfiguration.current.orientation
-    if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+    val aspectRatio = LocalConfiguration.current.screenHeightDp.toFloat() / LocalConfiguration.current.screenWidthDp
+    if (aspectRatio < UIDialogConstants.MAX_ASPECT_RATIO_TO_APPLY_MAX_HEIGHT) {
         return 1f
     }
     return computeWindowWidthSizeClass().let {


### PR DESCRIPTION
### Description
I've been testing the paywall dialog in tablets. I noticed it mostly looks fine on landscape, but not so great on portrait. So I added a max height to the dialog so it was not so stretched

| Before | After |
|-------|-------|
| ![image](https://github.com/RevenueCat/purchases-android/assets/808417/c727ebb9-e95e-4a42-ad64-e20d5b3e8e5f) | ![image](https://github.com/RevenueCat/purchases-android/assets/808417/4ce4fc19-f0f5-46d8-b469-45753f13cb76) |
| ![image](https://github.com/RevenueCat/purchases-android/assets/808417/9bf6999e-e2c3-4ada-82cf-2a07e35aef41) | ![image](https://github.com/RevenueCat/purchases-android/assets/808417/9bf6999e-e2c3-4ada-82cf-2a07e35aef41) |
| | ![image](https://github.com/RevenueCat/purchases-android/assets/808417/a7cd68c4-b9c2-48b8-a597-4cfea39cff7a) |
| | ![image](https://github.com/RevenueCat/purchases-android/assets/808417/4d957292-14ab-4d39-a753-160347cdccb6) |
| | ![image](https://github.com/RevenueCat/purchases-android/assets/808417/61799e74-313c-4926-aa1c-7395cf2cf997) |
| | ![image](https://github.com/RevenueCat/purchases-android/assets/808417/0f02fb08-0592-4fb9-a59d-7eba026bd23b) |
