### PR TITLE
Paywalls: Decrease max aspect ratio for tablets to have a max height

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 
 private object UIDialogConstants {
     const val MAX_HEIGHT_PERCENTAGE_TABLET = 0.85f
-    const val MAX_ASPECT_RATIO_TO_APPLY_MAX_HEIGHT = 1.5f
+    const val MAX_ASPECT_RATIO_TO_APPLY_MAX_HEIGHT = 1.25f
 }
 
 /**


### PR DESCRIPTION
### Description
Followup to #1419 

I was playing with this value and in a slightly more wide tablet, it would use the full height... So I want to decrease this max aspect ratio a bit to avoid those tablets from having the full height of the screen.