### PR TITLE
[EXTERNAL] Fixes a typo in PaywallColor. (#1644) via @JayShortway

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallColor.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallColor.kt
@@ -48,7 +48,7 @@ data class PaywallColor(
     }
 
     /**
-     * Creates a color from a Hex string: `#RRGGBB` or `#RRGGBBAA`.
+     * Creates a color from a Hex string: `#RRGGBB` or `#AARRGGBB`.
      */
     constructor(stringRepresentation: String) : this(
         stringRepresentation,


### PR DESCRIPTION
Contributed by @JayShortway in #1644 

### Motivation
There's a small typo in the docs of `PaywallColor`. `#RRGGBBAA` should have been `#AARRGGBB`, according to the docs of the underlying API being used ([`Color.parseColor()`](https://developer.android.com/reference/android/graphics/Color#parseColor(java.lang.String))). 
 
Regarding `purchases-ios`, `parseColor` in `PaywallColor.swift` does seem to follow the RRGGBBAA pattern, so the documentation is correct there. I couldn't find this API in the hybrids.  

Resolves #1643 

### Description
The documentation is aligned with the documentation of the underlying API. 
