### PR TITLE
Paywalls: Store paywall events on disk and API (1)

### DIFF
--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallTrackingAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallTrackingAPI.kt
@@ -1,0 +1,54 @@
+package com.revenuecat.apitester.kotlin.revenuecatui
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.paywalls.events.PaywallEvent
+import com.revenuecat.purchases.paywalls.events.PaywallEventType
+import java.util.Date
+import java.util.UUID
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@Suppress("unused", "UNUSED_VARIABLE")
+private class PaywallTrackingAPI {
+
+    fun check(purchases: Purchases, paywallEvent: PaywallEvent) {
+        purchases.track(paywallEvent)
+    }
+
+    fun checkPaywallEvent(eventType: PaywallEventType?, paywallRevision: Int) {
+        val paywallEvent = PaywallEvent(
+            PaywallEvent.CreationData(
+                UUID.randomUUID(),
+                Date(),
+            ),
+            PaywallEvent.Data(
+                "offeringId",
+                paywallRevision,
+                UUID.randomUUID(),
+                "footer",
+                "es_ES",
+                true,
+            ),
+            eventType!!,
+        )
+        val creationData: PaywallEvent.CreationData = paywallEvent.creationData
+        val eventUUID: UUID = creationData.id
+        val eventDate: Date = creationData.date
+        val data: PaywallEvent.Data = paywallEvent.data
+        val offeringId: String = data.offeringIdentifier
+        val paywallRevision: Int = data.paywallRevision
+        val sessionUUID: UUID = data.sessionIdentifier
+        val displayMode: String = data.displayMode
+        val locale: String = data.localeIdentifier
+        val darkMode: Boolean = data.darkMode
+    }
+
+    fun checkEventTypes(eventType: PaywallEventType) {
+        when (eventType) {
+            PaywallEventType.IMPRESSION,
+            PaywallEventType.CANCEL,
+            PaywallEventType.CLOSE,
+            -> {}
+        }
+    }
+}

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -21,6 +21,7 @@ import com.revenuecat.purchases.models.BillingFeature
 import com.revenuecat.purchases.models.GoogleProrationMode
 import com.revenuecat.purchases.models.InAppMessageType
 import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.strings.ConfigureStrings
 import java.net.URL
