### PR TITLE
Make all `PresentedOfferingContext` public

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PresentedOfferingContextAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PresentedOfferingContextAPI.java
@@ -6,9 +6,22 @@ import com.revenuecat.purchases.PresentedOfferingContext;
 final class PresentedOfferingContextAPI {
     static void check(final PresentedOfferingContext presentedOfferingContext) {
         final String offeringIdentifier = presentedOfferingContext.getOfferingIdentifier();
+        final String placementIdentifier = presentedOfferingContext.getPlacementIdentifier();
+        final PresentedOfferingContext.TargetingContext targetingContext = presentedOfferingContext.getTargetingContext();
     }
 
     static void checkConstructor(final String offeringIdentifier) {
-        final PresentedOfferingContext presentedOfferingContext = new PresentedOfferingContext(offeringIdentifier);
+        final PresentedOfferingContext presentedOfferingContext = new PresentedOfferingContext(offeringIdentifier, null, null);
+    }
+}
+
+final class TargetingContextAPI {
+    static void check(final PresentedOfferingContext.TargetingContext targetingContext) {
+        final int revision = targetingContext.getRevision();
+        final String ruleId = targetingContext.getRuleId();
+    }
+
+    static void checkConstructor(final int revision, final String ruleId) {
+        final PresentedOfferingContext.TargetingContext targetingContext = new PresentedOfferingContext.TargetingContext(revision, ruleId);
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PresentedOfferingContextAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PresentedOfferingContextAPI.kt
@@ -6,11 +6,32 @@ import com.revenuecat.purchases.PresentedOfferingContext
 private class PresentedOfferingContextAPI {
     fun check(presentedOfferingContext: PresentedOfferingContext) {
         val offeringIdentifier: String = presentedOfferingContext.offeringIdentifier
+        val placementIdentifier: String? = presentedOfferingContext.placementIdentifier
+        val targetingContext: PresentedOfferingContext.TargetingContext? = presentedOfferingContext.targetingContext
     }
 
     fun checkConstructor(
         offeringId: String,
+        placementId: String?,
+        targetingContext: PresentedOfferingContext.TargetingContext?,
     ) {
         val poc1 = PresentedOfferingContext(offeringId)
+        val poc2 = PresentedOfferingContext(offeringId, placementId)
+        val poc3 = PresentedOfferingContext(offeringId, placementId, targetingContext)
+    }
+}
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class TargetingContextAPI {
+    fun check(targetingContext: PresentedOfferingContext.TargetingContext) {
+        val revision: Int = targetingContext.revision
+        val ruleID: String = targetingContext.ruleId
+    }
+
+    fun checkConstructor(
+        revision: Int,
+        ruleId: String,
+    ) {
+        val targetingContext = PresentedOfferingContext.TargetingContext(revision, ruleId)
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PresentedOfferingContext.kt
@@ -7,7 +7,7 @@ import kotlinx.parcelize.Parcelize
  * Contains data about the context in which an offering was presented.
  */
 @Parcelize
-data class PresentedOfferingContext internal constructor(
+data class PresentedOfferingContext @JvmOverloads constructor(
     /**
      * The identifier of the offering used to obtain this object.
      */
@@ -15,16 +15,16 @@ data class PresentedOfferingContext internal constructor(
     /**
      * The identifier of the placement used to obtain this object.
      */
-    internal val placementIdentifier: String? = null,
+    val placementIdentifier: String? = null,
     /**
      * The targeting context used to obtain this object.
      */
-    internal val targetingContext: TargetingContext? = null,
+    val targetingContext: TargetingContext? = null,
 ) : Parcelable {
     constructor(offeringIdentifier: String) : this(offeringIdentifier, null, null)
 
     @Parcelize
-    internal data class TargetingContext(
+    data class TargetingContext(
         /**
          * The revision of the targeting used to obtain this object.
          */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
@@ -21,7 +21,7 @@ data class PurchaseParams(val builder: Builder) {
     internal val activity: Activity
 
     @get:JvmSynthetic
-    internal val presentedOfferingContext: PresentedOfferingContext?
+    internal var presentedOfferingContext: PresentedOfferingContext?
 
     init {
         this.isPersonalizedPrice = builder.isPersonalizedPrice
@@ -45,7 +45,7 @@ data class PurchaseParams(val builder: Builder) {
     open class Builder private constructor(
         @get:JvmSynthetic internal val activity: Activity,
         @get:JvmSynthetic internal val purchasingData: PurchasingData,
-        @get:JvmSynthetic internal val presentedOfferingContext: PresentedOfferingContext?,
+        @get:JvmSynthetic internal var presentedOfferingContext: PresentedOfferingContext?,
         @get:JvmSynthetic internal val product: StoreProduct?,
     ) {
         constructor(activity: Activity, packageToPurchase: Package) :
@@ -89,6 +89,15 @@ data class PurchaseParams(val builder: Builder) {
         @set:JvmSynthetic
         @get:JvmSynthetic
         internal var googleReplacementMode: GoogleReplacementMode = GoogleReplacementMode.WITHOUT_PRORATION
+
+        /*
+         * Sets the data about the context in which an offering was presented.
+         *
+         * Default is set from the Package, StoreProduct, or SubscriptionOption used in the constructor.
+         */
+        fun presentedOfferingContext(presentedOfferingContext: PresentedOfferingContext) = apply {
+            this.presentedOfferingContext = presentedOfferingContext
+        }
 
         /*
          * Indicates personalized pricing on products available for purchase in the EU.


### PR DESCRIPTION
### Motivation

All of `PresentedOfferingContext` needs to be public for hybrids

### Description

- Make `placementIdentifier` and `targetingContext` public on `PresentedOfferingContext`
- Make `TargetingContext` public
