### PR TITLE
Paywalls: Add paywall events flush logic and tests (3)

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -255,7 +255,7 @@ internal class PurchasesFactory(
                 postPendingTransactionsHelper,
                 syncPurchasesHelper,
                 offeringsManager,
-                createPaywallEventsManager(application, identityManager, eventsDispatcher),
+                createPaywallEventsManager(application, identityManager, eventsDispatcher, backend),
             )
 
             return Purchases(purchasesOrchestrator)
@@ -266,6 +266,7 @@ internal class PurchasesFactory(
         context: Context,
         identityManager: IdentityManager,
         eventsDispatcher: Dispatcher,
+        backend: Backend,
     ): PaywallEventsManager? {
         // RevenueCatUI is Android 24+ so it should always enter here when using RevenueCatUI.
         // Still, we check for Android N or newer since we use Streams which are 24+ and the main SDK supports
@@ -275,6 +276,7 @@ internal class PurchasesFactory(
                 PaywallEventsFileHelper(FileHelper(context)),
                 identityManager,
                 eventsDispatcher,
+                backend,
             )
         } else {
             debugLog("Paywall events are only supported on Android N or newer.")

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventsManagerTest.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.paywalls.events
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.FileHelper
 import com.revenuecat.purchases.common.SyncDispatcher
@@ -27,6 +28,7 @@ class PaywallEventsManagerTest {
     private lateinit var fileHelper: PaywallEventsFileHelper
     private lateinit var identityManager: IdentityManager
     private lateinit var paywallEventsDispatcher: Dispatcher
+    private lateinit var backend: Backend
 
     private lateinit var eventsManager: PaywallEventsManager
 
@@ -46,11 +48,13 @@ class PaywallEventsManagerTest {
             every { currentAppUserID } returns "testAppUserId"
         }
         paywallEventsDispatcher = SyncDispatcher()
+        backend = mockk()
 
         eventsManager = PaywallEventsManager(
             fileHelper,
             identityManager,
-            paywallEventsDispatcher
+            paywallEventsDispatcher,
+            backend,
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventsManagerTest.kt
@@ -10,7 +10,6 @@ import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.FileHelper
 import com.revenuecat.purchases.common.SyncDispatcher
 import com.revenuecat.purchases.identity.IdentityManager
-import com.revenuecat.purchases.utils.EventsFileHelper
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -50,7 +49,7 @@ class PaywallEventsManagerTest {
 
     private val testFolder = "temp_test_folder"
 
-    private lateinit var fileHelper: EventsFileHelper<PaywallStoredEvent>
+    private lateinit var fileHelper: PaywallEventsFileHelper
     private lateinit var identityManager: IdentityManager
     private lateinit var paywallEventsDispatcher: Dispatcher
     private lateinit var backend: Backend
@@ -68,10 +67,8 @@ class PaywallEventsManagerTest {
         val context = mockk<Context>().apply {
             every { filesDir } returns tempTestFolder
         }
-        fileHelper = EventsFileHelper(
+        fileHelper = PaywallEventsFileHelper(
             FileHelper(context),
-            PaywallEventsManager.PAYWALL_EVENTS_FILE_PATH,
-            PaywallStoredEvent::fromString
         )
         identityManager = mockk<IdentityManager>().apply {
             every { currentAppUserID } returns userID
@@ -257,12 +254,12 @@ class PaywallEventsManagerTest {
     }
 
     private fun checkFileNumberOfEvents(expectedNumberOfEvents: Int) {
-        val file = File(testFolder, PaywallEventsManager.PAYWALL_EVENTS_FILE_PATH)
+        val file = File(testFolder, PaywallEventsFileHelper.PAYWALL_EVENTS_FILE_PATH)
         assertThat(file.readLines().size).isEqualTo(expectedNumberOfEvents)
     }
 
     private fun checkFileContents(expectedContents: String) {
-        val file = File(testFolder, PaywallEventsManager.PAYWALL_EVENTS_FILE_PATH)
+        val file = File(testFolder, PaywallEventsFileHelper.PAYWALL_EVENTS_FILE_PATH)
         assertThat(file.readText()).isEqualTo(expectedContents)
     }
 


### PR DESCRIPTION
### Description
This adds the code to the `PaywallEventsManager` class to actually send the events to the backend and clear them locally once finished.
