### PR TITLE
Paywalls: Add condensed parameter to PaywallFooterView

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallFooterViewAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallFooterViewAPI.java
@@ -18,14 +18,16 @@ final class PaywallFooterViewAPI {
                                   int defStyleAttr,
                                   Offering offering,
                                   PaywallListener listener,
-                                  FontProvider fontProvider ) {
+                                  FontProvider fontProvider,
+                                  Boolean condensed) {
         PaywallFooterView footerView = new PaywallFooterView(context);
         PaywallFooterView footerView2 = new PaywallFooterView(context, attrs);
         PaywallFooterView footerView3 = new PaywallFooterView(context, attrs, defStyleAttr);
         PaywallFooterView footerView4 = new PaywallFooterView(context, offering);
         PaywallFooterView footerView5 = new PaywallFooterView(context, offering, listener);
         PaywallFooterView footerView6 = new PaywallFooterView(context, offering, listener, fontProvider);
-        PaywallFooterView footerView7 = new PaywallFooterView(context, offering, listener, fontProvider, () -> null);
+        PaywallFooterView footerView7 = new PaywallFooterView(context, offering, listener, fontProvider, condensed);
+        PaywallFooterView footerView8 = new PaywallFooterView(context, offering, listener, fontProvider, condensed, () -> null);
     }
 
     static void checkMethods(PaywallFooterView footerView, PaywallListener listener) {

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallFooterViewAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallFooterViewAPI.kt
@@ -25,6 +25,7 @@ private class PaywallFooterViewAPI {
         offering: Offering,
         listener: PaywallListener,
         fontProvider: FontProvider,
+        condensed: Boolean,
         dismissHandler: () -> Unit,
     ) {
         PaywallFooterView(context)
@@ -33,7 +34,8 @@ private class PaywallFooterViewAPI {
         PaywallFooterView(context, offering)
         PaywallFooterView(context, offering, listener)
         PaywallFooterView(context, offering, listener, fontProvider)
-        PaywallFooterView(context, offering, listener, fontProvider, dismissHandler)
+        PaywallFooterView(context, offering, listener, fontProvider, condensed)
+        PaywallFooterView(context, offering, listener, fontProvider, condensed, dismissHandler)
     }
 
     fun checkMethods(

--- a/api-tester/src/defaults/res/layout/paywall_footer_view_api.xml
+++ b/api-tester/src/defaults/res/layout/paywall_footer_view_api.xml
@@ -10,6 +10,7 @@
     <com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView
             android:fontFamily="FONT"
             app:offeringIdentifier="offering_id"
+            app:condensed="true"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
     <com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
@@ -26,6 +26,10 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 @ExperimentalPreviewRevenueCatUIPurchasesAPI
 class PaywallFooterView : FrameLayout {
 
+    companion object {
+        private const val DEFAULT_CONDENSED = false
+    }
+
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
         init(context, attrs)
     }
@@ -43,17 +47,20 @@ class PaywallFooterView : FrameLayout {
         offering: Offering? = null,
         listener: PaywallListener? = null,
         fontProvider: FontProvider? = null,
+        condensed: Boolean = DEFAULT_CONDENSED,
         dismissHandler: (() -> Unit)? = null,
     ) : super(context) {
         setPaywallListener(listener)
         setDismissHandler(dismissHandler)
         setOfferingId(offering?.identifier)
         this.fontProvider = fontProvider
+        this.condensed = condensed
         init(context, null)
     }
 
     private var offeringId: String? = null
     private var fontProvider: FontProvider? = null
+    private var condensed: Boolean = DEFAULT_CONDENSED
     private var dismissHandler: (() -> Unit)? = null
     private var listener: PaywallListener? = null
     private var internalListener: PaywallListener = object : PaywallListener {
@@ -102,6 +109,7 @@ class PaywallFooterView : FrameLayout {
                         .build()
                     PaywallFooter(
                         options = paywallOptions,
+                        condensed = condensed,
                     )
                 }
             },
@@ -111,6 +119,7 @@ class PaywallFooterView : FrameLayout {
     private fun parseAttributes(context: Context, attrs: AttributeSet?) {
         var fontFamilyId: Int? = null
         var offeringIdentifier: String? = null
+        var condensed: Boolean? = null
         context.obtainStyledAttributes(
             attrs,
             R.styleable.PaywallFooterView,
@@ -120,6 +129,11 @@ class PaywallFooterView : FrameLayout {
             try {
                 fontFamilyId = getResourceId(R.styleable.PaywallFooterView_android_fontFamily, 0)
                 offeringIdentifier = getString(R.styleable.PaywallFooterView_offeringIdentifier)
+                condensed = if (hasValue(R.styleable.PaywallFooterView_condensed)) {
+                    getBoolean(R.styleable.PaywallFooterView_condensed, DEFAULT_CONDENSED)
+                } else {
+                    null
+                }
             } finally {
                 recycle()
             }
@@ -133,5 +147,6 @@ class PaywallFooterView : FrameLayout {
             }
         }
         offeringIdentifier?.let { setOfferingId(offeringIdentifier) }
+        condensed?.let { this.condensed = it }
     }
 }

--- a/ui/revenuecatui/src/main/res/values/paywall_view_attrs.xml
+++ b/ui/revenuecatui/src/main/res/values/paywall_view_attrs.xml
@@ -3,5 +3,6 @@
     <declare-styleable name="PaywallFooterView">
         <attr name="android:fontFamily" />
         <attr name="offeringIdentifier" format="string" />
+        <attr name="condensed" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
### Description
Followup to #1509 

This adds a `condensed` parameter to the `PaywallFooterView`. This can be set either through the constructor or as an XML parameter.