### PR TITLE
Add targeting to `PresentedOfferingContext`

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PresentedOfferingContextAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PresentedOfferingContextAPI.java
@@ -8,7 +8,12 @@ final class PresentedOfferingContextAPI {
         final String offeringIdentifier = presentedOfferingContext.getOfferingIdentifier();
     }
 
-    static void checkConstructor(final String offeringIdentifier, final String placementIdentifier) {
-        final PresentedOfferingContext presentedOfferingContext = new PresentedOfferingContext(offeringIdentifier, placementIdentifier);
+    static void checkConstructor(final String offeringIdentifier,
+                                 final String placementIdentifier,
+                                 final Integer targetingRevision,
+                                 final String targetingRuleId) {
+        final PresentedOfferingContext presentedOfferingContext = new PresentedOfferingContext(
+                offeringIdentifier
+                );
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PresentedOfferingContextAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PresentedOfferingContextAPI.java
@@ -8,12 +8,7 @@ final class PresentedOfferingContextAPI {
         final String offeringIdentifier = presentedOfferingContext.getOfferingIdentifier();
     }
 
-    static void checkConstructor(final String offeringIdentifier,
-                                 final String placementIdentifier,
-                                 final Integer targetingRevision,
-                                 final String targetingRuleId) {
-        final PresentedOfferingContext presentedOfferingContext = new PresentedOfferingContext(
-                offeringIdentifier
-                );
+    static void checkConstructor(final String offeringIdentifier) {
+        final PresentedOfferingContext presentedOfferingContext = new PresentedOfferingContext(offeringIdentifier);
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
@@ -44,14 +44,7 @@ final class StoreProductAPI {
 
         final StoreProduct copyWithOfferingId = product.copyWithOfferingId("offeringId");
         final StoreProduct copyWithContext = product.copyWithPresentedOfferingContext(
-                new PresentedOfferingContext(
-                        "offeringId",
-                        "placementId",
-                        new PresentedOfferingContext.TargetingContext(
-                                1,
-                                "ruleId"
-                        )
-                )
+                new PresentedOfferingContext("offeringId")
         );
     }
 

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
@@ -47,8 +47,11 @@ final class StoreProductAPI {
                 new PresentedOfferingContext(
                         "offeringId",
                         "placementId",
-                        1,
-                        "ruleId")
+                        new PresentedOfferingContext.TargetingContext(
+                                1,
+                                "ruleId"
+                        )
+                )
         );
     }
 

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreProductAPI.java
@@ -43,7 +43,13 @@ final class StoreProductAPI {
         AmazonStoreProduct underlyingAmazonProduct = AmazonStoreProductKt.getAmazonProduct(product);
 
         final StoreProduct copyWithOfferingId = product.copyWithOfferingId("offeringId");
-        final StoreProduct copyWithContext = product.copyWithPresentedOfferingContext(new PresentedOfferingContext("offeringId", "placementId"));
+        final StoreProduct copyWithContext = product.copyWithPresentedOfferingContext(
+                new PresentedOfferingContext(
+                        "offeringId",
+                        "placementId",
+                        1,
+                        "ruleId")
+        );
     }
 
     static void check(final ProductType type) {

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PresentedOfferingContextAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PresentedOfferingContextAPI.kt
@@ -6,34 +6,11 @@ import com.revenuecat.purchases.PresentedOfferingContext
 private class PresentedOfferingContextAPI {
     fun check(presentedOfferingContext: PresentedOfferingContext) {
         val offeringIdentifier: String = presentedOfferingContext.offeringIdentifier
-        val placementIdentifier: String? = presentedOfferingContext.placementIdentifier
-        val targetingContext: PresentedOfferingContext.TargetingContext? = presentedOfferingContext.targetingContext
     }
 
     fun checkConstructor(
         offeringId: String,
-        placementId: String?,
-        targetingContext: PresentedOfferingContext.TargetingContext,
     ) {
         val poc1 = PresentedOfferingContext(offeringId)
-        val poc2 = PresentedOfferingContext(offeringId, placementId)
-        val poc3 = PresentedOfferingContext(offeringId, placementId, null)
-        val poc4 = PresentedOfferingContext(offeringId, null, targetingContext)
-        val poc5 = PresentedOfferingContext(offeringId, placementId, targetingContext)
-    }
-}
-
-@Suppress("unused", "UNUSED_VARIABLE")
-private class TargetingContextAPI {
-    fun check(targetingContext: PresentedOfferingContext.TargetingContext) {
-        val revision: Int = targetingContext.revision
-        val ruleId: String = targetingContext.ruleId
-    }
-
-    fun checkConstructor(
-        revision: Int,
-        ruleId: String,
-    ) {
-        val targetingContext = PresentedOfferingContext.TargetingContext(revision, ruleId)
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PresentedOfferingContextAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PresentedOfferingContextAPI.kt
@@ -22,3 +22,18 @@ private class PresentedOfferingContextAPI {
         val poc5 = PresentedOfferingContext(offeringId, placementId, targetingContext)
     }
 }
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class TargetingContextAPI {
+    fun check(targetingContext: PresentedOfferingContext.TargetingContext) {
+        val revision: Int = targetingContext.revision
+        val ruleId: String = targetingContext.ruleId
+    }
+
+    fun checkConstructor(
+        revision: Int,
+        ruleId: String,
+    ) {
+        val targetingContext = PresentedOfferingContext.TargetingContext(revision, ruleId)
+    }
+}

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PresentedOfferingContextAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PresentedOfferingContextAPI.kt
@@ -6,9 +6,17 @@ import com.revenuecat.purchases.PresentedOfferingContext
 private class PresentedOfferingContextAPI {
     fun check(presentedOfferingContext: PresentedOfferingContext) {
         val offeringIdentifier: String = presentedOfferingContext.offeringIdentifier
+        val placementIdentifier: String? = presentedOfferingContext.placementIdentifier
+        val targetingRevision: Int? = presentedOfferingContext.targetingRevision
+        val targetingRuleId: String? = presentedOfferingContext.targetingRuleId
     }
 
-    fun checkConstructor(offeringId: String, placementId: String?) {
-        val presentedOfferingContext = PresentedOfferingContext(offeringId, placementId)
+    fun checkConstructor(offeringId: String, placementId: String?, targetingRevision: Int?, targetingRuleId: String?) {
+        val presentedOfferingContext = PresentedOfferingContext(
+            offeringId,
+            placementId,
+            targetingRevision,
+            targetingRuleId,
+        )
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PresentedOfferingContextAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PresentedOfferingContextAPI.kt
@@ -7,16 +7,18 @@ private class PresentedOfferingContextAPI {
     fun check(presentedOfferingContext: PresentedOfferingContext) {
         val offeringIdentifier: String = presentedOfferingContext.offeringIdentifier
         val placementIdentifier: String? = presentedOfferingContext.placementIdentifier
-        val targetingRevision: Int? = presentedOfferingContext.targetingRevision
-        val targetingRuleId: String? = presentedOfferingContext.targetingRuleId
+        val targetingContext: PresentedOfferingContext.TargetingContext? = presentedOfferingContext.targetingContext
     }
 
-    fun checkConstructor(offeringId: String, placementId: String?, targetingRevision: Int?, targetingRuleId: String?) {
-        val presentedOfferingContext = PresentedOfferingContext(
-            offeringId,
-            placementId,
-            targetingRevision,
-            targetingRuleId,
-        )
+    fun checkConstructor(
+        offeringId: String,
+        placementId: String?,
+        targetingContext: PresentedOfferingContext.TargetingContext,
+    ) {
+        val poc1 = PresentedOfferingContext(offeringId)
+        val poc2 = PresentedOfferingContext(offeringId, placementId)
+        val poc3 = PresentedOfferingContext(offeringId, placementId, null)
+        val poc4 = PresentedOfferingContext(offeringId, null, targetingContext)
+        val poc5 = PresentedOfferingContext(offeringId, placementId, targetingContext)
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
@@ -44,7 +44,14 @@ private class StoreProductAPI {
             val underlyingAmazonProduct: AmazonStoreProduct? = amazonProduct
             val copiedProductWithOfferingId: StoreProduct = copyWithOfferingId("offeringId")
             val copiedProduct: StoreProduct = copyWithPresentedOfferingContext(null)
-            val copiedProduct2: StoreProduct = copyWithPresentedOfferingContext(PresentedOfferingContext("offeringId"))
+            val copiedProduct2: StoreProduct = copyWithPresentedOfferingContext(
+                PresentedOfferingContext(
+                    offeringIdentifier = "offeringId",
+                    placementIdentifier = "placementId",
+                    targetingRevision = 1,
+                    targetingRuleId = "ruleId",
+                ),
+            )
         }
     }
 

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
@@ -48,8 +48,10 @@ private class StoreProductAPI {
                 PresentedOfferingContext(
                     offeringIdentifier = "offeringId",
                     placementIdentifier = "placementId",
-                    targetingRevision = 1,
-                    targetingRuleId = "ruleId",
+                    targetingContext = PresentedOfferingContext.TargetingContext(
+                        revision = 1,
+                        ruleId = "ruleId",
+                    ),
                 ),
             )
         }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreProductAPI.kt
@@ -47,11 +47,6 @@ private class StoreProductAPI {
             val copiedProduct2: StoreProduct = copyWithPresentedOfferingContext(
                 PresentedOfferingContext(
                     offeringIdentifier = "offeringId",
-                    placementIdentifier = "placementId",
-                    targetingContext = PresentedOfferingContext.TargetingContext(
-                        revision = 1,
-                        ruleId = "ruleId",
-                    ),
                 ),
             )
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offerings.kt
@@ -10,8 +10,9 @@ data class Offerings internal constructor(
     val current: Offering?,
     val all: Map<String, Offering>,
     internal val placements: Placements? = null,
+    internal val targeting: Targeting? = null,
 ) {
-    constructor(current: Offering?, all: Map<String, Offering>) : this(current, all, null)
+    constructor(current: Offering?, all: Map<String, Offering>) : this(current, all, null, null)
 
     /**
      * Retrieves an specific offering by its identifier.
@@ -43,9 +44,19 @@ data class Offerings internal constructor(
         val showNoOffering = placements.offeringIdsByPlacement.containsKey(placementId)
         val offering = offeringForPlacement ?: if (showNoOffering) null else fallbackOffering
 
-        return offering?.withPlacement(placementId)
+        return offering?.withPresentedContext(placementId = placementId, targeting = this.targeting)
     }
 }
+
+/**
+ * This class contains information about the targeting that presented the offering.
+ * @property revision The revision of the targeting that presented the offering.
+ * @property ruleId The rule id of the targeting that presented the offering.
+ */
+internal data class Targeting(
+    val revision: Int,
+    val ruleId: String,
+)
 
 /**
  * This class contains all the offerings by placement configured in RevenueCat dashboard.
@@ -58,9 +69,13 @@ internal data class Placements(
     val offeringIdsByPlacement: Map<String, String?>,
 )
 
-private fun Offering.withPlacement(placementId: String): Offering {
+internal fun Offering.withPresentedContext(placementId: String?, targeting: Targeting?): Offering {
     val updatedAvailablePackages = this.availablePackages.map {
-        val context = it.presentedOfferingContext.copy(placementIdentifier = placementId)
+        val context = it.presentedOfferingContext.copy(
+            placementIdentifier = placementId,
+            targetingRevision = targeting?.revision,
+            targetingRuleId = targeting?.ruleId,
+        )
         val product = it.product.copyWithPresentedOfferingContext(context)
 
         Package(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
@@ -7,7 +7,7 @@ import kotlinx.parcelize.Parcelize
  * Contains data about the context in which an offering was presented.
  */
 @Parcelize
-data class PresentedOfferingContext(
+data class PresentedOfferingContext internal constructor(
     /**
      * The identifier of the offering used to obtain this object.
      */
@@ -17,6 +17,23 @@ data class PresentedOfferingContext(
      * The identifier of the placement used to obtain this object.
      */
     internal val placementIdentifier: String? = null,
+    /**
+     * The targeting context used to obtain this object.
+     */
+    internal val targetingContext: TargetingContext? = null,
 ) : Parcelable {
-    constructor(offeringIdentifier: String) : this(offeringIdentifier, null)
+    constructor(offeringIdentifier: String) : this(offeringIdentifier, null, null)
+
+    @Parcelize
+    internal data class TargetingContext(
+        /**
+         * The revision of the targeting used to obtain this object.
+         */
+        val revision: Int,
+
+        /**
+         * The rule id from the targeting used to obtain this object.
+         */
+        val ruleId: String,
+    ) : Parcelable
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
@@ -12,7 +12,6 @@ data class PresentedOfferingContext internal constructor(
      * The identifier of the offering used to obtain this object.
      */
     val offeringIdentifier: String,
-
     /**
      * The identifier of the placement used to obtain this object.
      */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -213,12 +213,8 @@ internal class Backend(
             "is_restore" to isRestore,
             "presented_offering_identifier" to receiptInfo.presentedOfferingContext?.offeringIdentifier,
             "presented_placement_identifier" to receiptInfo.presentedOfferingContext?.placementIdentifier,
-            "applied_targeting_rule" to receiptInfo.presentedOfferingContext?.let {
-                return@let if (it.targetingRevision != null && it.targetingRuleId != null) {
-                    mapOf("revision" to it.targetingRevision, "rule_id" to it.targetingRuleId)
-                } else {
-                    null
-                }
+            "applied_targeting_rule" to receiptInfo.presentedOfferingContext?.targetingContext?.let {
+                return@let mapOf("revision" to it.revision, "rule_id" to it.ruleId)
             },
             "observer_mode" to observerMode,
             "price" to receiptInfo.price,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -213,6 +213,13 @@ internal class Backend(
             "is_restore" to isRestore,
             "presented_offering_identifier" to receiptInfo.presentedOfferingContext?.offeringIdentifier,
             "presented_placement_identifier" to receiptInfo.presentedOfferingContext?.placementIdentifier,
+            "applied_targeting_rule" to receiptInfo.presentedOfferingContext?.let {
+                return@let if (it.targetingRevision != null && it.targetingRuleId != null) {
+                    mapOf("revision" to it.targetingRevision, "rule_id" to it.targetingRuleId)
+                } else {
+                    null
+                }
+            },
             "observer_mode" to observerMode,
             "price" to receiptInfo.price,
             "currency" to receiptInfo.currency,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -10,6 +10,8 @@ import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.strings.OfferingStrings
 import com.revenuecat.purchases.utils.getNullableString
+import com.revenuecat.purchases.utils.optNullableInt
+import com.revenuecat.purchases.utils.optNullableString
 import com.revenuecat.purchases.utils.replaceJsonNullWithKotlinNull
 import com.revenuecat.purchases.utils.toMap
 import com.revenuecat.purchases.withPresentedContext
@@ -53,10 +55,15 @@ internal abstract class OfferingParser {
         }
 
         val targeting: Offerings.Targeting? = offeringsJson.optJSONObject("targeting")?.let {
-            val revision = it.getInt("revision")
-            val ruleId = it.getString("rule_id")
+            val revision = it.optNullableInt("revision")
+            val ruleId = it.optNullableString("rule_id")
 
-            return@let Offerings.Targeting(revision, ruleId)
+            return@let if (revision != null && ruleId != null) {
+                Offerings.Targeting(revision, ruleId)
+            } else {
+                warnLog(OfferingStrings.TARGETING_ERROR)
+                null
+            }
         }
 
         val placements: Offerings.Placements? = offeringsJson.optJSONObject("placements")?.let {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -5,9 +5,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
-import com.revenuecat.purchases.Placements
 import com.revenuecat.purchases.PresentedOfferingContext
-import com.revenuecat.purchases.Targeting
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.strings.OfferingStrings
@@ -54,21 +52,21 @@ internal abstract class OfferingParser {
             }
         }
 
-        val targeting: Targeting? = offeringsJson.optJSONObject("targeting")?.let {
+        val targeting: Offerings.Targeting? = offeringsJson.optJSONObject("targeting")?.let {
             val revision = it.getInt("revision")
             val ruleId = it.getString("rule_id")
 
-            return@let Targeting(revision, ruleId)
+            return@let Offerings.Targeting(revision, ruleId)
         }
 
-        val placements: Placements? = offeringsJson.optJSONObject("placements")?.let {
+        val placements: Offerings.Placements? = offeringsJson.optJSONObject("placements")?.let {
             val fallbackOfferingId = it.getNullableString("fallback_offering_id")
             val offeringIdsByPlacement = it.optJSONObject("offering_ids_by_placement")
                 ?.toMap<String?>()
                 ?.replaceJsonNullWithKotlinNull()
 
             return@let offeringIdsByPlacement?.let {
-                Placements(
+                Offerings.Placements(
                     fallbackOfferingId = fallbackOfferingId,
                     offeringIdsByPlacement = offeringIdsByPlacement,
                 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -37,4 +37,5 @@ internal object OfferingStrings {
         "https://rev.cat/how-to-configure-offerings.\nMore information: https://rev.cat/why-are-offerings-empty"
     const val ERROR_FETCHING_OFFERINGS_USING_DISK_CACHE = "Error fetching offerings. Using disk cache."
     const val PLACEMENTS_EMPTY_ERROR = "Error while fetching placements - no placements defined"
+    const val TARGETING_ERROR = "Error while parsing targeting - skipping"
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JSONObjectExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/JSONObjectExtensions.kt
@@ -10,7 +10,11 @@ internal fun JSONObject.optDate(jsonKey: String): Date? = takeUnless { this.isNu
 
 internal fun JSONObject.getNullableString(name: String): String? = takeUnless { this.isNull(name) }?.getString(name)
 
+internal fun JSONObject.getNullableInt(name: String): Int? = takeUnless { this.isNull(name) }?.getInt(name)
+
 internal fun JSONObject.optNullableString(name: String): String? = takeIf { this.has(name) }?.getNullableString(name)
+
+internal fun JSONObject.optNullableInt(name: String): Int? = takeIf { this.has(name) }?.getNullableInt(name)
 
 internal fun <T> JSONObject.toMap(deep: Boolean = false): Map<String, T> {
     return this.keys().asSequence().map { jsonKey ->

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
@@ -1400,6 +1400,39 @@ class BackendTest {
         assertThat(requestBodySlot.captured["presented_placement_identifier"]).isEqualTo("placement_a")
     }
 
+    @Test
+    fun `postReceipt passes applied targeting rule in body`() {
+        val receiptInfo = ReceiptInfo(
+            productIDs = productIDs,
+            storeProduct = storeProduct,
+            presentedOfferingContext = PresentedOfferingContext(
+                "offering_a",
+                targetingRevision = 1,
+                targetingRuleId = "abc123"
+            ),
+        )
+
+        val expectedStoreUserId = "id"
+
+        mockPostReceiptResponseAndPost(
+            backend,
+            responseCode = 200,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            observerMode = true,
+            receiptInfo = receiptInfo,
+            storeAppUserID = expectedStoreUserId,
+            initiationSource = initiationSource,
+        )
+
+        assertThat(requestBodySlot.isCaptured).isTrue
+        assertThat(requestBodySlot.captured["applied_targeting_rule"]).isEqualTo(mapOf(
+            "revision" to 1,
+            "rule_id" to "abc123",
+        ))
+    }
+
     // endregion
 
     // region getOfferings

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
@@ -1407,8 +1407,10 @@ class BackendTest {
             storeProduct = storeProduct,
             presentedOfferingContext = PresentedOfferingContext(
                 "offering_a",
-                targetingRevision = 1,
-                targetingRuleId = "abc123"
+                targetingContext = PresentedOfferingContext.TargetingContext(
+                    revision = 1,
+                    ruleId = "abc123",
+                ),
             ),
         )
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
@@ -94,6 +94,69 @@ class OfferingsFactoryTest {
             "'current_offering_id': '$STUB_OFFERING_IDENTIFIER'" +
             "}"
     )
+    private val oneOfferingWithPlacement = JSONObject(
+        "" +
+            "{" +
+            "'offerings': [" +
+            "{" +
+            "'identifier': '$STUB_OFFERING_IDENTIFIER', " +
+            "'description': 'This is the base offering', " +
+            "'packages': [" +
+            "{'identifier': '\$rc_monthly','platform_product_identifier': '$STUB_PRODUCT_IDENTIFIER'}" +
+            "]" +
+            "}" +
+            "]," +
+            "'current_offering_id': '$STUB_OFFERING_IDENTIFIER',\n" +
+            "'placements': {\n" +
+            "    \"fallback_offering_id\": \"standard\",\n" +
+            "    \"offering_ids_by_placement\": {\n" +
+            "        \"onboarding\": null,\n" +
+            "        \"gate\": \"big_feature\"\n" +
+            "    }\n" +
+            "}" +
+            "}"
+    )
+    private val oneOfferingWithPlacementWithNullFallback = JSONObject(
+        "" +
+            "{" +
+            "'offerings': [" +
+            "{" +
+            "'identifier': '$STUB_OFFERING_IDENTIFIER', " +
+            "'description': 'This is the base offering', " +
+            "'packages': [" +
+            "{'identifier': '\$rc_monthly','platform_product_identifier': '$STUB_PRODUCT_IDENTIFIER'}" +
+            "]" +
+            "}" +
+            "]," +
+            "'current_offering_id': '$STUB_OFFERING_IDENTIFIER',\n" +
+            "'placements': {\n" +
+            "    \"fallback_offering_id\": null,\n" +
+            "    \"offering_ids_by_placement\": {\n" +
+            "        \"onboarding\": null,\n" +
+            "        \"gate\": \"big_feature\"\n" +
+            "    }\n" +
+            "}" +
+            "}"
+    )
+    private val oneOfferingWithTargeting = JSONObject(
+        "" +
+            "{" +
+            "'offerings': [" +
+            "{" +
+            "'identifier': '$STUB_OFFERING_IDENTIFIER', " +
+            "'description': 'This is the base offering', " +
+            "'packages': [" +
+            "{'identifier': '\$rc_monthly','platform_product_identifier': '$STUB_PRODUCT_IDENTIFIER'}" +
+            "]" +
+            "}" +
+            "]," +
+            "'current_offering_id': '$STUB_OFFERING_IDENTIFIER',\n" +
+            "'targeting': {\n" +
+            "    \"revision\": 1,\n" +
+            "    \"rule_id\": \"abc123\"\n" +
+            "}" +
+            "}"
+    )
 
     private val oneOfferingResponse = JSONObject(ONE_OFFERINGS_RESPONSE)
     private val oneOfferingInAppProductResponse = JSONObject(ONE_OFFERINGS_INAPP_PRODUCT_RESPONSE)
@@ -233,6 +296,72 @@ class OfferingsFactoryTest {
         assertThat(offerings).isNotNull
         assertThat(offerings!!.current).isNotNull
         assertThat(offerings!!.current?.paywall).isNull()
+    }
+
+    @Test
+    fun `createOfferings with placement`() {
+        val productIds = listOf(productId)
+        mockStoreProduct(productIds, emptyList(), ProductType.SUBS)
+        mockStoreProduct(productIds, productIds, ProductType.INAPP)
+
+        var offerings: Offerings? = null
+        offeringsFactory.createOfferings(
+            offeringsJSON = oneOfferingWithPlacement,
+            onError = { fail("Error: $it") },
+            onSuccess = { offerings = it }
+        )
+
+        assertThat(offerings).isNotNull
+        assertThat(offerings!!.current).isNotNull
+        assertThat(offerings!!.placements).isNotNull
+        assertThat(offerings!!.placements!!.fallbackOfferingId).isEqualTo("standard")
+        assertThat(offerings!!.placements!!.offeringIdsByPlacement).isEqualTo(mapOf(
+            "onboarding" to null,
+            "gate" to "big_feature"
+        ))
+    }
+
+    @Test
+    fun `createOfferings with placement with null fallback`() {
+        val productIds = listOf(productId)
+        mockStoreProduct(productIds, emptyList(), ProductType.SUBS)
+        mockStoreProduct(productIds, productIds, ProductType.INAPP)
+
+        var offerings: Offerings? = null
+        offeringsFactory.createOfferings(
+            offeringsJSON = oneOfferingWithPlacementWithNullFallback,
+            onError = { fail("Error: $it") },
+            onSuccess = { offerings = it }
+        )
+
+        assertThat(offerings).isNotNull
+        assertThat(offerings!!.current).isNotNull
+        assertThat(offerings!!.placements).isNotNull
+        assertThat(offerings!!.placements!!.fallbackOfferingId).isNull()
+        assertThat(offerings!!.placements!!.offeringIdsByPlacement).isEqualTo(mapOf(
+            "onboarding" to null,
+            "gate" to "big_feature"
+        ))
+    }
+
+    @Test
+    fun `createOfferings with targeting`() {
+        val productIds = listOf(productId)
+        mockStoreProduct(productIds, emptyList(), ProductType.SUBS)
+        mockStoreProduct(productIds, productIds, ProductType.INAPP)
+
+        var offerings: Offerings? = null
+        offeringsFactory.createOfferings(
+            offeringsJSON = oneOfferingWithTargeting,
+            onError = { fail("Error: $it") },
+            onSuccess = { offerings = it }
+        )
+
+        assertThat(offerings).isNotNull
+        assertThat(offerings!!.current).isNotNull
+        assertThat(offerings!!.targeting).isNotNull
+        assertThat(offerings!!.targeting!!.revision).isEqualTo(1)
+        assertThat(offerings!!.targeting!!.ruleId).isEqualTo("abc123")
     }
 
     // region helpers

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsFactoryTest.kt
@@ -358,10 +358,23 @@ class OfferingsFactoryTest {
         )
 
         assertThat(offerings).isNotNull
-        assertThat(offerings!!.current).isNotNull
         assertThat(offerings!!.targeting).isNotNull
         assertThat(offerings!!.targeting!!.revision).isEqualTo(1)
         assertThat(offerings!!.targeting!!.ruleId).isEqualTo("abc123")
+
+        assertThat(
+            offerings!!.current!!.availablePackages.first().presentedOfferingContext.targetingContext
+        ).isNotNull()
+        assertThat(
+            offerings!!.current!!.availablePackages.first().presentedOfferingContext.targetingContext!!.revision
+        ).isEqualTo(1)
+        assertThat(
+            offerings!!.current!!.availablePackages.first().presentedOfferingContext.targetingContext!!.ruleId
+        ).isEqualTo("abc123")
+
+        assertThat(
+            offerings!!.all.values.first().availablePackages.first().presentedOfferingContext.targetingContext
+        ).isNull()
     }
 
     // region helpers

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -5,7 +5,6 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
-import com.revenuecat.purchases.Placements
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.common.MICROS_MULTIPLIER


### PR DESCRIPTION
### Motivation

Get more context with targeting information 

### Description

- Parse targeting information into `Offerings`
- Add targeting context into `Offerings.current`
- Add targeting context into `getCurrentOffering(forPlacement: String)`
- Post targeting context in post receipts
