### PR TITLE
Add method to get storefront for Google and Amazon stores

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.common.ReceiptInfo
 import com.revenuecat.purchases.common.ReplaceProductInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.currentLogHandler
+import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.debugLogsEnabled
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.errorLog
@@ -53,6 +54,7 @@ import com.revenuecat.purchases.paywalls.PaywallPresentedCache
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventsManager
 import com.revenuecat.purchases.strings.AttributionStrings
+import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.strings.ConfigureStrings
 import com.revenuecat.purchases.strings.CustomerInfoStrings
 import com.revenuecat.purchases.strings.IdentityStrings
@@ -143,6 +145,14 @@ internal class PurchasesOrchestrator constructor(
         billing.stateListener = object : BillingAbstract.StateListener {
             override fun onConnected() {
                 postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount)
+                billing.getStoreCountryCode(
+                    onSuccess = { countryCode ->
+                        debugLog(BillingStrings.BILLING_COUNTRY_CODE.format(countryCode))
+                    },
+                    onError = { error ->
+                        errorLog(error)
+                    },
+                )
             }
         }
         billing.purchasesUpdatedListener = getPurchasesUpdatedListener()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -145,7 +145,7 @@ internal class PurchasesOrchestrator constructor(
         billing.stateListener = object : BillingAbstract.StateListener {
             override fun onConnected() {
                 postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount)
-                billing.getStoreCountryCode(
+                billing.getStorefront(
                     onSuccess = { countryCode ->
                         debugLog(BillingStrings.BILLING_COUNTRY_CODE.format(countryCode))
                     },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -299,7 +299,7 @@ internal class AmazonBilling constructor(
         // No-op: Amazon doesn't have in-app messages
     }
 
-    override fun getStoreCountryCode(
+    override fun getStorefront(
         onSuccess: (String) -> Unit,
         onError: PurchasesErrorCallback,
     ) {
@@ -319,7 +319,7 @@ internal class AmazonBilling constructor(
                         onSuccess(marketplace)
                     },
                     onError = { error ->
-                        errorLog(BillingStrings.BILLING_AMAZON_ERROR_STORE_COUNTRY.format(error))
+                        errorLog(BillingStrings.BILLING_AMAZON_ERROR_STOREFRONT.format(error))
                         onError(error)
                     },
                 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -39,6 +39,7 @@ import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.strings.PurchaseStrings
 import com.revenuecat.purchases.strings.RestoreStrings
 import org.json.JSONException
@@ -296,6 +297,37 @@ internal class AmazonBilling constructor(
         subscriptionStatusChange: () -> Unit,
     ) {
         // No-op: Amazon doesn't have in-app messages
+    }
+
+    override fun getStoreCountryCode(
+        onSuccess: (String) -> Unit,
+        onError: PurchasesErrorCallback,
+    ) {
+        executeRequestOnUIThread { connectionError ->
+            if (connectionError == null) {
+                userDataHandler.getUserData(
+                    onSuccess = { userData ->
+                        val marketplace = userData.marketplace ?: run {
+                            onError(
+                                PurchasesError(
+                                    PurchasesErrorCode.StoreProblemError,
+                                    AmazonStrings.ERROR_USER_DATA_MARKETPLACE_NULL_STORE_PROBLEM,
+                                ),
+                            )
+                            return@getUserData
+                        }
+                        onSuccess(marketplace)
+                    },
+                    onError = { error ->
+                        errorLog(BillingStrings.BILLING_AMAZON_ERROR_STORE_COUNTRY.format(error))
+                        onError(error)
+                    },
+                )
+            } else {
+                errorLog(BillingStrings.BILLING_CONNECTION_ERROR_STORE_COUNTRY.format(connectionError))
+                onError(connectionError)
+            }
+        }
     }
 
     private fun List<Receipt>.toMapOfReceiptHashesToRestoredPurchases(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonStrings.kt
@@ -36,6 +36,8 @@ internal object AmazonStrings {
         "Failed to get user data. Call is not supported."
     const val ERROR_USER_DATA_STORE_PROBLEM =
         "Failed to get user data. There was an Amazon store problem."
+    const val ERROR_USER_DATA_MARKETPLACE_NULL_STORE_PROBLEM =
+        "Failed to get marketplace from user data. It was null."
     const val PRODUCT_PRICE_MISSING = "Product %s is missing a price. This is common if you're trying to load a " +
         "product SKU instead of a subscription term SKU. Make sure you configure the subscription term SKUs " +
         "in the RevenueCat dashboard."

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -103,6 +103,15 @@ internal abstract class BillingAbstract {
         subscriptionStatusChange: () -> Unit,
     )
 
+    /**
+     * Obtain store country code in ISO 3166-1-alpha-2 standard format.
+     * Null if there has been an error.
+     */
+    abstract fun getStoreCountryCode(
+        onSuccess: (String) -> Unit,
+        onError: PurchasesErrorCallback,
+    )
+
     interface PurchasesUpdatedListener {
         fun onPurchasesUpdated(purchases: List<StoreTransaction>)
         fun onPurchasesFailedToUpdate(purchasesError: PurchasesError)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -107,7 +107,7 @@ internal abstract class BillingAbstract {
      * Obtain store country code in ISO 3166-1-alpha-2 standard format.
      * Null if there has been an error.
      */
-    abstract fun getStoreCountryCode(
+    abstract fun getStorefront(
         onSuccess: (String) -> Unit,
         onError: PurchasesErrorCallback,
     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -46,6 +46,7 @@ import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.sha256
 import com.revenuecat.purchases.common.toHumanReadableDescription
 import com.revenuecat.purchases.common.verboseLog
+import com.revenuecat.purchases.google.usecase.GetBillingConfigUseCase
 import com.revenuecat.purchases.google.usecase.QueryProductDetailsUseCase
 import com.revenuecat.purchases.google.usecase.QueryProductDetailsUseCaseParams
 import com.revenuecat.purchases.models.GooglePurchasingData
@@ -789,6 +790,19 @@ internal class BillingWrapper(
                 }
             }
         }
+    }
+
+    override fun getStoreCountryCode(
+        onSuccess: (String) -> Unit,
+        onError: PurchasesErrorCallback,
+    ) {
+        verboseLog(BillingStrings.BILLING_INITIATE_GETTING_COUNTRY_CODE)
+        GetBillingConfigUseCase(
+            onReceive = { billingConfig -> onSuccess(billingConfig.countryCode) },
+            onError = onError,
+            withConnectedClient = ::withConnectedClient,
+            executeRequestOnUIThread = ::executeRequestOnUIThread,
+        ).run()
     }
 
     private fun withConnectedClient(receivingFunction: BillingClient.() -> Unit) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -792,7 +792,7 @@ internal class BillingWrapper(
         }
     }
 
-    override fun getStoreCountryCode(
+    override fun getStorefront(
         onSuccess: (String) -> Unit,
         onError: PurchasesErrorCallback,
     ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/GetBillingConfigUseCase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/GetBillingConfigUseCase.kt
@@ -1,0 +1,48 @@
+package com.revenuecat.purchases.google.usecase
+
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingConfig
+import com.android.billingclient.api.GetBillingConfigParams
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCallback
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.common.LogIntent
+import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.strings.BillingStrings
+import com.revenuecat.purchases.strings.OfferingStrings
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class GetBillingConfigUseCase(
+    val onReceive: (BillingConfig) -> Unit,
+    val onError: PurchasesErrorCallback,
+    val withConnectedClient: (BillingClient.() -> Unit) -> Unit,
+    executeRequestOnUIThread: ((PurchasesError?) -> Unit) -> Unit,
+) : BillingClientUseCase<BillingConfig?>(onError, executeRequestOnUIThread) {
+    override val errorMessage: String
+        get() = "Error getting billing config"
+
+    override fun executeAsync() {
+        withConnectedClient {
+            val hasResponded = AtomicBoolean(false)
+
+            getBillingConfigAsync(GetBillingConfigParams.newBuilder().build()) { result, config ->
+                if (hasResponded.getAndSet(true)) {
+                    log(
+                        LogIntent.GOOGLE_ERROR,
+                        OfferingStrings.EXTRA_GET_BILLING_CONFIG_RESPONSE.format(result.responseCode),
+                    )
+                    return@getBillingConfigAsync
+                }
+                processResult(result, config)
+            }
+        }
+    }
+
+    override fun onOk(received: BillingConfig?) {
+        if (received == null) {
+            onError(PurchasesError(PurchasesErrorCode.StoreProblemError, BillingStrings.BILLING_CONFIG_NULL_ON_SUCCESS))
+        } else {
+            onReceive(received)
+        }
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -28,10 +28,16 @@ internal object BillingStrings {
         "BillingClient. This has been reported to occur on Samsung devices on unknown circumstances.\nException: %s"
     const val BILLING_CONNECTION_ERROR_INAPP_MESSAGES = "Error connecting to billing client to display " +
         "in-app messages: %s"
+    const val BILLING_CONNECTION_ERROR_STORE_COUNTRY = "Error connecting to billing client to get store " +
+        "country: %s"
+    const val BILLING_AMAZON_ERROR_STORE_COUNTRY = "Error obtaining store country in Amazon: %s"
+    const val BILLING_CONFIG_NULL_ON_SUCCESS = "Billing config is null even though Google return OK result"
     const val BILLING_INAPP_MESSAGE_NONE = "No Google Play in-app message was available."
     const val BILLING_INAPP_MESSAGE_UPDATE = "Subscription status was updated from in-app message."
     const val BILLING_INAPP_MESSAGE_UNEXPECTED_CODE = "Unexpected billing code: %s"
     const val BILLING_UNSPECIFIED_INAPP_MESSAGE_TYPES = "Tried to show in-app messages without specifying any types. " +
         "Please add what types of in-app message you want to display."
     const val BILLING_CLIENT_RETRY_ALREADY_SCHEDULED = "BillingClient connection retry already scheduled. Ignoring"
+    const val BILLING_INITIATE_GETTING_COUNTRY_CODE = "Billing client: Initiating getting country code."
+    const val BILLING_COUNTRY_CODE = "Billing connected with country code: %s"
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -30,7 +30,7 @@ internal object BillingStrings {
         "in-app messages: %s"
     const val BILLING_CONNECTION_ERROR_STORE_COUNTRY = "Error connecting to billing client to get store " +
         "country: %s"
-    const val BILLING_AMAZON_ERROR_STORE_COUNTRY = "Error obtaining store country in Amazon: %s"
+    const val BILLING_AMAZON_ERROR_STOREFRONT = "Error obtaining storefront in Amazon: %s"
     const val BILLING_CONFIG_NULL_ON_SUCCESS = "Billing config is null even though Google return OK result"
     const val BILLING_INAPP_MESSAGE_NONE = "No Google Play in-app message was available."
     const val BILLING_INAPP_MESSAGE_UPDATE = "Subscription status was updated from in-app message."

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -13,6 +13,8 @@ internal object OfferingStrings {
         "with result: %s. More info here: https://rev.cat/google-duplicated-listener-timeouts"
     const val EXTRA_QUERY_PURCHASES_RESPONSE = "BillingClient queryPurchases has returned more than once, " +
         "with result: %s."
+    const val EXTRA_GET_BILLING_CONFIG_RESPONSE = "BillingClient getBillingConfigAsync has returned more than once, " +
+        "with result: %s."
     const val NO_CACHED_OFFERINGS_FETCHING_NETWORK = "No cached Offerings, fetching from network"
     const val OFFERINGS_STALE_UPDATING_IN_BACKGROUND = "Offerings cache is stale, updating from network in background"
     const val OFFERINGS_STALE_UPDATING_IN_FOREGROUND = "Offerings cache is stale, updating from network in foreground"

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -1603,7 +1603,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
 
     @Test
     fun `on billing wrapper connected, sync pending purchases`() {
-        mockGetStoreCountryCode()
+        mockGetStorefront()
         capturedBillingWrapperStateListener.captured.onConnected()
         verify(exactly = 1) {
             mockPostPendingTransactionsHelper.syncPendingPurchaseQueue(any())
@@ -1623,11 +1623,11 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     // endregion
 
     @Test
-    fun `on billing wrapper connected, gets store country`() {
-        mockGetStoreCountryCode()
+    fun `on billing wrapper connected, gets storefront`() {
+        mockGetStorefront()
         capturedBillingWrapperStateListener.captured.onConnected()
         verify(exactly = 1) {
-            mockBillingAbstract.getStoreCountryCode(any(), any())
+            mockBillingAbstract.getStorefront(any(), any())
         }
     }
 
@@ -1776,9 +1776,9 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         }
     }
 
-    private fun mockGetStoreCountryCode() {
+    private fun mockGetStorefront() {
         every {
-            mockBillingAbstract.getStoreCountryCode(captureLambda(), any())
+            mockBillingAbstract.getStorefront(captureLambda(), any())
         } answers {
             lambda<(String) -> Unit>().captured.invoke("US")
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -1603,6 +1603,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
 
     @Test
     fun `on billing wrapper connected, sync pending purchases`() {
+        mockGetStoreCountryCode()
         capturedBillingWrapperStateListener.captured.onConnected()
         verify(exactly = 1) {
             mockPostPendingTransactionsHelper.syncPendingPurchaseQueue(any())
@@ -1620,6 +1621,15 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     // endregion
+
+    @Test
+    fun `on billing wrapper connected, gets store country`() {
+        mockGetStoreCountryCode()
+        capturedBillingWrapperStateListener.captured.onConnected()
+        verify(exactly = 1) {
+            mockBillingAbstract.getStoreCountryCode(any(), any())
+        }
+    }
 
     // region Private Methods
     private fun mockSynchronizeSubscriberAttributesForAllUsers() {
@@ -1763,6 +1773,14 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         } answers {
             lst.captured.run()
             true
+        }
+    }
+
+    private fun mockGetStoreCountryCode() {
+        every {
+            mockBillingAbstract.getStoreCountryCode(captureLambda(), any())
+        } answers {
+            lambda<(String) -> Unit>().captured.invoke("US")
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -981,11 +981,11 @@ class AmazonBillingTest {
     }
 
     @Test
-    fun `querying store country code success`() {
+    fun `querying storefront success`() {
         setup()
         mockGetUserData()
         var countryCode: String? = null
-        underTest.getStoreCountryCode(
+        underTest.getStorefront(
             onSuccess = { countryCode = it },
             onError = { fail("Should be a success") },
         )
@@ -993,11 +993,11 @@ class AmazonBillingTest {
     }
 
     @Test
-    fun `querying store country code error`() {
+    fun `querying storefront error`() {
         setup()
         mockGetUserDataError()
         var error: PurchasesError? = null
-        underTest.getStoreCountryCode(
+        underTest.getStorefront(
             onSuccess = { fail("Should be a error") },
             onError = { error = it },
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -8,6 +8,7 @@ import com.amazon.device.iap.model.ProductType
 import com.amazon.device.iap.model.Receipt
 import com.amazon.device.iap.model.UserData
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCallback
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.amazon.handler.ProductDataHandler
 import com.revenuecat.purchases.amazon.handler.PurchaseHandler
@@ -40,6 +41,7 @@ import kotlin.time.Duration.Companion.hours
 @RunWith(AndroidJUnit4::class)
 class AmazonBillingTest {
     private val appUserID: String = "appUserID"
+    private val countryCode = "JP"
     private lateinit var underTest: AmazonBilling
 
     private val mockPurchasingServiceProvider = mockk<PurchasingServiceProvider>()
@@ -480,17 +482,11 @@ class AmazonBillingTest {
         underTest.startConnection()
 
         val productIds = setOf("sku", "sku_2")
-        val marketplace = "ES"
-        val dummyUserData = dummyUserData(marketplace = marketplace)
 
-        every {
-            mockUserDataHandler.getUserData(captureLambda(), any())
-        } answers {
-            lambda<(UserData) -> Unit>().captured.invoke(dummyUserData)
-        }
+        mockGetUserData()
 
         val marketplaceSlot = slot<String>()
-        val storeProducts = listOfNotNull(dummyAmazonProduct().toStoreProduct(marketplace))
+        val storeProducts = listOfNotNull(dummyAmazonProduct().toStoreProduct(countryCode))
 
         every {
             mockProductDataHandler.getProductData(productIds, capture(marketplaceSlot), captureLambda(), any())
@@ -511,7 +507,7 @@ class AmazonBillingTest {
         )
 
         assertThat(onReceiveCalled).isTrue()
-        assertThat(marketplaceSlot.captured).isEqualTo(marketplace)
+        assertThat(marketplaceSlot.captured).isEqualTo(countryCode)
     }
 
     @Test
@@ -984,6 +980,30 @@ class AmazonBillingTest {
         assertThat(receivedCorrectProductID).isEqualTo(expectedTermSku)
     }
 
+    @Test
+    fun `querying store country code success`() {
+        setup()
+        mockGetUserData()
+        var countryCode: String? = null
+        underTest.getStoreCountryCode(
+            onSuccess = { countryCode = it },
+            onError = { fail("Should be a success") },
+        )
+        assertThat(countryCode).isEqualTo(countryCode)
+    }
+
+    @Test
+    fun `querying store country code error`() {
+        setup()
+        mockGetUserDataError()
+        var error: PurchasesError? = null
+        underTest.getStoreCountryCode(
+            onSuccess = { fail("Should be a error") },
+            onError = { error = it },
+        )
+        assertThat(error?.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+    }
+
     private fun verifyBackendCalled(
         receipt: Receipt,
         dummyUserData: UserData,
@@ -1044,6 +1064,22 @@ class AmazonBillingTest {
             )
         } answers {
             lambda<(JSONObject) -> Unit>().captured.invoke(JSONObject(successfulRVSResponse(expectedTermSku)))
+        }
+    }
+
+    private fun mockGetUserData(userData: UserData = dummyUserData(marketplace = countryCode)) {
+        every {
+            mockUserDataHandler.getUserData(captureLambda(), any())
+        } answers {
+            lambda<(UserData) -> Unit>().captured.invoke(userData)
+        }
+    }
+
+    private fun mockGetUserDataError(error: PurchasesError = PurchasesError(PurchasesErrorCode.StoreProblemError)) {
+        every {
+            mockUserDataHandler.getUserData(any(), captureLambda())
+        } answers {
+            lambda<PurchasesErrorCallback>().captured.invoke(error)
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/GetBillingConfigUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/GetBillingConfigUseCaseTest.kt
@@ -1,0 +1,143 @@
+package com.revenuecat.purchases.google.usecase
+
+import android.os.Handler
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingClientStateListener
+import com.android.billingclient.api.BillingConfig
+import com.android.billingclient.api.BillingConfigResponseListener
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.PurchasesUpdatedListener
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.google.BillingWrapper
+import com.revenuecat.purchases.utils.MockHandlerFactory
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class GetBillingConfigUseCaseTest {
+
+    private val expectedCountryCode = "JP"
+
+    private val mockConfig = mockk<BillingConfig>().apply {
+        every { countryCode } returns expectedCountryCode
+    }
+
+    private var mockClientFactory: BillingWrapper.ClientFactory = mockk()
+    private var mockClient: BillingClient = mockk()
+    private var purchasesUpdatedListener: PurchasesUpdatedListener? = null
+    private var billingClientStateListener: BillingClientStateListener? = null
+
+    private lateinit var handler: Handler
+
+    private lateinit var wrapper: BillingWrapper
+
+    @Before
+    fun setup() {
+        handler = MockHandlerFactory.createMockHandler()
+        purchasesUpdatedListener = null
+        billingClientStateListener = null
+
+        val listenerSlot = slot<PurchasesUpdatedListener>()
+        every {
+            mockClientFactory.buildClient(capture(listenerSlot))
+        } answers {
+            purchasesUpdatedListener = listenerSlot.captured
+            mockClient
+        }
+
+        val billingClientStateListenerSlot = slot<BillingClientStateListener>()
+        every {
+            mockClient.startConnection(capture(billingClientStateListenerSlot))
+        } answers {
+            billingClientStateListener = billingClientStateListenerSlot.captured
+        }
+
+        every {
+            mockClient.endConnection()
+        } just Runs
+
+        every {
+            mockClient.isReady
+        } returns false andThen true
+
+        wrapper = BillingWrapper(mockClientFactory, handler, mockk(), mockk(), mockk())
+        wrapper.purchasesUpdatedListener = mockk()
+        wrapper.startConnectionOnMainThread()
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `querying store country code success`() {
+        mockGetBillingConfig()
+        var countryCode: String? = null
+        wrapper.getStoreCountryCode(
+            onSuccess = { countryCode = it },
+            onError = { fail("Should succeed") }
+        )
+        assertThat(countryCode).isEqualTo(expectedCountryCode)
+    }
+
+    @Test
+    fun `querying store country code error code`() {
+        mockGetBillingConfig(BillingResponseCode.ERROR)
+        var error: PurchasesError? = null
+        wrapper.getStoreCountryCode(
+            onSuccess = { fail("Should error") },
+            onError = { error = it }
+        )
+        assertThat(error?.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+    }
+
+    @Test
+    fun `querying store country code only calls one response when BillingClient responds twice`() {
+        var numCallbacks = 0
+
+        val billingResult = BillingResult.newBuilder().setResponseCode(BillingResponseCode.OK).build()
+        val listenerSlot = slot<BillingConfigResponseListener>()
+        every {
+            mockClient.getBillingConfigAsync(any(), capture(listenerSlot))
+        } answers {
+            listenerSlot.captured.onBillingConfigResponse(billingResult, mockConfig)
+            listenerSlot.captured.onBillingConfigResponse(billingResult, mockConfig)
+        }
+
+        wrapper.getStoreCountryCode(
+            onSuccess = { numCallbacks++ },
+            onError = { numCallbacks++ }
+        )
+
+        assertThat(numCallbacks).isEqualTo(1)
+    }
+
+    private fun mockGetBillingConfig(
+        billingResponseCode: Int = BillingResponseCode.OK,
+        billingConfig: BillingConfig = mockConfig
+    ) {
+        val billingResult = BillingResult.newBuilder().setResponseCode(billingResponseCode).build()
+        val listenerSlot = slot<BillingConfigResponseListener>()
+        every {
+            mockClient.getBillingConfigAsync(any(), capture(listenerSlot))
+        } answers {
+            listenerSlot.captured.onBillingConfigResponse(billingResult, billingConfig)
+        }
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/GetBillingConfigUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/GetBillingConfigUseCaseTest.kt
@@ -86,10 +86,10 @@ class GetBillingConfigUseCaseTest {
     }
 
     @Test
-    fun `querying store country code success`() {
+    fun `querying storefront success`() {
         mockGetBillingConfig()
         var countryCode: String? = null
-        wrapper.getStoreCountryCode(
+        wrapper.getStorefront(
             onSuccess = { countryCode = it },
             onError = { fail("Should succeed") }
         )
@@ -97,10 +97,10 @@ class GetBillingConfigUseCaseTest {
     }
 
     @Test
-    fun `querying store country code error code`() {
+    fun `querying storefront error code`() {
         mockGetBillingConfig(BillingResponseCode.ERROR)
         var error: PurchasesError? = null
-        wrapper.getStoreCountryCode(
+        wrapper.getStorefront(
             onSuccess = { fail("Should error") },
             onError = { error = it }
         )
@@ -108,7 +108,7 @@ class GetBillingConfigUseCaseTest {
     }
 
     @Test
-    fun `querying store country code only calls one response when BillingClient responds twice`() {
+    fun `querying storefront only calls one response when BillingClient responds twice`() {
         var numCallbacks = 0
 
         val billingResult = BillingResult.newBuilder().setResponseCode(BillingResponseCode.OK).build()
@@ -120,7 +120,7 @@ class GetBillingConfigUseCaseTest {
             listenerSlot.captured.onBillingConfigResponse(billingResult, mockConfig)
         }
 
-        wrapper.getStoreCountryCode(
+        wrapper.getStorefront(
             onSuccess = { numCallbacks++ },
             onError = { numCallbacks++ }
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/MockHandlerFactory.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/MockHandlerFactory.kt
@@ -1,0 +1,27 @@
+package com.revenuecat.purchases.utils
+
+import android.os.Handler
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+
+object MockHandlerFactory {
+    fun createMockHandler(): Handler {
+        val handler = mockk<Handler>()
+        val slot = slot<Runnable>()
+        every {
+            handler.post(capture(slot))
+        } answers {
+            slot.captured.run()
+            true
+        }
+        val delayedSlot = slot<Runnable>()
+        every {
+            handler.postDelayed(capture(delayedSlot), any())
+        } answers {
+            delayedSlot.captured.run()
+            true
+        }
+        return handler
+    }
+}


### PR DESCRIPTION
### Description
This PR adds a new method to the `BillingAbstract` to obtain the country code of the store, now that it's been added in Google's BC 6.1.0.

In this PR, we only log the country as soon as we connect but we plan to send this data to the backend in future PRs.