### PR TITLE
`Paywalls`:  add 4 new variables

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableDataProvider.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.ui.revenuecatui.extensions.isMonthly
 import com.revenuecat.purchases.ui.revenuecatui.extensions.isSubscription
 import com.revenuecat.purchases.ui.revenuecatui.extensions.localizedAbbreviatedPeriod
 import com.revenuecat.purchases.ui.revenuecatui.extensions.localizedPeriod
+import com.revenuecat.purchases.ui.revenuecatui.extensions.localizedUnitPeriod
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ResourceProvider
 import java.util.Locale
 import kotlin.math.roundToInt
@@ -68,6 +69,14 @@ internal class VariableDataProvider(
         return stringId?.let { resourceProvider.getString(it) }
     }
 
+    fun periodLength(rcPackage: Package, locale: Locale): String? {
+        return rcPackage.product.period?.localizedUnitPeriod(locale)
+    }
+
+    fun periodNameAbbreviation(rcPackage: Package, locale: Locale): String? {
+        return rcPackage.product.period?.localizedAbbreviatedPeriod(locale)
+    }
+
     fun subscriptionDuration(rcPackage: Package, locale: Locale): String? {
         return rcPackage.product.period?.localizedPeriod(locale)
             ?: periodName(rcPackage)
@@ -94,12 +103,30 @@ internal class VariableDataProvider(
         } ?: localizedPrice
     }
 
