### PR TITLE
Correctly support RGBA colors

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallColorAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/revenuecatui/PaywallColorAPI.java
@@ -1,0 +1,19 @@
+package com.revenuecat.apitester.java.revenuecatui;
+
+import android.graphics.Color;
+
+import com.revenuecat.purchases.paywalls.PaywallColor;
+
+@SuppressWarnings({"unused"})
+final class PaywallColorAPI {
+    static void check(PaywallColor paywallColor) {
+        String stringRepresentation = paywallColor.getStringRepresentation();
+        Color underlyingColor = paywallColor.getUnderlyingColor();
+        Integer colorInt = paywallColor.getColorInt();
+    }
+
+    static void checkConstructor(Integer colorInt) {
+        PaywallColor paywallColor = new PaywallColor("#FFFFFF");
+        PaywallColor paywallColor2 = new PaywallColor(colorInt);
+    }
+}

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallColorAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallColorAPI.kt
@@ -1,0 +1,18 @@
+package com.revenuecat.apitester.kotlin.revenuecatui
+
+import android.graphics.Color
+import com.revenuecat.purchases.paywalls.PaywallColor
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class PaywallColorAPI {
+    fun check(paywallColor: PaywallColor) {
+        val stringRepresentation: String = paywallColor.stringRepresentation
+        val underlyingColor: Color? = paywallColor.underlyingColor
+        val colorInt: Int = paywallColor.colorInt
+    }
+
+    fun checkConstructor(colorInt: Int) {
+        val paywallColor = PaywallColor("#FFFFFF")
+        val paywallColor2 = PaywallColor(colorInt)
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallColor.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallColor.kt
@@ -33,7 +33,7 @@ data class PaywallColor(
      * The color converted to a @ColorInt representation
      */
     @ColorInt
-    val colorInt: Int = Color.parseColor(stringRepresentation)
+    val colorInt: Int = parseRGBAColor(stringRepresentation)
 
     object Serializer : KSerializer<PaywallColor> {
         override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("PaywallColor", PrimitiveKind.STRING)
@@ -53,7 +53,7 @@ data class PaywallColor(
     constructor(stringRepresentation: String) : this(
         stringRepresentation,
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            Color.valueOf(Color.parseColor(stringRepresentation))
+            Color.valueOf(parseRGBAColor(stringRepresentation))
         } else {
             null
         },
@@ -67,4 +67,23 @@ data class PaywallColor(
             null
         },
     )
+
+    companion object {
+        private val rgbaColorRegex = Regex("^#([A-Fa-f0-9]{8})$")
+
+        @Suppress("MagicNumber")
+        @ColorInt
+        private fun parseRGBAColor(stringRepresentation: String): Int {
+            return if (stringRepresentation.matches(rgbaColorRegex)) {
+                val radix = 16
+                val r = stringRepresentation.substring(1, 3).toInt(radix)
+                val g = stringRepresentation.substring(3, 5).toInt(radix)
+                val b = stringRepresentation.substring(5, 7).toInt(radix)
+                val a = stringRepresentation.substring(7, 9).toInt(radix)
+                Color.argb(a, r, g, b)
+            } else {
+                Color.parseColor(stringRepresentation)
+            }
+        }
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallColorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallColorTest.kt
@@ -35,10 +35,10 @@ class PaywallColorTest {
     @Test
     fun `paywall color can be created from RGBA string`() {
         val stringRepresentation = "#FFAABB11"
+        val expectedColor = Color.argb("11".toInt(16), "FF".toInt(16), "AA".toInt(16), "BB".toInt(16))
         val paywallColor = PaywallColor(stringRepresentation)
-        val color = Color.valueOf(Color.parseColor(stringRepresentation))
 
         assertThat(stringRepresentation).isEqualTo(paywallColor.stringRepresentation)
-        assertThat(color).isEqualTo(paywallColor.underlyingColor)
+        assertThat(paywallColor.underlyingColor).isEqualTo(Color.valueOf(expectedColor))
     }
 }


### PR DESCRIPTION
### Description
We were parsing RGBA paywall colors as ARGB. This isn't a problem right now since we currently don't support alpha colors in paywalls, but in case we do in the future, we need to match iOS, which uses RGBA.
