### PR TITLE
Fix amazon zero price

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostTransactionWithProductDetailsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostTransactionWithProductDetailsHelper.kt
@@ -35,7 +35,8 @@ internal class PostTransactionWithProductDetailsHelper(
                         val purchasedStoreProduct =
                             // Amazon purchases don't have subscription options
                             // Amazon is the only store that has marketplace
-                            // We want Google restores to enter in this if, that's why we need to filter Amazon only
+                            // We want Google restores to enter in this if condition,
+                            // that's why we need to filter Amazon only
                             if (transaction.type == ProductType.SUBS && transaction.marketplace == null) {
                                 storeProducts.firstOrNull { product ->
                                     product.subscriptionOptions?.let { subscriptionOptions ->
@@ -47,7 +48,7 @@ internal class PostTransactionWithProductDetailsHelper(
                                     product.id == transaction.productIds.firstOrNull()
                                 }
                             }
-                        debugLog("Purchased store product: $purchasedStoreProduct")
+                        debugLog("Store product found for transaction: $purchasedStoreProduct")
                         postReceiptHelper.postTransactionAndConsumeIfNeeded(
                             purchase = transaction,
                             storeProduct = purchasedStoreProduct,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostTransactionWithProductDetailsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostTransactionWithProductDetailsHelper.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases
 
 import com.revenuecat.purchases.common.BillingAbstract
+import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.StoreTransaction
@@ -31,18 +32,19 @@ internal class PostTransactionWithProductDetailsHelper(
                     productType = transaction.type,
                     productIds = transaction.productIds.toSet(),
                     onReceive = { storeProducts ->
-                        val purchasedStoreProduct = if (transaction.type == ProductType.SUBS) {
-                            storeProducts.firstOrNull { product ->
-                                product.subscriptionOptions?.let { subscriptionOptions ->
-                                    subscriptionOptions.any { it.id == transaction.subscriptionOptionId }
-                                } ?: false
+                        val purchasedStoreProduct =
+                            if (transaction.type == ProductType.SUBS && transaction.marketplace == null) {
+                                storeProducts.firstOrNull { product ->
+                                    product.subscriptionOptions?.let { subscriptionOptions ->
+                                        subscriptionOptions.any { it.id == transaction.subscriptionOptionId }
+                                    } ?: false
+                                }
+                            } else {
+                                storeProducts.firstOrNull { product ->
+                                    product.id == transaction.productIds.firstOrNull()
+                                }
                             }
-                        } else {
-                            storeProducts.firstOrNull { product ->
-                                product.id == transaction.productIds.firstOrNull()
-                            }
-                        }
-
+                        debugLog("Purchased store product: $purchasedStoreProduct")
                         postReceiptHelper.postTransactionAndConsumeIfNeeded(
                             purchase = transaction,
                             storeProduct = purchasedStoreProduct,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostTransactionWithProductDetailsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostTransactionWithProductDetailsHelper.kt
@@ -33,6 +33,9 @@ internal class PostTransactionWithProductDetailsHelper(
                     productIds = transaction.productIds.toSet(),
                     onReceive = { storeProducts ->
                         val purchasedStoreProduct =
+                            // Amazon purchases don't have subscription options
+                            // Amazon is the only store that has marketplace
+                            // We want Google restores to enter in this if, that's why we need to filter Amazon only
                             if (transaction.type == ProductType.SUBS && transaction.marketplace == null) {
                                 storeProducts.firstOrNull { product ->
                                     product.subscriptionOptions?.let { subscriptionOptions ->


### PR DESCRIPTION
We were never posting prices for Amazon purchases, because when we try to find the purchased product, we where using the `subscriptionOptions` property, which is always null for Amazon

This fix is a bit hacky right now, but we need to ship it quickly