### PR TITLE
`Paywalls`: new `{{ sub_price_per_week }}` variable

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
@@ -29,8 +29,12 @@ internal class VariableDataProvider(
         return rcPackage.product.price.formatted
     }
 
+    fun localizedPricePerWeek(rcPackage: Package, locale: Locale): String? {
+        return rcPackage.product.pricePerWeek(locale)?.formatted
+    }
+
     fun localizedPricePerMonth(rcPackage: Package, locale: Locale): String? {
-        return rcPackage.product.formattedPricePerMonth(locale)
+        return rcPackage.product.pricePerMonth(locale)?.formatted
     }
 
     fun localizedFirstIntroductoryOfferPrice(rcPackage: Package): String? {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
@@ -94,6 +94,10 @@ internal object VariableProcessor {
 
         VariableName.PRODUCT_NAME -> variableDataProvider.productName(rcPackage)
         VariableName.SUB_PERIOD -> variableDataProvider.periodName(rcPackage)
+        VariableName.SUB_PRICE_PER_WEEK -> variableDataProvider.localizedPricePerWeek(
+            rcPackage,
+            locale,
+        )
         VariableName.SUB_PRICE_PER_MONTH -> variableDataProvider.localizedPricePerMonth(
             rcPackage,
             locale,
@@ -117,6 +121,7 @@ internal object VariableProcessor {
         TOTAL_PRICE_AND_PER_MONTH("total_price_and_per_month"),
         PRODUCT_NAME("product_name"),
         SUB_PERIOD("sub_period"),
+        SUB_PRICE_PER_WEEK("sub_price_per_week"),
         SUB_PRICE_PER_MONTH("sub_price_per_month"),
         SUB_DURATION("sub_duration"),
         SUB_DURATION_IN_MONTHS("sub_duration_in_months"),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
@@ -175,6 +175,20 @@ class VariableProcessorTest {
 
     // endregion
 
+    // region sub_price_per_week
+
+    @Test
+    fun `process variables processes sub_price_per_week`() {
+        expectVariablesResult("{{ sub_price_per_week }}", "$1.30")
+    }
+
+    @Test
+    fun `process variables processes sub_price_per_week in other locales`() {
+        expectVariablesResult("{{ sub_price_per_week }}", "1,30 US$", esLocale)
+    }
+
+    // endregion
+
     // region sub_price_per_month
 
     @Test


### PR DESCRIPTION
Depends on #1426.
Equivalent to https://github.com/RevenueCat/purchases-ios/pull/3355.