### PR TITLE
Add revenuecatui docs to reference docs

### DIFF
--- a/ui/revenuecatui/build.gradle
+++ b/ui/revenuecatui/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     alias libs.plugins.android.library
+    alias libs.plugins.dokka
     alias libs.plugins.kotlin.android
     alias libs.plugins.kotlin.serialization
     alias libs.plugins.kotlin.parcelize
@@ -80,4 +81,23 @@ dependencies {
     androidTestImplementation libs.mockk.android
     androidTestImplementation libs.mockk.agent
     androidTestImplementation libs.androidx.test.compose
+}
+
+tasks.dokkaHtmlPartial.configure {
+    dokkaSourceSets {
+        named("main") {
+            reportUndocumented.set(true)
+            includeNonPublic.set(false)
+            skipDeprecated.set(true)
+
+            externalDocumentationLink {
+                url.set(uri("https://developer.android.com/reference/package-list").toURL())
+            }
+            sourceLink {
+                localDirectory.set(file("src/main/kotlin"))
+                remoteUrl.set(uri("https://github.com/revenuecat/purchases-android/blob/main/ui/revenuecatui/src/main/kotlin").toURL())
+                remoteLineSuffix.set("#L")
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Description
Add the `revenuecatui` module to generated documentation. We already had a multi-module setup, so it was straightforward to add it.

<img width="233" alt="image" src="https://github.com/RevenueCat/purchases-android/assets/808417/0920e3de-9dbe-4473-af95-6375fc16bb96">
