### PR TITLE
Report restore errors when using PaywallActivityLauncher

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -119,6 +119,10 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
         setResult(RESULT_OK, createResultIntent(result))
     }
 
+    override fun onRestoreError(error: PurchasesError) {
+        setResult(RESULT_OK, createResultIntent(PaywallResult.Error(error)))
+    }
+
     private fun createResultIntent(result: PaywallResult): Intent {
         return Intent().putExtra(RESULT_EXTRA, result)
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallResult.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallResult.kt
@@ -24,7 +24,7 @@ sealed class PaywallResult : Parcelable {
     data class Purchased(val customerInfo: CustomerInfo) : PaywallResult(), Parcelable
 
     /**
-     * The user tried to purchase a product but an error occurred. If they tried multiple times,
+     * The user tried to purchase a product or restore purchases but an error occurred. If they tried multiple times,
      * the error corresponds to the last attempt.
      */
     @Parcelize


### PR DESCRIPTION
### Description
In the `PaywallActivityLauncher` result, we were only reporting errors happening during purchasing, but not when an error happened during restores. 

This PR fixes that so we also report restore errors as long as that's the last operation that happened before closing the paywall.