### PR TITLE
Paywalls: Add `PaywallFooterView`

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallFooterViewAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallFooterViewAPI.java
@@ -18,14 +18,16 @@ final class PaywallFooterViewAPI {
                                   int defStyleAttr,
                                   Offering offering,
                                   PaywallListener listener,
-                                  FontProvider fontProvider ) {
+                                  FontProvider fontProvider,
+                                  Boolean condensed) {
         PaywallFooterView footerView = new PaywallFooterView(context);
         PaywallFooterView footerView2 = new PaywallFooterView(context, attrs);
         PaywallFooterView footerView3 = new PaywallFooterView(context, attrs, defStyleAttr);
         PaywallFooterView footerView4 = new PaywallFooterView(context, offering);
         PaywallFooterView footerView5 = new PaywallFooterView(context, offering, listener);
         PaywallFooterView footerView6 = new PaywallFooterView(context, offering, listener, fontProvider);
-        PaywallFooterView footerView7 = new PaywallFooterView(context, offering, listener, fontProvider, () -> null);
+        PaywallFooterView footerView7 = new PaywallFooterView(context, offering, listener, fontProvider, condensed);
+        PaywallFooterView footerView8 = new PaywallFooterView(context, offering, listener, fontProvider, condensed, () -> null);
     }
 
     static void checkMethods(PaywallFooterView footerView, PaywallListener listener) {

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallFooterViewAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallFooterViewAPI.java
@@ -7,7 +7,7 @@ import com.revenuecat.purchases.Offering;
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI;
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener;
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider;
-import com.revenuecat.purchases.ui.revenuecatui.fragment.PaywallFooterView;
+import com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView;
 
 @SuppressWarnings({"unused"})
 @ExperimentalPreviewRevenueCatUIPurchasesAPI

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallFooterViewAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallFooterViewAPI.java
@@ -1,0 +1,39 @@
+package com.revenuecat.apitester.java.revenuecatui;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import com.revenuecat.purchases.Offering;
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI;
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener;
+import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider;
+import com.revenuecat.purchases.ui.revenuecatui.fragment.PaywallFooterView;
+
+@SuppressWarnings({"unused"})
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
+final class PaywallFooterViewAPI {
+
+    static void checkConstructors(Context context,
+                                  AttributeSet attrs,
+                                  int defStyleAttr,
+                                  Offering offering,
+                                  PaywallListener listener,
+                                  FontProvider fontProvider ) {
+        PaywallFooterView footerView = new PaywallFooterView(context);
+        PaywallFooterView footerView2 = new PaywallFooterView(context, attrs);
+        PaywallFooterView footerView3 = new PaywallFooterView(context, attrs, defStyleAttr);
+        PaywallFooterView footerView4 = new PaywallFooterView(context, offering);
+        PaywallFooterView footerView5 = new PaywallFooterView(context, offering, listener);
+        PaywallFooterView footerView6 = new PaywallFooterView(context, offering, listener, fontProvider);
+        PaywallFooterView footerView7 = new PaywallFooterView(context, offering, listener, fontProvider, () -> null);
+    }
+
+    static void checkMethods(PaywallFooterView footerView, PaywallListener listener) {
+        footerView.setPaywallListener(null);
+        footerView.setPaywallListener(listener);
+        footerView.setDismissHandler(null);
+        footerView.setDismissHandler(() -> null);
+        footerView.setOfferingId(null);
+        footerView.setOfferingId("offeringId");
+    }
+}

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallViewAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallViewAPI.java
@@ -1,0 +1,41 @@
+package com.revenuecat.apitester.java.revenuecatui;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import com.revenuecat.purchases.Offering;
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI;
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener;
+import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider;
+import com.revenuecat.purchases.ui.revenuecatui.views.PaywallView;
+
+@SuppressWarnings({"unused"})
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
+final class PaywallViewAPI {
+
+    static void checkConstructors(Context context,
+                                  AttributeSet attrs,
+                                  int defStyleAttr,
+                                  Offering offering,
+                                  PaywallListener listener,
+                                  FontProvider fontProvider,
+                                  boolean shouldDisplayDismissButton) {
+        PaywallView paywallView = new PaywallView(context);
+        PaywallView paywallView2 = new PaywallView(context, attrs);
+        PaywallView paywallView3 = new PaywallView(context, attrs, defStyleAttr);
+        PaywallView paywallView4 = new PaywallView(context, offering);
+        PaywallView paywallView5 = new PaywallView(context, offering, listener);
+        PaywallView paywallView6 = new PaywallView(context, offering, listener, fontProvider);
+        PaywallView paywallView7 = new PaywallView(context, offering, listener, fontProvider, shouldDisplayDismissButton);
+        PaywallView paywallView8 = new PaywallView(context, offering, listener, fontProvider, shouldDisplayDismissButton, () -> null);
+    }
+
+    static void checkMethods(PaywallView paywallView, PaywallListener listener) {
+        paywallView.setPaywallListener(null);
+        paywallView.setPaywallListener(listener);
+        paywallView.setDismissHandler(null);
+        paywallView.setDismissHandler(() -> null);
+        paywallView.setOfferingId(null);
+        paywallView.setOfferingId("offeringId");
+    }
+}

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallAPI.kt
@@ -19,7 +19,9 @@ private class PaywallAPI {
 
     @Composable
     fun checkFooter(options: PaywallOptions) {
+        PaywallFooter(options = options)
         PaywallFooter(options = options, condensed = true)
+        PaywallFooter(options = options) {}
         PaywallFooter(options = options, condensed = true) {}
     }
 

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallAPI.kt
@@ -19,6 +19,7 @@ private class PaywallAPI {
 
     @Composable
     fun checkFooter(options: PaywallOptions) {
+        PaywallFooter(options = options, condensed = true)
         PaywallFooter(options = options, condensed = true) {}
     }
 

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallFooterViewAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallFooterViewAPI.kt
@@ -17,6 +17,7 @@ private class PaywallFooterViewAPI {
         val paywallFooterView: FrameLayout = PaywallFooterView(context)
     }
 
+    @Suppress("LongParameterList")
     fun checkConstructors(
         context: Context,
         attrs: AttributeSet?,

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallFooterViewAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallFooterViewAPI.kt
@@ -1,0 +1,50 @@
+package com.revenuecat.apitester.kotlin.revenuecatui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
+import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
+import com.revenuecat.purchases.ui.revenuecatui.fragment.PaywallFooterView
+
+@Suppress("unused", "UNUSED_VARIABLE")
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+private class PaywallFooterViewAPI {
+
+    fun checkType(context: Context) {
+        val paywallFooterView: FrameLayout = PaywallFooterView(context)
+    }
+
+    fun checkConstructors(
+        context: Context,
+        attrs: AttributeSet?,
+        defStyleAttr: Int,
+        offering: Offering,
+        listener: PaywallListener,
+        fontProvider: FontProvider,
+        dismissHandler: () -> Unit,
+    ) {
+        PaywallFooterView(context)
+        PaywallFooterView(context, attrs)
+        PaywallFooterView(context, attrs, defStyleAttr)
+        PaywallFooterView(context, offering)
+        PaywallFooterView(context, offering, listener)
+        PaywallFooterView(context, offering, listener, fontProvider)
+        PaywallFooterView(context, offering, listener, fontProvider, dismissHandler)
+    }
+
+    fun checkMethods(
+        paywallFooterView: PaywallFooterView,
+        paywallListener: PaywallListener,
+        dismissHandler: () -> Unit,
+    ) {
+        paywallFooterView.setPaywallListener(null)
+        paywallFooterView.setPaywallListener(paywallListener)
+        paywallFooterView.setDismissHandler(null)
+        paywallFooterView.setDismissHandler(dismissHandler)
+        paywallFooterView.setOfferingId(null)
+        paywallFooterView.setOfferingId("offering_id")
+    }
+}

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallFooterViewAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallFooterViewAPI.kt
@@ -25,6 +25,7 @@ private class PaywallFooterViewAPI {
         offering: Offering,
         listener: PaywallListener,
         fontProvider: FontProvider,
+        condensed: Boolean,
         dismissHandler: () -> Unit,
     ) {
         PaywallFooterView(context)
@@ -33,7 +34,8 @@ private class PaywallFooterViewAPI {
         PaywallFooterView(context, offering)
         PaywallFooterView(context, offering, listener)
         PaywallFooterView(context, offering, listener, fontProvider)
-        PaywallFooterView(context, offering, listener, fontProvider, dismissHandler)
+        PaywallFooterView(context, offering, listener, fontProvider, condensed)
+        PaywallFooterView(context, offering, listener, fontProvider, condensed, dismissHandler)
     }
 
     fun checkMethods(

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallFooterViewAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallFooterViewAPI.kt
@@ -7,7 +7,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
-import com.revenuecat.purchases.ui.revenuecatui.fragment.PaywallFooterView
+import com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView
 
 @Suppress("unused", "UNUSED_VARIABLE")
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallViewAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallViewAPI.kt
@@ -1,0 +1,53 @@
+package com.revenuecat.apitester.kotlin.revenuecatui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
+import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
+import com.revenuecat.purchases.ui.revenuecatui.views.PaywallView
+
+@Suppress("unused", "UNUSED_VARIABLE")
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+private class PaywallViewAPI {
+
+    fun checkType(context: Context) {
+        val paywallView: FrameLayout = PaywallView(context)
+    }
+
+    @Suppress("LongParameterList")
+    fun checkConstructors(
+        context: Context,
+        attrs: AttributeSet?,
+        defStyleAttr: Int,
+        offering: Offering,
+        listener: PaywallListener,
+        fontProvider: FontProvider,
+        shouldDisplayDismissButton: Boolean?,
+        dismissHandler: () -> Unit,
+    ) {
+        PaywallView(context)
+        PaywallView(context, attrs)
+        PaywallView(context, attrs, defStyleAttr)
+        PaywallView(context, offering)
+        PaywallView(context, offering, listener)
+        PaywallView(context, offering, listener, fontProvider)
+        PaywallView(context, offering, listener, fontProvider, shouldDisplayDismissButton)
+        PaywallView(context, offering, listener, fontProvider, shouldDisplayDismissButton, dismissHandler)
+    }
+
+    fun checkMethods(
+        paywallView: PaywallView,
+        paywallListener: PaywallListener,
+        dismissHandler: () -> Unit,
+    ) {
+        paywallView.setPaywallListener(null)
+        paywallView.setPaywallListener(paywallListener)
+        paywallView.setDismissHandler(null)
+        paywallView.setDismissHandler(dismissHandler)
+        paywallView.setOfferingId(null)
+        paywallView.setOfferingId("offering_id")
+    }
+}

--- a/api-tester/src/defaults/res/layout/paywall_footer_view_api.xml
+++ b/api-tester/src/defaults/res/layout/paywall_footer_view_api.xml
@@ -10,6 +10,7 @@
     <com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView
             android:fontFamily="FONT"
             app:offeringIdentifier="offering_id"
+            app:condensed="true"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
     <com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView

--- a/api-tester/src/defaults/res/layout/paywall_footer_view_api.xml
+++ b/api-tester/src/defaults/res/layout/paywall_footer_view_api.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:ignore="MissingDefaultResource">
+    <com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView
+            android:fontFamily="FONT"
+            app:offeringIdentifier="offering_id"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    <com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+</LinearLayout>

--- a/api-tester/src/defaults/res/layout/paywall_view_api.xml
+++ b/api-tester/src/defaults/res/layout/paywall_view_api.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:ignore="MissingDefaultResource">
+    <com.revenuecat.purchases.ui.revenuecatui.views.PaywallView
+            android:fontFamily="FONT"
+            app:offeringIdentifier="offering_id"
+            app:shouldDisplayDismissButton="true"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    <com.revenuecat.purchases.ui.revenuecatui.views.PaywallView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+</LinearLayout>

--- a/examples/paywall-tester/build.gradle
+++ b/examples/paywall-tester/build.gradle
@@ -50,6 +50,9 @@ android {
     buildFeatures {
         compose true
     }
+    viewBinding {
+        enabled = true
+    }
     composeOptions {
         kotlinCompilerExtensionVersion '1.4.0-alpha02'
     }
@@ -79,6 +82,7 @@ dependencies {
     implementation libs.compose.window.size
     implementation libs.navigation.compose
     implementation libs.compose.ui.google.fonts
+    implementation libs.androidx.appcompat
     debugImplementation libs.compose.ui.tooling
     debugImplementation libs.androidx.test.compose.manifest
 }

--- a/examples/paywall-tester/src/main/AndroidManifest.xml
+++ b/examples/paywall-tester/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
                 android:name=".PaywallFooterViewActivity"
                 android:exported="false" />
         <activity
+                android:name=".PaywallViewActivity"
+                android:exported="false" />
+        <activity
                 android:name=".MainActivity"
                 android:exported="true"
                 android:label="@string/app_name"

--- a/examples/paywall-tester/src/main/AndroidManifest.xml
+++ b/examples/paywall-tester/src/main/AndroidManifest.xml
@@ -2,13 +2,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+            android:name=".MainApplication"
             android:allowBackup="true"
             android:icon="@mipmap/icon"
             android:label="@string/app_name"
             android:roundIcon="@mipmap/icon_round"
             android:supportsRtl="true"
-            android:theme="@style/Theme.Purchasesandroid"
-            android:name=".MainApplication">
+            android:theme="@style/Theme.Purchasesandroid">
+        <activity
+                android:name=".PaywallFooterViewActivity"
+                android:exported="false" />
         <activity
                 android:name=".MainActivity"
                 android:exported="true"

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
@@ -1,5 +1,5 @@
 package com.revenuecat.paywallstester
 
 object Constants {
-    const val GOOGLE_API_KEY = "goog_uArAGtKQJeuXMWoSNXCAZBzTepD"
+    const val GOOGLE_API_KEY = "API_KEY"
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
@@ -1,5 +1,5 @@
 package com.revenuecat.paywallstester
 
 object Constants {
-    const val GOOGLE_API_KEY = "API_KEY"
+    const val GOOGLE_API_KEY = "goog_uArAGtKQJeuXMWoSNXCAZBzTepD"
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
@@ -41,10 +41,10 @@ class MainActivity : ComponentActivity(), PaywallResultHandler {
         paywallActivityLauncher.launch(offering)
     }
 
-    @Suppress("UnusedParameter")
     fun launchPaywallFooterViewAsActivity(offering: Offering? = null) {
-        // WIP: Pass offering to PaywallFooterViewActivity
+        // WIP: Change to use PaywallActivityLauncher
         val intent = Intent(this, PaywallFooterViewActivity::class.java)
+        offering?.identifier?.let { intent.putExtra("offering_id", it) }
         startActivity(intent)
     }
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
@@ -47,4 +47,11 @@ class MainActivity : ComponentActivity(), PaywallResultHandler {
         offering?.identifier?.let { intent.putExtra("offering_id", it) }
         startActivity(intent)
     }
+
+    fun launchPaywallViewAsActivity(offering: Offering? = null) {
+        // WIP: Change to use PaywallActivityLauncher
+        val intent = Intent(this, PaywallViewActivity::class.java)
+        offering?.identifier?.let { intent.putExtra("offering_id", it) }
+        startActivity(intent)
+    }
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.paywallstester
 
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -38,5 +39,12 @@ class MainActivity : ComponentActivity(), PaywallResultHandler {
 
     fun launchPaywall(offering: Offering? = null) {
         paywallActivityLauncher.launch(offering)
+    }
+
+    @Suppress("UnusedParameter")
+    fun launchPaywallFooterViewAsActivity(offering: Offering? = null) {
+        // WIP: Pass offering to PaywallFooterViewActivity
+        val intent = Intent(this, PaywallFooterViewActivity::class.java)
+        startActivity(intent)
     }
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallFooterViewActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallFooterViewActivity.kt
@@ -15,7 +15,6 @@ class PaywallFooterViewActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val offeringId = intent.getStringExtra("offering_id")
-        setContentView(R.layout.activity_paywall_footer_view)
         val binding = ActivityPaywallFooterViewBinding.inflate(layoutInflater)
         setContentView(binding.root)
         binding.paywallFooterView.setOfferingId(offeringId)

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallFooterViewActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallFooterViewActivity.kt
@@ -14,9 +14,11 @@ import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 class PaywallFooterViewActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val offeringId = intent.getStringExtra("offering_id")
         setContentView(R.layout.activity_paywall_footer_view)
         val binding = ActivityPaywallFooterViewBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        binding.paywallFooterView.setOfferingId(offeringId)
         binding.paywallFooterView.setPaywallListener(object : PaywallListener {
             override fun onPurchaseStarted(rcPackage: Package) {
                 super.onPurchaseStarted(rcPackage)

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallFooterViewActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallFooterViewActivity.kt
@@ -1,0 +1,33 @@
+package com.revenuecat.paywallstester
+
+import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import com.revenuecat.paywallstester.databinding.ActivityPaywallFooterViewBinding
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
+
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+class PaywallFooterViewActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_paywall_footer_view)
+        val binding = ActivityPaywallFooterViewBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        binding.paywallFooterView.setPaywallListener(object : PaywallListener {
+            override fun onPurchaseStarted(rcPackage: Package) {
+                super.onPurchaseStarted(rcPackage)
+                Log.d("PaywallsTester", "onPurchaseStarted")
+            }
+
+            override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
+                super.onPurchaseCompleted(customerInfo, storeTransaction)
+                Log.d("PaywallsTester", "onPurchaseCompleted")
+            }
+        })
+        binding.paywallFooterView.setDismissHandler { finish() }
+    }
+}

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallViewActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallViewActivity.kt
@@ -1,0 +1,34 @@
+package com.revenuecat.paywallstester
+
+import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import com.revenuecat.paywallstester.databinding.ActivityPaywallViewBinding
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
+
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+class PaywallViewActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val offeringId = intent.getStringExtra("offering_id")
+        val binding = ActivityPaywallViewBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        binding.paywallView.setOfferingId(offeringId)
+        binding.paywallView.setPaywallListener(object : PaywallListener {
+            override fun onPurchaseStarted(rcPackage: Package) {
+                super.onPurchaseStarted(rcPackage)
+                Log.d("PaywallsTester", "onPurchaseStarted")
+            }
+
+            override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
+                super.onPurchaseCompleted(customerInfo, storeTransaction)
+                Log.d("PaywallsTester", "onPurchaseCompleted")
+            }
+        })
+        binding.paywallView.setDismissHandler { finish() }
+    }
+}

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -164,6 +164,10 @@ private fun DisplayOfferingMenu(
             onClick = { activity.launchPaywall(offering) },
         )
         DropdownMenuItem(
+            text = { Text(text = "Display paywall as view in an activity") },
+            onClick = { activity.launchPaywallViewAsActivity(offering) },
+        )
+        DropdownMenuItem(
             text = { Text(text = "Display paywall as footer view in an activity") },
             onClick = { activity.launchPaywallFooterViewAsActivity(offering) },
         )

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -163,6 +163,10 @@ private fun DisplayOfferingMenu(
             text = { Text(text = "Display paywall as activity") },
             onClick = { activity.launchPaywall(offering) },
         )
+        DropdownMenuItem(
+            text = { Text(text = "Display paywall as footer view in an activity") },
+            onClick = { activity.launchPaywallFooterViewAsActivity(offering) },
+        )
     }
 }
 

--- a/examples/paywall-tester/src/main/res/font-v26/lobster_two.xml
+++ b/examples/paywall-tester/src/main/res/font-v26/lobster_two.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<font-family xmlns:android="http://schemas.android.com/apk/res/android">
+    <font
+            android:fontStyle="normal"
+            android:fontWeight="400"
+            android:font="@font/lobster_two_regular" />
+    <font
+            android:fontStyle="italic"
+            android:fontWeight="400"
+            android:font="@font/lobster_two_italic" />
+    <font
+            android:fontStyle="normal"
+            android:fontWeight="700"
+            android:font="@font/lobster_two_bold" />
+    <font
+            android:fontStyle="italic"
+            android:fontWeight="700"
+            android:font="@font/lobster_two_bold_italic" />
+</font-family>

--- a/examples/paywall-tester/src/main/res/font/lobster_two.xml
+++ b/examples/paywall-tester/src/main/res/font/lobster_two.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<font-family
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
+    <font
+            app:fontStyle="normal"
+            app:fontWeight="400"
+            app:font="@font/lobster_two_regular" />
+    <font
+            app:fontStyle="italic"
+            app:fontWeight="400"
+            app:font="@font/lobster_two_italic" />
+    <font
+            app:fontStyle="normal"
+            app:fontWeight="700"
+            app:font="@font/lobster_two_bold" />
+    <font
+            app:fontStyle="italic"
+            app:fontWeight="700"
+            app:font="@font/lobster_two_bold_italic" />
+</font-family>

--- a/examples/paywall-tester/src/main/res/layout/activity_paywall_footer_view.xml
+++ b/examples/paywall-tester/src/main/res/layout/activity_paywall_footer_view.xml
@@ -19,7 +19,7 @@
                 android:layout_height="wrap_content"/>
     </LinearLayout>
 
-    <com.revenuecat.purchases.ui.revenuecatui.fragment.PaywallFooterView
+    <com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView
             android:id="@+id/paywall_footer_view"
             android:layout_marginTop="-20dp"
             android:fontFamily="@font/lobster_two"

--- a/examples/paywall-tester/src/main/res/layout/activity_paywall_footer_view.xml
+++ b/examples/paywall-tester/src/main/res/layout/activity_paywall_footer_view.xml
@@ -7,6 +7,7 @@
         tools:context=".PaywallFooterViewActivity">
 
     <LinearLayout
+            android:background="@android:color/holo_blue_light"
             android:layout_weight="1"
             android:layout_width="match_parent"
             android:layout_height="0dp"
@@ -20,7 +21,9 @@
 
     <com.revenuecat.purchases.ui.revenuecatui.fragment.PaywallFooterView
             android:id="@+id/paywall_footer_view"
+            android:background="@android:color/holo_blue_light"
             android:fontFamily="@font/lobster_two"
+            android:layout_marginBottom="-10dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 

--- a/examples/paywall-tester/src/main/res/layout/activity_paywall_footer_view.xml
+++ b/examples/paywall-tester/src/main/res/layout/activity_paywall_footer_view.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".PaywallFooterViewActivity">
+
+    <LinearLayout
+            android:layout_weight="1"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:orientation="vertical"
+            android:gravity="center">
+        <TextView
+                android:text="Paywall Content"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+    </LinearLayout>
+
+    <com.revenuecat.purchases.ui.revenuecatui.fragment.PaywallFooterView
+            android:id="@+id/paywall_footer_view"
+            android:fontFamily="@font/lobster_two"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+</LinearLayout>

--- a/examples/paywall-tester/src/main/res/layout/activity_paywall_footer_view.xml
+++ b/examples/paywall-tester/src/main/res/layout/activity_paywall_footer_view.xml
@@ -23,7 +23,6 @@
             android:id="@+id/paywall_footer_view"
             android:background="@android:color/holo_blue_light"
             android:fontFamily="@font/lobster_two"
-            android:layout_marginBottom="-10dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 

--- a/examples/paywall-tester/src/main/res/layout/activity_paywall_footer_view.xml
+++ b/examples/paywall-tester/src/main/res/layout/activity_paywall_footer_view.xml
@@ -21,7 +21,7 @@
 
     <com.revenuecat.purchases.ui.revenuecatui.fragment.PaywallFooterView
             android:id="@+id/paywall_footer_view"
-            android:background="@android:color/holo_blue_light"
+            android:layout_marginTop="-20dp"
             android:fontFamily="@font/lobster_two"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>

--- a/examples/paywall-tester/src/main/res/layout/activity_paywall_view.xml
+++ b/examples/paywall-tester/src/main/res/layout/activity_paywall_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".PaywallViewActivity">
+
+    <com.revenuecat.purchases.ui.revenuecatui.views.PaywallView
+            android:id="@+id/paywall_view"
+            app:shouldDisplayDismissButton="true"
+            android:fontFamily="@font/lobster_two"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+</LinearLayout>

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
@@ -40,7 +41,7 @@ fun PaywallFooter(
         )
     }
     if (mainContent == null) {
-        Box(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxWidth().wrapContentHeight()) {
             paywallComposable()
         }
     } else {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
@@ -41,7 +40,7 @@ fun PaywallFooter(
         )
     }
     if (mainContent == null) {
-        Box(modifier = Modifier.fillMaxWidth().wrapContentHeight()) {
+        Box(modifier = Modifier.fillMaxSize()) {
             paywallComposable()
         }
     } else {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
@@ -29,27 +30,37 @@ import androidx.compose.ui.tooling.preview.Preview
 fun PaywallFooter(
     options: PaywallOptions,
     condensed: Boolean = false,
-    mainContent: @Composable (PaddingValues) -> Unit,
+    mainContent: @Composable ((PaddingValues) -> Unit)? = null,
 ) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        // This is a workaround to make the main content be able to go below the footer, so it's visible through
-        // the rounded corners. We pass this padding back to the developer so they can add this padding to their content
-        verticalArrangement = Arrangement.spacedBy(-UIConstant.defaultCornerRadius),
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-        ) {
-            mainContent(PaddingValues(bottom = UIConstant.defaultCornerRadius))
-        }
+    val paywallComposable = @Composable {
         Paywall(
             options.copy(
                 mode = PaywallMode.footerMode(condensed),
                 shouldDisplayDismissButton = false,
             ),
         )
+    }
+    if (mainContent == null) {
+        Box(modifier = Modifier.fillMaxWidth().wrapContentHeight()) {
+            paywallComposable()
+        }
+    } else {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            // This is a workaround to make the main content be able to go below the footer, so it's visible through
+            // the rounded corners. We pass this padding back to the developer so they can add this padding to
+            // their content
+            verticalArrangement = Arrangement.spacedBy(-UIConstant.defaultCornerRadius),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+            ) {
+                mainContent(PaddingValues(bottom = UIConstant.defaultCornerRadius))
+            }
+            paywallComposable()
+        }
     }
 }
 
@@ -73,4 +84,14 @@ private fun PaywallFooterPreview() {
             }
         }
     }
