### PR TITLE
Paywall events: Handle errors parsing specific paywall event lines

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventsManagerTest.kt
@@ -266,16 +266,25 @@ class PaywallEventsManagerTest {
         checkFileNumberOfEvents(4)
         eventsManager.flushEvents()
         checkFileNumberOfEvents(0)
-        val expectedRequest = PaywallEventRequest(
-            List(2) { storedEvent.toPaywallBackendEvent() }
-        )
-        verify(exactly = 1) {
-            backend.postPaywallEvents(
-                expectedRequest,
-                any(),
-                any(),
-            )
+        expectNumberOfEventsSynced(2)
+    }
+
+    @Test
+    fun `flushEvents with invalid events, flushes valid events when reaching max count per request`() {
+        mockBackendResponse(success = true)
+        for (i in 0..24) {
+            eventsManager.track(event)
         }
+        appendToFile("invalid event\n")
+        appendToFile("invalid event 2\n")
+        for (i in 0..49) {
+            eventsManager.track(event)
+        }
+        appendToFile("invalid event 3\n")
+        checkFileNumberOfEvents(78)
+        eventsManager.flushEvents()
+        checkFileNumberOfEvents(28)
+        expectNumberOfEventsSynced(48)
     }
 
 
@@ -300,6 +309,19 @@ class PaywallEventsManagerTest {
             } else {
                 errorSlot.captured.invoke(PurchasesError(PurchasesErrorCode.UnknownError), shouldMarkAsSyncedOnError)
             }
+        }
+    }
+
+    private fun expectNumberOfEventsSynced(eventsSynced: Int) {
+        val expectedRequest = PaywallEventRequest(
+            List(eventsSynced) { storedEvent.toPaywallBackendEvent() }
+        )
+        verify(exactly = 1) {
+            backend.postPaywallEvents(
+                expectedRequest,
+                any(),
+                any(),
+            )
         }
     }
 


### PR DESCRIPTION
### Description
Makes sure we handle errors in each event line correctly and that we clear errors from the file correctly.
