### PR TITLE
`Paywalls`: log error when creating `PaywallState.Error`

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -7,12 +7,17 @@ import androidx.compose.runtime.mutableStateOf
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.ProcessedLocalizedConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.isFullScreen
 
 internal sealed class PaywallState {
     object Loading : PaywallState()
 
-    data class Error(val errorMessage: String) : PaywallState()
+    data class Error(val errorMessage: String) : PaywallState() {
+        init {
+            Logger.e("Paywall transitioned to error state: $errorMessage")
+        }
+    }
 
     data class Loaded(
         val offering: Offering,


### PR DESCRIPTION
I'm currently debugging an issue with a developer, and realized that we have no way of knowing if the paywall goes into this state other than the error dialog being displayed.
This logs an error as well to make it easier to debug.

Example:
```
RevenueCatUI com.revenuecat.paywall_tester        E  Paywall transitioned to error state: Error 10: Error performing request.
```
