### PR TITLE
`PaywallActivityLauncher`: new constructor for a generic `ActivityResultCaller`

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallActivityLauncherAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallActivityLauncherAPI.java
@@ -2,6 +2,7 @@ package com.revenuecat.apitester.java.revenuecatui;
 
 
 import androidx.activity.ComponentActivity;
+import androidx.activity.result.ActivityResultCaller;
 import androidx.fragment.app.Fragment;
 
 import com.revenuecat.purchases.Offering;
@@ -17,12 +18,14 @@ final class PaywallActivityLauncherAPI {
     static void check(
             ComponentActivity activity,
             Fragment fragment,
+            ActivityResultCaller resultCaller,
             PaywallResultHandler resultHandler,
             Offering offering,
             ParcelizableFontProvider fontProvider
     ) {
         PaywallActivityLauncher launcher = new PaywallActivityLauncher(activity, resultHandler);
         PaywallActivityLauncher launcher2 = new PaywallActivityLauncher(fragment, resultHandler);
+        PaywallActivityLauncher launcher3 = new PaywallActivityLauncher(resultCaller, resultHandler);
         launcher.launch();
         launcher.launch(offering);
         launcher.launch(null, fontProvider);

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallActivityLauncherAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallActivityLauncherAPI.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.apitester.kotlin.revenuecatui
 
 import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultCaller
 import androidx.fragment.app.Fragment
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
@@ -9,18 +10,20 @@ import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResultHandler
 import com.revenuecat.purchases.ui.revenuecatui.fonts.ParcelizableFontProvider
 
-@Suppress("unused", "UNUSED_VARIABLE")
+@Suppress("unused", "UNUSED_VARIABLE", "LongParameterList")
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 private class PaywallActivityLauncherAPI {
     fun check(
         componentActivity: ComponentActivity,
         fragment: Fragment,
+        resultCaller: ActivityResultCaller,
         resultHandler: PaywallResultHandler,
         offering: Offering,
         fontProvider: ParcelizableFontProvider,
     ) {
         val activityLauncher = PaywallActivityLauncher(componentActivity, resultHandler)
         val activityLauncher2 = PaywallActivityLauncher(fragment, resultHandler)
+        val activityLauncher3 = PaywallActivityLauncher(resultCaller, resultHandler)
         activityLauncher.launch()
         activityLauncher.launch(offering)
         activityLauncher.launch(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -20,29 +20,15 @@ interface PaywallResultHandler : ActivityResultCallback<PaywallResult>
 
 /**
  * Launches the paywall activity. You need to create this object during the activity's onCreate.
- * Then launch the activity at your moment of choice
+ * Then launch the activity at your moment of choice.
+ * This can be instantiated with an [ActivityResultCaller] instance
+ * like a [ComponentActivity] or a [Fragment].
  */
 @ExperimentalPreviewRevenueCatUIPurchasesAPI
-class PaywallActivityLauncher {
+class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler: PaywallResultHandler) {
+    private val activityResultLauncher: ActivityResultLauncher<PaywallActivityArgs>
 
-    private var activityResultLauncher: ActivityResultLauncher<PaywallActivityArgs>
-
-    /**
-     * Creates a new PaywallActivityLauncher from an activity.
-     */
-    constructor(activity: ComponentActivity, resultHandler: PaywallResultHandler) :
-        this(activity as ActivityResultCaller, resultHandler)
-
-    /**
-     * Creates a new PaywallActivityLauncher from a fragment.
-     */
-    constructor(fragment: Fragment, resultHandler: PaywallResultHandler) :
-        this(fragment as ActivityResultCaller, resultHandler)
-
-    /**
-     * Creates a new PaywallActivityLauncher from an [ActivityResultCaller] instance.
-     */
-    constructor(resultCaller: ActivityResultCaller, resultHandler: PaywallResultHandler) {
+    init {
         activityResultLauncher = resultCaller.registerForActivityResult(PaywallContract(), resultHandler)
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui.activity
 
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.Fragment
 import com.revenuecat.purchases.CustomerInfo
@@ -29,15 +30,20 @@ class PaywallActivityLauncher {
     /**
      * Creates a new PaywallActivityLauncher from an activity.
      */
-    constructor(activity: ComponentActivity, resultHandler: PaywallResultHandler) {
-        activityResultLauncher = activity.registerForActivityResult(PaywallContract(), resultHandler)
-    }
+    constructor(activity: ComponentActivity, resultHandler: PaywallResultHandler) :
+        this(activity as ActivityResultCaller, resultHandler)
 
     /**
      * Creates a new PaywallActivityLauncher from a fragment.
      */
-    constructor(fragment: Fragment, resultHandler: PaywallResultHandler) {
-        activityResultLauncher = fragment.registerForActivityResult(PaywallContract(), resultHandler)
+    constructor(fragment: Fragment, resultHandler: PaywallResultHandler) :
+        this(fragment as ActivityResultCaller, resultHandler)
+
+    /**
+     * Creates a new PaywallActivityLauncher from an [ActivityResultCaller] instance.
+     */
+    constructor(resultCaller: ActivityResultCaller, resultHandler: PaywallResultHandler) {
+        activityResultLauncher = resultCaller.registerForActivityResult(PaywallContract(), resultHandler)
     }
 
     /**


### PR DESCRIPTION
#### Improvements:
- Remove duplicated `registerForActivityResult` call
- Allow using any instance, like `AppCompatActivity`
