### PR TITLE
Catch Exception instead of only IllegalArgumentException when decoding paywallData

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -67,10 +67,11 @@ internal abstract class OfferingParser {
 
         val paywallDataJson = offeringJson.optJSONObject("paywall")
 
+        @Suppress("TooGenericExceptionCaught")
         val paywallData: PaywallData? = paywallDataJson?.let {
             try {
                 json.decodeFromString<PaywallData>(it.toString())
-            } catch (e: IllegalArgumentException) {
+            } catch (e: Exception) {
                 errorLog("Error deserializing paywall data", e)
                 null
             }


### PR DESCRIPTION
We have a customer having a silent crash here. I am changing it to catch everything to get more insights