### PR TITLE
Use state listener in Amazon store

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -89,6 +89,7 @@ internal class AmazonBilling constructor(
 
         purchasingServiceProvider.registerListener(applicationContext, this)
         connected = true
+        stateListener?.onConnected()
         executePendingRequests()
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -18,6 +18,7 @@ import com.revenuecat.purchases.amazon.helpers.dummyAmazonProduct
 import com.revenuecat.purchases.amazon.helpers.dummyReceipt
 import com.revenuecat.purchases.amazon.helpers.dummyUserData
 import com.revenuecat.purchases.amazon.helpers.successfulRVSResponse
+import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.StoreProduct
@@ -846,6 +847,24 @@ class AmazonBillingTest {
 
         verify(exactly = 1) {
             mockPurchasingServiceProvider.registerListener(any(), any())
+        }
+    }
+
+    @Test
+    fun `on connection, stateListener called`() {
+        setup()
+        val stateListenerMock = mockk<BillingAbstract.StateListener>()
+        underTest.stateListener = stateListenerMock
+        every { stateListenerMock.onConnected() } just Runs
+
+        every {
+            mockPurchasingServiceProvider.registerListener(mockContext, any())
+        } just Runs
+
+        underTest.startConnection()
+
+        verify(exactly = 1) {
+            stateListenerMock.onConnected()
         }
     }
 


### PR DESCRIPTION
### Description
We were not calling the BillingAbstract `stateListener` after it was connected. This adds a call to make sure we call it and keep the same behavior as on Google. Currently, we were just syncing pending purchases in Google, which shouldn't matter much if we do it there for Amazon since we're also doing on app foreground.