### PR TITLE
Add `launchIfNeeded` with `offeringIdentifier`

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallActivityLauncherAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallActivityLauncherAPI.java
@@ -28,9 +28,25 @@ final class PaywallActivityLauncherAPI {
         PaywallActivityLauncher launcher3 = new PaywallActivityLauncher(resultCaller, resultHandler);
         launcher.launch();
         launcher.launch(offering);
+        launcher.launch(null);
+        launcher.launch(offering, fontProvider);
+        launcher.launch(offering, null);
         launcher.launch(null, fontProvider);
+        launcher.launch(null, null);
+        launcher.launch(offering, fontProvider, true);
+        launcher.launch(offering, null, true);
+        launcher.launch(null, fontProvider, true);
         launcher.launch(null, null, true);
         launcher.launchIfNeeded("requiredEntitlementIdentifier");
+        launcher.launchIfNeeded("requiredEntitlementIdentifier", offering);
+        launcher.launchIfNeeded("requiredEntitlementIdentifier", null);
+        launcher.launchIfNeeded("requiredEntitlementIdentifier", offering, fontProvider, true);
+        launcher.launchIfNeeded("requiredEntitlementIdentifier", offering, null, true);
+        launcher.launchIfNeeded("requiredEntitlementIdentifier", null, fontProvider, true);
+        launcher.launchIfNeeded("requiredEntitlementIdentifier", null, null, true);
+        launcher.launchIfNeeded(offering, fontProvider, true, customerInfo -> null);
+        launcher.launchIfNeeded(offering, null, true, customerInfo -> null);
+        launcher.launchIfNeeded(null, fontProvider, true, customerInfo -> null);
         launcher.launchIfNeeded(null, null, true, customerInfo -> null);
     }
 }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallActivityLauncherAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallActivityLauncherAPI.kt
@@ -10,7 +10,7 @@ import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResultHandler
 import com.revenuecat.purchases.ui.revenuecatui.fonts.ParcelizableFontProvider
 
