### PR TITLE
Paywalls: Call `PaywallDialog` dismiss handler after successful restore if needed

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant.defaultAnimation
 import com.revenuecat.purchases.ui.revenuecatui.composables.CloseButton
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
@@ -160,6 +161,7 @@ private fun TemplatePaywall(state: PaywallState.Loaded, viewModel: PaywallViewMo
 @Composable
 internal fun getPaywallViewModel(
     options: PaywallOptions,
+    shouldDisplayBlock: ((CustomerInfo) -> Boolean)? = null,
 ): PaywallViewModel {
     val applicationContext = LocalContext.current.applicationContext
     val viewModel = viewModel<PaywallViewModelImpl>(
@@ -168,10 +170,11 @@ internal fun getPaywallViewModel(
             options,
             MaterialTheme.colorScheme,
             isSystemInDarkTheme(),
+            shouldDisplayBlock = shouldDisplayBlock,
             preview = isInPreviewMode(),
         ),
     )
-    viewModel.updateOptions(options)
+    viewModel.updateOptions(options, shouldDisplayBlock)
     return viewModel
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -174,7 +174,7 @@ internal fun getPaywallViewModel(
             preview = isInPreviewMode(),
         ),
     )
-    viewModel.updateOptions(options, shouldDisplayBlock)
+    viewModel.updateOptions(options)
     return viewModel
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -51,7 +51,10 @@ fun PaywallDialog(
         }
         val paywallOptions = paywallDialogOptions.toPaywallOptions(dismissRequest)
 
-        val viewModel = getPaywallViewModel(options = paywallOptions)
+        val viewModel = getPaywallViewModel(
+            options = paywallOptions,
+            shouldDisplayBlock = paywallDialogOptions.shouldDisplayBlock,
+        )
 
         Dialog(
             onDismissRequest = {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -98,11 +98,7 @@ internal class PaywallViewModelImpl(
         updateState()
     }
 
-    fun updateOptions(options: PaywallOptions, shouldDisplayBlock: ((CustomerInfo) -> Boolean)?) {
-        if (this.shouldDisplayBlock != shouldDisplayBlock) {
-            // This is only used for closing the paywall upon a restore so no need to update the state here currently.
-            this.shouldDisplayBlock = shouldDisplayBlock
-        }
+    fun updateOptions(options: PaywallOptions) {
         if (this.options != options) {
             this.options = options
             updateState()
@@ -176,7 +172,7 @@ internal class PaywallViewModelImpl(
                 Logger.i("Restore purchases successful: $customerInfo")
                 listener?.onRestoreCompleted(customerInfo)
                 shouldDisplayBlock?.let {
-                    if (it(customerInfo)) {
+                    if (!it(customerInfo)) {
                         options.dismissRequest()
                     }
                 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -68,7 +68,7 @@ internal class PaywallViewModelImpl(
     private var options: PaywallOptions,
     colorScheme: ColorScheme,
     private var isDarkMode: Boolean,
-    private var shouldDisplayBlock: ((CustomerInfo) -> Boolean)?,
+    private val shouldDisplayBlock: ((CustomerInfo) -> Boolean)?,
     preview: Boolean = false,
 ) : ViewModel(), PaywallViewModel {
     private val variableDataProvider = VariableDataProvider(resourceProvider, preview)
@@ -168,11 +168,15 @@ internal class PaywallViewModelImpl(
         viewModelScope.launch {
             try {
                 listener?.onRestoreStarted()
+
                 val customerInfo = purchases.awaitRestore()
+
                 Logger.i("Restore purchases successful: $customerInfo")
                 listener?.onRestoreCompleted(customerInfo)
+
                 shouldDisplayBlock?.let {
                     if (!it(customerInfo)) {
+                        Logger.d("Dismissing paywall after restore since display condition has not been met")
                         options.dismissRequest()
                     }
                 }
@@ -207,6 +211,7 @@ internal class PaywallViewModelImpl(
                     PurchaseParams.Builder(activity, packageToPurchase),
                 )
                 listener?.onPurchaseCompleted(purchaseResult.customerInfo, purchaseResult.storeTransaction)
+                Logger.d("Dismissing paywall after purchase")
                 options.dismissRequest()
             } catch (e: PurchasesException) {
                 if (e.code == PurchasesErrorCode.PurchaseCancelledError) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui.data
 import androidx.compose.material3.ColorScheme
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ResourceProvider
@@ -13,6 +14,7 @@ internal class PaywallViewModelFactory(
     private val options: PaywallOptions,
     private val colorScheme: ColorScheme,
     private val isDarkMode: Boolean,
+    private val shouldDisplayBlock: ((CustomerInfo) -> Boolean)?,
     private val preview: Boolean = false,
 ) : ViewModelProvider.NewInstanceFactory() {
     @Suppress("UNCHECKED_CAST")
@@ -23,6 +25,7 @@ internal class PaywallViewModelFactory(
             colorScheme = colorScheme,
             isDarkMode = isDarkMode,
             preview = preview,
+            shouldDisplayBlock = shouldDisplayBlock,
         ) as T
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -128,9 +128,10 @@ class PaywallViewModelTest {
             options,
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
+            shouldDisplayBlock = null,
         )
         coVerify(exactly = 1) { purchases.awaitOfferings() }
-        model.updateOptions(options)
+        model.updateOptions(options, shouldDisplayBlock = null)
         coVerify(exactly = 1) { purchases.awaitOfferings() }
     }
 
@@ -148,11 +149,12 @@ class PaywallViewModelTest {
             options1,
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
+            shouldDisplayBlock = null,
         )
         coVerify(exactly = 1) { purchases.awaitOfferings() }
-        model.updateOptions(options1)
+        model.updateOptions(options1, shouldDisplayBlock = null)
         coVerify(exactly = 1) { purchases.awaitOfferings() }
-        model.updateOptions(options2)
+        model.updateOptions(options2, shouldDisplayBlock = null)
         coVerify(exactly = 2) { purchases.awaitOfferings() }
     }
 
@@ -358,6 +360,37 @@ class PaywallViewModelTest {
     }
 
     @Test
+    fun `restorePurchases calls onDismiss if shouldDisplayBlock condition true`() {
+        val model = create {
+            true
+        }
+
+        coEvery {
+            purchases.awaitRestore()
+        } returns customerInfo
+
+        model.restorePurchases()
+
+        assertThat(dismissInvoked).isTrue()
+    }
+
+    @Test
+    fun `restorePurchases does not call onDismiss if shouldDisplayBlock condition false`() {
+        val model = create {
+            false
+        }
+
+        coEvery {
+            purchases.awaitRestore()
+        } returns customerInfo
+
+        model.restorePurchases()
+
+        assertThat(dismissInvoked).isFalse()
+    }
+
+
+    @Test
     fun `restorePurchases fails`() {
         val model = create()
 
@@ -536,6 +569,7 @@ class PaywallViewModelTest {
         offering: Offering? = null,
         activeSubscriptions: Set<String> = setOf(),
         nonSubscriptionTransactionProductIdentifiers: Set<String> = setOf(),
+        shouldDisplayBlock: ((CustomerInfo) -> Boolean)? = null,
     ): PaywallViewModelImpl {
         mockActiveSubscriptions(activeSubscriptions)
         mockNonSubscriptionTransactions(nonSubscriptionTransactionProductIdentifiers)
@@ -549,6 +583,7 @@ class PaywallViewModelTest {
                 .build(),
             TestData.Constants.currentColorScheme,
             isDarkMode = false,
+            shouldDisplayBlock = shouldDisplayBlock,
         )
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -131,7 +131,7 @@ class PaywallViewModelTest {
             shouldDisplayBlock = null,
         )
         coVerify(exactly = 1) { purchases.awaitOfferings() }
-        model.updateOptions(options, shouldDisplayBlock = null)
+        model.updateOptions(options)
         coVerify(exactly = 1) { purchases.awaitOfferings() }
     }
 
@@ -152,9 +152,9 @@ class PaywallViewModelTest {
             shouldDisplayBlock = null,
         )
         coVerify(exactly = 1) { purchases.awaitOfferings() }
-        model.updateOptions(options1, shouldDisplayBlock = null)
+        model.updateOptions(options1)
         coVerify(exactly = 1) { purchases.awaitOfferings() }
-        model.updateOptions(options2, shouldDisplayBlock = null)
+        model.updateOptions(options2)
         coVerify(exactly = 2) { purchases.awaitOfferings() }
     }
 
@@ -360,9 +360,9 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `restorePurchases calls onDismiss if shouldDisplayBlock condition true`() {
+    fun `restorePurchases calls onDismiss if shouldDisplayBlock condition false`() {
         val model = create {
-            true
+            false
         }
 
         coEvery {
@@ -375,9 +375,9 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `restorePurchases does not call onDismiss if shouldDisplayBlock condition false`() {
+    fun `restorePurchases does not call onDismiss if shouldDisplayBlock condition true`() {
         val model = create {
-            false
+            true
         }
 
         coEvery {


### PR DESCRIPTION
### Description
When using `PaywallDialog` composable, if the user restored and matched the `requiredEntitlementIdentifier` or condition to display the paywall given by the developer, we were not dismissing the paywall automatically.

This fixes that, and auto-dismisses the paywall after a successful restore if it matches the given condition by the developer.
