### PR TITLE
Remove side effect from setting purchasesUpdatedListener

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -141,6 +141,7 @@ internal class PurchasesOrchestrator constructor(
             }
         }
         billing.purchasesUpdatedListener = getPurchasesUpdatedListener()
+        billing.startConnectionOnMainThread()
 
         dispatch {
             // This needs to happen after the billing client listeners have been set. This is because

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -22,16 +22,6 @@ internal abstract class BillingAbstract {
     @get:Synchronized
     @Volatile
     var purchasesUpdatedListener: PurchasesUpdatedListener? = null
-        set(value) {
-            synchronized(this@BillingAbstract) {
-                field = value
-            }
-            if (value != null) {
-                startConnectionOnMainThread()
-            } else {
-                endConnection()
-            }
-        }
 
     interface StateListener {
         fun onConnected()

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -41,6 +41,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.runs
 import io.mockk.slot
 import io.mockk.unmockkStatic
 import org.junit.After
@@ -154,6 +155,10 @@ internal open class BasePurchasesTest {
             } answers {
                 purchasesUpdatedListener = null
             }
+
+            every {
+                startConnectionOnMainThread()
+            } just runs
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -158,7 +158,7 @@ internal open class BasePurchasesTest {
 
             every {
                 startConnectionOnMainThread()
-            } just runs
+            } just Runs
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -847,8 +847,8 @@ class AmazonBillingTest {
         } just Runs
 
         underTest.startConnection()
-        // First call is when setting purchasesUpdatedListener
-        verify(exactly = 2) {
+
+        verify(exactly = 1) {
             mockPurchasingServiceProvider.registerListener(any(), any())
         }
     }


### PR DESCRIPTION
I removed a side effect on setting `purchasesUpdatedListener`. I don't think we should be starting/ending the connection there and we should do it independently