### PR TITLE
Fix serialization proguard rules

### DIFF
--- a/purchases/consumer-rules.pro
+++ b/purchases/consumer-rules.pro
@@ -6,3 +6,49 @@
 -dontwarn coil.**
 # Adding temporarily to fix issue after adding kotlin serialization
 -dontwarn java.lang.ClassValue
+
+# START Keep kotlinx.serialization annotations.
+
+# Keep `Companion` object fields of serializable classes.
+# This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+
+# Keep `serializer()` on companion objects (both default and named) of serializable classes.
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Keep `INSTANCE.serializer()` of serializable objects.
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static <1> INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# @Serializable and @Polymorphic are used at runtime for polymorphic serialization.
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault
+
+# Serializer for classes with named companion objects are retrieved using `getDeclaredClasses`.
+# If you have any, uncomment and replace classes with those containing named companion objects.
+#-keepattributes InnerClasses # Needed for `getDeclaredClasses`.
+#-if @kotlinx.serialization.Serializable class
+#com.example.myapplication.HasNamedCompanion, # <-- List serializable classes with named companions.
+#com.example.myapplication.HasNamedCompanion2
+#{
+#    static **$* *;
+#}
+#-keepnames class <1>$$serializer { # -keepnames suffices; class is kept when serializer() is kept.
+#    static <1>$$serializer INSTANCE;
+#}
+
+-keep class kotlinx.serialization.internal.ClassValueParametrizedCache$initClassValue$1 { ** computeValue(java.lang.Class); }
+-keep class kotlinx.serialization.internal.ClassValueCache$initClassValue$1 { ** computeValue(java.lang.Class); }
+# END Keep kotlinx.serialization annotations.

--- a/purchases/consumer-rules.pro
+++ b/purchases/consumer-rules.pro
@@ -49,6 +49,8 @@
 #    static <1>$$serializer INSTANCE;
 #}
 
+# Adding these because when target Android is 14 but compile version is lower than 14 there are r8 issues
+# https://github.com/RevenueCat/purchases-android/pull/1606
 -keep class kotlinx.serialization.internal.ClassValueParametrizedCache$initClassValue$1 { ** computeValue(java.lang.Class); }
 -keep class kotlinx.serialization.internal.ClassValueCache$initClassValue$1 { ** computeValue(java.lang.Class); }
 # END Keep kotlinx.serialization annotations.


### PR DESCRIPTION
- Added rules for version 1.4.1 https://github.com/Kotlin/kotlinx.serialization/blob/v1.4.1/README.md#android which are now included in the latest versions of kotlin serialization but starting from 1.5.0. We are still in 1.4.1 for kotlin compatibility reasons

- Added rules that fix issues when targetting Android SDK 34 and compiling with < 34 (like using version 33). There's been a breaking change in Android 14 (they added ClassValue) and copying what the [behavior changes website mentions](https://developer.android.com/about/versions/14/behavior-changes-14#core-libraries):

> The problem originates with a Kotlin library that changes runtime behaviour based on whether Class.forName("java.lang.ClassValue") returns a class or not. If your app was developed against an older version of the runtime without the java.lang.ClassValue class available, then these optimizations might remove the computeValue method from classes derived from java.lang.ClassValue.

This was causing some functions to be missing from the apk when compiling the app with R8 enabled. I compared both apps (compiling against 33 and 34) and realized  `ClassValueParametrizedCache` and `ClassValueCache` were missing their `computeValue` methods. So I generated methods for those. There's some discussion about this in this issue as well, and the solution they suggest is the same https://github.com/Kotlin/kotlinx.serialization/issues/2119 
 