### PR TITLE
Add AcknowledgePurchaseUseCase

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCase.kt
@@ -1,0 +1,50 @@
+package com.revenuecat.purchases.google.usecase
+
+import com.android.billingclient.api.AcknowledgePurchaseParams
+import com.android.billingclient.api.BillingClient
+import com.revenuecat.purchases.PostReceiptInitiationSource
+import com.revenuecat.purchases.PurchasesErrorCallback
+
+internal class AcknowledgePurchaseUseCaseParams(
+    val purchaseToken: String,
+    val initiationSource: PostReceiptInitiationSource,
+    override val appInBackground: Boolean,
+) : UseCaseParams
+
+internal class AcknowledgePurchaseUseCase(
+    private val useCaseParams: AcknowledgePurchaseUseCaseParams,
+    val onReceive: (purchaseToken: String) -> Unit,
+    val onError: PurchasesErrorCallback,
+    val withConnectedClient: (BillingClient.() -> Unit) -> Unit,
+    executeRequestOnUIThread: ExecuteRequestOnUIThreadFunction,
+) : BillingClientUseCase<String>(useCaseParams, onError, executeRequestOnUIThread) {
+
+    override val backoffForNetworkErrors: Boolean
+        get() = when (useCaseParams.initiationSource) {
+            PostReceiptInitiationSource.RESTORE,
+            PostReceiptInitiationSource.PURCHASE,
+            -> false
+            PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES -> true
+        }
+
+    override val errorMessage: String
+        get() = "Error consuming purchase"
+
+    override fun executeAsync() {
+        withConnectedClient {
+            val acknowledgePurchaseParams = AcknowledgePurchaseParams.newBuilder()
+                .setPurchaseToken(useCaseParams.purchaseToken)
+                .build()
+            acknowledgePurchase(acknowledgePurchaseParams) { billingResult ->
+                processResult(
+                    billingResult,
+                    useCaseParams.purchaseToken,
+                )
+            }
+        }
+    }
+
+    override fun onOk(received: String) {
+        onReceive(received)
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCase.kt
@@ -28,7 +28,7 @@ internal class AcknowledgePurchaseUseCase(
         }
 
     override val errorMessage: String
-        get() = "Error consuming purchase"
+        get() = "Error acknowledging purchase"
 
     override fun executeAsync() {
         withConnectedClient {

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1154,7 +1154,11 @@ class BillingWrapperTest {
         val token = "token"
 
         billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
-        wrapper.acknowledge(token) { _, _ -> }
+        wrapper.acknowledge(
+            token,
+            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+            appInBackground = false
+        ) { }
 
         assertThat(capturedAcknowledgePurchaseParams.isCaptured).isTrue
         assertThat(capturedAcknowledgePurchaseParams.captured.purchaseToken).isEqualTo(token)

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -102,9 +102,6 @@ class BillingWrapperTest {
 
     private var mockPurchasesListener: BillingAbstract.PurchasesUpdatedListener = mockk()
 
-    private var capturedAcknowledgeResponseListener = slot<AcknowledgePurchaseResponseListener>()
-    private var capturedAcknowledgePurchaseParams = slot<AcknowledgePurchaseParams>()
-
     private lateinit var wrapper: BillingWrapper
 
     private lateinit var mockDetailsList: List<ProductDetails>
@@ -147,13 +144,6 @@ class BillingWrapperTest {
         every {
             mockClient.endConnection()
         } just runs
-
-        every {
-            mockClient.acknowledgePurchase(
-                capture(capturedAcknowledgePurchaseParams),
-                capture(capturedAcknowledgeResponseListener)
-            )
-        } just Runs
 
         mockConsumeAsync(billingClientOKResult)
 
@@ -1150,21 +1140,6 @@ class BillingWrapperTest {
     }
 
     @Test
-    fun `Acknowledge works`() {
-        val token = "token"
-
-        billingClientStateListener!!.onBillingSetupFinished(billingClientOKResult)
-        wrapper.acknowledge(
-            token,
-            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false
-        ) { }
-
-        assertThat(capturedAcknowledgePurchaseParams.isCaptured).isTrue
-        assertThat(capturedAcknowledgePurchaseParams.captured.purchaseToken).isEqualTo(token)
-    }
-
-    @Test
     fun `Getting SUBS type`() {
         val inAppToken = "inAppToken"
         val subsToken = "subsToken"
@@ -1291,217 +1266,6 @@ class BillingWrapperTest {
 
         assertThat(errorReturned).isNotNull
         assertThat(errorReturned!!.code).isEqualTo(PurchasesErrorCode.PurchaseInvalidError)
-    }
-
-    @Test
-    fun `tokens are not saved in cache if acknowledge fails`() {
-        val sku = "sub"
-        val token = "token_sub"
-        val googlePurchaseWrapper = getMockedPurchaseWrapper(
-            sku,
-            token,
-            ProductType.SUBS,
-            "offering_a"
-        )
-
-        wrapper.consumeAndSave(
-            shouldTryToConsume = true,
-            purchase = googlePurchaseWrapper,
-            appInBackground = false,
-            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-        )
-
-        assertThat(capturedAcknowledgeResponseListener.isCaptured).isTrue
-        capturedAcknowledgeResponseListener.captured.onAcknowledgePurchaseResponse(
-            BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult()
-        )
-
-        verify(exactly = 0) {
-            mockDeviceCache.addSuccessfullyPostedToken(token)
-        }
-    }
-
-    @Test
-    fun `restored tokens are not save in cache if acknowledge fails`() {
-        val sku = "sub"
-        val token = "token_sub"
-        val historyRecordWrapper = getMockedPurchaseHistoryRecordWrapper(
-            sku,
-            token,
-            ProductType.SUBS
-        )
-
-        wrapper.consumeAndSave(
-            shouldTryToConsume = true,
-            purchase = historyRecordWrapper,
-            appInBackground = false,
-            initiationSource = PostReceiptInitiationSource.RESTORE
-        )
-
-        assertThat(capturedAcknowledgeResponseListener.isCaptured).isTrue
-        capturedAcknowledgeResponseListener.captured.onAcknowledgePurchaseResponse(
-            BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult()
-        )
-
-        verify(exactly = 0) {
-            mockDeviceCache.addSuccessfullyPostedToken(token)
-        }
-    }
-
-    @Test
-    fun `subscriptions are acknowledged`() {
-        val sku = "sub"
-        val token = "token_sub"
-        val googlePurchaseWrapper = getMockedPurchaseWrapper(
-            sku,
-            token,
-            ProductType.SUBS,
-            "offering_a"
-        )
-
-        every {
-            mockDeviceCache.addSuccessfullyPostedToken(token)
-        } just Runs
-
-        wrapper.consumeAndSave(
-            shouldTryToConsume = true,
-            purchase = googlePurchaseWrapper,
-            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false
-        )
-
-        assertThat(capturedAcknowledgeResponseListener.isCaptured).isTrue
-        capturedAcknowledgeResponseListener.captured.onAcknowledgePurchaseResponse(
-            billingClientOKResult
-        )
-
-        assertThat(capturedAcknowledgePurchaseParams.isCaptured).isTrue
-        val capturedAcknowledgeParams = capturedAcknowledgePurchaseParams.captured
-        assertThat(capturedAcknowledgeParams.purchaseToken).isEqualTo(token)
-    }
-
-    @Test
-    fun `restored subscriptions are acknowledged`() {
-        val sku = "sub"
-        val token = "token_sub"
-        val historyRecordWrapper = getMockedPurchaseHistoryRecordWrapper(
-            sku,
-            token,
-            ProductType.SUBS
-        )
-
-        every {
-            mockDeviceCache.addSuccessfullyPostedToken(token)
-        } just Runs
-
-        wrapper.consumeAndSave(
-            shouldTryToConsume = true,
-            purchase = historyRecordWrapper,
-            appInBackground = false,
-            initiationSource = PostReceiptInitiationSource.RESTORE,
-        )
-
-        assertThat(capturedAcknowledgeResponseListener.isCaptured).isTrue
-        capturedAcknowledgeResponseListener.captured.onAcknowledgePurchaseResponse(
-            billingClientOKResult
-        )
-
-        assertThat(capturedAcknowledgePurchaseParams.isCaptured).isTrue
-        val capturedAcknowledgeParams = capturedAcknowledgePurchaseParams.captured
-        assertThat(capturedAcknowledgeParams.purchaseToken).isEqualTo(token)
-    }
-
-    @Test
-    fun `if it shouldn't consume transactions, don't acknowledge and save it in cache`() {
-        val sku = "sub"
-        val token = "token_sub"
-        val googlePurchaseWrapper = getMockedPurchaseWrapper(
-            sku,
-            token,
-            ProductType.SUBS,
-            "offering_a"
-        )
-
-        every {
-            mockDeviceCache.addSuccessfullyPostedToken(token)
-        } just Runs
-
-        wrapper.consumeAndSave(
-            shouldTryToConsume = false,
-            purchase = googlePurchaseWrapper,
-            appInBackground = false,
-            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-        )
-
-        verify(exactly = 0) {
-            mockClient.acknowledgePurchase(any(), any())
-        }
-
-        verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token)
-        }
-    }
-
-    @Test
-    fun `if it shouldn't consume restored transactions, don't acknowledge and save it in cache`() {
-        val sku = "sub"
-        val token = "token_sub"
-        val historyRecordWrapper = getMockedPurchaseHistoryRecordWrapper(
-            sku,
-            token,
-            ProductType.SUBS
-        )
-
-        every {
-            mockDeviceCache.addSuccessfullyPostedToken(token)
-        } just Runs
-
-        wrapper.consumeAndSave(
-            shouldTryToConsume = false,
-            purchase = historyRecordWrapper,
-            appInBackground = false,
-            initiationSource = PostReceiptInitiationSource.RESTORE,
-        )
-
-        verify(exactly = 0) {
-            mockClient.acknowledgePurchase(any(), any())
-        }
-
-        verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token)
-        }
-    }
-
-    @Test
-    fun `Do not acknowledge purchases that are already acknowledged`() {
-        val sku = "sub"
-        val token = "token_sub"
-        val googlePurchaseWrapper = getMockedPurchaseWrapper(
-            sku,
-            token,
-            ProductType.SUBS,
-            "offering_a",
-            acknowledged = true
-        )
-
-        every {
-            mockDeviceCache.addSuccessfullyPostedToken(token)
-        } just Runs
-
-        wrapper.consumeAndSave(
-            shouldTryToConsume = true,
-            purchase = googlePurchaseWrapper,
-            appInBackground = false,
-            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-        )
-
-        verify(exactly = 0) {
-            mockClient.acknowledgePurchase(any(), any())
-        }
-
-        verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token)
-        }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -56,7 +56,6 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         } just Runs
     }
 
-
     @Test
     fun `Acknowledge works`() {
         val token = "token"
@@ -288,17 +287,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service is disconnected, re-executeRequestOnUIThread for purchases`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedToken: String? = null
         var timesExecutedInMainThread = 0
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.PURCHASE,
                 appInBackground = false,
@@ -315,16 +314,14 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
             executeRequestOnUIThread = { _, request ->
                 timesExecutedInMainThread++
 
-                consumeStubbing answers {
+                acknowledgeStubbing answers {
                     if (timesExecutedInMainThread == 1) {
-                        slot.captured.onConsumeResponse(
+                        slot.captured.onAcknowledgePurchaseResponse(
                             billingClientDisconnectedResult,
-                            "purchaseToken"
                         )
                     } else {
-                        slot.captured.onConsumeResponse(
+                        slot.captured.onAcknowledgePurchaseResponse(
                             billingClientOKResult,
-                            "purchaseToken"
                         )
                     }
                 }
@@ -342,17 +339,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service is disconnected, re-executeRequestOnUIThread for restores`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedToken: String? = null
         var timesExecutedInMainThread = 0
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.RESTORE,
                 appInBackground = false,
@@ -369,16 +366,14 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
             executeRequestOnUIThread = { _, request ->
                 timesExecutedInMainThread++
 
-                consumeStubbing answers {
+                acknowledgeStubbing answers {
                     if (timesExecutedInMainThread == 1) {
-                        slot.captured.onConsumeResponse(
+                        slot.captured.onAcknowledgePurchaseResponse(
                             billingClientDisconnectedResult,
-                            "purchaseToken"
                         )
                     } else {
-                        slot.captured.onConsumeResponse(
+                        slot.captured.onAcknowledgePurchaseResponse(
                             billingClientOKResult,
-                            "purchaseToken"
                         )
                     }
                 }
@@ -396,17 +391,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service is disconnected, re-executeRequestOnUIThread for unsynced active purchases`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedToken: String? = null
         var timesExecutedInMainThread = 0
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
                 appInBackground = false,
@@ -423,16 +418,14 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
             executeRequestOnUIThread = { _, request ->
                 timesExecutedInMainThread++
 
-                consumeStubbing answers {
+                acknowledgeStubbing answers {
                     if (timesExecutedInMainThread == 1) {
-                        slot.captured.onConsumeResponse(
+                        slot.captured.onAcknowledgePurchaseResponse(
                             billingClientDisconnectedResult,
-                            "purchaseToken"
                         )
                     } else {
-                        slot.captured.onConsumeResponse(
+                        slot.captured.onAcknowledgePurchaseResponse(
                             billingClientOKResult,
-                            "purchaseToken"
                         )
                     }
                 }
@@ -450,17 +443,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns NETWORK_ERROR, re-execute with backoff if source is unsynced active purchases`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         val capturedDelays = mutableListOf<Long>()
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
                 appInBackground = false,
@@ -476,10 +469,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
             },
             executeRequestOnUIThread = { delay, request ->
                 capturedDelays.add(delay)
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.NETWORK_ERROR.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -497,17 +489,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns NETWORK_ERROR, re-execute a max of 3 times if source is a purchase`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.PURCHASE,
                 appInBackground = false,
@@ -523,10 +515,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = { _, request ->
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.NETWORK_ERROR.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -543,17 +534,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns NETWORK_ERROR, re-execute a max of 3 times if source is a restore`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.RESTORE,
                 appInBackground = false,
@@ -569,10 +560,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = { _, request ->
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.NETWORK_ERROR.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -589,17 +579,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns ERROR, re-execute with backoff if source is unsynced active purchases`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         val capturedDelays = mutableListOf<Long>()
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
                 appInBackground = false,
@@ -615,10 +605,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
             },
             executeRequestOnUIThread = { delay, request ->
                 capturedDelays.add(delay)
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.ERROR.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -636,17 +625,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns ERROR, re-execute a max of 3 times if source is a purchase`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.PURCHASE,
                 appInBackground = false,
@@ -662,10 +651,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = { _, request ->
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.ERROR.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -682,17 +670,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns ERROR, re-execute a max of 3 times if source is a restore`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.RESTORE,
                 appInBackground = false,
@@ -708,10 +696,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = { _, request ->
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.ERROR.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -728,17 +715,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns SERVICE_UNAVAILABLE, re-execute with backoff for restores`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         val capturedDelays = mutableListOf<Long>()
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.RESTORE,
                 appInBackground = true,
@@ -754,10 +741,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
             },
             executeRequestOnUIThread = { delay, request ->
                 capturedDelays.add(delay)
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -775,17 +761,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session for restores`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.RESTORE,
                 appInBackground = false,
@@ -801,10 +787,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = { _, request ->
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -821,17 +806,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns SERVICE_UNAVAILABLE, re-execute with backoff for purchases`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         val capturedDelays = mutableListOf<Long>()
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.PURCHASE,
                 appInBackground = true,
@@ -847,10 +832,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
             },
             executeRequestOnUIThread = { delay, request ->
                 capturedDelays.add(delay)
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -868,17 +852,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session for purchases`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.PURCHASE,
                 appInBackground = false,
@@ -894,10 +878,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = { _, request ->
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -914,17 +897,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns SERVICE_UNAVAILABLE, re-execute with backoff for unsynced active purchases`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         val capturedDelays = mutableListOf<Long>()
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
                 appInBackground = true,
@@ -940,10 +923,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
             },
             executeRequestOnUIThread = { delay, request ->
                 capturedDelays.add(delay)
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -961,17 +943,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session for unsynced active purchases`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
                 appInBackground = false,
@@ -987,10 +969,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = { _, request ->
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -1007,17 +988,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns ITEM_UNAVAILABLE, doesn't retry for restores`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.RESTORE,
                 appInBackground = false,
@@ -1033,10 +1014,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = { _, request ->
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.ITEM_UNAVAILABLE.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -1053,17 +1033,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns ITEM_UNAVAILABLE, doesn't retry for purchases`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.PURCHASE,
                 appInBackground = false,
@@ -1079,10 +1059,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = { _, request ->
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.ITEM_UNAVAILABLE.buildResult(),
-                        "purchaseToken"
                     )
                 }
 
@@ -1099,17 +1078,17 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
     @Test
     fun `If service returns ITEM_UNAVAILABLE, doesn't retry for unsynced active purchases`() {
-        val slot = slot<ConsumeResponseListener>()
-        val consumeStubbing = every {
-            mockClient.consumeAsync(
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
                 any(),
                 capture(slot),
             )
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
-        val useCase = ConsumePurchaseUseCase(
-            ConsumePurchaseUseCaseParams(
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
                 PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
                 appInBackground = false,
@@ -1125,10 +1104,9 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 it.invoke(mockClient)
             },
             executeRequestOnUIThread = { _, request ->
-                consumeStubbing answers {
-                    slot.captured.onConsumeResponse(
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.ITEM_UNAVAILABLE.buildResult(),
-                        "purchaseToken"
                     )
                 }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -1,0 +1,1181 @@
+package com.revenuecat.purchases.google.usecase
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.billingclient.api.AcknowledgePurchaseParams
+import com.android.billingclient.api.AcknowledgePurchaseResponseListener
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClientStateListener
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ConsumeParams
+import com.android.billingclient.api.ConsumeResponseListener
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.PurchaseHistoryRecord
+import com.android.billingclient.api.PurchaseHistoryResponseListener
+import com.android.billingclient.api.QueryPurchaseHistoryParams
+import com.revenuecat.purchases.PostReceiptInitiationSource
+import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.amazon.createPeriod
+import com.revenuecat.purchases.common.firstSku
+import com.revenuecat.purchases.google.toStoreTransaction
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.utils.stubGooglePurchase
+import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
+
+    private var capturedAcknowledgeResponseListener = slot<AcknowledgePurchaseResponseListener>()
+    private var capturedAcknowledgePurchaseParams = slot<AcknowledgePurchaseParams>()
+
+    @Before
+    override fun setup() {
+        super.setup()
+        every {
+            mockClient.acknowledgePurchase(
+                capture(capturedAcknowledgePurchaseParams),
+                capture(capturedAcknowledgeResponseListener)
+            )
+        } just Runs
+    }
+
+
+    @Test
+    fun `Acknowledge works`() {
+        val token = "token"
+
+        wrapper.acknowledge(
+            token,
+            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+            appInBackground = false
+        ) { }
+
+        assertThat(capturedAcknowledgePurchaseParams.isCaptured).isTrue
+        assertThat(capturedAcknowledgePurchaseParams.captured.purchaseToken).isEqualTo(token)
+    }
+
+    @Test
+    fun `tokens are not saved in cache if acknowledge fails`() {
+        val sku = "sub"
+        val token = "token_sub"
+        val googlePurchaseWrapper = getMockedPurchaseWrapper(
+            sku,
+            token,
+            ProductType.SUBS,
+            "offering_a"
+        )
+
+        wrapper.consumeAndSave(
+            shouldTryToConsume = true,
+            purchase = googlePurchaseWrapper,
+            appInBackground = false,
+            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+        )
+
+        assertThat(capturedAcknowledgeResponseListener.isCaptured).isTrue
+        capturedAcknowledgeResponseListener.captured.onAcknowledgePurchaseResponse(
+            BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult()
+        )
+
+        verify(exactly = 0) {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        }
+    }
+
+    @Test
+    fun `restored tokens are not save in cache if acknowledge fails`() {
+        val sku = "sub"
+        val token = "token_sub"
+        val historyRecordWrapper = getMockedPurchaseHistoryRecordWrapper(
+            sku,
+            token,
+            ProductType.SUBS
+        )
+
+        wrapper.consumeAndSave(
+            shouldTryToConsume = true,
+            purchase = historyRecordWrapper,
+            appInBackground = false,
+            initiationSource = PostReceiptInitiationSource.RESTORE
+        )
+
+        assertThat(capturedAcknowledgeResponseListener.isCaptured).isTrue
+        capturedAcknowledgeResponseListener.captured.onAcknowledgePurchaseResponse(
+            BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult()
+        )
+
+        verify(exactly = 0) {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        }
+    }
+
+    @Test
+    fun `subscriptions are acknowledged`() {
+        val sku = "sub"
+        val token = "token_sub"
+        val googlePurchaseWrapper = getMockedPurchaseWrapper(
+            sku,
+            token,
+            ProductType.SUBS,
+            "offering_a"
+        )
+
+        every {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        } just Runs
+
+        wrapper.consumeAndSave(
+            shouldTryToConsume = true,
+            purchase = googlePurchaseWrapper,
+            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+            appInBackground = false
+        )
+
+        assertThat(capturedAcknowledgeResponseListener.isCaptured).isTrue
+        capturedAcknowledgeResponseListener.captured.onAcknowledgePurchaseResponse(
+            billingClientOKResult
+        )
+
+        assertThat(capturedAcknowledgePurchaseParams.isCaptured).isTrue
+        val capturedAcknowledgeParams = capturedAcknowledgePurchaseParams.captured
+        assertThat(capturedAcknowledgeParams.purchaseToken).isEqualTo(token)
+    }
+
+    @Test
+    fun `restored subscriptions are acknowledged`() {
+        val sku = "sub"
+        val token = "token_sub"
+        val historyRecordWrapper = getMockedPurchaseHistoryRecordWrapper(
+            sku,
+            token,
+            ProductType.SUBS
+        )
+
+        every {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        } just Runs
+
+        wrapper.consumeAndSave(
+            shouldTryToConsume = true,
+            purchase = historyRecordWrapper,
+            appInBackground = false,
+            initiationSource = PostReceiptInitiationSource.RESTORE,
+        )
+
+        assertThat(capturedAcknowledgeResponseListener.isCaptured).isTrue
+        capturedAcknowledgeResponseListener.captured.onAcknowledgePurchaseResponse(
+            billingClientOKResult
+        )
+
+        assertThat(capturedAcknowledgePurchaseParams.isCaptured).isTrue
+        val capturedAcknowledgeParams = capturedAcknowledgePurchaseParams.captured
+        assertThat(capturedAcknowledgeParams.purchaseToken).isEqualTo(token)
+    }
+
+    @Test
+    fun `if it shouldn't consume transactions, don't acknowledge and save it in cache`() {
+        val sku = "sub"
+        val token = "token_sub"
+        val googlePurchaseWrapper = getMockedPurchaseWrapper(
+            sku,
+            token,
+            ProductType.SUBS,
+            "offering_a"
+        )
+
+        every {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        } just Runs
+
+        wrapper.consumeAndSave(
+            shouldTryToConsume = false,
+            purchase = googlePurchaseWrapper,
+            appInBackground = false,
+            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+        )
+
+        verify(exactly = 0) {
+            mockClient.acknowledgePurchase(any(), any())
+        }
+
+        verify(exactly = 1) {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        }
+    }
+
+    @Test
+    fun `if it shouldn't consume restored transactions, don't acknowledge and save it in cache`() {
+        val sku = "sub"
+        val token = "token_sub"
+        val historyRecordWrapper = getMockedPurchaseHistoryRecordWrapper(
+            sku,
+            token,
+            ProductType.SUBS
+        )
+
+        every {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        } just Runs
+
+        wrapper.consumeAndSave(
+            shouldTryToConsume = false,
+            purchase = historyRecordWrapper,
+            appInBackground = false,
+            initiationSource = PostReceiptInitiationSource.RESTORE,
+        )
+
+        verify(exactly = 0) {
+            mockClient.acknowledgePurchase(any(), any())
+        }
+
+        verify(exactly = 1) {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        }
+    }
+
+    @Test
+    fun `Do not acknowledge purchases that are already acknowledged`() {
+        val sku = "sub"
+        val token = "token_sub"
+        val googlePurchaseWrapper = getMockedPurchaseWrapper(
+            sku,
+            token,
+            ProductType.SUBS,
+            "offering_a",
+            acknowledged = true
+        )
+
+        every {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        } just Runs
+
+        wrapper.consumeAndSave(
+            shouldTryToConsume = true,
+            purchase = googlePurchaseWrapper,
+            appInBackground = false,
+            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+        )
+
+        verify(exactly = 0) {
+            mockClient.acknowledgePurchase(any(), any())
+        }
+
+        verify(exactly = 1) {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        }
+    }
+
+
+
+    // region retries
+
+    @Test
+    fun `If service is disconnected, re-executeRequestOnUIThread for purchases`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedToken: String? = null
+        var timesExecutedInMainThread = 0
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.PURCHASE,
+                appInBackground = false,
+            ),
+            { received ->
+                receivedToken = received
+            },
+            { _ ->
+                Assertions.fail("shouldn't be an error")
+            },
+            withConnectedClient = {
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                timesExecutedInMainThread++
+
+                consumeStubbing answers {
+                    if (timesExecutedInMainThread == 1) {
+                        slot.captured.onConsumeResponse(
+                            billingClientDisconnectedResult,
+                            "purchaseToken"
+                        )
+                    } else {
+                        slot.captured.onConsumeResponse(
+                            billingClientOKResult,
+                            "purchaseToken"
+                        )
+                    }
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesExecutedInMainThread).isEqualTo(2)
+        assertThat(receivedToken).isNotNull
+        assertThat(receivedToken).isEqualTo("purchaseToken")
+    }
+
+    @Test
+    fun `If service is disconnected, re-executeRequestOnUIThread for restores`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedToken: String? = null
+        var timesExecutedInMainThread = 0
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.RESTORE,
+                appInBackground = false,
+            ),
+            { received ->
+                receivedToken = received
+            },
+            { _ ->
+                Assertions.fail("shouldn't be an error")
+            },
+            withConnectedClient = {
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                timesExecutedInMainThread++
+
+                consumeStubbing answers {
+                    if (timesExecutedInMainThread == 1) {
+                        slot.captured.onConsumeResponse(
+                            billingClientDisconnectedResult,
+                            "purchaseToken"
+                        )
+                    } else {
+                        slot.captured.onConsumeResponse(
+                            billingClientOKResult,
+                            "purchaseToken"
+                        )
+                    }
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesExecutedInMainThread).isEqualTo(2)
+        assertThat(receivedToken).isNotNull
+        assertThat(receivedToken).isEqualTo("purchaseToken")
+    }
+
+    @Test
+    fun `If service is disconnected, re-executeRequestOnUIThread for unsynced active purchases`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedToken: String? = null
+        var timesExecutedInMainThread = 0
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+                appInBackground = false,
+            ),
+            { received ->
+                receivedToken = received
+            },
+            { _ ->
+                Assertions.fail("shouldn't be an error")
+            },
+            withConnectedClient = {
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                timesExecutedInMainThread++
+
+                consumeStubbing answers {
+                    if (timesExecutedInMainThread == 1) {
+                        slot.captured.onConsumeResponse(
+                            billingClientDisconnectedResult,
+                            "purchaseToken"
+                        )
+                    } else {
+                        slot.captured.onConsumeResponse(
+                            billingClientOKResult,
+                            "purchaseToken"
+                        )
+                    }
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesExecutedInMainThread).isEqualTo(2)
+        assertThat(receivedToken).isNotNull
+        assertThat(receivedToken).isEqualTo("purchaseToken")
+    }
+
+    @Test
+    fun `If service returns NETWORK_ERROR, re-execute with backoff if source is unsynced active purchases`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        val capturedDelays = mutableListOf<Long>()
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+                appInBackground = false,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.NETWORK_ERROR.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(capturedDelays.size).isEqualTo(12)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.NetworkError)
+    }
+
+    @Test
+    fun `If service returns NETWORK_ERROR, re-execute a max of 3 times if source is a purchase`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        var timesRetried = 0
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.PURCHASE,
+                appInBackground = false,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                timesRetried++
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.NETWORK_ERROR.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesRetried).isEqualTo(4) // First attempt plus 3 retries
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.NetworkError)
+    }
+
+    @Test
+    fun `If service returns NETWORK_ERROR, re-execute a max of 3 times if source is a restore`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        var timesRetried = 0
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.RESTORE,
+                appInBackground = false,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                timesRetried++
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.NETWORK_ERROR.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesRetried).isEqualTo(4) // First attempt plus 3 retries
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.NetworkError)
+    }
+
+    @Test
+    fun `If service returns ERROR, re-execute with backoff if source is unsynced active purchases`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        val capturedDelays = mutableListOf<Long>()
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+                appInBackground = false,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.ERROR.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(capturedDelays.size).isEqualTo(12)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+    }
+
+    @Test
+    fun `If service returns ERROR, re-execute a max of 3 times if source is a purchase`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        var timesRetried = 0
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.PURCHASE,
+                appInBackground = false,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                timesRetried++
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.ERROR.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesRetried).isEqualTo(4) // First attempt plus 3 retries
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+    }
+
+    @Test
+    fun `If service returns ERROR, re-execute a max of 3 times if source is a restore`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        var timesRetried = 0
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.RESTORE,
+                appInBackground = false,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                timesRetried++
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.ERROR.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesRetried).isEqualTo(4) // First attempt plus 3 retries
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+    }
+
+    @Test
+    fun `If service returns SERVICE_UNAVAILABLE, re-execute with backoff for restores`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        val capturedDelays = mutableListOf<Long>()
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.RESTORE,
+                appInBackground = true,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(capturedDelays.size).isEqualTo(12)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+    }
+
+    @Test
+    fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session for restores`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        var timesRetried = 0
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.RESTORE,
+                appInBackground = false,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                timesRetried++
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesRetried).isEqualTo(1)
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+    }
+
+    @Test
+    fun `If service returns SERVICE_UNAVAILABLE, re-execute with backoff for purchases`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        val capturedDelays = mutableListOf<Long>()
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.PURCHASE,
+                appInBackground = true,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(capturedDelays.size).isEqualTo(12)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+    }
+
+    @Test
+    fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session for purchases`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        var timesRetried = 0
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.PURCHASE,
+                appInBackground = false,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                timesRetried++
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesRetried).isEqualTo(1)
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+    }
+
+    @Test
+    fun `If service returns SERVICE_UNAVAILABLE, re-execute with backoff for unsynced active purchases`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        val capturedDelays = mutableListOf<Long>()
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+                appInBackground = true,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(capturedDelays.size).isEqualTo(12)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+    }
+
+    @Test
+    fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session for unsynced active purchases`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        var timesRetried = 0
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+                appInBackground = false,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                timesRetried++
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesRetried).isEqualTo(1)
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
+    }
+
+    @Test
+    fun `If service returns ITEM_UNAVAILABLE, doesn't retry for restores`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        var timesRetried = 0
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.RESTORE,
+                appInBackground = false,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                timesRetried++
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.ITEM_UNAVAILABLE.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesRetried).isEqualTo(1)
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.ProductNotAvailableForPurchaseError)
+    }
+
+    @Test
+    fun `If service returns ITEM_UNAVAILABLE, doesn't retry for purchases`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        var timesRetried = 0
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.PURCHASE,
+                appInBackground = false,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                timesRetried++
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.ITEM_UNAVAILABLE.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesRetried).isEqualTo(1)
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.ProductNotAvailableForPurchaseError)
+    }
+
+    @Test
+    fun `If service returns ITEM_UNAVAILABLE, doesn't retry for unsynced active purchases`() {
+        val slot = slot<ConsumeResponseListener>()
+        val consumeStubbing = every {
+            mockClient.consumeAsync(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        var timesRetried = 0
+        val useCase = ConsumePurchaseUseCase(
+            ConsumePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+                appInBackground = false,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                timesRetried++
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                consumeStubbing answers {
+                    slot.captured.onConsumeResponse(
+                        BillingClient.BillingResponseCode.ITEM_UNAVAILABLE.buildResult(),
+                        "purchaseToken"
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesRetried).isEqualTo(1)
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.ProductNotAvailableForPurchaseError)
+    }
+
+    // endregion retries
+
+    private fun getMockedPurchaseWrapper(
+        productId: String,
+        purchaseToken: String,
+        productType: ProductType,
+        offeringIdentifier: String? = null,
+        purchaseState: Int = Purchase.PurchaseState.PURCHASED,
+        acknowledged: Boolean = false
+    ): StoreTransaction {
+        val p = stubGooglePurchase(
+            productIds = listOf(productId),
+            purchaseToken = purchaseToken,
+            purchaseState = purchaseState,
+            acknowledged = acknowledged
+        )
+
+        return p.toStoreTransaction(productType, offeringIdentifier)
+    }
+
+    private fun getMockedPurchaseHistoryRecordWrapper(
+        productId: String,
+        purchaseToken: String,
+        productType: ProductType
+    ): StoreTransaction {
+        val p: PurchaseHistoryRecord = stubPurchaseHistoryRecord(
+            productIds = listOf(productId),
+            purchaseToken = purchaseToken
+        )
+
+        return p.toStoreTransaction(
+            type = productType
+        )
+    }
+
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -71,6 +71,101 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
     }
 
     @Test
+    fun `tokens from UNSYNCED_ACTIVE_PURCHASES are saved in cache when acknowledging`() {
+        val sku = "sub"
+        val token = "token_sub"
+        val googlePurchaseWrapper = getMockedPurchaseWrapper(
+            sku,
+            token,
+            ProductType.SUBS,
+            "offering_a"
+        )
+
+        every {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        } just Runs
+
+        wrapper.consumeAndSave(
+            shouldTryToConsume = true,
+            purchase = googlePurchaseWrapper,
+            appInBackground = false,
+            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+        )
+
+        assertThat(capturedAcknowledgeResponseListener.isCaptured).isTrue
+        capturedAcknowledgeResponseListener.captured.onAcknowledgePurchaseResponse(
+            billingClientOKResult
+        )
+
+        verify(exactly = 1) {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        }
+    }
+
+    @Test
+    fun `tokens from PURCHASES are saved in cache when acknowledging`() {
+        val sku = "sub"
+        val token = "token_sub"
+        val googlePurchaseWrapper = getMockedPurchaseWrapper(
+            sku,
+            token,
+            ProductType.SUBS,
+            "offering_a"
+        )
+
+        every {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        } just Runs
+
+        wrapper.consumeAndSave(
+            shouldTryToConsume = true,
+            purchase = googlePurchaseWrapper,
+            appInBackground = false,
+            initiationSource = PostReceiptInitiationSource.PURCHASE,
+        )
+
+        assertThat(capturedAcknowledgeResponseListener.isCaptured).isTrue
+        capturedAcknowledgeResponseListener.captured.onAcknowledgePurchaseResponse(
+            billingClientOKResult
+        )
+
+        verify(exactly = 1) {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        }
+    }
+
+    @Test
+    fun `restored tokens are saved in cache when acknowledging`() {
+        val sku = "sub"
+        val token = "token_sub"
+        val historyRecordWrapper = getMockedPurchaseHistoryRecordWrapper(
+            sku,
+            token,
+            ProductType.SUBS
+        )
+
+        every {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        } just Runs
+
+        wrapper.consumeAndSave(
+            shouldTryToConsume = true,
+            purchase = historyRecordWrapper,
+            appInBackground = false,
+            initiationSource = PostReceiptInitiationSource.RESTORE,
+        )
+
+        assertThat(capturedAcknowledgeResponseListener.isCaptured).isTrue
+        capturedAcknowledgeResponseListener.captured.onAcknowledgePurchaseResponse(
+            billingClientOKResult
+        )
+
+        verify(exactly = 1) {
+            mockDeviceCache.addSuccessfullyPostedToken(token)
+        }
+    }
+
+    @Test
     fun `tokens are not saved in cache if acknowledge fails`() {
         val sku = "sub"
         val token = "token_sub"


### PR DESCRIPTION
Creates a `AcknowledgePurchaseUseCase`. Similar to https://github.com/RevenueCat/purchases-android/pull/1487