### PR TITLE
`Paywalls`: add test coverage for locales with different region

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
@@ -2,8 +2,9 @@ package com.revenuecat.purchases.paywalls
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.core.os.LocaleListCompat
+import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.utils.convertToCorrectlyFormattedLocale
+import com.revenuecat.purchases.utils.getDefaultLocales
 import com.revenuecat.purchases.utils.serializers.OptionalURLSerializer
 import com.revenuecat.purchases.utils.serializers.URLSerializer
 import com.revenuecat.purchases.utils.sharedLanguageCodeWith
@@ -50,19 +51,21 @@ data class PaywallData(
     val localizedConfiguration: Pair<Locale, LocalizedConfiguration>
         @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
         get() {
-            val preferredLocales = LocaleListCompat.getDefault()
-
-            for (i in 0 until preferredLocales.size()) {
-                preferredLocales.get(i)?.let { locale: Locale ->
-                    val localeToCheck = locale.convertToCorrectlyFormattedLocale()
-                    configForLocale(localeToCheck)?.let { localizedConfiguration ->
-                        return (localeToCheck to localizedConfiguration)
-                    }
-                }
-            }
-
-            return fallbackLocalizedConfiguration
+            return localizedConfiguration(locales = getDefaultLocales())
         }
+
+    @VisibleForTesting
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    fun localizedConfiguration(locales: List<Locale>): Pair<Locale, LocalizedConfiguration> {
+        for (locale in locales) {
+            val localeToCheck = locale.convertToCorrectlyFormattedLocale()
+            configForLocale(localeToCheck)?.let { localizedConfiguration ->
+                return (localeToCheck to localizedConfiguration)
+            }
+        }
+
+        return fallbackLocalizedConfiguration
+    }
 
     private val fallbackLocalizedConfiguration: Pair<Locale, LocalizedConfiguration>
         @RequiresApi(Build.VERSION_CODES.LOLLIPOP)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/LocaleExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/LocaleExtensions.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.utils
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.core.os.LocaleListCompat
 import com.revenuecat.purchases.common.errorLog
 import java.util.Locale
 import java.util.MissingResourceException
@@ -38,6 +39,13 @@ internal fun Locale.sharedLanguageCodeWith(locale: Locale): Boolean {
     }
 }
 
+/**
+ * @return list of Locales from LocaleListCompat.getDefault()
+ */
+fun getDefaultLocales(): List<Locale> {
+    return LocaleListCompat.getDefault().toList()
+}
+
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 private fun Locale.inferScript(): String {
     if (!script.isNullOrEmpty()) {
@@ -53,4 +61,10 @@ private fun Locale.inferScript(): String {
         }
         else -> ""
     }
+}
+
+private fun LocaleListCompat.toList(): List<Locale> {
+    return Array(size()) {
+        this.get(it)
+    }.filterNotNull()
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallDataTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallDataTest.kt
@@ -150,6 +150,19 @@ class PaywallDataTest {
     }
 
     @Test
+    fun `localized configuration finds locale with different region`() {
+        val paywall: PaywallData = decode(PAYWALLDATA_SAMPLE1)
+
+        val configuration = paywall.localizedConfiguration(
+            locales = listOf(
+                Locale("en", "IN")
+            )
+        )
+        assertThat(configuration).isNotNull
+        assertThat(configuration.second.title).isEqualTo("Paywall")
+    }
+
+    @Test
     fun `decodes empty images as null`() {
         val paywall: PaywallData = decode(PAYWALLDATA_EMPTY_IMAGES)
 

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/LocaleExtensionsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/LocaleExtensionsTest.kt
@@ -51,6 +51,14 @@ class LocaleExtensionsTest {
     }
 
     @Test
+    fun `sharedLanguageCodeWith - returns true without region`() {
+        val locale = Locale("en")
+        val otherLocale = Locale("en", "IN")
+        assertThat(locale.sharedLanguageCodeWith(otherLocale)).isTrue
+        assertThat(otherLocale.sharedLanguageCodeWith(locale)).isTrue
+    }
+
+    @Test
     fun `sharedLanguageCodeWith - returns false when locales don't share language code`() {
         val locale = Locale("es", "ES")
         val otherLocale = Locale("en", "ES")
@@ -69,5 +77,12 @@ class LocaleExtensionsTest {
         val locale = Locale("zh-Hant")
         val otherLocale = Locale("zh-Hans")
         assertThat(locale.sharedLanguageCodeWith(otherLocale)).isFalse
+    }
+
+    @Test
+    fun `getDefaultLocales returns the correct list`() {
+        assertThat(
+            getDefaultLocales().map { it.toString() }
+        ).isEqualTo(listOf("en_US"))
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/LocaleExtensionsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/LocaleExtensionsTest.kt
@@ -81,6 +81,9 @@ class LocaleExtensionsTest {
 
     @Test
     fun `getDefaultLocales returns the correct list`() {
+        // Note: this is primarily to test that we use LocaleListCompat correctly.
+        // It might fail locally, but it's meant to be checked on CI where we know this will be the locale.
+        // Fix-me: only run this on CI.
         assertThat(
             getDefaultLocales().map { it.toString() }
         ).isEqualTo(listOf("en_US"))


### PR DESCRIPTION
Test coverage to ensure that Android isn't affected by https://github.com/RevenueCat/purchases-ios/pull/3633.

I've also extracted `getDefaultLocales` and  `localizedConfiguration(List<Locale>)` so we can test those.
