### PR TITLE
Fix paywall POST receipt data for paywall revision

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEvent.kt
@@ -61,7 +61,7 @@ data class PaywallEvent(
     internal fun toPaywallPostReceiptData(): PaywallPostReceiptData {
         return PaywallPostReceiptData(
             sessionID = data.sessionIdentifier.toString(),
-            paywallRevision = data.paywallRevision,
+            revision = data.paywallRevision,
             displayMode = data.displayMode,
             darkMode = data.darkMode,
             localeIdentifier = data.localeIdentifier,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEvent.kt
@@ -65,6 +65,7 @@ data class PaywallEvent(
             displayMode = data.displayMode,
             darkMode = data.darkMode,
             localeIdentifier = data.localeIdentifier,
+            offeringId = data.offeringIdentifier,
         )
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallPostReceiptData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallPostReceiptData.kt
@@ -19,6 +19,8 @@ internal data class PaywallPostReceiptData(
     val darkMode: Boolean,
     @SerialName("locale")
     val localeIdentifier: String,
+    @SerialName("offering_id")
+    val offeringId: String,
 ) {
     companion object {
         val json = Json.Default

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallPostReceiptData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallPostReceiptData.kt
@@ -11,8 +11,8 @@ import kotlinx.serialization.json.encodeToJsonElement
 internal data class PaywallPostReceiptData(
     @SerialName("session_id")
     val sessionID: String,
-    @SerialName("paywall_revision")
-    val paywallRevision: Int,
+    @SerialName("revision")
+    val revision: Int,
     @SerialName("display_mode")
     val displayMode: String,
     @SerialName("dark_mode")


### PR DESCRIPTION
### Motivation

The API is expecting the `revision` key instead of `paywall_revision` for paywall data in POST receipt. The backend has a fix to support both but changing this for consistency between SDKs.

### Description

- Renamed `paywall_revision` to `revision` in `PaywallPostReceiptData`
- Added `offering_id` to `PaywallPostReceiptData`
