### PR TITLE
`Paywalls`: Update Norwegian "restore" localization

### DIFF
--- a/ui/revenuecatui/src/main/res/values-no/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-no/strings.xml
@@ -4,7 +4,7 @@
     <string name="all_plans">Alle abonnementer</string>
     <string name="privacy">Personvern</string>
     <string name="privacy_policy">Personvernerklæring</string>
-    <string name="restore">Restaurere</string>
+    <string name="restore">Gjenopprett</string>
     <string name="restore_purchases">Gjenopprette kjøp</string>
     <string name="terms">Vilkår</string>
     <string name="terms_and_conditions">Vilkår og betingelser</string>


### PR DESCRIPTION
### Motivation

Correct word but wrong context

### Description

`Restaurere` to `Gjenopprett`
