### PR TITLE
PaywallActivityLauncher: Add callback indicating whether the paywall was displayed when presented conditionally to an entitlement identifier

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallActivityLauncherAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallActivityLauncherAPI.java
@@ -56,7 +56,7 @@ final class PaywallActivityLauncherAPI {
     static void checkPaywallDisplayCallback() {
         PaywallDisplayCallback callback = new PaywallDisplayCallback() {
             @Override
-            public void onPaywallShouldDisplay(boolean shouldDisplayPaywall) {
+            public void onPaywallDisplayResult(boolean wasDisplayed) {
             }
         };
     }

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallActivityLauncherAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallActivityLauncherAPI.java
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment;
 import com.revenuecat.purchases.Offering;
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI;
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher;
+import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallDisplayCallback;
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResultHandler;
 import com.revenuecat.purchases.ui.revenuecatui.fonts.ParcelizableFontProvider;
 
@@ -25,7 +26,7 @@ final class PaywallActivityLauncherAPI {
             PaywallResultHandler resultHandler,
             Offering offering,
             ParcelizableFontProvider fontProvider,
-            Function1<Boolean, Unit> paywallDisplayedCallback
+            PaywallDisplayCallback paywallDisplayCallback
     ) {
         PaywallActivityLauncher launcher = new PaywallActivityLauncher(activity, resultHandler);
         PaywallActivityLauncher launcher2 = new PaywallActivityLauncher(fragment, resultHandler);
@@ -48,10 +49,18 @@ final class PaywallActivityLauncherAPI {
         launcher.launchIfNeeded("requiredEntitlementIdentifier", offering, null, true);
         launcher.launchIfNeeded("requiredEntitlementIdentifier", null, fontProvider, true);
         launcher.launchIfNeeded("requiredEntitlementIdentifier", null, null, true);
-        launcher.launchIfNeeded("requiredEntitlementIdentifier", offering, fontProvider, true, paywallDisplayedCallback);
+        launcher.launchIfNeeded("requiredEntitlementIdentifier", offering, fontProvider, true, paywallDisplayCallback);
         launcher.launchIfNeeded(offering, fontProvider, true, customerInfo -> null);
         launcher.launchIfNeeded(offering, null, true, customerInfo -> null);
         launcher.launchIfNeeded(null, fontProvider, true, customerInfo -> null);
         launcher.launchIfNeeded(null, null, true, customerInfo -> null);
+    }
+
+    static void checkPaywallDisplayCallback() {
+        PaywallDisplayCallback callback = new PaywallDisplayCallback() {
+            @Override
+            public void onPaywallShouldDisplay(boolean shouldDisplayPaywall) {
+            }
+        };
     }
 }

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallActivityLauncherAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallActivityLauncherAPI.java
@@ -12,9 +12,6 @@ import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallDisplayCallback;
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResultHandler;
 import com.revenuecat.purchases.ui.revenuecatui.fonts.ParcelizableFontProvider;
 
-import kotlin.Unit;
-import kotlin.jvm.functions.Function1;
-
 @SuppressWarnings({"unused"})
 @ExperimentalPreviewRevenueCatUIPurchasesAPI
 final class PaywallActivityLauncherAPI {

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallActivityLauncherAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallActivityLauncherAPI.java
@@ -11,6 +11,9 @@ import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResultHandler;
 import com.revenuecat.purchases.ui.revenuecatui.fonts.ParcelizableFontProvider;
 
+import kotlin.Unit;
+import kotlin.jvm.functions.Function1;
+
 @SuppressWarnings({"unused"})
 @ExperimentalPreviewRevenueCatUIPurchasesAPI
 final class PaywallActivityLauncherAPI {
@@ -21,7 +24,8 @@ final class PaywallActivityLauncherAPI {
             ActivityResultCaller resultCaller,
             PaywallResultHandler resultHandler,
             Offering offering,
-            ParcelizableFontProvider fontProvider
+            ParcelizableFontProvider fontProvider,
+            Function1<Boolean, Unit> paywallDisplayedCallback
     ) {
         PaywallActivityLauncher launcher = new PaywallActivityLauncher(activity, resultHandler);
         PaywallActivityLauncher launcher2 = new PaywallActivityLauncher(fragment, resultHandler);
@@ -44,6 +48,7 @@ final class PaywallActivityLauncherAPI {
         launcher.launchIfNeeded("requiredEntitlementIdentifier", offering, null, true);
         launcher.launchIfNeeded("requiredEntitlementIdentifier", null, fontProvider, true);
         launcher.launchIfNeeded("requiredEntitlementIdentifier", null, null, true);
+        launcher.launchIfNeeded("requiredEntitlementIdentifier", offering, fontProvider, true, paywallDisplayedCallback);
         launcher.launchIfNeeded(offering, fontProvider, true, customerInfo -> null);
         launcher.launchIfNeeded(offering, null, true, customerInfo -> null);
         launcher.launchIfNeeded(null, fontProvider, true, customerInfo -> null);

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallActivityLauncherAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallActivityLauncherAPI.kt
@@ -108,9 +108,9 @@ private class PaywallActivityLauncherAPI {
     }
 
     fun checkPaywallDisplayCallback() {
+        @Suppress("EmptyFunctionBlock")
         val paywallDisplayCallback = object : PaywallDisplayCallback {
-            override fun onPaywallShouldDisplay(shouldDisplayPaywall: Boolean) {
-            }
+            override fun onPaywallShouldDisplay(shouldDisplayPaywall: Boolean) {}
         }
     }
 }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallActivityLauncherAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallActivityLauncherAPI.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
+import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallDisplayCallback
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResultHandler
 import com.revenuecat.purchases.ui.revenuecatui.fonts.ParcelizableFontProvider
 
@@ -21,7 +22,7 @@ private class PaywallActivityLauncherAPI {
         offering: Offering,
         fontProvider: ParcelizableFontProvider,
         offeringIdentifier: String,
-        paywallDisplayedCallback: (Boolean) -> Unit,
+        paywallDisplayCallback: PaywallDisplayCallback,
     ) {
         val activityLauncher = PaywallActivityLauncher(componentActivity, resultHandler)
         val activityLauncher2 = PaywallActivityLauncher(fragment, resultHandler)
@@ -68,7 +69,7 @@ private class PaywallActivityLauncherAPI {
             offering = offering,
             fontProvider = fontProvider,
             shouldDisplayDismissButton = true,
-            paywallDisplayedCallback = paywallDisplayedCallback,
+            paywallDisplayCallback = paywallDisplayCallback,
         )
         activityLauncher.launchIfNeeded(
             requiredEntitlementIdentifier = "requiredEntitlementIdentifier",
@@ -90,7 +91,7 @@ private class PaywallActivityLauncherAPI {
             offeringIdentifier = offeringIdentifier,
             fontProvider = fontProvider,
             shouldDisplayDismissButton = true,
-            paywallDisplayedCallback = paywallDisplayedCallback,
+            paywallDisplayCallback = paywallDisplayCallback,
         )
         activityLauncher.launchIfNeeded {
             val customerInfo: CustomerInfo = it
@@ -103,6 +104,13 @@ private class PaywallActivityLauncherAPI {
         ) {
             val customerInfo: CustomerInfo = it
             true
+        }
+    }
+
+    fun checkPaywallDisplayCallback() {
+        val paywallDisplayCallback = object : PaywallDisplayCallback {
+            override fun onPaywallShouldDisplay(shouldDisplayPaywall: Boolean) {
+            }
         }
     }
 }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallActivityLauncherAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallActivityLauncherAPI.kt
@@ -110,7 +110,7 @@ private class PaywallActivityLauncherAPI {
     fun checkPaywallDisplayCallback() {
         @Suppress("EmptyFunctionBlock")
         val paywallDisplayCallback = object : PaywallDisplayCallback {
-            override fun onPaywallShouldDisplay(shouldDisplayPaywall: Boolean) {}
+            override fun onPaywallDisplayResult(wasDisplayed: Boolean) {}
         }
     }
 }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallActivityLauncherAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallActivityLauncherAPI.kt
@@ -21,6 +21,7 @@ private class PaywallActivityLauncherAPI {
         offering: Offering,
         fontProvider: ParcelizableFontProvider,
         offeringIdentifier: String,
+        paywallDisplayedCallback: (Boolean) -> Unit,
     ) {
         val activityLauncher = PaywallActivityLauncher(componentActivity, resultHandler)
         val activityLauncher2 = PaywallActivityLauncher(fragment, resultHandler)
@@ -64,6 +65,13 @@ private class PaywallActivityLauncherAPI {
         )
         activityLauncher.launchIfNeeded(
             requiredEntitlementIdentifier = "requiredEntitlementIdentifier",
+            offering = offering,
+            fontProvider = fontProvider,
+            shouldDisplayDismissButton = true,
+            paywallDisplayedCallback = paywallDisplayedCallback,
+        )
+        activityLauncher.launchIfNeeded(
+            requiredEntitlementIdentifier = "requiredEntitlementIdentifier",
             offeringIdentifier = offeringIdentifier,
         )
         activityLauncher.launchIfNeeded(
@@ -76,6 +84,13 @@ private class PaywallActivityLauncherAPI {
             offeringIdentifier = offeringIdentifier,
             fontProvider = fontProvider,
             shouldDisplayDismissButton = true,
+        )
+        activityLauncher.launchIfNeeded(
+            requiredEntitlementIdentifier = "requiredEntitlementIdentifier",
+            offeringIdentifier = offeringIdentifier,
+            fontProvider = fontProvider,
+            shouldDisplayDismissButton = true,
+            paywallDisplayedCallback = paywallDisplayedCallback,
         )
         activityLauncher.launchIfNeeded {
             val customerInfo: CustomerInfo = it

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -88,6 +88,7 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
      * @param requiredEntitlementIdentifier the paywall will be displayed only if the current user does not
      * have this entitlement active.
      * @param shouldDisplayDismissButton Whether to display the dismiss button in the paywall.
+     * @param paywallDisplayedCallback Callback that will be called with true if the paywall was displayed
      */
     @JvmOverloads
     fun launchIfNeeded(
@@ -95,9 +96,11 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
         offering: Offering? = null,
         fontProvider: ParcelizableFontProvider? = null,
         shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
+        paywallDisplayedCallback: ((Boolean) -> Unit)? = null,
     ) {
         val shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier)
         shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
+            paywallDisplayedCallback?.invoke(shouldDisplay)
             if (shouldDisplay) {
                 activityResultLauncher.launch(
                     PaywallActivityArgs(
@@ -123,6 +126,7 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
      * @param requiredEntitlementIdentifier the paywall will be displayed only if the current user does not
      * have this entitlement active.
      * @param shouldDisplayDismissButton Whether to display the dismiss button in the paywall.
+     * @param paywallDisplayedCallback Callback that will be called with true if the paywall was displayed
      */
     @JvmSynthetic
     fun launchIfNeeded(
@@ -130,9 +134,11 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
         offeringIdentifier: String,
         fontProvider: ParcelizableFontProvider? = null,
         shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
+        paywallDisplayedCallback: ((Boolean) -> Unit)? = null,
     ) {
         val shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier)
         shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
+            paywallDisplayedCallback?.invoke(shouldDisplay)
             if (shouldDisplay) {
                 activityResultLauncher.launch(
                     PaywallActivityArgs(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -23,7 +23,7 @@ interface PaywallResultHandler : ActivityResultCallback<PaywallResult>
  */
 @ExperimentalPreviewRevenueCatUIPurchasesAPI
 interface PaywallDisplayCallback {
-    fun onPaywallShouldDisplay(shouldDisplayPaywall: Boolean)
+    fun onPaywallDisplayResult(wasDisplayed: Boolean)
 }
 
 /**
@@ -108,7 +108,7 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
     ) {
         val shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier)
         shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
-            paywallDisplayCallback?.onPaywallShouldDisplay(shouldDisplay)
+            paywallDisplayCallback?.onPaywallDisplayResult(shouldDisplay)
             if (shouldDisplay) {
                 activityResultLauncher.launch(
                     PaywallActivityArgs(
@@ -146,7 +146,7 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
     ) {
         val shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier)
         shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
-            paywallDisplayCallback?.onPaywallShouldDisplay(shouldDisplay)
+            paywallDisplayCallback?.onPaywallDisplayResult(shouldDisplay)
             if (shouldDisplay) {
                 activityResultLauncher.launch(
                     PaywallActivityArgs(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -19,7 +19,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayPaywall
 interface PaywallResultHandler : ActivityResultCallback<PaywallResult>
 
 /**
- * Implement this interface to receive whether the paywall was launched when it's conditionally launched
+ * Implement this interface to receive whether the paywall was displayed when it depends on a condition.
  */
 @ExperimentalPreviewRevenueCatUIPurchasesAPI
 interface PaywallDisplayCallback {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -19,6 +19,14 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayPaywall
 interface PaywallResultHandler : ActivityResultCallback<PaywallResult>
 
 /**
+ * Implement this interface to receive whether the paywall was launched when it's conditionally launched
+ */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
+interface PaywallDisplayCallback {
+    fun onPaywallShouldDisplay(shouldDisplayPaywall: Boolean)
+}
+
+/**
  * Launches the paywall activity. You need to create this object during the activity's onCreate.
  * Then launch the activity at your moment of choice.
  * This can be instantiated with an [ActivityResultCaller] instance
@@ -88,7 +96,7 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
      * @param requiredEntitlementIdentifier the paywall will be displayed only if the current user does not
      * have this entitlement active.
      * @param shouldDisplayDismissButton Whether to display the dismiss button in the paywall.
-     * @param paywallDisplayedCallback Callback that will be called with true if the paywall was displayed
+     * @param paywallDisplayCallback Callback that will be called with true if the paywall was displayed
      */
     @JvmOverloads
     fun launchIfNeeded(
@@ -96,11 +104,11 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
         offering: Offering? = null,
         fontProvider: ParcelizableFontProvider? = null,
         shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
-        paywallDisplayedCallback: ((Boolean) -> Unit)? = null,
+        paywallDisplayCallback: PaywallDisplayCallback? = null,
     ) {
         val shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier)
         shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
-            paywallDisplayedCallback?.invoke(shouldDisplay)
+            paywallDisplayCallback?.onPaywallShouldDisplay(shouldDisplay)
             if (shouldDisplay) {
                 activityResultLauncher.launch(
                     PaywallActivityArgs(
@@ -126,7 +134,7 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
      * @param requiredEntitlementIdentifier the paywall will be displayed only if the current user does not
      * have this entitlement active.
      * @param shouldDisplayDismissButton Whether to display the dismiss button in the paywall.
-     * @param paywallDisplayedCallback Callback that will be called with true if the paywall was displayed
+     * @param paywallDisplayCallback Callback that will be called with true if the paywall was displayed
      */
     @JvmSynthetic
     fun launchIfNeeded(
@@ -134,11 +142,11 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
         offeringIdentifier: String,
         fontProvider: ParcelizableFontProvider? = null,
         shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
-        paywallDisplayedCallback: ((Boolean) -> Unit)? = null,
+        paywallDisplayCallback: PaywallDisplayCallback? = null,
     ) {
         val shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier)
         shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
-            paywallDisplayedCallback?.invoke(shouldDisplay)
+            paywallDisplayCallback?.onPaywallShouldDisplay(shouldDisplay)
             if (shouldDisplay) {
                 activityResultLauncher.launch(
                     PaywallActivityArgs(


### PR DESCRIPTION
### Description
In the hybrid SDKs, we want to return a result from the `presentPaywall`/`presentPaywallIfNeeded` methods with the result of the paywall. However, we can't do that easily since `presentPaywallIfNeeded` might not present the paywall at all, and there was no way to know whether the paywall was displayed in that case until now.

This adds a new parameter to the `launchIfNeeded` methods that receive a `requiredEntitlementIdentifier` that will indicate whether the paywall was displayed. Note that this isn't added to the `launchIfNeeded` method that received a block of code, since the client should know in that case whether the paywall was displayed or not, depending on the result of that callback.