### PR TITLE
`Paywalls`: improve template 5 layout for long product names

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
@@ -400,7 +400,7 @@ private fun ColumnScope.SelectPackageButton(
                     color = textColor,
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.SemiBold,
-                    modifier = Modifier.weight(1f, fill = true)
+                    modifier = Modifier.weight(1f, fill = true),
                 )
 
                 DiscountBanner(state = state, resourceProvider = viewModel.resourceProvider, packageInfo = packageInfo)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -399,10 +400,12 @@ private fun ColumnScope.SelectPackageButton(
                     color = textColor,
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f, fill = true)
                 )
-                Spacer(modifier = Modifier.weight(1f))
+
                 DiscountBanner(state = state, resourceProvider = viewModel.resourceProvider, packageInfo = packageInfo)
             }
+
             IntroEligibilityStateView(
                 textWithNoIntroOffer = packageInfo.localization.offerDetails,
                 textWithIntroOffer = packageInfo.localization.offerDetailsWithIntroOffer,
@@ -434,7 +437,7 @@ private fun CheckmarkBox(isSelected: Boolean, colors: TemplateConfiguration.Colo
 }
 
 @Composable
-private fun DiscountBanner(
+private fun RowScope.DiscountBanner(
     state: PaywallState.Loaded,
     resourceProvider: ResourceProvider,
     packageInfo: TemplateConfiguration.PackageInfo,
@@ -456,6 +459,7 @@ private fun DiscountBanner(
 
     Box(
         modifier = Modifier
+            .align(Alignment.Top)
             .offset(
                 x = UIConstant.defaultHorizontalPadding - Template5UIConstants.discountPadding,
                 y = -UIConstant.defaultVerticalSpacing + Template5UIConstants.discountPadding,


### PR DESCRIPTION
See also https://github.com/RevenueCat/purchases-ios/pull/3589

### Before
![Screenshot 2024-01-19 at 12 58 39](https://github.com/RevenueCat/purchases-android/assets/685609/9d085479-b4e4-4430-ac67-b6722d510c98)

### After
![Screenshot 2024-01-19 at 12 56 18](https://github.com/RevenueCat/purchases-android/assets/685609/c824f06b-f6da-4328-a9ea-c99862604295)
