### PR TITLE
Fix `DEFERRED` purchases when passing old product id in invalid format

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -931,7 +931,7 @@ internal class PurchasesOrchestrator constructor(
                     // This is so, in case a developer gives us an oldProductId in the form "oldProductId:basePlanId",
                     // we only use the oldProductId part as the callback key. Otherwise, it won't be able to find the
                     // callback when the purchase is completed.
-                    oldProductId.split(":")[0]
+                    oldProductId.substringBefore(Constants.SUBS_ID_BASE_PLAN_ID_SEPARATOR)
                 } else {
                     purchasingData.productId
                 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -927,8 +927,14 @@ internal class PurchasesOrchestrator constructor(
             if (!state.purchaseCallbacksByProductId.containsKey(purchasingData.productId)) {
                 // When using DEFERRED proration mode, callback needs to be associated with the *old* product we are
                 // switching from, because the transaction we receive on successful purchase is for the old product.
-                val productId =
-                    if (googleProrationMode == GoogleProrationMode.DEFERRED) oldProductId else purchasingData.productId
+                val productId = if (googleProrationMode == GoogleProrationMode.DEFERRED) {
+                    // This is so, in case a developer gives us an oldProductId in the form "oldProductId:basePlanId",
+                    // we only use the oldProductId part as the callback key. Otherwise, it won't be able to find the
+                    // callback when the purchase is completed.
+                    oldProductId.split(":")[0]
+                } else {
+                    purchasingData.productId
+                }
                 val mapOfProductIdToListener = mapOf(productId to purchaseCallback)
                 state = state.copy(
                     purchaseCallbacksByProductId = state.purchaseCallbacksByProductId + mapOfProductIdToListener,


### PR DESCRIPTION
`DEFERRED` is not currently supported in the latest SDK release, but on 6.9.5, the latest version it's supported on, the `DEFERRED` purchase might not work if the developer gives as an old product id in the format `productId:basePlanId`. Reason for it is that for deferred purchases, we used the given old product id as the key of the callback, which doesn't match the one returned once the purchase is completed, so the purchase is successful, but the value is never returned.

This applies a patch so we make sure to use only the `productId` as the `oldProductIdentifier` even if the developer gives us the other format (which can be obtained from several places in our SDK). This will be release as a hotfix and we will make hotfixes of the hybrids as well
