### PR TITLE
`Paywalls`: `PurchaseCancelledError` sends `onPurchaseCancelled` instead of an error

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallListener.kt
@@ -10,6 +10,7 @@ interface PaywallListener {
     fun onPurchaseStarted(rcPackage: Package) {}
     fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {}
     fun onPurchaseError(error: PurchasesError) {}
+    fun onPurchaseCancelled() {}
     fun onRestoreStarted() {}
     fun onRestoreCompleted(customerInfo: CustomerInfo) {}
     fun onRestoreError(error: PurchasesError) {}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -205,6 +205,7 @@ internal class PaywallViewModelImpl(
             } catch (e: PurchasesException) {
                 if (e.code == PurchasesErrorCode.PurchaseCancelledError) {
                     trackPaywallCancel()
+                    listener?.onPurchaseCancelled()
                 } else {
                     listener?.onPurchaseError(e.error)
                     _actionError.value = e.error

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -205,9 +205,10 @@ internal class PaywallViewModelImpl(
             } catch (e: PurchasesException) {
                 if (e.code == PurchasesErrorCode.PurchaseCancelledError) {
                     trackPaywallCancel()
+                } else {
+                    listener?.onPurchaseError(e.error)
+                    _actionError.value = e.error
                 }
-                listener?.onPurchaseError(e.error)
-                _actionError.value = e.error
             }
 
             finishAction()

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -450,6 +450,9 @@ class PaywallViewModelTest {
         verify(exactly = 0) {
             listener.onPurchaseError(any())
         }
+        verify(exactly = 1) {
+            listener.onPurchaseCancelled()
+        }
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -31,7 +31,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.verify
 import io.mockk.verifyOrder
@@ -446,6 +445,11 @@ class PaywallViewModelTest {
         model.purchaseSelectedPackage(activity)
 
         verifyEventTracked(PaywallEventType.CANCEL, 1)
+
+        assertThat(model.actionError.value).isNull()
+        verify(exactly = 0) {
+            listener.onPurchaseError(any())
+        }
     }
 
     @Test


### PR DESCRIPTION
Cancelling the purchase modal shouldn't display an error dialog.

This is a very confusing experience, especially because that error wouldn't be localized.
