### PR TITLE
Paywalls: Auto-close paywall activity if restore grants required entitlement identifier

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallResultAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallResultAPI.java
@@ -29,7 +29,10 @@ final class PaywallResultAPI {
         PurchasesError error2 = result2.getError();
         final PaywallResult.Purchased result3 = new PaywallResult.Purchased(customerInfo);
         CustomerInfo customerInfo2 = result3.getCustomerInfo();
+        final PaywallResult.Restored result4 = new PaywallResult.Restored(customerInfo);
+        CustomerInfo customerInfo3 = result4.getCustomerInfo();
         final PaywallResult result2AsSealedClass = result2;
         final PaywallResult result3AsSealedClass = result3;
+        final PaywallResult result4AsSealedClass = result4;
     }
 }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallResultAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallResultAPI.kt
@@ -26,9 +26,13 @@ private class PaywallResultAPI {
             is PaywallResult.Purchased -> {
                 val customerInfo2: CustomerInfo = paywallResult.customerInfo
             }
+            is PaywallResult.Restored -> {
+                val customerInfo3: CustomerInfo = paywallResult.customerInfo
+            }
         }
         val parcelable: Parcelable = paywallResult
         val result2 = PaywallResult.Error(error)
         val result3 = PaywallResult.Purchased(customerInfo)
+        val result4 = PaywallResult.Restored(customerInfo)
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -101,8 +101,8 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
     }
 
     override fun onRestoreCompleted(customerInfo: CustomerInfo) {
-        val requiredEntitlementIdentifier = getArgs()?.requiredEntitlementIdentifier ?: return
         setResult(RESULT_OK, createResultIntent(PaywallResult.Restored(customerInfo)))
+        val requiredEntitlementIdentifier = getArgs()?.requiredEntitlementIdentifier ?: return
         if (customerInfo.entitlements.active.containsKey(requiredEntitlementIdentifier)) {
             finish()
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -102,8 +102,8 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
 
     override fun onRestoreCompleted(customerInfo: CustomerInfo) {
         val requiredEntitlementIdentifier = getArgs()?.requiredEntitlementIdentifier ?: return
+        setResult(RESULT_OK, createResultIntent(PaywallResult.Restored(customerInfo)))
         if (customerInfo.entitlements.active.containsKey(requiredEntitlementIdentifier)) {
-            setResult(RESULT_OK, createResultIntent(PaywallResult.Restored(customerInfo)))
             finish()
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -100,6 +100,14 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
         finish()
     }
 
+    override fun onRestoreCompleted(customerInfo: CustomerInfo) {
+        val requiredEntitlementIdentifier = getArgs()?.requiredEntitlementIdentifier ?: return
+        if (customerInfo.entitlements.active.containsKey(requiredEntitlementIdentifier)) {
+            setResult(RESULT_OK, createResultIntent(PaywallResult.Restored(customerInfo)))
+            finish()
+        }
+    }
+
     override fun onPurchaseError(error: PurchasesError) {
         val result = if (error.code == PurchasesErrorCode.PurchaseCancelledError) {
             PaywallResult.Cancelled

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
@@ -12,15 +12,18 @@ internal const val DEFAULT_DISPLAY_DISMISS_BUTTON = true
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Parcelize
 internal data class PaywallActivityArgs(
+    val requiredEntitlementIdentifier: String? = null,
     val offeringId: String? = null,
     val fonts: Map<TypographyType, PaywallFontFamily?>? = null,
     val shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
 ) : Parcelable {
     constructor(
+        requiredEntitlementIdentifier: String? = null,
         offeringId: String? = null,
         fontProvider: ParcelizableFontProvider?,
         shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
     ) : this(
+        requiredEntitlementIdentifier,
         offeringId,
         fontProvider?.let { TypographyType.values().associateBy({ it }, { fontProvider.getFont(it) }) },
         shouldDisplayDismissButton,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -70,12 +70,19 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
         fontProvider: ParcelizableFontProvider? = null,
         shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
     ) {
-        launchIfNeeded(
-            offering = offering,
-            fontProvider = fontProvider,
-            shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier),
-            shouldDisplayDismissButton = shouldDisplayDismissButton,
-        )
+        val shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier)
+        shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
+            if (shouldDisplay) {
+                activityResultLauncher.launch(
+                    PaywallActivityArgs(
+                        requiredEntitlementIdentifier = requiredEntitlementIdentifier,
+                        offeringId = offering?.identifier,
+                        fontProvider = fontProvider,
+                        shouldDisplayDismissButton = shouldDisplayDismissButton,
+                    ),
+                )
+            }
+        }
     }
 
     /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallResult.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallResult.kt
@@ -24,9 +24,15 @@ sealed class PaywallResult : Parcelable {
     data class Purchased(val customerInfo: CustomerInfo) : PaywallResult(), Parcelable
 
     /**
-     * The user tried to purchase a product but an error occured. If they tried multiple times,
+     * The user tried to purchase a product but an error occurred. If they tried multiple times,
      * the error corresponds to the last attempt.
      */
     @Parcelize
     data class Error(val error: PurchasesError) : PaywallResult(), Parcelable
+
+    /**
+     * The user restored and got the required entitlement identifier granted.
+     */
+    @Parcelize
+    data class Restored(val customerInfo: CustomerInfo) : PaywallResult(), Parcelable
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallResult.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallResult.kt
@@ -31,7 +31,7 @@ sealed class PaywallResult : Parcelable {
     data class Error(val error: PurchasesError) : PaywallResult(), Parcelable
 
     /**
-     * The user restored and got the required entitlement identifier granted.
+     * The last action the user performed in the paywall activity was a restore.
      */
     @Parcelize
     data class Restored(val customerInfo: CustomerInfo) : PaywallResult(), Parcelable


### PR DESCRIPTION
### Description
Users could potentially restore their purchases and get entitlements granted but the paywall activity was not dismissing. This will add that functionality in the case where users use the `requiredEntitlementIdentifier` parameter to launch the activity.

This adds a new `PaywallResult` value, `Restored`. This will be returned if the last action the user performed was a restore.