### PR TITLE
Update circleci orb to latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ version: 2.1
 orbs:
   android: circleci/android@2.2.0
   gcp-cli: circleci/gcp-cli@2.1.0
-  revenuecat: revenuecat/sdks-common-config@2.0.0
+  revenuecat: revenuecat/sdks-common-config@2.2.0
   codecov: codecov/codecov@3.2.4
 
 parameters:


### PR DESCRIPTION
### Description
We were using an old version of the revenuecat circleci orb. [One of the fixes](https://github.com/RevenueCat/sdks-circleci-orb/pull/7) was to set git config globally, which would fix the issues recording snapshots in: https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/8733/workflows/98ffd3bc-7365-4364-b64a-ebfe948f330f/jobs/31537
