### PR TITLE
Avoid creating threads when dispatching tasks

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -85,9 +85,15 @@ internal class PurchasesFactory(
 
             val eTagManager = ETagManager(context)
 
-            val dispatcher = Dispatcher(createDefaultExecutor(), runningIntegrationTests)
-            val backendDispatcher = Dispatcher(service ?: createDefaultExecutor(), runningIntegrationTests)
-            val eventsDispatcher = Dispatcher(createEventsExecutor(), runningIntegrationTests)
+            val dispatcher = Dispatcher(createDefaultExecutor(), runningIntegrationTests = runningIntegrationTests)
+            val backendDispatcher = Dispatcher(
+                service ?: createDefaultExecutor(),
+                runningIntegrationTests = runningIntegrationTests,
+            )
+            val eventsDispatcher = Dispatcher(
+                createEventsExecutor(),
+                runningIntegrationTests = runningIntegrationTests,
+            )
 
             var diagnosticsFileHelper: DiagnosticsFileHelper? = null
             var diagnosticsTracker: DiagnosticsTracker? = null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Dispatcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Dispatcher.kt
@@ -62,13 +62,13 @@ internal open class Dispatcher(
     ) {
         synchronized(this.executorService) {
             if (!executorService.isShutdown) {
-                val commandHandlingExceptions: Runnable = Runnable {
+                val commandHandlingExceptions = Runnable {
                     try {
                         command.run()
                     } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                         errorLog("Exception running command: $e")
                         mainHandler?.post {
-                            e.cause?.let { throw it }
+                            throw e.cause ?: e
                         }
                     }
                 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Dispatcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Dispatcher.kt
@@ -67,8 +67,9 @@ internal open class Dispatcher(
                         command.run()
                     } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                         errorLog("Exception running command: $e")
+                        // We propagate the exception to the main thread to be sure it's not swallowed.
                         mainHandler?.post {
-                            throw e.cause ?: e
+                            throw e
                         }
                     }
                 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Dispatcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Dispatcher.kt
@@ -5,6 +5,8 @@
 
 package com.revenuecat.purchases.common
 
+import android.os.Handler
+import android.os.Looper
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.verification.SignatureVerificationException
@@ -24,6 +26,7 @@ internal enum class Delay(val minDelay: Duration, val maxDelay: Duration) {
 
 internal open class Dispatcher(
     private val executorService: ExecutorService,
+    private val mainHandler: Handler? = Handler(Looper.getMainLooper()),
     private val runningIntegrationTests: Boolean = false,
 ) {
     private companion object {
@@ -59,28 +62,24 @@ internal open class Dispatcher(
     ) {
         synchronized(this.executorService) {
             if (!executorService.isShutdown) {
-                val future = if (delay != Delay.NONE && executorService is ScheduledExecutorService) {
+                if (delay != Delay.NONE && executorService is ScheduledExecutorService) {
                     var delayToApply = (delay.minDelay.inWholeMilliseconds..delay.maxDelay.inWholeMilliseconds).random()
                     if (runningIntegrationTests) {
                         delayToApply = (delayToApply * INTEGRATION_TEST_DELAY_PERCENTAGE).toLong()
                     }
                     executorService.schedule(command, delayToApply, TimeUnit.MILLISECONDS)
                 } else {
-                    executorService.submit(command)
-                }
-
-                // Exceptions are being swallowed if using execute instead of submit
-                // Future.get is blocking so we create a Thread
-                // More info: https://github.com/RevenueCat/purchases-android/pull/234
-                Thread {
-                    try {
-                        future.get()
-                    } catch (e: InterruptedException) {
-                        Thread.currentThread().interrupt()
-                    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                        e.cause?.let { throw it }
+                    executorService.submit {
+                        try {
+                            command.run()
+                        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                            errorLog("Exception running command: $e")
+                            mainHandler?.post {
+                                e.cause?.let { throw it }
+                            }
+                        }
                     }
-                }.start()
+                }
             }
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Dispatcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Dispatcher.kt
@@ -62,7 +62,7 @@ internal open class Dispatcher(
     ) {
         synchronized(this.executorService) {
             if (!executorService.isShutdown) {
-                val commandHandlingExceptions = {
+                val commandHandlingExceptions: Runnable = Runnable {
                     try {
                         command.run()
                     } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/SyncDispatcher.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/SyncDispatcher.kt
@@ -5,7 +5,7 @@ import com.revenuecat.purchases.common.Dispatcher
 import io.mockk.mockk
 import java.util.concurrent.RejectedExecutionException
 
-internal class SyncDispatcher : Dispatcher(mockk()) {
+internal class SyncDispatcher : Dispatcher(mockk(), MockHandlerFactory.createMockHandler()) {
 
     private var closed = false
 


### PR DESCRIPTION
### Description
We were creating threads every time we added a task to the executor service. This shouldn't be a problem if tasks ended early and not too many tasks were in the queue, but it's not very efficient. This is another implementation to propagate exceptions to the main thread so they can be thrown and not swallowed when they happen on the thread pool.