### PR TITLE
Check diagnostics file size in background thread

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
@@ -45,10 +45,12 @@ internal class DiagnosticsSynchronizer(
     }
 
     fun clearDiagnosticsFileIfTooBig() {
-        if (diagnosticsFileHelper.isDiagnosticsFileTooBig()) {
-            verboseLog("Diagnostics file is too big. Deleting it.")
-            diagnosticsTracker.trackMaxEventsStoredLimitReached()
-            resetDiagnosticsStatus()
+        enqueue {
+            if (diagnosticsFileHelper.isDiagnosticsFileTooBig()) {
+                verboseLog("Diagnostics file is too big. Deleting it.")
+                diagnosticsTracker.trackMaxEventsStoredLimitReached()
+                resetDiagnosticsStatus()
+            }
         }
     }
 


### PR DESCRIPTION
### Description
We were checking the diagnostics file size in the main thread which was causing a disk read violation. This moves that operation to the diagnostics thread