### PR TITLE
Paywalls: No-op on all view model methods in the Loading paywall screen

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -186,19 +186,19 @@ private class LoadingViewModel(
     private val _state = MutableStateFlow(state)
 
     override fun selectPackage(packageToSelect: TemplateConfiguration.PackageInfo) {
-        error("Not supported")
+        // no-op
     }
 
     override fun closePaywall() {
-        error("Not supported")
+        // no-op
     }
 
     override fun purchaseSelectedPackage(activity: Activity?) {
-        error("Can't purchase loading view model")
+        // no-op
     }
 
     override fun restorePurchases() {
-        error("Can't restore purchases")
+        // no-op
     }
 
     override fun clearActionError() = Unit


### PR DESCRIPTION
### Description
Still trying to figure out repro steps for #1611 since we disable touches during the loading screen... However, I noticed we can probably just ignore all taps here which should avoid the crash entirely as well. Will fix #1611 
