### PR TITLE
`StoreProduct`: new `pricePerWeek` and `pricePerYear`

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
@@ -28,7 +28,9 @@ final class StoreProductAPI {
         final String description = product.getDescription();
         final Period period = product.getPeriod();
         final String formattedPricePerMonth = product.formattedPricePerMonth(locale);
+        final Price pricePerWeek = product.pricePerWeek(locale);
         final Price pricePerMonth = product.pricePerMonth(locale);
+        final Price pricePerYear = product.pricePerYear(locale);
 
         SubscriptionOptions subscriptionOptions = product.getSubscriptionOptions();
         SubscriptionOption defaultOption = product.getDefaultOption();

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
@@ -28,7 +28,9 @@ private class StoreProductAPI {
             val pricePerWeek: Price? = pricePerWeek(locale)
             val pricePerMonth: Price? = pricePerMonth(locale)
             val pricePerYear: Price? = pricePerYear(locale)
+            val pricePerWeekNoLocale: Price? = pricePerYear()
             val pricePerMonthNoLocale: Price? = pricePerMonth()
+            val pricePerYearNoLocale: Price? = pricePerYear()
             val title: String = title
             val description: String = description
             val period: Period? = period

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
@@ -25,7 +25,9 @@ private class StoreProductAPI {
             val price: Price? = price
             val formattedPricePerMonth: String? = formattedPricePerMonth(locale)
             val formattedPricePerMonthNoLocale: String? = formattedPricePerMonth()
+            val pricePerWeek: Price? = pricePerWeek(locale)
             val pricePerMonth: Price? = pricePerMonth(locale)
+            val pricePerYear: Price? = pricePerYear(locale)
             val pricePerMonthNoLocale: Price? = pricePerMonth()
             val title: String = title
             val description: String = description

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ billing = "6.0.1"
 lifecycle = "2.5.0"
 testLibraries = "1.4.0"
 testJUnit = "1.1.3"
+testJUnitParams = "1.1.1"
 roboelectric = "4.10.3"
 mockk = "1.12.8"
 assertJ = "3.22.0"
@@ -97,6 +98,7 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 mockk-agent = { module = "io.mockk:mockk-agent", version.ref = "mockk" }
+testJUnitParams = { module = "pl.pragmatists:JUnitParams", version.ref = "testJUnitParams" }
 
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
 

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -91,6 +91,7 @@ dependencies {
     testImplementation libs.amazon.appstore.sdk
     testImplementation libs.okhttp.mockwebserver
     testImplementation libs.playServices.ads.identifier
+    testImplementation libs.testJUnitParams
 
     androidTestImplementation libs.androidx.appcompat
     androidTestImplementation libs.androidx.lifecycle.runtime.ktx

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/Period.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/Period.kt
@@ -28,8 +28,11 @@ data class Period(
 ) : Parcelable {
 
     companion object Factory {
+        private const val DAYS_PER_WEEK = 7.0
         private const val DAYS_PER_MONTH = 30.0
+        private const val DAYS_PER_YEAR = 365.0
         private const val WEEKS_PER_MONTH = 4.0
+        private const val WEEKS_PER_YEAR = 52.14
         private const val MONTHS_PER_YEAR = 12.0
 
         fun create(iso8601: String): Period {
@@ -48,6 +51,21 @@ data class Period(
     }
 
     /**
+     * The period value in week units. This is an approximated value.
+     */
+    internal val valueInWeeks: Double
+        get() = when (unit) {
+            Unit.DAY -> value / DAYS_PER_WEEK
+            Unit.WEEK -> value.toDouble()
+            Unit.MONTH -> value.toDouble() * WEEKS_PER_MONTH
+            Unit.YEAR -> value * WEEKS_PER_YEAR
+            Unit.UNKNOWN -> {
+                errorLog("Unknown period unit trying to get value in months: $unit")
+                0.0
+            }
+        }
+
+    /**
      * The period value in month units. This is an approximated value.
      */
     val valueInMonths: Double
@@ -56,6 +74,21 @@ data class Period(
             Unit.WEEK -> value / WEEKS_PER_MONTH
             Unit.MONTH -> value.toDouble()
             Unit.YEAR -> value * MONTHS_PER_YEAR
+            Unit.UNKNOWN -> {
+                errorLog("Unknown period unit trying to get value in months: $unit")
+                0.0
+            }
+        }
+
+    /**
+     * The period value in week units. This is an approximated value.
+     */
+    internal val valueInYears: Double
+        get() = when (unit) {
+            Unit.DAY -> value / DAYS_PER_YEAR
+            Unit.WEEK -> value / WEEKS_PER_YEAR
+            Unit.MONTH -> value / MONTHS_PER_YEAR
+            Unit.YEAR -> value.toDouble()
             Unit.UNKNOWN -> {
                 errorLog("Unknown period unit trying to get value in months: $unit")
                 0.0

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
@@ -2,6 +2,8 @@ package com.revenuecat.purchases.models
 
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.utils.pricePerMonth
+import com.revenuecat.purchases.utils.pricePerWeek
+import com.revenuecat.purchases.utils.pricePerYear
 import java.util.Locale
 
 /**
@@ -92,6 +94,18 @@ interface StoreProduct {
     fun copyWithOfferingId(offeringId: String): StoreProduct
 
     /**
+     * Null for INAPP products. The price of the [StoreProduct] in the given locale in a weekly recurrence.
+     * This means that, for example, if the period is monthly, the price will be divided by 4.
+     * It uses a currency formatter to format the price in the given locale.
+     * Note that this value may be an approximation.
+     * For Google subscriptions, this value will use the basePlan to calculate the value.
+     * @param locale Locale to use for formatting the price. Default is the system default locale.
+     */
+    fun pricePerWeek(locale: Locale = Locale.getDefault()): Price? {
+        return period?.let { price.pricePerWeek(it, locale) }
+    }
+
+    /**
      * Null for INAPP products. The price of the [StoreProduct] in the given locale in a monthly recurrence.
      * This means that, for example, if the period is annual, the price will be divided by 12.
      * It uses a currency formatter to format the price in the given locale.
@@ -101,6 +115,18 @@ interface StoreProduct {
      */
     fun pricePerMonth(locale: Locale = Locale.getDefault()): Price? {
         return period?.let { price.pricePerMonth(it, locale) }
+    }
+
+    /**
+     * Null for INAPP products. The price of the [StoreProduct] in the given locale in a yearly recurrence.
+     * This means that, for example, if the period is monthly, the price will be multiplied by 12.
+     * It uses a currency formatter to format the price in the given locale.
+     * Note that this value may be an approximation.
+     * For Google subscriptions, this value will use the basePlan to calculate the value.
+     * @param locale Locale to use for formatting the price. Default is the system default locale.
+     */
+    fun pricePerYear(locale: Locale = Locale.getDefault()): Price? {
+        return period?.let { price.pricePerYear(it, locale) }
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PriceExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PriceExtensions.kt
@@ -8,12 +8,23 @@ import java.util.Locale
 
 private const val MICRO_MULTIPLIER = 1_000_000.0
 
+internal fun Price.pricePerWeek(billingPeriod: Period, locale: Locale): Price {
+    return pricePerPeriod(billingPeriod.valueInWeeks, locale)
+}
+
 internal fun Price.pricePerMonth(billingPeriod: Period, locale: Locale): Price {
-    val periodMonths = billingPeriod.valueInMonths
+    return pricePerPeriod(billingPeriod.valueInMonths, locale)
+}
+
+internal fun Price.pricePerYear(billingPeriod: Period, locale: Locale): Price {
+    return pricePerPeriod(billingPeriod.valueInYears, locale)
+}
+
+private fun Price.pricePerPeriod(units: Double, locale: Locale): Price {
     val numberFormat = NumberFormat.getCurrencyInstance(locale)
     numberFormat.currency = Currency.getInstance(currencyCode)
 
-    val value = amountMicros / periodMonths
+    val value = amountMicros / units
     val formatted = numberFormat.format(value / MICRO_MULTIPLIER)
 
     return Price(formatted, (value).toLong(), currencyCode)

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsPricePerMonthTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsPricePerMonthTest.kt
@@ -1,0 +1,42 @@
+package com.revenuecat.purchases.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+
+@RunWith(JUnitParamsRunner::class)
+@Category(AndroidJUnit4::class)
+class PriceExtensionsPricePerMonthTest: PriceExtensionsPricePerPeriodTest() {
+    @Test
+    @Parameters(
+        value = [
+            "$2, 1D, $60.00",
+            "$5, 15D, $10.00",
+            "$10, 1W, $40.00",
+            "$10, 2W, $20.00",
+            "$14.99, 1M, $14.99",
+            "$30, 2M, $15.00",
+            "$40, 3M, $13.33",
+            "$120, 1Y, $10.00",
+            "$50, 1Y, $4.17",
+            "$29.99, 1Y, $2.50",
+            "$720, 3Y, $20.00",
+        ]
+    )
+    fun `pricePerMonth`(
+        priceString: String,
+        periodString: String,
+        expectedString: String,
+    ) {
+        test(priceString, periodString, expectedString)
+    }
+
+    override fun compute(price: Price, period: Period): Price {
+        return price.pricePerMonth(period, locale)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsPricePerPeriodTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsPricePerPeriodTest.kt
@@ -1,0 +1,35 @@
+package com.revenuecat.purchases.utils
+
+import com.revenuecat.purchases.amazon.createPrice
+import com.revenuecat.purchases.common.MICROS_MULTIPLIER
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import java.util.Locale
+
+abstract class PriceExtensionsPricePerPeriodTest {
+    protected val locale: Locale = Locale.US
+
+    protected fun test(
+        priceString: String,
+        periodString: String,
+        expectedString: String,
+    ) {
+        val price = priceString.createPrice("US")
+        val period = Period.create("P$periodString")
+        val expected = expectedString.createPrice("US")
+
+        val result = compute(price, period)
+
+        assertThat(result.formatted).isEqualTo(expectedString)
+        assertThat(result.currencyCode).isEqualTo(price.currencyCode)
+        assertThat(result.amountMicros).isCloseTo(
+            expected.amountMicros,
+            // Ignore precision errors so we can compare "$3.99" without extra decimals
+            Offset.offset((MICROS_MULTIPLIER / 100).toLong())
+        )
+    }
+
+    protected abstract fun compute(price: Price, period: Period): Price
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsPricePerWeekTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsPricePerWeekTest.kt
@@ -1,0 +1,42 @@
+package com.revenuecat.purchases.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+
+@RunWith(JUnitParamsRunner::class)
+@Category(AndroidJUnit4::class)
+class PriceExtensionsPricePerWeekTest : PriceExtensionsPricePerPeriodTest() {
+    @Test
+    @Parameters(
+        value = [
+            "$1, 1D, $7.00",
+            "$2, 14D, $1.00",
+            "$10, 1W, $10.00",
+            "$10, 2W, $5.00",
+            "$14.99, 1M, $3.75",
+            "$30, 2M, $3.75",
+            "$40, 3M, $3.33",
+            "$120, 1Y, $2.30",
+            "$50, 1Y, $0.96",
+            "$29.99, 1Y, $0.58",
+            "$720, 3Y, $4.60",
+        ]
+    )
+    fun `pricePerWeek`(
+        priceString: String,
+        periodString: String,
+        expectedString: String,
+    ) {
+        test(priceString, periodString, expectedString)
+    }
+
+    override fun compute(price: Price, period: Period): Price {
+        return price.pricePerWeek(period, locale)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsPricePerYearTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/PriceExtensionsPricePerYearTest.kt
@@ -1,0 +1,44 @@
+package com.revenuecat.purchases.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+
+@RunWith(JUnitParamsRunner::class)
+@Category(AndroidJUnit4::class)
+class PriceExtensionsPricePerYearTest : PriceExtensionsPricePerPeriodTest() {
+    @Test
+    @Parameters(
+        value = [
+            "$1, 1D, $365.00",
+            "$2, 1D, $730.00",
+            "$5, 15D, $121.67",
+            "$10, 1W, $521.40",
+            "$10, 2W, $260.70",
+            "$14.99, 1M, $179.88",
+            "$5, 1M, $60.00",
+            "$30, 2M, $180.00",
+            "$40, 3M, $160.00",
+            "$120, 1Y, $120.00",
+            "$29.99, 1Y, $29.99",
+            "$50, 2Y, $25.00",
+            "$720, 3Y, $240.00",
+        ]
+    )
+    fun `pricePerYear`(
+        priceString: String,
+        periodString: String,
+        expectedString: String,
+    ) {
+        test(priceString, periodString, expectedString)
+    }
+
+    override fun compute(price: Price, period: Period): Price {
+        return price.pricePerYear(period, locale)
+    }
+}


### PR DESCRIPTION
This brings parity with `purchases-ios` and will be used for a new paywalls variable.