### PR TITLE
Paywalls: Support sending paywall events to servers (2)

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
@@ -35,6 +35,7 @@ internal class AppConfig(
         log(LogIntent.INFO, ConfigureStrings.CONFIGURING_PURCHASES_PROXY_URL_SET)
     } ?: URL("https://api.revenuecat.com/")
     val diagnosticsURL = URL("https://api-diagnostics.revenuecat.com/")
+    val paywallEventsURL = URL("https://api-paywalls.revenuecat.com/")
     val customEntitlementComputation: Boolean
         get() = dangerousSettings.customEntitlementComputation
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
@@ -20,6 +20,11 @@ internal class AppConfig(
     forceServerErrors: Boolean = false,
     forceSigningErrors: Boolean = false,
 ) {
+    companion object {
+        val diagnosticsURL = URL("https://api-diagnostics.revenuecat.com/")
+        val paywallEventsURL = URL("https://api-paywalls.revenuecat.com/")
+    }
+
     // Should only be used for tests
     var forceServerErrors: Boolean = forceServerErrors
         get() = runningTests && field
@@ -34,8 +39,6 @@ internal class AppConfig(
     val baseURL: URL = proxyURL?.also {
         log(LogIntent.INFO, ConfigureStrings.CONFIGURING_PURCHASES_PROXY_URL_SET)
     } ?: URL("https://api.revenuecat.com/")
-    val diagnosticsURL = URL("https://api-diagnostics.revenuecat.com/")
-    val paywallEventsURL = URL("https://api-paywalls.revenuecat.com/")
     val customEntitlementComputation: Boolean
         get() = dangerousSettings.customEntitlementComputation
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -5,6 +5,8 @@
 
 package com.revenuecat.purchases.common
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.PurchasesError
@@ -16,8 +18,12 @@ import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMap
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.models.GoogleReplacementMode
 import com.revenuecat.purchases.models.PricingPhase
+import com.revenuecat.purchases.paywalls.events.PaywallEventRequest
+import com.revenuecat.purchases.paywalls.events.PaywallEventsManager
 import com.revenuecat.purchases.strings.NetworkStrings
+import com.revenuecat.purchases.utils.asMap
 import com.revenuecat.purchases.utils.filterNotNullValues
+import kotlinx.serialization.json.encodeToJsonElement
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -54,6 +60,9 @@ internal typealias IdentifyCallback = Pair<(CustomerInfo, Boolean) -> Unit, (Pur
 internal typealias DiagnosticsCallback = Pair<(JSONObject) -> Unit, (PurchasesError, Boolean) -> Unit>
 
 /** @suppress */
+internal typealias PaywallEventsCallback = Pair<() -> Unit, (PurchasesError) -> Unit>
+
+/** @suppress */
 internal typealias ProductEntitlementCallback = Pair<(ProductEntitlementMapping) -> Unit, (PurchasesError) -> Unit>
 
 internal enum class PostReceiptErrorHandlingBehavior {
@@ -66,7 +75,7 @@ internal enum class PostReceiptErrorHandlingBehavior {
 internal class Backend(
     private val appConfig: AppConfig,
     private val dispatcher: Dispatcher,
-    private val diagnosticsDispatcher: Dispatcher,
+    private val eventsDispatcher: Dispatcher,
     private val httpClient: HTTPClient,
     private val backendHelper: BackendHelper,
 ) {
@@ -93,6 +102,9 @@ internal class Backend(
 
     @get:Synchronized @set:Synchronized
     @Volatile var diagnosticsCallbacks = mutableMapOf<CallbackCacheKey, MutableList<DiagnosticsCallback>>()
+
+    @get:Synchronized @set:Synchronized
+    @Volatile var paywallEventsCallbacks = mutableMapOf<CallbackCacheKey, MutableList<PaywallEventsCallback>>()
 
     @get:Synchronized @set:Synchronized
     @Volatile var productEntitlementCallbacks = mutableMapOf<String, MutableList<ProductEntitlementCallback>>()
@@ -441,8 +453,66 @@ internal class Backend(
         synchronized(this@Backend) {
             diagnosticsCallbacks.addCallback(
                 call,
-                diagnosticsDispatcher,
+                eventsDispatcher,
                 cacheKey,
+                onSuccessHandler to onErrorHandler,
+                Delay.LONG,
+            )
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    fun postPaywallEvents(
+        paywallEventRequest: PaywallEventRequest,
+        onSuccessHandler: () -> Unit,
+        onErrorHandler: (PurchasesError) -> Unit,
+    ) {
+        val body = PaywallEventsManager.json.encodeToJsonElement(paywallEventRequest).asMap()
+        if (body == null) {
+            onErrorHandler(
+                PurchasesError(
+                    PurchasesErrorCode.UnknownError,
+                    "Error encoding paywall event request",
+                ).also { errorLog(it) },
+            )
+            return
+        }
+        val call = object : Dispatcher.AsyncCall() {
+            override fun call(): HTTPResult {
+                return httpClient.performRequest(
+                    appConfig.paywallEventsURL,
+                    Endpoint.PostPaywallEvents,
+                    body,
+                    postFieldsToSign = null,
+                    backendHelper.authenticationHeaders,
+                )
+            }
+
+            override fun onError(error: PurchasesError) {
+                synchronized(this@Backend) {
+                    paywallEventsCallbacks.remove(paywallEventRequest.cacheKey)
+                }?.forEach { (_, onErrorHandler) ->
+                    onErrorHandler(error)
+                }
+            }
+
+            override fun onCompletion(result: HTTPResult) {
+                synchronized(this@Backend) {
+                    paywallEventsCallbacks.remove(paywallEventRequest.cacheKey)
+                }?.forEach { (onSuccessHandler, onErrorHandler) ->
+                    if (result.isSuccessful()) {
+                        onSuccessHandler()
+                    } else {
+                        onErrorHandler(result.toPurchasesError())
+                    }
+                }
+            }
+        }
+        synchronized(this@Backend) {
+            paywallEventsCallbacks.addCallback(
+                call,
+                eventsDispatcher,
+                paywallEventRequest.cacheKey,
                 onSuccessHandler to onErrorHandler,
                 Delay.LONG,
             )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -419,7 +419,7 @@ internal class Backend(
         val call = object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {
                 return httpClient.performRequest(
-                    appConfig.diagnosticsURL,
+                    AppConfig.diagnosticsURL,
                     Endpoint.PostDiagnostics,
                     body,
                     postFieldsToSign = null,
@@ -481,7 +481,7 @@ internal class Backend(
         val call = object : Dispatcher.AsyncCall() {
             override fun call(): HTTPResult {
                 return httpClient.performRequest(
-                    appConfig.paywallEventsURL,
+                    AppConfig.paywallEventsURL,
                     Endpoint.PostPaywallEvents,
                     body,
                     postFieldsToSign = null,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -19,6 +19,9 @@ internal sealed class Endpoint(val pathTemplate: String, val name: String) {
     object PostDiagnostics : Endpoint("/diagnostics", "post_diagnostics") {
         override fun getPath() = pathTemplate
     }
+    object PostPaywallEvents : Endpoint("/events", "post_paywall_events") {
+        override fun getPath() = pathTemplate
+    }
     data class PostAttributes(val userId: String) : Endpoint("/subscribers/%s/attributes", "post_attributes") {
         override fun getPath() = pathTemplate.format(Uri.encode(userId))
     }
@@ -44,6 +47,7 @@ internal sealed class Endpoint(val pathTemplate: String, val name: String) {
             is GetAmazonReceipt,
             is PostAttributes,
             PostDiagnostics,
+            PostPaywallEvents,
             ->
                 false
         }
@@ -59,6 +63,7 @@ internal sealed class Endpoint(val pathTemplate: String, val name: String) {
             is GetOfferings,
             is PostAttributes,
             PostDiagnostics,
+            PostPaywallEvents,
             GetProductEntitlementMapping,
             ->
                 false

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCHTTPStatusCodes.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCHTTPStatusCodes.kt
@@ -11,4 +11,9 @@ internal object RCHTTPStatusCodes {
 
     fun isSuccessful(statusCode: Int) = statusCode < BAD_REQUEST
     fun isServerError(statusCode: Int) = statusCode >= ERROR
+
+    // Note: this means that all 4xx (except 404) are considered as successfully synced.
+    // The reason is because it's likely due to a client error, so continuing to retry
+    // won't yield any different results and instead kill pandas.
+    fun isSynced(statusCode: Int) = isSuccessful(statusCode) || !(isServerError(statusCode) || statusCode == NOT_FOUND)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallBackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallBackendEvent.kt
@@ -1,0 +1,30 @@
+package com.revenuecat.purchases.paywalls.events
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class PaywallBackendEvent(
+    val id: String,
+    val version: Int,
+    val type: String,
+    @SerialName("app_user_id")
+    val appUserID: String,
+    @SerialName("session_id")
+    val sessionID: String,
+    @SerialName("offering_id")
+    val offeringID: String,
+    @SerialName("paywall_revision")
+    val paywallRevision: Int,
+    val timestamp: Long,
+    @SerialName("display_mode")
+    val displayMode: String,
+    @SerialName("dark_mode")
+    val darkMode: Boolean,
+    @SerialName("locale")
+    val localeIdentifier: String,
+) {
+    companion object {
+        const val PAYWALL_EVENT_SCHEMA_VERSION = 1
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEventRequest.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEventRequest.kt
@@ -1,0 +1,11 @@
+package com.revenuecat.purchases.paywalls.events
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class PaywallEventRequest(
+    val events: List<PaywallBackendEvent>,
+) {
+    val cacheKey: List<String>
+        get() = events.map { it.hashCode().toString() }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallStoredEvent.kt
@@ -8,4 +8,20 @@ import kotlinx.serialization.Serializable
 internal data class PaywallStoredEvent(
     val event: PaywallEvent,
     val userID: String,
-)
+) {
+    fun toPaywallBackendEvent(): PaywallBackendEvent {
+        return PaywallBackendEvent(
+            id = event.creationData.id.toString(),
+            version = PaywallBackendEvent.PAYWALL_EVENT_SCHEMA_VERSION,
+            type = event.type.value,
+            appUserID = userID,
+            sessionID = event.data.sessionIdentifier.toString(),
+            offeringID = event.data.offeringIdentifier,
+            paywallRevision = event.data.paywallRevision,
+            timestamp = event.creationData.date.time,
+            displayMode = event.data.displayMode,
+            darkMode = event.data.darkMode,
+            localeIdentifier = event.data.localeIdentifier,
+        )
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JsonElementExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JsonElementExtensions.kt
@@ -1,0 +1,55 @@
+package com.revenuecat.purchases.utils
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.floatOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+
+fun JsonElement.asMap(): Map<String, Any?>? {
+    if (this is JsonObject) {
+        return jsonObject.entries.associate {
+            it.key to it.value.extractedContent
+        }
+    }
+    return null
+}
+
+private val JsonElement.extractedContent: Any?
+    get() {
+        return when (this) {
+            is JsonPrimitive -> {
+                with(jsonPrimitive) {
+                    if (isString) {
+                        content
+                    } else {
+                        booleanOrNull
+                            ?: intOrNull
+                            ?: longOrNull
+                            ?: floatOrNull
+                            ?: doubleOrNull
+                            ?: contentOrNull
+                    }
+                }
+            }
+            is JsonArray -> {
+                jsonArray.map {
+                    it.extractedContent
+                }
+            }
+            is JsonObject -> {
+                jsonObject.entries.associate {
+                    it.key to it.value.extractedContent
+                }
+            }
+            else -> null
+        }
+    }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JsonElementExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JsonElementExtensions.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
 
-fun JsonElement.asMap(): Map<String, Any?>? {
+internal fun JsonElement.asMap(): Map<String, Any?>? {
     if (this is JsonObject) {
         return jsonObject.entries.associate {
             it.key to it.value.extractedContent

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
@@ -72,7 +72,6 @@ internal abstract class BaseBackendIntegrationTest {
     ) {
         appConfig = mockk<AppConfig>().apply {
             every { baseURL } returns URL("https://api.revenuecat.com")
-            every { paywallEventsURL } returns URL("https://api-paywalls.revenuecat.com/")
             every { store } returns Store.PLAY_STORE
             every { platformInfo } returns PlatformInfo("test-flavor", version = null)
             every { languageTag } returns "en-US"

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
@@ -72,6 +72,7 @@ internal abstract class BaseBackendIntegrationTest {
     ) {
         appConfig = mockk<AppConfig>().apply {
             every { baseURL } returns URL("https://api.revenuecat.com")
+            every { paywallEventsURL } returns URL("https://api-paywalls.revenuecat.com/")
             every { store } returns Store.PLAY_STORE
             every { platformInfo } returns PlatformInfo("test-flavor", version = null)
             every { languageTag } returns "en-US"

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -186,8 +186,8 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
                 onSuccessHandler = {
                     latch.countDown()
                 },
-                onErrorHandler = {
-                    fail("Expected success. Got $it")
+                onErrorHandler = { error, _ ->
+                    fail("Expected success. Got $error")
                 }
             )
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit
 @RunWith(AndroidJUnit4::class)
 class BackendPaywallEventTest {
 
-    private val testPaywallEventsURL = URL("http://mock-api-paywall-events-test.revenuecat.com/")
+
     private val paywallEventRequest = PaywallEventRequest(listOf(
         PaywallBackendEvent(
             id = "id",
@@ -63,9 +63,7 @@ class BackendPaywallEventTest {
 
     @Before
     fun setUp() {
-        appConfig = mockk<AppConfig>().apply {
-            every { paywallEventsURL } returns testPaywallEventsURL
-        }
+        appConfig = mockk()
         httpClient = mockk()
         val backendHelper = BackendHelper("TEST_API_KEY", SyncDispatcher(), appConfig, httpClient)
 
@@ -222,7 +220,7 @@ class BackendPaywallEventTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             httpClient.performRequest(
-                testPaywallEventsURL,
+                AppConfig.paywallEventsURL,
                 Endpoint.PostPaywallEvents,
                 body = any(),
                 postFieldsToSign = null,
@@ -236,7 +234,7 @@ class BackendPaywallEventTest {
         val expectedBody = PaywallEventsManager.json.encodeToJsonElement(expectedRequest).asMap()
         verify(exactly = 1) {
             httpClient.performRequest(
-                testPaywallEventsURL,
+                AppConfig.paywallEventsURL,
                 Endpoint.PostPaywallEvents,
                 body = expectedBody,
                 postFieldsToSign = null,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
@@ -16,12 +16,12 @@ import com.revenuecat.purchases.paywalls.events.PaywallBackendEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventRequest
 import com.revenuecat.purchases.paywalls.events.PaywallEventType
 import com.revenuecat.purchases.paywalls.events.PaywallEventsManager
+import com.revenuecat.purchases.utils.asMap
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.jsonObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Before
@@ -105,7 +105,7 @@ class BackendPaywallEventTest {
                     "{" +
                         "\"id\":\"id\"," +
                         "\"version\":1," +
-                        "\"type\":\"CANCEL\"," +
+                        "\"type\":\"paywall_cancel\"," +
                         "\"app_user_id\":\"appUserID\"," +
                         "\"session_id\":\"sessionID\"," +
                         "\"offering_id\":\"offeringID\"," +
@@ -185,7 +185,7 @@ class BackendPaywallEventTest {
 
     private fun verifyCallWithBody(body: String) {
         val expectedRequest: PaywallEventRequest = PaywallEventsManager.json.decodeFromString(body)
-        val expectedBody = PaywallEventsManager.json.encodeToJsonElement(expectedRequest).jsonObject
+        val expectedBody = PaywallEventsManager.json.encodeToJsonElement(expectedRequest).asMap()
         verify(exactly = 1) {
             httpClient.performRequest(
                 testPaywallEventsURL,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
@@ -1,0 +1,249 @@
+package com.revenuecat.purchases.common.backend
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.AppConfig
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BackendHelper
+import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.HTTPClient
+import com.revenuecat.purchases.common.SyncDispatcher
+import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import com.revenuecat.purchases.paywalls.events.PaywallBackendEvent
+import com.revenuecat.purchases.paywalls.events.PaywallEventRequest
+import com.revenuecat.purchases.paywalls.events.PaywallEventType
+import com.revenuecat.purchases.paywalls.events.PaywallEventsManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+import java.net.URL
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@RunWith(AndroidJUnit4::class)
+class BackendPaywallEventTest {
+
+    private val testPaywallEventsURL = URL("http://mock-api-paywall-events-test.revenuecat.com/")
+    private val paywallEventRequest = PaywallEventRequest(listOf(
+        PaywallBackendEvent(
+            id = "id",
+            version = 1,
+            type = PaywallEventType.CANCEL.value,
+            appUserID = "appUserID",
+            sessionID = "sessionID",
+            offeringID = "offeringID",
+            paywallRevision = 5,
+            timestamp = 123456789,
+            displayMode = "footer",
+            darkMode = true,
+            localeIdentifier = "en_US",
+        )
+    ))
+
+    private lateinit var appConfig: AppConfig
+    private lateinit var httpClient: HTTPClient
+
+    private lateinit var backend: Backend
+    private lateinit var asyncBackend: Backend
+
+    @Before
+    fun setUp() {
+        appConfig = mockk<AppConfig>().apply {
+            every { paywallEventsURL } returns testPaywallEventsURL
+        }
+        httpClient = mockk()
+        val backendHelper = BackendHelper("TEST_API_KEY", SyncDispatcher(), appConfig, httpClient)
+
+        val asyncDispatcher1 = createAsyncDispatcher()
+        val asyncDispatcher2 = createAsyncDispatcher()
+
+        val asyncBackendHelper = BackendHelper("TEST_API_KEY", asyncDispatcher1, appConfig, httpClient)
+
+        backend = Backend(
+            appConfig,
+            SyncDispatcher(),
+            SyncDispatcher(),
+            httpClient,
+            backendHelper,
+        )
+
+        asyncBackend = Backend(
+            appConfig,
+            asyncDispatcher1,
+            asyncDispatcher2,
+            httpClient,
+            asyncBackendHelper,
+        )
+    }
+
+    @Test
+    fun `postPaywallEvents posts events correctly`() {
+        mockHttpResult()
+        backend.postPaywallEvents(
+            paywallEventRequest,
+            onSuccessHandler = {},
+            onErrorHandler = {},
+        )
+        verifyCallWithBody(
+            "{" +
+                "\"events\":[" +
+                    "{" +
+                        "\"id\":\"id\"," +
+                        "\"version\":1," +
+                        "\"type\":\"CANCEL\"," +
+                        "\"app_user_id\":\"appUserID\"," +
+                        "\"session_id\":\"sessionID\"," +
+                        "\"offering_id\":\"offeringID\"," +
+                        "\"paywall_revision\":5," +
+                        "\"timestamp\":123456789," +
+                        "\"display_mode\":\"footer\"," +
+                        "\"dark_mode\":true," +
+                        "\"locale\":\"en_US\"" +
+                    "}" +
+                "]" +
+            "}"
+        )
+    }
+
+    @Test
+    fun `postPaywallEvents calls success handler`() {
+        mockHttpResult()
+        var successCalled = false
+        backend.postPaywallEvents(
+            paywallEventRequest,
+            onSuccessHandler = { successCalled = true },
+            onErrorHandler = { fail("Expected success") },
+        )
+        assertThat(successCalled).isTrue
+    }
+
+    @Test
+    fun `postPaywallEvents calls error handler if error response code`() {
+        mockHttpResult(responseCode = RCHTTPStatusCodes.ERROR)
+        var errorCalled = false
+        backend.postPaywallEvents(
+            paywallEventRequest,
+            onSuccessHandler = { fail("Expected error") },
+            onErrorHandler = { errorCalled = true },
+        )
+        assertThat(errorCalled).isTrue
+    }
+
+    @Test
+    fun `postPaywallEvents calls error handler if json error`() {
+        mockHttpClientException()
+        var errorCalled = false
+        backend.postPaywallEvents(
+            paywallEventRequest,
+            onSuccessHandler = { fail("Expected error") },
+            onErrorHandler = { errorCalled = true },
+        )
+        assertThat(errorCalled).isTrue
+    }
+
+    @Test
+    fun `postPaywallEvents multiple times with same request, only one is triggered`() {
+        mockHttpResult(delayMs = 10)
+        val lock = CountDownLatch(2)
+        asyncBackend.postPaywallEvents(
+            paywallEventRequest,
+            onSuccessHandler = { lock.countDown() },
+            onErrorHandler = {},
+        )
+        asyncBackend.postPaywallEvents(
+            paywallEventRequest,
+            onSuccessHandler = { lock.countDown() },
+            onErrorHandler = {},
+        )
+        lock.await(100, TimeUnit.MILLISECONDS)
+        assertThat(lock.count).isEqualTo(0)
+        verify(exactly = 1) {
+            httpClient.performRequest(
+                testPaywallEventsURL,
+                Endpoint.PostPaywallEvents,
+                body = any(),
+                postFieldsToSign = null,
+                requestHeaders = any(),
+            )
+        }
+    }
+
+    private fun verifyCallWithBody(body: String) {
+        val expectedRequest: PaywallEventRequest = PaywallEventsManager.json.decodeFromString(body)
+        val expectedBody = PaywallEventsManager.json.encodeToJsonElement(expectedRequest).jsonObject
+        verify(exactly = 1) {
+            httpClient.performRequest(
+                testPaywallEventsURL,
+                Endpoint.PostPaywallEvents,
+                body = expectedBody,
+                postFieldsToSign = null,
+                requestHeaders = any(),
+            )
+        }
+    }
+
+    private fun mockHttpResult(
+        responseCode: Int = RCHTTPStatusCodes.SUCCESS,
+        delayMs: Long? = null
+    ) {
+        every {
+            httpClient.performRequest(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } answers {
+            if (delayMs != null) {
+                Thread.sleep(delayMs)
+            }
+            HTTPResult(
+                responseCode,
+                "{}",
+                HTTPResult.Origin.BACKEND,
+                requestDate = null,
+                VerificationResult.NOT_REQUESTED
+            )
+        }
+    }
+
+    private fun mockHttpClientException() {
+        every {
+            httpClient.performRequest(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } throws IOException("Test exception")
+    }
+
+    private fun createAsyncDispatcher(): Dispatcher {
+        return Dispatcher(
+            ThreadPoolExecutor(
+                1,
+                2,
+                0,
+                TimeUnit.MILLISECONDS,
+                LinkedBlockingQueue()
+            )
+        )
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
@@ -47,12 +47,13 @@ import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.unmockkObject
 import io.mockk.verify
-import org.assertj.core.api.Assertions
-import org.assertj.core.api.Fail
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Fail.fail
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.After
-import org.junit.Assert
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -195,7 +196,7 @@ class BackendTest {
     // region general backend functionality
     @Test
     fun canBeCreated() {
-        Assertions.assertThat(backend).isNotNull
+        assertThat(backend).isNotNull
     }
 
     @Test
@@ -203,8 +204,8 @@ class BackendTest {
 
         val info = getCustomerInfo(200, null, null)
 
-        Assertions.assertThat(receivedCustomerInfo).isNotNull
-        Assertions.assertThat(receivedCustomerInfo).isEqualTo(info)
+        assertThat(receivedCustomerInfo).isNotNull
+        assertThat(receivedCustomerInfo).isEqualTo(info)
     }
 
     @Test
@@ -213,43 +214,43 @@ class BackendTest {
 
         getCustomerInfo(failureCode, null, null)
 
-        Assertions.assertThat(receivedCustomerInfo).isNull()
-        Assertions.assertThat(receivedError).`as`("Received error is not null").isNotNull
+        assertThat(receivedCustomerInfo).isNull()
+        assertThat(receivedError).`as`("Received error is not null").isNotNull
     }
 
     @Test
     fun clientErrorCallsErrorHandler() {
         getCustomerInfo(200, IOException(), null)
 
-        Assertions.assertThat(receivedCustomerInfo).isNull()
-        Assertions.assertThat(receivedError).`as`("Received error is not null").isNotNull
+        assertThat(receivedCustomerInfo).isNull()
+        assertThat(receivedError).`as`("Received error is not null").isNotNull
     }
 
     @Test
     fun attemptsToParseErrorMessageFromServer() {
         getCustomerInfo(404, null, "{'code': 7225, 'message': 'Dude not found'}")
 
-        Assertions.assertThat(receivedError).`as`("Received error is not null").isNotNull
-        Assertions.assertThat(receivedError!!.underlyingErrorMessage).`as`("Received underlying message is not null").isNotNull
-        Assertions.assertThat(receivedError!!.underlyingErrorMessage!!).contains("Dude not found")
+        assertThat(receivedError).`as`("Received error is not null").isNotNull
+        assertThat(receivedError!!.underlyingErrorMessage).`as`("Received underlying message is not null").isNotNull
+        assertThat(receivedError!!.underlyingErrorMessage!!).contains("Dude not found")
     }
 
     @Test
     fun handlesMissingMessageInErrorBody() {
         getCustomerInfo(404, null, "{'no_message': 'Dude not found'}")
-        Assertions.assertThat(receivedError).`as`("Received error is not null").isNotNull
+        assertThat(receivedError).`as`("Received error is not null").isNotNull
     }
 
     @Test
     fun `getCustomerInfo error callback returns isServerError true if response code is 500`() {
         getCustomerInfo(RCHTTPStatusCodes.ERROR, null, "{}")
-        Assertions.assertThat(receivedIsServerError).isEqualTo(true)
+        assertThat(receivedIsServerError).isEqualTo(true)
     }
 
     @Test
     fun `getCustomerInfo error callback returns isServerError false if response code is 400`() {
         getCustomerInfo(RCHTTPStatusCodes.BAD_REQUEST, null, "{}")
-        Assertions.assertThat(receivedIsServerError).isEqualTo(false)
+        assertThat(receivedIsServerError).isEqualTo(false)
     }
 
     @Test
@@ -303,8 +304,8 @@ class BackendTest {
 
         val info = getCustomerInfo(200, null, null)
 
-        Assertions.assertThat(receivedCustomerInfo).isNotNull
-        Assertions.assertThat(receivedCustomerInfo).isEqualTo(info)
+        assertThat(receivedCustomerInfo).isNotNull
+        assertThat(receivedCustomerInfo).isEqualTo(info)
     }
 
     @Test
@@ -313,8 +314,8 @@ class BackendTest {
 
         getCustomerInfo(failureCode, null, null)
 
-        Assertions.assertThat(receivedCustomerInfo).isNull()
-        Assertions.assertThat(receivedError).`as`("Received error is not null").isNotNull
+        assertThat(receivedCustomerInfo).isNull()
+        assertThat(receivedError).`as`("Received error is not null").isNotNull
     }
 
     @Test
@@ -335,7 +336,7 @@ class BackendTest {
             lock.countDown()
         }, onError = onReceiveCustomerInfoErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -365,7 +366,7 @@ class BackendTest {
             lock.countDown()
         }, onError = onReceiveCustomerInfoErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             asyncDispatcher.enqueue(any(), Delay.NONE)
         }
@@ -389,7 +390,7 @@ class BackendTest {
             lock.countDown()
         }, onError = onReceiveCustomerInfoErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 2) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -408,8 +409,8 @@ class BackendTest {
         getCustomerInfo(200, clientException = null, resultBody = null, appInBackground = true)
 
         val calledWithRandomDelay: Delay? = dispatcher.calledDelay
-        Assertions.assertThat(calledWithRandomDelay).isNotNull
-        Assertions.assertThat(calledWithRandomDelay).isEqualTo(Delay.DEFAULT)
+        assertThat(calledWithRandomDelay).isNotNull
+        assertThat(calledWithRandomDelay).isEqualTo(Delay.DEFAULT)
     }
 
     // endregion
@@ -430,8 +431,8 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(receivedCustomerInfo).`as`("Received info is not null").isNotNull
-        Assertions.assertThat(info).isEqualTo(receivedCustomerInfo)
+        assertThat(receivedCustomerInfo).`as`("Received info is not null").isNotNull
+        assertThat(info).isEqualTo(receivedCustomerInfo)
     }
 
     @Test
@@ -477,11 +478,11 @@ class BackendTest {
 
         val expectedPricingPhases = receiptInfo.pricingPhases
         val mappedExpectedPricingPhases = expectedPricingPhases?.map { it.toMap() }
-        Assertions.assertThat(requestBodySlot.isCaptured).isTrue
-        Assertions.assertThat(requestBodySlot.captured.keys).contains("pricing_phases")
-        Assertions.assertThat(requestBodySlot.captured["pricing_phases"]).isEqualTo(mappedExpectedPricingPhases)
+        assertThat(requestBodySlot.isCaptured).isTrue
+        assertThat(requestBodySlot.captured.keys).contains("pricing_phases")
+        assertThat(requestBodySlot.captured["pricing_phases"]).isEqualTo(mappedExpectedPricingPhases)
 
-        Assertions.assertThat(mappedExpectedPricingPhases).isEqualTo(
+        assertThat(mappedExpectedPricingPhases).isEqualTo(
             listOf(
                 mapOf(
                     "billingPeriod" to "P1M",
@@ -494,8 +495,8 @@ class BackendTest {
             )
         )
 
-        Assertions.assertThat(requestBodySlot.captured.keys).contains("proration_mode")
-        Assertions.assertThat(requestBodySlot.captured["proration_mode"]).isEqualTo("IMMEDIATE_WITHOUT_PRORATION")
+        assertThat(requestBodySlot.captured.keys).contains("proration_mode")
+        assertThat(requestBodySlot.captured["proration_mode"]).isEqualTo("IMMEDIATE_WITHOUT_PRORATION")
     }
 
     @Test
@@ -552,8 +553,8 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(requestBodySlot.isCaptured).isTrue
-        Assertions.assertThat(requestBodySlot.captured["platform_product_ids"]).isEqualTo(
+        assertThat(requestBodySlot.isCaptured).isTrue
+        assertThat(requestBodySlot.captured["platform_product_ids"]).isEqualTo(
             listOf(
                 mapOf(
                     "product_id" to productId,
@@ -596,8 +597,8 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(requestBodySlot.isCaptured).isTrue
-        Assertions.assertThat(requestBodySlot.captured["product_plan_id"]).isNull()
+        assertThat(requestBodySlot.isCaptured).isTrue
+        assertThat(requestBodySlot.captured["product_plan_id"]).isNull()
     }
 
     @Test
@@ -621,9 +622,9 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(requestBodySlot.isCaptured).isTrue
-        Assertions.assertThat(requestBodySlot.captured.keys).contains("normal_duration")
-        Assertions.assertThat(requestBodySlot.captured["normal_duration"]).isEqualTo(expectedDuration)
+        assertThat(requestBodySlot.isCaptured).isTrue
+        assertThat(requestBodySlot.captured.keys).contains("normal_duration")
+        assertThat(requestBodySlot.captured["normal_duration"]).isEqualTo(expectedDuration)
     }
 
     @Test
@@ -647,9 +648,9 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(requestBodySlot.isCaptured).isTrue
-        Assertions.assertThat(requestBodySlot.captured.keys).contains("store_user_id")
-        Assertions.assertThat(requestBodySlot.captured["store_user_id"]).isEqualTo(expectedStoreUserId)
+        assertThat(requestBodySlot.isCaptured).isTrue
+        assertThat(requestBodySlot.captured.keys).contains("store_user_id")
+        assertThat(requestBodySlot.captured["store_user_id"]).isEqualTo(expectedStoreUserId)
     }
 
     @Test
@@ -666,9 +667,9 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(requestBodySlot.isCaptured).isTrue
-        Assertions.assertThat(requestBodySlot.captured.keys).contains("initiation_source")
-        Assertions.assertThat(requestBodySlot.captured["initiation_source"]).isEqualTo(initiationSource.postReceiptFieldValue)
+        assertThat(requestBodySlot.isCaptured).isTrue
+        assertThat(requestBodySlot.captured.keys).contains("initiation_source")
+        assertThat(requestBodySlot.captured["initiation_source"]).isEqualTo(initiationSource.postReceiptFieldValue)
     }
 
     @Test
@@ -685,8 +686,8 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(receivedCustomerInfo).`as`("Received info is null").isNull()
-        Assertions.assertThat(receivedError).`as`("Received error is not null").isNotNull
+        assertThat(receivedCustomerInfo).`as`("Received info is null").isNull()
+        assertThat(receivedError).`as`("Received error is not null").isNotNull
     }
 
     @Test
@@ -721,7 +722,7 @@ class BackendTest {
         )
 
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -739,7 +740,7 @@ class BackendTest {
         val initialInfo = createCustomerInfo(Responses.validFullPurchaserResponse)
         val updatedInfo = createCustomerInfo(Responses.validEmptyPurchaserResponse)
 
-        Assertions.assertThat(initialInfo).isEqualTo(
+        assertThat(initialInfo).isEqualTo(
             CustomerInfoFactory.buildCustomerInfo(initialInfo.rawData, null, verificationResult)
         )
 
@@ -758,7 +759,7 @@ class BackendTest {
         // Given calls
 
         asyncBackend.getCustomerInfo(appUserID, appInBackground = false, onSuccess = {
-            Assertions.assertThat(it).isEqualTo(initialInfo)
+            assertThat(it).isEqualTo(initialInfo)
             lock.countDown()
         }, onError = onReceiveCustomerInfoErrorHandler)
         mockPostReceiptResponseAndPost(
@@ -785,14 +786,14 @@ class BackendTest {
             onError = postReceiptErrorCallback
         )
         asyncBackend.getCustomerInfo(appUserID, appInBackground = false, onSuccess = {
-            Assertions.assertThat(it).isEqualTo(updatedInfo)
+            assertThat(it).isEqualTo(updatedInfo)
             lock.countDown()
         }, onError = onReceiveCustomerInfoErrorHandler)
 
         // Expect requests:
 
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -827,8 +828,8 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(receivedCustomerInfo).`as`("Received info is not null").isNotNull
-        Assertions.assertThat(info).isEqualTo(receivedCustomerInfo)
+        assertThat(receivedCustomerInfo).`as`("Received info is not null").isNotNull
+        assertThat(info).isEqualTo(receivedCustomerInfo)
     }
 
     @Test
@@ -848,8 +849,8 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(receivedCustomerInfo).`as`("Received info is not null").isNotNull
-        Assertions.assertThat(info).isEqualTo(receivedCustomerInfo)
+        assertThat(receivedCustomerInfo).`as`("Received info is not null").isNotNull
+        assertThat(info).isEqualTo(receivedCustomerInfo)
     }
 
     @Test
@@ -896,7 +897,7 @@ class BackendTest {
             onError = postReceiptErrorCallback
         )
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 2) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -958,7 +959,7 @@ class BackendTest {
             onError = postReceiptErrorCallback
         )
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 2) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -1006,7 +1007,7 @@ class BackendTest {
             onError = postReceiptErrorCallback
         )
         lock.await()
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 2) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -1055,7 +1056,7 @@ class BackendTest {
             onError = postReceiptErrorCallback
         )
         lock.await()
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -1084,8 +1085,8 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(receivedCustomerInfo).`as`("Received purchaser info is not null").isNotNull
-        Assertions.assertThat(info).isEqualTo(receivedCustomerInfo)
+        assertThat(receivedCustomerInfo).`as`("Received purchaser info is not null").isNotNull
+        assertThat(info).isEqualTo(receivedCustomerInfo)
     }
 
     @Test
@@ -1121,7 +1122,7 @@ class BackendTest {
             onError = postReceiptErrorCallback
         )
         lock.await()
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 2) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -1150,12 +1151,12 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(receivedCustomerInfo).`as`("Received info is null").isNull()
-        Assertions.assertThat(receivedError).`as`("Received error is not null").isNotNull
-        Assertions.assertThat(receivedError!!.code)
+        assertThat(receivedCustomerInfo).`as`("Received info is null").isNull()
+        assertThat(receivedError).`as`("Received error is not null").isNotNull
+        assertThat(receivedError!!.code)
             .`as`("Received error code is the right one")
             .isEqualTo(PurchasesErrorCode.UnsupportedError)
-        Assertions.assertThat(receivedPostReceiptErrorHandlingBehavior)
+        assertThat(receivedPostReceiptErrorHandlingBehavior)
             .isEqualTo(PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
     }
 
@@ -1176,7 +1177,7 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(receivedPostReceiptErrorHandlingBehavior)
+        assertThat(receivedPostReceiptErrorHandlingBehavior)
             .isEqualTo(PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED)
     }
 
@@ -1197,7 +1198,7 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(receivedPostReceiptErrorHandlingBehavior)
+        assertThat(receivedPostReceiptErrorHandlingBehavior)
             .isEqualTo(PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
     }
 
@@ -1218,7 +1219,7 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(receivedPostReceiptErrorHandlingBehavior)
+        assertThat(receivedPostReceiptErrorHandlingBehavior)
             .isEqualTo(PostReceiptErrorHandlingBehavior.SHOULD_NOT_CONSUME)
     }
 
@@ -1239,9 +1240,9 @@ class BackendTest {
             initiationSource = initiationSource,
         )
 
-        Assertions.assertThat(headersSlot.isCaptured).isTrue
-        Assertions.assertThat(headersSlot.captured.keys).contains("price_string")
-        Assertions.assertThat(headersSlot.captured["price_string"]).isEqualTo("$4.99")
+        assertThat(headersSlot.isCaptured).isTrue
+        assertThat(headersSlot.captured.keys).contains("price_string")
+        assertThat(headersSlot.captured["price_string"]).isEqualTo("$4.99")
     }
 
     @Test
@@ -1262,9 +1263,9 @@ class BackendTest {
             marketplace = "DE"
         )
 
-        Assertions.assertThat(headersSlot.isCaptured).isTrue
-        Assertions.assertThat(headersSlot.captured.keys).contains("marketplace")
-        Assertions.assertThat(headersSlot.captured["marketplace"]).isEqualTo("DE")
+        assertThat(headersSlot.isCaptured).isTrue
+        assertThat(headersSlot.captured.keys).contains("marketplace")
+        assertThat(headersSlot.captured["marketplace"]).isEqualTo("DE")
     }
 
     @Test
@@ -1285,11 +1286,11 @@ class BackendTest {
             marketplace = "US"
         )
 
-        Assertions.assertThat(headersSlot.isCaptured).isTrue
-        Assertions.assertThat(headersSlot.captured.keys).contains("price_string")
-        Assertions.assertThat(headersSlot.captured["price_string"]).isEqualTo("$4.99")
-        Assertions.assertThat(headersSlot.captured.keys).contains("marketplace")
-        Assertions.assertThat(headersSlot.captured["marketplace"]).isEqualTo("US")
+        assertThat(headersSlot.isCaptured).isTrue
+        assertThat(headersSlot.captured.keys).contains("price_string")
+        assertThat(headersSlot.captured["price_string"]).isEqualTo("$4.99")
+        assertThat(headersSlot.captured.keys).contains("marketplace")
+        assertThat(headersSlot.captured["marketplace"]).isEqualTo("US")
     }
 
     @Test
@@ -1336,12 +1337,12 @@ class BackendTest {
             appUserID,
             appInBackground = false,
             onSuccess = onReceiveOfferingsResponseSuccessHandler,
-            onError = { _, _ -> Fail.fail("Should be success") }
+            onError = { _, _ -> fail("Should be success") }
         )
 
-        Assertions.assertThat(receivedOfferingsJSON).`as`("Received offerings response is not null").isNotNull
-        Assertions.assertThat(receivedOfferingsJSON!!.getJSONArray("offerings").length()).isZero
-        Assertions.assertThat(receivedOfferingsJSON!!.getNullableString("current_offering_id")).isNull()
+        assertThat(receivedOfferingsJSON).`as`("Received offerings response is not null").isNotNull
+        assertThat(receivedOfferingsJSON!!.getJSONArray("offerings").length()).isZero
+        assertThat(receivedOfferingsJSON!!.getNullableString("current_offering_id")).isNull()
     }
 
     @Test
@@ -1351,12 +1352,12 @@ class BackendTest {
         backend.getOfferings(
             appUserID,
             appInBackground = false,
-            onSuccess = { Fail.fail("Should be error") },
+            onSuccess = { fail("Should be error") },
             onError = onReceiveOfferingsErrorHandler
         )
 
-        Assertions.assertThat(receivedError).isNotNull
-        Assertions.assertThat(receivedIsServerError).isTrue
+        assertThat(receivedError).isNotNull
+        assertThat(receivedIsServerError).isTrue
     }
 
     @Test
@@ -1366,12 +1367,12 @@ class BackendTest {
         backend.getOfferings(
             appUserID,
             appInBackground = false,
-            onSuccess = { Fail.fail("Should be error") },
+            onSuccess = { fail("Should be error") },
             onError = onReceiveOfferingsErrorHandler
         )
 
-        Assertions.assertThat(receivedError).isNotNull
-        Assertions.assertThat(receivedIsServerError).isFalse
+        assertThat(receivedError).isNotNull
+        assertThat(receivedIsServerError).isFalse
     }
 
     @Test
@@ -1392,7 +1393,7 @@ class BackendTest {
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -1422,7 +1423,7 @@ class BackendTest {
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -1461,7 +1462,7 @@ class BackendTest {
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             asyncDispatcher.enqueue(any(), Delay.NONE)
         }
@@ -1485,7 +1486,7 @@ class BackendTest {
             lock.countDown()
         }, onError = onReceiveOfferingsErrorHandler)
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 2) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -1509,8 +1510,8 @@ class BackendTest {
         )
 
         val calledDelay = dispatcher.calledDelay
-        Assertions.assertThat(calledDelay).isNotNull
-        Assertions.assertThat(calledDelay).isEqualTo(Delay.DEFAULT)
+        assertThat(calledDelay).isNotNull
+        assertThat(calledDelay).isEqualTo(Delay.DEFAULT)
     }
 
     @Test
@@ -1521,7 +1522,7 @@ class BackendTest {
             appUserID,
             appInBackground = false,
             onSuccess = onReceiveOfferingsResponseSuccessHandler,
-            onError = { _, _ -> Fail.fail("Should be success") }
+            onError = { _, _ -> fail("Should be success") }
         )
 
         verify(exactly = 1) {
@@ -1558,7 +1559,7 @@ class BackendTest {
             newAppUserID,
             onLoginSuccessHandler
         ) {
-            Fail.fail("Should have called success")
+            fail("Should have called success")
         }
         verify(exactly = 1) {
             mockClient.performRequest(
@@ -1595,10 +1596,10 @@ class BackendTest {
             newAppUserID,
             onLoginSuccessHandler
         ) {
-            Fail.fail("Should have called success")
+            fail("Should have called success")
         }
-        Assertions.assertThat(receivedCustomerInfo).isEqualTo(expectedCustomerInfo)
-        Assertions.assertThat(receivedCustomerInfoCreated).isEqualTo(true)
+        assertThat(receivedCustomerInfo).isEqualTo(expectedCustomerInfo)
+        assertThat(receivedCustomerInfoCreated).isEqualTo(true)
     }
 
     @Test
@@ -1622,12 +1623,12 @@ class BackendTest {
             appUserID,
             newAppUserID,
             { _, _ ->
-                Fail.fail("Should have called error")
+                fail("Should have called error")
             },
             onReceiveLoginErrorHandler
         )
-        Assertions.assertThat(receivedError).isNotNull
-        Assertions.assertThat(receivedError?.code).isEqualTo(PurchasesErrorCode.UnknownError)
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError?.code).isEqualTo(PurchasesErrorCode.UnknownError)
     }
 
     @Test
@@ -1651,9 +1652,9 @@ class BackendTest {
             newAppUserID,
             onLoginSuccessHandler
         ) {
-            Fail.fail("Should have called success")
+            fail("Should have called success")
         }
-        Assertions.assertThat(receivedCustomerInfoCreated).isTrue
+        assertThat(receivedCustomerInfoCreated).isTrue
     }
 
     @Test
@@ -1677,9 +1678,9 @@ class BackendTest {
             newAppUserID,
             onLoginSuccessHandler
         ) {
-            Fail.fail("Should have called success")
+            fail("Should have called success")
         }
-        Assertions.assertThat(receivedCustomerInfoCreated).isFalse
+        assertThat(receivedCustomerInfoCreated).isFalse
     }
 
     @Test
@@ -1703,7 +1704,7 @@ class BackendTest {
             newAppUserID,
             onLoginSuccessHandler
         ) {
-            Fail.fail("Should have called success")
+            fail("Should have called success")
         }
 
         val expectedPostFieldsToSign = listOf(
@@ -1746,7 +1747,7 @@ class BackendTest {
                 lock.countDown()
             },
             {
-                Fail.fail("Should have called success")
+                fail("Should have called success")
             }
         )
         asyncBackend.logIn(
@@ -1756,11 +1757,11 @@ class BackendTest {
                 lock.countDown()
             },
             {
-                Fail.fail("Should have called success")
+                fail("Should have called success")
             }
         )
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -1794,7 +1795,7 @@ class BackendTest {
             appUserID,
             newAppUserID,
             { _, _ ->
-                Fail.fail("Should have called error")
+                fail("Should have called error")
             },
             {
                 lock.countDown()
@@ -1804,14 +1805,14 @@ class BackendTest {
             appUserID,
             newAppUserID,
             { _, _ ->
-                Fail.fail("Should have called error")
+                fail("Should have called error")
             },
             {
                 lock.countDown()
             }
         )
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -1845,7 +1846,7 @@ class BackendTest {
             appUserID,
             newAppUserID,
             { _, _ ->
-                Fail.fail("Should have called error")
+                fail("Should have called error")
             },
             {
                 lock.countDown()
@@ -1855,14 +1856,14 @@ class BackendTest {
             appUserID,
             newAppUserID,
             { _, _ ->
-                Fail.fail("Should have called error")
+                fail("Should have called error")
             },
             {
                 lock.countDown()
             }
         )
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
                 mockBaseURL,
@@ -1904,11 +1905,11 @@ class BackendTest {
             baseURL = mockDiagnosticsBaseURL
         )
         val lock = CountDownLatch(3)
-        asyncBackend.postDiagnostics(diagnosticsList, { lock.countDown() }, { _, _ -> Fail.fail("expected success") })
-        asyncBackend.postDiagnostics(diagnosticsList, { lock.countDown() }, { _, _ -> Fail.fail("expected success") })
-        asyncBackend.postDiagnostics(diagnosticsList, { lock.countDown() }, { _, _ -> Fail.fail("expected success") })
+        asyncBackend.postDiagnostics(diagnosticsList, { lock.countDown() }, { _, _ -> fail("expected success") })
+        asyncBackend.postDiagnostics(diagnosticsList, { lock.countDown() }, { _, _ -> fail("expected success") })
+        asyncBackend.postDiagnostics(diagnosticsList, { lock.countDown() }, { _, _ -> fail("expected success") })
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
                 baseURL = mockDiagnosticsBaseURL,
@@ -1933,13 +1934,13 @@ class BackendTest {
             baseURL = mockDiagnosticsBaseURL
         )
         val lock = CountDownLatch(1)
-        asyncBackend.postDiagnostics(diagnosticsList, { lock.countDown() }, { _, _ -> Fail.fail("expected success") })
+        asyncBackend.postDiagnostics(diagnosticsList, { lock.countDown() }, { _, _ -> fail("expected success") })
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         val lock2 = CountDownLatch(1)
-        asyncBackend.postDiagnostics(diagnosticsList, { lock2.countDown() }, { _, _ -> Fail.fail("expected success") })
+        asyncBackend.postDiagnostics(diagnosticsList, { lock2.countDown() }, { _, _ -> fail("expected success") })
         lock2.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock2.count).isEqualTo(0)
+        assertThat(lock2.count).isEqualTo(0)
         verify(exactly = 2) {
             mockClient.performRequest(
                 baseURL = mockDiagnosticsBaseURL,
@@ -1965,14 +1966,14 @@ class BackendTest {
         var errorCalled = false
         backend.postDiagnostics(
             diagnosticsList,
-            { Fail.fail("expected error") },
+            { fail("expected error") },
             { error, shouldRetry ->
                 errorCalled = true
-                Assertions.assertThat(error.code).isEqualTo(PurchasesErrorCode.InsufficientPermissionsError)
-                Assert.assertFalse(shouldRetry)
+                assertThat(error.code).isEqualTo(PurchasesErrorCode.InsufficientPermissionsError)
+                assertFalse(shouldRetry)
             }
         )
-        Assert.assertTrue(errorCalled)
+        assertTrue(errorCalled)
     }
 
     @Test
@@ -1989,14 +1990,14 @@ class BackendTest {
         var errorCalled = false
         backend.postDiagnostics(
             diagnosticsList,
-            { Fail.fail("expected error") },
+            { fail("expected error") },
             { error, shouldRetry ->
                 errorCalled = true
-                Assertions.assertThat(error.code).isEqualTo(PurchasesErrorCode.NetworkError)
-                Assert.assertTrue(shouldRetry)
+                assertThat(error.code).isEqualTo(PurchasesErrorCode.NetworkError)
+                assertTrue(shouldRetry)
             }
         )
-        Assert.assertTrue(errorCalled)
+        assertTrue(errorCalled)
     }
 
     @Test
@@ -2013,14 +2014,14 @@ class BackendTest {
         var errorCalled = false
         backend.postDiagnostics(
             diagnosticsList,
-            { Fail.fail("expected error") },
+            { fail("expected error") },
             { error, shouldRetry ->
                 errorCalled = true
-                Assertions.assertThat(error.code).isEqualTo(PurchasesErrorCode.UnknownBackendError)
-                Assert.assertTrue(shouldRetry)
+                assertThat(error.code).isEqualTo(PurchasesErrorCode.UnknownBackendError)
+                assertTrue(shouldRetry)
             }
         )
-        Assert.assertTrue(errorCalled)
+        assertTrue(errorCalled)
     }
 
     @Test
@@ -2037,14 +2038,14 @@ class BackendTest {
         var errorCalled = false
         backend.postDiagnostics(
             diagnosticsList,
-            { Fail.fail("expected error") },
+            { fail("expected error") },
             { error, shouldRetry ->
                 errorCalled = true
-                Assertions.assertThat(error.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
-                Assert.assertFalse(shouldRetry)
+                assertThat(error.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+                assertFalse(shouldRetry)
             }
         )
-        Assert.assertTrue(errorCalled)
+        assertTrue(errorCalled)
     }
 
     @Test
@@ -2064,11 +2065,11 @@ class BackendTest {
             diagnosticsList,
             {
                 successCalled = true
-                Assertions.assertThat(it.toString()).isEqualTo(resultBody)
+                assertThat(it.toString()).isEqualTo(resultBody)
             },
-            { _, _ -> Fail.fail("expected success") }
+            { _, _ -> fail("expected success") }
         )
-        Assert.assertTrue(successCalled)
+        assertTrue(successCalled)
     }
 
     @Test
@@ -2085,12 +2086,12 @@ class BackendTest {
         backend.postDiagnostics(
             listOf(JSONObject("{\"test-key\":\"test-value\"}")),
             {},
-            { _, _ -> Fail.fail("expected success") }
+            { _, _ -> fail("expected success") }
         )
 
         val calledDelay = dispatcher.calledDelay
-        Assertions.assertThat(calledDelay).isNotNull
-        Assertions.assertThat(calledDelay).isEqualTo(Delay.LONG)
+        assertThat(calledDelay).isNotNull
+        assertThat(calledDelay).isEqualTo(Delay.LONG)
     }
 
     // endregion
@@ -2122,11 +2123,11 @@ class BackendTest {
             delayed = true
         )
         val lock = CountDownLatch(3)
-        asyncBackend.getProductEntitlementMapping({ lock.countDown() }, { Fail.fail("expected succcess") })
-        asyncBackend.getProductEntitlementMapping({ lock.countDown() }, { Fail.fail("expected succcess") })
-        asyncBackend.getProductEntitlementMapping({ lock.countDown() }, { Fail.fail("expected succcess") })
+        asyncBackend.getProductEntitlementMapping({ lock.countDown() }, { fail("expected succcess") })
+        asyncBackend.getProductEntitlementMapping({ lock.countDown() }, { fail("expected succcess") })
+        asyncBackend.getProductEntitlementMapping({ lock.countDown() }, { fail("expected succcess") })
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
                 baseURL = mockBaseURL,
@@ -2150,14 +2151,14 @@ class BackendTest {
         )
 
         val lock = CountDownLatch(1)
-        asyncBackend.getProductEntitlementMapping({ lock.countDown() }, { Fail.fail("expected succcess") })
+        asyncBackend.getProductEntitlementMapping({ lock.countDown() }, { fail("expected succcess") })
         lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock.count).isEqualTo(0)
+        assertThat(lock.count).isEqualTo(0)
 
         val lock2 = CountDownLatch(1)
-        asyncBackend.getProductEntitlementMapping({ lock2.countDown() }, { Fail.fail("expected succcess") })
+        asyncBackend.getProductEntitlementMapping({ lock2.countDown() }, { fail("expected succcess") })
         lock2.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        Assertions.assertThat(lock2.count).isEqualTo(0)
+        assertThat(lock2.count).isEqualTo(0)
 
         verify(exactly = 2) {
             mockClient.performRequest(
@@ -2181,13 +2182,13 @@ class BackendTest {
         )
         var errorCalled = false
         backend.getProductEntitlementMapping(
-            { Fail.fail("expected error") },
+            { fail("expected error") },
             { error ->
                 errorCalled = true
-                Assertions.assertThat(error.code).isEqualTo(PurchasesErrorCode.NetworkError)
+                assertThat(error.code).isEqualTo(PurchasesErrorCode.NetworkError)
             }
         )
-        Assert.assertTrue(errorCalled)
+        assertTrue(errorCalled)
     }
 
     @Test
@@ -2202,13 +2203,13 @@ class BackendTest {
         )
         var errorCalled = false
         backend.getProductEntitlementMapping(
-            { Fail.fail("expected error") },
+            { fail("expected error") },
             { error ->
                 errorCalled = true
-                Assertions.assertThat(error.code).isEqualTo(PurchasesErrorCode.UnknownBackendError)
+                assertThat(error.code).isEqualTo(PurchasesErrorCode.UnknownBackendError)
             }
         )
-        Assert.assertTrue(errorCalled)
+        assertTrue(errorCalled)
     }
 
     @Test
@@ -2223,13 +2224,13 @@ class BackendTest {
         )
         var errorCalled = false
         backend.getProductEntitlementMapping(
-            { Fail.fail("expected error") },
+            { fail("expected error") },
             { error ->
                 errorCalled = true
-                Assertions.assertThat(error.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+                assertThat(error.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
             }
         )
-        Assert.assertTrue(errorCalled)
+        assertTrue(errorCalled)
     }
 
     @Test
@@ -2259,11 +2260,11 @@ class BackendTest {
                         )
                     )
                 )
-                Assertions.assertThat(it).isEqualTo(expectedMapping)
+                assertThat(it).isEqualTo(expectedMapping)
             },
-            { error -> Fail.fail("expected success $error", error) }
+            { error -> fail("expected success $error", error) }
         )
-        Assert.assertTrue(successCalled)
+        assertTrue(successCalled)
     }
 
     @Test
@@ -2279,12 +2280,12 @@ class BackendTest {
         dispatcher.calledDelay = null
         backend.getProductEntitlementMapping(
             {},
-            { Fail.fail("expected success") }
+            { fail("expected success") }
         )
 
         val calledDelay = dispatcher.calledDelay
-        Assertions.assertThat(calledDelay).isNotNull
-        Assertions.assertThat(calledDelay).isEqualTo(Delay.LONG)
+        assertThat(calledDelay).isNotNull
+        assertThat(calledDelay).isEqualTo(Delay.LONG)
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
@@ -52,8 +52,8 @@ import org.assertj.core.api.Fail.fail
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.After
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -88,13 +88,11 @@ class BackendTest {
 
     private var mockClient: HTTPClient = mockk(relaxed = true)
     private val mockBaseURL = URL("http://mock-api-test.revenuecat.com/")
-    private val mockDiagnosticsBaseURL = URL("https://mock-api-diagnostics.revenuecat.com/")
     private val diagnosticsEndpoint = Endpoint.PostDiagnostics
     private val productEntitlementMappingEndpoint = Endpoint.GetProductEntitlementMapping
     private val defaultAuthHeaders = mapOf("Authorization" to "Bearer $API_KEY")
     private val mockAppConfig: AppConfig = mockk<AppConfig>().apply {
         every { baseURL } returns mockBaseURL
-        every { diagnosticsURL } returns mockDiagnosticsBaseURL
         every { customEntitlementComputation } returns false
     }
     private val dispatcher = spyk(SyncDispatcher())
@@ -1883,7 +1881,7 @@ class BackendTest {
         backend.postDiagnostics(diagnosticsList, {}, { _, _ -> })
         verify(exactly = 1) {
             mockClient.performRequest(
-                baseURL = mockDiagnosticsBaseURL,
+                baseURL = AppConfig.diagnosticsURL,
                 endpoint = diagnosticsEndpoint,
                 body = mapOf("entries" to JSONArray(diagnosticsList)),
                 postFieldsToSign = null,
@@ -1902,7 +1900,7 @@ class BackendTest {
             clientException = null,
             resultBody = null,
             delayed = true,
-            baseURL = mockDiagnosticsBaseURL
+            baseURL = AppConfig.diagnosticsURL,
         )
         val lock = CountDownLatch(3)
         asyncBackend.postDiagnostics(diagnosticsList, { lock.countDown() }, { _, _ -> fail("expected success") })
@@ -1912,7 +1910,7 @@ class BackendTest {
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(
-                baseURL = mockDiagnosticsBaseURL,
+                baseURL = AppConfig.diagnosticsURL,
                 endpoint = diagnosticsEndpoint,
                 body = mapOf("entries" to JSONArray(diagnosticsList)),
                 postFieldsToSign = null,
@@ -1931,7 +1929,7 @@ class BackendTest {
             clientException = null,
             resultBody = null,
             delayed = true,
-            baseURL = mockDiagnosticsBaseURL
+            baseURL = AppConfig.diagnosticsURL,
         )
         val lock = CountDownLatch(1)
         asyncBackend.postDiagnostics(diagnosticsList, { lock.countDown() }, { _, _ -> fail("expected success") })
@@ -1943,7 +1941,7 @@ class BackendTest {
         assertThat(lock2.count).isEqualTo(0)
         verify(exactly = 2) {
             mockClient.performRequest(
-                baseURL = mockDiagnosticsBaseURL,
+                baseURL = AppConfig.diagnosticsURL,
                 endpoint = diagnosticsEndpoint,
                 body = mapOf("entries" to JSONArray(diagnosticsList)),
                 postFieldsToSign = null,
@@ -1961,7 +1959,7 @@ class BackendTest {
             responseCode = 200,
             clientException = SecurityException(),
             resultBody = null,
-            baseURL = mockDiagnosticsBaseURL
+            baseURL = AppConfig.diagnosticsURL,
         )
         var errorCalled = false
         backend.postDiagnostics(
@@ -1985,7 +1983,7 @@ class BackendTest {
             responseCode = 200,
             clientException = IOException(),
             resultBody = null,
-            baseURL = mockDiagnosticsBaseURL
+            baseURL = AppConfig.diagnosticsURL,
         )
         var errorCalled = false
         backend.postDiagnostics(
@@ -2009,7 +2007,7 @@ class BackendTest {
             responseCode = 500,
             clientException = null,
             resultBody = null,
-            baseURL = mockDiagnosticsBaseURL
+            baseURL = AppConfig.diagnosticsURL,
         )
         var errorCalled = false
         backend.postDiagnostics(
@@ -2033,7 +2031,7 @@ class BackendTest {
             responseCode = 400,
             clientException = null,
             resultBody = "{\"code\":7101}", // BackendStoreProblem
-            baseURL = mockDiagnosticsBaseURL
+            baseURL = AppConfig.diagnosticsURL,
         )
         var errorCalled = false
         backend.postDiagnostics(
@@ -2058,7 +2056,7 @@ class BackendTest {
             responseCode = 200,
             clientException = null,
             resultBody = resultBody,
-            baseURL = mockDiagnosticsBaseURL
+            baseURL = AppConfig.diagnosticsURL,
         )
         var successCalled = false
         backend.postDiagnostics(
@@ -2080,7 +2078,7 @@ class BackendTest {
             responseCode = 200,
             clientException = null,
             resultBody = "{}",
-            baseURL = mockDiagnosticsBaseURL
+            baseURL = AppConfig.diagnosticsURL,
         )
         dispatcher.calledDelay = null
         backend.postDiagnostics(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -19,6 +19,7 @@ class EndpointTest {
         Endpoint.GetAmazonReceipt("test-user-id", "test-receipt-id"),
         Endpoint.PostAttributes("test-user-id"),
         Endpoint.PostDiagnostics,
+        Endpoint.PostPaywallEvents,
     )
 
     @Test
@@ -53,6 +54,13 @@ class EndpointTest {
     fun `Diagnostics has correct path`() {
         val endpoint = Endpoint.PostDiagnostics
         val expectedPath = "/diagnostics"
+        assertThat(endpoint.getPath()).isEqualTo(expectedPath)
+    }
+
+    @Test
+    fun `Paywall events has correct path`() {
+        val endpoint = Endpoint.PostPaywallEvents
+        val expectedPath = "/events"
         assertThat(endpoint.getPath()).isEqualTo(expectedPath)
     }
 
@@ -99,6 +107,7 @@ class EndpointTest {
             Endpoint.GetAmazonReceipt("test-user-id", "test-receipt-id"),
             Endpoint.PostAttributes("test-user-id"),
             Endpoint.PostDiagnostics,
+            Endpoint.PostPaywallEvents,
         )
         for (endpoint in expectedNotSupportsValidationEndpoints) {
             assertThat(endpoint.supportsSignatureVerification)
@@ -140,6 +149,7 @@ class EndpointTest {
             Endpoint.GetAmazonReceipt("test-user-id", "test-receipt-id"),
             Endpoint.PostAttributes("test-user-id"),
             Endpoint.PostDiagnostics,
+            Endpoint.PostPaywallEvents,
         )
         for (endpoint in expectedEndpoints) {
             assertThat(endpoint.needsNonceToPerformSigning)

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventRequestSerializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventRequestSerializationTest.kt
@@ -1,0 +1,61 @@
+package com.revenuecat.purchases.paywalls.events
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@RunWith(AndroidJUnit4::class)
+class PaywallEventRequestSerializationTest {
+
+    private val request = PaywallEventRequest(listOf(
+        PaywallBackendEvent(
+            id = "id",
+            version = 1,
+            type = PaywallEventType.CANCEL.value,
+            appUserID = "appUserID",
+            sessionID = "sessionID",
+            offeringID = "offeringID",
+            paywallRevision = 5,
+            timestamp = 123456789,
+            displayMode = "footer",
+            darkMode = true,
+            localeIdentifier = "en_US",
+        )
+    ))
+
+    @Test
+    fun `can encode paywall event request correctly`() {
+        val requestString = PaywallEventsManager.json.encodeToString(request)
+        Assertions.assertThat(requestString).isEqualTo(
+            "{" +
+                "\"events\":[" +
+                    "{" +
+                        "\"id\":\"id\"," +
+                        "\"version\":1," +
+                        "\"type\":\"paywall_cancel\"," +
+                        "\"app_user_id\":\"appUserID\"," +
+                        "\"session_id\":\"sessionID\"," +
+                        "\"offering_id\":\"offeringID\"," +
+                        "\"paywall_revision\":5," +
+                        "\"timestamp\":123456789," +
+                        "\"display_mode\":\"footer\"," +
+                        "\"dark_mode\":true," +
+                        "\"locale\":\"en_US\"" +
+                    "}" +
+                "]" +
+            "}"
+        )
+    }
+
+    @Test
+    fun `can encode and decode event correctly`() {
+        val requestString = PaywallEventsManager.json.encodeToString(request)
+        val decodedRequest = PaywallEventsManager.json.decodeFromString<PaywallEventRequest>(requestString)
+        Assertions.assertThat(decodedRequest).isEqualTo(request)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/JsonElementExtensionsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/JsonElementExtensionsTest.kt
@@ -1,0 +1,37 @@
+package com.revenuecat.purchases.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class JsonElementExtensionsTest {
+    @Test
+    fun `can convert map with different types of elements`() {
+        val mapOfElements: JsonElement = JsonObject(
+            mapOf(
+                "int" to JsonPrimitive(123),
+                "bool" to JsonPrimitive(true),
+                "float" to JsonPrimitive(1234.4f),
+                "string" to JsonPrimitive("my_text"),
+                "list" to JsonArray(listOf(JsonPrimitive(123), JsonPrimitive(456), JsonPrimitive(789))),
+                "map" to JsonObject(mapOf("key1" to JsonPrimitive(123), "key2" to JsonPrimitive(true)))
+            )
+        )
+        assertThat(mapOfElements.asMap()).isEqualTo(
+            mapOf(
+                "int" to 123,
+                "bool" to true,
+                "float" to 1234.4f,
+                "string" to "my_text",
+                "list" to listOf(123, 456, 789),
+                "map" to mapOf("key1" to 123, "key2" to true)
+            )
+        )
+    }
+}


### PR DESCRIPTION
### Description
This follows up on #1436. 

Here we are adding the code to send paywall events to our servers. This is not connected with the work done in #1436 yet. That will be done in followup PRs.
- [ ] Actually read events from disk and use this to send them to servers.
- [ ] Use paywall events to detect whether a purchase came from a paywall.