### PR TITLE
Fix integration tests

### DIFF
--- a/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -143,8 +143,9 @@ open class BasePurchasesIntegrationTest {
         every {
             mockBillingAbstract.queryPurchases(
                 testUserId,
-                capture(callbackSlot),
-                any(),
+                appInBackground = any(),
+                onSuccess = capture(callbackSlot),
+                onError = any(),
             )
         } answers {
             callbackSlot.captured.invoke(activePurchases)

--- a/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/offlineentitlements/BaseOfflineEntitlementsIntegrationTest.kt
+++ b/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/offlineentitlements/BaseOfflineEntitlementsIntegrationTest.kt
@@ -50,13 +50,13 @@ abstract class BaseOfflineEntitlementsIntegrationTest : BasePurchasesIntegration
 
     protected fun assertAcknowledgePurchaseDidNotHappen() {
         verify(exactly = 0) {
-            mockBillingAbstract.consumeAndSave(any(), any(), initiationSource)
+            mockBillingAbstract.consumeAndSave(any(), any(), initiationSource = any(), appInBackground = any())
         }
     }
 
     protected fun assertAcknowledgePurchaseDidHappen(timeout: Duration = testTimeout) {
         verify(timeout = timeout.inWholeMilliseconds) {
-            mockBillingAbstract.consumeAndSave(any(), any(), initiationSource)
+            mockBillingAbstract.consumeAndSave(any(), any(), initiationSource = any(), appInBackground = any())
         }
     }
 


### PR DESCRIPTION
### Description
Looks like integration tests broke in the recent billing wrapper refactors. We didn't notice since these run nightly on main. This fixes them