-@Suppress("unused", "UNUSED_VARIABLE", "LongParameterList")
+@Suppress("unused", "UNUSED_VARIABLE", "LongParameterList", "LongMethod")
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 private class PaywallActivityLauncherAPI {
     fun check(
@@ -20,6 +20,7 @@ private class PaywallActivityLauncherAPI {
         resultHandler: PaywallResultHandler,
         offering: Offering,
         fontProvider: ParcelizableFontProvider,
+        offeringIdentifier: String,
     ) {
         val activityLauncher = PaywallActivityLauncher(componentActivity, resultHandler)
         val activityLauncher2 = PaywallActivityLauncher(fragment, resultHandler)
@@ -29,12 +30,50 @@ private class PaywallActivityLauncherAPI {
         activityLauncher.launch(
             offering = offering,
             fontProvider = fontProvider,
+        )
+        activityLauncher.launch(
+            offering = offering,
+            fontProvider = fontProvider,
+            shouldDisplayDismissButton = true,
+        )
+        activityLauncher.launch(offeringIdentifier)
+        activityLauncher.launch(
+            offeringIdentifier = offeringIdentifier,
+            fontProvider = fontProvider,
+        )
+        activityLauncher.launch(
+            offeringIdentifier = offeringIdentifier,
+            fontProvider = fontProvider,
             shouldDisplayDismissButton = true,
         )
         activityLauncher.launchIfNeeded("requiredEntitlementIdentifier")
         activityLauncher.launchIfNeeded(
             requiredEntitlementIdentifier = "requiredEntitlementIdentifier",
             offering = offering,
+        )
+        activityLauncher.launchIfNeeded(
+            requiredEntitlementIdentifier = "requiredEntitlementIdentifier",
+            offering = offering,
+            fontProvider = fontProvider,
+        )
+        activityLauncher.launchIfNeeded(
+            requiredEntitlementIdentifier = "requiredEntitlementIdentifier",
+            offering = offering,
+            fontProvider = fontProvider,
+            shouldDisplayDismissButton = true,
+        )
+        activityLauncher.launchIfNeeded(
+            requiredEntitlementIdentifier = "requiredEntitlementIdentifier",
+            offeringIdentifier = offeringIdentifier,
+        )
+        activityLauncher.launchIfNeeded(
+            requiredEntitlementIdentifier = "requiredEntitlementIdentifier",
+            offeringIdentifier = offeringIdentifier,
+            fontProvider = fontProvider,
+        )
+        activityLauncher.launchIfNeeded(
+            requiredEntitlementIdentifier = "requiredEntitlementIdentifier",
+            offeringIdentifier = offeringIdentifier,
             fontProvider = fontProvider,
             shouldDisplayDismissButton = true,
         )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -55,6 +55,32 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
     }
 
     /**
+     * Do not use this method, use the method with the same name that takes an [Offering] instead.
+     * This method is used internally by the hybrid SDKs.
+     *
+     * Launch the paywall activity.
+     * @param offeringIdentifier The offering identifier of the offering to be shown in the paywall. If null, the
+     * current offering will be shown.
+     * @param fontProvider The [ParcelizableFontProvider] to be used in the paywall. If null, the default fonts
+     * will be used.
+     * @param shouldDisplayDismissButton Whether to display the dismiss button in the paywall.
+     */
+    @JvmOverloads
+    fun launch(
+        offeringIdentifier: String,
+        fontProvider: ParcelizableFontProvider? = null,
+        shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
+    ) {
+        activityResultLauncher.launch(
+            PaywallActivityArgs(
+                offeringId = offeringIdentifier,
+                fontProvider = fontProvider,
+                shouldDisplayDismissButton = shouldDisplayDismissButton,
+            ),
+        )
+    }
+
+    /**
      * Launch the paywall activity if the current user does not have [requiredEntitlementIdentifier] active.
      * @param offering The offering to be shown in the paywall. If null, the current offering will be shown.
      * @param fontProvider The [ParcelizableFontProvider] to be used in the paywall. If null, the default fonts
@@ -70,12 +96,19 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
         fontProvider: ParcelizableFontProvider? = null,
         shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
     ) {
-        launchIfNeeded(
-            requiredEntitlementIdentifier = requiredEntitlementIdentifier,
-            offeringIdentifier = offering?.identifier,
-            fontProvider = fontProvider,
-            shouldDisplayDismissButton = shouldDisplayDismissButton,
-        )
+        val shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier)
+        shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
+            if (shouldDisplay) {
+                activityResultLauncher.launch(
+                    PaywallActivityArgs(
+                        requiredEntitlementIdentifier = requiredEntitlementIdentifier,
+                        offeringId = offering?.identifier,
+                        fontProvider = fontProvider,
+                        shouldDisplayDismissButton = shouldDisplayDismissButton,
+                    ),
+                )
+            }
+        }
     }
 
     /**
@@ -83,8 +116,8 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
      * This method is used internally by the hybrid SDKs.
      *
      * Launch the paywall activity if the current user does not have [requiredEntitlementIdentifier] active.
-     * @param offeringIdentifier The offering identifier to be shown in the paywall. If null, the current offering
-     * will be shown.
+     * @param offeringIdentifier The offering identifier of the ofering to be shown in the paywall. If null, the
+     * current offering will be shown.
      * @param fontProvider The [ParcelizableFontProvider] to be used in the paywall. If null, the default fonts
      * will be used.
      * @param requiredEntitlementIdentifier the paywall will be displayed only if the current user does not
@@ -94,7 +127,7 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
     @JvmOverloads
     fun launchIfNeeded(
         requiredEntitlementIdentifier: String,
-        offeringIdentifier: String? = null,
+        offeringIdentifier: String,
         fontProvider: ParcelizableFontProvider? = null,
         shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
     ) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -70,13 +70,41 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
         fontProvider: ParcelizableFontProvider? = null,
         shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
     ) {
+        launchIfNeeded(
+            requiredEntitlementIdentifier = requiredEntitlementIdentifier,
+            offeringIdentifier = offering?.identifier,
+            fontProvider = fontProvider,
+            shouldDisplayDismissButton = shouldDisplayDismissButton,
+        )
+    }
+
+    /**
+     * Do not use this method, use the method with the same name that takes an [Offering] instead.
+     * This method is used internally by the hybrid SDKs.
+     *
+     * Launch the paywall activity if the current user does not have [requiredEntitlementIdentifier] active.
+     * @param offeringIdentifier The offering identifier to be shown in the paywall. If null, the current offering
+     * will be shown.
+     * @param fontProvider The [ParcelizableFontProvider] to be used in the paywall. If null, the default fonts
+     * will be used.
+     * @param requiredEntitlementIdentifier the paywall will be displayed only if the current user does not
+     * have this entitlement active.
+     * @param shouldDisplayDismissButton Whether to display the dismiss button in the paywall.
+     */
+    @JvmOverloads
+    fun launchIfNeeded(
+        requiredEntitlementIdentifier: String,
+        offeringIdentifier: String? = null,
+        fontProvider: ParcelizableFontProvider? = null,
+        shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
+    ) {
         val shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier)
         shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
             if (shouldDisplay) {
                 activityResultLauncher.launch(
                     PaywallActivityArgs(
                         requiredEntitlementIdentifier = requiredEntitlementIdentifier,
-                        offeringId = offering?.identifier,
+                        offeringId = offeringIdentifier,
                         fontProvider = fontProvider,
                         shouldDisplayDismissButton = shouldDisplayDismissButton,
                     ),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -65,7 +65,7 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
      * will be used.
      * @param shouldDisplayDismissButton Whether to display the dismiss button in the paywall.
      */
-    @JvmOverloads
+    @JvmSynthetic
     fun launch(
         offeringIdentifier: String,
         fontProvider: ParcelizableFontProvider? = null,
@@ -124,7 +124,7 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
      * have this entitlement active.
      * @param shouldDisplayDismissButton Whether to display the dismiss button in the paywall.
      */
-    @JvmOverloads
+    @JvmSynthetic
     fun launchIfNeeded(
         requiredEntitlementIdentifier: String,
         offeringIdentifier: String,


### PR DESCRIPTION
We need a version of `launchIfNeeded` that accepts a `offeringIdentifier` for `purchases-hybrid-common` to be able to call the function from `PaywallFragment`