### PR TITLE
Revert google ads library bump to remove `AD_ID` permission

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,9 @@ recyclerview = "1.2.1"
 amazon = "3.0.3"
 espresso = "3.4.0"
 material = "1.6.0"
-adsIdentifier = "18.0.1"
+# Note that version 18.0.1 adds the AD_ID permission to the SDK.
+# We should not add that permission ourselves, so keeping it at 17.0.1 for now.
+adsIdentifier = "17.0.1"
 viewmodelCompose = "2.4.0"
 paparrazzi = "1.3.1"
 coil = "2.4.0"


### PR DESCRIPTION
### Description
We bumped the ad library version in #1550. However, that version of the library adds the `AD_ID` permission, forcing our customers to have it as well, which is not intended. This reverts that bump but keeps the null pointer exception handling.
