### PR TITLE
`Offering`: restore constructor with no `PaywallData`

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingAPI.java
@@ -1,7 +1,10 @@
 package com.revenuecat.apitester.java;
 
+import androidx.annotation.Nullable;
+
 import com.revenuecat.purchases.Offering;
 import com.revenuecat.purchases.Package;
+import com.revenuecat.purchases.paywalls.PaywallData;
 
 import java.util.List;
 import java.util.Map;
@@ -25,5 +28,22 @@ final class OfferingAPI {
 
         final Map<String, Object> metadata = offering.getMetadata();
         final String metadataString = offering.getMetadataString("key", "default");
+
+        final @Nullable PaywallData paywallData = offering.getPaywall();
+
+        new Offering(
+                identifier,
+                serverDescription,
+                metadata,
+                availablePackages
+        );
+
+        new Offering(
+                identifier,
+                serverDescription,
+                metadata,
+                availablePackages,
+                paywallData
+        );
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/OfferingAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/OfferingAPI.kt
@@ -2,6 +2,7 @@ package com.revenuecat.apitester.kotlin
 
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.paywalls.PaywallData
 
 @Suppress("unused", "UNUSED_VARIABLE")
 private class OfferingAPI {
@@ -21,6 +22,22 @@ private class OfferingAPI {
             val p2: Package = getPackage("")
             val metadata: Map<String, Any> = metadata
             val metadataString: String = getMetadataString("key", "default")
+            val paywall: PaywallData? = paywall
+
+            Offering(
+                identifier = identifier,
+                serverDescription = serverDescription,
+                metadata = metadata,
+                availablePackages = availablePackages,
+            )
+
+            Offering(
+                identifier = identifier,
+                serverDescription = serverDescription,
+                metadata = metadata,
+                availablePackages = availablePackages,
+                paywall = paywall
+            )
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/OfferingAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/OfferingAPI.kt
@@ -36,7 +36,7 @@ private class OfferingAPI {
                 serverDescription = serverDescription,
                 metadata = metadata,
                 availablePackages = availablePackages,
-                paywall = paywall
+                paywall = paywall,
             )
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
@@ -15,12 +15,12 @@ import com.revenuecat.purchases.paywalls.PaywallData
  * @property availablePackages Array of [Package] objects available for purchase.
  * @property metadata Offering metadata defined in RevenueCat dashboard.
  */
-data class Offering constructor(
+data class Offering @JvmOverloads constructor(
     val identifier: String,
     val serverDescription: String,
     val metadata: Map<String, Any>,
     val availablePackages: List<Package>,
-    val paywall: PaywallData?,
+    val paywall: PaywallData? = null,
 ) {
 
     /**


### PR DESCRIPTION
We were missing the constructors in the API tester so we didn't realize that we removed the previous constructor with no `PaywallData`.
This was caught by PHC: https://github.com/RevenueCat/purchases-hybrid-common/pull/544
