### PR TITLE
Remove confusing placements error log

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -78,8 +78,6 @@ internal abstract class OfferingParser {
                     offeringIdsByPlacement = offeringIdsByPlacement,
                 )
             } ?: run {
-                // This shouldn't ever happen due to validations on the backend
-                errorLog(OfferingStrings.PLACEMENTS_EMPTY_ERROR)
                 null
             }
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -37,6 +37,5 @@ internal object OfferingStrings {
         "the RevenueCat dashboard or Play Store.\nTo configure products, follow the instructions in " +
         "https://rev.cat/how-to-configure-offerings.\nMore information: https://rev.cat/why-are-offerings-empty"
     const val ERROR_FETCHING_OFFERINGS_USING_DISK_CACHE = "Error fetching offerings. Using disk cache."
-    const val PLACEMENTS_EMPTY_ERROR = "Error while fetching placements - no placements defined"
     const val TARGETING_ERROR = "Error while parsing targeting - skipping"
 }


### PR DESCRIPTION
### Description
This removes an error log which was happening even in normal situations. The response from the backend may have a `placements` key with only a fallback, but no `offering_ids_by_placement`, which was logging it as an error, which it wasn't
