### PR TITLE
Lower request jitter log level from warning to debug

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -527,7 +527,7 @@ internal class Backend(
         val foregroundCacheKey = cacheKey.copy(appInBackground = false)
         val foregroundCallAlreadyInPlace = containsKey(foregroundCacheKey)
         val cacheKeyToUse = if (cacheKey.appInBackground && foregroundCallAlreadyInPlace) {
-            warnLog(NetworkStrings.SAME_CALL_SCHEDULED_WITHOUT_JITTER.format(foregroundCacheKey))
+            debugLog(NetworkStrings.SAME_CALL_SCHEDULED_WITHOUT_JITTER.format(foregroundCacheKey))
             foregroundCacheKey
         } else {
             cacheKey
@@ -538,7 +538,7 @@ internal class Backend(
         val backgroundedCacheKey = cacheKey.copy(appInBackground = true)
         val backgroundCallAlreadyInPlace = containsKey(foregroundCacheKey)
         if (!cacheKey.appInBackground && backgroundCallAlreadyInPlace) {
-            warnLog(NetworkStrings.SAME_CALL_SCHEDULED_WITH_JITTER.format(foregroundCacheKey))
+            debugLog(NetworkStrings.SAME_CALL_SCHEDULED_WITH_JITTER.format(foregroundCacheKey))
             remove(backgroundedCacheKey)?.takeIf { it.isNotEmpty() }?.let { backgroundedCallbacks ->
                 if (containsKey(cacheKey)) {
                     this[cacheKey]?.addAll(backgroundedCallbacks)


### PR DESCRIPTION
### Description
These logs were added in https://github.com/RevenueCat/purchases-android/pull/1204. These logs might happen primarily if the developer calls getCustomerInfo/getOfferings before any activity has started. In those situations, we have to handle it so the request does not wait for the whole jitter.

There is nothing much the developer can do about this and it's not actually an error, so lowering the log level from warning to debug for these.

Fixes https://github.com/RevenueCat/react-native-purchases/issues/757