### PR TITLE
Update CHANGELOG with 6.9.6 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -375,6 +375,11 @@ Purchases.configure(
 
 ### Bugfixes
 * Add `awaitRestore` to customEntitlementComputation library (#1275) via Toni Rico (@tonidero)
+
+## 6.9.6
+### Bugfixes
+* Fix `DEFERRED` purchases when passing old product id in invalid format (#1593) via Toni Rico (@tonidero)
+
 ## 6.9.5
 ### Bugfixes
 * Catch IllegalStateException and forward StoreProblemError (#1248) via Cesar de la Vega (@vegaro)


### PR DESCRIPTION
### Description
This brings the release notes for #1595 (6.9.6) to `main`