@@ -448,6 +449,15 @@ class Purchases internal constructor(
      */
     fun invalidateCustomerInfoCache() {
         purchasesOrchestrator.invalidateCustomerInfoCache()
+    }
+
+    /**
+     * Used by `RevenueCatUI` to keep track of [PaywallEvent]s.
+     */
+    @ExperimentalPreviewRevenueCatPurchasesAPI
+    @JvmSynthetic
+    fun track(paywallEvent: PaywallEvent) {
+        purchasesOrchestrator.track(paywallEvent)
     }
 
     // region Subscriber Attributes

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -267,6 +267,9 @@ internal class PurchasesFactory(
         identityManager: IdentityManager,
         eventsDispatcher: Dispatcher,
     ): PaywallEventsManager? {
+        // RevenueCatUI is Android 24+ so it should always enter here when using RevenueCatUI.
+        // Still, we check for Android N or newer since we use Streams which are 24+ and the main SDK supports
+        // older versions.
         return if (isAndroidNOrNewer()) {
             PaywallEventsManager(
                 PaywallEventsFileHelper(FileHelper(context)),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
@@ -4,6 +4,8 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.os.LocaleListCompat
 import com.revenuecat.purchases.utils.convertToCorrectlyFormattedLocale
+import com.revenuecat.purchases.utils.serializers.OptionalURLSerializer
+import com.revenuecat.purchases.utils.serializers.URLSerializer
 import com.revenuecat.purchases.utils.sharedLanguageCodeWith
 import com.revenuecat.purchases.utils.toLocale
 import kotlinx.serialization.SerialName

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEvent.kt
@@ -1,0 +1,60 @@
+package com.revenuecat.purchases.paywalls.events
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.utils.serializers.DateSerializer
+import com.revenuecat.purchases.utils.serializers.UUIDSerializer
+import kotlinx.serialization.Serializable
+import java.util.Date
+import java.util.UUID
+
+/**
+ * Types of paywall events. Meant for RevenueCatUI use.
+ */
+@ExperimentalPreviewRevenueCatPurchasesAPI
+enum class PaywallEventType(val value: String) {
+    /**
+     * The paywall was shown to the user.
+     */
+    IMPRESSION("paywall_impression"),
+
+    /**
+     * The user cancelled a purchase.
+     */
+    CANCEL("paywall_cancel"),
+
+    /**
+     * The paywall was dismissed.
+     */
+    CLOSE("paywall_close"),
+}
+
+/**
+ * Type representing a paywall event and associated data. Meant for RevenueCatUI use.
+ */
+@ExperimentalPreviewRevenueCatPurchasesAPI
+@Serializable
+data class PaywallEvent(
+    val creationData: CreationData,
+    val data: Data,
+    val type: PaywallEventType,
+) {
+
+    @Serializable
+    data class CreationData(
+        @Serializable(with = UUIDSerializer::class)
+        val id: UUID,
+        @Serializable(with = DateSerializer::class)
+        val date: Date,
+    )
+
+    @Serializable
+    data class Data(
+        val offeringIdentifier: String,
+        val paywallRevision: Int,
+        @Serializable(with = UUIDSerializer::class)
+        val sessionIdentifier: UUID,
+        val displayMode: String, // Refer to PaywallMode in the RevenueCatUI module.
+        val localeIdentifier: String,
+        val darkMode: Boolean,
+    )
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEventsFileHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEventsFileHelper.kt
@@ -1,0 +1,39 @@
+package com.revenuecat.purchases.paywalls.events
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.revenuecat.purchases.common.FileHelper
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import java.util.stream.Stream
+
+@RequiresApi(Build.VERSION_CODES.N)
+internal class PaywallEventsFileHelper(
+    private val fileHelper: FileHelper,
+) {
+    companion object {
+        const val PAYWALL_EVENTS_FILE_PATH = "RevenueCat/paywall_event_store/paywall_event_store.jsonl"
+    }
+
+    @Synchronized
+    fun appendEvent(event: PaywallStoredEvent) {
+        val eventString = PaywallEventsManager.json.encodeToString(event)
+        fileHelper.appendToFile(PAYWALL_EVENTS_FILE_PATH, eventString + "\n")
+    }
+
+    @Synchronized
+    fun readFile(streamBlock: ((Stream<PaywallStoredEvent>) -> Unit)) {
+        if (fileHelper.fileIsEmpty(PAYWALL_EVENTS_FILE_PATH)) {
+            streamBlock(Stream.empty())
+        } else {
+            fileHelper.readFilePerLines(PAYWALL_EVENTS_FILE_PATH) { stream ->
+                streamBlock(stream.map { PaywallEventsManager.json.decodeFromString(it) })
+            }
+        }
+    }
+
+    @Synchronized
+    fun clear(eventsToDeleteCount: Int) {
+        fileHelper.removeFirstLinesFromFile(PAYWALL_EVENTS_FILE_PATH, eventsToDeleteCount)
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEventsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEventsManager.kt
@@ -1,0 +1,40 @@
+package com.revenuecat.purchases.paywalls.events
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.common.Delay
+import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.identity.IdentityManager
+import kotlinx.serialization.json.Json
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@RequiresApi(Build.VERSION_CODES.N)
+internal class PaywallEventsManager(
+    private val fileHelper: PaywallEventsFileHelper,
+    private val identityManager: IdentityManager,
+    private val paywallEventsDispatcher: Dispatcher,
+) {
+
+    companion object {
+        internal val json = Json.Default
+    }
+
+    fun track(event: PaywallEvent) {
+        enqueue {
+            debugLog("Tracking paywall event: $event")
+            fileHelper.appendEvent(PaywallStoredEvent(event, identityManager.currentAppUserID))
+        }
+    }
+
+    fun flushEvents() {
+        // WIP
+    }
+
+    private fun enqueue(delay: Delay = Delay.NONE, command: () -> Unit) {
+        paywallEventsDispatcher.enqueue({
+            command()
+        }, delay)
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallStoredEvent.kt
@@ -1,0 +1,11 @@
+package com.revenuecat.purchases.paywalls.events
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import kotlinx.serialization.Serializable
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@Serializable
+internal data class PaywallStoredEvent(
+    val event: PaywallEvent,
+    val userID: String,
+)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/DateSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/DateSerializer.kt
@@ -1,0 +1,22 @@
+package com.revenuecat.purchases.utils.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.util.Date
+
+internal object DateSerializer : KSerializer<Date> {
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("Date", PrimitiveKind.LONG)
+
+    override fun deserialize(decoder: Decoder): Date {
+        return Date(decoder.decodeLong())
+    }
+
+    override fun serialize(encoder: Encoder, value: Date) {
+        encoder.encodeLong(value.time)
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/URLSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/URLSerializer.kt
@@ -1,4 +1,4 @@
-package com.revenuecat.purchases.paywalls
+package com.revenuecat.purchases.utils.serializers
 
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.nullable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/UUIDSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/UUIDSerializer.kt
@@ -1,0 +1,21 @@
+package com.revenuecat.purchases.utils.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.util.UUID
+
+internal object UUIDSerializer : KSerializer<UUID> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): UUID {
+        return UUID.fromString(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: UUID) {
+        return encoder.encodeString(value.toString())
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -28,6 +28,7 @@ import com.revenuecat.purchases.models.GoogleReplacementMode
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.SubscriptionOption
+import com.revenuecat.purchases.paywalls.events.PaywallEventsManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.utils.STUB_PRODUCT_IDENTIFIER
 import com.revenuecat.purchases.utils.createMockOneTimeProductDetails
@@ -67,6 +68,7 @@ internal open class BasePurchasesTest {
     internal val mockPostPendingTransactionsHelper = mockk<PostPendingTransactionsHelper>()
     internal val mockSyncPurchasesHelper = mockk<SyncPurchasesHelper>()
     protected val mockOfferingsManager = mockk<OfferingsManager>()
+    internal val mockPaywallEventsManager = mockk<PaywallEventsManager>()
 
     protected var capturedPurchasesUpdatedListener = slot<BillingAbstract.PurchasesUpdatedListener>()
     protected var capturedBillingWrapperStateListener = slot<BillingAbstract.StateListener>()
@@ -109,6 +111,9 @@ internal open class BasePurchasesTest {
         every {
             mockOfflineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         } just Runs
+        every {
+            mockPaywallEventsManager.flushEvents()
+        } just Runs
 
         anonymousSetup(false)
     }
@@ -123,6 +128,7 @@ internal open class BasePurchasesTest {
             mockOfferingsManager,
             mockCustomerInfoUpdateHandler,
             mockPostPendingTransactionsHelper,
+            mockPaywallEventsManager,
         )
         unmockkStatic(ProcessLifecycleOwner::class)
     }
@@ -364,7 +370,8 @@ internal open class BasePurchasesTest {
             postTransactionWithProductDetailsHelper = postTransactionsHelper,
             postPendingTransactionsHelper = mockPostPendingTransactionsHelper,
             syncPurchasesHelper = mockSyncPurchasesHelper,
-            offeringsManager = mockOfferingsManager
+            offeringsManager = mockOfferingsManager,
+            paywallEventsManager = mockPaywallEventsManager,
         )
         purchases = Purchases(purchasesOrchestrator)
         Purchases.sharedInstance = purchases

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventSerializationTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventSerializationTests.kt
@@ -1,0 +1,67 @@
+package com.revenuecat.purchases.paywalls.events
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Date
+import java.util.UUID
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@RunWith(AndroidJUnit4::class)
+class PaywallEventSerializationTests {
+
+    private val event = PaywallStoredEvent(
+        event = PaywallEvent(
+            creationData = PaywallEvent.CreationData(
+                id = UUID.fromString("298207f4-87af-4b57-a581-eb27bcc6e009"),
+                date = Date(1699270688884)
+            ),
+            data = PaywallEvent.Data(
+                offeringIdentifier = "offeringID",
+                paywallRevision = 5,
+                sessionIdentifier = UUID.fromString("315107f4-98bf-4b68-a582-eb27bcb6e111"),
+                displayMode = "footer",
+                localeIdentifier = "es_ES",
+                darkMode = true
+            ),
+            type = PaywallEventType.IMPRESSION,
+        ),
+        userID = "testAppUserId",
+    )
+
+    @Test
+    fun `can encode paywall event correctly`() {
+        val eventString = PaywallEventsManager.json.encodeToString(event)
+        assertThat(eventString).isEqualTo(
+            "{" +
+                "\"event\":{" +
+                    "\"creationData\":{" +
+                        "\"id\":\"298207f4-87af-4b57-a581-eb27bcc6e009\"," +
+                        "\"date\":1699270688884" +
+                    "}," +
+                    "\"data\":{" +
+                        "\"offeringIdentifier\":\"offeringID\"," +
+                        "\"paywallRevision\":5," +
+                        "\"sessionIdentifier\":\"315107f4-98bf-4b68-a582-eb27bcb6e111\"," +
+                        "\"displayMode\":\"footer\"," +
+                        "\"localeIdentifier\":\"es_ES\"," +
+                        "\"darkMode\":true" +
+                    "}," +
+                    "\"type\":\"IMPRESSION\"" +
+                "}," +
+                "\"userID\":\"testAppUserId\"" +
+            "}"
+        )
+    }
+
+    @Test
+    fun `can encode and decode event correctly`() {
+        val eventString = PaywallEventsManager.json.encodeToString(event)
+        val decodedEvent = PaywallEventsManager.json.decodeFromString<PaywallStoredEvent>(eventString)
+        assertThat(decodedEvent).isEqualTo(event)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventsManagerTest.kt
@@ -1,0 +1,142 @@
+package com.revenuecat.purchases.paywalls.events
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.FileHelper
+import com.revenuecat.purchases.common.SyncDispatcher
+import com.revenuecat.purchases.identity.IdentityManager
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.util.Date
+import java.util.UUID
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@RunWith(AndroidJUnit4::class)
+class PaywallEventsManagerTest {
+
+    private val testFolder = "temp_test_folder"
+
+    private lateinit var fileHelper: PaywallEventsFileHelper
+    private lateinit var identityManager: IdentityManager
+    private lateinit var paywallEventsDispatcher: Dispatcher
+
+    private lateinit var eventsManager: PaywallEventsManager
+
+    @Before
+    fun setUp() {
+        val tempTestFolder = File(testFolder)
+        if (tempTestFolder.exists()) {
+            error("Temp test folder should not exist before starting tests")
+        }
+        tempTestFolder.mkdirs()
+
+        val context = mockk<Context>().apply {
+            every { filesDir } returns tempTestFolder
+        }
+        fileHelper = PaywallEventsFileHelper(FileHelper(context))
+        identityManager = mockk<IdentityManager>().apply {
+            every { currentAppUserID } returns "testAppUserId"
+        }
+        paywallEventsDispatcher = SyncDispatcher()
+
+        eventsManager = PaywallEventsManager(
+            fileHelper,
+            identityManager,
+            paywallEventsDispatcher
+        )
+    }
+
+    @After
+    fun tearDown() {
+        val tempTestFolder = File(testFolder)
+        tempTestFolder.deleteRecursively()
+    }
+
+    @Test
+    fun `tracking events adds them to file`() {
+        val event = PaywallEvent(
+            creationData = PaywallEvent.CreationData(
+                id = UUID.fromString("298207f4-87af-4b57-a581-eb27bcc6e009"),
+                date = Date(1699270688884)
+            ),
+            data = PaywallEvent.Data(
+                offeringIdentifier = "offeringID",
+                paywallRevision = 5,
+                sessionIdentifier = UUID.fromString("315107f4-98bf-4b68-a582-eb27bcb6e111"),
+                displayMode = "footer",
+                localeIdentifier = "es_ES",
+                darkMode = true
+            ),
+            type = PaywallEventType.IMPRESSION,
+        )
+        eventsManager.track(event)
+        checkFileContents("{" +
+            "\"event\":{" +
+                "\"creationData\":{" +
+                    "\"id\":\"298207f4-87af-4b57-a581-eb27bcc6e009\"," +
+                    "\"date\":1699270688884" +
+                "}," +
+                "\"data\":{" +
+                    "\"offeringIdentifier\":\"offeringID\"," +
+                    "\"paywallRevision\":5," +
+                    "\"sessionIdentifier\":\"315107f4-98bf-4b68-a582-eb27bcb6e111\"," +
+                    "\"displayMode\":\"footer\"," +
+                    "\"localeIdentifier\":\"es_ES\"," +
+                    "\"darkMode\":true" +
+                "}," +
+                "\"type\":\"IMPRESSION\"" +
+            "}," +
+            "\"userID\":\"testAppUserId\"" +
+        "}\n")
+        eventsManager.track(event.copy(type = PaywallEventType.CANCEL))
+        checkFileContents("{" +
+            "\"event\":{" +
+                "\"creationData\":{" +
+                    "\"id\":\"298207f4-87af-4b57-a581-eb27bcc6e009\"," +
+                    "\"date\":1699270688884" +
+                "}," +
+                "\"data\":{" +
+                    "\"offeringIdentifier\":\"offeringID\"," +
+                    "\"paywallRevision\":5," +
+                    "\"sessionIdentifier\":\"315107f4-98bf-4b68-a582-eb27bcb6e111\"," +
+                    "\"displayMode\":\"footer\"," +
+                    "\"localeIdentifier\":\"es_ES\"," +
+                    "\"darkMode\":true" +
+                "}," +
+                "\"type\":\"IMPRESSION\"" +
+            "}," +
+            "\"userID\":\"testAppUserId\"" +
+        "}\n" +
+        "{" +
+            "\"event\":{" +
+                "\"creationData\":{" +
+                    "\"id\":\"298207f4-87af-4b57-a581-eb27bcc6e009\"," +
+                    "\"date\":1699270688884" +
+                "}," +
+                "\"data\":{" +
+                    "\"offeringIdentifier\":\"offeringID\"," +
+                    "\"paywallRevision\":5," +
+                    "\"sessionIdentifier\":\"315107f4-98bf-4b68-a582-eb27bcb6e111\"," +
+                    "\"displayMode\":\"footer\"," +
+                    "\"localeIdentifier\":\"es_ES\"," +
+                    "\"darkMode\":true" +
+                "}," +
+                "\"type\":\"CANCEL\"" +
+            "}," +
+            "\"userID\":\"testAppUserId\"" +
+        "}\n")
+    }
+
+    private fun checkFileContents(expectedContents: String) {
+        val file = File(testFolder, PaywallEventsFileHelper.PAYWALL_EVENTS_FILE_PATH)
+        assertThat(file.readText()).isEqualTo(expectedContents)
+    }
+}

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -96,6 +96,7 @@ class SubscriberAttributesPurchasesTests {
             postPendingTransactionsHelper = postPendingTransactionsHelper,
             syncPurchasesHelper = mockk(),
             offeringsManager = offeringsManagerMock,
+            paywallEventsManager = null,
         )
 
         underTest = Purchases(purchasesOrchestrator)


### PR DESCRIPTION
### Description
This adds support for storing paywall events into disk. In followup PRs, we will send these events to our servers for analytics and use these events to indicate whether a purchase came from our paywalls.
- [ ] Send events to server
- [ ] Use events to detect whether a purchase came from paywall.
