### PR TITLE
Add missing forwarding to `PaywallListener.onPurchaseCancelled`

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
@@ -70,10 +70,10 @@ open class PaywallFooterView : FrameLayout {
             listener?.onPurchaseCompleted(customerInfo, storeTransaction)
         }
         override fun onPurchaseError(error: PurchasesError) { listener?.onPurchaseError(error) }
+        override fun onPurchaseCancelled() { listener?.onPurchaseCancelled() }
         override fun onRestoreStarted() { listener?.onRestoreStarted() }
         override fun onRestoreCompleted(customerInfo: CustomerInfo) { listener?.onRestoreCompleted(customerInfo) }
         override fun onRestoreError(error: PurchasesError) { listener?.onRestoreError(error) }
-        override fun onPurchaseCancelled() { listener?.onPurchaseCancelled() }
     }
 
     /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
@@ -73,6 +73,7 @@ open class PaywallFooterView : FrameLayout {
         override fun onRestoreStarted() { listener?.onRestoreStarted() }
         override fun onRestoreCompleted(customerInfo: CustomerInfo) { listener?.onRestoreCompleted(customerInfo) }
         override fun onRestoreError(error: PurchasesError) { listener?.onRestoreError(error) }
+        override fun onPurchaseCancelled() { listener?.onPurchaseCancelled() }
     }
 
     /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
@@ -70,10 +70,10 @@ class PaywallView : FrameLayout {
             listener?.onPurchaseCompleted(customerInfo, storeTransaction)
         }
         override fun onPurchaseError(error: PurchasesError) { listener?.onPurchaseError(error) }
+        override fun onPurchaseCancelled() { listener?.onPurchaseCancelled() }
         override fun onRestoreStarted() { listener?.onRestoreStarted() }
         override fun onRestoreCompleted(customerInfo: CustomerInfo) { listener?.onRestoreCompleted(customerInfo) }
         override fun onRestoreError(error: PurchasesError) { listener?.onRestoreError(error) }
-        override fun onPurchaseCancelled() { listener?.onPurchaseCancelled() }
     }
 
     /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
@@ -73,6 +73,7 @@ class PaywallView : FrameLayout {
         override fun onRestoreStarted() { listener?.onRestoreStarted() }
         override fun onRestoreCompleted(customerInfo: CustomerInfo) { listener?.onRestoreCompleted(customerInfo) }
         override fun onRestoreError(error: PurchasesError) { listener?.onRestoreError(error) }
+        override fun onPurchaseCancelled() { listener?.onPurchaseCancelled() }
     }
 
     /**


### PR DESCRIPTION
We were missing calling `onPurchaseCancelled` when creating an internal PaywallListener