### PR TITLE
`OfferingsFactory`: debug logs when creating `Offerings`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -31,6 +31,8 @@ internal abstract class OfferingParser {
      * Note: this may return an empty Offerings.
      */
     fun createOfferings(offeringsJson: JSONObject, productsById: Map<String, List<StoreProduct>>): Offerings {
+        log(LogIntent.DEBUG, OfferingStrings.BUILDING_OFFERINGS.format(productsById.size))
+
         val jsonOfferings = offeringsJson.getJSONArray("offerings")
         val currentOfferingID = offeringsJson.getString("current_offering_id")
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
@@ -52,6 +52,7 @@ internal class OfferingsFactory(
                                     ),
                                 )
                             } else {
+                                log(LogIntent.DEBUG, OfferingStrings.CREATED_OFFERINGS.format(offerings))
                                 onSuccess(offerings)
                             }
                         } catch (error: Exception) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.strings.OfferingStrings
 import kotlinx.serialization.SerializationException
@@ -52,7 +53,7 @@ internal class OfferingsFactory(
                                     ),
                                 )
                             } else {
-                                log(LogIntent.VERBOSE, OfferingStrings.CREATED_OFFERINGS.format(offerings))
+                                verboseLog(OfferingStrings.CREATED_OFFERINGS.format(offerings))
                                 onSuccess(offerings)
                             }
                         } catch (error: Exception) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
@@ -52,7 +52,7 @@ internal class OfferingsFactory(
                                     ),
                                 )
                             } else {
-                                log(LogIntent.DEBUG, OfferingStrings.CREATED_OFFERINGS.format(offerings))
+                                log(LogIntent.VERBOSE, OfferingStrings.CREATED_OFFERINGS.format(offerings))
                                 onSuccess(offerings)
                             }
                         } catch (error: Exception) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -7,6 +7,8 @@ internal object OfferingStrings {
     const val FETCHING_OFFERINGS_ERROR = "Error fetching offerings - %s"
     const val FETCHING_PRODUCTS = "Requesting products from the store with identifiers: %s"
     const val FETCHING_PRODUCTS_FINISHED = "Products request finished for %s"
+    const val BUILDING_OFFERINGS = "Building offerings response with %d products"
+    const val CREATED_OFFERINGS = "Offerings object created: %s"
     const val JSON_EXCEPTION_ERROR = "JSONException when building Offerings object. Message: %s"
     const val LIST_PRODUCTS = "%s - %s"
     const val EXTRA_QUERY_PRODUCT_DETAILS_RESPONSE = "BillingClient queryProductDetails has returned more than once, " +


### PR DESCRIPTION
While debugging an issue, I realized that the SDK never prints anything after fetching products.
This should provide more visibility on the `Offerings` initialization.
