### PR TITLE
`Trusted Entitlements`: Enable enforced mode

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/EntitlementVerificationModeAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/EntitlementVerificationModeAPI.java
@@ -8,8 +8,7 @@ final class EntitlementVerificationModeAPI {
         switch (verificationMode) {
             case DISABLED:
             case INFORMATIONAL:
-            // Hidden ENFORCED mode during feature beta
-            // case ENFORCED:
+            case ENFORCED:
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementVerificationModeAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementVerificationModeAPI.kt
@@ -8,8 +8,7 @@ private class EntitlementVerificationModeAPI {
         when (verificationMode) {
             EntitlementVerificationMode.DISABLED,
             EntitlementVerificationMode.INFORMATIONAL,
-            // Hidden ENFORCED mode during feature beta
-            // EntitlementVerificationMode.ENFORCED
+            EntitlementVerificationMode.ENFORCED
             -> {}
         }.exhaustive
     }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -44,6 +44,7 @@ class ConfigureFragment : Fragment() {
             android.R.layout.simple_spinner_item,
             EntitlementVerificationMode.values(),
         )
+        binding.verificationOptionsInput.setSelection(EntitlementVerificationMode.ENFORCED.ordinal)
         setupSupportedStoresRadioButtons()
 
         lifecycleScope.launch {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementVerificationMode.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementVerificationMode.kt
@@ -21,10 +21,13 @@ enum class EntitlementVerificationMode {
      */
     INFORMATIONAL,
 
-    ;
-
-    // Hidden ENFORCED mode during feature beta
-    // ENFORCED;
+    /**
+     * Enable entitlement verification.
+     *
+     * If verification fails when fetching [CustomerInfo] and/or [EntitlementInfos]
+     * [PurchasesErrorCode.SignatureVerificationError] will be returned in the error handler.
+     */
+    ENFORCED;
 
     companion object {
         /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/verification/SignatureVerificationMode.kt
@@ -12,9 +12,8 @@ internal sealed class SignatureVerificationMode {
                 EntitlementVerificationMode.DISABLED -> Disabled
                 EntitlementVerificationMode.INFORMATIONAL ->
                     Informational(IntermediateSignatureHelper(rootVerifier ?: DefaultSignatureVerifier()))
-                // Hidden ENFORCED mode temporarily. Will be added back in the future.
-                // EntitlementVerificationMode.ENFORCED ->
-                //     Enforced(signatureVerifier ?: DefaultSignatureVerifier())
+                 EntitlementVerificationMode.ENFORCED ->
+                     Enforced(IntermediateSignatureHelper(rootVerifier ?: DefaultSignatureVerifier()))
             }
         }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/verification/SignatureVerificationModeTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/verification/SignatureVerificationModeTest.kt
@@ -19,10 +19,9 @@ class SignatureVerificationModeTest {
         assertThat(
             SignatureVerificationMode.fromEntitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
         ).isInstanceOf(SignatureVerificationMode.Informational::class.java)
-        // Hidden ENFORCED mode during feature beta
-//         assertThat(
-//             SignatureVerificationMode.fromEntitlementVerificationMode(EntitlementVerificationMode.ENFORCED)
-//         ).isInstanceOf(SignatureVerificationMode.Enforced::class.java)
+         assertThat(
+             SignatureVerificationMode.fromEntitlementVerificationMode(EntitlementVerificationMode.ENFORCED)
+         ).isInstanceOf(SignatureVerificationMode.Enforced::class.java)
     }
 
     @Test


### PR DESCRIPTION
### Description
This adds the enforced mode to the public API. I've also retested it manually to make sure the behavior is expected.

- [ ] Holding until we're ready to ship this.