### PR TITLE
Fix flaky test in BillingWrapperTest

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -2776,7 +2776,7 @@ class BillingWrapperTest {
             }
         )
 
-        lock.await(2, TimeUnit.SECONDS)
+        lock.await(300, TimeUnit.MILLISECONDS)
         assertThat(lock.count).isEqualTo(0)
 
         assertThat(numCallbacks.get()).isEqualTo(1)

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -85,6 +85,7 @@ import java.lang.Thread.sleep
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -2743,7 +2744,9 @@ class BillingWrapperTest {
         val numCallbacks = AtomicInteger(0)
 
         val slot = slot<PurchasesResponseListener>()
-        val lock = CountDownLatch(3)
+        // queryPurchasesAsync is called twice, so 4 would come from calls to onQueryPurchasesResponse
+        // and 1 for the onSuccess
+        val lock = CountDownLatch(5)
         every {
             mockClient.queryPurchasesAsync(
                 any<QueryPurchasesParams>(),
@@ -2773,7 +2776,7 @@ class BillingWrapperTest {
             }
         )
 
-        lock.await()
+        lock.await(2, TimeUnit.SECONDS)
         assertThat(lock.count).isEqualTo(0)
 
         assertThat(numCallbacks.get()).isEqualTo(1)


### PR DESCRIPTION
`queryPurchasesAsync` is called twice in the function, so 4 would come from calls to `onQueryPurchasesResponse` and 1 for the `onSuccess`	