### PR TITLE
`Paywalls`: improve error log when images fail to load

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
@@ -105,7 +105,7 @@ private fun Image(
                         is ImageSource.Remote -> "Error loading image from '${source.urlString}'"
                     }
 
-                    Logger.e("$error: ${it.result}")
+                    Logger.e(error, it.result.throwable)
                 }
                 else -> {}
             }


### PR DESCRIPTION
Without this, the error we were logging didn't have any information:
> RevenueCatUI E Error loading image from 'https://assets.pawwalls.com/....jpg[':](https://assets.pawwalls.com/....jpg':) coil.request.ErrorResult@2678e133