### PR TITLE
Send diagnostics timetamps as ISO8601 string

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.common.diagnostics
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
 import com.revenuecat.purchases.utils.Event
+import com.revenuecat.purchases.utils.Iso8601Utils
 import org.json.JSONObject
 import java.util.Date
 
@@ -29,6 +30,6 @@ internal data class DiagnosticsEntry(
         put(VERSION_KEY, VERSION)
         put(NAME_KEY, name.name.lowercase())
         put(PROPERTIES_KEY, JSONObject(properties))
-        put(TIMESTAMP_KEY, dateTime.time)
+        put(TIMESTAMP_KEY, Iso8601Utils.format(dateTime))
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
@@ -13,7 +13,7 @@ import java.util.Date
 @Config(manifest = Config.NONE)
 class DiagnosticsEntryTest {
 
-    private val testDate = Date(1675954145L) // Thursday, February 9, 2023 2:49:05 PM GMT
+    private val testDate = Date(1675954145000L) // Thursday, February 9, 2023 2:49:05 PM GMT
 
     private lateinit var testDateProvider: DateProvider
 
@@ -37,7 +37,7 @@ class DiagnosticsEntryTest {
             "\"version\":1," +
             "\"name\":\"http_request_performed\"," +
             "\"properties\":{\"test-key-1\":\"test-value-1\",\"test-key-2\":123,\"test-key-3\":true}," +
-            "\"timestamp\":1675954145" +
+            "\"timestamp\":\"2023-02-09T14:49:05.000Z\"" +
             "}"
         assertThat(eventAsString).isEqualTo(expectedString)
     }


### PR DESCRIPTION
### Description
We decided to send the diagnostics timestamp as an ISO8601 string instead of milliseconds since epoch.