### PR TITLE
Exposing fontprovider

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
@@ -89,6 +89,11 @@ open class PaywallFooterView : FrameLayout {
         invalidate()
     }
 
+    fun setFontProvider(fontProvider: FontProvider) {
+        this.fontProvider = fontProvider
+        invalidate()
+    }
+
     private fun init(context: Context, attrs: AttributeSet?) {
         parseAttributes(context, attrs)
         addView(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
@@ -89,6 +89,9 @@ open class PaywallFooterView : FrameLayout {
         invalidate()
     }
 
+    /**
+     * Sets the font provider to be used to display the Paywall Footer View.
+     */
     fun setFontProvider(fontProvider: FontProvider) {
         this.fontProvider = fontProvider
         invalidate()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
@@ -92,6 +92,14 @@ class PaywallView : FrameLayout {
         invalidate()
     }
 
+    /**
+     * Sets the font provider to be used to display the Paywall.
+     */
+    fun setFontProvider(fontProvider: FontProvider) {
+        this.fontProvider = fontProvider
+        invalidate()
+    }
+
     private fun init(context: Context, attrs: AttributeSet?) {
         parseAttributes(context, attrs)
         addView(


### PR DESCRIPTION
### Checklist
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
- I haven't made the PR yet for react-native-purchases, but it's not possible for us to change the font family in react-native-purchase as of now.
- My hope was to expose this font provider methods for the RN Bridge so that we can at least set googleFonts.

### Description
- Exposing fontProviders for PaywallFooterView and PaywallView.
- Invalidate views when font provider changes.

What do you guys think about adding something like this on the React Native side.
```typescript
@ReactProp(name = "googleFontName")
    fun setGoogleFont(view: PaywallFooterView, googleFontName: String?){
        val googleFontProvider = GoogleFontProvider(R.array.com_google_android_gms_fonts_certs)
        val weightList = listOf(
            FontWeight.W100 ,
            FontWeight.W200,
            FontWeight.W300,
            FontWeight.W400,
            FontWeight.W500,
            FontWeight.W600,
            FontWeight.W700,
            FontWeight.W800,
            FontWeight.W900
        )
        val fontList = weightList.map {
            Font(
                GoogleFont(fontName),
                googleFontProvider.toGoogleProvider(),
                it,
                FontStyle.Normal
            )
        }
        view.setFontProvider(CustomFontProvider(FontFamily(fontList)))
    }
```

If agreed, I can go ahead and make these changes on ios and RN.

<img width="350" alt="Screenshot 2024-01-26 at 10 04 03 PM" src="https://github.com/RevenueCat/purchases-android/assets/6516487/e8e41b0d-c1fd-4446-8d5b-11cb9de200e5">
