### PR TITLE
Improve fullscreen templates in landscape orientation

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -14,12 +14,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.window.core.layout.WindowWidthSizeClass
 import com.revenuecat.purchases.ui.revenuecatui.helpers.computeWindowWidthSizeClass
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayPaywall
+import com.revenuecat.purchases.ui.revenuecatui.helpers.windowAspectRatio
 import kotlinx.coroutines.launch
 
 private object UIDialogConstants {
@@ -84,8 +84,7 @@ private fun DialogScaffold(paywallOptions: PaywallOptions) {
 @Composable
 @ReadOnlyComposable
 private fun getDialogMaxHeightPercentage(): Float {
-    val aspectRatio = LocalConfiguration.current.screenHeightDp.toFloat() / LocalConfiguration.current.screenWidthDp
-    if (aspectRatio < UIDialogConstants.MAX_ASPECT_RATIO_TO_APPLY_MAX_HEIGHT) {
+    if (windowAspectRatio() < UIDialogConstants.MAX_ASPECT_RATIO_TO_APPLY_MAX_HEIGHT) {
         return 1f
     }
     return computeWindowWidthSizeClass().let {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/IntSizeExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/IntSizeExtensions.kt
@@ -2,5 +2,5 @@ package com.revenuecat.purchases.ui.revenuecatui.extensions
 
 import androidx.compose.ui.unit.IntSize
 
-val IntSize.aspectRatio: Float
+internal val IntSize.aspectRatio: Float
     get() = width.toFloat() / height

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/IntSizeExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/IntSizeExtensions.kt
@@ -1,0 +1,6 @@
+package com.revenuecat.purchases.ui.revenuecatui.extensions
+
+import androidx.compose.ui.unit.IntSize
+
+val IntSize.aspectRatio: Float
+    get() = width.toFloat() / height

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/HelperFunctions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/HelperFunctions.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui.helpers
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalInspectionMode
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Purchases
@@ -13,6 +14,12 @@ import kotlin.coroutines.suspendCoroutine
 @Composable
 @ReadOnlyComposable
 internal fun isInPreviewMode() = LocalInspectionMode.current
+
+@Composable
+@ReadOnlyComposable
+internal fun windowAspectRatio(): Float {
+    return LocalConfiguration.current.screenHeightDp.toFloat() / LocalConfiguration.current.screenWidthDp
+}
 
 /**
  * Evaluates [shouldDisplayBlock] with the current CustomerInfo to determine if a paywall should be displayed.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/HelperFunctions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/HelperFunctions.kt
@@ -18,7 +18,8 @@ internal fun isInPreviewMode() = LocalInspectionMode.current
 @Composable
 @ReadOnlyComposable
 internal fun windowAspectRatio(): Float {
-    return LocalConfiguration.current.screenHeightDp.toFloat() / LocalConfiguration.current.screenWidthDp
+    val configuration = LocalConfiguration.current
+    return configuration.screenHeightDp.toFloat() / configuration.screenWidthDp
 }
 
 /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -18,6 +18,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,12 +34,14 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.asAndroidPath
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
@@ -56,15 +62,16 @@ import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
-import com.revenuecat.purchases.ui.revenuecatui.helpers.windowAspectRatio
 
 @Composable
 internal fun Template1(state: PaywallState.Loaded, viewModel: PaywallViewModel) {
+    var size by remember { mutableStateOf(IntSize.Zero) }
+
     Column(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().onGloballyPositioned { size = it.size },
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Template1MainContent(state)
+        Template1MainContent(state, size)
         PurchaseButton(state, viewModel)
         Footer(templateConfiguration = state.templateConfiguration, viewModel = viewModel)
     }
@@ -72,7 +79,7 @@ internal fun Template1(state: PaywallState.Loaded, viewModel: PaywallViewModel) 
 
 @SuppressWarnings("LongMethod")
 @Composable
-private fun ColumnScope.Template1MainContent(state: PaywallState.Loaded) {
+private fun ColumnScope.Template1MainContent(state: PaywallState.Loaded, template1Size: IntSize) {
     val localizedConfig = state.selectedLocalization
     val colors = state.currentColors
 
@@ -86,7 +93,7 @@ private fun ColumnScope.Template1MainContent(state: PaywallState.Loaded) {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
-            HeaderImage(state.templateConfiguration.images.headerUri)
+            HeaderImage(state.templateConfiguration.images.headerUri, template1Size)
 
             Spacer(modifier = Modifier.weight(1f))
 
@@ -131,10 +138,10 @@ private fun ColumnScope.Template1MainContent(state: PaywallState.Loaded) {
 }
 
 @Composable
-private fun HeaderImage(uri: Uri?) {
+private fun HeaderImage(uri: Uri?, template1Size: IntSize) {
     uri?.let {
         CircleMask {
-            val aspectRatio = windowAspectRatio()
+            val aspectRatio = template1Size.height.toFloat() / template1Size.width
             val screenHeight = LocalConfiguration.current.screenHeightDp
             RemoteImage(
                 urlString = uri.toString(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -30,12 +30,14 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.asAndroidPath
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
@@ -53,6 +55,8 @@ import com.revenuecat.purchases.ui.revenuecatui.data.isInFullScreenMode
 import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
+import com.revenuecat.purchases.ui.revenuecatui.helpers.windowAspectRatio
 
 @Composable
 internal fun Template1(state: PaywallState.Loaded, viewModel: PaywallViewModel) {
@@ -130,10 +134,17 @@ private fun ColumnScope.Template1MainContent(state: PaywallState.Loaded) {
 private fun HeaderImage(uri: Uri?) {
     uri?.let {
         CircleMask {
+            val aspectRatio = windowAspectRatio()
+            val screenHeight = LocalConfiguration.current.screenHeightDp
             RemoteImage(
                 urlString = uri.toString(),
                 modifier = Modifier
-                    .aspectRatio(ratio = 1.2f),
+                    .conditional(aspectRatio > 1f) {
+                        aspectRatio(ratio = 1.2f)
+                    }
+                    .conditional(aspectRatio <= 1f) {
+                        fillMaxWidth().height(screenHeight.dp / 2f)
+                    },
                 contentScale = ContentScale.Crop,
             )
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -61,6 +61,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.isInFullScreenMode
 import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.extensions.aspectRatio
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 
 @Composable
@@ -138,15 +139,15 @@ private fun ColumnScope.Template1MainContent(state: PaywallState.Loaded, templat
 }
 
 @Composable
-private fun HeaderImage(uri: Uri?, template1Size: IntSize) {
+private fun HeaderImage(uri: Uri?, templateSize: IntSize) {
     uri?.let {
         CircleMask {
-            val aspectRatio = template1Size.height.toFloat() / template1Size.width
+            val aspectRatio = templateSize.aspectRatio
             val screenHeight = LocalConfiguration.current.screenHeightDp
             RemoteImage(
                 urlString = uri.toString(),
                 modifier = Modifier
-                    .conditional(aspectRatio > 1f || template1Size == IntSize.Zero) {
+                    .conditional(aspectRatio > 1f || templateSize == IntSize.Zero) {
                         aspectRatio(ratio = 1.2f)
                     }
                     .conditional(aspectRatio <= 1f) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -146,7 +146,7 @@ private fun HeaderImage(uri: Uri?, template1Size: IntSize) {
             RemoteImage(
                 urlString = uri.toString(),
                 modifier = Modifier
-                    .conditional(aspectRatio > 1f) {
+                    .conditional(aspectRatio > 1f || template1Size == IntSize.Zero) {
                         aspectRatio(ratio = 1.2f)
                     }
                     .conditional(aspectRatio <= 1f) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -51,6 +52,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
@@ -80,7 +82,6 @@ import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 import com.revenuecat.purchases.ui.revenuecatui.extensions.packageButtonActionInProgressOpacityAnimation
 import com.revenuecat.purchases.ui.revenuecatui.extensions.packageButtonColorAnimation
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toAndroidContext
-import com.revenuecat.purchases.ui.revenuecatui.helpers.windowAspectRatio
 
 private object Template5UIConstants {
     val featureIconSize = 25.dp
@@ -95,13 +96,17 @@ internal fun Template5(
     state: PaywallState.Loaded,
     viewModel: PaywallViewModel,
 ) {
-    Column {
+    var size by remember { mutableStateOf(IntSize.Zero) }
+
+    Column(
+        modifier = Modifier.onGloballyPositioned { size = it.size },
+    ) {
         var packageSelectorVisible by remember {
             mutableStateOf(state.templateConfiguration.mode != PaywallMode.FOOTER_CONDENSED)
         }
 
         if (state.isInFullScreenMode) {
-            HeaderImage(state.templateConfiguration.images.headerUri)
+            HeaderImage(state.templateConfiguration.images.headerUri, size)
         }
 
         Template5MainContent(state, viewModel, packageSelectorVisible)
@@ -171,9 +176,9 @@ private fun ColumnScope.Template5MainContent(
 }
 
 @Composable
-private fun HeaderImage(uri: Uri?) {
+private fun HeaderImage(uri: Uri?, template5Size: IntSize) {
     uri?.let {
-        val aspectRatio = windowAspectRatio()
+        val aspectRatio = template5Size.height.toFloat() / template5Size.width.toFloat()
         RemoteImage(
             urlString = uri.toString(),
             modifier = Modifier

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
@@ -79,12 +80,14 @@ import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 import com.revenuecat.purchases.ui.revenuecatui.extensions.packageButtonActionInProgressOpacityAnimation
 import com.revenuecat.purchases.ui.revenuecatui.extensions.packageButtonColorAnimation
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toAndroidContext
+import com.revenuecat.purchases.ui.revenuecatui.helpers.windowAspectRatio
 
 private object Template5UIConstants {
     val featureIconSize = 25.dp
     val checkmarkSize = 18.dp
     val discountPadding = 8.dp
     const val headerAspectRatio = 2f
+    const val percentageScreenImageInLandscape = 0.4f
 }
 
 @Composable
@@ -170,10 +173,16 @@ private fun ColumnScope.Template5MainContent(
 @Composable
 private fun HeaderImage(uri: Uri?) {
     uri?.let {
+        val aspectRatio = windowAspectRatio()
         RemoteImage(
             urlString = uri.toString(),
             modifier = Modifier
-                .aspectRatio(ratio = Template5UIConstants.headerAspectRatio),
+                .conditional(aspectRatio > 1f) {
+                    aspectRatio(ratio = Template5UIConstants.headerAspectRatio)
+                }
+                .conditional(aspectRatio <= 1f) {
+                    fillMaxHeight(Template5UIConstants.percentageScreenImageInLandscape).fillMaxWidth()
+                },
             contentScale = ContentScale.Crop,
         )
     }
@@ -425,6 +434,7 @@ private val TemplateConfiguration.Colors.unselectedDiscountText: Color
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Preview(showBackground = true, locale = "en-rUS")
 @Preview(showBackground = true, locale = "es-rES")
+@Preview(showBackground = true, widthDp = 1000, heightDp = 1000)
 @Preview(showBackground = true, device = Devices.NEXUS_7)
 @Preview(showBackground = true, device = Devices.NEXUS_10)
 @Composable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
@@ -182,7 +182,7 @@ private fun HeaderImage(uri: Uri?, template5Size: IntSize) {
         RemoteImage(
             urlString = uri.toString(),
             modifier = Modifier
-                .conditional(aspectRatio > 1f) {
+                .conditional(aspectRatio > 1f || template5Size == IntSize.Zero) {
                     aspectRatio(ratio = Template5UIConstants.headerAspectRatio)
                 }
                 .conditional(aspectRatio <= 1f) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
@@ -77,6 +77,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.processed.localizedDiscount
 import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.extensions.aspectRatio
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 import com.revenuecat.purchases.ui.revenuecatui.extensions.packageButtonActionInProgressOpacityAnimation
@@ -176,13 +177,13 @@ private fun ColumnScope.Template5MainContent(
 }
 
 @Composable
-private fun HeaderImage(uri: Uri?, template5Size: IntSize) {
+private fun HeaderImage(uri: Uri?, templateSize: IntSize) {
     uri?.let {
-        val aspectRatio = template5Size.height.toFloat() / template5Size.width.toFloat()
+        val aspectRatio = templateSize.aspectRatio
         RemoteImage(
             urlString = uri.toString(),
             modifier = Modifier
-                .conditional(aspectRatio > 1f || template5Size == IntSize.Zero) {
+                .conditional(aspectRatio > 1f || templateSize == IntSize.Zero) {
                     aspectRatio(ratio = Template5UIConstants.headerAspectRatio)
                 }
                 .conditional(aspectRatio <= 1f) {


### PR DESCRIPTION
### Description
This modifies templates 1 and 5 so the top images don't use the full height of the screen when using devices in horizontal. This is not a problem when presenting as a dialog, since the width is limited, but if using the composables directly, it might be problematic.