+}
+
+@Suppress("MagicNumber")
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
+@Preview(showBackground = true)
+@Composable
+private fun PaywallFooterNoContentPreview() {
+    PaywallFooter(
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
+    )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fragment/PaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fragment/PaywallFooterView.kt
@@ -1,0 +1,86 @@
+package com.revenuecat.purchases.ui.revenuecatui.fragment
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import androidx.compose.ui.platform.ComposeView
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import com.revenuecat.purchases.ui.revenuecatui.PaywallFooter
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
+
+/**
+ * WIP: Add docs
+ */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
+class PaywallFooterView : FrameLayout {
+
+    constructor(context: Context) : super(context) {
+        init(context, null)
+    }
+
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
+        init(context, attrs)
+    }
+
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
+        init(context, attrs)
+    }
+
+    private var dismissHandler: (() -> Unit)? = null
+    private var listener: PaywallListener? = null
+    private var internalListener: PaywallListener = object : PaywallListener {
+        override fun onPurchaseStarted(rcPackage: Package) { listener?.onPurchaseStarted(rcPackage) }
+        override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
+            listener?.onPurchaseCompleted(customerInfo, storeTransaction)
+        }
+        override fun onPurchaseError(error: PurchasesError) { listener?.onPurchaseError(error) }
+        override fun onRestoreStarted() { listener?.onRestoreStarted() }
+        override fun onRestoreCompleted(customerInfo: CustomerInfo) { listener?.onRestoreCompleted(customerInfo) }
+        override fun onRestoreError(error: PurchasesError) { listener?.onRestoreError(error) }
+    }
+
+    /**
+     * WIP: Add docs
+     */
+    fun setPaywallListener(listener: PaywallListener) {
+        this.listener = listener
+    }
+
+    /**
+     * WIP: Add docs
+     */
+    fun setDismissHandler(dismissHandler: () -> Unit) {
+        this.dismissHandler = dismissHandler
+    }
+
+    @Suppress("UnusedParameter")
+    private fun init(context: Context, attrs: AttributeSet?) {
+//        WIP: Add font support
+//        val typedArray = context.obtainStyledAttributes(attrs, R.styleable.PaywallFooterView, 0, 0)
+//        val fontProvider = typedArray
+//          .getString(R.styleable.PaywallFooterView_android_fontFamily)?.let { fontFamilyName ->
+//            val font = Typeface.create() ResourcesCompat.getFont(context, )
+//            object : FontProvider {
+//                override fun getFont(type: TypographyType): FontFamily? {
+//                    return FontFamily(Font(fontFamilyName))
+//                }
+//            }
+//        }
+        addView(
+            ComposeView(context).apply {
+                setContent {
+                    PaywallFooter(
+                        options = PaywallOptions.Builder { dismissHandler?.invoke() }
+                            .setListener(internalListener)
+                            .build(),
+                    )
+                }
+            },
+        )
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fragment/PaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/fragment/PaywallFooterView.kt
@@ -21,7 +21,7 @@ import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 /**
- * WIP: Add docs
+ * View that wraps the [PaywallFooter] Composable to display the Paywall Footer through XML layouts and the View system.
  */
 @ExperimentalPreviewRevenueCatUIPurchasesAPI
 class PaywallFooterView : FrameLayout {
@@ -35,8 +35,7 @@ class PaywallFooterView : FrameLayout {
     }
 
     /**
-     * Constructor when not using XML layouts.
-     * WIP: Add docs
+     * Constructor when creating the view programmatically.
      */
     @JvmOverloads
     constructor(
@@ -69,21 +68,22 @@ class PaywallFooterView : FrameLayout {
     }
 
     /**
-     * WIP: Add docs
+     * Sets a [PaywallListener] to receive callbacks from the Paywall.
      */
     fun setPaywallListener(listener: PaywallListener?) {
         this.listener = listener
     }
 
     /**
-     * WIP: Add docs
+     * Sets a dismiss handler which will be called when the user successfully purchases or if there is an error
+     * loading the offerings and the user clicks through the error dialog.
      */
     fun setDismissHandler(dismissHandler: (() -> Unit)?) {
         this.dismissHandler = dismissHandler
     }
 
     /**
-     * WIP: Add docs
+     * Sets the offering id to be used to display the Paywall. If not set, the default one will be used.
      */
     fun setOfferingId(offeringId: String?) {
         this.offeringId = offeringId

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
@@ -1,4 +1,4 @@
-package com.revenuecat.purchases.ui.revenuecatui.fragment
+package com.revenuecat.purchases.ui.revenuecatui.views
 
 import android.content.Context
 import android.util.AttributeSet

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
@@ -124,7 +124,7 @@ class PaywallFooterView : FrameLayout {
                 recycle()
             }
         }
-        fontFamilyId?.let {
+        fontFamilyId?.takeIf { it > 0 }?.let {
             val typeface = ResourcesCompat.getFont(context, it)
             if (typeface == null) {
                 Logger.e("Font given for PaywallFooterView not found")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
@@ -26,6 +26,10 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 @ExperimentalPreviewRevenueCatUIPurchasesAPI
 class PaywallFooterView : FrameLayout {
 
+    companion object {
+        private const val DEFAULT_CONDENSED = false
+    }
+
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
         init(context, attrs)
     }
@@ -43,17 +47,20 @@ class PaywallFooterView : FrameLayout {
         offering: Offering? = null,
         listener: PaywallListener? = null,
         fontProvider: FontProvider? = null,
+        condensed: Boolean = DEFAULT_CONDENSED,
         dismissHandler: (() -> Unit)? = null,
     ) : super(context) {
         setPaywallListener(listener)
         setDismissHandler(dismissHandler)
         setOfferingId(offering?.identifier)
         this.fontProvider = fontProvider
+        this.condensed = condensed
         init(context, null)
     }
 
     private var offeringId: String? = null
     private var fontProvider: FontProvider? = null
+    private var condensed: Boolean = DEFAULT_CONDENSED
     private var dismissHandler: (() -> Unit)? = null
     private var listener: PaywallListener? = null
     private var internalListener: PaywallListener = object : PaywallListener {
@@ -102,6 +109,7 @@ class PaywallFooterView : FrameLayout {
                         .build()
                     PaywallFooter(
                         options = paywallOptions,
+                        condensed = condensed,
                     )
                 }
             },
@@ -111,6 +119,7 @@ class PaywallFooterView : FrameLayout {
     private fun parseAttributes(context: Context, attrs: AttributeSet?) {
         var fontFamilyId: Int? = null
         var offeringIdentifier: String? = null
+        var condensed: Boolean? = null
         context.obtainStyledAttributes(
             attrs,
             R.styleable.PaywallFooterView,
@@ -120,6 +129,11 @@ class PaywallFooterView : FrameLayout {
             try {
                 fontFamilyId = getResourceId(R.styleable.PaywallFooterView_android_fontFamily, 0)
                 offeringIdentifier = getString(R.styleable.PaywallFooterView_offeringIdentifier)
+                condensed = if (hasValue(R.styleable.PaywallFooterView_condensed)) {
+                    getBoolean(R.styleable.PaywallFooterView_condensed, DEFAULT_CONDENSED)
+                } else {
+                    null
+                }
             } finally {
                 recycle()
             }
@@ -133,5 +147,6 @@ class PaywallFooterView : FrameLayout {
             }
         }
         offeringIdentifier?.let { setOfferingId(offeringIdentifier) }
+        condensed?.let { this.condensed = it }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
@@ -10,17 +10,17 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
-import com.revenuecat.purchases.ui.revenuecatui.PaywallFooter
+import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
 
 /**
- * View that wraps the [PaywallFooter] Composable to display the Paywall Footer through XML layouts and the View system.
+ * View that wraps the [Paywall] Composable to display the Paywall through XML layouts and the View system.
  */
 @ExperimentalPreviewRevenueCatUIPurchasesAPI
-class PaywallFooterView : FrameLayout {
+class PaywallView : FrameLayout {
 
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
         init(context, attrs)
@@ -39,22 +39,22 @@ class PaywallFooterView : FrameLayout {
         offering: Offering? = null,
         listener: PaywallListener? = null,
         fontProvider: FontProvider? = null,
-        condensed: Boolean = PaywallViewAttributesReader.DEFAULT_CONDENSED,
+        shouldDisplayDismissButton: Boolean? = null,
         dismissHandler: (() -> Unit)? = null,
     ) : super(context) {
         setPaywallListener(listener)
         setDismissHandler(dismissHandler)
         setOfferingId(offering?.identifier)
+        this.shouldDisplayDismissButton = shouldDisplayDismissButton
         this.fontProvider = fontProvider
-        this.condensed = condensed
         init(context, null)
     }
 
     private var offeringId: String? = null
     private var fontProvider: FontProvider? = null
-    private var condensed: Boolean = PaywallViewAttributesReader.DEFAULT_CONDENSED
     private var dismissHandler: (() -> Unit)? = null
     private var listener: PaywallListener? = null
+    private var shouldDisplayDismissButton: Boolean? = null
     private var internalListener: PaywallListener = object : PaywallListener {
         override fun onPurchaseStarted(rcPackage: Package) { listener?.onPurchaseStarted(rcPackage) }
         override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
@@ -74,8 +74,11 @@ class PaywallFooterView : FrameLayout {
     }
 
     /**
-     * Sets a dismiss handler which will be called when the user successfully purchases or if there is an error
-     * loading the offerings and the user clicks through the error dialog.
+     * Sets a dismiss handler which will be called:
+     * - When the user successfully purchases
+     * - If there is an error loading the offerings and the user clicks through the error dialog
+     * - If the user taps on the close button
+     * - If the user calls the back button with the paywall present.
      */
     fun setDismissHandler(dismissHandler: (() -> Unit)?) {
         this.dismissHandler = dismissHandler
@@ -98,10 +101,10 @@ class PaywallFooterView : FrameLayout {
                         .setListener(internalListener)
                         .setFontProvider(fontProvider)
                         .setOfferingId(offeringId)
+                        .setShouldDisplayDismissButton(shouldDisplayDismissButton ?: false)
                         .build()
-                    PaywallFooter(
+                    Paywall(
                         options = paywallOptions,
-                        condensed = condensed,
                     )
                 }
             },
@@ -110,10 +113,10 @@ class PaywallFooterView : FrameLayout {
 
     @SuppressWarnings("DestructuringDeclarationWithTooManyEntries")
     private fun parseAttributes(context: Context, attrs: AttributeSet?) {
-        val (offeringId, fontProvider, _, condensed) =
-            PaywallViewAttributesReader.parseAttributes(context, attrs, R.styleable.PaywallFooterView) ?: return
+        val (offeringId, fontProvider, shouldDisplayDismissButton, _) =
+            PaywallViewAttributesReader.parseAttributes(context, attrs, R.styleable.PaywallView) ?: return
         setOfferingId(offeringId)
         this.fontProvider = fontProvider
-        condensed?.let { this.condensed = it }
+        this.shouldDisplayDismissButton = shouldDisplayDismissButton
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallViewAttributesReader.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallViewAttributesReader.kt
@@ -1,0 +1,97 @@
+package com.revenuecat.purchases.ui.revenuecatui.views
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.compose.ui.text.font.FontFamily
+import androidx.core.content.res.ResourcesCompat
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import com.revenuecat.purchases.ui.revenuecatui.R
+import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
+import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+internal class PaywallViewAttributesReader {
+    companion object {
+        internal const val DEFAULT_CONDENSED = false
+
+        private enum class Attributes {
+            OfferingId,
+            ShouldDisplayDismissButton,
+            FontFamily,
+        }
+        private val styleablesByStyleSet: Map<IntArray, Map<Attributes, Int>> = mapOf(
+            R.styleable.PaywallView to mapOf(
+                Attributes.OfferingId to R.styleable.PaywallView_offeringIdentifier,
+                Attributes.ShouldDisplayDismissButton to R.styleable.PaywallView_shouldDisplayDismissButton,
+                Attributes.FontFamily to R.styleable.PaywallView_android_fontFamily,
+            ),
+            R.styleable.PaywallFooterView to mapOf(
+                Attributes.OfferingId to R.styleable.PaywallFooterView_offeringIdentifier,
+                Attributes.FontFamily to R.styleable.PaywallFooterView_android_fontFamily,
+            ),
+        )
+
+        @Suppress("ReturnCount", "NestedBlockDepth")
+        fun parseAttributes(context: Context, attrsSet: AttributeSet?, styleAttrs: IntArray): PaywallViewAttributes? {
+            if (attrsSet == null) {
+                return null
+            }
+            var fontFamilyId: Int? = null
+            var offeringIdentifier: String? = null
+            var shouldDisplayDismissButton: Boolean? = null
+            var condensed: Boolean? = null
+            context.obtainStyledAttributes(
+                attrsSet,
+                styleAttrs,
+                0,
+                0,
+            ).apply {
+                try {
+                    val styleables = styleablesByStyleSet[styleAttrs] ?: run {
+                        Logger.e("Styleable not found for PaywallView")
+                        return null
+                    }
+                    fontFamilyId = styleables[Attributes.FontFamily]?.let { getResourceId(it, 0) }
+                    offeringIdentifier = styleables[Attributes.OfferingId]?.let { getString(it) }
+                    styleables[Attributes.ShouldDisplayDismissButton]?.let {
+                        shouldDisplayDismissButton = if (hasValue(it)) {
+                            getBoolean(it, false)
+                        } else {
+                            null
+                        }
+                    }
+                    condensed = if (hasValue(R.styleable.PaywallFooterView_condensed)) {
+                        getBoolean(R.styleable.PaywallFooterView_condensed, DEFAULT_CONDENSED)
+                    } else {
+                        null
+                    }
+                } finally {
+                    recycle()
+                }
+            }
+            val fontFamily = fontFamilyId?.takeIf { it > 0 }?.let {
+                val typeface = ResourcesCompat.getFont(context, it)
+                if (typeface == null) {
+                    Logger.e("Font given for PaywallView not found")
+                    null
+                } else {
+                    CustomFontProvider(FontFamily(typeface))
+                }
+            }
+            return PaywallViewAttributes(
+                offeringId = offeringIdentifier,
+                fontProvider = fontFamily,
+                shouldDisplayDismissButton = shouldDisplayDismissButton,
+                condensed = condensed,
+            )
+        }
+    }
+
+    data class PaywallViewAttributes(
+        val offeringId: String?,
+        val fontProvider: FontProvider?,
+        val shouldDisplayDismissButton: Boolean?,
+        val condensed: Boolean?,
+    )
+}

--- a/ui/revenuecatui/src/main/res/values/paywall_view_attrs.xml
+++ b/ui/revenuecatui/src/main/res/values/paywall_view_attrs.xml
@@ -3,5 +3,6 @@
     <declare-styleable name="PaywallFooterView">
         <attr name="android:fontFamily" />
         <attr name="offeringIdentifier" format="string" />
+        <attr name="condensed" format="boolean" />
     </declare-styleable>
 </resources>

--- a/ui/revenuecatui/src/main/res/values/paywall_view_attrs.xml
+++ b/ui/revenuecatui/src/main/res/values/paywall_view_attrs.xml
@@ -2,5 +2,6 @@
 <resources>
     <declare-styleable name="PaywallFooterView">
         <attr name="android:fontFamily" />
+        <attr name="offeringIdentifier" format="string" />
     </declare-styleable>
 </resources>

--- a/ui/revenuecatui/src/main/res/values/paywall_view_attrs.xml
+++ b/ui/revenuecatui/src/main/res/values/paywall_view_attrs.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <attr name="offeringIdentifier" format="string" />
     <declare-styleable name="PaywallFooterView">
         <attr name="android:fontFamily" />
-        <attr name="offeringIdentifier" format="string" />
+        <attr name="offeringIdentifier" />
         <attr name="condensed" format="boolean" />
+    </declare-styleable>
+    <declare-styleable name="PaywallView">
+        <attr name="android:fontFamily" />
+        <attr name="offeringIdentifier" />
+        <attr name="shouldDisplayDismissButton" format="boolean" />
     </declare-styleable>
 </resources>

--- a/ui/revenuecatui/src/main/res/values/paywall_view_attrs.xml
+++ b/ui/revenuecatui/src/main/res/values/paywall_view_attrs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="PaywallFooterView">
+        <attr name="android:fontFamily" />
+    </declare-styleable>
+</resources>


### PR DESCRIPTION
### Description
This adds a new view `PaywallFooterView` which acts as a wrapper for the `PaywallFooter` composable. It has some limitations:
- Condensed form not supported
- Need to set most of the attributes on the construction of the view.

This view will be used in the hybrids in order to support footer view.
![image](https://github.com/RevenueCat/purchases-android/assets/808417/ff8a7905-a0a1-4332-9782-8349ff920e32)

