### PR TITLE
Paywalls: Move paywall view attributes parsing

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.text.font.FontFamily
-import androidx.core.content.res.ResourcesCompat
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
@@ -16,9 +14,7 @@ import com.revenuecat.purchases.ui.revenuecatui.PaywallFooter
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.R
-import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
-import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 /**
  * View that wraps the [PaywallFooter] Composable to display the Paywall Footer through XML layouts and the View system.
@@ -109,29 +105,9 @@ class PaywallFooterView : FrameLayout {
     }
 
     private fun parseAttributes(context: Context, attrs: AttributeSet?) {
-        var fontFamilyId: Int? = null
-        var offeringIdentifier: String? = null
-        context.obtainStyledAttributes(
-            attrs,
-            R.styleable.PaywallFooterView,
-            0,
-            0,
-        ).apply {
-            try {
-                fontFamilyId = getResourceId(R.styleable.PaywallFooterView_android_fontFamily, 0)
-                offeringIdentifier = getString(R.styleable.PaywallFooterView_offeringIdentifier)
-            } finally {
-                recycle()
-            }
-        }
-        fontFamilyId?.let {
-            val typeface = ResourcesCompat.getFont(context, it)
-            if (typeface == null) {
-                Logger.e("Font given for PaywallFooterView not found")
-            } else {
-                fontProvider = CustomFontProvider(FontFamily(typeface))
-            }
-        }
-        offeringIdentifier?.let { setOfferingId(offeringIdentifier) }
+        val (offeringId, fontProvider, _) =
+            PaywallViewAttributesReader.parseAttributes(context, attrs, R.styleable.PaywallFooterView) ?: return
+        setOfferingId(offeringId)
+        this.fontProvider = fontProvider
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.text.font.FontFamily
-import androidx.core.content.res.ResourcesCompat
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
@@ -16,9 +14,7 @@ import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.R
-import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
-import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 /**
  * View that wraps the [Paywall] Composable to display the Paywall through XML layouts and the View system.
@@ -116,36 +112,10 @@ class PaywallView : FrameLayout {
     }
 
     private fun parseAttributes(context: Context, attrs: AttributeSet?) {
-        var fontFamilyId: Int? = null
-        var offeringIdentifier: String? = null
-        var shouldShowCloseButton: Boolean? = null
-        context.obtainStyledAttributes(
-            attrs,
-            R.styleable.PaywallView,
-            0,
-            0,
-        ).apply {
-            try {
-                fontFamilyId = getResourceId(R.styleable.PaywallView_android_fontFamily, 0)
-                offeringIdentifier = getString(R.styleable.PaywallView_offeringIdentifier)
-                shouldShowCloseButton = if (hasValue(R.styleable.PaywallView_shouldDisplayDismissButton)) {
-                    getBoolean(R.styleable.PaywallView_shouldDisplayDismissButton, false)
-                } else {
-                    null
-                }
-            } finally {
-                recycle()
-            }
-        }
-        fontFamilyId?.takeIf { it > 0 }?.let {
-            val typeface = ResourcesCompat.getFont(context, it)
-            if (typeface == null) {
-                Logger.e("Font given for PaywallView not found")
-            } else {
-                fontProvider = CustomFontProvider(FontFamily(typeface))
-            }
-        }
-        offeringIdentifier?.let { setOfferingId(offeringIdentifier) }
-        shouldShowCloseButton?.let { shouldDisplayDismissButton = it }
+        val (offeringId, fontProvider, shouldDisplayDismissButton) =
+            PaywallViewAttributesReader.parseAttributes(context, attrs, R.styleable.PaywallView) ?: return
+        setOfferingId(offeringId)
+        this.fontProvider = fontProvider
+        this.shouldDisplayDismissButton = shouldDisplayDismissButton
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallViewAttributesReader.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallViewAttributesReader.kt
@@ -1,0 +1,87 @@
+package com.revenuecat.purchases.ui.revenuecatui.views
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.compose.ui.text.font.FontFamily
+import androidx.core.content.res.ResourcesCompat
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import com.revenuecat.purchases.ui.revenuecatui.R
+import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
+import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+internal class PaywallViewAttributesReader {
+    companion object {
+        private enum class Attributes {
+            OfferingId,
+            ShouldDisplayDismissButton,
+            FontFamily,
+        }
+        private val styleablesByStyleSet: Map<IntArray, Map<Attributes, Int>> = mapOf(
+            R.styleable.PaywallView to mapOf(
+                Attributes.OfferingId to R.styleable.PaywallView_offeringIdentifier,
+                Attributes.ShouldDisplayDismissButton to R.styleable.PaywallView_shouldDisplayDismissButton,
+                Attributes.FontFamily to R.styleable.PaywallView_android_fontFamily,
+            ),
+            R.styleable.PaywallFooterView to mapOf(
+                Attributes.OfferingId to R.styleable.PaywallFooterView_offeringIdentifier,
+                Attributes.FontFamily to R.styleable.PaywallFooterView_android_fontFamily,
+            ),
+        )
+
+        @Suppress("ReturnCount", "NestedBlockDepth")
+        fun parseAttributes(context: Context, attrsSet: AttributeSet?, styleAttrs: IntArray): PaywallViewAttributes? {
+            if (attrsSet == null) {
+                return null
+            }
+            var fontFamilyId: Int? = null
+            var offeringIdentifier: String? = null
+            var shouldDisplayDismissButton: Boolean? = null
+            context.obtainStyledAttributes(
+                attrsSet,
+                styleAttrs,
+                0,
+                0,
+            ).apply {
+                try {
+                    val styleables = styleablesByStyleSet[styleAttrs] ?: run {
+                        Logger.e("Styleable not found for PaywallView")
+                        return null
+                    }
+                    fontFamilyId = styleables[Attributes.FontFamily]?.let { getResourceId(it, 0) }
+                    offeringIdentifier = styleables[Attributes.OfferingId]?.let { getString(it) }
+                    styleables[Attributes.ShouldDisplayDismissButton]?.let {
+                        shouldDisplayDismissButton = if (hasValue(it)) {
+                            getBoolean(it, false)
+                        } else {
+                            null
+                        }
+                    }
+                } finally {
+                    recycle()
+                }
+            }
+            val fontFamily = fontFamilyId?.takeIf { it > 0 }?.let {
+                val typeface = ResourcesCompat.getFont(context, it)
+                if (typeface == null) {
+                    Logger.e("Font given for PaywallView not found")
+                    null
+                } else {
+                    CustomFontProvider(FontFamily(typeface))
+                }
+            }
+            return PaywallViewAttributes(
+                offeringId = offeringIdentifier,
+                fontProvider = fontFamily,
+                shouldDisplayDismissButton = shouldDisplayDismissButton,
+            )
+        }
+    }
+
+    data class PaywallViewAttributes(
+        val offeringId: String?,
+        val fontProvider: FontProvider?,
+        val shouldDisplayDismissButton: Boolean?,
+    )
+}


### PR DESCRIPTION
### Description
This is a possible approach to [this comment](https://github.com/RevenueCat/purchases-android/pull/1510#pullrequestreview-1762883695). Basically, there is a bunch of duplicated logic between `PaywallView` and `PaywallFooterView`. This extracts part of it to a different class, the logic related to parsing xml attributes.

We could try to create a superclass/interface that abstracts some of the other methods... But that is relatively straightforward, and didn't want to have to expose another type just for that. 