### PR TITLE
Remove unnecessary appInBackground parameters

### DIFF
--- a/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -143,7 +143,6 @@ open class BasePurchasesIntegrationTest {
         every {
             mockBillingAbstract.queryPurchases(
                 testUserId,
-                appInBackground = any(),
                 onSuccess = capture(callbackSlot),
                 onError = any(),
             )

--- a/purchases/src/androidTest/kotlin/com/revenuecat/purchases/helpers/BillingAbstractMockHelper.kt
+++ b/purchases/src/androidTest/kotlin/com/revenuecat/purchases/helpers/BillingAbstractMockHelper.kt
@@ -18,7 +18,6 @@ internal fun BillingAbstract.mockQueryProductDetails(
             queryProductDetailsAsync(
                 productType = ProductType.SUBS,
                 productIds = any(),
-                appInBackground = any(),
                 onReceive = capture(subsReceiveCallbackSlot),
                 onError = any(),
             )
@@ -31,7 +30,6 @@ internal fun BillingAbstract.mockQueryProductDetails(
             queryProductDetailsAsync(
                 productType = ProductType.INAPP,
                 productIds = any(),
-                appInBackground = any(),
                 capture(inappReceiveCallbackSlot),
                 any(),
             )

--- a/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/offlineentitlements/BaseOfflineEntitlementsIntegrationTest.kt
+++ b/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/offlineentitlements/BaseOfflineEntitlementsIntegrationTest.kt
@@ -50,13 +50,13 @@ abstract class BaseOfflineEntitlementsIntegrationTest : BasePurchasesIntegration
 
     protected fun assertAcknowledgePurchaseDidNotHappen() {
         verify(exactly = 0) {
-            mockBillingAbstract.consumeAndSave(any(), any(), initiationSource = any(), appInBackground = any())
+            mockBillingAbstract.consumeAndSave(any(), any(), initiationSource = any())
         }
     }
 
     protected fun assertAcknowledgePurchaseDidHappen(timeout: Duration = testTimeout) {
         verify(timeout = timeout.inWholeMilliseconds) {
-            mockBillingAbstract.consumeAndSave(any(), any(), initiationSource = any(), appInBackground = any())
+            mockBillingAbstract.consumeAndSave(any(), any(), initiationSource = any())
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfoHelper.kt
@@ -79,7 +79,6 @@ internal class CustomerInfoHelper(
     ) {
         postPendingTransactionsHelper.syncPendingPurchaseQueue(
             allowSharingPlayStoreAccount,
-            appInBackground,
             onError = { getCustomerInfoFetchOnly(appUserID, appInBackground, callback) },
             onSuccess = { customerInfo ->
                 if (customerInfo == null) {
@@ -117,7 +116,6 @@ internal class CustomerInfoHelper(
                 ) {
                     offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
                         appUserID,
-                        appInBackground,
                         onSuccess = { offlineComputedCustomerInfo ->
                             customerInfoUpdateHandler.notifyListeners(offlineComputedCustomerInfo)
                             dispatch { callback?.onReceived(offlineComputedCustomerInfo) }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostPendingTransactionsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostPendingTransactionsHelper.kt
@@ -23,7 +23,6 @@ internal class PostPendingTransactionsHelper(
 
     fun syncPendingPurchaseQueue(
         allowSharingPlayStoreAccount: Boolean,
-        appInBackground: Boolean,
         onError: ((PurchasesError) -> Unit)? = null,
         onSuccess: ((CustomerInfo?) -> Unit)? = null,
     ) {
@@ -37,7 +36,6 @@ internal class PostPendingTransactionsHelper(
         dispatcher.enqueue({
             billing.queryPurchases(
                 appUserID,
-                appInBackground,
                 onSuccess = { purchasesByHashedToken ->
                     purchasesByHashedToken.forEach { (hash, purchase) ->
                         log(
@@ -51,7 +49,6 @@ internal class PostPendingTransactionsHelper(
                         transactionsToSync,
                         allowSharingPlayStoreAccount,
                         appUserID,
-                        appInBackground,
                         onError,
                         onSuccess,
                     )
@@ -69,7 +66,6 @@ internal class PostPendingTransactionsHelper(
         transactionsToSync: List<StoreTransaction>,
         allowSharingPlayStoreAccount: Boolean,
         appUserID: String,
-        appInBackground: Boolean,
         onError: ((PurchasesError) -> Unit)? = null,
         onSuccess: ((CustomerInfo?) -> Unit)? = null,
     ) {
@@ -83,7 +79,6 @@ internal class PostPendingTransactionsHelper(
                 allowSharingPlayStoreAccount,
                 appUserID,
                 PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-                appInBackground,
                 transactionPostSuccess = { _, customerInfo ->
                     results.add(Result.Success(customerInfo))
                     callCompletionFromResults(transactionsToSync, results, onError, onSuccess)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -106,12 +106,12 @@ internal class PostReceiptHelper(
             marketplace = purchase.marketplace,
             initiationSource = initiationSource,
             onSuccess = { info ->
-                billing.consumeAndSave(finishTransactions, purchase, initiationSource, appInBackground)
+                billing.consumeAndSave(finishTransactions, purchase, initiationSource)
                 onSuccess?.let { it(purchase, info) }
             },
             onError = { backendError, errorHandlingBehavior, _ ->
                 if (errorHandlingBehavior == PostReceiptErrorHandlingBehavior.SHOULD_BE_CONSUMED) {
-                    billing.consumeAndSave(finishTransactions, purchase, initiationSource, appInBackground)
+                    billing.consumeAndSave(finishTransactions, purchase, initiationSource)
                 }
                 useOfflineEntitlementsCustomerInfoIfNeeded(
                     errorHandlingBehavior,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -41,7 +41,6 @@ internal class PostReceiptHelper(
         appUserID: String,
         marketplace: String?,
         initiationSource: PostReceiptInitiationSource,
-        appInBackground: Boolean,
         onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -64,7 +63,6 @@ internal class PostReceiptHelper(
                 useOfflineEntitlementsCustomerInfoIfNeeded(
                     errorHandlingBehavior,
                     appUserID,
-                    appInBackground,
                     onSuccess = {
                         onSuccess(it)
                     },
@@ -86,7 +84,6 @@ internal class PostReceiptHelper(
         isRestore: Boolean,
         appUserID: String,
         initiationSource: PostReceiptInitiationSource,
-        appInBackground: Boolean,
         onSuccess: (SuccessfulPurchaseCallback)? = null,
         onError: (ErrorPurchaseCallback)? = null,
     ) {
@@ -116,7 +113,6 @@ internal class PostReceiptHelper(
                 useOfflineEntitlementsCustomerInfoIfNeeded(
                     errorHandlingBehavior,
                     appUserID,
-                    appInBackground,
                     onSuccess = { customerInfo ->
                         onSuccess?.let { it(purchase, customerInfo) }
                     },
@@ -181,7 +177,6 @@ internal class PostReceiptHelper(
     private fun useOfflineEntitlementsCustomerInfoIfNeeded(
         errorHandlingBehavior: PostReceiptErrorHandlingBehavior,
         appUserID: String,
-        appInBackground: Boolean,
         onSuccess: (CustomerInfo) -> Unit,
         onError: () -> Unit,
     ) {
@@ -190,7 +185,6 @@ internal class PostReceiptHelper(
         if (offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInPostReceipt(isServerError)) {
             calculateOfflineCustomerInfo(
                 appUserID,
-                appInBackground,
                 onSuccess = onSuccess,
                 onError = {
                     onError()
@@ -203,13 +197,11 @@ internal class PostReceiptHelper(
 
     private fun calculateOfflineCustomerInfo(
         appUserID: String,
-        appInBackground: Boolean,
         onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
-            appInBackground,
             onSuccess = { customerInfo ->
                 customerInfoUpdateHandler.notifyListeners(customerInfo)
                 onSuccess(customerInfo)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostTransactionWithProductDetailsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostTransactionWithProductDetailsHelper.kt
@@ -22,7 +22,6 @@ internal class PostTransactionWithProductDetailsHelper(
         allowSharingPlayStoreAccount: Boolean,
         appUserID: String,
         initiationSource: PostReceiptInitiationSource,
-        appInBackground: Boolean,
         transactionPostSuccess: (SuccessfulPurchaseCallback)? = null,
         transactionPostError: (ErrorPurchaseCallback)? = null,
     ) {
@@ -50,7 +49,6 @@ internal class PostTransactionWithProductDetailsHelper(
                             isRestore = allowSharingPlayStoreAccount,
                             appUserID = appUserID,
                             initiationSource = initiationSource,
-                            appInBackground = appInBackground,
                             onSuccess = transactionPostSuccess,
                             onError = transactionPostError,
                         )
@@ -62,7 +60,6 @@ internal class PostTransactionWithProductDetailsHelper(
                             isRestore = allowSharingPlayStoreAccount,
                             appUserID = appUserID,
                             initiationSource = initiationSource,
-                            appInBackground = appInBackground,
                             onSuccess = transactionPostSuccess,
                             onError = transactionPostError,
                         )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostTransactionWithProductDetailsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostTransactionWithProductDetailsHelper.kt
@@ -31,7 +31,6 @@ internal class PostTransactionWithProductDetailsHelper(
                 billing.queryProductDetailsAsync(
                     productType = transaction.type,
                     productIds = transaction.productIds.toSet(),
-                    appInBackground = appInBackground,
                     onReceive = { storeProducts ->
                         val purchasedStoreProduct = if (transaction.type == ProductType.SUBS) {
                             storeProducts.firstOrNull { product ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -751,7 +751,6 @@ internal class PurchasesOrchestrator constructor(
             billing.queryProductDetailsAsync(
                 productType = it,
                 productIds = productIds,
-                appInBackground = state.appInBackground,
                 onReceive = { storeProducts ->
                     dispatch {
                         getProductsOfTypes(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -356,7 +356,6 @@ internal class PurchasesOrchestrator constructor(
 
         billing.queryAllPurchases(
             appUserID,
-            state.appInBackground,
             onReceivePurchaseHistory = { allPurchases ->
                 if (allPurchases.isEmpty()) {
                     getCustomerInfo(callback)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -142,7 +142,6 @@ internal class PurchasesOrchestrator constructor(
             override fun onConnected() {
                 postPendingTransactionsHelper.syncPendingPurchaseQueue(
                     allowSharingPlayStoreAccount,
-                    state.appInBackground,
                 )
                 billing.getStorefront(
                     state.appInBackground,
@@ -202,7 +201,7 @@ internal class PurchasesOrchestrator constructor(
             )
         }
         offeringsManager.onAppForeground(identityManager.currentAppUserID)
-        postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount, state.appInBackground)
+        postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount)
         synchronizeSubscriberAttributesIfNeeded()
         offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         flushPaywallEvents()
@@ -261,7 +260,6 @@ internal class PurchasesOrchestrator constructor(
                     appUserID,
                     marketplace = null,
                     PostReceiptInitiationSource.RESTORE,
-                    state.appInBackground,
                     {
                         val logMessage = PurchaseStrings.PURCHASE_SYNCED_USER_ID.format(receiptID, amazonUserID)
                         log(LogIntent.PURCHASE, logMessage)
@@ -368,7 +366,6 @@ internal class PurchasesOrchestrator constructor(
                                 isRestore = true,
                                 appUserID = appUserID,
                                 initiationSource = PostReceiptInitiationSource.RESTORE,
-                                appInBackground = state.appInBackground,
                                 onSuccess = { _, info ->
                                     log(LogIntent.DEBUG, RestoreStrings.PURCHASE_RESTORED.format(purchase))
                                     if (sortedByTime.last() == purchase) {
@@ -834,7 +831,6 @@ internal class PurchasesOrchestrator constructor(
                     allowSharingPlayStoreAccount,
                     appUserID,
                     PostReceiptInitiationSource.PURCHASE,
-                    appInBackground = state.appInBackground,
                     transactionPostSuccess = callbackPair.first,
                     transactionPostError = callbackPair.second,
                 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -1096,7 +1096,6 @@ internal class PurchasesOrchestrator constructor(
             appUserID,
             ProductType.SUBS,
             previousProductId,
-            state.appInBackground,
             onCompletion = { purchaseRecord ->
                 log(LogIntent.PURCHASE, PurchaseStrings.FOUND_EXISTING_PURCHASE.format(previousProductId))
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -144,7 +144,6 @@ internal class PurchasesOrchestrator constructor(
                     allowSharingPlayStoreAccount,
                 )
                 billing.getStorefront(
-                    state.appInBackground,
                     onSuccess = { countryCode ->
                         debugLog(BillingStrings.BILLING_COUNTRY_CODE.format(countryCode))
                     },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
@@ -54,7 +54,6 @@ internal class SyncPurchasesHelper(
                             appUserID,
                             purchase.marketplace,
                             PostReceiptInitiationSource.RESTORE,
-                            appInBackground,
                             {
                                 log(LogIntent.PURCHASE, PurchaseStrings.PURCHASE_SYNCED.format(purchase))
                                 handleLastPurchase(purchase, lastPurchase)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
@@ -29,7 +29,6 @@ internal class SyncPurchasesHelper(
 
         billing.queryAllPurchases(
             appUserID,
-            appInBackground,
             onReceivePurchaseHistory = { allPurchases ->
                 if (allPurchases.isNotEmpty()) {
                     val lastPurchase = allPurchases.last()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -194,7 +194,6 @@ internal class AmazonBilling constructor(
         shouldTryToConsume: Boolean,
         purchase: StoreTransaction,
         initiationSource: PostReceiptInitiationSource,
-        appInBackground: Boolean,
     ) {
         if (checkObserverMode() || purchase.type == RevenueCatProductType.UNKNOWN) return
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -313,7 +313,6 @@ internal class AmazonBilling constructor(
     }
 
     override fun getStorefront(
-        appInBackground: Boolean,
         onSuccess: (String) -> Unit,
         onError: PurchasesErrorCallback,
     ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -119,7 +119,6 @@ internal class AmazonBilling constructor(
 
     override fun queryAllPurchases(
         appUserID: String,
-        appInBackground: Boolean,
         onReceivePurchaseHistory: (List<StoreTransaction>) -> Unit,
         onReceivePurchaseHistoryError: PurchasesErrorCallback,
     ) {
@@ -227,7 +226,6 @@ internal class AmazonBilling constructor(
         log(LogIntent.DEBUG, RestoreStrings.QUERYING_PURCHASE_WITH_TYPE.format(productId, productType.name))
         queryAllPurchases(
             appUserID,
-            appInBackground,
             onReceivePurchaseHistory = {
                 // We get productIds[0] because the list is guaranteed to have just one item in Amazon's case.
                 val record: StoreTransaction? = it.firstOrNull { record -> productId == record.productIds[0] }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -293,7 +293,6 @@ internal class AmazonBilling constructor(
 
     override fun queryPurchases(
         appUserID: String,
-        appInBackground: Boolean,
         onSuccess: (Map<String, StoreTransaction>) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -170,7 +170,6 @@ internal class AmazonBilling constructor(
     override fun queryProductDetailsAsync(
         productType: RevenueCatProductType,
         productIds: Set<String>,
-        appInBackground: Boolean,
         onReceive: StoreProductsCallback,
         onError: PurchasesErrorCallback,
     ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -217,7 +217,6 @@ internal class AmazonBilling constructor(
         appUserID: String,
         productType: RevenueCatProductType,
         productId: String,
-        appInBackground: Boolean,
         onCompletion: (StoreTransaction) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -59,7 +59,6 @@ internal abstract class BillingAbstract(
         shouldTryToConsume: Boolean,
         purchase: StoreTransaction,
         initiationSource: PostReceiptInitiationSource,
-        appInBackground: Boolean,
     )
 
     @SuppressWarnings("LongParameterList")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -44,7 +44,6 @@ internal abstract class BillingAbstract(
 
     abstract fun queryAllPurchases(
         appUserID: String,
-        appInBackground: Boolean,
         onReceivePurchaseHistory: (List<StoreTransaction>) -> Unit,
         onReceivePurchaseHistoryError: PurchasesErrorCallback,
     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -66,7 +66,6 @@ internal abstract class BillingAbstract(
         appUserID: String,
         productType: ProductType,
         productId: String,
-        appInBackground: Boolean,
         onCompletion: (StoreTransaction) -> Unit,
         onError: (PurchasesError) -> Unit,
     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -51,7 +51,6 @@ internal abstract class BillingAbstract(
     abstract fun queryProductDetailsAsync(
         productType: ProductType,
         productIds: Set<String>,
-        appInBackground: Boolean,
         onReceive: StoreProductsCallback,
         onError: PurchasesErrorCallback,
     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -114,7 +114,6 @@ internal abstract class BillingAbstract(
      * Null if there has been an error.
      */
     abstract fun getStorefront(
-        appInBackground: Boolean,
         onSuccess: (String) -> Unit,
         onError: PurchasesErrorCallback,
     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -84,7 +84,6 @@ internal abstract class BillingAbstract(
 
     abstract fun queryPurchases(
         appUserID: String,
-        appInBackground: Boolean,
         onSuccess: (Map<String, StoreTransaction>) -> Unit,
         onError: (PurchasesError) -> Unit,
     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
@@ -24,7 +24,6 @@ internal class OfferingsFactory(
     @SuppressWarnings("TooGenericExceptionCaught", "LongMethod")
     fun createOfferings(
         offeringsJSON: JSONObject,
-        appInBackground: Boolean,
         onError: (PurchasesError) -> Unit,
         onSuccess: (Offerings) -> Unit,
     ) {
@@ -40,7 +39,6 @@ internal class OfferingsFactory(
             } else {
                 getStoreProductsById(
                     productIds = allRequestedProductIdentifiers,
-                    appInBackground = appInBackground,
                     onCompleted = { productsById ->
                         try {
                             logMissingProducts(allRequestedProductIdentifiers, productsById)
@@ -109,14 +107,12 @@ internal class OfferingsFactory(
 
     private fun getStoreProductsById(
         productIds: Set<String>,
-        appInBackground: Boolean,
         onCompleted: (Map<String, List<StoreProduct>>) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
         billing.queryProductDetailsAsync(
             productType = ProductType.SUBS,
             productIds = productIds,
-            appInBackground = appInBackground,
             onReceive = { subscriptionProducts ->
                 dispatcher.enqueue(command = {
                     val productsById = subscriptionProducts
@@ -129,7 +125,6 @@ internal class OfferingsFactory(
                         billing.queryProductDetailsAsync(
                             productType = ProductType.INAPP,
                             productIds = inAppProductIds,
-                            appInBackground = appInBackground,
                             onReceive = { inAppProducts ->
                                 dispatcher.enqueue(command = {
                                     productsById.putAll(inAppProducts.map { it.purchasingData.productId to listOf(it) })

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -66,7 +66,7 @@ internal class OfferingsManager(
             appUserID,
             appInBackground,
             {
-                createAndCacheOfferings(it, appInBackground, onError, onSuccess)
+                createAndCacheOfferings(it, onError, onSuccess)
             },
             { backendError, isServerError ->
                 if (isServerError) {
@@ -75,7 +75,7 @@ internal class OfferingsManager(
                         handleErrorFetchingOfferings(backendError, onError)
                     } else {
                         warnLog(OfferingStrings.ERROR_FETCHING_OFFERINGS_USING_DISK_CACHE)
-                        createAndCacheOfferings(cachedOfferingsResponse, appInBackground, onError, onSuccess)
+                        createAndCacheOfferings(cachedOfferingsResponse, onError, onSuccess)
                     }
                 } else {
                     handleErrorFetchingOfferings(backendError, onError)
@@ -86,13 +86,11 @@ internal class OfferingsManager(
 
     private fun createAndCacheOfferings(
         offeringsJSON: JSONObject,
-        appInBackground: Boolean,
         onError: ((PurchasesError) -> Unit)? = null,
         onSuccess: ((Offerings) -> Unit)? = null,
     ) {
         offeringsFactory.createOfferings(
             offeringsJSON,
-            appInBackground,
             onError = { error ->
                 handleErrorFetchingOfferings(error, onError)
             },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculator.kt
@@ -38,13 +38,11 @@ internal class OfflineCustomerInfoCalculator(
      */
     fun computeOfflineCustomerInfo(
         appUserID: String,
-        appInBackground: Boolean,
         onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
         purchasedProductsFetcher.queryActiveProducts(
             appUserID,
-            appInBackground,
             onSuccess = { purchasedProducts ->
                 val containsAnyActiveInAppPurchase = purchasedProducts.any {
                     it.storeTransaction.type == ProductType.INAPP

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -48,7 +48,6 @@ internal class OfflineEntitlementsManager(
     @Suppress("FunctionOnlyReturningConstant")
     fun calculateAndCacheOfflineCustomerInfo(
         appUserId: String,
-        appInBackground: Boolean,
         onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -72,7 +71,6 @@ internal class OfflineEntitlementsManager(
         }
         offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
             appUserId,
-            appInBackground,
             onSuccess = { customerInfo ->
                 synchronized(this@OfflineEntitlementsManager) {
                     warnLog(OfflineEntitlementsStrings.USING_OFFLINE_ENTITLEMENTS_CUSTOMER_INFO)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcher.kt
@@ -20,7 +20,6 @@ internal class PurchasedProductsFetcher(
 
     fun queryActiveProducts(
         appUserID: String,
-        appInBackground: Boolean,
         onSuccess: (List<PurchasedProduct>) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
@@ -36,7 +35,6 @@ internal class PurchasedProductsFetcher(
 
         billing.queryPurchases(
             appUserID,
-            appInBackground,
             onSuccess = { activePurchasesByHashedToken ->
                 val activePurchases = activePurchasesByHashedToken.values.toList()
                 val purchasedProducts = activePurchases.map {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -325,7 +325,6 @@ internal class BillingWrapper(
 
     override fun queryAllPurchases(
         appUserID: String,
-        appInBackground: Boolean,
         onReceivePurchaseHistory: (List<StoreTransaction>) -> Unit,
         onReceivePurchaseHistoryError: (PurchasesError) -> Unit,
     ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -303,7 +303,6 @@ internal class BillingWrapper(
 
     fun queryPurchaseHistoryAsync(
         @BillingClient.ProductType productType: String,
-        appInBackground: Boolean,
         onReceivePurchaseHistory: (List<PurchaseHistoryRecord>) -> Unit,
         onReceivePurchaseHistoryError: (PurchasesError) -> Unit,
     ) {
@@ -329,11 +328,9 @@ internal class BillingWrapper(
     ) {
         queryPurchaseHistoryAsync(
             BillingClient.ProductType.SUBS,
-            appInBackground,
             { subsPurchasesList ->
                 queryPurchaseHistoryAsync(
                     BillingClient.ProductType.INAPP,
-                    appInBackground,
                     { inAppPurchasesList ->
                         onReceivePurchaseHistory(
                             subsPurchasesList.map {
@@ -371,14 +368,12 @@ internal class BillingWrapper(
             consumePurchase(
                 purchase.purchaseToken,
                 initiationSource,
-                appInBackground,
                 onConsumed = deviceCache::addSuccessfullyPostedToken,
             )
         } else if (shouldTryToConsume && !alreadyAcknowledged) {
             acknowledge(
                 purchase.purchaseToken,
                 initiationSource,
-                appInBackground,
                 onAcknowledged = deviceCache::addSuccessfullyPostedToken,
             )
         } else {
@@ -389,7 +384,6 @@ internal class BillingWrapper(
     internal fun consumePurchase(
         token: String,
         initiationSource: PostReceiptInitiationSource,
-        appInBackground: Boolean,
         onConsumed: (purchaseToken: String) -> Unit,
     ) {
         log(LogIntent.PURCHASE, PurchaseStrings.CONSUMING_PURCHASE.format(token))
@@ -416,7 +410,6 @@ internal class BillingWrapper(
     internal fun acknowledge(
         token: String,
         initiationSource: PostReceiptInitiationSource,
-        appInBackground: Boolean,
         onAcknowledged: (purchaseToken: String) -> Unit,
     ) {
         log(LogIntent.PURCHASE, PurchaseStrings.ACKNOWLEDGING_PURCHASE.format(token))

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -354,7 +354,6 @@ internal class BillingWrapper(
         shouldTryToConsume: Boolean,
         purchase: StoreTransaction,
         initiationSource: PostReceiptInitiationSource,
-        appInBackground: Boolean,
     ) {
         if (purchase.type == ProductType.UNKNOWN) {
             // Would only get here if the purchase was triggered from outside of the app and there was

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -738,7 +738,6 @@ internal class BillingWrapper(
     }
 
     override fun getStorefront(
-        appInBackground: Boolean,
         onSuccess: (String) -> Unit,
         onError: PurchasesErrorCallback,
     ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -195,7 +195,6 @@ internal class BillingWrapper(
     override fun queryProductDetailsAsync(
         productType: ProductType,
         productIds: Set<String>,
-        appInBackground: Boolean,
         onReceive: StoreProductsCallback,
         onError: PurchasesErrorCallback,
     ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -465,7 +465,6 @@ internal class BillingWrapper(
         appUserID: String,
         productType: ProductType,
         productId: String,
-        appInBackground: Boolean,
         onCompletion: (StoreTransaction) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -443,7 +443,6 @@ internal class BillingWrapper(
     @Suppress("ReturnCount", "LongMethod")
     override fun queryPurchases(
         appUserID: String,
-        appInBackground: Boolean,
         onSuccess: (Map<String, StoreTransaction>) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -196,7 +196,6 @@ internal open class BasePurchasesTest {
                     isRestore = any(),
                     appUserID = any(),
                     initiationSource = any(),
-                    appInBackground = any(),
                     onSuccess = captureLambda(),
                     onError = any(),
                 )
@@ -215,7 +214,6 @@ internal open class BasePurchasesTest {
                     appUserID = any(),
                     marketplace = any(),
                     initiationSource = any(),
-                    appInBackground = any(),
                     onSuccess = captureLambda(),
                     onError = any(),
                 )

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -346,7 +346,6 @@ internal open class BasePurchasesTest {
             mockBillingAbstract.queryProductDetailsAsync(
                 type,
                 productIds.toSet(),
-                any(),
                 captureLambda(),
                 any(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -152,7 +152,6 @@ internal open class BasePurchasesTest {
                     capture(capturedShouldTryToConsume),
                     capture(capturedConsumePurchaseWrapper),
                     any(),
-                    any(),
                 )
             } just Runs
             every {

--- a/purchases/src/test/java/com/revenuecat/purchases/CustomerInfoHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/CustomerInfoHelperTest.kt
@@ -319,7 +319,6 @@ class CustomerInfoHelperTest {
         verify(exactly = 0) {
             mockOfflineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
                 appUserId = any(),
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any(),
             )
@@ -340,7 +339,6 @@ class CustomerInfoHelperTest {
         verify(exactly = 1) {
             mockOfflineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
                 appUserId = appUserId,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any(),
             )
@@ -395,7 +393,6 @@ class CustomerInfoHelperTest {
         every {
             mockOfflineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
                 appUserId = appUserId,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = captureLambda(),
             )
@@ -437,7 +434,6 @@ class CustomerInfoHelperTest {
         verify(exactly = 1) {
             mockPostPendingTransactionsHelper.syncPendingPurchaseQueue(
                 allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
-                appInBackground = any(),
                 onError = any(),
                 onSuccess = any()
             )
@@ -463,7 +459,6 @@ class CustomerInfoHelperTest {
         verify(exactly = 1) {
             mockPostPendingTransactionsHelper.syncPendingPurchaseQueue(
                 allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
-                appInBackground = any(),
                 onError = any(),
                 onSuccess = any()
             )
@@ -490,7 +485,6 @@ class CustomerInfoHelperTest {
         verify(exactly = 1) {
             mockPostPendingTransactionsHelper.syncPendingPurchaseQueue(
                 allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
-                appInBackground = any(),
                 onError = any(),
                 onSuccess = any()
             )
@@ -760,7 +754,6 @@ class CustomerInfoHelperTest {
         every {
             mockOfflineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
                 appUserId = appUserId,
-                appInBackground = any(),
                 onSuccess = captureLambda(),
                 onError = any(),
             )
@@ -787,7 +780,6 @@ class CustomerInfoHelperTest {
         every {
             mockPostPendingTransactionsHelper.syncPendingPurchaseQueue(
                 allowSharingPlayStoreAccount = any(),
-                appInBackground = any(),
                 onError = any(),
                 onSuccess = captureNullable(slotList),
             )
@@ -800,7 +792,6 @@ class CustomerInfoHelperTest {
         every {
             mockPostPendingTransactionsHelper.syncPendingPurchaseQueue(
                 allowSharingPlayStoreAccount = any(),
-                appInBackground = any(),
                 onError = captureLambda(),
                 onSuccess = any(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
@@ -73,7 +73,6 @@ class PostPendingTransactionsHelperTest {
         verify(exactly = 0) {
             billing.queryPurchases(
                 appUserID = any(),
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -84,7 +83,6 @@ class PostPendingTransactionsHelperTest {
                 allowSharingPlayStoreAccount = any(),
                 appUserID = any(),
                 initiationSource = any(),
-                appInBackground = any(),
                 transactionPostSuccess = any(),
                 transactionPostError = any()
             )
@@ -107,7 +105,6 @@ class PostPendingTransactionsHelperTest {
         verify(exactly = 1) {
             billing.queryPurchases(
                 appUserID = appUserId,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -133,10 +130,7 @@ class PostPendingTransactionsHelperTest {
 
         mockPostTransactionsSuccessful(mockk())
 
-        postPendingTransactionsHelper.syncPendingPurchaseQueue(
-            allowSharingPlayStoreAccount,
-            appInBackground = false
-        )
+        postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount)
 
         verify(exactly = 1) {
             postTransactionWithProductDetailsHelper.postTransactions(
@@ -144,7 +138,6 @@ class PostPendingTransactionsHelperTest {
                 allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
                 appUserID = appUserId,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 transactionPostSuccess = any(),
                 transactionPostError = any()
             )
@@ -212,7 +205,6 @@ class PostPendingTransactionsHelperTest {
         every {
             billing.queryPurchases(
                 appUserID = appUserId,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = captureLambda()
             )
@@ -272,7 +264,6 @@ class PostPendingTransactionsHelperTest {
                 allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
                 appUserID = appUserId,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 transactionPostSuccess = captureLambda(),
                 transactionPostError = any()
             )
@@ -323,7 +314,6 @@ class PostPendingTransactionsHelperTest {
                 allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
                 appUserID = appUserId,
                 initiationSource = initiationSource,
-                appInBackground = false,
                 transactionPostSuccess = capture(successSlot),
                 transactionPostError = capture(errorSlot)
             )
@@ -348,7 +338,6 @@ class PostPendingTransactionsHelperTest {
                 allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
                 appUserID = appUserId,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 transactionPostSuccess = captureLambda(),
                 transactionPostError = any()
             )
@@ -387,7 +376,6 @@ class PostPendingTransactionsHelperTest {
         every {
             billing.queryPurchases(
                 appUserId,
-                appInBackground = false,
                 onSuccess = captureLambda(),
                 onError = any()
             )
@@ -410,7 +398,6 @@ class PostPendingTransactionsHelperTest {
         var successCallCount = 0
         postPendingTransactionsHelper.syncPendingPurchaseQueue(
             allowSharingPlayStoreAccount,
-            appInBackground = false,
             onError = { fail("Should be success") },
             onSuccess = {
                 assertThat(it).isEqualTo(resultCustomerInfo)
@@ -424,7 +411,6 @@ class PostPendingTransactionsHelperTest {
         var receivedError: PurchasesError? = null
         postPendingTransactionsHelper.syncPendingPurchaseQueue(
             allowSharingPlayStoreAccount,
-            appInBackground = false,
             onError = { receivedError = it },
             onSuccess = { fail("Should be error") },
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -276,7 +276,6 @@ class PostReceiptHelperTest {
             billing.consumeAndSave(
                 shouldTryToConsume = expectedShouldConsumeFlag,
                 purchase = mockStoreTransaction,
-                appInBackground = false,
                 initiationSource = initiationSource,
             )
         }
@@ -304,7 +303,6 @@ class PostReceiptHelperTest {
             billing.consumeAndSave(
                 shouldTryToConsume = expectedShouldConsumeFlag,
                 purchase = mockStoreTransaction,
-                appInBackground = false,
                 initiationSource = initiationSource,
             )
         }
@@ -404,7 +402,6 @@ class PostReceiptHelperTest {
             billing.consumeAndSave(
                 shouldTryToConsume = true,
                 purchase = mockStoreTransaction,
-                appInBackground = false,
                 initiationSource = initiationSource
             )
         }
@@ -430,7 +427,6 @@ class PostReceiptHelperTest {
             billing.consumeAndSave(
                 shouldTryToConsume = false,
                 purchase = mockStoreTransaction,
-                appInBackground = false,
                 initiationSource = initiationSource,
             )
         }
@@ -455,7 +451,6 @@ class PostReceiptHelperTest {
             billing.consumeAndSave(
                 shouldTryToConsume = any(),
                 purchase = any(),
-                appInBackground = any(),
                 initiationSource = initiationSource
             )
         }
@@ -638,7 +633,6 @@ class PostReceiptHelperTest {
         verify(exactly = 0) { billing.consumeAndSave(
             shouldTryToConsume = any(),
             purchase = any(),
-            appInBackground = any(),
             initiationSource = initiationSource
         ) }
         verify(exactly = 0) { deviceCache.addSuccessfullyPostedToken(any()) }
@@ -778,8 +772,8 @@ class PostReceiptHelperTest {
         every { billing.consumeAndSave(
             shouldTryToConsume = true,
             purchase = purchase,
-            initiationSource = initiationSource,
-            appInBackground = false)
+            initiationSource = initiationSource
+        )
         } just Runs
 
         postReceiptHelper.postTransactionAndConsumeIfNeeded(
@@ -1212,8 +1206,8 @@ class PostReceiptHelperTest {
             billing.consumeAndSave(
                 shouldTryToConsume = any(),
                 purchase = any(),
-                initiationSource = initiationSource,
-                appInBackground = any())
+                initiationSource = initiationSource
+            )
         }
     }
 
@@ -1241,8 +1235,7 @@ class PostReceiptHelperTest {
             billing.consumeAndSave(
                 shouldTryToConsume = any(),
                 purchase = any(),
-                initiationSource = initiationSource,
-                appInBackground = any()
+                initiationSource = initiationSource
             )
         }
     }
@@ -1427,8 +1420,7 @@ class PostReceiptHelperTest {
         verify(exactly = 0) { billing.consumeAndSave(
             shouldTryToConsume = any(),
             purchase = any(),
-            initiationSource = initiationSource,
-            appInBackground = any()
+            initiationSource = initiationSource
         ) }
         verify(exactly = 0) { deviceCache.addSuccessfullyPostedToken(any()) }
     }
@@ -1580,8 +1572,8 @@ class PostReceiptHelperTest {
             every { billing.consumeAndSave(
                 shouldTryToConsume = any(),
                 purchase = mockStoreTransaction,
-                initiationSource = initiationSource,
-                appInBackground = any())
+                initiationSource = initiationSource
+            )
             } just Runs
         } else {
             every { deviceCache.addSuccessfullyPostedToken(postToken) } just Runs
@@ -1637,8 +1629,7 @@ class PostReceiptHelperTest {
                 every { billing.consumeAndSave(
                     shouldTryToConsume = any(),
                     purchase = mockStoreTransaction,
-                    initiationSource = initiationSource,
-                    appInBackground = any()
+                    initiationSource = initiationSource
                 ) } just Runs
             } else {
                 every { deviceCache.addSuccessfullyPostedToken(postToken) } just Runs

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -145,7 +145,6 @@ class PostReceiptHelperTest {
             isRestore = allowSharingPlayStoreAccount,
             appUserID = appUserID,
             initiationSource = PostReceiptInitiationSource.PURCHASE,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -186,7 +185,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -220,7 +218,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -244,7 +241,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -267,7 +263,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -294,7 +289,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -320,7 +314,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { transaction, customerInfo ->
                 successTransaction = transaction
                 successCustomerInfo = customerInfo
@@ -343,7 +336,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -368,7 +360,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -393,7 +384,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -418,7 +408,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -442,7 +431,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -468,7 +456,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { transaction, error ->
                 errorTransaction = transaction
@@ -492,7 +479,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -512,7 +498,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -520,7 +505,7 @@ class PostReceiptHelperTest {
         verify(exactly = 1) {
             offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInPostReceipt(isServerError = false)
         }
-        verify(exactly = 0) { offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, any(), any(), any()) }
+        verify(exactly = 0) { offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, any(), any()) }
     }
 
     @Test
@@ -533,7 +518,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> fail("Expected error") },
             onError = { _, _ -> }
         )
@@ -543,7 +527,6 @@ class PostReceiptHelperTest {
         }
         verify(exactly = 1) { offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserId = appUserID,
-            appInBackground = any(),
             onSuccess = any(),
             onError = any()
         ) }
@@ -554,7 +537,7 @@ class PostReceiptHelperTest {
         mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         every {
-            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, false, captureLambda(), any())
+            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
         } answers {
             lambda<(CustomerInfo) -> Unit>().captured(defaultCustomerInfo)
         }
@@ -569,7 +552,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, customerInfo -> receivedCustomerInfo = customerInfo },
             onError = { _, _ -> fail("Expected success") }
         )
@@ -583,7 +565,7 @@ class PostReceiptHelperTest {
         mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         every {
-            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, false, captureLambda(), any())
+            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
         } answers {
             lambda<(CustomerInfo) -> Unit>().captured(defaultCustomerInfo)
         }
@@ -597,7 +579,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ ->  },
             onError = { _, _ -> fail("Expected success") }
         )
@@ -611,7 +592,7 @@ class PostReceiptHelperTest {
         mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         every {
-            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, false, captureLambda(), any())
+            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
         } answers {
             lambda<(CustomerInfo) -> Unit>().captured(defaultCustomerInfo)
         }
@@ -625,7 +606,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ ->  },
             onError = { _, _ -> fail("Expected success") }
         )
@@ -644,7 +624,7 @@ class PostReceiptHelperTest {
         mockPostReceiptError(errorHandlingBehavior = PostReceiptErrorHandlingBehavior.SHOULD_USE_OFFLINE_ENTITLEMENTS_AND_NOT_CONSUME)
 
         every {
-            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, false, captureLambda(), any())
+            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
         } answers {
             lambda<(CustomerInfo) -> Unit>().captured(defaultCustomerInfo)
         }
@@ -658,7 +638,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ ->  },
             onError = { _, _ -> fail("Expected success") }
         )
@@ -678,7 +657,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -696,7 +674,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -714,7 +691,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -733,7 +709,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -751,7 +726,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -782,7 +756,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -800,7 +773,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -818,7 +790,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -841,7 +812,6 @@ class PostReceiptHelperTest {
             isRestore = true,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -876,7 +846,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = PostReceiptInitiationSource.RESTORE,
-            appInBackground = false,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -912,7 +881,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = PostReceiptInitiationSource.PURCHASE,
-            appInBackground = false,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -948,7 +916,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -974,7 +941,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -997,7 +963,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should succeed") }
         )
@@ -1020,7 +985,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -1043,7 +1007,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { successCalledCount++ },
             onError = { fail("Should succeed") }
         )
@@ -1067,7 +1030,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { fail("Should fail") },
             onError = { }
         )
@@ -1097,7 +1059,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { fail("Should fail") },
             onError = { }
         )
@@ -1126,7 +1087,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { fail("Should fail") },
             onError = { }
         )
@@ -1151,7 +1111,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { fail("Should fail") },
             onError = { }
         )
@@ -1177,7 +1136,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { fail("Should fail") },
             onError = { purchasesError = it }
         )
@@ -1197,7 +1155,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -1226,7 +1183,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { fail("Should fail") },
             onError = { }
         )
@@ -1254,7 +1210,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -1279,7 +1234,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { fail("Expected error") },
             onError = { }
         )
@@ -1289,7 +1243,6 @@ class PostReceiptHelperTest {
         }
         verify(exactly = 0) { offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserId = appUserID,
-            appInBackground = any(),
             onSuccess = any(),
             onError = any()
         ) }
@@ -1310,7 +1263,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { fail("Expected error") },
             onError = { }
         )
@@ -1318,7 +1270,7 @@ class PostReceiptHelperTest {
         verify(exactly = 1) {
             offlineEntitlementsManager.shouldCalculateOfflineCustomerInfoInPostReceipt(isServerError = true)
         }
-        verify(exactly = 1) { offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, any(), any(), any()) }
+        verify(exactly = 1) { offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, any(), any()) }
     }
 
     @Test
@@ -1329,7 +1281,7 @@ class PostReceiptHelperTest {
         )
 
         every {
-            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, false, captureLambda(), any())
+            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
         } answers {
             lambda<(CustomerInfo) -> Unit>().captured(defaultCustomerInfo)
         }
@@ -1346,7 +1298,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { successCallCount++ },
             onError = { fail("Should succeed") }
         )
@@ -1363,7 +1314,7 @@ class PostReceiptHelperTest {
         )
 
         every {
-            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, false, captureLambda(), any())
+            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
         } answers {
             lambda<(CustomerInfo) -> Unit>().captured(defaultCustomerInfo)
         }
@@ -1379,7 +1330,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -1396,7 +1346,7 @@ class PostReceiptHelperTest {
         )
 
         every {
-            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, false, captureLambda(), any())
+            offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(appUserID, captureLambda(), any())
         } answers {
             lambda<(CustomerInfo) -> Unit>().captured(defaultCustomerInfo)
         }
@@ -1412,7 +1362,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -1436,7 +1385,6 @@ class PostReceiptHelperTest {
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
                 appUserId = appUserID,
-                appInBackground = false,
                 onSuccess = captureLambda(),
                 onError = any()
             )
@@ -1455,7 +1403,6 @@ class PostReceiptHelperTest {
             appUserID = appUserID,
             marketplace = marketplace,
             initiationSource = initiationSource,
-            appInBackground = false,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -1482,7 +1429,6 @@ class PostReceiptHelperTest {
             isRestore = false,
             appUserID = appUserID,
             initiationSource = PostReceiptInitiationSource.PURCHASE,
-            appInBackground = false,
             onSuccess = { _, _ -> },
             onError = { _, _ -> fail("Should succeed") }
         )
@@ -1516,7 +1462,6 @@ class PostReceiptHelperTest {
             isRestore = false,
             appUserID = appUserID,
             initiationSource = PostReceiptInitiationSource.PURCHASE,
-            appInBackground = false,
             onSuccess = { _, _ -> fail("Should error") },
             onError = { _, _ -> }
         )
@@ -1614,7 +1559,6 @@ class PostReceiptHelperTest {
         every {
             offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
                 appUserId = appUserID,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = captureLambda()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PostTransactionWithProductDetailsHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostTransactionWithProductDetailsHelperTest.kt
@@ -238,7 +238,6 @@ class PostTransactionWithProductDetailsHelperTest {
             billing.queryProductDetailsAsync(
                 productType = transaction.type,
                 productIds = transaction.productIds.toSet(),
-                appInBackground = false,
                 onReceive = captureLambda(),
                 onError = any(),
             )
@@ -255,7 +254,6 @@ class PostTransactionWithProductDetailsHelperTest {
             billing.queryProductDetailsAsync(
                 productType = transaction.type,
                 productIds = transaction.productIds.toSet(),
-                appInBackground = false,
                 onReceive = any(),
                 onError = captureLambda(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PostTransactionWithProductDetailsHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostTransactionWithProductDetailsHelperTest.kt
@@ -54,7 +54,6 @@ class PostTransactionWithProductDetailsHelperTest {
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             transactionPostSuccess = { _, _ -> fail("Should not be called") },
             transactionPostError = { _, _ -> fail("Should not be called") },
         )
@@ -71,7 +70,6 @@ class PostTransactionWithProductDetailsHelperTest {
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             transactionPostSuccess = { _, _ -> fail("Should not be called") },
             transactionPostError = { _, error -> receivedError = error },
         )
@@ -92,7 +90,6 @@ class PostTransactionWithProductDetailsHelperTest {
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             transactionPostSuccess = { _, _ -> fail("Should not be called") },
             transactionPostError = { _, _ -> errorCallCount++ },
         )
@@ -115,7 +112,6 @@ class PostTransactionWithProductDetailsHelperTest {
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             transactionPostSuccess = { _, _ ->  },
             transactionPostError = { _, _ -> fail("Should be success") },
         )
@@ -127,7 +123,6 @@ class PostTransactionWithProductDetailsHelperTest {
                 isRestore = allowSharingPlayStoreAccount,
                 appUserID = appUserID,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any(),
             )
@@ -144,7 +139,6 @@ class PostTransactionWithProductDetailsHelperTest {
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             transactionPostSuccess = { _, _ ->  },
             transactionPostError = { _, _ -> fail("Should be success") },
         )
@@ -156,7 +150,6 @@ class PostTransactionWithProductDetailsHelperTest {
                 isRestore = allowSharingPlayStoreAccount,
                 appUserID = appUserID,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any(),
             )
@@ -173,7 +166,6 @@ class PostTransactionWithProductDetailsHelperTest {
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             transactionPostSuccess = { _, _ ->  },
             transactionPostError = { _, _ -> fail("Should be success") },
         )
@@ -185,7 +177,6 @@ class PostTransactionWithProductDetailsHelperTest {
                 isRestore = allowSharingPlayStoreAccount,
                 appUserID = appUserID,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any(),
             )
@@ -205,7 +196,6 @@ class PostTransactionWithProductDetailsHelperTest {
             allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
             appUserID = appUserID,
             initiationSource = initiationSource,
-            appInBackground = false,
             transactionPostSuccess = { storeTransaction, customerInfo ->
                 receivedStoreTransaction = storeTransaction
                 receivedCustomerInfo = customerInfo
@@ -274,7 +264,6 @@ class PostTransactionWithProductDetailsHelperTest {
                 isRestore = allowSharingPlayStoreAccount,
                 appUserID = appUserID,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 onSuccess = captureLambda(),
                 onError = any()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -1631,7 +1631,7 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         mockGetStorefront()
         capturedBillingWrapperStateListener.captured.onConnected()
         verify(exactly = 1) {
-            mockBillingAbstract.getStorefront(any(), any(), any())
+            mockBillingAbstract.getStorefront(any(), any())
         }
     }
 
@@ -1783,7 +1783,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     private fun mockGetStorefront() {
         every {
             mockBillingAbstract.getStorefront(
-                appInBackground = any(),
                 onSuccess = captureLambda(),
                 onError = any()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -271,7 +271,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 appUserId,
                 ProductType.SUBS,
                 oldSubId,
-                appInBackground = false,
                 onCompletion = captureLambda(),
                 onError = any()
             )
@@ -1039,7 +1038,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 appUserID = appUserId,
                 productType = ProductType.SUBS,
                 productId = oldProductId,
-                appInBackground = any(),
                 onCompletion = any(),
                 onError = captureLambda()
             )
@@ -1144,7 +1142,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 appUserID = appUserId,
                 productType = ProductType.SUBS,
                 productId = oldSubId,
-                appInBackground = any(),
                 onCompletion = captureLambda(),
                 onError = any(),
             )
@@ -1209,7 +1206,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 appUserID = appUserId,
                 productType = ProductType.SUBS,
                 productId = oldSubId,
-                appInBackground = any(),
                 onCompletion = captureLambda(),
                 onError = any(),
             )
@@ -1753,7 +1749,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 appUserID = appUserId,
                 productType = ProductType.SUBS,
                 productId = oldProductId,
-                appInBackground = any(),
                 onCompletion = if (error == null) captureLambda() else any(),
                 onError = if (error != null) captureLambda() else any()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -1730,7 +1730,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 productType = storeProduct.type,
                 productIds = setOf(productId),
-                appInBackground = false,
                 onReceive = captureLambda(),
                 onError = any(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -541,7 +541,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                     isRestore = false,
                     appUserID = appUserId,
                     initiationSource = initiationSource,
-                    appInBackground = any(),
                     onSuccess = captureLambda(),
                     onError = any(),
                 )
@@ -559,7 +558,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -569,7 +567,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -587,7 +584,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 isRestore = any(),
                 appUserID = any(),
                 initiationSource = any(),
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any(),
             )
@@ -1100,7 +1096,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -1360,7 +1355,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 isRestore = true,
                 appUserID = randomAppUserId,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -1384,7 +1378,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
                 isRestore = false,
                 appUserID = appUserId,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesCommonTest.kt
@@ -242,7 +242,6 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
         every {
             mockBillingAbstract.queryAllPurchases(
                 appUserID = appUserId,
-                appInBackground = any(),
                 onReceivePurchaseHistory = captureLambda(),
                 onReceivePurchaseHistoryError = any(),
             )
@@ -257,7 +256,6 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
         verify(exactly = 1) {
             mockBillingAbstract.queryAllPurchases(
                 appUserId,
-                any(),
                 any(),
                 any(),
             )
@@ -288,7 +286,6 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
         every {
             mockBillingAbstract.queryAllPurchases(
                 appUserID = appUserId,
-                appInBackground = any(),
                 onReceivePurchaseHistory = captureLambda(),
                 onReceivePurchaseHistoryError = any()
             )
@@ -303,7 +300,6 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
         verify(exactly = 1) {
             mockBillingAbstract.queryAllPurchases(
                 appUserID = appUserId,
-                appInBackground = any(),
                 onReceivePurchaseHistory = any(),
                 onReceivePurchaseHistoryError = any(),
             )
@@ -318,7 +314,6 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
         every {
             mockBillingAbstract.queryAllPurchases(
                 appUserID = appUserId,
-                appInBackground = any(),
                 onReceivePurchaseHistory = any(),
                 onReceivePurchaseHistoryError = captureLambda(),
             )
@@ -337,7 +332,6 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
         verify(exactly = 1) {
             mockBillingAbstract.queryAllPurchases(
                 appUserID = appUserId,
-                appInBackground = any(),
                 onReceivePurchaseHistory = any(),
                 onReceivePurchaseHistoryError = any(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesCommonTest.kt
@@ -174,7 +174,6 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 productType = ProductType.SUBS,
                 productIds = productIds.toSet(),
-                appInBackground = any(),
                 onReceive = captureLambda(),
                 onError = any(),
             )
@@ -185,7 +184,6 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 productType = ProductType.INAPP,
                 productIds = productIds.toSet(),
-                appInBackground = any(),
                 onReceive = captureLambda(),
                 onError = any(),
             )
@@ -211,7 +209,6 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 productType = ProductType.SUBS,
                 productIds = productIds.toSet(),
-                appInBackground = any(),
                 onReceive = any(),
                 onError = captureLambda(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCoroutinesCommonTest.kt
@@ -271,7 +271,6 @@ internal class PurchasesCoroutinesCommonTest : BasePurchasesTest() {
                 isRestore = true,
                 appUserID = appUserId,
                 initiationSource = PostReceiptInitiationSource.RESTORE,
-                appInBackground = any(),
                 onSuccess = captureLambda(),
                 onError = any(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
@@ -67,7 +67,7 @@ class SyncPurchasesHelperTest {
         assertThat(receivedCustomerInfo).isEqualTo(customerInfoMock)
         verify(exactly = 0) {
             postReceiptHelper.postTokenWithoutConsuming(
-                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(),
             )
         }
     }
@@ -110,7 +110,6 @@ class SyncPurchasesHelperTest {
                 appUserID = any(),
                 marketplace = any(),
                 initiationSource = any(),
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any(),
             )
@@ -142,7 +141,6 @@ class SyncPurchasesHelperTest {
                 appUserID = any(),
                 marketplace = any(),
                 initiationSource = any(),
-                appInBackground = any(),
                 onSuccess = captureLambda(),
                 onError = any(),
             )
@@ -168,7 +166,6 @@ class SyncPurchasesHelperTest {
                 appUserID = appUserID,
                 marketplace = null,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -180,7 +177,6 @@ class SyncPurchasesHelperTest {
                 appUserID = appUserID,
                 marketplace = "test-marketplace",
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -205,7 +201,7 @@ class SyncPurchasesHelperTest {
 
         every {
             postReceiptHelper.postTokenWithoutConsuming(
-                any(), any(), any(), any(), any(), any(), any(), any(), any(), captureLambda(),
+                any(), any(), any(), any(), any(), any(), any(), any(), captureLambda(),
             )
         } answers {
             lambda<(PurchasesError) -> Unit>().captured.invoke(testError)
@@ -229,7 +225,6 @@ class SyncPurchasesHelperTest {
                 appUserID = appUserID,
                 marketplace = null,
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -241,7 +236,6 @@ class SyncPurchasesHelperTest {
                 appUserID = appUserID,
                 marketplace = "test-marketplace",
                 initiationSource = initiationSource,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = any()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
@@ -270,7 +270,6 @@ class SyncPurchasesHelperTest {
         every {
             billing.queryAllPurchases(
                 appUserID = appUserID,
-                appInBackground = any(),
                 onReceivePurchaseHistory = captureLambda(),
                 onReceivePurchaseHistoryError = any()
             )
@@ -285,7 +284,6 @@ class SyncPurchasesHelperTest {
         every {
             billing.queryAllPurchases(
                 appUserID = appUserID,
-                appInBackground = any(),
                 onReceivePurchaseHistory = any(),
                 onReceivePurchaseHistoryError = captureLambda()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -513,7 +513,6 @@ class AmazonBillingTest {
         underTest.queryProductDetailsAsync(
             productType = com.revenuecat.purchases.ProductType.SUBS,
             productIds = productIds,
-            appInBackground = false,
             onError = {
                 fail("should be a success")
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -1013,7 +1013,6 @@ class AmazonBillingTest {
         mockGetUserData()
         var countryCode: String? = null
         underTest.getStorefront(
-            appInBackground = false,
             onSuccess = { countryCode = it },
             onError = { fail("Should be a success") },
         )
@@ -1026,7 +1025,6 @@ class AmazonBillingTest {
         mockGetUserDataError()
         var error: PurchasesError? = null
         underTest.getStorefront(
-            appInBackground = false,
             onSuccess = { fail("Should be a error") },
             onError = { error = it },
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -540,7 +540,6 @@ class AmazonBillingTest {
                 ),
             ),
             initiationSource = PostReceiptInitiationSource.PURCHASE,
-            appInBackground = false,
         )
 
         verify(exactly = 0) {
@@ -573,7 +572,6 @@ class AmazonBillingTest {
                 )
             ),
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false,
         )
 
         verify(exactly = 1) {
@@ -610,7 +608,6 @@ class AmazonBillingTest {
                 )
             ),
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false,
         )
 
         verify(exactly = 0) {

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -115,7 +115,6 @@ class AmazonBillingTest {
         var receivedPurchases: Map<String, StoreTransaction>? = null
         underTest.queryPurchases(
             appUserID,
-            appInBackground = false,
             onSuccess = {
                 receivedPurchases = it
             },
@@ -144,7 +143,6 @@ class AmazonBillingTest {
         var receivedPurchases: Map<String, StoreTransaction>? = null
         underTest.queryPurchases(
             appUserID,
-            appInBackground = false,
             onSuccess = {
                 receivedPurchases = it
             },
@@ -185,7 +183,6 @@ class AmazonBillingTest {
         var receivedPurchases: Map<String, StoreTransaction>? = null
         underTest.queryPurchases(
             appUserID,
-            appInBackground = false,
             onSuccess = {
                 receivedPurchases = it
             },
@@ -235,7 +232,6 @@ class AmazonBillingTest {
         var receivedPurchases: Map<String, StoreTransaction>? = null
         underTest.queryPurchases(
             appUserID,
-            appInBackground = false,
             onSuccess = {
                 receivedPurchases = it
             },
@@ -283,7 +279,6 @@ class AmazonBillingTest {
         var receivedPurchases: Map<String, StoreTransaction>? = null
         underTest.queryPurchases(
             appUserID,
-            appInBackground = false,
             onSuccess = {
                 receivedPurchases = it
             },
@@ -323,7 +318,6 @@ class AmazonBillingTest {
         var receivedPurchases: Map<String, StoreTransaction>? = null
         underTest.queryPurchases(
             appUserID,
-            appInBackground = false,
             onSuccess = {
                 receivedPurchases = it
             },
@@ -365,7 +359,6 @@ class AmazonBillingTest {
         var receivedPurchases: Map<String, StoreTransaction>? = null
         underTest.queryPurchases(
             appUserID,
-            appInBackground = false,
             onSuccess = {
                 receivedPurchases = it
             },
@@ -427,7 +420,6 @@ class AmazonBillingTest {
         var receivedError: PurchasesError? = null
         underTest.queryPurchases(
             appUserID,
-            appInBackground = false,
             onSuccess = {
                 fail("Should be an error")
             },
@@ -473,7 +465,6 @@ class AmazonBillingTest {
         var successCalled: Boolean = false
         underTest.queryPurchases(
             appUserID,
-            appInBackground = false,
             onSuccess = {
                 successCalled = true
                 receivedPurchases = it

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -13,7 +13,6 @@ import com.revenuecat.purchases.PurchasesErrorCallback
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesState
 import com.revenuecat.purchases.PurchasesStateCache
-import com.revenuecat.purchases.PurchasesStateProvider
 import com.revenuecat.purchases.amazon.handler.ProductDataHandler
 import com.revenuecat.purchases.amazon.handler.PurchaseHandler
 import com.revenuecat.purchases.amazon.handler.PurchaseUpdatesHandler
@@ -640,7 +639,6 @@ class AmazonBillingTest {
         var receivedPurchases: List<StoreTransaction>? = null
         underTest.queryAllPurchases(
             appUserID,
-            appInBackground = false,
             onReceivePurchaseHistory = {
                 receivedPurchases = it
             },
@@ -816,7 +814,6 @@ class AmazonBillingTest {
         var receivedPurchases: List<StoreTransaction>? = null
         underTest.queryAllPurchases(
             appUserID,
-            appInBackground = false,
             onReceivePurchaseHistory = {
                 receivedPurchases = it
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
@@ -122,7 +122,6 @@ class OfferingsFactoryTest {
         var purchasesError: PurchasesError? = null
         offeringsFactory.createOfferings(
             offeringsJSON = oneOfferingWithNoProductsResponse,
-            appInBackground = false,
             onError = { purchasesError = it },
             onSuccess = { fail("Expected error") }
         )
@@ -138,7 +137,6 @@ class OfferingsFactoryTest {
         var purchasesError: PurchasesError? = null
         offeringsFactory.createOfferings(
             offeringsJSON = JSONObject("{}"),
-            appInBackground = false,
             onError = { purchasesError = it },
             onSuccess = { fail("Expected error") }
         )
@@ -155,7 +153,6 @@ class OfferingsFactoryTest {
         var purchasesError: PurchasesError? = null
         offeringsFactory.createOfferings(
             offeringsJSON = oneOfferingResponse,
-            appInBackground = false,
             onError = { purchasesError = it },
             onSuccess = { fail("Expected error") }
         )
@@ -258,7 +255,6 @@ class OfferingsFactoryTest {
             billing.queryProductDetailsAsync(
                 type,
                 productIds.toSet(),
-                any(),
                 captureLambda(),
                 any(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
@@ -172,7 +172,6 @@ class OfferingsFactoryTest {
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
             offeringsJSON = oneOfferingResponse,
-            appInBackground = false,
             onError = { fail("Expected success. Got error: $it") },
             onSuccess = { offerings = it }
         )
@@ -191,7 +190,6 @@ class OfferingsFactoryTest {
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
             offeringsJSON = oneOfferingInAppProductResponse,
-            appInBackground = false,
             onError = { fail("Expected success. Got error: $it") },
             onSuccess = { offerings = it }
         )
@@ -210,7 +208,6 @@ class OfferingsFactoryTest {
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
             offeringsJSON = oneOfferingWithPaywall,
-            appInBackground = false,
             onError = { fail("Error: $it") },
             onSuccess = { offerings = it }
         )
@@ -229,7 +226,6 @@ class OfferingsFactoryTest {
         var offerings: Offerings? = null
         offeringsFactory.createOfferings(
             offeringsJSON = oneOfferingWithInvalidPaywallResponse,
-            appInBackground = false,
             onError = { fail("Error: $it") },
             onSuccess = { offerings = it }
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -353,7 +353,6 @@ class OfferingsManagerTest {
         verify(exactly = 1) { cache.cacheOfferings(testOfferings, backendResponse) }
         verify(exactly = 1) { offeringsFactory.createOfferings(
             offeringsJSON = backendResponse,
-            appInBackground = any(),
             onError = any(),
             onSuccess = any()
         ) }
@@ -497,7 +496,6 @@ class OfferingsManagerTest {
             every {
                 offeringsFactory.createOfferings(
                     offeringsJSON = any(),
-                    appInBackground = any(),
                     onError = any(),
                     onSuccess = captureLambda()
                 )
@@ -508,7 +506,6 @@ class OfferingsManagerTest {
             every {
                 offeringsFactory.createOfferings(
                     offeringsJSON = any(),
-                    appInBackground = any(),
                     onError = captureLambda(),
                     onSuccess = any()
                 )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineCustomerInfoCalculatorTest.kt
@@ -70,7 +70,6 @@ class OfflineCustomerInfoCalculatorTest {
         var receivedCustomerInfo: CustomerInfo? = null
         offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
             appUserID = appUserID,
-            appInBackground = false,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should've succeeded") }
         )
@@ -91,7 +90,6 @@ class OfflineCustomerInfoCalculatorTest {
         var receivedCustomerInfo: CustomerInfo? = null
         offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
             appUserID = appUserID,
-            appInBackground = false,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should've succeeded") }
         )
@@ -134,7 +132,6 @@ class OfflineCustomerInfoCalculatorTest {
         var receivedCustomerInfo: CustomerInfo? = null
         offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
             appUserID = appUserID,
-            appInBackground = false,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should've succeeded") }
         )
@@ -188,7 +185,6 @@ class OfflineCustomerInfoCalculatorTest {
         every {
             purchasedProductsFetcher.queryActiveProducts(
                 appUserID = appUserID,
-                appInBackground = any(),
                 onSuccess = captureLambda(),
                 onError = any()
             )
@@ -199,7 +195,6 @@ class OfflineCustomerInfoCalculatorTest {
         var receivedCustomerInfo: CustomerInfo? = null
         offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
             appUserID = appUserID,
-            appInBackground = false,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should've succeeded") }
         )
@@ -258,7 +253,6 @@ class OfflineCustomerInfoCalculatorTest {
         var receivedCustomerInfo: CustomerInfo? = null
         offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
             appUserID = appUserID,
-            appInBackground = false,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should've succeeded") }
         )
@@ -304,7 +298,6 @@ class OfflineCustomerInfoCalculatorTest {
         var receivedCustomerInfo: CustomerInfo? = null
         offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
             appUserID = appUserID,
-            appInBackground = false,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should've succeeded") }
         )
@@ -346,7 +339,6 @@ class OfflineCustomerInfoCalculatorTest {
         var receivedCustomerInfo: CustomerInfo? = null
         offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
             appUserID = appUserID,
-            appInBackground = false,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should've succeeded") }
         )
@@ -381,7 +373,6 @@ class OfflineCustomerInfoCalculatorTest {
         var receivedCustomerInfo: CustomerInfo? = null
         offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
             appUserID = appUserID,
-            appInBackground = false,
             onSuccess = { receivedCustomerInfo = it },
             onError = { fail("Should've succeeded") }
         )
@@ -414,7 +405,6 @@ class OfflineCustomerInfoCalculatorTest {
         every {
             purchasedProductsFetcher.queryActiveProducts(
                 appUserID = appUserID,
-                appInBackground = any(),
                 onSuccess = captureLambda(),
                 onError = any()
             )
@@ -425,7 +415,6 @@ class OfflineCustomerInfoCalculatorTest {
         var receivedError: PurchasesError? = null
         offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
             appUserID = appUserID,
-            appInBackground = false,
             onSuccess = { fail("Should've failed") },
             onError = { receivedError = it }
         )
@@ -438,7 +427,6 @@ class OfflineCustomerInfoCalculatorTest {
         every {
             purchasedProductsFetcher.queryActiveProducts(
                 appUserID = appUserID,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = captureLambda()
             )
@@ -449,7 +437,6 @@ class OfflineCustomerInfoCalculatorTest {
         var receivedError: PurchasesError? = null
         offlineCustomerInfoCalculator.computeOfflineCustomerInfo(
             appUserID = appUserID,
-            appInBackground = false,
             onSuccess = { fail("Should've failed") },
             onError = { receivedError = it }
         )
@@ -514,7 +501,6 @@ class OfflineCustomerInfoCalculatorTest {
         every {
             purchasedProductsFetcher.queryActiveProducts(
                 appUserID = appUserID,
-                appInBackground = any(),
                 onSuccess = captureLambda(),
                 onError = any()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
@@ -211,7 +211,6 @@ class OfflineEntitlementsManagerTest {
         mockCalculateOfflineEntitlements(successCustomerInfo = customerInfo)
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
-            appInBackground = false,
             onSuccess = {},
             onError = { fail("Should succeed") })
         assertThat(offlineEntitlementsManager.offlineCustomerInfo).isEqualTo(customerInfo)
@@ -229,13 +228,11 @@ class OfflineEntitlementsManagerTest {
         var receivedError: PurchasesError? = null
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
-            appInBackground = false,
             onSuccess = { fail("Should error") },
             onError = { receivedError = it }
         )
         verify(exactly = 0) { offlineEntitlementsCalculator.computeOfflineCustomerInfo(
             appUserID = any(),
-            appInBackground = any(),
             onSuccess = any(),
             onError = any()
         ) }
@@ -249,7 +246,6 @@ class OfflineEntitlementsManagerTest {
         var customerInfoFromCallback: CustomerInfo? = null
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
-            appInBackground = false,
             onSuccess = { customerInfoFromCallback = it },
             onError = { fail("Should succeed") }
         )
@@ -262,7 +258,6 @@ class OfflineEntitlementsManagerTest {
         mockCalculateOfflineEntitlements(successCustomerInfo = customerInfo)
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
-            appInBackground = false,
             onSuccess = {},
             onError = { fail("Should succeed") }
         )
@@ -275,7 +270,6 @@ class OfflineEntitlementsManagerTest {
         mockCalculateOfflineEntitlements(successCustomerInfo = customerInfo)
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
-            appInBackground = false,
             onSuccess = {},
             onError = { fail("Should succeed") }
         )
@@ -291,7 +285,6 @@ class OfflineEntitlementsManagerTest {
         every {
             offlineEntitlementsCalculator.computeOfflineCustomerInfo(
                 appUserID,
-                appInBackground = any(),
                 onSuccess = capture(successCallbackSlot),
                 onError = any()
             )
@@ -299,24 +292,22 @@ class OfflineEntitlementsManagerTest {
         var callback1CustomerInfo: CustomerInfo? = null
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
-            appInBackground = false,
             onSuccess = { callback1CustomerInfo = it },
             onError = { fail("Should succeed") }
         )
         var callback2CustomerInfo: CustomerInfo? = null
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
-            appInBackground = false,
             onSuccess = { callback2CustomerInfo = it },
             onError = { fail("Should succeed") }
         )
         assertThat(callback1CustomerInfo).isNull()
         assertThat(callback2CustomerInfo).isNull()
-        verify(exactly = 1) { offlineEntitlementsCalculator.computeOfflineCustomerInfo(any(), any(), any(), any()) }
+        verify(exactly = 1) { offlineEntitlementsCalculator.computeOfflineCustomerInfo(any(), any(), any()) }
         successCallbackSlot.invoke(customerInfo)
         assertThat(callback1CustomerInfo).isEqualTo(customerInfo)
         assertThat(callback2CustomerInfo).isEqualTo(customerInfo)
-        verify(exactly = 1) { offlineEntitlementsCalculator.computeOfflineCustomerInfo(any(), any(), any(), any()) }
+        verify(exactly = 1) { offlineEntitlementsCalculator.computeOfflineCustomerInfo(any(), any(), any()) }
     }
 
     @Test
@@ -324,7 +315,6 @@ class OfflineEntitlementsManagerTest {
         mockCalculateOfflineEntitlements(error = PurchasesError(PurchasesErrorCode.UnknownError))
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
-            appInBackground = false,
             onSuccess = { fail("Should error") },
             onError = {}
         )
@@ -336,7 +326,6 @@ class OfflineEntitlementsManagerTest {
         mockCalculateOfflineEntitlements(error = PurchasesError(PurchasesErrorCode.UnknownError))
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
-            appInBackground = false,
             onSuccess = { fail("Should error") },
             onError = {}
         )
@@ -352,7 +341,6 @@ class OfflineEntitlementsManagerTest {
         var receivedError: PurchasesError? = null
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
-            appInBackground = false,
             onSuccess = { fail("Should error") },
             onError = { receivedError = it }
         )
@@ -366,7 +354,6 @@ class OfflineEntitlementsManagerTest {
         every {
             offlineEntitlementsCalculator.computeOfflineCustomerInfo(
                 appUserID,
-                appInBackground = any(),
                 onSuccess = any(),
                 onError = capture(errorCallbackSlot)
             )
@@ -374,26 +361,23 @@ class OfflineEntitlementsManagerTest {
         var callback1Error: PurchasesError? = null
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
-            appInBackground = false,
             onSuccess = { fail("Should error") },
             onError = { callback1Error = it }
         )
         var callback2Error: PurchasesError? = null
         offlineEntitlementsManager.calculateAndCacheOfflineCustomerInfo(
             appUserID,
-            appInBackground = false,
             onSuccess = { fail("Should error") },
             onError = { callback2Error = it }
         )
         assertThat(callback1Error).isNull()
         assertThat(callback2Error).isNull()
-        verify(exactly = 1) { offlineEntitlementsCalculator.computeOfflineCustomerInfo(any(), any(), any(), any()) }
+        verify(exactly = 1) { offlineEntitlementsCalculator.computeOfflineCustomerInfo(any(), any(), any()) }
         errorCallbackSlot.invoke(error)
         assertThat(callback1Error).isEqualTo(error)
         assertThat(callback2Error).isEqualTo(error)
         verify(exactly = 1) { offlineEntitlementsCalculator.computeOfflineCustomerInfo(
             appUserID = any(),
-            appInBackground = any(),
             onSuccess = any(),
             onError = any()
         ) }
@@ -480,7 +464,6 @@ class OfflineEntitlementsManagerTest {
             every {
                 offlineEntitlementsCalculator.computeOfflineCustomerInfo(
                     appUserID,
-                    appInBackground = any(),
                     onSuccess = captureLambda(),
                     onError = any()
                 )
@@ -491,7 +474,6 @@ class OfflineEntitlementsManagerTest {
             every {
                 offlineEntitlementsCalculator.computeOfflineCustomerInfo(
                     appUserID,
-                    appInBackground = any(),
                     onSuccess = any(),
                     onError = captureLambda()
                 )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcherTest.kt
@@ -58,7 +58,6 @@ class PurchasedProductsFetcherTest {
 
         fetcher.queryActiveProducts(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = { fail("Should not have succeeded") },
             onError = { error = it },
         )
@@ -75,7 +74,6 @@ class PurchasedProductsFetcherTest {
 
         fetcher.queryActiveProducts(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = { fail("Should not have succeeded") },
             onError = { error = it },
         )
@@ -92,7 +90,6 @@ class PurchasedProductsFetcherTest {
         every {
             billing.queryPurchases(
                 appUserID,
-                appInBackground = any(),
                 onSuccess = captureLambda(),
                 onError = any(),
             )
@@ -103,7 +100,6 @@ class PurchasedProductsFetcherTest {
 
         fetcher.queryActiveProducts(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = {
                 receivedListOfPurchasedProducts = it
             },
@@ -119,7 +115,6 @@ class PurchasedProductsFetcherTest {
         every {
             billing.queryPurchases(
                 appUserID,
-                appInBackground = any(),
                 onSuccess = captureLambda(),
                 onError = any(),
             )
@@ -130,7 +125,6 @@ class PurchasedProductsFetcherTest {
 
         fetcher.queryActiveProducts(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = {
                 receivedListOfPurchasedProducts = it
             },
@@ -154,7 +148,6 @@ class PurchasedProductsFetcherTest {
 
         fetcher.queryActiveProducts(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = {
                 receivedListOfPurchasedProducts = it
             },
@@ -183,7 +176,6 @@ class PurchasedProductsFetcherTest {
 
         fetcher.queryActiveProducts(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = {
                 receivedListOfPurchasedProducts = it
             },
@@ -223,7 +215,6 @@ class PurchasedProductsFetcherTest {
 
         fetcher.queryActiveProducts(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = {
                 receivedListOfPurchasedProducts = it
             },
@@ -272,7 +263,6 @@ class PurchasedProductsFetcherTest {
 
         fetcher.queryActiveProducts(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = {
                 receivedListOfPurchasedProducts = it
             },
@@ -315,7 +305,6 @@ class PurchasedProductsFetcherTest {
         every {
             billing.queryPurchases(
                 appUserID,
-                appInBackground = any(),
                 onSuccess = captureLambda(),
                 onError = any(),
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1000,7 +1000,6 @@ class BillingWrapperTest {
         wrapper.queryProductDetailsAsync(
             ProductType.SUBS,
             setOf("product_a"),
-            appInBackground = false,
             {},
             {
                 fail("shouldn't be an error")
@@ -1227,7 +1226,6 @@ class BillingWrapperTest {
         wrapper.queryProductDetailsAsync(
             productType = ProductType.SUBS,
             productIds = setOf("test-sku"),
-            appInBackground = false,
             onReceive = {},
             onError = { fail("shouldn't be an error") }
         )
@@ -1263,7 +1261,6 @@ class BillingWrapperTest {
         wrapper.queryProductDetailsAsync(
             productType = ProductType.SUBS,
             productIds = setOf("test-sku"),
-            appInBackground = false,
             onReceive = { fail("should be an error") },
             onError = {}
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -5,8 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Handler
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.billingclient.api.AcknowledgePurchaseParams
-import com.android.billingclient.api.AcknowledgePurchaseResponseListener
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingFlowParams
@@ -19,8 +17,6 @@ import com.android.billingclient.api.InAppMessageResult
 import com.android.billingclient.api.InAppMessageResult.InAppMessageResponseCode
 import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.ProductDetailsResponseListener
-import com.android.billingclient.api.Purchase
-import com.android.billingclient.api.PurchaseHistoryRecord
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.ProductType
@@ -28,7 +24,6 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesState
 import com.revenuecat.purchases.PurchasesStateCache
-import com.revenuecat.purchases.PurchasesStateProvider
 import com.revenuecat.purchases.assertDebugLog
 import com.revenuecat.purchases.assertErrorLog
 import com.revenuecat.purchases.assertVerboseLog
@@ -37,7 +32,6 @@ import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.ReplaceProductInfo
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
-import com.revenuecat.purchases.common.firstSku
 import com.revenuecat.purchases.common.sha256
 import com.revenuecat.purchases.models.GoogleReplacementMode
 import com.revenuecat.purchases.models.InAppMessageType
@@ -1048,7 +1042,6 @@ class BillingWrapperTest {
         var receivedPurchases = listOf<StoreTransaction>()
         wrapper.queryAllPurchases(
             appUserID = "appUserID",
-            appInBackground = false,
             onReceivePurchaseHistory = {
                 receivedPurchases = it
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -280,7 +280,6 @@ class BillingWrapperTest {
         var error: PurchasesError? = null
         wrapper.queryPurchases(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = {
                 fail("should be an error")
             },
@@ -1384,7 +1383,6 @@ class BillingWrapperTest {
         var receivedError: PurchasesError? = null
         wrapper.queryPurchases(
             appUserID = "abc",
-            appInBackground = false,
             onSuccess = {
                 error("Unexpected success")
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -206,7 +206,6 @@ class BillingWrapperTest {
         wrapper.consumePurchase(
             token = token,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false,
         ) {
             consumePurchaseCompleted = true
         }
@@ -230,7 +229,6 @@ class BillingWrapperTest {
         wrapper.consumePurchase(
             token = token,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false,
         ) {
             consumePurchaseResponse1Called = true
         }
@@ -239,7 +237,6 @@ class BillingWrapperTest {
         wrapper.consumePurchase(
             token = token,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false,
         ) {
             consumePurchaseResponse2Called = true
         }
@@ -262,7 +259,6 @@ class BillingWrapperTest {
         wrapper.consumePurchase(
             token = token,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false,
         ) {  }
 
         verify(exactly = 2) {
@@ -961,7 +957,6 @@ class BillingWrapperTest {
         wrapper.consumePurchase(
             token = "token",
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false,
         ) { }
 
         verify(exactly = 1) { // Just the original connection

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -51,7 +51,6 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.acknowledge(
             token,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false
         ) { }
 
         assertThat(capturedAcknowledgePurchaseParams.isCaptured).isTrue

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -70,7 +70,6 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = true,
             purchase = googlePurchaseWrapper,
-            appInBackground = false,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
         )
 
@@ -96,7 +95,6 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = true,
             purchase = googlePurchaseWrapper,
-            appInBackground = false,
             initiationSource = PostReceiptInitiationSource.PURCHASE,
         )
 
@@ -122,7 +120,6 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = true,
             purchase = historyRecordWrapper,
-            appInBackground = false,
             initiationSource = PostReceiptInitiationSource.RESTORE,
         )
 
@@ -144,7 +141,6 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = true,
             purchase = googlePurchaseWrapper,
-            appInBackground = false,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
         )
 
@@ -166,7 +162,6 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = true,
             purchase = historyRecordWrapper,
-            appInBackground = false,
             initiationSource = PostReceiptInitiationSource.RESTORE
         )
 
@@ -192,8 +187,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = true,
             purchase = googlePurchaseWrapper,
-            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false
+            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES
         )
 
         assertThat(capturedAcknowledgeResponseListener.isCaptured).isTrue
@@ -218,7 +212,6 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = true,
             purchase = historyRecordWrapper,
-            appInBackground = false,
             initiationSource = PostReceiptInitiationSource.RESTORE,
         )
 
@@ -244,7 +237,6 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = false,
             purchase = googlePurchaseWrapper,
-            appInBackground = false,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
         )
 
@@ -269,7 +261,6 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = false,
             purchase = historyRecordWrapper,
-            appInBackground = false,
             initiationSource = PostReceiptInitiationSource.RESTORE,
         )
 
@@ -294,7 +285,6 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = true,
             purchase = googlePurchaseWrapper,
-            appInBackground = false,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
         )
 

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCaseTest.kt
@@ -48,7 +48,6 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumePurchase(
             token,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false
         ) {  }
 
         assertThat(capturedConsumeResponseListener.isCaptured).isTrue

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCaseTest.kt
@@ -82,7 +82,6 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
             shouldTryToConsume = true,
             purchase = googlePurchaseWrapper,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false,
         )
 
         assertThat(capturedConsumeResponseListener.isCaptured).isTrue
@@ -110,7 +109,6 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
             shouldTryToConsume = true,
             purchase = historyRecordWrapper,
             initiationSource = PostReceiptInitiationSource.RESTORE,
-            appInBackground = false,
         )
 
         assertThat(capturedConsumeResponseListener.isCaptured).isTrue
@@ -136,8 +134,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = true,
             purchase = googlePurchaseWrapper,
-            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false
+            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES
         )
 
         assertThat(capturedConsumeResponseListener.isCaptured).isTrue
@@ -163,8 +160,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = true,
             purchase = historyRecordWrapper,
-            initiationSource = PostReceiptInitiationSource.RESTORE,
-            appInBackground = false
+            initiationSource = PostReceiptInitiationSource.RESTORE
         )
 
         assertThat(capturedConsumeResponseListener.isCaptured).isTrue
@@ -192,8 +188,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = true,
             purchase = googlePurchaseWrapper,
-            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false
+            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES
         )
 
         assertThat(capturedConsumeResponseListener.isCaptured).isTrue
@@ -224,8 +219,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = true,
             purchase = historyRecordWrapper,
-            initiationSource = PostReceiptInitiationSource.RESTORE,
-            appInBackground = false
+            initiationSource = PostReceiptInitiationSource.RESTORE
         )
 
         assertThat(capturedConsumeResponseListener.isCaptured).isTrue
@@ -257,8 +251,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = false,
             purchase = googlePurchaseWrapper,
-            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false
+            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES
         )
 
         verify(exactly = 0) {
@@ -287,8 +280,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         wrapper.consumeAndSave(
             shouldTryToConsume = false,
             purchase = historyRecordWrapper,
-            initiationSource = PostReceiptInitiationSource.RESTORE,
-            appInBackground = false
+            initiationSource = PostReceiptInitiationSource.RESTORE
         )
 
         verify(exactly = 0) {
@@ -320,7 +312,6 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
             shouldTryToConsume = true,
             purchase = googlePurchaseWrapper,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-            appInBackground = false,
         )
 
         verify(exactly = 0) {

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCaseTest.kt
@@ -2,29 +2,22 @@ package com.revenuecat.purchases.google.usecase
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.BillingClient
-import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ConsumeParams
 import com.android.billingclient.api.ConsumeResponseListener
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryRecord
-import com.android.billingclient.api.PurchaseHistoryResponseListener
-import com.android.billingclient.api.QueryPurchaseHistoryParams
 import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
-import com.revenuecat.purchases.amazon.createPeriod
-import com.revenuecat.purchases.common.firstSku
 import com.revenuecat.purchases.google.toStoreTransaction
-import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.utils.stubGooglePurchase
 import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
-import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions
@@ -33,7 +26,6 @@ import org.assertj.core.data.Offset
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/GetBillingConfigUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/GetBillingConfigUseCaseTest.kt
@@ -41,7 +41,6 @@ internal class GetBillingConfigUseCaseTest: BaseBillingUseCaseTest() {
         mockGetBillingConfig()
         var countryCode: String? = null
         wrapper.getStorefront(
-            appInBackground = false,
             onSuccess = { countryCode = it },
             onError = { fail("Should succeed") }
         )
@@ -52,7 +51,6 @@ internal class GetBillingConfigUseCaseTest: BaseBillingUseCaseTest() {
     fun `querying store country code stores country code in cache`() {
         mockGetBillingConfig()
         wrapper.getStorefront(
-            appInBackground = false,
             onSuccess = { },
             onError = { fail("Should succeed") }
         )
@@ -64,7 +62,6 @@ internal class GetBillingConfigUseCaseTest: BaseBillingUseCaseTest() {
         mockGetBillingConfig(BillingResponseCode.ERROR)
         var error: PurchasesError? = null
         wrapper.getStorefront(
-            appInBackground = false,
             onSuccess = { fail("Should error") },
             onError = { error = it }
         )
@@ -85,7 +82,6 @@ internal class GetBillingConfigUseCaseTest: BaseBillingUseCaseTest() {
         }
 
         wrapper.getStorefront(
-            appInBackground = false,
             onSuccess = { numCallbacks++ },
             onError = { numCallbacks++ }
         )
@@ -97,7 +93,6 @@ internal class GetBillingConfigUseCaseTest: BaseBillingUseCaseTest() {
     fun `querying store country code does not store country code on error`() {
         mockGetBillingConfig(BillingResponseCode.ERROR)
         wrapper.getStorefront(
-            appInBackground = false,
             onSuccess = { fail("Should error") },
             onError = { }
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryProductDetailsUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryProductDetailsUseCaseTest.kt
@@ -53,7 +53,6 @@ internal class QueryProductDetailsUseCaseTest: BaseBillingUseCaseTest() {
         wrapper.queryProductDetailsAsync(
             productType = ProductType.SUBS,
             productIds = productIDs,
-            appInBackground = false,
             onReceive = {
                 receivedList = it
             },
@@ -81,7 +80,6 @@ internal class QueryProductDetailsUseCaseTest: BaseBillingUseCaseTest() {
         wrapper.queryProductDetailsAsync(
             productType = ProductType.UNKNOWN,
             productIds = productIDs,
-            appInBackground = false,
             onReceive = {
                 this@QueryProductDetailsUseCaseTest.storeProducts = it
             },
@@ -106,7 +104,6 @@ internal class QueryProductDetailsUseCaseTest: BaseBillingUseCaseTest() {
         wrapper.queryProductDetailsAsync(
             productType = ProductType.SUBS,
             productIds = productIdsSet,
-            appInBackground = false,
             onReceive = {},
             onError = {
                 AssertionsForClassTypes.fail("shouldn't be an error")
@@ -124,7 +121,6 @@ internal class QueryProductDetailsUseCaseTest: BaseBillingUseCaseTest() {
         wrapper.queryProductDetailsAsync(
             productType = ProductType.SUBS,
             productIds = emptySet(),
-            appInBackground = false,
             onReceive = {
                 assertThat(it).isEmpty()
             },
@@ -143,7 +139,6 @@ internal class QueryProductDetailsUseCaseTest: BaseBillingUseCaseTest() {
         wrapper.queryProductDetailsAsync(
             productType = ProductType.SUBS,
             productIds = setOf("", ""),
-            appInBackground = false,
             onReceive = {
                 assertThat(it).isEmpty()
             },
@@ -175,7 +170,6 @@ internal class QueryProductDetailsUseCaseTest: BaseBillingUseCaseTest() {
         wrapper.queryProductDetailsAsync(
             productType = ProductType.SUBS,
             productIds = setOf("asdf", "asdf"),
-            appInBackground = false,
             onReceive = {
                 Thread.sleep(200)
                 numCallbacks++
@@ -214,7 +208,6 @@ internal class QueryProductDetailsUseCaseTest: BaseBillingUseCaseTest() {
         wrapper.queryProductDetailsAsync(
             productType = ProductType.SUBS,
             productIds = setOf("asdf"),
-            appInBackground = false,
             onReceive = {
                 // ensuring we don't hit an edge case where numCallbacks doesn't increment before the final assert
                 numCallbacks.incrementAndGet()

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
@@ -313,7 +313,6 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
             appUserID = appUserId,
             productType = ProductType.SUBS,
             productId = sku,
-            appInBackground = false,
             onCompletion = {
                 recordFound = it
             },
@@ -344,7 +343,6 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
             appUserID = appUserId,
             productType = ProductType.SUBS,
             productId = sku,
-            appInBackground = false,
             onCompletion = {
                 fail("should be error")
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
@@ -3,8 +3,6 @@ package com.revenuecat.purchases.google.usecase
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingResult
-import com.android.billingclient.api.ConsumeParams
-import com.android.billingclient.api.ConsumeResponseListener
 import com.android.billingclient.api.PurchaseHistoryRecord
 import com.android.billingclient.api.PurchaseHistoryResponseListener
 import com.android.billingclient.api.QueryPurchaseHistoryParams
@@ -47,7 +45,6 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
         var error: PurchasesError? = null
         wrapper.queryPurchaseHistoryAsync(
             productType = ProductType.SUBS.toGoogleProductType()!!,
-            appInBackground = false,
             onReceivePurchaseHistory = {
                 fail("call should not succeed")
             },
@@ -69,7 +66,6 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
         var errorCalled = false
         wrapper.queryPurchaseHistoryAsync(
             productType = "notValid",
-            appInBackground = false,
             onReceivePurchaseHistory = {
                 fail("call should not succeed")
             },
@@ -97,7 +93,6 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
 
         wrapper.queryPurchaseHistoryAsync(
             productType = BillingClient.ProductType.SUBS,
-            appInBackground = false,
             onReceivePurchaseHistory = {
                 numCallbacks++
             }, onReceivePurchaseHistoryError = {
@@ -132,7 +127,6 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
 
         wrapper.queryPurchaseHistoryAsync(
             productType = BillingClient.ProductType.SUBS,
-            appInBackground = false,
             onReceivePurchaseHistory = {
                 // ensuring we don't hit an edge case where numCallbacks doesn't increment before the final assert
                 numCallbacks.incrementAndGet()
@@ -157,7 +151,6 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
         var successCalled = false
         wrapper.queryPurchaseHistoryAsync(
             productType = subsGoogleProductType,
-            appInBackground = false,
             onReceivePurchaseHistory = {
                 successCalled = true
             },
@@ -178,7 +171,6 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
         var errorCalled = false
         wrapper.queryPurchaseHistoryAsync(
             productType = subsGoogleProductType,
-            appInBackground = false,
             onReceivePurchaseHistory = {
                 fail("should go to on error")
             },
@@ -200,7 +192,6 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
 
         wrapper.queryPurchaseHistoryAsync(
             productType = subsGoogleProductType,
-            appInBackground = false,
             onReceivePurchaseHistory = {},
             onReceivePurchaseHistoryError = {}
         )
@@ -214,7 +205,6 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
 
         wrapper.queryPurchaseHistoryAsync(
             productType = inAppGoogleProductType,
-            appInBackground = false,
             onReceivePurchaseHistory = {},
             onReceivePurchaseHistoryError = {}
         )
@@ -244,7 +234,6 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
 
         wrapper.queryPurchaseHistoryAsync(
             productType = BillingClient.ProductType.SUBS,
-            appInBackground = false,
             onReceivePurchaseHistory = {},
             onReceivePurchaseHistoryError = { fail("shouldn't be an error") }
         )
@@ -279,10 +268,8 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
 
         wrapper.queryPurchaseHistoryAsync(
             productType = BillingClient.ProductType.SUBS,
-            appInBackground = false,
-            onReceivePurchaseHistory = { fail("should be an error") },
-            onReceivePurchaseHistoryError = {}
-        )
+            onReceivePurchaseHistory = { fail("should be an error") }
+        ) {}
 
         verify(exactly = 1) {
             mockDiagnosticsTracker.trackGoogleQueryPurchaseHistoryRequest(

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchasesUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchasesUseCaseTest.kt
@@ -69,7 +69,6 @@ internal class QueryPurchasesUseCaseTest : BaseBillingUseCaseTest() {
         var purchasesByHashedToken: Map<String, StoreTransaction>? = null
         wrapper.queryPurchases(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = {
                 purchasesByHashedToken = it
             },
@@ -89,7 +88,6 @@ internal class QueryPurchasesUseCaseTest : BaseBillingUseCaseTest() {
         var purchasesByHashedToken: Map<String, StoreTransaction>? = null
         wrapper.queryPurchases(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = {
                 purchasesByHashedToken = it
             },
@@ -129,7 +127,6 @@ internal class QueryPurchasesUseCaseTest : BaseBillingUseCaseTest() {
         var receivedError: PurchasesError? = null
         wrapper.queryPurchases(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = { fail("should be an error") },
             onError = { receivedError = it }
         )
@@ -166,7 +163,6 @@ internal class QueryPurchasesUseCaseTest : BaseBillingUseCaseTest() {
         var purchasesByHashedToken: Map<String, StoreTransaction>? = null
         wrapper.queryPurchases(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = {
                 purchasesByHashedToken = it
             },
@@ -209,7 +205,6 @@ internal class QueryPurchasesUseCaseTest : BaseBillingUseCaseTest() {
         var purchasesByHashedToken: Map<String, StoreTransaction>? = null
         wrapper.queryPurchases(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = {
                 purchasesByHashedToken = it
             },
@@ -258,7 +253,6 @@ internal class QueryPurchasesUseCaseTest : BaseBillingUseCaseTest() {
 
         wrapper.queryPurchases(
             appUserID = appUserId,
-            appInBackground = false,
             onSuccess = {},
             onError = { fail("shouldn't be an error") }
         )
@@ -299,7 +293,6 @@ internal class QueryPurchasesUseCaseTest : BaseBillingUseCaseTest() {
 
         wrapper.queryPurchases(
             appUserID = appUserId,
-            appInBackground = false,
             onSuccess = { fail("should be an error") },
             onError = {}
         )
@@ -335,7 +328,6 @@ internal class QueryPurchasesUseCaseTest : BaseBillingUseCaseTest() {
 
         wrapper.queryPurchases(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = {
                 numCallbacks++
             },
@@ -374,7 +366,6 @@ internal class QueryPurchasesUseCaseTest : BaseBillingUseCaseTest() {
 
         wrapper.queryPurchases(
             appUserID = "appUserID",
-            appInBackground = false,
             onSuccess = {
                 // ensuring we don't hit an edge case where numCallbacks doesn't increment before the final assert
                 numCallbacks.incrementAndGet()

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -1059,7 +1059,6 @@ internal class PurchasesTest : BasePurchasesTest() {
         every {
             mockBillingAbstract.queryAllPurchases(
                 appUserID = appUserId,
-                appInBackground = false,
                 onReceivePurchaseHistory = captureLambda(),
                 onReceivePurchaseHistoryError = any()
             )
@@ -1075,7 +1074,6 @@ internal class PurchasesTest : BasePurchasesTest() {
         verify {
             mockBillingAbstract.queryAllPurchases(
                 appUserID = appUserId,
-                appInBackground = any(),
                 onReceivePurchaseHistory = any(),
                 onReceivePurchaseHistoryError = any()
             )
@@ -1091,7 +1089,6 @@ internal class PurchasesTest : BasePurchasesTest() {
         every {
             mockBillingAbstract.queryAllPurchases(
                 appUserID = appUserId,
-                appInBackground = any(),
                 onReceivePurchaseHistory = captureLambda(),
                 onReceivePurchaseHistoryError = any()
             )
@@ -1139,7 +1136,6 @@ internal class PurchasesTest : BasePurchasesTest() {
         every {
             mockBillingAbstract.queryAllPurchases(
                 appUserID = appUserId,
-                appInBackground = false,
                 onReceivePurchaseHistory = any(),
                 onReceivePurchaseHistoryError = captureLambda()
             )
@@ -1169,7 +1165,6 @@ internal class PurchasesTest : BasePurchasesTest() {
         every {
             mockBillingAbstract.queryAllPurchases(
                 appUserID = appUserId,
-                appInBackground = false,
                 onReceivePurchaseHistory = captureLambda(),
                 onReceivePurchaseHistoryError = any()
             )
@@ -1214,7 +1209,6 @@ internal class PurchasesTest : BasePurchasesTest() {
         verify(exactly = 1) {
             mockBillingAbstract.queryAllPurchases(
                 appUserID = appUserId,
-                appInBackground = any(),
                 onReceivePurchaseHistory = any(),
                 onReceivePurchaseHistoryError = any()
             )
@@ -1228,7 +1222,6 @@ internal class PurchasesTest : BasePurchasesTest() {
         every {
             mockBillingAbstract.queryAllPurchases(
                 appUserID = appUserId,
-                appInBackground = any(),
                 onReceivePurchaseHistory = captureLambda(),
                 onReceivePurchaseHistoryError = any(),
             )

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -101,7 +101,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = true,
                 appUserID = appUserId,
                 initiationSource = initiationSource,
-                appInBackground = false,
                 onSuccess = any(),
                 onError = any(),
             )
@@ -703,7 +702,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 appUserID = appUserId,
                 marketplace = null,
                 initiationSource = restoreInitiationSource,
-                appInBackground = false,
                 onSuccess = any(),
                 onError = any()
             )
@@ -761,7 +759,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 appUserID = appUserId,
                 marketplace = null,
                 initiationSource = restoreInitiationSource,
-                appInBackground = false,
                 onSuccess = any(),
                 onError = any()
             )
@@ -788,7 +785,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 appUserID = appUserId,
                 marketplace = null,
                 initiationSource = restoreInitiationSource,
-                appInBackground = false,
                 onSuccess = any(),
                 onError = any()
             )
@@ -840,7 +836,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 appUserID = appUserId,
                 marketplace = null,
                 initiationSource = restoreInitiationSource,
-                appInBackground = false,
                 onSuccess = any(),
                 onError = any()
             )
@@ -896,7 +891,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 appUserID = appUserId,
                 marketplace = null,
                 initiationSource = restoreInitiationSource,
-                appInBackground = false,
                 onSuccess = any(),
                 onError = any()
             )
@@ -978,7 +972,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 appUserID = appUserId,
                 marketplace = null,
                 initiationSource = restoreInitiationSource,
-                appInBackground = false,
                 onSuccess = any(),
                 onError = any(),
             )
@@ -1038,7 +1031,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 appUserID = appUserId,
                 marketplace = null,
                 initiationSource = restoreInitiationSource,
-                appInBackground = false,
                 onSuccess = any(),
                 onError = any(),
             )
@@ -1111,7 +1103,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = true,
                 appUserID = appUserId,
                 initiationSource = restoreInitiationSource,
-                appInBackground = false,
                 onSuccess = any(),
                 onError = any()
             )
@@ -1121,7 +1112,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = true,
                 appUserID = appUserId,
                 initiationSource = restoreInitiationSource,
-                appInBackground = false,
                 onSuccess = any(),
                 onError = any()
             )
@@ -1187,7 +1177,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 isRestore = any(),
                 appUserID = any(),
                 initiationSource = any(),
-                appInBackground = any(),
                 onSuccess = captureLambda(),
                 onError = any(),
             )

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -128,7 +128,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 appUserID = appUserId,
                 productType = ProductType.SUBS,
                 productId = oldSubId,
-                appInBackground = false,
                 onCompletion = captureLambda(),
                 onError = any(),
             )
@@ -173,7 +172,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 appUserID = appUserId,
                 productType = ProductType.SUBS,
                 productId = oldSubId,
-                appInBackground = false,
                 onCompletion = captureLambda(),
                 onError = any(),
             )
@@ -1392,7 +1390,6 @@ internal class PurchasesTest : BasePurchasesTest() {
                 appUserID = appUserId,
                 productType = ProductType.SUBS,
                 productId = oldProductId,
-                appInBackground = any(),
                 onCompletion = if (error == null) captureLambda() else any(),
                 onError = if (error != null) captureLambda() else any(),
             )

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -1369,7 +1369,6 @@ internal class PurchasesTest : BasePurchasesTest() {
             mockBillingAbstract.queryProductDetailsAsync(
                 productType = storeProduct.type,
                 productIds = setOf(productId),
-                appInBackground = any(),
                 onReceive = captureLambda(),
                 onError = any(),
             )


### PR DESCRIPTION
With #1502 we don't need to pass `appInBackground` as a parameter to the functions in `BillingAbstract`.

This PR removes those parameters.