### PR TITLE
Make clearing diagnostics file happen during tracking

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsAnonymizer
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsFileHelper
+import com.revenuecat.purchases.common.diagnostics.DiagnosticsHelper
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.log
@@ -96,13 +97,16 @@ internal class PurchasesFactory(
             )
 
             var diagnosticsFileHelper: DiagnosticsFileHelper? = null
+            var diagnosticsHelper: DiagnosticsHelper? = null
             var diagnosticsTracker: DiagnosticsTracker? = null
             if (diagnosticsEnabled && isAndroidNOrNewer()) {
                 diagnosticsFileHelper = DiagnosticsFileHelper(FileHelper(context))
+                diagnosticsHelper = DiagnosticsHelper(context, diagnosticsFileHelper)
                 diagnosticsTracker = DiagnosticsTracker(
                     appConfig,
                     diagnosticsFileHelper,
                     DiagnosticsAnonymizer(Anonymizer()),
+                    diagnosticsHelper,
                     eventsDispatcher,
                 )
             } else if (diagnosticsEnabled) {
@@ -221,9 +225,14 @@ internal class PurchasesFactory(
             val offeringParser = OfferingParserFactory.createOfferingParser(store)
 
             var diagnosticsSynchronizer: DiagnosticsSynchronizer? = null
-            if (diagnosticsFileHelper != null && diagnosticsTracker != null && isAndroidNOrNewer()) {
+            @Suppress("ComplexCondition")
+            if (diagnosticsFileHelper != null &&
+                diagnosticsHelper != null &&
+                diagnosticsTracker != null &&
+                isAndroidNOrNewer()
+            ) {
                 diagnosticsSynchronizer = DiagnosticsSynchronizer(
-                    context,
+                    diagnosticsHelper,
                     diagnosticsFileHelper,
                     diagnosticsTracker,
                     backend,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -176,7 +176,6 @@ internal class PurchasesOrchestrator constructor(
         }
 
         if (isAndroidNOrNewer()) {
-            diagnosticsSynchronizer?.clearDiagnosticsFileIfTooBig()
             diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsHelper.kt
@@ -6,7 +6,6 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 
-@RequiresApi(Build.VERSION_CODES.N)
 internal class DiagnosticsHelper(
     context: Context,
     private val diagnosticsFileHelper: DiagnosticsFileHelper,
@@ -22,6 +21,8 @@ internal class DiagnosticsHelper(
                 Context.MODE_PRIVATE,
             )
     }
+
+    @RequiresApi(Build.VERSION_CODES.N)
     fun resetDiagnosticsStatus() {
         clearConsecutiveNumberOfErrors()
         diagnosticsFileHelper.deleteFile()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsHelper.kt
@@ -1,0 +1,39 @@
+package com.revenuecat.purchases.common.diagnostics
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.annotation.VisibleForTesting
+
+@RequiresApi(Build.VERSION_CODES.N)
+internal class DiagnosticsHelper(
+    context: Context,
+    private val diagnosticsFileHelper: DiagnosticsFileHelper,
+    private val sharedPreferences: Lazy<SharedPreferences> = lazy { initializeSharedPreferences(context) },
+) {
+    companion object {
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        const val CONSECUTIVE_FAILURES_COUNT_KEY = "consecutive_failures_count"
+
+        fun initializeSharedPreferences(context: Context): SharedPreferences =
+            context.getSharedPreferences(
+                "com_revenuecat_purchases_${context.packageName}_preferences_diagnostics",
+                Context.MODE_PRIVATE,
+            )
+    }
+    fun resetDiagnosticsStatus() {
+        clearConsecutiveNumberOfErrors()
+        diagnosticsFileHelper.deleteFile()
+    }
+
+    fun clearConsecutiveNumberOfErrors() {
+        sharedPreferences.value.edit().remove(CONSECUTIVE_FAILURES_COUNT_KEY).apply()
+    }
+
+    fun increaseConsecutiveNumberOfErrors(): Int {
+        var count = sharedPreferences.value.getInt(CONSECUTIVE_FAILURES_COUNT_KEY, 0)
+        sharedPreferences.value.edit().putInt(CONSECUTIVE_FAILURES_COUNT_KEY, ++count).apply()
+        return count
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.common.diagnostics
 
 import android.os.Build
-import androidx.annotation.RequiresApi
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -109,9 +109,6 @@ internal open class BasePurchasesTest {
             mockIdentityManager.configure(any())
         } just Runs
         every {
-            mockDiagnosticsSynchronizer.clearDiagnosticsFileIfTooBig()
-        } just Runs
-        every {
             mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
         } just Runs
         every {

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -90,11 +90,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     @Test
-    fun `diagnostics is cleared if diagnostics file too big on constructor`() {
-        verify(exactly = 1) { mockDiagnosticsSynchronizer.clearDiagnosticsFileIfTooBig() }
-    }
-
-    @Test
     fun `diagnostics is synced if needed on constructor`() {
         verify(exactly = 1) { mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded() }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
@@ -53,6 +53,7 @@ class DiagnosticsSynchronizerTest {
         diagnosticsSynchronizer = DiagnosticsSynchronizer(
             DiagnosticsHelper(mockk(), diagnosticsFileHelper, lazy { sharedPreferences }),
             diagnosticsFileHelper,
+            diagnosticsTracker,
             backend,
             dispatcher,
         )
@@ -156,7 +157,7 @@ class DiagnosticsSynchronizerTest {
         val errorCallbackResponse = Pair(PurchasesError(PurchasesErrorCode.ConfigurationError), true)
         mockBackendResponse(testDiagnosticsEntryJSONs, errorReturn = errorCallbackResponse)
         every {
-            sharedPreferences.getInt(DiagnosticsSynchronizer.CONSECUTIVE_FAILURES_COUNT_KEY, 0)
+            sharedPreferences.getInt(DiagnosticsHelper.CONSECUTIVE_FAILURES_COUNT_KEY, 0)
         } returns DiagnosticsSynchronizer.MAX_NUMBER_POST_RETRIES - 1
 
         diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
@@ -51,48 +51,12 @@ class DiagnosticsSynchronizerTest {
         mockDiagnosticsFileHelper()
 
         diagnosticsSynchronizer = DiagnosticsSynchronizer(
-            mockk(),
+            DiagnosticsHelper(mockk(), diagnosticsFileHelper, lazy { sharedPreferences }),
             diagnosticsFileHelper,
-            diagnosticsTracker,
             backend,
             dispatcher,
-            lazy { sharedPreferences }
         )
     }
-
-    // region clearDiagnosticsFileIfTooBig
-
-    @Test
-    fun `clearDiagnosticsFileIfTooBig does nothing if dianostics file not too big`() {
-        every { diagnosticsFileHelper.isDiagnosticsFileTooBig() } returns false
-
-        diagnosticsSynchronizer.clearDiagnosticsFileIfTooBig()
-
-        verify(exactly = 0) { diagnosticsTracker.trackMaxEventsStoredLimitReached() }
-        verify(exactly = 0) { diagnosticsFileHelper.deleteFile() }
-    }
-
-    @Test
-    fun `clearDiagnosticsFileIfTooBig tracks max events store limit reached if dianostics file too big`() {
-        every { diagnosticsFileHelper.isDiagnosticsFileTooBig() } returns true
-        every { diagnosticsTracker.trackMaxEventsStoredLimitReached() } just Runs
-
-        diagnosticsSynchronizer.clearDiagnosticsFileIfTooBig()
-
-        verify(exactly = 1) { diagnosticsTracker.trackMaxEventsStoredLimitReached() }
-    }
-
-    @Test
-    fun `clearDiagnosticsFileIfTooBig clears diagnostics file if dianostics file too big`() {
-        every { diagnosticsFileHelper.isDiagnosticsFileTooBig() } returns true
-        every { diagnosticsTracker.trackMaxEventsStoredLimitReached() } just Runs
-
-        diagnosticsSynchronizer.clearDiagnosticsFileIfTooBig()
-
-        verify(exactly = 1) { diagnosticsFileHelper.deleteFile() }
-    }
-
-    // endregion clearDiagnosticsFileIfTooBig
 
     // region syncDiagnosticsFileIfNeeded
 
@@ -131,7 +95,7 @@ class DiagnosticsSynchronizerTest {
 
         diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
 
-        verify(exactly = 1) { sharedPreferencesEditor.remove(DiagnosticsSynchronizer.CONSECUTIVE_FAILURES_COUNT_KEY) }
+        verify(exactly = 1) { sharedPreferencesEditor.remove(DiagnosticsHelper.CONSECUTIVE_FAILURES_COUNT_KEY) }
     }
 
     @Test
@@ -142,10 +106,10 @@ class DiagnosticsSynchronizerTest {
         diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
 
         verify(exactly = 1) {
-            sharedPreferencesEditor.putInt(DiagnosticsSynchronizer.CONSECUTIVE_FAILURES_COUNT_KEY, 1)
+            sharedPreferencesEditor.putInt(DiagnosticsHelper.CONSECUTIVE_FAILURES_COUNT_KEY, 1)
         }
         verify(exactly = 0) { diagnosticsFileHelper.deleteFile() }
-        verify(exactly = 0) { sharedPreferencesEditor.remove(DiagnosticsSynchronizer.CONSECUTIVE_FAILURES_COUNT_KEY) }
+        verify(exactly = 0) { sharedPreferencesEditor.remove(DiagnosticsHelper.CONSECUTIVE_FAILURES_COUNT_KEY) }
     }
 
     @Test
@@ -164,7 +128,7 @@ class DiagnosticsSynchronizerTest {
         val errorCallbackResponse = Pair(PurchasesError(PurchasesErrorCode.ConfigurationError), true)
         mockBackendResponse(testDiagnosticsEntryJSONs, errorReturn = errorCallbackResponse)
         every {
-            sharedPreferences.getInt(DiagnosticsSynchronizer.CONSECUTIVE_FAILURES_COUNT_KEY, 0)
+            sharedPreferences.getInt(DiagnosticsHelper.CONSECUTIVE_FAILURES_COUNT_KEY, 0)
         } returns DiagnosticsSynchronizer.MAX_NUMBER_POST_RETRIES - 1
 
         diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
@@ -178,12 +142,12 @@ class DiagnosticsSynchronizerTest {
         val errorCallbackResponse = Pair(PurchasesError(PurchasesErrorCode.ConfigurationError), true)
         mockBackendResponse(testDiagnosticsEntryJSONs, errorReturn = errorCallbackResponse)
         every {
-            sharedPreferences.getInt(DiagnosticsSynchronizer.CONSECUTIVE_FAILURES_COUNT_KEY, 0)
+            sharedPreferences.getInt(DiagnosticsHelper.CONSECUTIVE_FAILURES_COUNT_KEY, 0)
         } returns DiagnosticsSynchronizer.MAX_NUMBER_POST_RETRIES - 1
 
         diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
 
-        verify(exactly = 1) { sharedPreferencesEditor.remove(DiagnosticsSynchronizer.CONSECUTIVE_FAILURES_COUNT_KEY) }
+        verify(exactly = 1) { sharedPreferencesEditor.remove(DiagnosticsHelper.CONSECUTIVE_FAILURES_COUNT_KEY) }
     }
 
     @Test
@@ -219,7 +183,7 @@ class DiagnosticsSynchronizerTest {
 
         diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
 
-        verify(exactly = 1) { sharedPreferencesEditor.remove(DiagnosticsSynchronizer.CONSECUTIVE_FAILURES_COUNT_KEY) }
+        verify(exactly = 1) { sharedPreferencesEditor.remove(DiagnosticsHelper.CONSECUTIVE_FAILURES_COUNT_KEY) }
     }
 
     @Test
@@ -251,7 +215,7 @@ class DiagnosticsSynchronizerTest {
     fun `syncDiagnosticsFileIfNeeded removes consecutive failures count if IOException happens`() {
         every { diagnosticsFileHelper.readFileAsJson(any()) } throws IOException()
         diagnosticsSynchronizer.syncDiagnosticsFileIfNeeded()
-        verify(exactly = 1) { sharedPreferencesEditor.remove(DiagnosticsSynchronizer.CONSECUTIVE_FAILURES_COUNT_KEY) }
+        verify(exactly = 1) { sharedPreferencesEditor.remove(DiagnosticsHelper.CONSECUTIVE_FAILURES_COUNT_KEY) }
     }
 
     @Test
@@ -269,13 +233,13 @@ class DiagnosticsSynchronizerTest {
         every { sharedPreferences.edit() } returns sharedPreferencesEditor
         every { sharedPreferencesEditor.apply() } just Runs
         every {
-            sharedPreferencesEditor.remove(DiagnosticsSynchronizer.CONSECUTIVE_FAILURES_COUNT_KEY)
+            sharedPreferencesEditor.remove(DiagnosticsHelper.CONSECUTIVE_FAILURES_COUNT_KEY)
         } returns sharedPreferencesEditor
         every {
-            sharedPreferencesEditor.putInt(DiagnosticsSynchronizer.CONSECUTIVE_FAILURES_COUNT_KEY, any())
+            sharedPreferencesEditor.putInt(DiagnosticsHelper.CONSECUTIVE_FAILURES_COUNT_KEY, any())
         } returns sharedPreferencesEditor
         every {
-            sharedPreferences.getInt(DiagnosticsSynchronizer.CONSECUTIVE_FAILURES_COUNT_KEY, 0)
+            sharedPreferences.getInt(DiagnosticsHelper.CONSECUTIVE_FAILURES_COUNT_KEY, 0)
         } returns 0
     }
 


### PR DESCRIPTION
### Description
We were clearing the diagnostics file during SDK configuration if we detected the file to be too big. We could make this clearing happen during tracking of events. Advantages of this:
- We make sure the file never gets too big 
- We don't miss extra events if we need to clear the file

This shouldn't be a problem performance-wise since we are doing all this in a background thread + checking the file size is pretty quick.