### PR TITLE
Paywalls: Track paywall events

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -47,7 +47,7 @@ internal fun InternalPaywall(
     viewModel: PaywallViewModel = getPaywallViewModel(options),
 ) {
     BackHandler {
-        viewModel.close()
+        viewModel.closePaywall()
     }
     PaywallTheme(fontProvider = options.fontProvider) {
         viewModel.refreshStateIfLocaleChanged()
@@ -63,7 +63,7 @@ internal fun InternalPaywall(
             LoadingPaywall(
                 mode = options.mode,
                 shouldDisplayDismissButton = options.shouldDisplayDismissButton,
-                onDismiss = viewModel::close,
+                onDismiss = viewModel::closePaywall,
             )
         }
 
@@ -118,7 +118,7 @@ private fun LoadedPaywall(state: PaywallState.Loaded, viewModel: PaywallViewMode
             },
     ) {
         TemplatePaywall(state = state, viewModel = viewModel)
-        CloseButton(state.shouldDisplayDismissButton, viewModel::close)
+        CloseButton(state.shouldDisplayDismissButton, viewModel::closePaywall)
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -1,9 +1,11 @@
 package com.revenuecat.purchases.ui.revenuecatui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
@@ -44,9 +46,13 @@ internal fun InternalPaywall(
     options: PaywallOptions,
     viewModel: PaywallViewModel = getPaywallViewModel(options),
 ) {
+    viewModel.trackPaywallImpressionIfNeeded()
+    BackHandler {
+        viewModel.close()
+    }
     PaywallTheme(fontProvider = options.fontProvider) {
         viewModel.refreshStateIfLocaleChanged()
-        viewModel.refreshStateIfColorsChanged(MaterialTheme.colorScheme)
+        viewModel.refreshStateIfColorsChanged(MaterialTheme.colorScheme, isSystemInDarkTheme())
 
         val state = viewModel.state.collectAsState().value
 
@@ -58,7 +64,7 @@ internal fun InternalPaywall(
             LoadingPaywall(
                 mode = options.mode,
                 shouldDisplayDismissButton = options.shouldDisplayDismissButton,
-                onDismiss = viewModel::closeButtonPressed,
+                onDismiss = viewModel::close,
             )
         }
 
@@ -112,7 +118,7 @@ private fun LoadedPaywall(state: PaywallState.Loaded, viewModel: PaywallViewMode
             },
     ) {
         TemplatePaywall(state = state, viewModel = viewModel)
-        CloseButton(state.shouldDisplayDismissButton, viewModel::closeButtonPressed)
+        CloseButton(state.shouldDisplayDismissButton, viewModel::close)
     }
 }
 
@@ -129,7 +135,7 @@ private fun TemplatePaywall(state: PaywallState.Loaded, viewModel: PaywallViewMo
 
 @ExperimentalPreviewRevenueCatUIPurchasesAPI
 @Composable
-private fun getPaywallViewModel(
+internal fun getPaywallViewModel(
     options: PaywallOptions,
 ): PaywallViewModel {
     val applicationContext = LocalContext.current.applicationContext
@@ -138,6 +144,7 @@ private fun getPaywallViewModel(
             applicationContext.toAndroidContext(),
             options,
             MaterialTheme.colorScheme,
+            isSystemInDarkTheme(),
             preview = isInPreviewMode(),
         ),
     )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -46,7 +46,6 @@ internal fun InternalPaywall(
     options: PaywallOptions,
     viewModel: PaywallViewModel = getPaywallViewModel(options),
 ) {
-    viewModel.trackPaywallImpressionIfNeeded()
     BackHandler {
         viewModel.close()
     }
@@ -100,6 +99,7 @@ internal fun InternalPaywall(
 
 @Composable
 private fun LoadedPaywall(state: PaywallState.Loaded, viewModel: PaywallViewModel) {
+    viewModel.trackPaywallImpressionIfNeeded()
     val backgroundColor = state.templateConfiguration.getCurrentColors().background
     Box(
         modifier = Modifier

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -180,7 +180,7 @@ private class LoadingViewModel(
         error("Not supported")
     }
 
-    override fun close() {
+    override fun closePaywall() {
         error("Not supported")
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -170,8 +170,9 @@ private class LoadingViewModel(
     override val actionInProgress: State<Boolean> = mutableStateOf(false)
     override val actionError: State<PurchasesError?> = mutableStateOf(null)
 
+    override fun trackPaywallImpressionIfNeeded() = Unit
     override fun refreshStateIfLocaleChanged() = Unit
-    override fun refreshStateIfColorsChanged(colorScheme: ColorScheme) = Unit
+    override fun refreshStateIfColorsChanged(colorScheme: ColorScheme, isDarkMode: Boolean) = Unit
 
     private val _state = MutableStateFlow(state)
 
@@ -179,7 +180,7 @@ private class LoadingViewModel(
         error("Not supported")
     }
 
-    override fun closeButtonPressed() {
+    override fun close() {
         error("Not supported")
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -57,7 +57,7 @@ fun PaywallDialog(
         Dialog(
             onDismissRequest = {
                 dismissRequest()
-                viewModel.close()
+                viewModel.closePaywall()
                 paywallDialogOptions.dismissRequest?.invoke()
             },
             properties = DialogProperties(usePlatformDefaultWidth = shouldUsePlatformDefaultWidth()),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -50,15 +50,19 @@ fun PaywallDialog(
         val dismissRequest = {
             shouldDisplayDialog = false
         }
+        val paywallOptions = paywallDialogOptions.toPaywallOptions(dismissRequest)
+
+        val viewModel = getPaywallViewModel(options = paywallOptions)
 
         Dialog(
             onDismissRequest = {
                 dismissRequest()
+                viewModel.close()
                 paywallDialogOptions.dismissRequest?.invoke()
             },
             properties = DialogProperties(usePlatformDefaultWidth = shouldUsePlatformDefaultWidth()),
         ) {
-            DialogScaffold(paywallDialogOptions.toPaywallOptions(dismissRequest))
+            DialogScaffold(paywallOptions)
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.mutableStateOf
+import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.ProcessedLocalizedConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.isFullScreen
@@ -14,16 +15,18 @@ internal sealed class PaywallState {
     data class Error(val errorMessage: String) : PaywallState()
 
     data class Loaded(
+        val offering: Offering,
         val templateConfiguration: TemplateConfiguration,
         val selectedPackage: MutableState<TemplateConfiguration.PackageInfo>,
         val shouldDisplayDismissButton: Boolean,
     ) : PaywallState() {
         constructor(
+            offering: Offering,
             templateConfiguration: TemplateConfiguration,
             selectedPackage: TemplateConfiguration.PackageInfo,
             shouldDisplayDismissButton: Boolean,
         ) :
-            this(templateConfiguration, mutableStateOf(selectedPackage), shouldDisplayDismissButton)
+            this(offering, templateConfiguration, mutableStateOf(selectedPackage), shouldDisplayDismissButton)
 
         fun selectPackage(packageInfo: TemplateConfiguration.PackageInfo) {
             selectedPackage.value = packageInfo

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -48,7 +48,7 @@ internal interface PaywallViewModel {
     fun refreshStateIfColorsChanged(colorScheme: ColorScheme, isDark: Boolean)
     fun selectPackage(packageToSelect: TemplateConfiguration.PackageInfo)
     fun trackPaywallImpressionIfNeeded()
-    fun close()
+    fun closePaywall()
 
     /**
      * Purchase the selected package
@@ -135,7 +135,7 @@ internal class PaywallViewModelImpl(
         }
     }
 
-    override fun close() {
+    override fun closePaywall() {
         Logger.d("Paywalls: Close paywall initiated")
         trackPaywallClose()
         options.dismissRequest()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -14,7 +14,6 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PurchaseParams
-import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
@@ -304,7 +303,7 @@ internal class PaywallViewModelImpl(
     private fun track(eventType: PaywallEventType) {
         val eventData = paywallPresentationData
         if (eventData == null) {
-            Logger.e("Paywall event data is null, not tracking event")
+            Logger.e("Paywall event data is null, not tracking event $eventType")
             return
         }
         val event = PaywallEvent(
@@ -313,7 +312,7 @@ internal class PaywallViewModelImpl(
             type = eventType,
         )
 
-        Purchases.sharedInstance.track(event)
+        purchases.track(event)
     }
 
     @Suppress("ReturnCount")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -10,11 +10,16 @@ import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PurchaseParams
+import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.paywalls.events.PaywallEvent
+import com.revenuecat.purchases.paywalls.events.PaywallEventType
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
@@ -31,6 +36,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
 
 internal interface PaywallViewModel {
     val state: StateFlow<PaywallState>
@@ -38,9 +46,10 @@ internal interface PaywallViewModel {
     val actionError: State<PurchasesError?>
 
     fun refreshStateIfLocaleChanged()
-    fun refreshStateIfColorsChanged(colorScheme: ColorScheme)
+    fun refreshStateIfColorsChanged(colorScheme: ColorScheme, isDark: Boolean)
     fun selectPackage(packageToSelect: TemplateConfiguration.PackageInfo)
-    fun closeButtonPressed()
+    fun trackPaywallImpressionIfNeeded()
+    fun close()
 
     /**
      * Purchase the selected package
@@ -60,6 +69,7 @@ internal class PaywallViewModelImpl(
     private val purchases: PurchasesType = PurchasesImpl(),
     private var options: PaywallOptions,
     colorScheme: ColorScheme,
+    private var isDarkMode: Boolean,
     preview: Boolean = false,
 ) : ViewModel(), PaywallViewModel {
     private val variableDataProvider = VariableDataProvider(applicationContext, preview)
@@ -83,6 +93,9 @@ internal class PaywallViewModelImpl(
     private val mode: PaywallMode
         get() = options.mode
 
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    private var paywallPresentationData: PaywallEvent.Data? = null
+
     init {
         updateState()
     }
@@ -101,7 +114,11 @@ internal class PaywallViewModelImpl(
         }
     }
 
-    override fun refreshStateIfColorsChanged(colorScheme: ColorScheme) {
+    override fun refreshStateIfColorsChanged(colorScheme: ColorScheme, isDark: Boolean) {
+        if (isDarkMode != isDark) {
+            // This is only used for events so no need to update the state here currently.
+            isDarkMode = isDark
+        }
         if (_colorScheme.value != colorScheme) {
             _colorScheme.value = colorScheme
             updateState()
@@ -120,8 +137,9 @@ internal class PaywallViewModelImpl(
         }
     }
 
-    override fun closeButtonPressed() {
-        Logger.d("Paywalls: Close button pressed.")
+    override fun close() {
+        Logger.d("Paywalls: Close paywall initiated")
+        trackPaywallClose()
         options.dismissRequest()
     }
 
@@ -166,6 +184,14 @@ internal class PaywallViewModelImpl(
         _actionError.value = null
     }
 
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    override fun trackPaywallImpressionIfNeeded() {
+        if (paywallPresentationData == null) {
+            paywallPresentationData = createEventData()
+            track(PaywallEventType.IMPRESSION)
+        }
+    }
+
     private fun purchasePackage(activity: Activity, packageToPurchase: Package) {
         if (verifyNoActionInProgressOrStartAction()) { return }
 
@@ -178,6 +204,9 @@ internal class PaywallViewModelImpl(
                 listener?.onPurchaseCompleted(purchaseResult.customerInfo, purchaseResult.storeTransaction)
                 options.dismissRequest()
             } catch (e: PurchasesException) {
+                if (e.code == PurchasesErrorCode.PurchaseCancelledError) {
+                    trackPaywallCancel()
+                }
                 listener?.onPurchaseError(e.error)
                 _actionError.value = e.error
             }
@@ -261,5 +290,58 @@ internal class PaywallViewModelImpl(
 
     private fun finishAction() {
         _actionInProgress.value = false
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    private fun trackPaywallClose() {
+        if (paywallPresentationData != null) {
+            track(PaywallEventType.CLOSE)
+            paywallPresentationData = null
+        }
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    private fun trackPaywallCancel() {
+        track(PaywallEventType.CANCEL)
+    }
+
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    private fun track(eventType: PaywallEventType) {
+        val eventData = paywallPresentationData
+        if (eventData == null) {
+            Logger.e("Paywall event data is null, not tracking event")
+            return
+        }
+        val event = PaywallEvent(
+            creationData = PaywallEvent.CreationData(UUID.randomUUID(), Date()),
+            data = eventData,
+            type = eventType,
+        )
+
+        Purchases.sharedInstance.track(event)
+    }
+
+    @Suppress("ReturnCount")
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+    private fun createEventData(): PaywallEvent.Data? {
+        val currentState = state.value
+        if (currentState !is PaywallState.Loaded) {
+            Logger.e("Unexpected state trying to create event data: $currentState")
+            return null
+        }
+        val offering = currentState.offering
+        val paywallData = currentState.offering.paywall ?: kotlin.run {
+            Logger.e("Null paywall revision trying to create event data")
+            return null
+        }
+        val locale = _lastLocaleList.value.get(0) ?: Locale.getDefault()
+        return PaywallEvent.Data(
+            offeringIdentifier = offering.identifier,
+            paywallRevision = paywallData.revision,
+            sessionIdentifier = UUID.randomUUID(),
+            displayMode = mode.name.lowercase(),
+            localeIdentifier = locale.toString(),
+            darkMode = isDarkMode,
+        )
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -62,7 +62,7 @@ internal interface PaywallViewModel {
     fun clearActionError()
 }
 
-@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class, ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Suppress("TooManyFunctions")
 internal class PaywallViewModelImpl(
     private val applicationContext: ApplicationContext,
@@ -93,7 +93,6 @@ internal class PaywallViewModelImpl(
     private val mode: PaywallMode
         get() = options.mode
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private var paywallPresentationData: PaywallEvent.Data? = null
 
     init {
@@ -184,7 +183,6 @@ internal class PaywallViewModelImpl(
         _actionError.value = null
     }
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     override fun trackPaywallImpressionIfNeeded() {
         if (paywallPresentationData == null) {
             paywallPresentationData = createEventData()
@@ -292,7 +290,6 @@ internal class PaywallViewModelImpl(
         _actionInProgress.value = false
     }
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private fun trackPaywallClose() {
         if (paywallPresentationData != null) {
             track(PaywallEventType.CLOSE)
@@ -300,12 +297,10 @@ internal class PaywallViewModelImpl(
         }
     }
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private fun trackPaywallCancel() {
         track(PaywallEventType.CANCEL)
     }
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private fun track(eventType: PaywallEventType) {
         val eventData = paywallPresentationData
         if (eventData == null) {
@@ -322,7 +317,6 @@ internal class PaywallViewModelImpl(
     }
 
     @Suppress("ReturnCount")
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     private fun createEventData(): PaywallEvent.Data? {
         val currentState = state.value
         if (currentState !is PaywallState.Loaded) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
@@ -12,6 +12,7 @@ internal class PaywallViewModelFactory(
     private val applicationContext: ApplicationContext,
     private val options: PaywallOptions,
     private val colorScheme: ColorScheme,
+    private val isDarkMode: Boolean,
     private val preview: Boolean = false,
 ) : ViewModelProvider.NewInstanceFactory() {
     @Suppress("UNCHECKED_CAST")
@@ -20,6 +21,7 @@ internal class PaywallViewModelFactory(
             applicationContext = applicationContext,
             options = options,
             colorScheme = colorScheme,
+            isDarkMode = isDarkMode,
             preview = preview,
         ) as T
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui.data
 
 import com.revenuecat.purchases.CacheFetchPolicy
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.PurchaseParams
 import com.revenuecat.purchases.PurchaseResult
@@ -10,10 +11,12 @@ import com.revenuecat.purchases.awaitCustomerInfo
 import com.revenuecat.purchases.awaitOfferings
 import com.revenuecat.purchases.awaitPurchase
 import com.revenuecat.purchases.awaitRestore
+import com.revenuecat.purchases.paywalls.events.PaywallEvent
 
 /**
  * Abstraction over [Purchases] that can be mocked.
  */
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal interface PurchasesType {
     suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult
 
@@ -24,8 +27,11 @@ internal interface PurchasesType {
     suspend fun awaitCustomerInfo(
         fetchPolicy: CacheFetchPolicy = CacheFetchPolicy.default(),
     ): CustomerInfo
+
+    fun track(event: PaywallEvent)
 }
 
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal class PurchasesImpl(private val purchases: Purchases = Purchases.sharedInstance) : PurchasesType {
     override suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult {
         return purchases.awaitPurchase(purchaseParams.build())
@@ -41,5 +47,9 @@ internal class PurchasesImpl(private val purchases: Purchases = Purchases.shared
 
     override suspend fun awaitCustomerInfo(fetchPolicy: CacheFetchPolicy): CustomerInfo {
         return purchases.awaitCustomerInfo(fetchPolicy)
+    }
+
+    override fun track(event: PaywallEvent) {
+        purchases.track(event)
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -315,14 +315,15 @@ internal class MockViewModel(
     private val _actionInProgress = mutableStateOf(false)
     private val _actionError = mutableStateOf<PurchasesError?>(null)
 
+    override fun trackPaywallImpressionIfNeeded() = Unit
     override fun refreshStateIfLocaleChanged() = Unit
-    override fun refreshStateIfColorsChanged(colorScheme: ColorScheme) = Unit
+    override fun refreshStateIfColorsChanged(colorScheme: ColorScheme, isDarkMode: Boolean) = Unit
 
     override fun selectPackage(packageToSelect: TemplateConfiguration.PackageInfo) {
         error("Not supported")
     }
 
-    override fun closeButtonPressed() {
+    override fun close() {
         error("Not supported")
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -323,7 +323,7 @@ internal class MockViewModel(
         error("Not supported")
     }
 
-    override fun close() {
+    override fun closePaywall() {
         error("Not supported")
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -90,6 +90,7 @@ internal fun Offering.toPaywallState(
         return PaywallState.Error(it.message ?: "Unknown error")
     }
     return PaywallState.Loaded(
+        offering = this,
         templateConfiguration = templateConfiguration,
         selectedPackage = templateConfiguration.packages.default,
         shouldDisplayDismissButton = shouldDisplayDismissButton,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -16,7 +16,6 @@ import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.Transaction
 import com.revenuecat.purchases.paywalls.PaywallData
-import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventType
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
@@ -110,7 +109,7 @@ class PaywallViewModelTest {
 
     @Test
     fun `Initial state is correct`() {
-        delayGettingOfferings()
+        delayFetchingOfferings()
 
         val model = create()
 
@@ -377,7 +376,7 @@ class PaywallViewModelTest {
         val model = create()
 
         assertThat(dismissInvoked).isFalse
-        model.close()
+        model.closePaywall()
         assertThat(dismissInvoked).isTrue
     }
 
@@ -405,7 +404,7 @@ class PaywallViewModelTest {
     fun `trackPaywallImpression after close tracks again`() {
         val model = create()
         model.trackPaywallImpressionIfNeeded()
-        model.close()
+        model.closePaywall()
         model.trackPaywallImpressionIfNeeded()
         verifyEventTracked(PaywallEventType.IMPRESSION, 2)
     }
@@ -414,7 +413,7 @@ class PaywallViewModelTest {
     fun `close tracks close event`() {
         val model = create()
         model.trackPaywallImpressionIfNeeded()
-        model.close()
+        model.closePaywall()
         verifyEventTracked(PaywallEventType.CLOSE, 1)
     }
 
@@ -422,9 +421,9 @@ class PaywallViewModelTest {
     fun `close tracks close event only once before another impression`() {
         val model = create()
         model.trackPaywallImpressionIfNeeded()
-        model.close()
-        model.close()
-        model.close()
+        model.closePaywall()
+        model.closePaywall()
+        model.closePaywall()
         verify(exactly = 1) {
             purchases.track(
                 withArg {
@@ -437,7 +436,7 @@ class PaywallViewModelTest {
             )
         }
         model.trackPaywallImpressionIfNeeded()
-        model.close()
+        model.closePaywall()
         verifyEventTracked(PaywallEventType.CLOSE, 2)
     }
 
@@ -471,7 +470,7 @@ class PaywallViewModelTest {
 
     @Test
     fun `trackPaywallImpression does nothing if state is loading`() {
-        delayGettingOfferings()
+        delayFetchingOfferings()
         val model = create()
         model.trackPaywallImpressionIfNeeded()
         assertThat(model.state.value).isInstanceOf(PaywallState.Loading::class.java)
@@ -568,7 +567,7 @@ class PaywallViewModelTest {
         }
     }
 
-    private fun delayGettingOfferings() {
+    private fun delayFetchingOfferings() {
         coEvery { purchases.awaitOfferings() } coAnswers {
             // Delay response to verify initial state
             delay(100)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -132,7 +132,8 @@ class PaywallViewModelTest {
             MockApplicationContext(),
             purchases,
             options,
-            TestData.Constants.currentColorScheme
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
         )
         coVerify(exactly = 1) { purchases.awaitOfferings() }
         model.updateOptions(options)
@@ -151,7 +152,8 @@ class PaywallViewModelTest {
             MockApplicationContext(),
             purchases,
             options1,
-            TestData.Constants.currentColorScheme
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
         )
         coVerify(exactly = 1) { purchases.awaitOfferings() }
         model.updateOptions(options1)
@@ -373,7 +375,7 @@ class PaywallViewModelTest {
         val model = create()
 
         assertThat(dismissInvoked).isFalse
-        model.closeButtonPressed()
+        model.close()
         assertThat(dismissInvoked).isTrue
     }
 
@@ -392,7 +394,8 @@ class PaywallViewModelTest {
                 .setListener(listener)
                 .setOffering(offering)
                 .build(),
-            TestData.Constants.currentColorScheme
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
         )
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
@@ -15,6 +16,8 @@ import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.Transaction
 import com.revenuecat.purchases.paywalls.PaywallData
+import com.revenuecat.purchases.paywalls.events.PaywallEvent
+import com.revenuecat.purchases.paywalls.events.PaywallEventType
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
@@ -23,6 +26,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfigura
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockApplicationContext
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.extensions.getActivity
+import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -44,7 +48,7 @@ import org.junit.runner.RunWith
 import java.util.Date
 import java.util.UUID
 
-@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class, ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @RunWith(AndroidJUnit4::class)
 class PaywallViewModelTest {
     private val defaultOffering = TestData.template2Offering
@@ -89,6 +93,8 @@ class PaywallViewModelTest {
         coEvery { purchases.awaitOfferings() } returns offerings
         coEvery { purchases.awaitCustomerInfo(any()) } returns customerInfo
 
+        every { purchases.track(any()) } just Runs
+
         every { listener.onPurchaseStarted(any()) } just runs
         every { listener.onPurchaseCompleted(any(), any()) } just runs
         every { listener.onPurchaseError(any()) } just runs
@@ -104,11 +110,7 @@ class PaywallViewModelTest {
 
     @Test
     fun `Initial state is correct`() {
-        coEvery { purchases.awaitOfferings() } coAnswers {
-            // Delay response to verify initial state
-            delay(100)
-            offerings
-        }
+        delayGettingOfferings()
 
         val model = create()
 
@@ -379,6 +381,112 @@ class PaywallViewModelTest {
         assertThat(dismissInvoked).isTrue
     }
 
+    // region events
+
+    @Test
+    fun `trackPaywallImpression tracks event with correct data`() {
+        val model = create()
+        model.trackPaywallImpressionIfNeeded()
+        verifyEventTracked(PaywallEventType.IMPRESSION, 1)
+    }
+
+    @Test
+    fun `trackPaywallImpression multiple times in a row only tracks once`() {
+        val model = create()
+        model.trackPaywallImpressionIfNeeded()
+        model.trackPaywallImpressionIfNeeded()
+        model.trackPaywallImpressionIfNeeded()
+        verify(exactly = 1) {
+            purchases.track(any())
+        }
+    }
+
+    @Test
+    fun `trackPaywallImpression after close tracks again`() {
+        val model = create()
+        model.trackPaywallImpressionIfNeeded()
+        model.close()
+        model.trackPaywallImpressionIfNeeded()
+        verifyEventTracked(PaywallEventType.IMPRESSION, 2)
+    }
+
+    @Test
+    fun `close tracks close event`() {
+        val model = create()
+        model.trackPaywallImpressionIfNeeded()
+        model.close()
+        verifyEventTracked(PaywallEventType.CLOSE, 1)
+    }
+
+    @Test
+    fun `close tracks close event only once before another impression`() {
+        val model = create()
+        model.trackPaywallImpressionIfNeeded()
+        model.close()
+        model.close()
+        model.close()
+        verify(exactly = 1) {
+            purchases.track(
+                withArg {
+                    assertThat(it.data.offeringIdentifier).isEqualTo(defaultOffering.identifier)
+                    assertThat(it.data.paywallRevision).isEqualTo(defaultOffering.paywall!!.revision)
+                    assertThat(it.data.displayMode).isEqualTo("full_screen")
+                    assertThat(it.data.darkMode).isFalse
+                    assertThat(it.type).isEqualTo(PaywallEventType.CLOSE)
+                }
+            )
+        }
+        model.trackPaywallImpressionIfNeeded()
+        model.close()
+        verifyEventTracked(PaywallEventType.CLOSE, 2)
+    }
+
+    @Test
+    fun `purchase cancellation tracks cancel event`() {
+        val model = create()
+        model.trackPaywallImpressionIfNeeded()
+        val expectedError = PurchasesError(PurchasesErrorCode.PurchaseCancelledError)
+        coEvery {
+            purchases.awaitPurchase(any())
+        } throws PurchasesException(expectedError)
+
+        model.purchaseSelectedPackage(context)
+
+        verifyEventTracked(PaywallEventType.CANCEL, 1)
+    }
+
+    @Test
+    fun `purchase errors other than cancellation do not track cancel event`() {
+        val model = create()
+        model.trackPaywallImpressionIfNeeded()
+        val expectedError = PurchasesError(PurchasesErrorCode.StoreProblemError)
+        coEvery {
+            purchases.awaitPurchase(any())
+        } throws PurchasesException(expectedError)
+
+        model.purchaseSelectedPackage(context)
+
+        verifyNoEventsOfTypeTracked(PaywallEventType.CANCEL)
+    }
+
+    @Test
+    fun `trackPaywallImpression does nothing if state is loading`() {
+        delayGettingOfferings()
+        val model = create()
+        model.trackPaywallImpressionIfNeeded()
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loading::class.java)
+        verify(exactly = 0) { purchases.track(any()) }
+    }
+
+    @Test
+    fun `trackPaywallImpression does nothing if offering does not have a paywall`() {
+        val model = create(offering = defaultOffering.copy(paywall = null))
+        model.trackPaywallImpressionIfNeeded()
+        verify(exactly = 0) { purchases.track(any()) }
+    }
+
+    // endregion events
+
     private fun create(
         offering: Offering? = null,
         activeSubscriptions: Set<String> = setOf(),
@@ -434,5 +542,37 @@ class PaywallViewModelTest {
         assertThat(state.templateConfiguration.template.id).isEqualTo(expectedPaywall.templateName)
         assertThat(state.templateConfiguration.mode).isEqualTo(PaywallMode.FULL_SCREEN)
         assertThat(state.templateConfiguration.packages.all).hasSameSizeAs(expectedPaywall.config.packageIds)
+    }
+
+    private fun verifyEventTracked(eventType: PaywallEventType, times: Int) {
+        verify(exactly = times) {
+            purchases.track(
+                withArg {
+                    assertThat(it.data.offeringIdentifier).isEqualTo(defaultOffering.identifier)
+                    assertThat(it.data.paywallRevision).isEqualTo(defaultOffering.paywall!!.revision)
+                    assertThat(it.data.displayMode).isEqualTo("full_screen")
+                    assertThat(it.data.darkMode).isFalse
+                    assertThat(it.type).isEqualTo(eventType)
+                }
+            )
+        }
+    }
+
+    private fun verifyNoEventsOfTypeTracked(eventType: PaywallEventType) {
+        verify(exactly = 0) {
+            purchases.track(
+                withArg {
+                    assertThat(it.type).isEqualTo(eventType)
+                }
+            )
+        }
+    }
+
+    private fun delayGettingOfferings() {
+        coEvery { purchases.awaitOfferings() } coAnswers {
+            // Delay response to verify initial state
+            delay(100)
+            offerings
+        }
     }
 }


### PR DESCRIPTION
### Description
This PR adds tracking of the `paywall_impression`, `paywall_close` and `paywall_cancel` events to the paywalls.