### PR TITLE
Paywalls: Fix template 1 header aspect ratio

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -147,10 +147,10 @@ private fun HeaderImage(uri: Uri?, templateSize: IntSize) {
             RemoteImage(
                 urlString = uri.toString(),
                 modifier = Modifier
-                    .conditional(aspectRatio > 1f || templateSize == IntSize.Zero) {
+                    .conditional(aspectRatio <= 1f || templateSize == IntSize.Zero) {
                         aspectRatio(ratio = 1.2f)
                     }
-                    .conditional(aspectRatio <= 1f) {
+                    .conditional(aspectRatio > 1f) {
                         fillMaxWidth().height(screenHeight.dp / 2f)
                     },
                 contentScale = ContentScale.Crop,


### PR DESCRIPTION
### Description
Similar to #1465 but in template 1. This was caused by a bad refactor when extracting the `aspectRatio` calculation to an extension.