### PR TITLE
Update android executor to a non-deprecated tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
     executor:
       name: android/android-machine
       resource-class: large
-      tag: 2023.11.1
+      tag: 2024.01.1
 
 version: 2.1
 orbs:


### PR DESCRIPTION
The version we are using is deprecated

https://discuss.circleci.com/t/android-image-deprecations-and-eol-for-2024/50180/15