### PR TITLE
`Paywalls`: fix template 5 header aspect ratio

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
@@ -182,10 +182,10 @@ private fun HeaderImage(uri: Uri?, templateSize: IntSize) {
         RemoteImage(
             urlString = uri.toString(),
             modifier = Modifier
-                .conditional(aspectRatio > 1f || templateSize == IntSize.Zero) {
+                .conditional(aspectRatio < 1f || templateSize == IntSize.Zero) {
                     aspectRatio(ratio = Template5UIConstants.headerAspectRatio)
                 }
-                .conditional(aspectRatio <= 1f) {
+                .conditional(aspectRatio > 1f) {
                     fillMaxHeight(Template5UIConstants.percentageScreenImageInLandscape).fillMaxWidth()
                 },
             contentScale = ContentScale.Crop,


### PR DESCRIPTION
### Before:

![image](https://github.com/RevenueCat/purchases-android/assets/685609/7d07357e-9be6-4970-ae8d-55628680b841)

### After

![Screenshot 2023-11-13 at 18 10 09](https://github.com/RevenueCat/purchases-android/assets/685609/03bfc5f0-7880-41e5-8587-e321c1ffd02a)
