### PR TITLE
Improvements on BillingWrapper retrying mechanism 

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -697,6 +697,17 @@ internal class BillingWrapper(
                 -> {
                     val originalErrorMessage = billingResult.toHumanReadableDescription()
 
+                    /**
+                     * We check for cases when Google sends Google Play In-app Billing API version is less than 3
+                     * as a debug message. Version 3 is from 2012, so the message is a bit useless.
+                     * We have detected this message in several cases:
+                     *
+                     * - When there's no Google account configured in the device
+                     * - When there's no Play Store (this happens in incorrectly configured emulators)
+                     * - When language is changed in the device and Play Store caches get corrupted. Opening the
+                     * Play Store or clearing its caches would fix this case.
+                     * See https://github.com/RevenueCat/purchases-android/issues/1288
+                     */
                     val error = if (billingResult.debugMessage == IN_APP_BILLING_LESS_THAN_3_ERROR_MESSAGE) {
                         val underlyingErrorMessage =
                             BillingStrings.BILLING_UNAVAILABLE_LESS_THAN_3.format(originalErrorMessage)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/errors.kt
@@ -12,6 +12,8 @@ internal fun @receiver:BillingClient.BillingResponseCode Int.getBillingResponseC
         ?: "$this"
 }
 
+internal const val IN_APP_BILLING_LESS_THAN_3_ERROR_MESSAGE = "Google Play In-app Billing API version is less than 3"
+
 internal fun Int.billingResponseToPurchasesError(underlyingErrorMessage: String): PurchasesError {
     val errorCode = when (this) {
         BillingClient.BillingResponseCode.BILLING_UNAVAILABLE,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -9,6 +9,9 @@ internal object BillingStrings {
     const val BILLING_SERVICE_DISCONNECTED = "Billing Service disconnected for %s"
     const val BILLING_SERVICE_SETUP_FINISHED = "Billing Service Setup finished for %s"
     const val BILLING_UNAVAILABLE = "Billing is not available in this device. %s"
+    const val BILLING_UNAVAILABLE_LESS_THAN_3 = "Billing is not available in this device. Make sure there's an " +
+        "account configured in Play Store. Reopen the Play Store or clean its caches if this keeps happening. " +
+        "Original error message: %s"
     const val BILLING_WRAPPER_PURCHASES_ERROR = "BillingWrapper purchases failed to update: %s"
     const val BILLING_WRAPPER_PURCHASES_UPDATED = "BillingWrapper purchases updated: %s"
     const val BILLING_PURCHASE_HISTORY_RECORD_MORE_THAN_ONE_SKU = "There's more than one sku in the " +

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -2685,6 +2685,36 @@ class BillingWrapperTest {
 
     // endregion inapp messages
 
+    // region BILLING_UNAVAILABLE
+
+    @Test
+    fun `BILLING_UNAVAILABLE errors are forwarded to billing client calls`() {
+        every { mockClient.isReady } returns false
+
+        var receivedError: PurchasesError? = null
+        wrapper.queryPurchases(
+            "abc",
+            {
+                error("Unexpected success")
+            },
+            { error ->
+                receivedError = error
+            }
+        )
+        val billingResult = BillingResult.newBuilder()
+            .setResponseCode(BillingClient.BillingResponseCode.BILLING_UNAVAILABLE)
+            .setDebugMessage(IN_APP_BILLING_LESS_THAN_3_ERROR_MESSAGE)
+            .build()
+
+        billingClientStateListener!!.onBillingSetupFinished(billingResult)
+
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+    }
+
+
+    // endregion
+
     private fun mockEmptyProductDetailsResponse() {
         val slot = slot<ProductDetailsResponseListener>()
         every {


### PR DESCRIPTION
We recently started getting reports of app performance issues when retrying to reconnect to Billing Client after a disconnection. See https://github.com/RevenueCat/purchases-android/issues/1288 

There's a related issue opened in Google's sample repository https://github.com/android/play-billing-samples/issues/636

It looks like after changing language in the system settings, the BillingClient will never connect again until the Play Store is opened or their caches are cleared. The way it behaves is when trying to connect, it will instantly call `onBillingServiceDisconnected` then call `onBillingSetupFinished` with a `BILLING_UNAVAILABLE`.

In our current code, we would retry to reconnect with a backoff on `onBillingServiceDisconnected`, which should be fine, because we would just back off an exponential amount of time before trying to connect.

In #1288 we have this stacktrace where we can see the user reached the max backoff (15 min):

```
2023-09-23 13:04:55.112 28721-29147 [Purchases] - DEBUG                        D  ℹ️ Saving tokens []
2023-09-23 13:04:55.113 28721-29147 [Purchases] - DEBUG                        D  ℹ️ Tokens already posted: []
2023-09-23 13:04:55.117 28721-29150 [Purchases] - DEBUG                        D  ℹ️ Cleaning previously sent tokens
2023-09-23 13:04:55.117 28721-29150 [Purchases] - DEBUG                        D  ℹ️ Tokens already posted: []
2023-09-23 13:04:55.118 28721-29150 [Purchases] - DEBUG                        D  ℹ️ Saving tokens []
2023-09-23 13:04:55.118 28721-29150 [Purchases] - DEBUG                        D  ℹ️ Tokens already posted: []
2023-09-23 13:04:55.119 28721-29150 [Purchases] - DEBUG                        D  ℹ️ No pending purchases to sync
2023-09-23 13:04:55.119 28721-29133 [Purchases] - DEBUG                        D  ℹ️ Cleaning previously sent tokens
2023-09-23 13:04:55.120 28721-29133 [Purchases] - DEBUG                        D  ℹ️ Tokens already posted: []
2023-09-23 13:04:55.120 28721-29133 [Purchases] - DEBUG                        D  ℹ️ Saving tokens []
2023-09-23 13:04:55.121 28721-29133 [Purchases] - DEBUG                        D  ℹ️ Tokens already posted: []
2023-09-23 13:04:55.121 28721-29133 [Purchases] - DEBUG                        D  ℹ️ No pending purchases to sync
2023-09-23 13:04:55.122 28721-29147 [Purchases] - DEBUG                        D  ℹ️ No pending purchases to sync
2023-09-23 13:04:55.124 28721-29034 [Purchases] - DEBUG                        D  ℹ️ Cleaning previously sent tokens
2023-09-23 13:04:55.125 28721-29034 [Purchases] - DEBUG                        D  ℹ️ Tokens already posted: []
2023-09-23 13:04:55.125 28721-29034 [Purchases] - DEBUG                        D  ℹ️ Saving tokens []
2023-09-23 13:04:55.126 28721-29034 [Purchases] - DEBUG                        D  ℹ️ Tokens already posted: []
2023-09-23 13:04:55.126 28721-29034 [Purchases] - DEBUG                        D  ℹ️ No pending purchases to sync
2023-09-23 13:04:55.436 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 1000 milliseconds.
2023-09-23 13:04:55.437 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 2000 milliseconds.
2023-09-23 13:04:55.438 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 4000 milliseconds.
2023-09-23 13:04:55.440 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 8000 milliseconds.
2023-09-23 13:04:55.441 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 16000 milliseconds.
2023-09-23 13:04:55.442 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 32000 milliseconds.
2023-09-23 13:04:55.444 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 64000 milliseconds.
2023-09-23 13:04:55.446 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 128000 milliseconds.
2023-09-23 13:04:55.447 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 256000 milliseconds.
2023-09-23 13:04:55.448 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 512000 milliseconds.
2023-09-23 13:04:55.450 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.452 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.453 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.454 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.456 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.457 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.460 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.461 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.463 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.465 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.467 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.468 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.469 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.471 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.472 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.473 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.475 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.476 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.477 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.479 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.480 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.481 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.482 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.483 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.484 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.485 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.486 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.487 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.488 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.488 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.489 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.491 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.491 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.492 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.493 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.494 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.494 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.495 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.496 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.496 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.497 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.498 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.498 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.499 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.500 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.501 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.501 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.502 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.503 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.503 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Retrying BillingClient connection after backoff of 900000 milliseconds.
2023-09-23 13:04:55.504 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.504 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.505 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.505 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.505 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.506 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.506 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.507 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.507 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.508 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.508 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.508 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.509 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.509 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.510 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.510 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.511 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Starting connection for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.530 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.531 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.531 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.532 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.532 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.533 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.533 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.533 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.534 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.534 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.535 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.535 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.535 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.536 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.536 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.537 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.537 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.538 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.538 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.539 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.539 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.539 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.540 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.540 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.541 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.541 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.542 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.542 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.542 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.543 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.543 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.544 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.544 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.545 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Billing Service disconnected for com.android.billingclient.api.BillingClientImpl@fc8d31a
2023-09-23 13:04:55.545 28721-28721 [Purchases] - DEBUG                        D  ℹ️ Starting connection for com.android.billingclient.api.BillingClientImpl@fc8d31a
```

My stacktrace looks a bit different, and I see some OK responses, that reset the backoff. BillingClient  sometimes would send an `OK` response, and we reset the backoff when the response is OK, making the issue even bigger since stopping when hitting the max backoff wouldn't help:

```
2023-10-31 18:57:33.219 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Startconnection
2023-10-31 18:57:34.051 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:34.051 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Retry with 1000
2023-10-31 18:57:34.051 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result BILLING_UNAVAILABLE
2023-10-31 18:57:34.811 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Startconnection
2023-10-31 18:57:34.815 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Startconnection
2023-10-31 18:57:34.862 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:34.863 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:35.080 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:35.080 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Retry with 1000
2023-10-31 18:57:35.081 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:35.081 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Startconnection
2023-10-31 18:57:35.329 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:35.330 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:35.331 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:35.446 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:35.446 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Retry with 1000
2023-10-31 18:57:35.447 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:35.447 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:36.082 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Startconnection
2023-10-31 18:57:36.399 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:36.401 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:36.402 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:36.404 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:36.473 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:36.474 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Retry with 1000
2023-10-31 18:57:36.474 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:36.475 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:36.476 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:37.477 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Startconnection
2023-10-31 18:57:37.797 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:37.801 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:37.805 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:37.809 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:37.815 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:37.894 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:37.895 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Retry with 1000
2023-10-31 18:57:37.895 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:37.896 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:37.896 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:37.897 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:38.897 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Startconnection
2023-10-31 18:57:39.215 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:39.220 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:39.223 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:39.226 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:39.230 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:39.233 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:39.333 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:39.334 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Retry with 1000
2023-10-31 18:57:39.334 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:39.335 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:39.335 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:39.336 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:39.336 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:40.337 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Startconnection
2023-10-31 18:57:40.640 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:40.644 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:40.648 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:40.651 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:40.655 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:40.659 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:40.663 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:40.711 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:40.714 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Retry with 1000
2023-10-31 18:57:40.715 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:40.718 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:40.720 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:40.722 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:40.725 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:40.727 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:41.717 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Startconnection
2023-10-31 18:57:42.015 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:42.021 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:42.023 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:42.024 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:42.025 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:42.026 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:42.028 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:42.029 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:42.124 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:42.124 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Retry with 1000
2023-10-31 18:57:42.125 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:42.125 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:42.126 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:42.126 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:42.127 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:42.127 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:42.127 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:43.127 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Startconnection
2023-10-31 18:57:43.398 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:43.401 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:43.402 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:43.405 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:43.408 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:43.412 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:43.415 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:43.418 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:43.424 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:43.510 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:43.512 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Retry with 1000
2023-10-31 18:57:43.513 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:43.516 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:43.519 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:43.522 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:43.523 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:43.525 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:43.527 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:43.529 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:44.514 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Startconnection
2023-10-31 18:57:44.798 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:44.803 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:44.804 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:44.805 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:44.806 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:44.808 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:44.811 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:44.816 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:44.818 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:44.820 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:44.890 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:44.891 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Retry with 1000
2023-10-31 18:57:44.891 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:44.892 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:44.893 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:44.893 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:44.894 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:44.895 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:44.895 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:44.896 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:44.897 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:45.893 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Startconnection
2023-10-31 18:57:46.151 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:46.154 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:46.157 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:46.158 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:46.159 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:46.163 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:46.164 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:46.166 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:46.168 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:46.169 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:46.171 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Result OK
2023-10-31 18:57:46.286 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:46.286 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Retry with 1000
2023-10-31 18:57:46.287 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:46.287 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:46.287 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:46.288 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:46.288 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:46.289 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:46.289 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:46.289 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:46.290 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
2023-10-31 18:57:46.290 27059-27059 BillingWrapper-Issue    com.revenuecat.paywall_tester        W  Disconnected
```

The performance hit is horrible, specially bad for my stacktrace:

![image](https://github.com/RevenueCat/purchases-android/assets/664544/bb9e8147-23fe-4ca2-a4d7-513517384b18)

After a lot of debugging and reading, I found this very useful [guide](https://developer.android.com/google/play/billing/errors) from Google. This was a useful read and made me realize we are doing a lot of things wrong, like not retrying after errors with interactions with the BillingClient.

First change would be to remove reconnections when trying to interact with the BillingClient if the connection has ended (we currently start connection from `executeRequestOnUIThread`). For this, we would need to make this change:

```
 @Synchronized
    private fun executeRequestOnUIThread(request: (PurchasesError?) -> Unit) {
        if (purchasesUpdatedListener != null) {
            serviceRequests.add(request)
            if (billingClient?.isReady == false) {
                startConnectionOnMainThread()
            } else {
                executePendingRequests()
            }
        } else {
            // This shouldn't happen, but if it does, we want to propagate an error instead of hanging.
            request(PurchasesError(PurchasesErrorCode.UnknownError, "BillingWrapper is not attached to a listener"))
        }
    }
``` 

To:

```
 @Synchronized
    private fun executeRequestOnUIThread(request: (PurchasesError?) -> Unit) {
        if (purchasesUpdatedListener != null) {
            serviceRequests.add(request)
            executePendingRequests()
        } else {
            // This shouldn't happen, but if it does, we want to propagate an error instead of hanging.
            request(PurchasesError(PurchasesErrorCode.UnknownError, "BillingWrapper is not attached to a listener"))
        }
    }
```

This means a lot of refactoring since it involves better checking and add retry mechanism to the errors we get when interacting with the billing client (like when calling `queryPurchases`, `acknowledge`, `consume`, etc). We currently don't really retry or check for specific errors after calling these functions, because we trust we will connect in `executeRequestOnUIThread` before executing it.

Apart from that, it is recommended to reconnect in `onBillingServiceDisconnected` using a max retry mechanism. I tried that by doing what they recommend in their guide:

```
private fun retryBillingServiceConnection() {
    val maxTries = 3
    var tries = 1
    var isConnectionEstablished = false
    do {
      try {
        billingClient.startConnection(object : BillingClientStateListener {
          override fun onBillingSetupFinished(billingResult: BillingResult) {
            if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
              isConnectionEstablished = true
              Log.d(TAG, "Billing connection retry succeeded.")
            } else {
              tries++
              Log.e(
                TAG,
                "Billing connection retry failed: ${billingResult.debugMessage}"
              )
            }
          }
        })
      } catch (e: Exception) {
        e.message?.let { Log.e(TAG, it) }
        tries++
      }
    } while (tries <= maxTries && !isConnectionEstablished)
  }
```
 
The problem with that code is that it always gets a `DEVELOPER_ERROR` when trying to reconnect. My guess is because the main thread is being used and `onBillingSetupFinished` hasn't been called yet with a result. This is the main reason why I didn't add this retry with a max number of retries to `onBillingServiceDisconnected`. Not only that, even after calling  `startConnection` only three times, `onBillingSetupFinished` would get called many more.

Since we can't know in `onBillingServiceDisconnected` that the disconnection is due to a `BILLING_UNAVAILABLE` error, which we shouldn't try to reconnect for, I decided to remove it from that function. We are already reconnecting when interacting with the billing client.

With this new approach:

- We trigger reconnections when interacting with the billing client if it's disconnected. If the reconnection fails, and the error is one we should be retrying for we retry with a backoff.
- We don't try to reconnect with backoff for every disconnection. Google actually recommends not retrying if the issue is `BILLING_UNAVAILABLE` because it's not recoverable, and since we can't know what's causing `onBillingServiceDisconnected` to be called, we just don't retry there.
- We prevent errors when trying to interact with a disconnected BillingClient, because we are connecting before that interaction.
- `BILLING_UNAVAILABLE` errors are captured and translated into a more meaningful log and `PurchasesError` that gets forwarded to the functions.

We need to do a whole rewrite of BillingWrapper, but I think this will fix those performance issues for now.