### PR TITLE
Add `getCurrentOffering(forPlacement: String)` to `Offerings`

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingsAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingsAPI.java
@@ -12,6 +12,6 @@ final class OfferingsAPI {
         final Map<String, Offering> all = offerings.getAll();
         final Offering o1 = offerings.getOffering("");
         final Offering o2 = offerings.get("");
-        final Offering o3 = offerings.getCurrentOfferingForPlacement("")
+        final Offering o3 = offerings.getCurrentOfferingForPlacement("");
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingsAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingsAPI.java
@@ -12,5 +12,6 @@ final class OfferingsAPI {
         final Map<String, Offering> all = offerings.getAll();
         final Offering o1 = offerings.getOffering("");
         final Offering o2 = offerings.get("");
+        final Offering o3 = offerings.getCurrentOfferingForPlacement("")
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PresentedOfferingContextAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PresentedOfferingContextAPI.java
@@ -6,9 +6,10 @@ import com.revenuecat.purchases.PresentedOfferingContext;
 final class PresentedOfferingContextAPI {
     static void check(final PresentedOfferingContext presentedOfferingContext) {
         final String offeringIdentifier = presentedOfferingContext.getOfferingIdentifier();
+        final String placementIdentifier = presentedOfferingContext.getPlacementIdentifier();
     }
 
-    static void checkConstructor(final String offeringIdentifier) {
-        final PresentedOfferingContext presentedOfferingContext = new PresentedOfferingContext(offeringIdentifier);
+    static void checkConstructor(final String offeringIdentifier, final String placementIdentifier) {
+        final PresentedOfferingContext presentedOfferingContext = new PresentedOfferingContext(offeringIdentifier, placementIdentifier);
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PresentedOfferingContextAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PresentedOfferingContextAPI.java
@@ -6,7 +6,6 @@ import com.revenuecat.purchases.PresentedOfferingContext;
 final class PresentedOfferingContextAPI {
     static void check(final PresentedOfferingContext presentedOfferingContext) {
         final String offeringIdentifier = presentedOfferingContext.getOfferingIdentifier();
-        final String placementIdentifier = presentedOfferingContext.getPlacementIdentifier();
     }
 
     static void checkConstructor(final String offeringIdentifier, final String placementIdentifier) {

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
@@ -43,7 +43,7 @@ final class StoreProductAPI {
         AmazonStoreProduct underlyingAmazonProduct = AmazonStoreProductKt.getAmazonProduct(product);
 
         final StoreProduct copyWithOfferingId = product.copyWithOfferingId("offeringId");
-        final StoreProduct copyWithContext = product.copyWithPresentedOfferingContext(new PresentedOfferingContext("offeringId"));
+        final StoreProduct copyWithContext = product.copyWithPresentedOfferingContext(new PresentedOfferingContext("offeringId", null));
     }
 
     static void check(final ProductType type) {

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
@@ -43,7 +43,7 @@ final class StoreProductAPI {
         AmazonStoreProduct underlyingAmazonProduct = AmazonStoreProductKt.getAmazonProduct(product);
 
         final StoreProduct copyWithOfferingId = product.copyWithOfferingId("offeringId");
-        final StoreProduct copyWithContext = product.copyWithPresentedOfferingContext(new PresentedOfferingContext("offeringId", null));
+        final StoreProduct copyWithContext = product.copyWithPresentedOfferingContext(new PresentedOfferingContext("offeringId", "placementId"));
     }
 
     static void check(final ProductType type) {

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/OfferingsAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/OfferingsAPI.kt
@@ -11,6 +11,7 @@ private class OfferingsAPI {
             val all: Map<String, Offering> = all
             val o1: Offering? = getOffering("")
             val o2: Offering? = this[""]
+            val o3: Offering? = getCurrentOfferingForPlacement("")
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PresentedOfferingContextAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PresentedOfferingContextAPI.kt
@@ -8,7 +8,7 @@ private class PresentedOfferingContextAPI {
         val offeringIdentifier: String = presentedOfferingContext.offeringIdentifier
     }
 
-    fun checkConstructor(offeringId: String) {
-        val presentedOfferingContext = PresentedOfferingContext(offeringId)
+    fun checkConstructor(offeringId: String, placementId: String?) {
+        val presentedOfferingContext = PresentedOfferingContext(offeringId, placementId)
     }
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
@@ -1,5 +1,5 @@
 package com.revenuecat.paywallstester
 
 object Constants {
-    const val GOOGLE_API_KEY = "goog_uArAGtKQJeuXMWoSNXCAZBzTepD"
+    const val GOOGLE_API_KEY = "API_KEY"
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
@@ -1,5 +1,5 @@
 package com.revenuecat.paywallstester
 
 object Constants {
-    const val GOOGLE_API_KEY = "API_KEY"
+    const val GOOGLE_API_KEY = "goog_uArAGtKQJeuXMWoSNXCAZBzTepD"
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallTesterApp.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallTesterApp.kt
@@ -21,6 +21,7 @@ fun PaywallTesterApp(
     AppNavHost(navController = navController)
 }
 
+@Suppress("LongMethod")
 @Composable
 private fun AppNavHost(
     navController: NavHostController,
@@ -46,11 +47,23 @@ private fun AppNavHost(
                             .plus("?${PaywallScreenViewModel.FOOTER_CONDENSED_KEY}=true"),
                     )
                 },
+                navigateToPaywallByPlacementScreen = { placementId ->
+                    navController.navigate(
+                        AppScreen.PaywallByPlacement.route
+                            .plus("/$placementId"),
+                    )
+                },
             )
         }
         composable(
             route = AppScreen.Paywall.route.plus("/{${PaywallScreenViewModel.OFFERING_ID_KEY}}"),
             arguments = listOf(navArgument(PaywallScreenViewModel.OFFERING_ID_KEY) { type = NavType.StringType }),
+        ) {
+            PaywallScreen(dismissRequest = navController::popBackStack)
+        }
+        composable(
+            route = AppScreen.PaywallByPlacement.route.plus("/{${PaywallScreenViewModel.PLACEMENT_ID_KEY}}"),
+            arguments = listOf(navArgument(PaywallScreenViewModel.PLACEMENT_ID_KEY) { type = NavType.StringType }),
         ) {
             PaywallScreen(dismissRequest = navController::popBackStack)
         }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/AppScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/AppScreen.kt
@@ -4,4 +4,6 @@ sealed class AppScreen(val route: String) {
     object Main : AppScreen("main")
     object Paywall : AppScreen("paywall")
     object PaywallFooter : AppScreen("paywall_footer")
+
+    object PaywallByPlacement : AppScreen("paywall_by_placement")
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/MainScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/MainScreen.kt
@@ -27,6 +27,7 @@ fun MainScreen(
     navigateToPaywallScreen: (Offering?) -> Unit,
     navigateToPaywallFooterScreen: (Offering?) -> Unit,
     navigateToPaywallCondensedFooterScreen: (Offering?) -> Unit,
+    navigateToPaywallByPlacementScreen: (String) -> Unit,
     navController: NavHostController = rememberNavController(),
 ) {
     Scaffold(
@@ -37,6 +38,7 @@ fun MainScreen(
             navigateToPaywallScreen,
             navigateToPaywallFooterScreen,
             navigateToPaywallCondensedFooterScreen,
+            navigateToPaywallByPlacementScreen,
             Modifier.padding(it),
         )
     }
@@ -49,6 +51,7 @@ fun MainScreenPreview() {
         navigateToPaywallScreen = {},
         navigateToPaywallFooterScreen = {},
         navigateToPaywallCondensedFooterScreen = {},
+        navigateToPaywallByPlacementScreen = {},
     )
 }
 
@@ -58,12 +61,14 @@ private val bottomNavigationItems = listOf(
     Tab.Offerings,
 )
 
+@Suppress("LongParameterList")
 @Composable
 private fun MainNavHost(
     navController: NavHostController,
     navigateToPaywallScreen: (Offering?) -> Unit,
     navigateToPaywallFooterScreen: (Offering?) -> Unit,
     navigateToPaywallCondensedFooterScreen: (Offering?) -> Unit,
+    navigateToPaywallByPlacementScreen: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     NavHost(
@@ -82,6 +87,7 @@ private fun MainNavHost(
                 tappedOnOffering = { offering -> navigateToPaywallScreen(offering) },
                 tappedOnOfferingFooter = { offering -> navigateToPaywallFooterScreen(offering) },
                 tappedOnOfferingCondensedFooter = { offering -> navigateToPaywallCondensedFooterScreen(offering) },
+                tappedOnOfferingByPlacement = { placementId -> navigateToPaywallByPlacementScreen(placementId) },
             )
         }
     }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -213,7 +213,6 @@ private fun OfferingsListScreen(
                             Purchases.sharedInstance.getOfferingsWith {
                                 it.getCurrentOfferingForPlacement(placementId)?.let { offering ->
                                     showDialog.value = false
-//                                    placementOffering.value = offering
                                     tappedOnNavigateToOfferingByPlacement(placementId)
                                 } ?: run {
                                     noPlacementFoundMessage.value = "No offering found for placement '$placementId'"

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -187,6 +187,7 @@ fun OfferingsScreenPreview() {
                     Offerings(
                         current = null,
                         all = emptyMap(),
+                        null,
                     ),
                 ),
             )

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -49,6 +49,7 @@ fun OfferingsScreen(
     tappedOnOffering: (Offering) -> Unit,
     tappedOnOfferingFooter: (Offering) -> Unit,
     tappedOnOfferingCondensedFooter: (Offering) -> Unit,
+    tappedOnOfferingByPlacement: (String) -> Unit,
     viewModel: OfferingsViewModel = viewModel<OfferingsViewModelImpl>(),
 ) {
     when (val state = viewModel.offeringsState.collectAsState().value) {
@@ -58,6 +59,7 @@ fun OfferingsScreen(
             tappedOnNavigateToOffering = tappedOnOffering,
             tappedOnNavigateToOfferingFooter = tappedOnOfferingFooter,
             tappedOnNavigateToOfferingCondensedFooter = tappedOnOfferingCondensedFooter,
+            tappedOnNavigateToOfferingByPlacement = tappedOnOfferingByPlacement,
         )
         OfferingsState.Loading -> LoadingOfferingsScreen()
     }
@@ -83,6 +85,7 @@ private fun LoadingOfferingsScreen() {
     }
 }
 
+@Suppress("LongMethod")
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Composable
 private fun OfferingsListScreen(
@@ -90,6 +93,7 @@ private fun OfferingsListScreen(
     tappedOnNavigateToOffering: (Offering) -> Unit,
     tappedOnNavigateToOfferingFooter: (Offering) -> Unit,
     tappedOnNavigateToOfferingCondensedFooter: (Offering) -> Unit,
+    tappedOnNavigateToOfferingByPlacement: (String) -> Unit,
 ) {
     var dropdownExpandedOffering by remember { mutableStateOf<Offering?>(null) }
     var displayPaywallDialogOffering by remember { mutableStateOf<Offering?>(null) }
@@ -178,23 +182,23 @@ private fun OfferingsListScreen(
                 noPlacementFoundMessage.value = null
                 placementIdentifier.value = ""
             },
-            properties = DialogProperties(usePlatformDefaultWidth = false)
+            properties = DialogProperties(usePlatformDefaultWidth = false),
         ) {
             Surface(
                 color = Color.White,
                 shape = MaterialTheme.shapes.medium,
-                modifier = Modifier.padding(16.dp)
+                modifier = Modifier.padding(16.dp),
             ) {
                 Column(
                     modifier = Modifier.padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
                     Text("Please enter text and submit")
 
                     OutlinedTextField(
                         value = placementIdentifier.value,
                         onValueChange = { placementIdentifier.value = it },
-                        label = { Text("Enter placement identifier") }
+                        label = { Text("Enter placement identifier") },
                     )
 
                     noPlacementFoundMessage.value?.let {
@@ -209,13 +213,14 @@ private fun OfferingsListScreen(
                             Purchases.sharedInstance.getOfferingsWith {
                                 it.getCurrentOfferingForPlacement(placementId)?.let { offering ->
                                     showDialog.value = false
-                                    placementOffering.value = offering
+//                                    placementOffering.value = offering
+                                    tappedOnNavigateToOfferingByPlacement(placementId)
                                 } ?: run {
                                     noPlacementFoundMessage.value = "No offering found for placement '$placementId'"
                                 }
                             }
                         },
-                        modifier = Modifier.align(Alignment.End)
+                        modifier = Modifier.align(Alignment.End),
                     ) {
                         Text("Submit")
                     }
@@ -275,6 +280,7 @@ fun OfferingsScreenPreview() {
         tappedOnOffering = {},
         tappedOnOfferingFooter = {},
         tappedOnOfferingCondensedFooter = {},
+        tappedOnOfferingByPlacement = {},
         viewModel = object : OfferingsViewModel() {
             private val _offeringsState = MutableStateFlow<OfferingsState>(
                 OfferingsState.Loaded(

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -99,22 +99,9 @@ private fun OfferingsListScreen(
     var displayPaywallDialogOffering by remember { mutableStateOf<Offering?>(null) }
 
     val showDialog = remember { mutableStateOf(false) }
-    val placementIdentifier = remember { mutableStateOf("") }
-    val placementOffering = remember { mutableStateOf<Offering?>(null) }
-    val noPlacementFoundMessage = remember { mutableStateOf<String?>(null) }
 
     LazyColumn {
         item {
-            placementOffering.value?.let {
-                DisplayOfferingMenu(
-                    offering = it,
-                    tappedOnNavigateToOffering = tappedOnNavigateToOffering,
-                    tappedOnDisplayOfferingAsDialog = { displayPaywallDialogOffering = it },
-                    tappedOnDisplayOfferingAsFooter = tappedOnNavigateToOfferingFooter,
-                    tappedOnDisplayOfferingAsCondensedFooter = tappedOnNavigateToOfferingCondensedFooter,
-                    dismissed = { dropdownExpandedOffering = null },
-                )
-            }
             Box(modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.fillMaxWidth()) {
                     Row(
@@ -176,53 +163,64 @@ private fun OfferingsListScreen(
     }
 
     if (showDialog.value) {
-        Dialog(
-            onDismissRequest = {
-                showDialog.value = false
-                noPlacementFoundMessage.value = null
-                placementIdentifier.value = ""
-            },
-            properties = DialogProperties(usePlatformDefaultWidth = false),
+        PlacementDialog(tappedOnNavigateToOfferingByPlacement = tappedOnNavigateToOfferingByPlacement)
+    }
+}
+
+@Composable
+private fun PlacementDialog(
+    tappedOnNavigateToOfferingByPlacement: (String) -> Unit,
+) {
+    val showDialog = remember { mutableStateOf(false) }
+    val placementIdentifier = remember { mutableStateOf("") }
+    val noPlacementFoundMessage = remember { mutableStateOf<String?>(null) }
+
+    Dialog(
+        onDismissRequest = {
+            showDialog.value = false
+            noPlacementFoundMessage.value = null
+            placementIdentifier.value = ""
+        },
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Surface(
+            color = Color.White,
+            shape = MaterialTheme.shapes.medium,
+            modifier = Modifier.padding(16.dp),
         ) {
-            Surface(
-                color = Color.White,
-                shape = MaterialTheme.shapes.medium,
+            Column(
                 modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                Column(
-                    modifier = Modifier.padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(10.dp),
-                ) {
-                    Text("Please enter text and submit")
+                Text("Please enter text and submit")
 
-                    OutlinedTextField(
-                        value = placementIdentifier.value,
-                        onValueChange = { placementIdentifier.value = it },
-                        label = { Text("Enter placement identifier") },
-                    )
+                OutlinedTextField(
+                    value = placementIdentifier.value,
+                    onValueChange = { placementIdentifier.value = it },
+                    label = { Text("Enter placement identifier") },
+                )
 
-                    noPlacementFoundMessage.value?.let {
-                        Text(it)
-                    }
+                noPlacementFoundMessage.value?.let {
+                    Text(it)
+                }
 
-                    // Submit Button
-                    Button(
-                        onClick = {
-                            val placementId = placementIdentifier.value
+                // Submit Button
+                Button(
+                    onClick = {
+                        val placementId = placementIdentifier.value
 
-                            Purchases.sharedInstance.getOfferingsWith {
-                                it.getCurrentOfferingForPlacement(placementId)?.let { offering ->
-                                    showDialog.value = false
-                                    tappedOnNavigateToOfferingByPlacement(placementId)
-                                } ?: run {
-                                    noPlacementFoundMessage.value = "No offering found for placement '$placementId'"
-                                }
+                        Purchases.sharedInstance.getOfferingsWith {
+                            it.getCurrentOfferingForPlacement(placementId)?.let { offering ->
+                                showDialog.value = false
+                                tappedOnNavigateToOfferingByPlacement(placementId)
+                            } ?: run {
+                                noPlacementFoundMessage.value = "No offering found for placement '$placementId'"
                             }
-                        },
-                        modifier = Modifier.align(Alignment.End),
-                    ) {
-                        Text("Submit")
-                    }
+                        }
+                    },
+                    modifier = Modifier.align(Alignment.End),
+                ) {
+                    Text("Submit")
                 }
             }
         }
@@ -286,7 +284,6 @@ fun OfferingsScreenPreview() {
                     Offerings(
                         current = null,
                         all = emptyMap(),
-                        null,
                     ),
                 ),
             )

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -10,8 +10,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -21,13 +25,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.paywallstester.MainActivity
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.getOfferingsWith
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialog
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions
@@ -85,7 +94,39 @@ private fun OfferingsListScreen(
     var dropdownExpandedOffering by remember { mutableStateOf<Offering?>(null) }
     var displayPaywallDialogOffering by remember { mutableStateOf<Offering?>(null) }
 
+    val showDialog = remember { mutableStateOf(false) }
+    val placementIdentifier = remember { mutableStateOf("") }
+    val placementOffering = remember { mutableStateOf<Offering?>(null) }
+    val noPlacementFoundMessage = remember { mutableStateOf<String?>(null) }
+
     LazyColumn {
+        item {
+            placementOffering.value?.let {
+                DisplayOfferingMenu(
+                    offering = it,
+                    tappedOnNavigateToOffering = tappedOnNavigateToOffering,
+                    tappedOnDisplayOfferingAsDialog = { displayPaywallDialogOffering = it },
+                    tappedOnDisplayOfferingAsFooter = tappedOnNavigateToOfferingFooter,
+                    tappedOnDisplayOfferingAsCondensedFooter = tappedOnNavigateToOfferingCondensedFooter,
+                    dismissed = { dropdownExpandedOffering = null },
+                )
+            }
+            Box(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .clickable { showDialog.value = true }
+                            .padding(16.dp),
+                    ) {
+                        Column {
+                            Text("Get offering by placement")
+                        }
+                    }
+                    Divider()
+                }
+            }
+        }
         items(offeringsState.offerings.all.values.toList()) { offering ->
             Box(modifier = Modifier.fillMaxWidth()) {
                 if (offering == dropdownExpandedOffering) {
@@ -128,6 +169,59 @@ private fun OfferingsListScreen(
                 .setOffering(displayPaywallDialogOffering)
                 .build(),
         )
+    }
+
+    if (showDialog.value) {
+        Dialog(
+            onDismissRequest = {
+                showDialog.value = false
+                noPlacementFoundMessage.value = null
+                placementIdentifier.value = ""
+            },
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            Surface(
+                color = Color.White,
+                shape = MaterialTheme.shapes.medium,
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Text("Please enter text and submit")
+
+                    OutlinedTextField(
+                        value = placementIdentifier.value,
+                        onValueChange = { placementIdentifier.value = it },
+                        label = { Text("Enter placement identifier") }
+                    )
+
+                    noPlacementFoundMessage.value?.let {
+                        Text(it)
+                    }
+
+                    // Submit Button
+                    Button(
+                        onClick = {
+                            val placementId = placementIdentifier.value
+
+                            Purchases.sharedInstance.getOfferingsWith {
+                                it.getCurrentOfferingForPlacement(placementId)?.let { offering ->
+                                    showDialog.value = false
+                                    placementOffering.value = offering
+                                } ?: run {
+                                    noPlacementFoundMessage.value = "No offering found for placement '$placementId'"
+                                }
+                            }
+                        },
+                        modifier = Modifier.align(Alignment.End)
+                    ) {
+                        Text("Submit")
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -198,7 +198,9 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
                         duration = requireContext().resources.getInteger(R.integer.transition_duration).toLong()
                     }
 
-                    val directions = OverviewFragmentDirections.actionOverviewFragmentToOfferingFragment(offering.identifier)
+                    val directions = OverviewFragmentDirections.actionOverviewFragmentToOfferingFragment(
+                        offering.identifier,
+                    )
                     findNavController().navigate(directions)
                 } ?: run {
                     print("no offering")

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -64,6 +64,10 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
             showPurchaseProductIdDialog()
         }
 
+        binding.findByPlacementButton.setOnClickListener {
+            showFindPlacementDialog()
+        }
+
         viewModel = OverviewViewModel(this)
         binding.lifecycleOwner = this
         binding.viewModel = viewModel
@@ -168,6 +172,38 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
                     }
                 },
             )
+        }
+        builder.setNegativeButton("Cancel") { dialog, which ->
+            dialog.cancel()
+        }
+        val dialog = builder.create()
+        dialog.show()
+    }
+
+    private fun showFindPlacementDialog() {
+        val builder = MaterialAlertDialogBuilder(requireContext())
+        builder.setTitle("Enter the Placement ID you want to get:")
+        val input = EditText(context)
+        input.inputType = InputType.TYPE_CLASS_TEXT
+        builder.setView(input)
+        builder.setPositiveButton("Find") { dialog, which ->
+            var placementId = input.text.toString()
+
+            Purchases.sharedInstance.getOfferingsWith {
+                it.getCurrentOfferingForPlacement(placementId)?.let { offering ->
+                    exitTransition = MaterialElevationScale(false).apply {
+                        duration = requireContext().resources.getInteger(R.integer.transition_duration).toLong()
+                    }
+                    reenterTransition = MaterialElevationScale(true).apply {
+                        duration = requireContext().resources.getInteger(R.integer.transition_duration).toLong()
+                    }
+
+                    val directions = OverviewFragmentDirections.actionOverviewFragmentToOfferingFragment(offering.identifier)
+                    findNavController().navigate(directions)
+                } ?: run {
+                    print("no offering")
+                }
+            }
         }
         builder.setNegativeButton("Cancel") { dialog, which ->
             dialog.cancel()

--- a/examples/purchase-tester/src/main/res/layout/fragment_overview.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_overview.xml
@@ -234,32 +234,61 @@
         </ScrollView>
 
         <LinearLayout
+                android:orientation="vertical"
+                android:layout_gravity="end|bottom"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
+            <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_gravity="end|bottom"
+                    android:layout_marginBottom="@dimen/padding_small"
+                    android:layout_marginEnd="@dimen/padding_large"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content">
+                <com.google.android.material.button.MaterialButton
+                        android:id="@+id/find_by_placement_button"
+                        android:text="@string/find_placement"
+                        android:layout_gravity="end|bottom"
+                        android:layout_marginEnd="@dimen/padding_small"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+            </LinearLayout>
+            <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_gravity="end|bottom"
+                    android:layout_marginBottom="@dimen/padding_small"
+                    android:layout_marginEnd="@dimen/padding_large"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content">
+                <com.google.android.material.button.MaterialButton
+                        android:id="@+id/purchase_product_id_button"
+                        android:text="@string/buy_product"
+                        android:layout_gravity="end|bottom"
+                        android:layout_marginEnd="@dimen/padding_small"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+            </LinearLayout>
+            <LinearLayout
                 android:orientation="horizontal"
                 android:layout_gravity="end|bottom"
                 android:layout_marginBottom="@dimen/padding_medium"
                 android:layout_marginEnd="@dimen/padding_large"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content">
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/purchase_product_id_button"
-                    android:text="@string/buy_product"
-                    android:layout_gravity="end|bottom"
-                    android:layout_marginEnd="@dimen/padding_small"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"/>
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/proxy_button"
-                    android:text="@string/proxy"
-                    android:layout_gravity="end|bottom"
-                    android:layout_marginEnd="@dimen/padding_small"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"/>
-            <com.google.android.material.button.MaterialButton
-                    android:id="@+id/logs_button"
-                    android:text="@string/logs"
-                    android:layout_gravity="end|bottom"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"/>
+                <com.google.android.material.button.MaterialButton
+                        android:id="@+id/proxy_button"
+                        android:text="@string/proxy"
+                        android:layout_gravity="end|bottom"
+                        android:layout_marginEnd="@dimen/padding_small"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+                <com.google.android.material.button.MaterialButton
+                        android:id="@+id/logs_button"
+                        android:text="@string/logs"
+                        android:layout_gravity="end|bottom"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+            </LinearLayout>
         </LinearLayout>
     </FrameLayout>
 

--- a/examples/purchase-tester/src/main/res/values/strings.xml
+++ b/examples/purchase-tester/src/main/res/values/strings.xml
@@ -20,4 +20,5 @@
     <string name="proxy_server_down">Server down (All requests will return 500)</string>
     <string name="proxy">Proxy</string>
     <string name="buy_product">Buy Product</string>
+    <string name="find_placement">Find Placement</string>
 </resources>

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -9,8 +9,12 @@ package com.revenuecat.purchases
 data class Offerings(
     val current: Offering?,
     val all: Map<String, Offering>,
-    val placements: Placements?,
 ) {
+    internal var placements: Placements? = null
+
+    internal constructor(current: Offering?, all: Map<String, Offering>, placements: Placements?) : this(current, all) {
+        this.placements = placements
+    }
 
     /**
      * Retrieves an specific offering by its identifier.
@@ -52,7 +56,7 @@ data class Offerings(
  * @property fallbackOfferingId The optional offering identifier to fallback on if the placement isn't found.
  * @property offeringIdsByPlacement Dictionary of all offering identifiers keyed by their placement identifier.
  */
-private data class Placements(
+internal data class Placements(
     val fallbackOfferingId: String?,
     val offeringIdsByPlacement: Map<String, String?>,
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -9,6 +9,7 @@ package com.revenuecat.purchases
 data class Offerings(
     val current: Offering?,
     val all: Map<String, Offering>,
+    val placement: Placement?,
 ) {
 
     /**
@@ -24,4 +25,11 @@ data class Offerings(
      * @param identifier Offering identifier
      */
     operator fun get(identifier: String) = getOffering(identifier)
+}
+
+data class Placement(
+    val fallbackOfferingId: String?,
+    val offeringIdsByPlacement: Map<String, String?>,
+) {
+
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -9,7 +9,7 @@ package com.revenuecat.purchases
 data class Offerings(
     val current: Offering?,
     val all: Map<String, Offering>,
-    val placement: Placement?,
+    val placement: Placements?,
 ) {
 
     /**
@@ -25,11 +25,27 @@ data class Offerings(
      * @param identifier Offering identifier
      */
     operator fun get(identifier: String) = getOffering(identifier)
+
+    fun getCurrentOffering(forPlacement: String): Offering? {
+        val placement = this.placement ?: run {
+            return null
+        }
+
+        val offeringForPlacement = placement.offeringIdsByPlacement[forPlacement]?.let { getOffering(it) }
+        val fallbackOffering = placement.fallbackOfferingId?.let { getOffering(it) }
+
+        val showNoOffering = placement.offeringIdsByPlacement.containsKey(forPlacement)
+        return offeringForPlacement ?: if (showNoOffering) null else fallbackOffering
+    }
 }
 
-data class Placement(
+/**
+ * This class contains all the offerings by placement configured in RevenueCat dashboard.
+ * For more info see https://www.revenuecat.com/docs/targeting
+ * @property fallbackOfferingId The optional offering identifier to fallback on if the placement isn't found.
+ * @property offeringIdsByPlacement Dictionary of all offering identifiers (or null) keyed by their placement identifier.
+ */
+data class Placements(
     val fallbackOfferingId: String?,
     val offeringIdsByPlacement: Map<String, String?>,
-) {
-
-}
+)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -9,7 +9,7 @@ package com.revenuecat.purchases
 data class Offerings(
     val current: Offering?,
     val all: Map<String, Offering>,
-    val placement: Placements?,
+    val placements: Placements?,
 ) {
 
     /**
@@ -32,14 +32,14 @@ data class Offerings(
      * @param placementId Placement identifier
      */
     fun getCurrentOfferingForPlacement(placementId: String): Offering? {
-        val placement = this.placement ?: run {
+        val placements = this.placements ?: run {
             return null
         }
 
-        val offeringForPlacement = placement.offeringIdsByPlacement[placementId]?.let { getOffering(it) }
-        val fallbackOffering = placement.fallbackOfferingId?.let { getOffering(it) }
+        val offeringForPlacement = placements.offeringIdsByPlacement[placementId]?.let { getOffering(it) }
+        val fallbackOffering = placements.fallbackOfferingId?.let { getOffering(it) }
 
-        val showNoOffering = placement.offeringIdsByPlacement.containsKey(placementId)
+        val showNoOffering = placements.offeringIdsByPlacement.containsKey(placementId)
         val offering = offeringForPlacement ?: if (showNoOffering) null else fallbackOffering
 
         return offering?.withPlacement(placementId)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -6,15 +6,12 @@ package com.revenuecat.purchases
  * @property current Current offering configured in the RevenueCat dashboard.
  * @property all Dictionary of all Offerings [Offering] objects keyed by their identifier.
  */
-data class Offerings(
+data class Offerings internal constructor(
     val current: Offering?,
     val all: Map<String, Offering>,
+    internal val placements: Placements? = null,
 ) {
-    internal var placements: Placements? = null
-
-    internal constructor(current: Offering?, all: Map<String, Offering>, placements: Placements?) : this(current, all) {
-        this.placements = placements
-    }
+    constructor(current: Offering?, all: Map<String, Offering>) : this(current, all, null)
 
     /**
      * Retrieves an specific offering by its identifier.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -26,16 +26,23 @@ data class Offerings(
      */
     operator fun get(identifier: String) = getOffering(identifier)
 
-    fun getCurrentOffering(forPlacement: String): Offering? {
+    /**
+     * Retrieves an specific offering by a placement identifier.
+     * For more info see https://www.revenuecat.com/docs/tools/targeting
+     * @param placementId Placement identifier
+     */
+    fun getCurrentOfferingForPlacement(placementId: String): Offering? {
         val placement = this.placement ?: run {
             return null
         }
 
-        val offeringForPlacement = placement.offeringIdsByPlacement[forPlacement]?.let { getOffering(it) }
+        val offeringForPlacement = placement.offeringIdsByPlacement[placementId]?.let { getOffering(it) }
         val fallbackOffering = placement.fallbackOfferingId?.let { getOffering(it) }
 
-        val showNoOffering = placement.offeringIdsByPlacement.containsKey(forPlacement)
-        return offeringForPlacement ?: if (showNoOffering) null else fallbackOffering
+        val showNoOffering = placement.offeringIdsByPlacement.containsKey(placementId)
+        val offering = offeringForPlacement ?: if (showNoOffering) null else fallbackOffering
+
+        return offering?.withPlacement(placementId)
     }
 }
 
@@ -43,9 +50,14 @@ data class Offerings(
  * This class contains all the offerings by placement configured in RevenueCat dashboard.
  * For more info see https://www.revenuecat.com/docs/targeting
  * @property fallbackOfferingId The optional offering identifier to fallback on if the placement isn't found.
- * @property offeringIdsByPlacement Dictionary of all offering identifiers (or null) keyed by their placement identifier.
+ * @property offeringIdsByPlacement Dictionary of all offering identifiers keyed by their placement identifier.
  */
 data class Placements(
     val fallbackOfferingId: String?,
     val offeringIdsByPlacement: Map<String, String?>,
 )
+
+private fun Offering.withPlacement(placementId: String): Offering {
+    // TODO: Inject the placement id into the presented offering context
+    return this
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -59,10 +59,7 @@ data class Placements(
 
 private fun Offering.withPlacement(placementId: String): Offering {
     val updatedAvailablePackages = this.availablePackages.map {
-        val context = PresentedOfferingContext(
-            offeringIdentifier = it.presentedOfferingContext.offeringIdentifier,
-            placementIdentifier = placementId,
-        )
+        val context = it.presentedOfferingContext.copy(placementIdentifier = placementId)
         val product = it.product.copyWithPresentedOfferingContext(context)
 
         Package(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -52,7 +52,7 @@ data class Offerings(
  * @property fallbackOfferingId The optional offering identifier to fallback on if the placement isn't found.
  * @property offeringIdsByPlacement Dictionary of all offering identifiers keyed by their placement identifier.
  */
-data class Placements(
+private data class Placements(
     val fallbackOfferingId: String?,
     val offeringIdsByPlacement: Map<String, String?>,
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -58,6 +58,26 @@ data class Placements(
 )
 
 private fun Offering.withPlacement(placementId: String): Offering {
-    // TODO: Inject the placement id into the presented offering context
-    return this
+    val updatedAvailablePackages = this.availablePackages.map {
+        val context = PresentedOfferingContext(
+            offeringIdentifier = it.presentedOfferingContext.offeringIdentifier,
+            placementIdentifier = placementId,
+        )
+        val product = it.product.copyWithPresentedOfferingContext(context)
+
+        Package(
+            identifier = it.identifier,
+            packageType = it.packageType,
+            product = product,
+            presentedOfferingContext = context,
+        )
+    }
+
+    return Offering(
+        identifier = this.identifier,
+        serverDescription = this.serverDescription,
+        metadata = this.metadata,
+        availablePackages = updatedAvailablePackages,
+        paywall = this.paywall,
+    )
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
@@ -16,5 +16,7 @@ data class PresentedOfferingContext(
     /**
      * The identifier of the placement used to obtain this object.
      */
-    val placementIdentifier: String? = null,
-) : Parcelable
+    internal val placementIdentifier: String? = null,
+) : Parcelable {
+    constructor(offeringIdentifier: String) : this(offeringIdentifier, null)
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
@@ -7,7 +7,7 @@ import kotlinx.parcelize.Parcelize
  * Contains data about the context in which an offering was presented.
  */
 @Parcelize
-internal data class PresentedOfferingContext(
+data class PresentedOfferingContext(
     /**
      * The identifier of the offering used to obtain this object.
      */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
@@ -12,4 +12,9 @@ data class PresentedOfferingContext(
      * The identifier of the offering used to obtain this object.
      */
     val offeringIdentifier: String,
+
+    /**
+     * The identifier of the placement used to obtain this object.
+     */
+    val placementIdentifier: String? = null,
 ) : Parcelable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
@@ -7,7 +7,7 @@ import kotlinx.parcelize.Parcelize
  * Contains data about the context in which an offering was presented.
  */
 @Parcelize
-data class PresentedOfferingContext(
+internal data class PresentedOfferingContext(
     /**
      * The identifier of the offering used to obtain this object.
      */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -212,6 +212,7 @@ internal class Backend(
             APP_USER_ID to appUserID,
             "is_restore" to isRestore,
             "presented_offering_identifier" to receiptInfo.presentedOfferingContext?.offeringIdentifier,
+            "presented_placement_identifier" to receiptInfo.presentedOfferingContext?.placementIdentifier,
             "observer_mode" to observerMode,
             "price" to receiptInfo.price,
             "currency" to receiptInfo.currency,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.strings.OfferingStrings
+import com.revenuecat.purchases.utils.replaceJsonNullWithKotlinNull
 import com.revenuecat.purchases.utils.toMap
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -53,7 +54,8 @@ internal abstract class OfferingParser {
         val placements: Placements? = offeringsJson.optJSONObject("placements")?.let {
             Placements(
                 it.optString("fallback_offering_id"),
-                it.optJSONObject("offering_ids_by_placement")?.toMap<String?>() ?: emptyMap()
+                it.optJSONObject("offering_ids_by_placement")
+                    ?.toMap<String?>()?.replaceJsonNullWithKotlinNull() ?: emptyMap(),
             )
         }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -5,7 +5,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
-import com.revenuecat.purchases.Placement
+import com.revenuecat.purchases.Placements
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.paywalls.PaywallData
@@ -50,14 +50,14 @@ internal abstract class OfferingParser {
             }
         }
 
-        val placement: Placement? = offeringsJson.optJSONObject("placement")?.let {
-            Placement(
+        val placements: Placements? = offeringsJson.optJSONObject("placements")?.let {
+            Placements(
                 it.optString("fallback_offering_id"),
                 it.optJSONObject("offering_ids_by_placement")?.toMap<String?>() ?: emptyMap()
             )
         }
 
-        return Offerings(offerings[currentOfferingID], offerings, placement)
+        return Offerings(offerings[currentOfferingID], offerings, placements)
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.Placement
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.paywalls.PaywallData
@@ -49,7 +50,14 @@ internal abstract class OfferingParser {
             }
         }
 
-        return Offerings(offerings[currentOfferingID], offerings)
+        val placement: Placement? = offeringsJson.optJSONObject("placement")?.let {
+            Placement(
+                it.optString("fallback_offering_id"),
+                it.optJSONObject("offering_ids_by_placement")?.toMap<String?>() ?: emptyMap()
+            )
+        }
+
+        return Offerings(offerings[currentOfferingID], offerings, placement)
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -64,6 +64,7 @@ internal abstract class OfferingParser {
                     offeringIdsByPlacement = offeringIdsByPlacement,
                 )
             } ?: run {
+                // This shouldn't ever happen due to validations on the backend
                 errorLog(OfferingStrings.PLACEMENTS_EMPTY_ERROR)
                 null
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -36,4 +36,5 @@ internal object OfferingStrings {
         "the RevenueCat dashboard or Play Store.\nTo configure products, follow the instructions in " +
         "https://rev.cat/how-to-configure-offerings.\nMore information: https://rev.cat/why-are-offerings-empty"
     const val ERROR_FETCHING_OFFERINGS_USING_DISK_CACHE = "Error fetching offerings. Using disk cache."
+    const val PLACEMENTS_EMPTY_ERROR = "Error while fetching placements - no placements defined"
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JSONArrayExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JSONArrayExtensions.kt
@@ -19,3 +19,19 @@ internal fun <T> JSONArray.toList(): List<T>? {
 
     return list
 }
+
+internal fun <T> List<T?>.replaceJsonNullWithKotlinNull(): List<T?> {
+    @Suppress("UNCHECKED_CAST")
+    return this.map { item ->
+        when (item) {
+            is Map<*, *> ->
+                @Suppress("UNCHECKED_CAST")
+                (item as Map<T, T?>).replaceJsonNullWithKotlinNull()
+            is List<*> ->
+                @Suppress("UNCHECKED_CAST")
+                (item as List<T?>).replaceJsonNullWithKotlinNull()
+            JSONObject.NULL -> null
+            else -> item
+        }
+    } as List<T?>
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
@@ -459,6 +459,79 @@ class OfferingsTest {
         assertThat(offering2YearlyPackages.size).isEqualTo(0)
     }
 
+    @Test
+    fun `createOfferings creates returns placement object with a fallback offering`() {
+        val storeProductMonthly = getStoreProduct(productIdentifier, monthlyPeriod, monthlyBasePlanId)
+        val storeProductAnnual = getStoreProduct(productIdentifier, annualPeriod, annualBasePlanId)
+
+        val placementsJSON = getPlacementsJSON(
+            fallbackOfferingId = "offering_b",
+            offeringIdsByPlacement = mapOf(
+                "onboarding_start" to "offering_a",
+                "onboarding_end" to null,
+            )
+        )
+
+        val products = mapOf(productIdentifier to listOf(storeProductMonthly, storeProductAnnual))
+        val offeringsJson = getOfferingsJSON(placements = placementsJSON)
+
+        val offerings = offeringsParser.createOfferings(offeringsJson, products)
+        assertThat(offerings).isNotNull
+        assertThat(offerings.all.size).isEqualTo(2)
+        assertThat(offerings.current!!.identifier).isEqualTo(offeringsJson.getString("current_offering_id"))
+        assertThat(offerings["offering_a"]).isNotNull
+        assertThat(offerings["offering_b"]).isNotNull
+
+        assertThat(offerings.placements).isNotNull
+        assertThat(offerings.placements!!.fallbackOfferingId).isEqualTo("offering_b")
+        assertThat(offerings.placements!!.offeringIdsByPlacement.containsKey("onboarding_start")).isTrue()
+        assertThat(offerings.placements!!.offeringIdsByPlacement.containsKey("onboarding_end")).isTrue()
+        assertThat(offerings.placements!!.offeringIdsByPlacement["onboarding_start"]).isEqualTo("offering_a")
+        assertThat(offerings.placements!!.offeringIdsByPlacement["onboarding_end"]).isNull()
+
+        assertThat(offerings.getCurrentOfferingForPlacement("onboarding_start")).isNotNull
+        assertThat(offerings.getCurrentOfferingForPlacement("onboarding_start")!!.identifier).isEqualTo("offering_a")
+        assertThat(offerings.getCurrentOfferingForPlacement("onboarding_end")).isNull()
+        assertThat(offerings.getCurrentOfferingForPlacement("does_not_exist_but_falls_back")).isNotNull
+        assertThat(offerings.getCurrentOfferingForPlacement("does_not_exist_but_falls_back")!!.identifier).isEqualTo("offering_b")
+    }
+
+    @Test
+    fun `createOfferings creates returns placement object with no fallback offering`() {
+        val storeProductMonthly = getStoreProduct(productIdentifier, monthlyPeriod, monthlyBasePlanId)
+        val storeProductAnnual = getStoreProduct(productIdentifier, annualPeriod, annualBasePlanId)
+
+        val placementsJSON = getPlacementsJSON(
+            fallbackOfferingId = null,
+            offeringIdsByPlacement = mapOf(
+                "onboarding_start" to "offering_a",
+                "onboarding_end" to null,
+            )
+        )
+
+        val products = mapOf(productIdentifier to listOf(storeProductMonthly, storeProductAnnual))
+        val offeringsJson = getOfferingsJSON(placements = placementsJSON)
+
+        val offerings = offeringsParser.createOfferings(offeringsJson, products)
+        assertThat(offerings).isNotNull
+        assertThat(offerings.all.size).isEqualTo(2)
+        assertThat(offerings.current!!.identifier).isEqualTo(offeringsJson.getString("current_offering_id"))
+        assertThat(offerings["offering_a"]).isNotNull
+        assertThat(offerings["offering_b"]).isNotNull
+
+        assertThat(offerings.placements).isNotNull
+        assertThat(offerings.placements!!.fallbackOfferingId).isNull()
+        assertThat(offerings.placements!!.offeringIdsByPlacement.containsKey("onboarding_start")).isTrue()
+        assertThat(offerings.placements!!.offeringIdsByPlacement.containsKey("onboarding_end")).isTrue()
+        assertThat(offerings.placements!!.offeringIdsByPlacement["onboarding_start"]).isEqualTo("offering_a")
+        assertThat(offerings.placements!!.offeringIdsByPlacement["onboarding_end"]).isNull()
+
+        assertThat(offerings.getCurrentOfferingForPlacement("onboarding_start")).isNotNull
+        assertThat(offerings.getCurrentOfferingForPlacement("onboarding_start")!!.identifier).isEqualTo("offering_a")
+        assertThat(offerings.getCurrentOfferingForPlacement("onboarding_end")).isNull()
+        assertThat(offerings.getCurrentOfferingForPlacement("does_not_exist_do_not_fall_back")).isNull()
+    }
+
     private fun testPackageType(packageType: PackageType) {
         var identifier = packageType.identifier
         if (identifier == null) {
@@ -533,7 +606,8 @@ class OfferingsTest {
                         monthlyBasePlanId
                     )
                 )
-            )
+            ),
+        placements: JSONObject? = null,
     ): JSONObject {
         val offeringJsons = mutableListOf<JSONObject>()
         offeringPackagesById.forEach { (offeringId, packages) ->
@@ -551,6 +625,21 @@ class OfferingsTest {
         return JSONObject().apply {
             put("offerings", offeringsJsonArray)
             put("current_offering_id", currentOfferingId)
+            placements?.let { put("placements", placements) }
+        }
+    }
+
+    private fun getPlacementsJSON(
+        fallbackOfferingId: String?,
+        offeringIdsByPlacement: Map<String, String?>,
+    ): JSONObject {
+        return JSONObject().apply {
+            put("fallback_offering_id", fallbackOfferingId ?: JSONObject.NULL)
+            put("offering_ids_by_placement", JSONObject().apply {
+                offeringIdsByPlacement.forEach { (key, value) ->
+                    put(key, value ?: JSONObject.NULL)
+                }
+            })
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
@@ -1370,6 +1370,36 @@ class BackendTest {
         ))
     }
 
+    @Test
+    fun `postReceipt passes presented_placement_identifier in body`() {
+        val receiptInfo = ReceiptInfo(
+            productIDs = productIDs,
+            storeProduct = storeProduct,
+            presentedOfferingContext = PresentedOfferingContext(
+                "offering_a",
+                placementIdentifier = "placement_a"
+            ),
+        )
+
+        val expectedStoreUserId = "id"
+
+        mockPostReceiptResponseAndPost(
+            backend,
+            responseCode = 200,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            observerMode = true,
+            receiptInfo = receiptInfo,
+            storeAppUserID = expectedStoreUserId,
+            initiationSource = initiationSource,
+        )
+
+        assertThat(requestBodySlot.isCaptured).isTrue
+        assertThat(requestBodySlot.captured["presented_offering_identifier"]).isEqualTo("offering_a")
+        assertThat(requestBodySlot.captured["presented_placement_identifier"]).isEqualTo("placement_a")
+    }
+
     // endregion
 
     // region getOfferings

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
@@ -2443,6 +2443,7 @@ class BackendTest {
             "product_ids" to receiptInfo.productIDs,
             "is_restore" to isRestore,
             "presented_offering_identifier" to receiptInfo.presentedOfferingContext?.offeringIdentifier,
+            "presented_placement_identifier" to receiptInfo.presentedOfferingContext?.placementIdentifier,
             "observer_mode" to observerMode,
             "price" to receiptInfo.price,
             "currency" to receiptInfo.currency,

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.Placement
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.common.MICROS_MULTIPLIER
@@ -283,9 +284,11 @@ fun stubOfferings(storeProduct: StoreProduct): Pair<StoreProduct, Offerings> {
         listOf(packageObject),
         null,
     )
+    val placement: Placement? = null
     val offerings = Offerings(
         offering,
         mapOf(offering.identifier to offering),
+        placement,
     )
     return Pair(storeProduct, offerings)
 }
@@ -304,9 +307,11 @@ fun stubOTPOffering(inAppProduct: StoreProduct): Pair<StoreProduct, Offerings> {
         listOf(packageObject),
         null,
     )
+    val placement: Placement? = null
     val offerings = Offerings(
         offering,
         mapOf(offering.identifier to offering),
+        placement
     )
     return Pair(inAppProduct, offerings)
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -5,7 +5,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
-import com.revenuecat.purchases.Placement
+import com.revenuecat.purchases.Placements
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.common.MICROS_MULTIPLIER
@@ -284,11 +284,10 @@ fun stubOfferings(storeProduct: StoreProduct): Pair<StoreProduct, Offerings> {
         listOf(packageObject),
         null,
     )
-    val placement: Placement? = null
     val offerings = Offerings(
         offering,
         mapOf(offering.identifier to offering),
-        placement,
+        null,
     )
     return Pair(storeProduct, offerings)
 }
@@ -307,11 +306,10 @@ fun stubOTPOffering(inAppProduct: StoreProduct): Pair<StoreProduct, Offerings> {
         listOf(packageObject),
         null,
     )
-    val placement: Placement? = null
     val offerings = Offerings(
         offering,
         mapOf(offering.identifier to offering),
-        placement
+        null,
     )
     return Pair(inAppProduct, offerings)
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -65,7 +65,6 @@ class PaywallViewModelTest {
             TestData.template1Offering.identifier to TestData.template1Offering,
             TestData.template2Offering.identifier to TestData.template2Offering
         ),
-        null,
     )
 
     @get:Rule
@@ -212,7 +211,6 @@ class PaywallViewModelTest {
         coEvery { purchases.awaitOfferings() } returns Offerings(
             null,
             mapOf(),
-            null,
         )
 
         val model = create(

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -64,7 +64,8 @@ class PaywallViewModelTest {
         mapOf(
             TestData.template1Offering.identifier to TestData.template1Offering,
             TestData.template2Offering.identifier to TestData.template2Offering
-        )
+        ),
+        null,
     )
 
     @get:Rule
@@ -210,7 +211,8 @@ class PaywallViewModelTest {
     fun `Error loading empty offerings`() {
         coEvery { purchases.awaitOfferings() } returns Offerings(
             null,
-            mapOf()
+            mapOf(),
+            null,
         )
 
         val model = create(


### PR DESCRIPTION
### Motivation

New function to get `Offering` by a placement identifier

### Description

New `getCurrentOfferingForPlacement(placementId: String): Offering?` method on `Offerings`
- Added demo button for this in paywalls example app
- Added demo button for this in purchase tester app

```kotlin
// Example usage
offerings.getCurrentOfferingForPlacement("onboarding")?.let {
  showPaywall(it)
}
```

#### Logic flow

1. Returns an `Offering` if the placement identifier has a value
2. Checks if the placement identifier key exists in the `placements` dictionary
    - If the key exists (and value is `null`)
          1. Returns `null` if the placement identifier key exists in the dictionary but has a `null` value (this is intentional by the developer to NOT have an `Offering` for this placement identifier)
    - If the key doesn't exist
          1. Return the `Offering` for `fallback_offering_id` (if its not null)

#### New placements object in offerings response

```js
{
    // other offerings stuff
    "placements": {
        "fallback_offering_id": "offering_a", // can be null
        "offering_ids_by_placement": {
            "onboarding_start": null,
            "onboarding_end": "offering_b",
        }
  }
}
```

#### Mapping `JSONObject.NULL` to `null`

Placements is the first thing that I think is allowed to have a null value where JSONObject.toMap() was needed. This function, even though allowed for an optional T type with Map<String, T>, it didn't' actually properly map a value to null. Instead, it kept it as a JSONObject.NULL

Due to Kotlin typecasting, it wasn't really possible check if T was T or T? so JSONObject.NULL couldn't be mapped safely to null.

This feels not as nice because its a whole new method, but its very explicit in what it does... but I'm also happy if we have a better name than this 😛

### Demo

#### Purchase Tester

https://github.com/RevenueCat/purchases-android/assets/401294/6384d93d-ef1c-44de-b151-299f612b7514

#### Paywall Tester

https://github.com/RevenueCat/purchases-android/assets/401294/3477a014-7303-42c2-aaf8-8211584e5ee7


