### PR TITLE
Remove scroll in Template 2 and 5 in Footer mode

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -129,11 +129,11 @@ private fun ColumnScope.Template2MainContent(
     packageSelectionVisible: Boolean,
     childModifier: Modifier,
 ) {
+    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
-            .verticalScroll(rememberScrollState())
             .conditional(state.isInFullScreenMode) {
-                Modifier.weight(1f)
+                Modifier.verticalScroll(scrollState).weight(1f)
             }
             .padding(horizontal = UIConstant.defaultHorizontalPadding, vertical = UIConstant.defaultVerticalSpacing),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
@@ -137,11 +137,11 @@ private fun ColumnScope.Template5MainContent(
     viewModel: PaywallViewModel,
     packageSelectionVisible: Boolean,
 ) {
+    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
-            .verticalScroll(rememberScrollState())
             .conditional(state.isInFullScreenMode) {
-                Modifier.weight(1f)
+                Modifier.verticalScroll(scrollState).weight(1f)
             }
             .padding(horizontal = UIConstant.defaultHorizontalPadding, vertical = UIConstant.defaultVerticalSpacing),
         horizontalAlignment = Alignment.CenterHorizontally,


### PR DESCRIPTION
This was making https://github.com/RevenueCat/react-native-purchases/pull/799/files#diff-8eaf252c074773fc7f002e444b255a9c2c60b23a2c75448799b85abb2f509bf9R20 crash when measuring the size giving this error:

![image](https://github.com/RevenueCat/purchases-android/assets/664544/b2b0718e-a897-4b68-bc09-47a8b42b24fb)

I removed the scroll in Footer mode because it's not needed