### PR TITLE
Add retries to queryPurchaseHistoryAsync

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCase.kt
@@ -1,0 +1,96 @@
+package com.revenuecat.purchases.google.usecase
+
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.PurchaseHistoryRecord
+import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCallback
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.LogIntent
+import com.revenuecat.purchases.common.between
+import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
+import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.common.toHumanReadableDescription
+import com.revenuecat.purchases.google.buildQueryPurchaseHistoryParams
+import com.revenuecat.purchases.google.toHumanReadableDescription
+import com.revenuecat.purchases.strings.PurchaseStrings
+import com.revenuecat.purchases.strings.RestoreStrings
+import java.util.Date
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration
+
+internal data class QueryPurchaseHistoryUseCaseParams(
+    val dateProvider: DateProvider = DefaultDateProvider(),
+    val diagnosticsTrackerIfEnabled: DiagnosticsTracker?,
+    @BillingClient.ProductType val productType: String,
+)
+
+internal class QueryPurchaseHistoryUseCase(
+    private val useCaseParams: QueryPurchaseHistoryUseCaseParams,
+    val onReceive: (List<PurchaseHistoryRecord>) -> Unit,
+    val onError: PurchasesErrorCallback,
+    val withConnectedClient: (BillingClient.() -> Unit) -> Unit,
+    executeRequestOnUIThread: ((PurchasesError?) -> Unit) -> Unit,
+) : BillingClientUseCase<List<PurchaseHistoryRecord>?>(onError, executeRequestOnUIThread) {
+
+    override val errorMessage: String
+        get() = "Error receiving purchase history"
+
+    override fun executeAsync() {
+        withConnectedClient {
+            val hasResponded = AtomicBoolean(false)
+            val requestStartTime = useCaseParams.dateProvider.now
+
+            useCaseParams.productType.buildQueryPurchaseHistoryParams()?.let { queryPurchaseHistoryParams ->
+                queryPurchaseHistoryAsync(queryPurchaseHistoryParams) { billingResult, purchaseHistory ->
+                    if (hasResponded.getAndSet(true)) {
+                        log(
+                            LogIntent.GOOGLE_ERROR,
+                            RestoreStrings.EXTRA_QUERY_PURCHASE_HISTORY_RESPONSE.format(billingResult.responseCode),
+                        )
+                    } else {
+                        trackGoogleQueryPurchaseHistoryRequestIfNeeded(
+                            useCaseParams.productType,
+                            billingResult,
+                            requestStartTime,
+                        )
+                        processResult(billingResult, purchaseHistory)
+                    }
+                }
+            } ?: run {
+                errorLog(PurchaseStrings.INVALID_PRODUCT_TYPE.format("getPurchaseType"))
+                val devErrorResponseCode = BillingResult.newBuilder()
+                    .setResponseCode(BillingClient.BillingResponseCode.DEVELOPER_ERROR)
+                    .build()
+                processResult(devErrorResponseCode, null)
+            }
+        }
+    }
+
+    override fun onOk(received: List<PurchaseHistoryRecord>?) {
+        received.takeUnless { it.isNullOrEmpty() }?.forEach {
+            log(
+                LogIntent.RC_PURCHASE_SUCCESS,
+                RestoreStrings.PURCHASE_HISTORY_RETRIEVED
+                    .format(it.toHumanReadableDescription()),
+            )
+        } ?: log(LogIntent.DEBUG, RestoreStrings.PURCHASE_HISTORY_EMPTY)
+        onReceive(received ?: emptyList())
+    }
+
+    private fun trackGoogleQueryPurchaseHistoryRequestIfNeeded(
+        @BillingClient.ProductType productType: String,
+        billingResult: BillingResult,
+        requestStartTime: Date,
+    ) {
+        useCaseParams.diagnosticsTrackerIfEnabled?.trackGoogleQueryPurchaseHistoryRequest(
+            productType,
+            billingResult.responseCode,
+            billingResult.debugMessage,
+            responseTime = Duration.between(requestStartTime, useCaseParams.dateProvider.now),
+        )
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryProductDetailsUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryProductDetailsUseCaseTest.kt
@@ -27,6 +27,7 @@ import com.revenuecat.purchases.google.productId
 import com.revenuecat.purchases.google.productList
 import com.revenuecat.purchases.google.productType
 import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.utils.MockHandlerFactory
 import com.revenuecat.purchases.utils.mockProductDetails
 import io.mockk.Runs
 import io.mockk.clearAllMocks
@@ -56,7 +57,6 @@ class QueryProductDetailsUseCaseTest {
     private var mockClient: BillingClient = mockk()
     private var purchasesUpdatedListener: PurchasesUpdatedListener? = null
     private var billingClientStateListener: BillingClientStateListener? = null
-    private var handler: Handler = mockk()
     private var mockDeviceCache: DeviceCache = mockk()
     private var mockDiagnosticsTracker: DiagnosticsTracker = mockk()
     private var mockDateProvider: DateProvider = mockk()
@@ -68,6 +68,7 @@ class QueryProductDetailsUseCaseTest {
     private var capturedConsumeResponseListener = slot<ConsumeResponseListener>()
     private var capturedConsumeParams = slot<ConsumeParams>()
 
+    private lateinit var handler: Handler
     private lateinit var wrapper: BillingWrapper
 
     private lateinit var mockDetailsList: List<ProductDetails>
@@ -79,11 +80,12 @@ class QueryProductDetailsUseCaseTest {
 
     @Before
     fun setup() {
+        handler = MockHandlerFactory.createMockHandler()
+
         storeProducts = null
         purchasesUpdatedListener = null
         billingClientStateListener = null
 
-        mockRunnables()
         mockDiagnosticsTracker()
         every { mockDateProvider.now } returns Date(1676379370000) // Tuesday, February 14, 2023 12:56:10 PM GMT
 
@@ -587,24 +589,6 @@ class QueryProductDetailsUseCaseTest {
                 billingResult,
                 capturedConsumeParams.captured.purchaseToken
             )
-        }
-    }
-
-    private fun mockRunnables() {
-        val slot = slot<Runnable>()
-        every {
-            handler.post(capture(slot))
-        } answers {
-            slot.captured.run()
-            true
-        }
-
-        val delayedSlot = slot<Runnable>()
-        every {
-            handler.postDelayed(capture(delayedSlot), any())
-        } answers {
-            delayedSlot.captured.run()
-            true
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
@@ -12,9 +12,10 @@ import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ConsumeParams
 import com.android.billingclient.api.ConsumeResponseListener
 import com.android.billingclient.api.ProductDetails
-import com.android.billingclient.api.ProductDetailsResponseListener
+import com.android.billingclient.api.PurchaseHistoryRecord
+import com.android.billingclient.api.PurchaseHistoryResponseListener
 import com.android.billingclient.api.PurchasesUpdatedListener
-import com.android.billingclient.api.QueryProductDetailsParams
+import com.android.billingclient.api.QueryPurchaseHistoryParams
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -22,12 +23,13 @@ import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
+import com.revenuecat.purchases.common.firstSku
 import com.revenuecat.purchases.google.BillingWrapper
-import com.revenuecat.purchases.google.productId
-import com.revenuecat.purchases.google.productList
-import com.revenuecat.purchases.google.productType
+import com.revenuecat.purchases.google.toGoogleProductType
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.utils.mockProductDetails
+import com.revenuecat.purchases.utils.mockQueryPurchaseHistory
+import com.revenuecat.purchases.utils.verifyQueryPurchaseHistoryCalledWithType
 import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -37,7 +39,6 @@ import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
-import org.assertj.core.api.AssertionsForClassTypes
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -46,10 +47,16 @@ import org.robolectric.annotation.Config
 import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
-class QueryProductDetailsUseCaseTest {
+class QueryPurchaseHistoryUseCaseTest {
+
+    private companion object {
+        const val timestamp0 = 1676379370000 // Tuesday, February 14, 2023 12:56:10.000 PM GMT
+        const val timestamp123 = 1676379370123 // Tuesday, February 14, 2023 12:56:10.123 PM GMT
+    }
 
     private var onConnectedCalled: Boolean = false
     private var mockClientFactory: BillingWrapper.ClientFactory = mockk()
@@ -76,6 +83,9 @@ class QueryProductDetailsUseCaseTest {
 
     private val billingClientOKResult = BillingClient.BillingResponseCode.OK.buildResult()
     private var mockActivity = mockk<Activity>()
+
+    private val subsGoogleProductType = ProductType.SUBS.toGoogleProductType()!!
+    private val inAppGoogleProductType = ProductType.INAPP.toGoogleProductType()!!
 
     @Before
     fun setup() {
@@ -147,163 +157,102 @@ class QueryProductDetailsUseCaseTest {
     }
 
     @Test
-    fun whenProductDetailsIsEmptyPassAnEmptyListToTheListener() {
-        mockEmptyProductDetailsResponse()
+    fun `if no listener is set, we fail`() {
+        wrapper.purchasesUpdatedListener = null
 
-        val productIDs = setOf("product_a")
-
-        var receivedList: List<StoreProduct>? = null
-        wrapper.queryProductDetailsAsync(
-            ProductType.SUBS,
-            productIDs, {
-                receivedList = it
-            }, {
-                AssertionsForClassTypes.fail("shouldn't be an error")
-            })
-        wrapper.onBillingSetupFinished(billingClientOKResult)
-        assertThat(receivedList).isNotNull
-        assertThat(receivedList!!.size).isZero
-    }
-
-    @Test
-    fun `product type defaults to INAPP when querying product details`() {
-        val slot = slot<QueryProductDetailsParams>()
-        every {
-            mockClient.queryProductDetailsAsync(
-                capture(slot),
-                any()
-            )
-        } just Runs
-
-        val productIDs = setOf("product_a")
-
-        wrapper.queryProductDetailsAsync(
-            ProductType.UNKNOWN,
-            productIDs,
+        var error: PurchasesError? = null
+        wrapper.queryPurchaseHistoryAsync(
+            ProductType.SUBS.toGoogleProductType()!!,
             {
-                this@QueryProductDetailsUseCaseTest.storeProducts = it
-            }, {
-                AssertionsForClassTypes.fail("shouldn't be an error")
-            })
-
-        assertThat(slot.isCaptured).isTrue
-        assertThat(slot.captured.productList[0].productType).isEqualTo(BillingClient.ProductType.INAPP)
-    }
-
-    @Test
-    fun `queryProductDetails filters empty productIds before querying BillingClient`() {
-        val productIdsSet = setOf("abcd", "", "1", "")
-
-        val slot = slot<QueryProductDetailsParams>()
-        every {
-            mockClient.queryProductDetailsAsync(capture(slot), any())
-        } just Runs
-
-        wrapper.queryProductDetailsAsync(
-            ProductType.SUBS,
-            productIdsSet,
-            {}, {
-                AssertionsForClassTypes.fail("shouldn't be an error")
-            })
-
-        assertThat(slot.captured).isNotNull
-        val queryProductDetailsParamsProductList = slot.captured.productList
-        val queriedProductIds = queryProductDetailsParamsProductList.map { it.productId }
-        assertThat(queriedProductIds).isEqualTo(productIdsSet.filter { it.isNotEmpty() })
-    }
-
-    @Test
-    fun `queryProductDetails with empty list returns empty list and does not query BillingClient`() {
-        wrapper.queryProductDetailsAsync(
-            ProductType.SUBS,
-            emptySet(),
+                fail("call should not succeed")
+            },
             {
-                assertThat(it).isEmpty()
-            }, {
-                AssertionsForClassTypes.fail("shouldn't be an error")
-            })
-
-        verify(exactly = 0) {
-            mockClient.queryProductDetailsAsync(any(), any())
-        }
+                error = it
+            }
+        )
+        assertThat(error).isNotNull
+        assertThat(error?.code).isEqualTo(PurchasesErrorCode.UnknownError)
+        assertThat(error?.underlyingErrorMessage).isEqualTo("BillingWrapper is not attached to a listener")
     }
 
     @Test
-    fun `queryProductDetails with only empty productIds returns empty list and does not query BillingClient`() {
-        wrapper.queryProductDetailsAsync(
-            ProductType.SUBS,
-            setOf("", ""),
+    fun `queryPurchaseHistoryAsync fails if sent invalid type`() {
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
+
+        mockClient.mockQueryPurchaseHistory(
+            billingClientOKResult,
+            emptyList()
+        )
+        var errorCalled = false
+        wrapper.queryPurchaseHistoryAsync(
+            "notValid",
             {
-                assertThat(it).isEmpty()
-            }, {
-                AssertionsForClassTypes.fail("shouldn't be an error")
-            })
-
-        verify(exactly = 0) {
-            mockClient.queryProductDetailsAsync(any(), any())
-        }
+                fail("call should not succeed")
+            },
+            {
+                errorCalled = true
+            }
+        )
+        assertThat(errorCalled).isTrue
     }
 
     @Test
-    fun `queryProductDetailsAsync only calls one response when BillingClient responds twice`() {
+    fun `queryPurchaseHistoryAsync only calls one response when BillingClient responds twice`() {
         var numCallbacks = 0
 
-        val slot = slot<ProductDetailsResponseListener>()
+        val slot = slot<PurchaseHistoryResponseListener>()
         every {
-            mockClient.queryProductDetailsAsync(
-                any(),
+            mockClient.queryPurchaseHistoryAsync(
+                any<QueryPurchaseHistoryParams>(),
                 capture(slot)
             )
         } answers {
-            slot.captured.onProductDetailsResponse(billingClientOKResult, emptyList())
-            slot.captured.onProductDetailsResponse(billingClientOKResult, emptyList())
+            slot.captured.onPurchaseHistoryResponse(billingClientOKResult, null)
+            slot.captured.onPurchaseHistoryResponse(billingClientOKResult, null)
         }
 
-        wrapper.queryProductDetailsAsync(
-            ProductType.SUBS,
-            setOf("asdf", "asdf"),
+        wrapper.queryPurchaseHistoryAsync(
+            BillingClient.ProductType.SUBS,
             {
-                Thread.sleep(200)
                 numCallbacks++
             }, {
-                numCallbacks++
+                fail("shouldn't be an error")
             })
 
         assertThat(numCallbacks).isEqualTo(1)
     }
 
     @Test
-    fun `queryProductDetailsAsync only calls one response when BillingClient responds twice in separate threads`() {
+    fun `queryPurchaseHistoryAsync only calls one response when BillingClient responds twice from different threads`() {
         val numCallbacks = AtomicInteger(0)
 
-        val slot = slot<ProductDetailsResponseListener>()
+        val slot = slot<PurchaseHistoryResponseListener>()
         val lock = CountDownLatch(3)
         every {
-            mockClient.queryProductDetailsAsync(
-                any(),
+            mockClient.queryPurchaseHistoryAsync(
+                any<QueryPurchaseHistoryParams>(),
                 capture(slot)
             )
         } answers {
             Thread {
-                slot.captured.onProductDetailsResponse(billingClientOKResult, emptyList())
+                slot.captured.onPurchaseHistoryResponse(billingClientOKResult, null)
                 lock.countDown()
             }.start()
 
             Thread {
-                slot.captured.onProductDetailsResponse(billingClientOKResult, emptyList())
+                slot.captured.onPurchaseHistoryResponse(billingClientOKResult, null)
                 lock.countDown()
             }.start()
         }
 
-        wrapper.queryProductDetailsAsync(
-            ProductType.SUBS,
-            setOf("asdf"),
+        wrapper.queryPurchaseHistoryAsync(
+            BillingClient.ProductType.SUBS,
             {
                 // ensuring we don't hit an edge case where numCallbacks doesn't increment before the final assert
                 numCallbacks.incrementAndGet()
                 lock.countDown()
             }, {
-                AssertionsForClassTypes.fail("shouldn't be an error")
+                fail("shouldn't be an error")
             })
 
         lock.await()
@@ -312,26 +261,165 @@ class QueryProductDetailsUseCaseTest {
         assertThat(numCallbacks.get()).isEqualTo(1)
     }
 
+    @Test
+    fun queryHistoryCallsListenerIfOk() {
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
+
+        mockClient.mockQueryPurchaseHistory(
+            billingClientOKResult,
+            emptyList()
+        )
+
+        var successCalled = false
+        wrapper.queryPurchaseHistoryAsync(
+            subsGoogleProductType,
+            {
+                successCalled = true
+            },
+            {
+                fail("shouldn't go to on error")
+            }
+        )
+        assertThat(successCalled).isTrue
+    }
+
+    @Test
+    fun queryHistoryErrorCalledIfNotOK() {
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
+
+        mockClient.mockQueryPurchaseHistory(
+            BillingClient.BillingResponseCode.FEATURE_NOT_SUPPORTED.buildResult(),
+            emptyList()
+        )
+
+        var errorCalled = false
+        wrapper.queryPurchaseHistoryAsync(
+            subsGoogleProductType,
+            {
+                fail("should go to on error")
+            },
+            {
+                assertThat(it.code).isEqualTo(PurchasesErrorCode.PurchaseNotAllowedError)
+                errorCalled = true
+            }
+        )
+
+        assertThat(errorCalled).isTrue
+    }
+
+    @Test
+    fun `queryPurchaseHistoryAsync sets correct type`() {
+        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
+
+        val subsBuilder = mockClient.mockQueryPurchaseHistory(
+            billingClientOKResult,
+            emptyList()
+        )
+
+        wrapper.queryPurchaseHistoryAsync(
+            subsGoogleProductType,
+            {},
+            {}
+        )
+
+        mockClient.verifyQueryPurchaseHistoryCalledWithType(subsGoogleProductType, subsBuilder)
+
+        val inAppBuilder = mockClient.mockQueryPurchaseHistory(
+            billingClientOKResult,
+            emptyList()
+        )
+
+        wrapper.queryPurchaseHistoryAsync(
+            inAppGoogleProductType,
+            {},
+            {}
+        )
+
+        mockClient.verifyQueryPurchaseHistoryCalledWithType(inAppGoogleProductType, inAppBuilder)
+    }
+
+    // region diagnostics tracking
+
+    @Test
+    fun `queryPurchaseHistoryAsync tracks diagnostics call with correct parameters`() {
+        every { mockDateProvider.now } returnsMany listOf(Date(timestamp0), Date(timestamp123))
+
+        val result = BillingResult.newBuilder()
+            .setResponseCode(BillingClient.BillingResponseCode.OK)
+            .setDebugMessage("test-debug-message")
+            .build()
+        val slot = slot<PurchaseHistoryResponseListener>()
+        every {
+            mockClient.queryPurchaseHistoryAsync(
+                any<QueryPurchaseHistoryParams>(),
+                capture(slot)
+            )
+        } answers {
+            slot.captured.onPurchaseHistoryResponse(result, null)
+        }
+
+        wrapper.queryPurchaseHistoryAsync(BillingClient.ProductType.SUBS, {}, { fail("shouldn't be an error") })
+
+        verify(exactly = 1) {
+            mockDiagnosticsTracker.trackGoogleQueryPurchaseHistoryRequest(
+                BillingClient.ProductType.SUBS,
+                BillingClient.BillingResponseCode.OK,
+                billingDebugMessage = "test-debug-message",
+                responseTime = 123.milliseconds
+            )
+        }
+    }
+
+    @Test
+    fun `queryPurchaseHistoryAsync tracks diagnostics call with correct parameters on error`() {
+        every { mockDateProvider.now } returnsMany listOf(Date(timestamp0), Date(timestamp123))
+
+        val result = BillingResult.newBuilder()
+            .setResponseCode(BillingClient.BillingResponseCode.BILLING_UNAVAILABLE)
+            .setDebugMessage("test-debug-message")
+            .build()
+        val slot = slot<PurchaseHistoryResponseListener>()
+        every {
+            mockClient.queryPurchaseHistoryAsync(
+                any<QueryPurchaseHistoryParams>(),
+                capture(slot)
+            )
+        } answers {
+            slot.captured.onPurchaseHistoryResponse(result, null)
+        }
+
+        wrapper.queryPurchaseHistoryAsync(BillingClient.ProductType.SUBS, { fail("should be an error") }, {})
+
+        verify(exactly = 1) {
+            mockDiagnosticsTracker.trackGoogleQueryPurchaseHistoryRequest(
+                BillingClient.ProductType.SUBS,
+                BillingClient.BillingResponseCode.BILLING_UNAVAILABLE,
+                billingDebugMessage = "test-debug-message",
+                responseTime = 123.milliseconds
+            )
+        }
+    }
+
+    // endregion
+
     // region retries
 
     @Test
     fun `If service is disconnected, re-executeRequestOnUIThread`() {
-        val slot = slot<ProductDetailsResponseListener>()
-        val queryProductDetailsStubbing = every {
-            mockClient.queryProductDetailsAsync(
-                any(),
-                capture(slot)
+        val slot = slot<PurchaseHistoryResponseListener>()
+        val queryPurchaseHistoryStubbing = every {
+            mockClient.queryPurchaseHistoryAsync(
+                any<QueryPurchaseHistoryParams>(),
+                capture(slot),
             )
         }
-        val productIDs = setOf("product_a")
-        var receivedList: List<StoreProduct>? = null
+        var receivedList: List<PurchaseHistoryRecord>? = null
         var timesExecutedInMainThread = 0
-        val useCase = QueryProductDetailsUseCase(
-            QueryProductDetailsUseCaseParams(
+        val useCase = QueryPurchaseHistoryUseCase(
+            QueryPurchaseHistoryUseCaseParams(
                 mockDateProvider,
                 mockDiagnosticsTracker,
-                productIDs,
-                ProductType.SUBS,
+                BillingClient.ProductType.SUBS,
             ),
             { received ->
                 receivedList = received
@@ -345,16 +433,20 @@ class QueryProductDetailsUseCaseTest {
             executeRequestOnUIThread = {
                 timesExecutedInMainThread++
 
-                queryProductDetailsStubbing answers {
+                queryPurchaseHistoryStubbing answers {
                     if (timesExecutedInMainThread == 0) {
-                        slot.captured.onProductDetailsResponse(
+                        slot.captured.onPurchaseHistoryResponse(
                             BillingClient.BillingResponseCode.SERVICE_DISCONNECTED.buildResult(),
                             emptyList()
                         )
                     } else {
-                        slot.captured.onProductDetailsResponse(
+                        val sku = "aPurchase"
+                        val purchaseHistoryRecord = mockk<PurchaseHistoryRecord>(relaxed = true).also {
+                            every { it.firstSku } returns sku + "somethingrandom"
+                        }
+                        slot.captured.onPurchaseHistoryResponse(
                             BillingClient.BillingResponseCode.OK.buildResult(),
-                            mockDetailsList
+                            listOf(purchaseHistoryRecord)
                         )
                     }
                 }
@@ -371,22 +463,20 @@ class QueryProductDetailsUseCaseTest {
 
     @Test
     fun `If service returns NETWORK_ERROR, re-execute a max of 3 times`() {
-        val slot = slot<ProductDetailsResponseListener>()
-        val queryProductDetailsStubbing = every {
-            mockClient.queryProductDetailsAsync(
-                any(),
-                capture(slot)
+        val slot = slot<PurchaseHistoryResponseListener>()
+        val queryPurchaseHistoryStubbing = every {
+            mockClient.queryPurchaseHistoryAsync(
+                any<QueryPurchaseHistoryParams>(),
+                capture(slot),
             )
         }
-        val productIDs = setOf("product_a")
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = QueryProductDetailsUseCase(
-            QueryProductDetailsUseCaseParams(
+        val useCase = QueryPurchaseHistoryUseCase(
+            QueryPurchaseHistoryUseCaseParams(
                 mockDateProvider,
                 mockDiagnosticsTracker,
-                productIDs,
-                ProductType.SUBS,
+                BillingClient.ProductType.SUBS,
             ),
             { _ ->
                 fail("shouldn't be success")
@@ -399,8 +489,8 @@ class QueryProductDetailsUseCaseTest {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = {
-                queryProductDetailsStubbing answers {
-                    slot.captured.onProductDetailsResponse(
+                queryPurchaseHistoryStubbing answers {
+                    slot.captured.onPurchaseHistoryResponse(
                         BillingClient.BillingResponseCode.NETWORK_ERROR.buildResult(),
                         emptyList()
                     )
@@ -419,22 +509,20 @@ class QueryProductDetailsUseCaseTest {
 
     @Test
     fun `If service returns SERVICE_UNAVAILABLE, re-execute a max of 3 times`() {
-        val slot = slot<ProductDetailsResponseListener>()
-        val queryProductDetailsStubbing = every {
-            mockClient.queryProductDetailsAsync(
-                any(),
+        val slot = slot<PurchaseHistoryResponseListener>()
+        val queryPurchaseHistoryStubbing = every {
+            mockClient.queryPurchaseHistoryAsync(
+                any<QueryPurchaseHistoryParams>(),
                 capture(slot)
             )
         }
-        val productIDs = setOf("product_a")
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = QueryProductDetailsUseCase(
-            QueryProductDetailsUseCaseParams(
+        val useCase = QueryPurchaseHistoryUseCase(
+            QueryPurchaseHistoryUseCaseParams(
                 mockDateProvider,
                 mockDiagnosticsTracker,
-                productIDs,
-                ProductType.SUBS,
+                BillingClient.ProductType.SUBS,
             ),
             { _ ->
                 fail("shouldn't be success")
@@ -447,8 +535,8 @@ class QueryProductDetailsUseCaseTest {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = {
-                queryProductDetailsStubbing answers {
-                    slot.captured.onProductDetailsResponse(
+                queryPurchaseHistoryStubbing answers {
+                    slot.captured.onPurchaseHistoryResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
                         emptyList()
                     )
@@ -467,22 +555,20 @@ class QueryProductDetailsUseCaseTest {
 
     @Test
     fun `If service returns ERROR, re-execute a max of 3 times`() {
-        val slot = slot<ProductDetailsResponseListener>()
-        val queryProductDetailsStubbing = every {
-            mockClient.queryProductDetailsAsync(
-                any(),
+        val slot = slot<PurchaseHistoryResponseListener>()
+        val queryPurchaseHistoryStubbing = every {
+            mockClient.queryPurchaseHistoryAsync(
+                any<QueryPurchaseHistoryParams>(),
                 capture(slot)
             )
         }
-        val productIDs = setOf("product_a")
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = QueryProductDetailsUseCase(
-            QueryProductDetailsUseCaseParams(
+        val useCase = QueryPurchaseHistoryUseCase(
+            QueryPurchaseHistoryUseCaseParams(
                 mockDateProvider,
                 mockDiagnosticsTracker,
-                productIDs,
-                ProductType.SUBS,
+                BillingClient.ProductType.SUBS,
             ),
             { _ ->
                 fail("shouldn't be success")
@@ -495,8 +581,8 @@ class QueryProductDetailsUseCaseTest {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = {
-                queryProductDetailsStubbing answers {
-                    slot.captured.onProductDetailsResponse(
+                queryPurchaseHistoryStubbing answers {
+                    slot.captured.onPurchaseHistoryResponse(
                         BillingClient.BillingResponseCode.ERROR.buildResult(),
                         emptyList()
                     )
@@ -515,22 +601,20 @@ class QueryProductDetailsUseCaseTest {
 
     @Test
     fun `If service returns ITEM_UNAVAILABLE, doesn't retry`() {
-        val slot = slot<ProductDetailsResponseListener>()
-        val queryProductDetailsStubbing = every {
-            mockClient.queryProductDetailsAsync(
-                any(),
-                capture(slot)
+        val slot = slot<PurchaseHistoryResponseListener>()
+        val queryPurchaseHistoryStubbing = every {
+            mockClient.queryPurchaseHistoryAsync(
+                any<QueryPurchaseHistoryParams>(),
+                capture(slot),
             )
         }
-        val productIDs = setOf("product_a")
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = QueryProductDetailsUseCase(
-            QueryProductDetailsUseCaseParams(
+        val useCase = QueryPurchaseHistoryUseCase(
+            QueryPurchaseHistoryUseCaseParams(
                 mockDateProvider,
                 mockDiagnosticsTracker,
-                productIDs,
-                ProductType.SUBS,
+                BillingClient.ProductType.SUBS,
             ),
             { _ ->
                 fail("shouldn't be success")
@@ -543,8 +627,8 @@ class QueryProductDetailsUseCaseTest {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = {
-                queryProductDetailsStubbing answers {
-                    slot.captured.onProductDetailsResponse(
+                queryPurchaseHistoryStubbing answers {
+                    slot.captured.onPurchaseHistoryResponse(
                         BillingClient.BillingResponseCode.ITEM_UNAVAILABLE.buildResult(),
                         emptyList()
                     )
@@ -562,18 +646,6 @@ class QueryProductDetailsUseCaseTest {
     }
 
     // endregion
-
-    private fun mockEmptyProductDetailsResponse() {
-        val slot = slot<ProductDetailsResponseListener>()
-        every {
-            mockClient.queryProductDetailsAsync(
-                any(),
-                capture(slot)
-            )
-        } answers {
-            slot.captured.onProductDetailsResponse(billingClientOKResult, emptyList())
-        }
-    }
 
     private fun Int.buildResult(): BillingResult {
         return BillingResult.newBuilder().setResponseCode(this).build()

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
@@ -400,7 +400,7 @@ class QueryPurchaseHistoryUseCaseTest {
         }
     }
 
-    // endregion
+    // endregion diagnostics tracking
 
     // region retries
 
@@ -645,7 +645,7 @@ class QueryPurchaseHistoryUseCaseTest {
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.ProductNotAvailableForPurchaseError)
     }
 
-    // endregion
+    // endregion retries
 
     private fun Int.buildResult(): BillingResult {
         return BillingResult.newBuilder().setResponseCode(this).build()

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
@@ -27,6 +27,7 @@ import com.revenuecat.purchases.common.firstSku
 import com.revenuecat.purchases.google.BillingWrapper
 import com.revenuecat.purchases.google.toGoogleProductType
 import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.utils.MockHandlerFactory
 import com.revenuecat.purchases.utils.mockProductDetails
 import com.revenuecat.purchases.utils.mockQueryPurchaseHistory
 import com.revenuecat.purchases.utils.verifyQueryPurchaseHistoryCalledWithType
@@ -63,7 +64,7 @@ class QueryPurchaseHistoryUseCaseTest {
     private var mockClient: BillingClient = mockk()
     private var purchasesUpdatedListener: PurchasesUpdatedListener? = null
     private var billingClientStateListener: BillingClientStateListener? = null
-    private var handler: Handler = mockk()
+
     private var mockDeviceCache: DeviceCache = mockk()
     private var mockDiagnosticsTracker: DiagnosticsTracker = mockk()
     private var mockDateProvider: DateProvider = mockk()
@@ -75,6 +76,7 @@ class QueryPurchaseHistoryUseCaseTest {
     private var capturedConsumeResponseListener = slot<ConsumeResponseListener>()
     private var capturedConsumeParams = slot<ConsumeParams>()
 
+    private lateinit var handler: Handler
     private lateinit var wrapper: BillingWrapper
 
     private lateinit var mockDetailsList: List<ProductDetails>
@@ -89,11 +91,12 @@ class QueryPurchaseHistoryUseCaseTest {
 
     @Before
     fun setup() {
+        handler = MockHandlerFactory.createMockHandler()
+
         storeProducts = null
         purchasesUpdatedListener = null
         billingClientStateListener = null
 
-        mockRunnables()
         mockDiagnosticsTracker()
         every { mockDateProvider.now } returns Date(1676379370000) // Tuesday, February 14, 2023 12:56:10 PM GMT
 
@@ -659,24 +662,6 @@ class QueryPurchaseHistoryUseCaseTest {
                 billingResult,
                 capturedConsumeParams.captured.purchaseToken
             )
-        }
-    }
-
-    private fun mockRunnables() {
-        val slot = slot<Runnable>()
-        every {
-            handler.post(capture(slot))
-        } answers {
-            slot.captured.run()
-            true
-        }
-
-        val delayedSlot = slot<Runnable>()
-        every {
-            handler.postDelayed(capture(delayedSlot), any())
-        } answers {
-            delayedSlot.captured.run()
-            true
         }
     }
 


### PR DESCRIPTION
Counterpart of https://github.com/RevenueCat/purchases-android/pull/1444 for `queryPurchaseHistoryAsync`