### PR TITLE
Initialize shared preferences lazily

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -83,8 +83,7 @@ internal class PurchasesFactory(
 
             val prefs = PreferenceManager.getDefaultSharedPreferences(application)
 
-            val sharedPreferencesForETags = ETagManager.initializeSharedPreferences(context)
-            val eTagManager = ETagManager(sharedPreferencesForETags)
+            val eTagManager = ETagManager(context)
 
             val dispatcher = Dispatcher(createDefaultExecutor(), runningIntegrationTests)
             val backendDispatcher = Dispatcher(service ?: createDefaultExecutor(), runningIntegrationTests)
@@ -212,11 +211,11 @@ internal class PurchasesFactory(
             var diagnosticsSynchronizer: DiagnosticsSynchronizer? = null
             if (diagnosticsFileHelper != null && diagnosticsTracker != null && isAndroidNOrNewer()) {
                 diagnosticsSynchronizer = DiagnosticsSynchronizer(
+                    context,
                     diagnosticsFileHelper,
                     diagnosticsTracker,
                     backend,
                     eventsDispatcher,
-                    DiagnosticsSynchronizer.initializeSharedPreferences(context),
                 )
             }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
@@ -21,11 +21,12 @@ import java.util.stream.Collectors
  */
 @RequiresApi(Build.VERSION_CODES.N)
 internal class DiagnosticsSynchronizer(
+    context: Context,
     private val diagnosticsFileHelper: DiagnosticsFileHelper,
     private val diagnosticsTracker: DiagnosticsTracker,
     private val backend: Backend,
     private val diagnosticsDispatcher: Dispatcher,
-    private val sharedPreferences: SharedPreferences,
+    private val sharedPreferences: Lazy<SharedPreferences> = lazy { initializeSharedPreferences(context) },
 ) {
     companion object {
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -117,12 +118,12 @@ internal class DiagnosticsSynchronizer(
     }
 
     private fun clearConsecutiveNumberOfErrors() {
-        sharedPreferences.edit().remove(CONSECUTIVE_FAILURES_COUNT_KEY).apply()
+        sharedPreferences.value.edit().remove(CONSECUTIVE_FAILURES_COUNT_KEY).apply()
     }
 
     private fun increaseConsecutiveNumberOfErrors(): Int {
-        var count = sharedPreferences.getInt(CONSECUTIVE_FAILURES_COUNT_KEY, 0)
-        sharedPreferences.edit().putInt(CONSECUTIVE_FAILURES_COUNT_KEY, ++count).apply()
+        var count = sharedPreferences.value.getInt(CONSECUTIVE_FAILURES_COUNT_KEY, 0)
+        sharedPreferences.value.edit().putInt(CONSECUTIVE_FAILURES_COUNT_KEY, ++count).apply()
         return count
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/ETagManager.kt
@@ -49,7 +49,8 @@ internal data class HTTPResultWithETag(
 }
 
 internal class ETagManager(
-    private val prefs: SharedPreferences,
+    context: Context,
+    private val prefs: Lazy<SharedPreferences> = lazy { initializeSharedPreferences(context) },
     private val dateProvider: DateProvider = DefaultDateProvider(),
 ) {
 
@@ -126,7 +127,7 @@ internal class ETagManager(
 
     @Synchronized
     internal fun clearCaches() {
-        prefs.edit().clear().apply()
+        prefs.value.edit().clear().apply()
     }
 
     @Synchronized
@@ -138,11 +139,11 @@ internal class ETagManager(
         val cacheResult = result.copy(origin = HTTPResult.Origin.CACHE)
         val eTagData = ETagData(eTag, dateProvider.now)
         val httpResultWithETag = HTTPResultWithETag(eTagData, cacheResult)
-        prefs.edit().putString(path, httpResultWithETag.serialize()).apply()
+        prefs.value.edit().putString(path, httpResultWithETag.serialize()).apply()
     }
 
     private fun getStoredResultSavedInSharedPreferences(path: String): HTTPResultWithETag? {
-        val serializedHTTPResultWithETag = prefs.getString(path, null)
+        val serializedHTTPResultWithETag = prefs.value.getString(path, null)
         return serializedHTTPResultWithETag?.let {
             HTTPResultWithETag.deserialize(it)
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
@@ -94,7 +94,7 @@ internal abstract class BaseBackendIntegrationTest {
             every { getString(any(), any()) } answers { secondArg() as String? }
             every { edit() } returns sharedPreferencesEditor
         }
-        eTagManager = ETagManager(sharedPreferences)
+        eTagManager = ETagManager(mockk(), lazy { sharedPreferences })
         signingManager = spyk(SigningManager(signatureVerificationMode, appConfig, apiKey()))
         deviceCache = DeviceCache(sharedPreferences, apiKey())
         httpClient = HTTPClient(appConfig, eTagManager, diagnosticsTrackerIfEnabled = null, signingManager, deviceCache)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerFunctionalTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerFunctionalTest.kt
@@ -40,11 +40,12 @@ class DiagnosticsSynchronizerFunctionalTest {
         every { diagnosticsTracker.trackMaxEventsStoredLimitReached() } just Runs
 
         diagnosticsSynchronizer = DiagnosticsSynchronizer(
+            mockk(),
             DiagnosticsFileHelper(FileHelper(applicationContext)),
             diagnosticsTracker = diagnosticsTracker,
             backend = mockk(),
             diagnosticsDispatcher = SyncDispatcher(),
-            sharedPreferences = mockk(relaxed = true),
+            sharedPreferences = lazy { mockk(relaxed = true) },
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
@@ -51,11 +51,12 @@ class DiagnosticsSynchronizerTest {
         mockDiagnosticsFileHelper()
 
         diagnosticsSynchronizer = DiagnosticsSynchronizer(
+            mockk(),
             diagnosticsFileHelper,
             diagnosticsTracker,
             backend,
             dispatcher,
-            sharedPreferences
+            lazy { sharedPreferences }
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/ETagManagerTest.kt
@@ -30,7 +30,7 @@ class ETagManagerTest {
             get() = testDate
     }
     private val mockedPrefs = mockk<SharedPreferences>()
-    private val underTest = ETagManager(mockedPrefs, testDateProvider)
+    private val underTest = ETagManager(mockk(), lazy { mockedPrefs }, testDateProvider)
     private val slotPutStringSharedPreferencesKey = slot<String>()
     private val slotPutSharedPreferencesValue = slot<String>()
     private val mockEditor = mockk<SharedPreferences.Editor>()


### PR DESCRIPTION
### Description
We detected some `DiskReadViolation` caused by initilizing shared preferences. This should have a very low impact on initialization time, but might be good to delay that so it's not caused until actually needed. We currently have 3 shared preferences files, 2 of them are only used later on and can be initialized later.