### PR TITLE
Hide action bar from paywall activity

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui.activity
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.view.Window
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Box
@@ -76,6 +77,7 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        requestWindowFeature(Window.FEATURE_NO_TITLE)
         super.onCreate(savedInstanceState)
         val args = getArgs()
         val paywallOptions = PaywallOptions.Builder(dismissRequest = ::finish)


### PR DESCRIPTION
### Description
After #1511, in flutter/rn, we might display the action bar in the paywall when being presented as an activity depending on the theme.

![image](https://github.com/RevenueCat/purchases-android/assets/808417/a00e05f5-01f0-4581-8c52-32497cb847a1)

This change makes sure we hide the action bar independently of the theme.
