### PR TITLE
`Paywalls`: improve error display

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -227,7 +227,9 @@ internal class PaywallViewModelImpl(
                 }
 
                 if (currentOffering == null) {
-                    _state.value = PaywallState.Error("No offering or current offering")
+                    _state.value = PaywallState.Error(
+                        "The RevenueCat dashboard does not have a current offering configured.",
+                    )
                 } else {
                     _state.value = calculateState(
                         currentOffering,
@@ -236,7 +238,9 @@ internal class PaywallViewModelImpl(
                     )
                 }
             } catch (e: PurchasesException) {
-                _state.value = PaywallState.Error(e.toString())
+                _state.value = PaywallState.Error(
+                    "Error ${e.code.code}: ${e.code.description}",
+                )
             }
         }
     }


### PR DESCRIPTION
Equivalent to https://github.com/RevenueCat/purchases-ios/pull/3577

I've also added test coverage for errors in `PaywallViewModel`.

### Before
![Before](https://github.com/RevenueCat/purchases-android/assets/685609/9bb193cd-3325-4a5c-a0f6-3680d7dca8fb)

### After
![After](https://github.com/RevenueCat/purchases-android/assets/685609/5178877b-755a-4f48-8bef-a061dfda968d)
