### PR TITLE
Fix paywall dialog composable sizing issues

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -16,8 +16,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.window.core.layout.WindowHeightSizeClass
 import androidx.window.core.layout.WindowWidthSizeClass
+import com.revenuecat.purchases.ui.revenuecatui.helpers.computeWindowHeightSizeClass
 import com.revenuecat.purchases.ui.revenuecatui.helpers.computeWindowWidthSizeClass
+import com.revenuecat.purchases.ui.revenuecatui.helpers.hasCompactDimension
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayPaywall
 import com.revenuecat.purchases.ui.revenuecatui.helpers.windowAspectRatio
 import kotlinx.coroutines.launch
@@ -91,19 +94,11 @@ private fun getDialogMaxHeightPercentage(): Float {
     if (windowAspectRatio() < UIDialogConstants.MAX_ASPECT_RATIO_TO_APPLY_MAX_HEIGHT) {
         return 1f
     }
-    return computeWindowWidthSizeClass().let {
-        when (it) {
-            WindowWidthSizeClass.MEDIUM, WindowWidthSizeClass.EXPANDED -> UIDialogConstants.MAX_HEIGHT_PERCENTAGE_TABLET
-            else -> 1f
-        }
-    }
+    return if (hasCompactDimension()) 1f else UIDialogConstants.MAX_HEIGHT_PERCENTAGE_TABLET
 }
 
 @Composable
 @ReadOnlyComposable
 private fun shouldUsePlatformDefaultWidth(): Boolean {
-    return when (computeWindowWidthSizeClass()) {
-        WindowWidthSizeClass.MEDIUM, WindowWidthSizeClass.EXPANDED -> true
-        else -> false
-    }
+    return !hasCompactDimension()
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -16,10 +16,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.window.core.layout.WindowHeightSizeClass
-import androidx.window.core.layout.WindowWidthSizeClass
-import com.revenuecat.purchases.ui.revenuecatui.helpers.computeWindowHeightSizeClass
-import com.revenuecat.purchases.ui.revenuecatui.helpers.computeWindowWidthSizeClass
 import com.revenuecat.purchases.ui.revenuecatui.helpers.hasCompactDimension
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayPaywall
 import com.revenuecat.purchases.ui.revenuecatui.helpers.windowAspectRatio

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/WindowHelper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/WindowHelper.kt
@@ -27,6 +27,13 @@ internal fun computeWindowHeightSizeClass(): WindowHeightSizeClass {
 
 @Composable
 @ReadOnlyComposable
+internal fun hasCompactDimension(): Boolean {
+    return computeWindowHeightSizeClass() == WindowHeightSizeClass.COMPACT ||
+        computeWindowWidthSizeClass() == WindowWidthSizeClass.COMPACT
+}
+
+@Composable
+@ReadOnlyComposable
 internal fun PaywallState.Loaded.shouldUseLandscapeLayout(): Boolean {
     return shouldUseLandscapeLayout(mode = templateConfiguration.mode)
 }


### PR DESCRIPTION
### Description
As I was testing #1551, I noticed that the dialog size wasn't correct. The width of the device sometimes was `MEDIUM` on a phone, causing it to present the dialog in a narrowed version. After more testing, I noticed that it was always one of the dimensions that were not `COMPACT` on my emulator, so I decided to check both. If one of the dimensions is `COMPACT`, we would present the dialog as full screen.

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/RevenueCat/purchases-android/assets/808417/de5900ca-f0cc-48d1-8e32-64ea58819a7c) |  ![image](https://github.com/RevenueCat/purchases-android/assets/808417/c3a987a8-37b2-444c-81cc-4e8a16a98b44) |