+    fun localizedPricePerPeriodFull(rcPackage: Package, locale: Locale): String {
+        val localizedPrice = localizedPrice(rcPackage)
+        return rcPackage.product.period?.let { period ->
+            val formattedPeriod = period.localizedUnitPeriod(locale)
+            "$localizedPrice/$formattedPeriod"
+        } ?: localizedPrice
+    }
+
     fun localizedPriceAndPerMonth(rcPackage: Package, locale: Locale): String {
         if (!rcPackage.isSubscription || rcPackage.isMonthly) {
             return localizedPricePerPeriod(rcPackage, locale)
         }
         val unit = Period(1, Period.Unit.MONTH, "P1M").localizedAbbreviatedPeriod(locale)
         val pricePerPeriod = localizedPricePerPeriod(rcPackage, locale)
+        val pricePerMonth = localizedPricePerMonth(rcPackage, locale)
+        return "$pricePerPeriod ($pricePerMonth/$unit)"
+    }
+
+    fun localizedPriceAndPerMonthFull(rcPackage: Package, locale: Locale): String {
+        if (!rcPackage.isSubscription || rcPackage.isMonthly) {
+            return localizedPricePerPeriodFull(rcPackage, locale)
+        }
+        val unit = Period(1, Period.Unit.MONTH, "P1M").localizedUnitPeriod(locale)
+        val pricePerPeriod = localizedPricePerPeriodFull(rcPackage, locale)
         val pricePerMonth = localizedPricePerMonth(rcPackage, locale)
         return "$pricePerPeriod ($pricePerMonth/$unit)"
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
@@ -87,13 +87,20 @@ internal object VariableProcessor {
         VariableName.APP_NAME -> variableDataProvider.applicationName
         VariableName.PRICE -> variableDataProvider.localizedPrice(rcPackage)
         VariableName.PRICE_PER_PERIOD -> variableDataProvider.localizedPricePerPeriod(rcPackage, locale)
+        VariableName.PRICE_PER_PERIOD_FULL -> variableDataProvider.localizedPricePerPeriodFull(rcPackage, locale)
         VariableName.TOTAL_PRICE_AND_PER_MONTH -> variableDataProvider.localizedPriceAndPerMonth(
+            rcPackage,
+            locale,
+        )
+        VariableName.TOTAL_PRICE_AND_PER_MONTH_FULL -> variableDataProvider.localizedPriceAndPerMonthFull(
             rcPackage,
             locale,
         )
 
         VariableName.PRODUCT_NAME -> variableDataProvider.productName(rcPackage)
         VariableName.SUB_PERIOD -> variableDataProvider.periodName(rcPackage)
+        VariableName.SUB_PERIOD_LENGTH -> variableDataProvider.periodLength(rcPackage, locale)
+        VariableName.SUB_PERIOD_ABBREVIATED -> variableDataProvider.periodNameAbbreviation(rcPackage, locale)
         VariableName.SUB_PRICE_PER_WEEK -> variableDataProvider.localizedPricePerWeek(
             rcPackage,
             locale,
@@ -118,9 +125,13 @@ internal object VariableProcessor {
         APP_NAME("app_name"),
         PRICE("price"),
         PRICE_PER_PERIOD("price_per_period"),
+        PRICE_PER_PERIOD_FULL("price_per_period_full"),
         TOTAL_PRICE_AND_PER_MONTH("total_price_and_per_month"),
+        TOTAL_PRICE_AND_PER_MONTH_FULL("total_price_and_per_month_full"),
         PRODUCT_NAME("product_name"),
         SUB_PERIOD("sub_period"),
+        SUB_PERIOD_LENGTH("sub_period_length"),
+        SUB_PERIOD_ABBREVIATED("sub_period_abbreviated"),
         SUB_PRICE_PER_WEEK("sub_price_per_week"),
         SUB_PRICE_PER_MONTH("sub_price_per_month"),
         SUB_DURATION("sub_duration"),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PeriodExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PeriodExtensions.kt
@@ -9,11 +9,12 @@ import java.util.Locale
 internal fun Period.localizedAbbreviatedPeriod(
     locale: Locale,
 ): String {
-    var formattedPeriod = localizedPeriod(locale, MeasureFormat.FormatWidth.SHORT)
-    if (value == 1 && formattedPeriod.startsWith("1")) {
-        formattedPeriod = formattedPeriod.substring(startIndex = 1).trim()
-    }
-    return formattedPeriod
+    return localized(locale, MeasureFormat.FormatWidth.SHORT)
+}
+internal fun Period.localizedUnitPeriod(
+    locale: Locale,
+): String {
+    return localized(locale, MeasureFormat.FormatWidth.WIDE)
 }
 
 internal fun Period.localizedPeriod(
@@ -33,3 +34,14 @@ private val Period.Unit.measureUnit: MeasureUnit?
         Period.Unit.YEAR -> MeasureUnit.YEAR
         Period.Unit.UNKNOWN -> null
     }
+
+private fun Period.localized(
+    locale: Locale,
+    width: MeasureFormat.FormatWidth,
+): String {
+    var formattedPeriod = localizedPeriod(locale, width)
+    if (value == 1 && formattedPeriod.startsWith("1")) {
+        formattedPeriod = formattedPeriod.substring(startIndex = 1).trim()
+    }
+    return formattedPeriod
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessorTest.kt
@@ -118,6 +118,32 @@ class VariableProcessorTest {
 
     // endregion
 
+    // region price_per_period_full
+
+    @Test
+    fun `process variables processes price_per_period_full`() {
+        expectVariablesResult("{{ price_per_period_full }}", "$67.99/year", rcPackage = TestData.Packages.annual)
+        expectVariablesResult("{{ price_per_period_full }}", "$7.99/month", rcPackage = TestData.Packages.monthly)
+        expectVariablesResult("{{ price_per_period_full }}", "$1.49/week", rcPackage = TestData.Packages.weekly)
+        expectVariablesResult("{{ price_per_period_full }}", "$15.99/2 months", rcPackage = TestData.Packages.bimonthly)
+        expectVariablesResult("{{ price_per_period_full }}", "$23.99/3 months", rcPackage = TestData.Packages.quarterly)
+        expectVariablesResult("{{ price_per_period_full }}", "$39.99/6 months", rcPackage = TestData.Packages.semester)
+        expectVariablesResult("{{ price_per_period_full }}", "$1,000", rcPackage = TestData.Packages.lifetime)
+    }
+
+    @Test
+    fun `process variables processes price_per_period_full localized in spanish`() {
+        expectVariablesResult("{{ price_per_period_full }}", "$67.99/año", esLocale, TestData.Packages.annual)
+        expectVariablesResult("{{ price_per_period_full }}", "$7.99/mes", esLocale, TestData.Packages.monthly)
+        expectVariablesResult("{{ price_per_period_full }}", "$1.49/semana", esLocale, TestData.Packages.weekly)
+        expectVariablesResult("{{ price_per_period_full }}", "$15.99/2 meses", esLocale, TestData.Packages.bimonthly)
+        expectVariablesResult("{{ price_per_period_full }}", "$23.99/3 meses", esLocale, TestData.Packages.quarterly)
+        expectVariablesResult("{{ price_per_period_full }}", "$39.99/6 meses", esLocale, TestData.Packages.semester)
+        expectVariablesResult("{{ price_per_period_full }}", "$1,000", esLocale, TestData.Packages.lifetime)
+    }
+
+    // endregion
+
     // region total_price_and_per_month
 
     @Test
@@ -134,6 +160,26 @@ class VariableProcessorTest {
         expectVariablesResult("{{ total_price_and_per_month }}", "$7.99/m.", esLocale, TestData.Packages.monthly)
         expectVariablesResult("{{ total_price_and_per_month }}", "$1.49/sem. (6,47 US$/m.)", esLocale, TestData.Packages.weekly)
         expectVariablesResult("{{ total_price_and_per_month }}", "$1,000", esLocale, TestData.Packages.lifetime)
+    }
+
+    // endregion
+
+    // region total_price_and_per_month_full
+
+    @Test
+    fun `process variables processes total_price_and_per_month_full`() {
+        expectVariablesResult("{{ total_price_and_per_month_full }}", "$67.99/year ($5.67/month)", rcPackage = TestData.Packages.annual)
+        expectVariablesResult("{{ total_price_and_per_month_full }}", "$7.99/month", rcPackage = TestData.Packages.monthly)
+        expectVariablesResult("{{ total_price_and_per_month_full }}", "$1.49/week ($6.47/month)", rcPackage = TestData.Packages.weekly)
+        expectVariablesResult("{{ total_price_and_per_month_full }}", "$1,000", rcPackage = TestData.Packages.lifetime)
+    }
+
+    @Test
+    fun `process variables processes total_price_and_per_month_full in spanish`() {
+        expectVariablesResult("{{ total_price_and_per_month_full }}", "$67.99/año (5,67 US$/mes)", esLocale, TestData.Packages.annual)
+        expectVariablesResult("{{ total_price_and_per_month_full }}", "$7.99/mes", esLocale, TestData.Packages.monthly)
+        expectVariablesResult("{{ total_price_and_per_month_full }}", "$1.49/semana (6,47 US$/mes)", esLocale, TestData.Packages.weekly)
+        expectVariablesResult("{{ total_price_and_per_month_full }}", "$1,000", esLocale, TestData.Packages.lifetime)
     }
 
     // endregion
@@ -175,6 +221,36 @@ class VariableProcessorTest {
     fun `process variables processes sub_period unknown period`() {
         expectVariablesResult("{{ sub_period }}", "Unknown", rcPackage = TestData.Packages.unknown)
     }
+    // endregion
+
+    // region sub_period_length
+
+    @Test
+    fun `process variables processes sub_period_length`() {
+        expectVariablesResult("{{ sub_period_length }}", "year", rcPackage = TestData.Packages.annual)
+        expectVariablesResult("{{ sub_period_length }}", "month", rcPackage = TestData.Packages.monthly)
+        expectVariablesResult("{{ sub_period_length }}", "week", rcPackage = TestData.Packages.weekly)
+        expectVariablesResult("{{ sub_period_length }}", "2 months", rcPackage = TestData.Packages.bimonthly)
+        expectVariablesResult("{{ sub_period_length }}", "3 months", rcPackage = TestData.Packages.quarterly)
+        expectVariablesResult("{{ sub_period_length }}", "6 months", rcPackage = TestData.Packages.semester)
+        expectVariablesResult("{{ sub_period_length }}", "", rcPackage = TestData.Packages.lifetime)
+    }
+
+    // endregion
+
+    // region sub_period_abbreviated
+
+    @Test
+    fun `process variables processes sub_period_abbreviated`() {
+        expectVariablesResult("{{ sub_period_abbreviated }}", "yr", rcPackage = TestData.Packages.annual)
+        expectVariablesResult("{{ sub_period_abbreviated }}", "mth", rcPackage = TestData.Packages.monthly)
+        expectVariablesResult("{{ sub_period_abbreviated }}", "wk", rcPackage = TestData.Packages.weekly)
+        expectVariablesResult("{{ sub_period_abbreviated }}", "2 mths", rcPackage = TestData.Packages.bimonthly)
+        expectVariablesResult("{{ sub_period_abbreviated }}", "3 mths", rcPackage = TestData.Packages.quarterly)
+        expectVariablesResult("{{ sub_period_abbreviated }}", "6 mths", rcPackage = TestData.Packages.semester)
+        expectVariablesResult("{{ sub_period_abbreviated }}", "", rcPackage = TestData.Packages.lifetime)
+    }
+
     // endregion
 
     // region sub_price_per_week


### PR DESCRIPTION
Android equivalent of https://github.com/RevenueCat/purchases-ios/pull/3629

### Added:
- `price_per_period_full`
- `total_price_and_per_month_full`
- `sub_period_length`
- `sub_period_abbreviated`
