### PR TITLE
Prevents queryPurchases from being called twice

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -925,7 +925,7 @@ internal class BillingWrapper(
             if (hasResponded.getAndSet(true)) {
                 log(
                     LogIntent.GOOGLE_ERROR,
-                    OfferingStrings.EXTRA_QUERY_PRODUCT_DETAILS_RESPONSE.format(billingResult.responseCode),
+                    OfferingStrings.EXTRA_QUERY_PURCHASES_RESPONSE.format(billingResult.responseCode),
                 )
                 return@queryPurchasesAsync
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -875,14 +875,12 @@ internal class BillingWrapper(
         val hasResponded = AtomicBoolean(false)
         val requestStartTime = dateProvider.now
         queryProductDetailsAsync(params) { billingResult, productDetailsList ->
-            synchronized(this@BillingWrapper) {
-                if (hasResponded.getAndSet(true)) {
-                    log(
-                        LogIntent.GOOGLE_ERROR,
-                        OfferingStrings.EXTRA_QUERY_PRODUCT_DETAILS_RESPONSE.format(billingResult.responseCode),
-                    )
-                    return@queryProductDetailsAsync
-                }
+            if (hasResponded.getAndSet(true)) {
+                log(
+                    LogIntent.GOOGLE_ERROR,
+                    OfferingStrings.EXTRA_QUERY_PRODUCT_DETAILS_RESPONSE.format(billingResult.responseCode),
+                )
+                return@queryProductDetailsAsync
             }
             trackGoogleQueryProductDetailsRequestIfNeeded(productType, billingResult, requestStartTime)
             listener.onProductDetailsResponse(billingResult, productDetailsList)
@@ -898,14 +896,12 @@ internal class BillingWrapper(
 
         productType.buildQueryPurchaseHistoryParams()?.let { queryPurchaseHistoryParams ->
             queryPurchaseHistoryAsync(queryPurchaseHistoryParams) { billingResult, purchaseHistory ->
-                synchronized(this@BillingWrapper) {
-                    if (hasResponded.getAndSet(true)) {
-                        log(
-                            LogIntent.GOOGLE_ERROR,
-                            RestoreStrings.EXTRA_QUERY_PURCHASE_HISTORY_RESPONSE.format(billingResult.responseCode),
-                        )
-                        return@queryPurchaseHistoryAsync
-                    }
+                if (hasResponded.getAndSet(true)) {
+                    log(
+                        LogIntent.GOOGLE_ERROR,
+                        RestoreStrings.EXTRA_QUERY_PURCHASE_HISTORY_RESPONSE.format(billingResult.responseCode),
+                    )
+                    return@queryPurchaseHistoryAsync
                 }
                 trackGoogleQueryPurchaseHistoryRequestIfNeeded(productType, billingResult, requestStartTime)
                 listener.onPurchaseHistoryResponse(billingResult, purchaseHistory)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -12,6 +12,8 @@ internal object OfferingStrings {
     const val LIST_PRODUCTS = "%s - %s"
     const val EXTRA_QUERY_PRODUCT_DETAILS_RESPONSE = "BillingClient queryProductDetails has returned more than once, " +
         "with result: %s. More info here: https://rev.cat/google-duplicated-listener-timeouts"
+    const val EXTRA_QUERY_PURCHASES_RESPONSE = "BillingClient queryPurchases has returned more than once, " +
+        "with result: %s."
     const val NO_CACHED_OFFERINGS_FETCHING_NETWORK = "No cached Offerings, fetching from network"
     const val OFFERINGS_STALE_UPDATING_IN_BACKGROUND = "Offerings cache is stale, updating from network in background"
     const val OFFERINGS_STALE_UPDATING_IN_FOREGROUND = "Offerings cache is stale, updating from network in foreground"

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -85,6 +85,7 @@ import java.lang.Thread.sleep
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 
 @RunWith(AndroidJUnit4::class)
@@ -2739,7 +2740,7 @@ class BillingWrapperTest {
 
     @Test
     fun `queryPurchasesAsync only calls one response when BillingClient responds twice from different threads`() {
-        var numCallbacks = 0
+        val numCallbacks = AtomicInteger(0)
 
         val slot = slot<PurchasesResponseListener>()
         val lock = CountDownLatch(3)
@@ -2764,7 +2765,7 @@ class BillingWrapperTest {
             appUserID = "appUserID",
             onSuccess = {
                 // ensuring we don't hit an edge case where numCallbacks doesn't increment before the final assert
-                numCallbacks++
+                numCallbacks.incrementAndGet()
                 lock.countDown()
             },
             onError = {
@@ -2775,7 +2776,7 @@ class BillingWrapperTest {
         lock.await()
         assertThat(lock.count).isEqualTo(0)
 
-        assertThat(numCallbacks).isEqualTo(1)
+        assertThat(numCallbacks.get()).isEqualTo(1)
     }
 
     private fun mockEmptyProductDetailsResponse() {

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -370,7 +370,7 @@ class BillingWrapperTest {
 
     @Test
     fun `queryPurchaseHistoryAsync only calls one response when BillingClient responds twice from different threads`() {
-        var numCallbacks = 0
+        val numCallbacks = AtomicInteger(0)
 
         val slot = slot<PurchaseHistoryResponseListener>()
         val lock = CountDownLatch(3)
@@ -395,7 +395,7 @@ class BillingWrapperTest {
             BillingClient.ProductType.SUBS,
             {
                 // ensuring we don't hit an edge case where numCallbacks doesn't increment before the final assert
-                numCallbacks++
+                numCallbacks.incrementAndGet()
                 lock.countDown()
             }, {
                 fail("shouldn't be an error")
@@ -404,7 +404,7 @@ class BillingWrapperTest {
         lock.await()
         assertThat(lock.count).isEqualTo(0)
 
-        assertThat(numCallbacks).isEqualTo(1)
+        assertThat(numCallbacks.get()).isEqualTo(1)
     }
 
     @Test
@@ -2219,7 +2219,7 @@ class BillingWrapperTest {
 
     @Test
     fun `queryProductDetailsAsync only calls one response when BillingClient responds twice in separate threads`() {
-        var numCallbacks = 0
+        val numCallbacks = AtomicInteger(0)
 
         val slot = slot<ProductDetailsResponseListener>()
         val lock = CountDownLatch(3)
@@ -2245,7 +2245,7 @@ class BillingWrapperTest {
             setOf("asdf"),
             {
                 // ensuring we don't hit an edge case where numCallbacks doesn't increment before the final assert
-                numCallbacks++
+                numCallbacks.incrementAndGet()
                 lock.countDown()
             }, {
                 fail("shouldn't be an error")
@@ -2254,7 +2254,7 @@ class BillingWrapperTest {
         lock.await()
         assertThat(lock.count).isEqualTo(0)
 
-        assertThat(numCallbacks).isEqualTo(1)
+        assertThat(numCallbacks.get()).isEqualTo(1)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -372,7 +372,7 @@ class BillingWrapperTest {
         var numCallbacks = 0
 
         val slot = slot<PurchaseHistoryResponseListener>()
-        val lock = CountDownLatch(2)
+        val lock = CountDownLatch(3)
         every {
             mockClient.queryPurchaseHistoryAsync(
                 any<QueryPurchaseHistoryParams>(),
@@ -394,9 +394,8 @@ class BillingWrapperTest {
             BillingClient.ProductType.SUBS,
             {
                 // ensuring we don't hit an edge case where numCallbacks doesn't increment before the final assert
-                handler.post {
-                    numCallbacks++
-                }
+                numCallbacks++
+                lock.countDown()
             }, {
                 fail("shouldn't be an error")
             })
@@ -2222,7 +2221,7 @@ class BillingWrapperTest {
         var numCallbacks = 0
 
         val slot = slot<ProductDetailsResponseListener>()
-        val lock = CountDownLatch(2)
+        val lock = CountDownLatch(3)
         every {
             mockClient.queryProductDetailsAsync(
                 any(),
@@ -2245,9 +2244,8 @@ class BillingWrapperTest {
             setOf("asdf"),
             {
                 // ensuring we don't hit an edge case where numCallbacks doesn't increment before the final assert
-                handler.post {
-                    numCallbacks++
-                }
+                numCallbacks++
+                lock.countDown()
             }, {
                 fail("shouldn't be an error")
             })
@@ -2744,7 +2742,7 @@ class BillingWrapperTest {
         var numCallbacks = 0
 
         val slot = slot<PurchasesResponseListener>()
-        val lock = CountDownLatch(2)
+        val lock = CountDownLatch(3)
         every {
             mockClient.queryPurchasesAsync(
                 any<QueryPurchasesParams>(),
@@ -2766,9 +2764,8 @@ class BillingWrapperTest {
             appUserID = "appUserID",
             onSuccess = {
                 // ensuring we don't hit an edge case where numCallbacks doesn't increment before the final assert
-                handler.post {
-                    numCallbacks++
-                }
+                numCallbacks++
+                lock.countDown()
             },
             onError = {
                 fail("shouldn't be an error")


### PR DESCRIPTION
We are getting this exception:

```
Exception java.lang.IllegalStateException:
  at kotlin.coroutines.SafeContinuation.resumeWith (SafeContinuationJvm.kt:44)
  at <private>
  at com.revenuecat.purchases.CustomerInfoHelper$getCustomerInfoFetchOnly$1$1.invoke (CustomerInfoHelper.kt:107)
  at com.revenuecat.purchases.CustomerInfoHelper$getCustomerInfoFetchOnly$1$1.invoke (CustomerInfoHelper.kt:107)
  at com.revenuecat.purchases.CustomerInfoHelper.dispatch$lambda$0 (CustomerInfoHelper.kt:197)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:240)
  at android.os.Looper.loop (Looper.java:351)
  at android.app.ActivityThread.main (ActivityThread.java:8381)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:584)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1013)
  ```
  
  I haven't been able to reproduce it but it looks like `getCustomerInfoFetchOnly` is calling the same continuation twice. If `queryPurchases` callback gets called twice, it would cause the same exception. We have other functions that are called twice, so I have added a check to prevent `queryPurchases` callback from being called twice.