### PR TITLE
Add `doNotConsumeIAP` dangerousSetting

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 
 import com.revenuecat.purchases.CacheFetchPolicy;
 import com.revenuecat.purchases.CustomerInfo;
+import com.revenuecat.purchases.DangerousSettings;
 import com.revenuecat.purchases.EntitlementVerificationMode;
 import com.revenuecat.purchases.LogLevel;
 import com.revenuecat.purchases.Offerings;
@@ -116,16 +117,38 @@ final class PurchasesAPI {
 
     static void checkConfiguration(final Context context,
                                    final ExecutorService executorService,
-                                   final PurchasesConfiguration purchasesConfiguration) {
+                                   final PurchasesConfiguration purchasesConfiguration,
+                                   final DangerousSettings dangerousSettings) {
         final boolean configured = Purchases.isConfigured();
 
         Purchases.configure(purchasesConfiguration);
 
         final boolean debugLogs = Purchases.getDebugLogsEnabled();
+
+        PurchasesConfiguration configuration = new PurchasesConfiguration.Builder(context, "")
+                .appUserID("")
+                .observerMode(true)
+                .observerMode(false)
+                .service(executorService)
+                .diagnosticsEnabled(true)
+                .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
+                .showInAppMessagesAutomatically(true)
+                .dangerousSettings(dangerousSettings)
+                .build();
+    }
+
+    static void checkDangerousSettings(Boolean autoSyncPurchases, Boolean doNotConsumeIAP) {
+        final DangerousSettings dangerousSettings = new DangerousSettings();
+        final DangerousSettings dangerousSettings1 = new DangerousSettings(autoSyncPurchases);
+        final DangerousSettings dangerousSettings2 = new DangerousSettings(autoSyncPurchases, doNotConsumeIAP);
+
+        final Boolean autoSyncPurchases1 = dangerousSettings.getAutoSyncPurchases();
+        final Boolean doNotConsumeIAP1 = dangerousSettings.getDoNotConsumeIAP();
     }
 
     static void checkAmazonConfiguration(final Context context,
-                                         final ExecutorService executorService) {
+                                         final ExecutorService executorService,
+                                         final DangerousSettings dangerousSettings) {
         PurchasesConfiguration amazonConfiguration = new AmazonConfiguration.Builder(context, "")
                 .appUserID("")
                 .observerMode(true)
@@ -134,6 +157,7 @@ final class PurchasesAPI {
                 .diagnosticsEnabled(true)
                 .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
                 .showInAppMessagesAutomatically(true)
+                .dangerousSettings(dangerousSettings)
                 .build();
     }
 }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -3,6 +3,7 @@ package com.revenuecat.apitester.kotlin
 import android.content.Context
 import com.revenuecat.purchases.CacheFetchPolicy
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.DangerousSettings
 import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Offerings
@@ -159,7 +160,10 @@ private class PurchasesAPI {
 
     @Suppress("ForbiddenComment")
     fun checkConfiguration(
+        context: Context,
+        executorService: ExecutorService,
         purchasesConfiguration: PurchasesConfiguration,
+        dangerousSettings: DangerousSettings,
     ) {
         val features: List<BillingFeature> = ArrayList()
         val configured: Boolean = Purchases.isConfigured
@@ -167,6 +171,27 @@ private class PurchasesAPI {
         Purchases.configure(purchasesConfiguration)
 
         Purchases.debugLogsEnabled = true
+
+        val configuration: PurchasesConfiguration = PurchasesConfiguration.Builder(context, "")
+            .appUserID("")
+            .observerMode(true)
+            .observerMode(false)
+            .showInAppMessagesAutomatically(true)
+            .service(executorService)
+            .diagnosticsEnabled(true)
+            .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
+            .dangerousSettings(dangerousSettings)
+            .build()
+    }
+
+    fun checkDangerousSettings() {
+        val dangerousSettings: DangerousSettings = DangerousSettings()
+        val dangerousSettings2: DangerousSettings = DangerousSettings(autoSyncPurchases = false)
+        val dangerousSettings3: DangerousSettings = DangerousSettings(doNotConsumeIAP = true)
+        val dangerousSettings4: DangerousSettings = DangerousSettings(autoSyncPurchases = false, doNotConsumeIAP = true)
+
+        val doNotConsumeIAP: Boolean = dangerousSettings.doNotConsumeIAP
+        val autoSyncPurchases: Boolean = dangerousSettings.autoSyncPurchases
     }
 
     fun checkLogInResult(
@@ -177,7 +202,11 @@ private class PurchasesAPI {
         LogInResult(customerInfo, created)
     }
 
-    fun checkAmazonConfiguration(context: Context, executorService: ExecutorService) {
+    fun checkAmazonConfiguration(
+        context: Context,
+        executorService: ExecutorService,
+        dangerousSettings: DangerousSettings,
+    ) {
         val amazonConfiguration: PurchasesConfiguration = AmazonConfiguration.Builder(context, "")
             .appUserID("")
             .observerMode(true)
@@ -186,6 +215,7 @@ private class PurchasesAPI {
             .service(executorService)
             .diagnosticsEnabled(true)
             .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
+            .dangerousSettings(dangerousSettings)
             .build()
     }
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.revenuecat.purchases.DangerousSettings
 import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
@@ -117,6 +118,7 @@ class ConfigureFragment : Fragment() {
         val entitlementVerificationMode = EntitlementVerificationMode.values()[verificationModeIndex]
         val useAmazonStore = binding.storeRadioGroup.checkedRadioButtonId == R.id.amazon_store_radio_id
         val useObserverMode = binding.observerModeCheckbox.isChecked
+        val doNotConsumeIAP = binding.doNotConsumeIapCheckbox.isChecked
 
         val application = (requireActivity().application as MainApplication)
 
@@ -133,6 +135,7 @@ class ConfigureFragment : Fragment() {
             .diagnosticsEnabled(true)
             .entitlementVerificationMode(entitlementVerificationMode)
             .observerMode(useObserverMode)
+            .dangerousSettings(DangerousSettings(doNotConsumeIAP = doNotConsumeIAP))
             .build()
         Purchases.configure(configuration)
 

--- a/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
@@ -153,11 +153,30 @@
                 android:layout_height="wrap_content"/>
 
         <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/do_not_consume_iap_label"
+                android:text="@string/do_not_consume_iap"
+                android:textSize="15sp"
+                android:layout_marginTop="20dp"
+                app:layout_constraintTop_toBottomOf="@id/observer_mode_label"
+                app:layout_constraintStart_toStartOf="parent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+
+        <CheckBox
+                android:id="@+id/do_not_consume_iap_checkbox"
+                app:layout_constraintTop_toTopOf="@id/do_not_consume_iap_label"
+                app:layout_constraintBottom_toBottomOf="@id/do_not_consume_iap_label"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:orientation="horizontal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+
+        <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/google_unavailable_text_view"
                 android:text="@string/google_store_is_unavailable"
                 android:textAlignment="textEnd"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/observer_mode_checkbox"
+                app:layout_constraintTop_toBottomOf="@id/do_not_consume_iap_checkbox"
                 app:layout_constraintWidth_percent="0.7"
                 android:visibility="gone"
                 tools:visibility="visible"

--- a/examples/purchase-tester/src/main/res/values/strings.xml
+++ b/examples/purchase-tester/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="proxy">Proxy</string>
     <string name="buy_product">Buy Product</string>
     <string name="find_placement">Find Placement</string>
+    <string name="do_not_consume_iap">Do not consume IAP</string>
 </resources>

--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -276,7 +276,13 @@ class Purchases internal constructor(
             }
             val configuration = PurchasesConfiguration.Builder(context, apiKey)
                 .appUserID(appUserID)
-                .dangerousSettings(DangerousSettings(customEntitlementComputation = true))
+                .dangerousSettings(
+                    DangerousSettings(
+                        autoSyncPurchases = true,
+                        doNotConsumeIAP = false,
+                        customEntitlementComputation = true,
+                    ),
+                )
                 .build()
             return PurchasesFactory().createPurchases(
                 configuration,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases
 import android.app.Application
 import android.os.Handler
 import com.revenuecat.purchases.amazon.AmazonBilling
+import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
@@ -20,6 +21,7 @@ internal object BillingFactory {
         observerMode: Boolean,
         diagnosticsTrackerIfEnabled: DiagnosticsTracker?,
         stateProvider: PurchasesStateProvider,
+        appConfig: AppConfig,
     ) = when (store) {
         Store.PLAY_STORE -> BillingWrapper(
             BillingWrapper.ClientFactory(application),
@@ -27,6 +29,7 @@ internal object BillingFactory {
             cache,
             diagnosticsTrackerIfEnabled,
             stateProvider,
+            appConfig,
         )
         Store.AMAZON -> {
             try {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
@@ -9,7 +9,7 @@ data class DangerousSettings internal constructor(
      * automatically, and you will have to call syncPurchases whenever a new purchase is completed in order to send it
      * to the RevenueCat's backend. Auto syncing of purchases is enabled by default.
      */
-    val autoSyncPurchases: Boolean = true,
+    val autoSyncPurchases: Boolean,
 
     /**
      * Do not consume IAP (In app products) after a successful purchase. This can be useful when using IAP as lifetime
@@ -18,10 +18,11 @@ data class DangerousSettings internal constructor(
      * synced with multiple users in different devices, unless they are logged in with the same user ID.
      * This does not affect Amazon. This is disabled by default.
      */
-    val doNotConsumeIAP: Boolean = false,
+    val doNotConsumeIAP: Boolean,
 
     internal val customEntitlementComputation: Boolean = false,
 ) {
+    @JvmOverloads
     constructor(autoSyncPurchases: Boolean = true, doNotConsumeIAP: Boolean = false) :
-        this(autoSyncPurchases, doNotConsumeIAP, false)
+        this(autoSyncPurchases, doNotConsumeIAP, customEntitlementComputation = false)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
@@ -11,7 +11,17 @@ data class DangerousSettings internal constructor(
      */
     val autoSyncPurchases: Boolean = true,
 
+    /**
+     * Do not consume IAP (In app products) after a successful purchase. This can be useful when using IAP as lifetime
+     * products and you don't want them to disappear from the Google query method. DO NOT use this if you allow
+     * purchasing the same IAP multiple times, like for currency/items. This also means that the purchase might be
+     * synced with multiple users in different devices, unless they are logged in with the same user ID.
+     * This does not affect Amazon. This is disabled by default.
+     */
+    val doNotConsumeIAP: Boolean = false,
+
     internal val customEntitlementComputation: Boolean = false,
 ) {
-    constructor(autoSyncPurchases: Boolean = true) : this(autoSyncPurchases, false)
+    constructor(autoSyncPurchases: Boolean = true, doNotConsumeIAP: Boolean = false) :
+        this(autoSyncPurchases, doNotConsumeIAP, false)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -137,6 +137,7 @@ internal class PurchasesFactory(
                 observerMode,
                 diagnosticsTracker,
                 purchasesStateProvider,
+                appConfig,
             )
 
             val subscriberAttributesPoster = SubscriberAttributesPoster(backendHelper)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -173,6 +173,9 @@ internal class PurchasesOrchestrator constructor(
         if (!appConfig.dangerousSettings.autoSyncPurchases) {
             log(LogIntent.WARNING, ConfigureStrings.AUTO_SYNC_PURCHASES_DISABLED)
         }
+        if (appConfig.dangerousSettings.doNotConsumeIAP) {
+            log(LogIntent.DEBUG, ConfigureStrings.DO_NOT_CONSUME_IAP_ENABLED)
+        }
 
         if (isAndroidNOrNewer()) {
             diagnosticsSynchronizer?.clearDiagnosticsFileIfTooBig()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/ConfigureStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/ConfigureStrings.kt
@@ -34,6 +34,7 @@ internal object ConfigureStrings {
         "after the transaction is finished, so make sure purchases are synced before \n" +
         "finishing any consumable transaction, otherwise RevenueCat won’t register the \n" +
         "purchase."
+    const val DO_NOT_CONSUME_IAP_ENABLED = "Dangerous setting: Consumption of IAP purchases has been disabled."
     const val INSTANCE_ALREADY_EXISTS = "Purchases instance already set. " +
         "Did you mean to configure two Purchases objects?"
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/PurchaseStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/PurchaseStrings.kt
@@ -7,6 +7,8 @@ internal object PurchaseStrings {
         "BillingClient is not connected yet."
     const val CONSUMING_PURCHASE = "Consuming purchase with token %s"
     const val CONSUMING_PURCHASE_ERROR = "Error consuming purchase. Will retry next queryPurchases. %s"
+    const val NOT_CONSUMING_PURCHASE_SETTING_ENABLED = "Not consuming IAP since doNotConsumeIAP dangerous setting" +
+        " is enabled."
     const val FOUND_EXISTING_PURCHASE = "Found existing purchase for SKU: %s"
     const val NO_EXISTING_PURCHASE = "Couldn't find existing purchase for SKU: %s"
     const val ERROR_FINDING_PURCHASE = "Error finding existing purchase for SKU: %s"

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -381,6 +381,7 @@ internal open class BasePurchasesTest {
             store = Store.PLAY_STORE,
             dangerousSettings = DangerousSettings(
                 autoSyncPurchases = autoSync,
+                doNotConsumeIAP = false,
                 customEntitlementComputation = customEntitlementComputation,
             )
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases
 
 import android.app.Application
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
@@ -18,6 +19,7 @@ class BillingFactoryTest {
         val mockBackendHelper = mockk<BackendHelper>(relaxed = true)
         val mockCache = mockk<DeviceCache>(relaxed = true)
         val mockDiagnosticsTracker = mockk<DiagnosticsTracker>(relaxed = true)
+        val mockAppConfig = mockk<AppConfig>(relaxed = true)
 
         BillingFactory.createBilling(
             Store.PLAY_STORE,
@@ -26,7 +28,8 @@ class BillingFactoryTest {
             mockCache,
             observerMode = false,
             mockDiagnosticsTracker,
-            PurchasesStateCache(PurchasesState())
+            PurchasesStateCache(PurchasesState()),
+            appConfig = mockAppConfig,
         )
     }
 
@@ -35,6 +38,7 @@ class BillingFactoryTest {
         val mockApplication = mockk<Application>(relaxed = true)
         val mockBackendHelper = mockk<BackendHelper>(relaxed = true)
         val mockCache = mockk<DeviceCache>(relaxed = true)
+        val mockAppConfig = mockk<AppConfig>(relaxed = true)
 
         BillingFactory.createBilling(
             Store.PLAY_STORE,
@@ -43,7 +47,8 @@ class BillingFactoryTest {
             mockCache,
             observerMode = false,
             diagnosticsTrackerIfEnabled = null,
-            PurchasesStateCache(PurchasesState())
+            PurchasesStateCache(PurchasesState()),
+            appConfig = mockAppConfig,
         )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.PurchasesState
 import com.revenuecat.purchases.PurchasesStateCache
 import com.revenuecat.purchases.PurchasesStateProvider
 import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
@@ -23,6 +24,7 @@ class BillingFactoryAmazonTest {
         val mockBackendHelper = mockk<BackendHelper>(relaxed = true)
         val mockCache = mockk<DeviceCache>(relaxed = true)
         val mockDiagnosticsTracker = mockk<DiagnosticsTracker>(relaxed = true)
+        val mockAppConfig = mockk<AppConfig>(relaxed = true)
 
         BillingFactory.createBilling(
             Store.AMAZON,
@@ -31,7 +33,8 @@ class BillingFactoryAmazonTest {
             mockCache,
             observerMode = false,
             mockDiagnosticsTracker,
-            stateProvider = PurchasesStateCache(PurchasesState())
+            stateProvider = PurchasesStateCache(PurchasesState()),
+            appConfig = mockAppConfig,
         )
     }
 
@@ -40,6 +43,7 @@ class BillingFactoryAmazonTest {
         val mockApplication = mockk<Application>(relaxed = true)
         val mockBackendHelper = mockk<BackendHelper>(relaxed = true)
         val mockCache = mockk<DeviceCache>(relaxed = true)
+        val mockAppConfig = mockk<AppConfig>(relaxed = true)
 
         BillingFactory.createBilling(
             Store.AMAZON,
@@ -48,7 +52,8 @@ class BillingFactoryAmazonTest {
             mockCache,
             observerMode = false,
             diagnosticsTrackerIfEnabled = null,
-            stateProvider = PurchasesStateCache(PurchasesState())
+            stateProvider = PurchasesStateCache(PurchasesState()),
+            appConfig = mockAppConfig,
         )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -233,7 +233,11 @@ class AppConfigTest {
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,
-            dangerousSettings = DangerousSettings(customEntitlementComputation = true)
+            dangerousSettings = DangerousSettings(
+                autoSyncPurchases = true,
+                doNotConsumeIAP = false,
+                customEntitlementComputation = true,
+            ),
         )
         assertThat(appConfig.customEntitlementComputation).isTrue
         val appConfig2 = AppConfig(
@@ -243,7 +247,11 @@ class AppConfigTest {
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,
-            dangerousSettings = DangerousSettings(customEntitlementComputation = false)
+            dangerousSettings = DangerousSettings(
+                autoSyncPurchases = true,
+                doNotConsumeIAP = false,
+                customEntitlementComputation = false,
+            ),
         )
         assertThat(appConfig2.customEntitlementComputation).isFalse
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -361,7 +361,10 @@ class AppConfigTest {
             "AppConfig(" +
                 "platformInfo=PlatformInfo(flavor=native, version=3.2.0), " +
                 "store=PLAY_STORE, " +
-                "dangerousSettings=DangerousSettings(autoSyncPurchases=true, customEntitlementComputation=false), " +
+                "dangerousSettings=DangerousSettings(" +
+                    "autoSyncPurchases=true, " +
+                    "doNotConsumeIAP=false, " +
+                    "customEntitlementComputation=false), " +
                 "languageTag='', " +
                 "versionName='', " +
                 "packageName='', " +

--- a/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -91,7 +91,11 @@ internal abstract class BaseHTTPClientTest {
             platformInfo = platformInfo,
             proxyURL = proxyURL,
             store = store,
-            dangerousSettings = DangerousSettings(customEntitlementComputation = customEntitlementComputation),
+            dangerousSettings = DangerousSettings(
+                autoSyncPurchases = true,
+                doNotConsumeIAP = false,
+                customEntitlementComputation = customEntitlementComputation,
+            ),
             runningTests = true,
             forceServerErrors = forceServerErrors,
             forceSigningErrors = forceSigningErrors,

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -28,6 +28,7 @@ import com.revenuecat.purchases.PurchasesStateCache
 import com.revenuecat.purchases.assertDebugLog
 import com.revenuecat.purchases.assertErrorLog
 import com.revenuecat.purchases.assertVerboseLog
+import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.ReplaceProductInfo
@@ -92,6 +93,7 @@ class BillingWrapperTest {
     private var handler: Handler = mockk()
     private var mockDeviceCache: DeviceCache = mockk()
     private var mockDiagnosticsTracker: DiagnosticsTracker = mockk()
+    private var mockAppConfig: AppConfig = mockk()
     private var mockDateProvider: DateProvider = mockk()
 
     private var mockPurchasesListener: BillingAbstract.PurchasesUpdatedListener = mockk()
@@ -158,6 +160,7 @@ class BillingWrapperTest {
             mockDeviceCache,
             mockDiagnosticsTracker,
             purchasesStateProvider,
+            mockAppConfig,
             mockDateProvider
         )
         wrapper.purchasesUpdatedListener = mockPurchasesListener

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/BaseBillingUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/BaseBillingUseCaseTest.kt
@@ -5,9 +5,11 @@ import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.PurchasesUpdatedListener
+import com.revenuecat.purchases.DangerousSettings
 import com.revenuecat.purchases.PurchasesState
 import com.revenuecat.purchases.PurchasesStateCache
 import com.revenuecat.purchases.PurchasesStateProvider
+import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
@@ -40,6 +42,11 @@ internal open class BaseBillingUseCaseTest {
     protected var mockClient: BillingClient = mockk()
     protected var mockDeviceCache: DeviceCache = mockk()
     protected var mockDiagnosticsTracker: DiagnosticsTracker = mockk()
+    protected var mockAppConfig: AppConfig = mockk<AppConfig>().apply {
+        every { dangerousSettings } returns mockk<DangerousSettings>().apply {
+            every { doNotConsumeIAP } returns false
+        }
+    }
     protected var mockDateProvider: DateProvider = mockk()
 
     protected val billingClientOKResult = BillingClient.BillingResponseCode.OK.buildResult()
@@ -85,6 +92,7 @@ internal open class BaseBillingUseCaseTest {
             mockDeviceCache,
             mockDiagnosticsTracker,
             purchasesStateProvider,
+            mockAppConfig,
             mockDateProvider
         )
         wrapper.purchasesUpdatedListener = mockPurchasesListener


### PR DESCRIPTION
### Description
This adds a new dangerous setting `doNotConsumeIAP` that makes the SDK not to automatically consume in app products
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
