### PR TITLE
Paywall events: Send paywall data with post receipt requests

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -34,6 +34,7 @@ import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.identity.IdentityManager
+import com.revenuecat.purchases.paywalls.PaywallPresentedCache
 import com.revenuecat.purchases.paywalls.events.PaywallEventsManager
 import com.revenuecat.purchases.paywalls.events.PaywallStoredEvent
 import com.revenuecat.purchases.strings.ConfigureStrings
@@ -171,6 +172,8 @@ internal class PurchasesFactory(
                 appConfig = appConfig,
             )
 
+            val paywallPresentedCache = PaywallPresentedCache()
+
             val postReceiptHelper = PostReceiptHelper(
                 appConfig,
                 backend,
@@ -179,6 +182,7 @@ internal class PurchasesFactory(
                 cache,
                 subscriberAttributesManager,
                 offlineEntitlementsManager,
+                paywallPresentedCache,
             )
 
             val postTransactionWithProductDetailsHelper = PostTransactionWithProductDetailsHelper(
@@ -257,6 +261,7 @@ internal class PurchasesFactory(
                 syncPurchasesHelper,
                 offeringsManager,
                 createPaywallEventsManager(application, identityManager, eventsDispatcher, backend),
+                paywallPresentedCache,
             )
 
             return Purchases(purchasesOrchestrator)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -49,6 +49,7 @@ import com.revenuecat.purchases.models.InAppMessageType
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.paywalls.PaywallPresentedCache
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventsManager
 import com.revenuecat.purchases.strings.AttributionStrings
@@ -84,6 +85,7 @@ internal class PurchasesOrchestrator constructor(
     private val syncPurchasesHelper: SyncPurchasesHelper,
     private val offeringsManager: OfferingsManager,
     private val paywallEventsManager: PaywallEventsManager?,
+    private val paywallPresentedCache: PaywallPresentedCache,
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper()),
 ) : LifecycleDelegate, CustomActivityLifecycleHandler {
@@ -490,6 +492,7 @@ internal class PurchasesOrchestrator constructor(
 
     @ExperimentalPreviewRevenueCatPurchasesAPI
     fun track(paywallEvent: PaywallEvent) {
+        paywallPresentedCache.receiveEvent(paywallEvent)
         if (isAndroidNOrNewer()) {
             paywallEventsManager?.track(paywallEvent)
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.models.GoogleReplacementMode
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.paywalls.events.PaywallEventRequest
+import com.revenuecat.purchases.paywalls.events.PaywallPostReceiptData
 import com.revenuecat.purchases.strings.NetworkStrings
 import com.revenuecat.purchases.utils.asMap
 import com.revenuecat.purchases.utils.filterNotNullValues
@@ -190,6 +191,7 @@ internal class Backend(
         @SuppressWarnings("UnusedPrivateMember")
         marketplace: String? = null,
         initiationSource: PostReceiptInitiationSource,
+        paywallPostReceiptData: PaywallPostReceiptData?,
         onSuccess: PostReceiptDataSuccessCallback,
         onError: PostReceiptDataErrorCallback,
     ) {
@@ -219,6 +221,7 @@ internal class Backend(
             "pricing_phases" to receiptInfo.pricingPhases?.map { it.toMap() },
             "proration_mode" to (receiptInfo.replacementMode as? GoogleReplacementMode)?.asGoogleProrationMode?.name,
             "initiation_source" to initiationSource.postReceiptFieldValue,
+            "paywall" to paywallPostReceiptData?.toMap(),
         ).filterNotNullValues()
 
         val postFieldsToSign = listOf(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallPresentedCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallPresentedCache.kt
@@ -1,0 +1,36 @@
+package com.revenuecat.purchases.paywalls
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.common.verboseLog
+import com.revenuecat.purchases.paywalls.events.PaywallEvent
+import com.revenuecat.purchases.paywalls.events.PaywallEventType
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+internal class PaywallPresentedCache {
+    private var lastPaywallImpressionEvent: PaywallEvent? = null
+
+    fun getAndRemovePresentedEvent(): PaywallEvent? {
+        val event = lastPaywallImpressionEvent
+        lastPaywallImpressionEvent = null
+        return event
+    }
+
+    fun cachePresentedPaywall(paywallEvent: PaywallEvent) {
+        lastPaywallImpressionEvent = paywallEvent
+    }
+
+    fun receiveEvent(event: PaywallEvent) {
+        when (event.type) {
+            PaywallEventType.IMPRESSION -> {
+                verboseLog("Caching paywall impression event.")
+                lastPaywallImpressionEvent = event
+            }
+            PaywallEventType.CLOSE -> {
+                verboseLog("Clearing cached paywall impression event.")
+                lastPaywallImpressionEvent = null
+            }
+            else -> {
+            }
+        }
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallPresentedCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallPresentedCache.kt
@@ -7,6 +7,8 @@ import com.revenuecat.purchases.paywalls.events.PaywallEventType
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal class PaywallPresentedCache {
+    @get:Synchronized
+    @set:Synchronized
     private var lastPaywallImpressionEvent: PaywallEvent? = null
 
     fun getAndRemovePresentedEvent(): PaywallEvent? {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallPresentedCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallPresentedCache.kt
@@ -11,16 +11,19 @@ internal class PaywallPresentedCache {
     @set:Synchronized
     private var lastPaywallImpressionEvent: PaywallEvent? = null
 
+    @Synchronized
     fun getAndRemovePresentedEvent(): PaywallEvent? {
         val event = lastPaywallImpressionEvent
         lastPaywallImpressionEvent = null
         return event
     }
 
+    @Synchronized
     fun cachePresentedPaywall(paywallEvent: PaywallEvent) {
         lastPaywallImpressionEvent = paywallEvent
     }
 
+    @Synchronized
     fun receiveEvent(event: PaywallEvent) {
         when (event.type) {
             PaywallEventType.IMPRESSION -> {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEvent.kt
@@ -57,4 +57,14 @@ data class PaywallEvent(
         val localeIdentifier: String,
         val darkMode: Boolean,
     )
+
+    internal fun toPaywallPostReceiptData(): PaywallPostReceiptData {
+        return PaywallPostReceiptData(
+            sessionID = data.sessionIdentifier.toString(),
+            paywallRevision = data.paywallRevision,
+            displayMode = data.displayMode,
+            darkMode = data.darkMode,
+            localeIdentifier = data.localeIdentifier,
+        )
+    }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallPostReceiptData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallPostReceiptData.kt
@@ -1,0 +1,31 @@
+package com.revenuecat.purchases.paywalls.events
+
+import com.revenuecat.purchases.utils.asMap
+import com.revenuecat.purchases.utils.filterNotNullValues
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+
+@Serializable
+internal data class PaywallPostReceiptData(
+    @SerialName("session_id")
+    val sessionID: String,
+    @SerialName("paywall_revision")
+    val paywallRevision: Int,
+    @SerialName("display_mode")
+    val displayMode: String,
+    @SerialName("dark_mode")
+    val darkMode: Boolean,
+    @SerialName("locale")
+    val localeIdentifier: String,
+) {
+    companion object {
+        val json = Json.Default
+    }
+
+    fun toMap(): Map<String, Any>? {
+        val map = json.encodeToJsonElement(this).asMap() ?: return null
+        return map.filterNotNullValues()
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -28,6 +28,7 @@ import com.revenuecat.purchases.models.GoogleReplacementMode
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.models.SubscriptionOption
+import com.revenuecat.purchases.paywalls.PaywallPresentedCache
 import com.revenuecat.purchases.paywalls.events.PaywallEventsManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.utils.STUB_PRODUCT_IDENTIFIER
@@ -76,6 +77,8 @@ internal open class BasePurchasesTest {
     private val capturedConsumePurchaseWrapper = slot<StoreTransaction>()
     private val capturedShouldTryToConsume = slot<Boolean>()
 
+    protected lateinit var paywallPresentedCache: PaywallPresentedCache
+
     protected val randomAppUserId = "\$RCAnonymousID:ff68f26e432648369a713849a9f93b58"
     protected val appUserId = "fakeUserID"
     protected lateinit var purchases: Purchases
@@ -96,6 +99,7 @@ internal open class BasePurchasesTest {
         mockCustomerInfoHelper()
         mockCustomerInfoUpdateHandler()
         mockPostPendingTransactionsHelper()
+        paywallPresentedCache = PaywallPresentedCache()
 
         every {
             updatedCustomerInfoListener.onReceived(any())
@@ -377,6 +381,7 @@ internal open class BasePurchasesTest {
             syncPurchasesHelper = mockSyncPurchasesHelper,
             offeringsManager = mockOfferingsManager,
             paywallEventsManager = mockPaywallEventsManager,
+            paywallPresentedCache = paywallPresentedCache,
         )
         purchases = Purchases(purchasesOrchestrator)
         Purchases.sharedInstance = purchases

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
@@ -2368,6 +2368,7 @@ class BackendTest {
             storeAppUserID = storeAppUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
+            paywallPostReceiptData = null,
             onSuccess = onSuccess,
             onError = onError
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -310,6 +310,7 @@ class SubscriberAttributesPosterTests {
             receiptInfo = productInfo,
             storeAppUserID = null,
             initiationSource = initiationSource,
+            paywallPostReceiptData = null,
             onSuccess = expectedOnSuccessPostReceipt,
             onError = unexpectedOnErrorPostReceipt
         )
@@ -337,6 +338,7 @@ class SubscriberAttributesPosterTests {
             receiptInfo = productInfo,
             storeAppUserID = null,
             initiationSource = initiationSource,
+            paywallPostReceiptData = null,
             onSuccess = expectedOnSuccessPostReceipt,
             onError = unexpectedOnErrorPostReceipt
         )
@@ -363,6 +365,7 @@ class SubscriberAttributesPosterTests {
             receiptInfo = productInfo,
             storeAppUserID = null,
             initiationSource = initiationSource,
+            paywallPostReceiptData = null,
             onSuccess = expectedOnSuccessPostReceipt,
             onError = unexpectedOnErrorPostReceipt
         )
@@ -392,6 +395,7 @@ class SubscriberAttributesPosterTests {
             receiptInfo = productInfo,
             storeAppUserID = null,
             initiationSource = initiationSource,
+            paywallPostReceiptData = null,
             onSuccess = expectedOnSuccessPostReceipt,
             onError = unexpectedOnErrorPostReceipt
         )
@@ -420,6 +424,7 @@ class SubscriberAttributesPosterTests {
             receiptInfo = productInfo,
             storeAppUserID = null,
             initiationSource = initiationSource,
+            paywallPostReceiptData = null,
             onSuccess = unexpectedOnSuccessPostReceipt,
             onError = expectedOnErrorPostReceipt
         )
@@ -448,6 +453,7 @@ class SubscriberAttributesPosterTests {
             receiptInfo = productInfo,
             storeAppUserID = null,
             initiationSource = initiationSource,
+            paywallPostReceiptData = null,
             onSuccess = unexpectedOnSuccessPostReceipt,
             onError = expectedOnErrorPostReceipt
         )

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
 import com.revenuecat.purchases.identity.IdentityManager
+import com.revenuecat.purchases.paywalls.PaywallPresentedCache
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.utils.SyncDispatcher
 import io.mockk.Runs
@@ -97,6 +98,7 @@ class SubscriberAttributesPurchasesTests {
             syncPurchasesHelper = mockk(),
             offeringsManager = offeringsManagerMock,
             paywallEventsManager = null,
+            paywallPresentedCache = PaywallPresentedCache()
         )
 
         underTest = Purchases(purchasesOrchestrator)


### PR DESCRIPTION
### Description
This sends the paywall data during the post receipt requests to make sure we attribute purchases to paywalls. We do this by caching the paywall events as needed.