### PR TITLE
Refactor `presentedOfferingIdentifier` into `presentedOfferingContext` object

### DIFF
--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -234,7 +234,7 @@ class Purchases internal constructor(
         purchasesOrchestrator.startDeprecatedProductChange(
             activity,
             storeProduct.purchasingData,
-            null,
+            PresentedOfferingContext(),
             upgradeInfo.oldSku,
             GoogleProrationMode.fromPlayBillingClientMode(upgradeInfo.prorationMode)?.asGoogleReplacementMode,
             listener,
@@ -265,7 +265,7 @@ class Purchases internal constructor(
         purchasesOrchestrator.startPurchase(
             activity,
             storeProduct.purchasingData,
-            null,
+            PresentedOfferingContext(),
             null,
             callback,
         )
@@ -302,7 +302,7 @@ class Purchases internal constructor(
         purchasesOrchestrator.startDeprecatedProductChange(
             activity,
             packageToPurchase.product.purchasingData,
-            packageToPurchase.offering,
+            packageToPurchase.presentedOfferingContext,
             upgradeInfo.oldSku,
             GoogleProrationMode.fromPlayBillingClientMode(upgradeInfo.prorationMode)?.asGoogleReplacementMode,
             callback,
@@ -333,7 +333,7 @@ class Purchases internal constructor(
         purchasesOrchestrator.startPurchase(
             activity,
             packageToPurchase.product.purchasingData,
-            packageToPurchase.offering,
+            packageToPurchase.presentedOfferingContext,
             null,
             listener,
         )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Package.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Package.kt
@@ -7,14 +7,41 @@ import com.revenuecat.purchases.models.StoreProduct
  * @property identifier Unique identifier for this package. Can be one a predefined package type or a custom one.
  * @property packageType Package type for the product. Will be one of [PackageType].
  * @property product [StoreProduct] assigned to this package.
- * @property offering offering this package was returned from.
+ * @property offering offering Id this package was returned from.
+ * @property presentedOfferingContext [PresentedOfferingContext] from which this package was obtained.
  */
 data class Package(
     val identifier: String,
     val packageType: PackageType,
     val product: StoreProduct,
-    val offering: String,
-)
+    val presentedOfferingContext: PresentedOfferingContext,
+) {
+    @Deprecated(
+        "Use constructor with presentedOfferingContext instead",
+        ReplaceWith(
+            "Package(identifier, packageType, product, offering, " +
+                "PresentedOfferingContext(offeringIdentifier = offering))",
+        ),
+    )
+    constructor(
+        identifier: String,
+        packageType: PackageType,
+        product: StoreProduct,
+        offering: String,
+    ) : this(
+        identifier,
+        packageType,
+        product,
+        PresentedOfferingContext(offeringIdentifier = offering),
+    )
+
+    @Deprecated(
+        "Use presentedOfferingContext.offeringIdentifier instead",
+        ReplaceWith("presentedOfferingContext.offeringIdentifier"),
+    )
+    val offering: String
+        get() = presentedOfferingContext.offeringIdentifier ?: ""
+}
 
 /**
  *  Enumeration of all possible Package types.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -89,7 +89,7 @@ internal class PostReceiptHelper(
     ) {
         val receiptInfo = ReceiptInfo(
             productIDs = purchase.productIds,
-            offeringIdentifier = purchase.presentedOfferingIdentifier,
+            presentedOfferingContext = purchase.presentedOfferingContext,
             storeProduct = storeProduct,
             subscriptionOptionId = purchase.subscriptionOptionId,
             replacementMode = purchase.replacementMode,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
@@ -1,0 +1,18 @@
+package com.revenuecat.purchases
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Contains data about the context in which an offering was presented.
+ */
+@Parcelize
+data class PresentedOfferingContext(
+    /**
+     * The identifier of the offering used to obtain this object.
+     *
+     * Null if not using RevenueCat offerings system, if fetched directly via `Purchases.getProducts`,
+     * or on restores/syncs.
+     */
+    val offeringIdentifier: String? = null,
+) : Parcelable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
@@ -21,7 +21,7 @@ data class PurchaseParams(val builder: Builder) {
     internal val activity: Activity
 
     @get:JvmSynthetic
-    internal val presentedOfferingIdentifier: String?
+    internal val presentedOfferingContext: PresentedOfferingContext
 
     init {
         this.isPersonalizedPrice = builder.isPersonalizedPrice
@@ -29,7 +29,7 @@ data class PurchaseParams(val builder: Builder) {
         this.googleReplacementMode = builder.googleReplacementMode
         this.purchasingData = builder.purchasingData
         this.activity = builder.activity
-        this.presentedOfferingIdentifier = builder.presentedOfferingIdentifier
+        this.presentedOfferingContext = builder.presentedOfferingContext
     }
 
     /**
@@ -45,19 +45,19 @@ data class PurchaseParams(val builder: Builder) {
     open class Builder private constructor(
         @get:JvmSynthetic internal val activity: Activity,
         @get:JvmSynthetic internal val purchasingData: PurchasingData,
-        @get:JvmSynthetic internal val presentedOfferingIdentifier: String? = null,
+        @get:JvmSynthetic internal val presentedOfferingContext: PresentedOfferingContext,
         @get:JvmSynthetic internal val product: StoreProduct?,
     ) {
         constructor(activity: Activity, packageToPurchase: Package) :
             this(
                 activity,
                 packageToPurchase.product.purchasingData,
-                packageToPurchase.offering,
+                packageToPurchase.presentedOfferingContext,
                 packageToPurchase.product,
             )
 
         constructor(activity: Activity, storeProduct: StoreProduct) :
-            this(activity, storeProduct.purchasingData, storeProduct.presentedOfferingIdentifier, storeProduct)
+            this(activity, storeProduct.purchasingData, storeProduct.presentedOfferingContext, storeProduct)
 
         private fun ensureNoTestProduct(storeProduct: StoreProduct) {
             if (storeProduct is TestStoreProduct) {
@@ -74,7 +74,7 @@ data class PurchaseParams(val builder: Builder) {
             this(
                 activity,
                 subscriptionOption.purchasingData,
-                subscriptionOption.presentedOfferingIdentifier,
+                subscriptionOption.presentedOfferingContext,
                 product = null,
             )
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -323,7 +323,7 @@ internal class PurchasesOrchestrator constructor(
                 startProductChange(
                     activity,
                     purchasingData,
-                    presentedOfferingIdentifier,
+                    presentedOfferingContext,
                     productId,
                     googleReplacementMode,
                     isPersonalizedPrice,
@@ -333,7 +333,7 @@ internal class PurchasesOrchestrator constructor(
                 startPurchase(
                     activity,
                     purchasingData,
-                    presentedOfferingIdentifier,
+                    presentedOfferingContext,
                     isPersonalizedPrice,
                     callback,
                 )
@@ -896,7 +896,7 @@ internal class PurchasesOrchestrator constructor(
     fun startPurchase(
         activity: Activity,
         purchasingData: PurchasingData,
-        presentedOfferingIdentifier: String?,
+        presentedOfferingContext: PresentedOfferingContext,
         isPersonalizedPrice: Boolean?,
         listener: PurchaseCallback,
     ) {
@@ -904,8 +904,8 @@ internal class PurchasesOrchestrator constructor(
             LogIntent.PURCHASE,
             PurchaseStrings.PURCHASE_STARTED.format(
                 " $purchasingData ${
-                    presentedOfferingIdentifier?.let {
-                        PurchaseStrings.OFFERING + "$presentedOfferingIdentifier"
+                    presentedOfferingContext.offeringIdentifier?.let {
+                        PurchaseStrings.OFFERING + "$it"
                     }
                 }",
             ),
@@ -930,7 +930,7 @@ internal class PurchasesOrchestrator constructor(
                 appUserID,
                 purchasingData,
                 null,
-                presentedOfferingIdentifier,
+                presentedOfferingContext,
                 isPersonalizedPrice,
             )
         } ?: listener.dispatch(PurchasesError(PurchasesErrorCode.OperationAlreadyInProgressError).also { errorLog(it) })
@@ -939,7 +939,7 @@ internal class PurchasesOrchestrator constructor(
     fun startProductChange(
         activity: Activity,
         purchasingData: PurchasingData,
-        offeringIdentifier: String?,
+        presentedOfferingContext: PresentedOfferingContext,
         oldProductId: String,
         googleReplacementMode: GoogleReplacementMode,
         isPersonalizedPrice: Boolean?,
@@ -959,8 +959,8 @@ internal class PurchasesOrchestrator constructor(
             LogIntent.PURCHASE,
             PurchaseStrings.PRODUCT_CHANGE_STARTED.format(
                 " $purchasingData ${
-                    offeringIdentifier?.let {
-                        PurchaseStrings.OFFERING + "$offeringIdentifier"
+                    presentedOfferingContext.offeringIdentifier?.let {
+                        PurchaseStrings.OFFERING + "$it"
                     }
                 } oldProductId: $oldProductId googleReplacementMode $googleReplacementMode",
 
@@ -988,7 +988,7 @@ internal class PurchasesOrchestrator constructor(
                 googleReplacementMode,
                 activity,
                 appUserID,
-                offeringIdentifier,
+                presentedOfferingContext,
                 isPersonalizedPrice,
                 purchaseCallback,
             )
@@ -1003,7 +1003,7 @@ internal class PurchasesOrchestrator constructor(
     fun startDeprecatedProductChange(
         activity: Activity,
         purchasingData: PurchasingData,
-        offeringIdentifier: String?,
+        presentedOfferingContext: PresentedOfferingContext,
         oldProductId: String,
         googleReplacementMode: GoogleReplacementMode?,
         listener: ProductChangeCallback,
@@ -1023,8 +1023,8 @@ internal class PurchasesOrchestrator constructor(
             LogIntent.PURCHASE,
             PurchaseStrings.PRODUCT_CHANGE_STARTED.format(
                 " $purchasingData ${
-                    offeringIdentifier?.let {
-                        PurchaseStrings.OFFERING + "$offeringIdentifier"
+                    presentedOfferingContext.offeringIdentifier?.let {
+                        PurchaseStrings.OFFERING + "$it"
                     }
                 } oldProductId: $oldProductId googleReplacementMode $googleReplacementMode",
 
@@ -1047,7 +1047,7 @@ internal class PurchasesOrchestrator constructor(
                 googleReplacementMode,
                 activity,
                 appUserID,
-                offeringIdentifier,
+                presentedOfferingContext,
                 null,
                 listener,
             )
@@ -1063,7 +1063,7 @@ internal class PurchasesOrchestrator constructor(
         googleReplacementMode: GoogleReplacementMode?,
         activity: Activity,
         appUserID: String,
-        presentedOfferingIdentifier: String?,
+        presentedOfferingContext: PresentedOfferingContext,
         isPersonalizedPrice: Boolean?,
         listener: PurchaseErrorCallback,
     ) {
@@ -1099,7 +1099,7 @@ internal class PurchasesOrchestrator constructor(
                     appUserID,
                     purchasingData,
                     ReplaceProductInfo(purchaseRecord, googleReplacementMode),
-                    presentedOfferingIdentifier,
+                    presentedOfferingContext,
                     isPersonalizedPrice,
                 )
             },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -13,6 +13,7 @@ import com.amazon.device.iap.model.Receipt
 import com.amazon.device.iap.model.UserData
 import com.amazon.device.iap.model.UserDataResponse
 import com.revenuecat.purchases.PostReceiptInitiationSource
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCallback
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -52,7 +53,7 @@ import com.revenuecat.purchases.ProductType as RevenueCatProductType
 private const val TERM_SKU_JSON_KEY = "termSku"
 
 @SuppressWarnings("LongParameterList", "TooManyFunctions")
-internal class AmazonBilling constructor(
+internal class AmazonBilling(
     private val applicationContext: Context,
     private val amazonBackend: AmazonBackend,
     private val cache: AmazonCache,
@@ -244,7 +245,7 @@ internal class AmazonBilling constructor(
         appUserID: String,
         purchasingData: PurchasingData,
         replaceProductInfo: ReplaceProductInfo?,
-        presentedOfferingIdentifier: String?,
+        presentedOfferingContext: PresentedOfferingContext,
         isPersonalizedPrice: Boolean?,
     ) {
         val amazonPurchaseInfo = purchasingData as? AmazonPurchasingData.Product
@@ -275,9 +276,9 @@ internal class AmazonBilling constructor(
                     activity,
                     appUserID,
                     storeProduct,
-                    presentedOfferingIdentifier,
+                    presentedOfferingContext,
                     onSuccess = { receipt, userData ->
-                        handleReceipt(receipt, userData, storeProduct, presentedOfferingIdentifier)
+                        handleReceipt(receipt, userData, storeProduct, presentedOfferingContext)
                     },
                     onError = {
                         onPurchaseError(it)
@@ -354,7 +355,7 @@ internal class AmazonBilling constructor(
         }
         val amazonPurchaseWrapper = receipt.toStoreTransaction(
             productId = sku,
-            presentedOfferingIdentifier = null,
+            presentedOfferingContext = null,
             purchaseState = PurchaseState.UNSPECIFIED_STATE,
             userData,
         )
@@ -515,7 +516,7 @@ internal class AmazonBilling constructor(
         receipt: Receipt,
         userData: UserData,
         storeProduct: StoreProduct,
-        presentedOfferingIdentifier: String?,
+        presentedOfferingContext: PresentedOfferingContext,
     ) {
         if (receipt.productType != ProductType.SUBSCRIPTION) {
             /**
@@ -526,7 +527,7 @@ internal class AmazonBilling constructor(
              */
             val amazonPurchaseWrapper = receipt.toStoreTransaction(
                 productId = storeProduct.id,
-                presentedOfferingIdentifier = presentedOfferingIdentifier,
+                presentedOfferingContext = presentedOfferingContext,
                 purchaseState = PurchaseState.PURCHASED,
                 userData,
             )
@@ -541,7 +542,7 @@ internal class AmazonBilling constructor(
                 val termSku = response[TERM_SKU_JSON_KEY] as String
                 val amazonPurchaseWrapper = receipt.toStoreTransaction(
                     productId = termSku,
-                    presentedOfferingIdentifier = presentedOfferingIdentifier,
+                    presentedOfferingContext = presentedOfferingContext,
                     purchaseState = PurchaseState.PURCHASED,
                     userData,
                 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonStoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonStoreProduct.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.amazon
 
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
@@ -8,7 +9,7 @@ import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.SubscriptionOptions
 import org.json.JSONObject
 
-data class AmazonStoreProduct(
+data class AmazonStoreProduct @JvmOverloads constructor(
 
     /**
      * The productId
@@ -76,11 +77,9 @@ data class AmazonStoreProduct(
     val originalProductJSON: JSONObject,
 
     /**
-     * The offering ID this `AmazonStoreProduct` was returned from.
-     *
-     * Null if not using RevenueCat offerings system, or if fetched directly via `Purchases.getProducts`
+     * The context from which this product was obtained.
      */
-    override val presentedOfferingIdentifier: String? = null,
+    override val presentedOfferingContext: PresentedOfferingContext = PresentedOfferingContext(),
 ) : StoreProduct {
 
     @Deprecated(
@@ -120,6 +119,44 @@ data class AmazonStoreProduct(
         presentedOfferingIdentifier = presentedOfferingIdentifier,
     )
 
+    @Deprecated(
+        "Replaced with constructor that takes a presentedOfferingContext",
+        ReplaceWith(
+            "AmazonStoreProduct(productId, type, name, title, description, period, price, " +
+                "subscriptionOptions, defaultOption, iconUrl, freeTrialPeriod, originalProductJSON, " +
+                "PresentedOfferingContext(presentedOfferingIdentifier))",
+        ),
+    )
+    constructor(
+        id: String,
+        type: ProductType,
+        name: String,
+        title: String,
+        description: String,
+        period: Period?,
+        price: Price,
+        subscriptionOptions: SubscriptionOptions?,
+        defaultOption: SubscriptionOption?,
+        iconUrl: String,
+        freeTrialPeriod: Period?,
+        originalProductJSON: JSONObject,
+        presentedOfferingIdentifier: String? = null,
+    ) : this(
+        id = id,
+        type = type,
+        name = name,
+        title = title,
+        description = description,
+        period = period,
+        price = price,
+        subscriptionOptions = subscriptionOptions,
+        defaultOption = defaultOption,
+        iconUrl = iconUrl,
+        freeTrialPeriod = freeTrialPeriod,
+        originalProductJSON = originalProductJSON,
+        presentedOfferingContext = PresentedOfferingContext(presentedOfferingIdentifier),
+    )
+
     /**
      * Contains only data that is required to make the purchase.
      */
@@ -134,11 +171,31 @@ data class AmazonStoreProduct(
         get() = id
 
     /**
+     * The offering ID this `AmazonStoreProduct` was returned from.
+     *
+     * Null if not using RevenueCat offerings system, or if fetched directly via `Purchases.getProducts`
+     */
+    @Deprecated(
+        "Use presentedOfferingContext instead",
+        ReplaceWith("presentedOfferingContext.offeringIdentifier"),
+    )
+    override val presentedOfferingIdentifier: String?
+        get() = presentedOfferingContext.offeringIdentifier
+
+    /**
      * For internal RevenueCat use.
      *
      * Creates a copy of this `AmazonStoreProduct` with the specified `offeringId` set.
      */
+    @Deprecated(
+        "Replaced with copyWithPresentedOfferingContext",
+        ReplaceWith("copyWithPresentedOfferingContext(PresentedOfferingContext(offeringId))"),
+    )
     override fun copyWithOfferingId(offeringId: String): StoreProduct {
+        return copyWithPresentedOfferingContext(PresentedOfferingContext(offeringId))
+    }
+
+    override fun copyWithPresentedOfferingContext(presentedOfferingContext: PresentedOfferingContext): StoreProduct {
         return AmazonStoreProduct(
             this.id,
             this.type,
@@ -152,7 +209,7 @@ data class AmazonStoreProduct(
             this.iconUrl,
             this.freeTrialPeriod,
             this.originalProductJSON,
-            offeringId,
+            presentedOfferingContext,
         )
     }
 
@@ -186,7 +243,7 @@ private data class ComparableData(
     val defaultOption: SubscriptionOption?,
     val iconUrl: String,
     val freeTrialPeriod: Period?,
-    val offeringId: String?,
+    val presentedOfferingContext: PresentedOfferingContext,
 ) {
     constructor(
         amazonStoreProduct: AmazonStoreProduct,
@@ -201,6 +258,6 @@ private data class ComparableData(
         defaultOption = amazonStoreProduct.defaultOption,
         iconUrl = amazonStoreProduct.iconUrl,
         freeTrialPeriod = amazonStoreProduct.freeTrialPeriod,
-        offeringId = amazonStoreProduct.presentedOfferingIdentifier,
+        presentedOfferingContext = amazonStoreProduct.presentedOfferingContext,
     )
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/listener/PurchaseResponseListener.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/listener/PurchaseResponseListener.kt
@@ -8,6 +8,7 @@ import com.amazon.device.iap.model.PurchaseUpdatesResponse
 import com.amazon.device.iap.model.Receipt
 import com.amazon.device.iap.model.UserData
 import com.amazon.device.iap.model.UserDataResponse
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.models.StoreProduct
 
@@ -31,7 +32,7 @@ internal interface PurchaseResponseListener : PurchasingListener {
         activity: Activity,
         appUserID: String,
         storeProduct: StoreProduct,
-        presentedOfferingIdentifier: String?,
+        presentedOfferingContext: PresentedOfferingContext,
         onSuccess: (Receipt, UserData) -> Unit,
         onError: (PurchasesError) -> Unit,
     )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/storeTransactionConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/storeTransactionConversions.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.amazon
 
 import com.amazon.device.iap.model.Receipt
 import com.amazon.device.iap.model.UserData
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.PurchaseType
@@ -9,7 +10,7 @@ import com.revenuecat.purchases.models.StoreTransaction
 
 internal fun Receipt.toStoreTransaction(
     productId: String,
-    presentedOfferingIdentifier: String?,
+    presentedOfferingContext: PresentedOfferingContext?,
     purchaseState: PurchaseState,
     userData: UserData,
 ): StoreTransaction {
@@ -24,7 +25,7 @@ internal fun Receipt.toStoreTransaction(
         isAutoRenewing = if (type == ProductType.SUBS) !this.isCanceled else false,
         signature = null,
         originalJson = this.toJSON(),
-        presentedOfferingIdentifier = presentedOfferingIdentifier,
+        presentedOfferingContext = presentedOfferingContext,
         storeUserID = userData.userId,
         purchaseType = PurchaseType.AMAZON_PURCHASE,
         marketplace = userData.marketplace,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -211,7 +211,7 @@ internal class Backend(
             "platform_product_ids" to receiptInfo.platformProductIds?.map { it.asMap },
             APP_USER_ID to appUserID,
             "is_restore" to isRestore,
-            "presented_offering_identifier" to receiptInfo.offeringIdentifier,
+            "presented_offering_identifier" to receiptInfo.presentedOfferingContext?.offeringIdentifier,
             "observer_mode" to observerMode,
             "price" to receiptInfo.price,
             "currency" to receiptInfo.currency,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/BillingAbstract.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.common
 
 import android.app.Activity
 import com.revenuecat.purchases.PostReceiptInitiationSource
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCallback
@@ -76,7 +77,7 @@ internal abstract class BillingAbstract(
         appUserID: String,
         purchasingData: PurchasingData,
         replaceProductInfo: ReplaceProductInfo?,
-        presentedOfferingIdentifier: String?,
+        presentedOfferingContext: PresentedOfferingContext,
         isPersonalizedPrice: Boolean? = null,
     )
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.strings.OfferingStrings
@@ -56,11 +57,12 @@ internal abstract class OfferingParser {
         val offeringIdentifier = offeringJson.getString("identifier")
         val metadata = offeringJson.optJSONObject("metadata")?.toMap<Any>(deep = true) ?: emptyMap()
         val jsonPackages = offeringJson.getJSONArray("packages")
+        val presentedOfferingContext = PresentedOfferingContext(offeringIdentifier)
 
         val availablePackages = mutableListOf<Package>()
         for (i in 0 until jsonPackages.length()) {
             val packageJson = jsonPackages.getJSONObject(i)
-            createPackage(packageJson, productsById, offeringIdentifier)?.let {
+            createPackage(packageJson, productsById, presentedOfferingContext)?.let {
                 availablePackages.add(it)
             }
         }
@@ -94,14 +96,19 @@ internal abstract class OfferingParser {
     fun createPackage(
         packageJson: JSONObject,
         productsById: Map<String, List<StoreProduct>>,
-        offeringIdentifier: String,
+        presentedOfferingContext: PresentedOfferingContext,
     ): Package? {
         val packageIdentifier = packageJson.getString("identifier")
         val product = findMatchingProduct(productsById, packageJson)
 
         val packageType = packageIdentifier.toPackageType()
         return product?.let {
-            Package(packageIdentifier, packageType, product.copyWithOfferingId(offeringIdentifier), offeringIdentifier)
+            Package(
+                packageIdentifier,
+                packageType,
+                product.copyWithPresentedOfferingContext(presentedOfferingContext),
+                presentedOfferingContext,
+            )
         }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/ReceiptInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/ReceiptInfo.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.common
 
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ReplacementMode
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
 import com.revenuecat.purchases.models.PricingPhase
@@ -9,7 +10,7 @@ import com.revenuecat.purchases.models.SubscriptionOption
 @SuppressWarnings("LongParameterList")
 internal class ReceiptInfo(
     val productIDs: List<String>,
-    val offeringIdentifier: String? = null,
+    val presentedOfferingContext: PresentedOfferingContext? = null,
     val subscriptionOptionId: String? = null,
     val storeProduct: StoreProduct? = null,
 
@@ -32,7 +33,7 @@ internal class ReceiptInfo(
         other as ReceiptInfo
 
         if (productIDs != other.productIDs) return false
-        if (offeringIdentifier != other.offeringIdentifier) return false
+        if (presentedOfferingContext != other.presentedOfferingContext) return false
         if (storeProduct != other.storeProduct) return false
         if (price != other.price) return false
         if (currency != other.currency) return false
@@ -59,7 +60,7 @@ internal class ReceiptInfo(
 
     override fun hashCode(): Int {
         var result = productIDs.hashCode()
-        result = 31 * result + (offeringIdentifier?.hashCode() ?: 0)
+        result = 31 * result + (presentedOfferingContext?.hashCode() ?: 0)
         result = 31 * result + (storeProduct?.hashCode() ?: 0)
         result = 31 * result + (subscriptionOptionId?.hashCode() ?: 0)
         return result
@@ -68,7 +69,7 @@ internal class ReceiptInfo(
     override fun toString(): String {
         return "ReceiptInfo(" +
             "productIDs='${productIDs.joinToString()}', " +
-            "offeringIdentifier=$offeringIdentifier, " +
+            "presentedOfferingContext=$presentedOfferingContext, " +
             "storeProduct=$storeProduct, " +
             "subscriptionOptionId=$subscriptionOptionId, " +
             "pricingPhases=$pricingPhases, " +

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -21,6 +21,7 @@ import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryRecord
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.revenuecat.purchases.PostReceiptInitiationSource
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCallback
@@ -220,7 +221,7 @@ internal class BillingWrapper(
         appUserID: String,
         purchasingData: PurchasingData,
         replaceProductInfo: ReplaceProductInfo?,
-        presentedOfferingIdentifier: String?,
+        presentedOfferingContext: PresentedOfferingContext,
         isPersonalizedPrice: Boolean?,
     ) {
         val googlePurchasingData = purchasingData as? GooglePurchasingData
@@ -261,7 +262,7 @@ internal class BillingWrapper(
             val productId = googlePurchasingData.productId
             purchaseContext[productId] = PurchaseContext(
                 googlePurchasingData.productType,
-                presentedOfferingIdentifier,
+                presentedOfferingContext,
                 subscriptionOptionId,
                 replaceProductInfo?.replacementMode as? GoogleReplacementMode?,
             )
@@ -779,10 +780,7 @@ internal class BillingWrapper(
 
             getPurchaseType(purchase.purchaseToken) { type ->
                 completion(
-                    purchase.toStoreTransaction(
-                        type,
-                        context?.presentedOfferingId,
-                    ),
+                    purchase.toStoreTransaction(type),
                 )
             }
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/PurchaseContext.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/PurchaseContext.kt
@@ -1,11 +1,12 @@
 package com.revenuecat.purchases.google
 
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.models.GoogleReplacementMode
 
 internal class PurchaseContext(
     val productType: ProductType,
-    val presentedOfferingId: String?,
+    val presentedOfferingContext: PresentedOfferingContext,
     val selectedSubscriptionOptionId: String?,
     val replacementMode: GoogleReplacementMode?,
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/storeProductConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/storeProductConversions.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.google
 
 import com.android.billingclient.api.ProductDetails
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.log
@@ -40,7 +41,7 @@ internal fun ProductDetails.toStoreProduct(
         subscriptionOptions = subscriptionOptions,
         defaultOption = subscriptionOptions?.defaultOffer,
         productDetails = this,
-        presentedOfferingIdentifier = null,
+        presentedOfferingContext = PresentedOfferingContext(),
     )
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/storeTransactionConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/storeTransactionConversions.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.google
 
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryRecord
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.models.GoogleReplacementMode
 import com.revenuecat.purchases.models.PurchaseState
@@ -11,7 +12,7 @@ import org.json.JSONObject
 
 internal fun Purchase.toStoreTransaction(
     productType: ProductType,
-    presentedOfferingIdentifier: String? = null,
+    presentedOfferingContext: PresentedOfferingContext? = null,
     subscriptionOptionId: String? = null,
     replacementMode: GoogleReplacementMode? = null,
 ): StoreTransaction = StoreTransaction(
@@ -24,7 +25,7 @@ internal fun Purchase.toStoreTransaction(
     isAutoRenewing = this.isAutoRenewing,
     signature = this.signature,
     originalJson = JSONObject(this.originalJson),
-    presentedOfferingIdentifier = presentedOfferingIdentifier,
+    presentedOfferingContext = presentedOfferingContext,
     storeUserID = null,
     purchaseType = PurchaseType.GOOGLE_PURCHASE,
     marketplace = null,
@@ -35,7 +36,7 @@ internal fun Purchase.toStoreTransaction(
 internal fun Purchase.toStoreTransaction(purchaseContext: PurchaseContext): StoreTransaction =
     toStoreTransaction(
         purchaseContext.productType,
-        purchaseContext.presentedOfferingId,
+        purchaseContext.presentedOfferingContext,
         purchaseContext.selectedSubscriptionOptionId,
         purchaseContext.replacementMode,
     )
@@ -59,7 +60,7 @@ internal fun PurchaseHistoryRecord.toStoreTransaction(
         isAutoRenewing = null,
         signature = this.signature,
         originalJson = JSONObject(this.originalJson),
-        presentedOfferingIdentifier = null,
+        presentedOfferingContext = null,
         storeUserID = null,
         purchaseType = PurchaseType.GOOGLE_RESTORED_PURCHASE,
         marketplace = null,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleSubscriptionOption.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleSubscriptionOption.kt
@@ -1,11 +1,12 @@
 package com.revenuecat.purchases.models
 
 import com.android.billingclient.api.ProductDetails
+import com.revenuecat.purchases.PresentedOfferingContext
 
 /**
  * Defines an option for purchasing a Google subscription
  */
-data class GoogleSubscriptionOption(
+data class GoogleSubscriptionOption @JvmOverloads constructor(
     /**
      * If this SubscriptionOption represents a base plan, this will be the basePlanId.
      * If it represents an offer, it will be basePlanId:offerId
@@ -51,10 +52,22 @@ data class GoogleSubscriptionOption(
      *
      * Null if not using RevenueCat offerings system, or if fetched directly via `Purchases.getProducts`
      */
+    @Deprecated(
+        "Use presentedOfferingContext instead",
+        ReplaceWith("presentedOfferingContext.offeringIdentifier"),
+    )
     override val presentedOfferingIdentifier: String? = null,
+
+    /**
+     * The context from which this subscription option was obtained.
+     */
+    override val presentedOfferingContext: PresentedOfferingContext = PresentedOfferingContext(),
 ) : SubscriptionOption {
 
-    internal constructor(subscriptionOption: GoogleSubscriptionOption, presentedOfferingIdentifier: String?) :
+    internal constructor(
+        subscriptionOption: GoogleSubscriptionOption,
+        presentedOfferingContext: PresentedOfferingContext,
+    ) :
         this(
             subscriptionOption.productId,
             subscriptionOption.basePlanId,
@@ -63,7 +76,8 @@ data class GoogleSubscriptionOption(
             subscriptionOption.tags,
             subscriptionOption.productDetails,
             subscriptionOption.offerToken,
-            presentedOfferingIdentifier,
+            presentedOfferingContext.offeringIdentifier,
+            presentedOfferingContext,
         )
 
     override val id: String

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.models
 
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.utils.pricePerMonth
 import com.revenuecat.purchases.utils.pricePerWeek
@@ -92,7 +93,16 @@ interface StoreProduct {
      *
      * Null if not using RevenueCat offerings system, or if fetched directly via `Purchases.getProducts`
      */
+    @Deprecated(
+        "Replaced with presentedOfferingContext",
+        ReplaceWith("presentedOfferingContext.offeringIdentifier"),
+    )
     val presentedOfferingIdentifier: String?
+
+    /**
+     * The context from which this product was obtained.
+     */
+    val presentedOfferingContext: PresentedOfferingContext
 
     /**
      * The sku of the StoreProduct
@@ -108,7 +118,18 @@ interface StoreProduct {
      *
      * Creates a copy of this `StoreProduct` with the specified `offeringId` set.
      */
+    @Deprecated(
+        "Replaced with copyWithPresentedOfferingContext",
+        ReplaceWith("copyWithPresentedOfferingContext(presentedOfferingContext)"),
+    )
     fun copyWithOfferingId(offeringId: String): StoreProduct
+
+    /**
+     * For internal RevenueCat use.
+     *
+     * Creates a copy of this `StoreProduct` with the specified `presentedOfferingContext` set.
+     */
+    fun copyWithPresentedOfferingContext(presentedOfferingContext: PresentedOfferingContext): StoreProduct
 
     /**
      * Null for INAPP products. The price of the [StoreProduct] in the given locale in a weekly recurrence.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreTransaction.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreTransaction.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.models
 
 import android.os.Parcelable
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.ProrationMode
 import com.revenuecat.purchases.ReplacementMode
@@ -70,9 +71,9 @@ data class StoreTransaction(
     val originalJson: JSONObject,
 
     /**
-     * Offering that was presented when making the purchase. Always null for restored purchases.
+     * Context of the offering that was presented when making the purchase.
      */
-    val presentedOfferingIdentifier: String?,
+    val presentedOfferingContext: PresentedOfferingContext?,
 
     /**
      * Amazon's store user id. Null for Google
@@ -104,6 +105,41 @@ data class StoreTransaction(
     val replacementMode: ReplacementMode?,
 ) : Parcelable {
 
+    @Deprecated("Use constructor with presentedOfferingContext instead")
+    constructor(
+        orderId: String?,
+        productIds: List<String>,
+        type: ProductType,
+        purchaseTime: Long,
+        purchaseToken: String,
+        purchaseState: PurchaseState,
+        isAutoRenewing: Boolean?,
+        signature: String?,
+        originalJson: JSONObject,
+        presentedOfferingIdentifier: String?,
+        storeUserID: String?,
+        purchaseType: PurchaseType,
+        marketplace: String?,
+        subscriptionOptionId: String?,
+        replacementMode: ReplacementMode?,
+    ) : this(
+        orderId,
+        productIds,
+        type,
+        purchaseTime,
+        purchaseToken,
+        purchaseState,
+        isAutoRenewing,
+        signature,
+        originalJson,
+        PresentedOfferingContext(presentedOfferingIdentifier),
+        storeUserID,
+        purchaseType,
+        marketplace,
+        subscriptionOptionId,
+        replacementMode,
+    )
+
     @Deprecated("prorationMode is deprecated, use constructor with replacementMode")
     constructor(
         orderId: String?,
@@ -131,7 +167,7 @@ data class StoreTransaction(
         isAutoRenewing,
         signature,
         originalJson,
-        presentedOfferingIdentifier,
+        PresentedOfferingContext(presentedOfferingIdentifier),
         storeUserID,
         purchaseType,
         marketplace,
@@ -150,6 +186,16 @@ data class StoreTransaction(
     )
     val prorationMode: ProrationMode?
         get() = (replacementMode as? GoogleReplacementMode)?.asGoogleProrationMode
+
+    /**
+     * Offering that was presented when making the purchase. Always null for restored purchases.
+     */
+    @Deprecated(
+        "Use presentedOfferingContext",
+        ReplaceWith("presentedOfferingContext.offeringIdentifier"),
+    )
+    val presentedOfferingIdentifier: String?
+        get() = presentedOfferingContext?.offeringIdentifier
 
     /**
      * Skus associated with the transaction
@@ -181,7 +227,7 @@ private data class ComparableData(
     val purchaseState: PurchaseState,
     val isAutoRenewing: Boolean?,
     val signature: String?,
-    val presentedOfferingIdentifier: String?,
+    val presentedOfferingContext: PresentedOfferingContext?,
     val storeUserID: String?,
     val purchaseType: PurchaseType,
     val marketplace: String?,
@@ -198,7 +244,7 @@ private data class ComparableData(
         purchaseState = storeTransaction.purchaseState,
         isAutoRenewing = storeTransaction.isAutoRenewing,
         signature = storeTransaction.signature,
-        presentedOfferingIdentifier = storeTransaction.presentedOfferingIdentifier,
+        presentedOfferingContext = storeTransaction.presentedOfferingContext,
         storeUserID = storeTransaction.storeUserID,
         purchaseType = storeTransaction.purchaseType,
         marketplace = storeTransaction.marketplace,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/SubscriptionOption.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/SubscriptionOption.kt
@@ -1,5 +1,7 @@
 package com.revenuecat.purchases.models
 
+import com.revenuecat.purchases.PresentedOfferingContext
+
 /**
  * A purchase-able entity for a subscription product.
  */
@@ -29,7 +31,16 @@ interface SubscriptionOption {
      *
      * Null if not using RevenueCat offerings system, or if fetched directly via `Purchases.getProducts`
      */
+    @Deprecated(
+        "Use presentedOfferingContext instead",
+        ReplaceWith("presentedOfferingContext.offeringIdentifier"),
+    )
     val presentedOfferingIdentifier: String?
+
+    /**
+     * The context from which this subscription option was obtained.
+     */
+    val presentedOfferingContext: PresentedOfferingContext
 
     /**
      * True if this SubscriptionOption represents a Google subscription base plan (rather than an offer).

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/TestStoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/TestStoreProduct.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.models
 
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 
 /**
@@ -54,12 +55,27 @@ data class TestStoreProduct(
             override val productType: ProductType
                 get() = type
         }
+
+    @Deprecated(
+        "Use presentedOfferingContext",
+        ReplaceWith("presentedOfferingContext.offeringIdentifier"),
+    )
     override val presentedOfferingIdentifier: String?
-        get() = null
+        get() = presentedOfferingContext.offeringIdentifier
+    override val presentedOfferingContext: PresentedOfferingContext
+        get() = PresentedOfferingContext()
     override val sku: String
         get() = id
 
+    @Deprecated(
+        "Use copyWithPresentedOfferingContext instead",
+        ReplaceWith("copyWithPresentedOfferingContext(PresentedOfferingContext(offeringId))"),
+    )
     override fun copyWithOfferingId(offeringId: String): StoreProduct {
+        return copyWithPresentedOfferingContext(PresentedOfferingContext(offeringId))
+    }
+
+    override fun copyWithPresentedOfferingContext(presentedOfferingContext: PresentedOfferingContext): StoreProduct {
         return this
     }
 
@@ -106,10 +122,15 @@ private class TestSubscriptionOption(
     override val pricingPhases: List<PricingPhase>,
     val basePlanId: String = "testBasePlanId",
     override val tags: List<String> = emptyList(),
-    override val presentedOfferingIdentifier: String? = "offering",
+    override val presentedOfferingContext: PresentedOfferingContext = PresentedOfferingContext(
+        offeringIdentifier = "offering",
+    ),
 ) : SubscriptionOption {
     override val id: String
         get() = if (pricingPhases.size == 1) basePlanId else "$basePlanId:testOfferId"
+
+    override val presentedOfferingIdentifier: String?
+        get() = presentedOfferingContext.offeringIdentifier
 
     override val purchasingData: PurchasingData
         get() = object : PurchasingData {


### PR DESCRIPTION
### Description
With some new incoming features, we will need to pass more context information about where the package/product was obtained from. This PR prepares for that by adding a new class `PresentedOfferingContext` which right now only holds the `presentedOfferingIdentifier` but that we can add more info later on that allows to pass more information to our servers.

#### TODO
- [ ] Fix API tests
- [ ] Fix and add tests