### PR TITLE
Manual darkmode option

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -60,7 +60,7 @@ internal fun InternalPaywall(
     }
     PaywallTheme(fontProvider = options.fontProvider) {
         viewModel.refreshStateIfLocaleChanged()
-        viewModel.refreshStateIfColorsChanged(MaterialTheme.colorScheme, isSystemInDarkTheme())
+        viewModel.refreshStateIfColorsChanged(MaterialTheme.colorScheme, options.isDarkMode ?: isSystemInDarkTheme())
 
         val state = viewModel.state.collectAsState().value
 
@@ -73,6 +73,7 @@ internal fun InternalPaywall(
                 mode = options.mode,
                 shouldDisplayDismissButton = options.shouldDisplayDismissButton,
                 onDismiss = viewModel::closePaywall,
+                isDarkMode = options.isDarkMode ?: isSystemInDarkTheme(),
             )
         }
 
@@ -167,7 +168,7 @@ internal fun getPaywallViewModel(
             applicationContext.toResourceProvider(),
             options,
             MaterialTheme.colorScheme,
-            isSystemInDarkTheme(),
+            options.isDarkMode ?: isSystemInDarkTheme(),
             preview = isInPreviewMode(),
         ),
     )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -45,6 +45,7 @@ internal fun LoadingPaywall(
     mode: PaywallMode,
     shouldDisplayDismissButton: Boolean,
     onDismiss: () -> Unit,
+    isDarkMode: Boolean,
 ) {
     val resourceProvider = LocalContext.current.toResourceProvider()
 
@@ -73,6 +74,7 @@ internal fun LoadingPaywall(
         validatedPaywallData = paywallData,
         template = LoadingPaywallConstants.template,
         shouldDisplayDismissButton = shouldDisplayDismissButton,
+        isDarkMode = isDarkMode,
     )
 
     when (state) {
@@ -211,5 +213,6 @@ internal fun LoadingPaywallPreview() {
         mode = PaywallMode.FULL_SCREEN,
         shouldDisplayDismissButton = false,
         onDismiss = {},
+        isDarkMode = false,
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -27,6 +27,7 @@ internal sealed class OfferingSelection {
 data class PaywallOptions internal constructor(
     internal val offeringSelection: OfferingSelection,
     internal val shouldDisplayDismissButton: Boolean,
+    val isDarkMode: Boolean?,
     val fontProvider: FontProvider?,
     val listener: PaywallListener?,
     internal val mode: PaywallMode,
@@ -40,6 +41,7 @@ data class PaywallOptions internal constructor(
         listener = builder.listener,
         mode = builder.mode,
         dismissRequest = builder.dismissRequest,
+        isDarkMode = builder.isDarkMode
     )
 
     class Builder(
@@ -50,6 +52,7 @@ data class PaywallOptions internal constructor(
         internal var fontProvider: FontProvider? = null
         internal var listener: PaywallListener? = null
         internal var mode: PaywallMode = PaywallMode.default
+        internal var isDarkMode: Boolean = false
 
         fun setOffering(offering: Offering?) = apply {
             this.offeringSelection = offering?.let { OfferingSelection.OfferingType(it) }
@@ -59,6 +62,10 @@ data class PaywallOptions internal constructor(
         internal fun setOfferingId(offeringId: String?) = apply {
             this.offeringSelection = offeringId?.let { OfferingSelection.OfferingId(it) }
                 ?: OfferingSelection.None
+        }
+
+        fun setDarkMode(isDarkMode: Boolean) {
+            this.isDarkMode = isDarkMode
         }
 
         /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -51,7 +51,6 @@ internal val PaywallState.Loaded.selectedLocalization: ProcessedLocalizedConfigu
     get() = selectedPackage.value.localization
 
 internal val PaywallState.Loaded.currentColors: TemplateConfiguration.Colors
-    @Composable @ReadOnlyComposable
     get() = templateConfiguration.getCurrentColors()
 
 internal val PaywallState.Loaded.isInFullScreenMode: Boolean

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -112,14 +112,17 @@ internal class PaywallViewModelImpl(
     }
 
     override fun refreshStateIfColorsChanged(colorScheme: ColorScheme, isDark: Boolean) {
-        if (isDarkMode != isDark) {
-            // This is only used for events so no need to update the state here currently.
+        val isDarkModeChangePending = isDarkMode != isDark
+        val isColorChangePending = _colorScheme.value != colorScheme
+
+        if (isDarkModeChangePending) {
             isDarkMode = isDark
         }
-        if (_colorScheme.value != colorScheme) {
+        if (isColorChangePending) {
             _colorScheme.value = colorScheme
-            updateState()
         }
+        if (isDarkModeChangePending || isColorChangePending)
+            updateState()
     }
 
     override fun selectPackage(packageToSelect: TemplateConfiguration.PackageInfo) {
@@ -277,6 +280,7 @@ internal class PaywallViewModelImpl(
             validatedPaywallData = displayablePaywall,
             template = template,
             shouldDisplayDismissButton = options.shouldDisplayDismissButton,
+            isDarkMode = isDarkMode,
         )
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfiguration.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfiguration.kt
@@ -22,10 +22,8 @@ internal data class TemplateConfiguration(
     private val darkModeColors = ColorsFactory.create(configuration.colors.dark ?: configuration.colors.light)
     private val lightModeColors = ColorsFactory.create(configuration.colors.light)
 
-    @Composable
-    @ReadOnlyComposable
     fun getCurrentColors(): Colors {
-        return if (isDarkMode || isSystemInDarkTheme()) darkModeColors else lightModeColors
+        return if (isDarkMode) darkModeColors else lightModeColors
     }
 
     data class PackageInfo(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfiguration.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfiguration.kt
@@ -17,6 +17,7 @@ internal data class TemplateConfiguration(
     val configuration: PaywallData.Configuration,
     val images: Images,
     val locale: Locale,
+    val isDarkMode: Boolean,
 ) {
     private val darkModeColors = ColorsFactory.create(configuration.colors.dark ?: configuration.colors.light)
     private val lightModeColors = ColorsFactory.create(configuration.colors.light)
@@ -24,7 +25,7 @@ internal data class TemplateConfiguration(
     @Composable
     @ReadOnlyComposable
     fun getCurrentColors(): Colors {
-        return if (isSystemInDarkTheme()) darkModeColors else lightModeColors
+        return if (isDarkMode || isSystemInDarkTheme()) darkModeColors else lightModeColors
     }
 
     data class PackageInfo(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
@@ -15,6 +15,7 @@ internal object TemplateConfigurationFactory {
         activelySubscribedProductIdentifiers: Set<String>,
         nonSubscriptionProductIdentifiers: Set<String>,
         template: PaywallTemplate,
+        isDarkMode: Boolean,
     ): Result<TemplateConfiguration> {
         val (locale, localizedConfiguration) = paywallData.localizedConfiguration
         val sourceImages = paywallData.config.images
@@ -48,6 +49,7 @@ internal object TemplateConfigurationFactory {
                 packages = packageConfiguration,
                 configuration = paywallData.config,
                 images = images,
+                isDarkMode = isDarkMode,
             ),
         )
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -343,6 +343,7 @@ internal class MockViewModel(
             validatedPaywallData = offering.paywall!!,
             template = PaywallTemplate.fromId(offering.paywall!!.templateName)!!,
             shouldDisplayDismissButton = false,
+            isDarkMode = false,
         ),
     )
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -76,6 +76,7 @@ internal fun Offering.toPaywallState(
     validatedPaywallData: PaywallData,
     template: PaywallTemplate,
     shouldDisplayDismissButton: Boolean,
+    isDarkMode: Boolean,
 ): PaywallState {
     val createTemplateConfigurationResult = TemplateConfigurationFactory.create(
         variableDataProvider = variableDataProvider,
@@ -85,6 +86,7 @@ internal fun Offering.toPaywallState(
         activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers,
         nonSubscriptionProductIdentifiers = nonSubscriptionProductIdentifiers,
         template,
+        isDarkMode = isDarkMode,
     )
     val templateConfiguration = createTemplateConfigurationResult.getOrElse {
         return PaywallState.Error(it.message ?: "Unknown error")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallFooterView.kt
@@ -116,6 +116,13 @@ open class PaywallFooterView : AbstractComposeView {
         paywallOptions = paywallOptions.copy(fontProvider = fontProvider)
     }
 
+    /**
+     * Sets the paywall dark mode. true => darkmode, false => lightmode, null => systemDarkMode.
+     */
+    fun setDarkMode(isDarkMode: Boolean?) {
+        paywallOptions = paywallOptions.copy(isDarkMode = isDarkMode)
+    }
+
     private fun init(context: Context, attrs: AttributeSet?) {
         parseAttributes(context, attrs)
         paywallOptions = PaywallOptions.Builder { dismissHandler?.invoke() }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
@@ -119,6 +119,13 @@ class PaywallView : AbstractComposeView {
         paywallOptions = paywallOptions.copy(fontProvider = fontProvider)
     }
 
+    /**
+     * Sets the paywall dark mode. true => darkmode, false => lightmode, null => systemDarkMode.
+     */
+    fun setDarkMode(isDarkMode: Boolean?) {
+        paywallOptions = paywallOptions.copy(isDarkMode = isDarkMode)
+    }
+
     private fun init(context: Context, attrs: AttributeSet?) {
         parseAttributes(context, attrs)
         paywallOptions = PaywallOptions.Builder { dismissHandler?.invoke() }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
@@ -41,6 +41,7 @@ internal class TemplateConfigurationFactoryTest {
                 TestData.Packages.lifetime.product.id
             ),
             template = PaywallTemplate.TEMPLATE_2,
+            isDarkMode = false,
         )
         template2Configuration = result.getOrNull()!!
     }


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
- As of now, if the app has a separate preference or settings to set dark mode, we're not able to do so in RN.

### Description
- This adds `isDarkMode` boolean nullable in `PaywallOptions`. 
- If it's true => dark mode, if it's false => light mode, and if it's null it'll use the system settings.
<!-- Please describe in detail how you tested your changes -->

[darkmode.webm](https://github.com/RevenueCat/purchases-android/assets/6516487/64f78bdc-6683-4f0e-aa49-f1f82f857df7)

Fixing the issue below
<img width="400" alt="Screenshot 2024-02-05 at 1 49 27 AM" src="https://github.com/RevenueCat/purchases-android/assets/6516487/6c34cf45-c96d-4295-b8cf-3e1bccb9b80a">
