### PR TITLE
[EXTERNAL] Exposing fontprovider setter in `PaywallView` and `PaywallFooterView` by @Jjastiny

### DIFF
--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallFooterViewAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallFooterViewAPI.kt
@@ -2,7 +2,7 @@ package com.revenuecat.apitester.kotlin.revenuecatui
 
 import android.content.Context
 import android.util.AttributeSet
-import android.widget.FrameLayout
+import androidx.compose.ui.platform.AbstractComposeView
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
@@ -14,7 +14,7 @@ import com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView
 private class PaywallFooterViewAPI {
 
     fun checkType(context: Context) {
-        val paywallFooterView: FrameLayout = PaywallFooterView(context)
+        val paywallFooterView: AbstractComposeView = PaywallFooterView(context)
     }
 
     @Suppress("LongParameterList")

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallViewAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallViewAPI.kt
@@ -2,7 +2,7 @@ package com.revenuecat.apitester.kotlin.revenuecatui
 
 import android.content.Context
 import android.util.AttributeSet
-import android.widget.FrameLayout
+import androidx.compose.ui.platform.AbstractComposeView
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
@@ -14,7 +14,7 @@ import com.revenuecat.purchases.ui.revenuecatui.views.PaywallView
 private class PaywallViewAPI {
 
     fun checkType(context: Context) {
-        val paywallView: FrameLayout = PaywallView(context)
+        val paywallView: AbstractComposeView = PaywallView(context)
     }
 
     @Suppress("LongParameterList")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
@@ -107,6 +107,7 @@ open class PaywallFooterView : AbstractComposeView {
         }
         paywallOptions = paywallOptions.copy(offeringSelection = offeringSelection)
     }
+
     /**
      * Sets the font provider to be used for the Paywall. If not set, the default one will be used.
      */

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
@@ -120,7 +120,7 @@ class PaywallView : AbstractComposeView {
 
     private fun init(context: Context, attrs: AttributeSet?) {
         parseAttributes(context, attrs)
-        paywallOptionsState.value = PaywallOptions.Builder { dismissHandler?.invoke() }
+        paywallOptions = PaywallOptions.Builder { dismissHandler?.invoke() }
             .setListener(internalListener)
             .setFontProvider(initialFontProvider)
             .setOfferingId(initialOfferingId)


### PR DESCRIPTION
External contribution from #1588 

### Checklist
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
- It's not possible for us to change the font family in react-native-purchase.
- My hope was to expose this font provider methods for the RN Bridge so that we can at least set custom font family.

### Description
- Exposing fontProviders for PaywallFooterView and PaywallView.
- theme composition local provider should update this autmoatically.

Need to add something like this on the React Native side.
If user did link the font via
```xml
<font-family xmlns:app="http://schemas.android.com/apk/res/android">
        <font app:fontStyle="normal" android:fontWeight="200" android:font="@font/montserrat" />
</font-family>
```

```kotlin
    ReactFontManager.getInstance().addCustomFont(this, "Montserrat", R.font.montserrat);
```

We could just bring the font family 
```kotlin
    @ReactProp(name= "fontFamily")
    fun setFontFamily(view: PaywallFooterView, fontFamily: String?){
        val typeface = ReactFontManager.getInstance()
            .getTypeface(fontFamily /** Montserrat in this case. **/, ReactFontManager.TypefaceStyle.NORMAL, assets)
        
        view.setFontProvider(CustomFontProvider(FontFamily(typeface)))
    }
```

<img width="350" alt="Screenshot 2024-01-26 at 10 04 03 PM" src="https://github.com/RevenueCat/purchases-android/assets/6516487/e8e41b0d-c1fd-4446-8d5b-11cb9de200e5">
