### PR TITLE
Fixes on generate_snapshots_RCUI lane

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "fastlane"
 gem 'danger'
+gem 'rest-client'
 
 eval_gemfile("fastlane/Pluginfile")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,7 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     highline (2.0.3)
+    http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     httpclient (2.8.3)
@@ -186,6 +187,9 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
+    mime-types (3.5.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.1003)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     multi_json (1.15.0)
@@ -193,6 +197,7 @@ GEM
     nanaimo (0.3.0)
     nap (1.1.0)
     naturally (2.2.1)
+    netrc (0.11.0)
     no_proxy_fix (0.1.2)
     octokit (7.2.0)
       faraday (>= 1, < 3)
@@ -208,6 +213,11 @@ GEM
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (3.1.2)
     rexml (3.2.6)
     rouge (2.0.7)
@@ -257,6 +267,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-revenuecat_internal!
   fastlane-plugin-versioning_android
+  rest-client
 
 BUNDLED WITH
    2.3.14

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -624,7 +624,6 @@ DESC
     Dir.chdir("..") do
       sh "cp -rf #{revenuecatui_snapshots_location}/** #{snapshots_repo_name}/revenuecatui"
     end
-    create_snapshots_repo_pr
   end
 
   desc "Creates a new PR on purchases-ios-snapshots after new snapshot files were generated"
@@ -641,7 +640,7 @@ DESC
   desc "Trigger CircleCI job to generate snapshots for RevenueCatUI"
   lane :generate_snapshots_RCUI do
     generate_snapshots(
-      pipeline: "record-revenuecatui-snapshots"
+      action: "generate_revenuecatui_snapshots"
     )
   end
 
@@ -662,18 +661,18 @@ DESC
   private_lane :generate_snapshots do |options|
     require 'rest-client'
 
+    # Get CircleCI token
+    circle_token = ENV["CIRCLE_TOKEN"]
+    UI.user_error! "Please set the CIRCLE_TOKEN environment variable" unless circle_token
+
     # Prompt branch
     default_branch = git_branch
     branch = UI.input("Branch (defaults to #{default_branch}): ")
     branch = default_branch if branch == ""
 
-    # Get CircleCI token
-    circle_token = ENV["CIRCLE_TOKEN"]
-    UI.user_error! "Please set the CIRCLE_TOKEN environment variable" unless circle_token
-
     # Make request
     headers = {"Circle-Token": circle_token, "Content-Type": "application/json", "Accept": "application/json"}
-    data = {parameters: {options[:pipeline] => true}, branch: branch}
+    data = {parameters: {:action => options[:action]}, branch: branch}
     url = "https://circleci.com/api/v2/project/github/RevenueCat/#{repo_name}/pipeline"
 
     resp = RestClient.post url, data.to_json, headers


### PR DESCRIPTION
- Fixed missing dependency
- Fixed passing wrong parameter to CircleCI (`Unexpected argument(s): record-revenuecatui-snapshots`)
- Fixed duplicated `create_snapshots_repo_pr` https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/9068/workflows/743d2c2b-7063-4cca-861b-cef31d0e7b48/jobs/33675
