### PR TITLE
`Paywalls`: disallow Markdown links in `PurchaseButton`

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
@@ -125,6 +125,7 @@ private fun PurchaseButton(
                         textAlign = TextAlign.Center,
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold,
+                        allowLinks = false,
                         modifier = Modifier
                             .padding(vertical = UIConstant.defaultVerticalSpacing / 3)
                             .alpha(labelOpacity),


### PR DESCRIPTION
See #1411.
This fixes inconsistent touch behavior when tapping on it.