### PR TITLE
Create `PurchasesStateProvider`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
@@ -19,12 +19,14 @@ internal object BillingFactory {
         cache: DeviceCache,
         observerMode: Boolean,
         diagnosticsTrackerIfEnabled: DiagnosticsTracker?,
+        stateProvider: PurchasesStateProvider,
     ) = when (store) {
         Store.PLAY_STORE -> BillingWrapper(
             BillingWrapper.ClientFactory(application),
             Handler(application.mainLooper),
             cache,
             diagnosticsTrackerIfEnabled,
+            stateProvider,
         )
         Store.AMAZON -> {
             try {
@@ -34,6 +36,7 @@ internal object BillingFactory {
                     observerMode,
                     Handler(application.mainLooper),
                     backendHelper,
+                    stateProvider,
                 )
             } catch (e: NoClassDefFoundError) {
                 errorLog("Make sure purchases-amazon is added as dependency", e)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -126,6 +126,8 @@ internal class PurchasesFactory(
                 backendHelper,
             )
 
+            val purchasesStateProvider = PurchasesStateProvider()
+
             // Override used for integration tests.
             val billing: BillingAbstract = overrideBillingAbstract ?: BillingFactory.createBilling(
                 store,
@@ -134,6 +136,7 @@ internal class PurchasesFactory(
                 cache,
                 observerMode,
                 diagnosticsTracker,
+                purchasesStateProvider,
             )
 
             val subscriberAttributesPoster = SubscriberAttributesPoster(backendHelper)
@@ -268,6 +271,7 @@ internal class PurchasesFactory(
                 offeringsManager,
                 createPaywallEventsManager(application, identityManager, eventsDispatcher, backend),
                 paywallPresentedCache,
+                purchasesStateProvider,
             )
 
             return Purchases(purchasesOrchestrator)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -88,20 +88,19 @@ internal class PurchasesOrchestrator constructor(
     private val offeringsManager: OfferingsManager,
     private val paywallEventsManager: PaywallEventsManager?,
     private val paywallPresentedCache: PaywallPresentedCache,
+    private val stateProvider: PurchasesStateProvider,
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper()),
 ) : LifecycleDelegate, CustomActivityLifecycleHandler {
 
     /** @suppress */
-    @Suppress("RedundantGetter", "RedundantSetter")
-    @Volatile
-    internal var state = PurchasesState()
+    internal var state: PurchasesState
         @Synchronized
-        get() = field
+        get() = stateProvider.purchasesState
 
         @Synchronized
         set(value) {
-            field = value
+            stateProvider.purchasesState = value
         }
 
     var finishTransactions: Boolean

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesStateProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesStateProvider.kt
@@ -1,0 +1,5 @@
+package com.revenuecat.purchases
+
+internal data class PurchasesStateProvider(
+    var purchasesState: PurchasesState = PurchasesState(),
+)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCallback
+import com.revenuecat.purchases.PurchasesStateProvider
 import com.revenuecat.purchases.models.InAppMessageType
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreProduct
@@ -13,7 +14,10 @@ import com.revenuecat.purchases.models.StoreTransaction
 internal typealias StoreProductsCallback = (List<StoreProduct>) -> Unit
 
 @SuppressWarnings("TooManyFunctions")
-internal abstract class BillingAbstract {
+internal abstract class BillingAbstract(
+    @get:Synchronized
+    protected val purchasesStateProvider: PurchasesStateProvider,
+) {
 
     @get:Synchronized
     @set:Synchronized

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -25,6 +25,7 @@ import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCallback
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesStateProvider
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
@@ -81,8 +82,9 @@ internal class BillingWrapper(
     private val deviceCache: DeviceCache,
     @Suppress("unused")
     private val diagnosticsTrackerIfEnabled: DiagnosticsTracker?,
+    purchasesStateProvider: PurchasesStateProvider,
     private val dateProvider: DateProvider = DefaultDateProvider(),
-) : BillingAbstract(), PurchasesUpdatedListener, BillingClientStateListener {
+) : BillingAbstract(purchasesStateProvider), PurchasesUpdatedListener, BillingClientStateListener {
 
     @get:Synchronized
     @set:Synchronized
@@ -523,7 +525,7 @@ internal class BillingWrapper(
             QueryPurchasesByTypeUseCaseParams(
                 dateProvider,
                 diagnosticsTrackerIfEnabled,
-                appInBackground = false,
+                appInBackground = purchasesStateProvider.purchasesState.appInBackground,
                 productType = productType,
             ),
             onSuccess = { purchases ->

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -70,6 +70,7 @@ internal open class BasePurchasesTest {
     internal val mockSyncPurchasesHelper = mockk<SyncPurchasesHelper>()
     protected val mockOfferingsManager = mockk<OfferingsManager>()
     internal val mockPaywallEventsManager = mockk<PaywallEventsManager>()
+    private val purchasesStateProvider = PurchasesStateProvider()
 
     protected var capturedPurchasesUpdatedListener = slot<BillingAbstract.PurchasesUpdatedListener>()
     protected var capturedBillingWrapperStateListener = slot<BillingAbstract.StateListener>()
@@ -407,6 +408,7 @@ internal open class BasePurchasesTest {
             offeringsManager = mockOfferingsManager,
             paywallEventsManager = mockPaywallEventsManager,
             paywallPresentedCache = paywallPresentedCache,
+            stateProvider = purchasesStateProvider,
         )
         purchases = Purchases(purchasesOrchestrator)
         Purchases.sharedInstance = purchases

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
@@ -25,7 +25,8 @@ class BillingFactoryTest {
             mockBackendHelper,
             mockCache,
             observerMode = false,
-            mockDiagnosticsTracker
+            mockDiagnosticsTracker,
+            PurchasesStateProvider()
         )
     }
 
@@ -41,7 +42,8 @@ class BillingFactoryTest {
             mockBackendHelper,
             mockCache,
             observerMode = false,
-            diagnosticsTrackerIfEnabled = null
+            diagnosticsTrackerIfEnabled = null,
+            PurchasesStateProvider()
         )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCallback
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesStateProvider
 import com.revenuecat.purchases.amazon.handler.ProductDataHandler
 import com.revenuecat.purchases.amazon.handler.PurchaseHandler
 import com.revenuecat.purchases.amazon.handler.PurchaseUpdatesHandler
@@ -70,7 +71,8 @@ class AmazonBillingTest {
             purchaseHandler = mockPurchaseHandler,
             purchaseUpdatesHandler = mockPurchaseUpdatesHandler,
             userDataHandler = mockUserDataHandler,
-            mainHandler = handler
+            mainHandler = handler,
+            stateProvider = PurchasesStateProvider()
         )
 
         mockSetupFunctions()
@@ -90,7 +92,8 @@ class AmazonBillingTest {
             productDataHandler = mockProductDataHandler,
             purchaseHandler = mockPurchaseHandler,
             purchaseUpdatesHandler = mockPurchaseUpdatesHandler,
-            userDataHandler = mockUserDataHandler
+            userDataHandler = mockUserDataHandler,
+            stateProvider = PurchasesStateProvider()
         )
 
         mockSetupFunctions()

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.amazon
 import android.app.Application
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.BillingFactory
+import com.revenuecat.purchases.PurchasesStateProvider
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.caching.DeviceCache
@@ -27,7 +28,8 @@ class BillingFactoryAmazonTest {
             mockBackendHelper,
             mockCache,
             observerMode = false,
-            mockDiagnosticsTracker
+            mockDiagnosticsTracker,
+            stateProvider = PurchasesStateProvider()
         )
     }
 
@@ -43,7 +45,8 @@ class BillingFactoryAmazonTest {
             mockBackendHelper,
             mockCache,
             observerMode = false,
-            diagnosticsTrackerIfEnabled = null
+            diagnosticsTrackerIfEnabled = null,
+            stateProvider = PurchasesStateProvider()
         )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesStateProvider
 import com.revenuecat.purchases.assertDebugLog
 import com.revenuecat.purchases.assertErrorLog
 import com.revenuecat.purchases.assertVerboseLog
@@ -110,6 +111,7 @@ class BillingWrapperTest {
 
     private val subsGoogleProductType = ProductType.SUBS.toGoogleProductType()!!
     private val inAppGoogleProductType = ProductType.INAPP.toGoogleProductType()!!
+    private val purchasesStateProvider = PurchasesStateProvider()
 
     @Before
     fun setup() {
@@ -153,7 +155,14 @@ class BillingWrapperTest {
 
         mockDetailsList = listOf(mockProductDetails())
 
-        wrapper = BillingWrapper(mockClientFactory, handler, mockDeviceCache, mockDiagnosticsTracker, mockDateProvider)
+        wrapper = BillingWrapper(
+            mockClientFactory,
+            handler,
+            mockDeviceCache,
+            mockDiagnosticsTracker,
+            purchasesStateProvider,
+            mockDateProvider
+        )
         wrapper.purchasesUpdatedListener = mockPurchasesListener
         wrapper.startConnectionOnMainThread()
         onConnectedCalled = false

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/BaseBillingUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/BaseBillingUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.PurchasesUpdatedListener
+import com.revenuecat.purchases.PurchasesStateProvider
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
@@ -45,6 +46,7 @@ internal open class BaseBillingUseCaseTest {
 
     private var onConnectedCalled: Boolean = false
     private var mockPurchasesListener: BillingAbstract.PurchasesUpdatedListener = mockk()
+    private val purchasesStateProvider = PurchasesStateProvider()
 
     @Before
     open fun setup() {
@@ -75,7 +77,14 @@ internal open class BaseBillingUseCaseTest {
             mockClient.isReady
         } returns false andThen true
 
-        wrapper = BillingWrapper(mockClientFactory, handler, mockDeviceCache, mockDiagnosticsTracker, mockDateProvider)
+        wrapper = BillingWrapper(
+            mockClientFactory,
+            handler,
+            mockDeviceCache,
+            mockDiagnosticsTracker,
+            purchasesStateProvider,
+            mockDateProvider
+        )
         wrapper.purchasesUpdatedListener = mockPurchasesListener
         wrapper.startConnectionOnMainThread()
         onConnectedCalled = false

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.PostReceiptHelper
 import com.revenuecat.purchases.PostTransactionWithProductDetailsHelper
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesOrchestrator
+import com.revenuecat.purchases.PurchasesStateProvider
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
@@ -98,7 +99,8 @@ class SubscriberAttributesPurchasesTests {
             syncPurchasesHelper = mockk(),
             offeringsManager = offeringsManagerMock,
             paywallEventsManager = null,
-            paywallPresentedCache = PaywallPresentedCache()
+            paywallPresentedCache = PaywallPresentedCache(),
+            stateProvider = PurchasesStateProvider()
         )
 
         underTest = Purchases(purchasesOrchestrator)


### PR DESCRIPTION
This will help removing `appInForeground` as a parameter of many functions, specially in the `BillingWrapper`

Since this could become a very big refactor I decided to just go with changing the getter of `PurchasesOrchestrator.state` for now to get the state held by a `PurchasesStateProvider`.

Future PRs will remove the `appInForeground` parameter and access the state directly.