### PR TITLE
`Paywalls`: Fix Turkish translation

### DIFF
--- a/ui/revenuecatui/src/main/res/values-tr/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-tr/strings.xml
@@ -2,11 +2,11 @@
 <resources>
     <string name="OK">TAMAM</string>
     <string name="all_plans">Tüm abonelikler</string>
-    <string name="privacy">Mahremiyet</string>
+    <string name="privacy">Gizlilik</string>
     <string name="privacy_policy">Gizlilik Politikası</string>
-    <string name="restore">Eski haline getirmek</string>
-    <string name="restore_purchases">Satın alınanları geri yükle</string>
-    <string name="terms">şartlar</string>
+    <string name="restore">Geri yükle</string>
+    <string name="restore_purchases">Satın almaları geri yükle</string>
+    <string name="terms">Şartlar</string>
     <string name="terms_and_conditions">Şartlar ve koşullar</string>
     <string name="annual">Yıllık</string>
     <string name="semester">6 ay</string>
@@ -14,8 +14,8 @@
     <string name="bimonthly">2 ay</string>
     <string name="monthly">Aylık</string>
     <string name="weekly">Haftalık</string>
-    <string name="lifetime">Ömür</string>
+    <string name="lifetime">Ömür boyu</string>
     <string name="package_discount">%1$d%% indirim</string>
-    <string name="continue_cta">Devam etmek</string>
+    <string name="continue_cta">Devam et</string>
     <string name="default_offer_details_with_intro_offer">{{ sub_offer_duration }} denemenizi başlatın, ardından {{ total_price_and_per_month }}.</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Turkish translation was wrong, I fixed `purchases-ios`' translation before. Fixing `purchases-android` now to have the same translation. (https://github.com/RevenueCat/purchases-ios/blob/main/RevenueCatUI/Resources/tr.lproj/Localizable.strings)

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
I updated `privacy`, `restore`, `restore_purchases`, `terms`, `lifetime` and `continue_cta`'s translations.
