### PR TITLE
Add space to title in Template 5

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/UIConstant.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/UIConstant.kt
@@ -20,7 +20,7 @@ internal object UIConstant {
     // But lower than 1.0f
     const val halfWeight = 0.5f
 
-    val closeButtonSize = 24.dp
+    val iconButtonSize = 48.dp
 
     fun <T> defaultAnimation() = tween<T>(
         durationMillis = defaultAnimationDurationMillis,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/UIConstant.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/UIConstant.kt
@@ -20,6 +20,8 @@ internal object UIConstant {
     // But lower than 1.0f
     const val halfWeight = 0.5f
 
+    val closeButtonSize = 24.dp
+
     fun <T> defaultAnimation() = tween<T>(
         durationMillis = defaultAnimationDurationMillis,
         easing = LinearOutSlowInEasing,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
@@ -144,7 +144,7 @@ private fun ColumnScope.Template5PortraitContent(
                 if (!state.shouldDisplayDismissButton) {
                     StatusBarSpacer()
                 }
-                Spacer(Modifier.height(UIConstant.closeButtonSize))
+                Spacer(Modifier.height(UIConstant.iconButtonSize))
             }
             Title(state)
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
@@ -65,6 +65,7 @@ import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIcon
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIconName
 import com.revenuecat.purchases.ui.revenuecatui.composables.PurchaseButton
 import com.revenuecat.purchases.ui.revenuecatui.composables.RemoteImage
+import com.revenuecat.purchases.ui.revenuecatui.composables.StatusBarSpacer
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.currentColors
@@ -121,8 +122,9 @@ private fun ColumnScope.Template5PortraitContent(
     viewModel: PaywallViewModel,
     packageSelectionVisible: Boolean,
 ) {
+    val headerUri = state.templateConfiguration.images.headerUri
     if (state.isInFullScreenMode) {
-        HeaderImage(state.templateConfiguration.images.headerUri)
+        HeaderImage(headerUri)
     }
 
     val scrollState = rememberScrollState()
@@ -138,6 +140,12 @@ private fun ColumnScope.Template5PortraitContent(
         verticalArrangement = Arrangement.spacedBy(UIConstant.defaultVerticalSpacing, Alignment.CenterVertically),
     ) {
         if (state.isInFullScreenMode) {
+            if (headerUri == null) {
+                if (!state.shouldDisplayDismissButton) {
+                    StatusBarSpacer()
+                }
+                Spacer(Modifier.height(UIConstant.closeButtonSize))
+            }
             Title(state)
 
             Spacer(Modifier.weight(1f))


### PR DESCRIPTION
If there's no header image in template 5, the close button overlaps the title

<img width="178" alt="Screenshot 2024-03-20 at 13 12 06" src="https://github.com/RevenueCat/purchases-android/assets/664544/03223acc-6413-412e-af38-d269c1c48c7e">

Adds some space if there's no header image:
<img width="226" alt="Screenshot 2024-03-20 at 14 48 12" src="https://github.com/RevenueCat/purchases-android/assets/664544/d9f9bb6b-ecda-4132-b865-29eced466ed1">
