### PR TITLE
Deprecate observerMode in favor of purchasesAreCompletedBy

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/DeprecatedPurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/DeprecatedPurchasesAPI.java
@@ -17,6 +17,8 @@ import com.revenuecat.purchases.models.StoreProduct;
 import com.revenuecat.purchases.models.StoreTransaction;
 import com.revenuecat.purchases.models.SubscriptionOption;
 
+import kotlin.Unit;
+
 @SuppressWarnings({"unused"})
 final class DeprecatedPurchasesAPI {
     static void check(final Purchases purchases,
@@ -51,6 +53,17 @@ final class DeprecatedPurchasesAPI {
         purchases.purchaseProduct(activity, storeProduct, makePurchaseListener);
         purchases.purchasePackage(activity, packageToPurchase, upgradeInfo, purchaseChangeListener);
         purchases.purchasePackage(activity, packageToPurchase, makePurchaseListener);
+
+        boolean finishTransactions = purchases.getFinishTransactions();
+        purchases.setFinishTransactions(true);
+
+        purchases.syncObserverModeAmazonPurchase(
+                storeProduct.getId(),
+                "receipt-id",
+                "amazon-user-id",
+                "EUR",
+                1.99
+        );
     }
 
 }

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -121,13 +121,13 @@ final class PurchasesAPI {
     }
 
     static void checkAmazonConfiguration(final Context context,
-                                         final ExecutorService executorService) {
+                                         final ExecutorService executorService,
+                                         final PurchasesAreCompletedBy purchaseCompleter) {
         PurchasesConfiguration amazonConfiguration = new AmazonConfiguration.Builder(context, "")
                 .appUserID("")
                 .observerMode(true)
                 .observerMode(false)
-                .purchasesAreCompletedBy(PurchasesAreCompletedBy.REVENUECAT)
-                .purchasesAreCompletedBy(PurchasesAreCompletedBy.MY_APP)
+                .purchasesAreCompletedBy(purchaseCompleter)
                 .service(executorService)
                 .diagnosticsEnabled(true)
                 .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -7,7 +7,6 @@ import androidx.annotation.NonNull;
 import com.revenuecat.purchases.CacheFetchPolicy;
 import com.revenuecat.purchases.CustomerInfo;
 import com.revenuecat.purchases.EntitlementVerificationMode;
-import com.revenuecat.purchases.LogLevel;
 import com.revenuecat.purchases.Offerings;
 import com.revenuecat.purchases.Purchases;
 import com.revenuecat.purchases.PurchasesConfiguration;
@@ -18,13 +17,9 @@ import com.revenuecat.purchases.interfaces.LogInCallback;
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback;
 import com.revenuecat.purchases.interfaces.SyncAttributesAndOfferingsCallback;
 import com.revenuecat.purchases.interfaces.SyncPurchasesCallback;
-import com.revenuecat.purchases.models.BillingFeature;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
@@ -130,6 +125,8 @@ final class PurchasesAPI {
                 .appUserID("")
                 .observerMode(true)
                 .observerMode(false)
+                .finishTransactions(true)
+                .finishTransactions(false)
                 .service(executorService)
                 .diagnosticsEnabled(true)
                 .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.CustomerInfo;
 import com.revenuecat.purchases.EntitlementVerificationMode;
 import com.revenuecat.purchases.Offerings;
 import com.revenuecat.purchases.Purchases;
+import com.revenuecat.purchases.PurchasesAreCompletedBy;
 import com.revenuecat.purchases.PurchasesConfiguration;
 import com.revenuecat.purchases.PurchasesError;
 import com.revenuecat.purchases.Store;
@@ -125,8 +126,8 @@ final class PurchasesAPI {
                 .appUserID("")
                 .observerMode(true)
                 .observerMode(false)
-                .finishTransactions(true)
-                .finishTransactions(false)
+                .purchasesAreCompletedBy(PurchasesAreCompletedBy.REVENUECAT)
+                .purchasesAreCompletedBy(PurchasesAreCompletedBy.MY_APP)
                 .service(executorService)
                 .diagnosticsEnabled(true)
                 .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/DeprecatedPurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/DeprecatedPurchasesAPI.kt
@@ -103,5 +103,8 @@ private class DeprecatedPurchasesAPI {
 
         Purchases.debugLogsEnabled = false
         val debugLogs: Boolean = Purchases.debugLogsEnabled
+
+        val finishTransactions: Boolean = purchases.finishTransactions
+        purchases.finishTransactions = true
     }
 }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/DeprecatedPurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/DeprecatedPurchasesAPI.kt
@@ -106,5 +106,13 @@ private class DeprecatedPurchasesAPI {
 
         val finishTransactions: Boolean = purchases.finishTransactions
         purchases.finishTransactions = true
+
+        val unit: Unit = purchases.syncObserverModeAmazonPurchase(
+            productID = storeProduct.id,
+            receiptID = "receipt-id",
+            amazonUserID = "amazon-user-id",
+            isoCurrencyCode = "EUR",
+            price = 1.99,
+        )
     }
 }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.Store
@@ -67,8 +68,8 @@ private class PurchasesAPI {
         purchases.getCustomerInfo(receiveCustomerInfoCallback)
         purchases.getCustomerInfo(CacheFetchPolicy.CACHED_OR_FETCHED, receiveCustomerInfoCallback)
 
-        val finishTransactions: Boolean = purchases.finishTransactions
-        purchases.finishTransactions = true
+        val purchasesAreCompletedBy: PurchasesAreCompletedBy = purchases.purchasesAreCompletedBy
+        purchases.purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT
 
         val anonymous: Boolean = purchases.isAnonymous
 
@@ -182,8 +183,8 @@ private class PurchasesAPI {
             .appUserID("")
             .observerMode(true)
             .observerMode(false)
-            .finishTransactions(true)
-            .finishTransactions(false)
+            .purchasesAreCompletedBy(PurchasesAreCompletedBy.REVENUECAT)
+            .purchasesAreCompletedBy(PurchasesAreCompletedBy.MY_APP)
             .showInAppMessagesAutomatically(true)
             .service(executorService)
             .diagnosticsEnabled(true)

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -182,6 +182,8 @@ private class PurchasesAPI {
             .appUserID("")
             .observerMode(true)
             .observerMode(false)
+            .finishTransactions(true)
+            .finishTransactions(false)
             .showInAppMessagesAutomatically(true)
             .service(executorService)
             .diagnosticsEnabled(true)

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -178,13 +178,16 @@ private class PurchasesAPI {
         LogInResult(customerInfo, created)
     }
 
-    fun checkAmazonConfiguration(context: Context, executorService: ExecutorService) {
+    fun checkAmazonConfiguration(
+        context: Context,
+        executorService: ExecutorService,
+        purchaseCompleter: PurchasesAreCompletedBy,
+    ) {
         val amazonConfiguration: PurchasesConfiguration = AmazonConfiguration.Builder(context, "")
             .appUserID("")
             .observerMode(true)
             .observerMode(false)
-            .purchasesAreCompletedBy(PurchasesAreCompletedBy.REVENUECAT)
-            .purchasesAreCompletedBy(PurchasesAreCompletedBy.MY_APP)
+            .purchasesAreCompletedBy(purchaseCompleter)
             .showInAppMessagesAutomatically(true)
             .service(executorService)
             .diagnosticsEnabled(true)

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAreCompletedByAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesAreCompletedByAPI.java
@@ -1,0 +1,13 @@
+package com.revenuecat.apitester.java;
+
+import com.revenuecat.purchases.PurchasesAreCompletedBy;
+
+@SuppressWarnings({"unused"})
+final class PurchasesAreCompletedByAPI {
+    static void check(final PurchasesAreCompletedBy mode) {
+        switch (mode) {
+            case REVENUECAT:
+            case MY_APP:
+        }
+    }
+}

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
@@ -24,8 +24,8 @@ import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback;
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener;
 import com.revenuecat.purchases.models.BillingFeature;
 import com.revenuecat.purchases.models.GoogleProrationMode;
-import com.revenuecat.purchases.models.InAppMessageType;
 import com.revenuecat.purchases.models.GoogleReplacementMode;
+import com.revenuecat.purchases.models.InAppMessageType;
 import com.revenuecat.purchases.models.StoreProduct;
 import com.revenuecat.purchases.models.StoreTransaction;
 import com.revenuecat.purchases.models.SubscriptionOption;
@@ -146,6 +146,8 @@ final class PurchasesCommonAPI {
                 .appUserID("")
                 .observerMode(true)
                 .observerMode(false)
+                .finishTransactions(true)
+                .finishTransactions(false)
                 .service(executorService)
                 .diagnosticsEnabled(true)
                 .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
@@ -15,6 +15,7 @@ import com.revenuecat.purchases.Package;
 import com.revenuecat.purchases.ProductType;
 import com.revenuecat.purchases.PurchaseParams;
 import com.revenuecat.purchases.Purchases;
+import com.revenuecat.purchases.PurchasesAreCompletedBy;
 import com.revenuecat.purchases.PurchasesConfiguration;
 import com.revenuecat.purchases.PurchasesError;
 import com.revenuecat.purchases.Store;
@@ -146,8 +147,8 @@ final class PurchasesCommonAPI {
                 .appUserID("")
                 .observerMode(true)
                 .observerMode(false)
-                .finishTransactions(true)
-                .finishTransactions(false)
+                .purchasesAreCompletedBy(PurchasesAreCompletedBy.REVENUECAT)
+                .purchasesAreCompletedBy(PurchasesAreCompletedBy.MY_APP)
                 .service(executorService)
                 .diagnosticsEnabled(true)
                 .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAreCompletedByAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesAreCompletedByAPI.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.apitester.kotlin
+
+import com.revenuecat.purchases.PurchasesAreCompletedBy
+
+@Suppress("unused")
+private class PurchasesAreCompletedByAPI {
+    fun check(mode: PurchasesAreCompletedBy) {
+        when (mode) {
+            PurchasesAreCompletedBy.REVENUECAT,
+            PurchasesAreCompletedBy.MY_APP,
+            -> {
+            }
+        }.exhaustive
+    }
+}

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchaseParams
 import com.revenuecat.purchases.PurchaseResult
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.Store
@@ -191,8 +192,8 @@ private class PurchasesCommonAPI {
             .appUserID("")
             .observerMode(true)
             .observerMode(false)
-            .finishTransactions(true)
-            .finishTransactions(false)
+            .purchasesAreCompletedBy(PurchasesAreCompletedBy.REVENUECAT)
+            .purchasesAreCompletedBy(PurchasesAreCompletedBy.MY_APP)
             .showInAppMessagesAutomatically(true)
             .service(executorService)
             .diagnosticsEnabled(true)

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
@@ -191,6 +191,8 @@ private class PurchasesCommonAPI {
             .appUserID("")
             .observerMode(true)
             .observerMode(false)
+            .finishTransactions(true)
+            .finishTransactions(false)
             .showInAppMessagesAutomatically(true)
             .service(executorService)
             .diagnosticsEnabled(true)

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/MainApplication.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/MainApplication.kt
@@ -23,7 +23,7 @@ class MainApplication : Application() {
         Initialize the RevenueCat Purchases SDK.
 
         - appUserID is nil, so an anonymous ID will be generated automatically by the Purchases SDK. Read more about Identifying Users here: https://docs.revenuecat.com/docs/user-ids
-        - purchasesAreCompletedBy is set to REVENUECAT, so Purchases will automatically handle finishing transactions. Read more about finishing transactions here: https://docs.revenuecat.com/docs/finishing-transactions
+        - purchasesAreCompletedBy is set to REVENUECAT, so Purchases will automatically handle finishing transactions. Read more about finishing transactions here: https://docs.revenuecat.com/docs/observer-mode
          */
         val builder = when (BuildConfig.STORE) {
             "amazon" -> AmazonConfiguration.Builder(this, Constants.AMAZON_API_KEY)

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/MainApplication.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/MainApplication.kt
@@ -2,6 +2,7 @@ package com.revenuecat.sample
 
 import android.app.Application
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.amazon.AmazonConfiguration
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
@@ -22,7 +23,7 @@ class MainApplication : Application() {
         Initialize the RevenueCat Purchases SDK.
 
         - appUserID is nil, so an anonymous ID will be generated automatically by the Purchases SDK. Read more about Identifying Users here: https://docs.revenuecat.com/docs/user-ids
-        - finishTransactions is true, so Purchases will automatically handle finishing transactions. Read more about finishing transactions here: https://docs.revenuecat.com/docs/finishing-transactions
+        - purchasesAreCompletedBy is set to REVENUECAT, so Purchases will automatically handle finishing transactions. Read more about finishing transactions here: https://docs.revenuecat.com/docs/finishing-transactions
          */
         val builder = when (BuildConfig.STORE) {
             "amazon" -> AmazonConfiguration.Builder(this, Constants.AMAZON_API_KEY)
@@ -31,7 +32,7 @@ class MainApplication : Application() {
         }
         Purchases.configure(
             builder
-                .finishTransactions(true)
+                .purchasesAreCompletedBy(PurchasesAreCompletedBy.REVENUECAT)
                 .appUserID(null)
                 .build(),
         )

--- a/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/MainApplication.kt
+++ b/examples/MagicWeather/app/src/main/java/com/revenuecat/sample/MainApplication.kt
@@ -22,7 +22,7 @@ class MainApplication : Application() {
         Initialize the RevenueCat Purchases SDK.
 
         - appUserID is nil, so an anonymous ID will be generated automatically by the Purchases SDK. Read more about Identifying Users here: https://docs.revenuecat.com/docs/user-ids
-        - observerMode is false, so Purchases will automatically handle finishing transactions. Read more about Observer Mode here: https://docs.revenuecat.com/docs/observer-mode
+        - finishTransactions is true, so Purchases will automatically handle finishing transactions. Read more about finishing transactions here: https://docs.revenuecat.com/docs/finishing-transactions
          */
         val builder = when (BuildConfig.STORE) {
             "amazon" -> AmazonConfiguration.Builder(this, Constants.AMAZON_API_KEY)
@@ -31,7 +31,7 @@ class MainApplication : Application() {
         }
         Purchases.configure(
             builder
-                .observerMode(false)
+                .finishTransactions(true)
                 .appUserID(null)
                 .build(),
         )

--- a/examples/MagicWeatherCompose/app/src/main/java/com/revenuecat/sample/MainApplication.kt
+++ b/examples/MagicWeatherCompose/app/src/main/java/com/revenuecat/sample/MainApplication.kt
@@ -21,7 +21,7 @@ class MainApplication : Application() {
         Initialize the RevenueCat Purchases SDK.
 
         - appUserID is nil, so an anonymous ID will be generated automatically by the Purchases SDK. Read more about Identifying Users here: https://docs.revenuecat.com/docs/user-ids
-        - observerMode is false, so Purchases will automatically handle finishing transactions. Read more about Observer Mode here: https://docs.revenuecat.com/docs/observer-mode
+        - finishTransactions is true, so Purchases will automatically handle finishing transactions. Read more about finishing transactions here: https://docs.revenuecat.com/docs/finishing-transactions
          */
         val builder = when (BuildConfig.STORE) {
             "amazon" -> AmazonConfiguration.Builder(this, Constants.AMAZON_API_KEY)
@@ -30,7 +30,7 @@ class MainApplication : Application() {
         }
         Purchases.configure(
             builder
-                .observerMode(false)
+                .finishTransactions(true)
                 .appUserID(null)
                 .diagnosticsEnabled(true)
                 .build(),

--- a/examples/MagicWeatherCompose/app/src/main/java/com/revenuecat/sample/MainApplication.kt
+++ b/examples/MagicWeatherCompose/app/src/main/java/com/revenuecat/sample/MainApplication.kt
@@ -22,7 +22,7 @@ class MainApplication : Application() {
         Initialize the RevenueCat Purchases SDK.
 
         - appUserID is nil, so an anonymous ID will be generated automatically by the Purchases SDK. Read more about Identifying Users here: https://docs.revenuecat.com/docs/user-ids
-        - purchasesAreCompletedBy is set to REVENUECAT, so Purchases will automatically handle finishing transactions. Read more about finishing transactions here: https://docs.revenuecat.com/docs/finishing-transactions
+        - purchasesAreCompletedBy is set to REVENUECAT, so Purchases will automatically handle finishing transactions. Read more about finishing transactions here: https://docs.revenuecat.com/docs/observer-mode
          */
         val builder = when (BuildConfig.STORE) {
             "amazon" -> AmazonConfiguration.Builder(this, Constants.AMAZON_API_KEY)

--- a/examples/MagicWeatherCompose/app/src/main/java/com/revenuecat/sample/MainApplication.kt
+++ b/examples/MagicWeatherCompose/app/src/main/java/com/revenuecat/sample/MainApplication.kt
@@ -3,6 +3,7 @@ package com.revenuecat.sample
 import android.app.Application
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.amazon.AmazonConfiguration
 import com.revenuecat.sample.data.Constants
@@ -21,7 +22,7 @@ class MainApplication : Application() {
         Initialize the RevenueCat Purchases SDK.
 
         - appUserID is nil, so an anonymous ID will be generated automatically by the Purchases SDK. Read more about Identifying Users here: https://docs.revenuecat.com/docs/user-ids
-        - finishTransactions is true, so Purchases will automatically handle finishing transactions. Read more about finishing transactions here: https://docs.revenuecat.com/docs/finishing-transactions
+        - purchasesAreCompletedBy is set to REVENUECAT, so Purchases will automatically handle finishing transactions. Read more about finishing transactions here: https://docs.revenuecat.com/docs/finishing-transactions
          */
         val builder = when (BuildConfig.STORE) {
             "amazon" -> AmazonConfiguration.Builder(this, Constants.AMAZON_API_KEY)
@@ -30,7 +31,7 @@ class MainApplication : Application() {
         }
         Purchases.configure(
             builder
-                .finishTransactions(true)
+                .purchasesAreCompletedBy(PurchasesAreCompletedBy.REVENUECAT)
                 .appUserID(null)
                 .diagnosticsEnabled(true)
                 .build(),

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainApplication.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainApplication.kt
@@ -3,6 +3,7 @@ package com.revenuecat.paywallstester
 import android.app.Application
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesConfiguration
 
 class MainApplication : Application() {
@@ -14,7 +15,7 @@ class MainApplication : Application() {
 
         Purchases.configure(
             PurchasesConfiguration.Builder(this, Constants.GOOGLE_API_KEY)
-                .finishTransactions(true)
+                .purchasesAreCompletedBy(PurchasesAreCompletedBy.REVENUECAT)
                 .appUserID(null)
                 .diagnosticsEnabled(true)
                 .build(),

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainApplication.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainApplication.kt
@@ -14,7 +14,7 @@ class MainApplication : Application() {
 
         Purchases.configure(
             PurchasesConfiguration.Builder(this, Constants.GOOGLE_API_KEY)
-                .observerMode(false)
+                .finishTransactions(true)
                 .appUserID(null)
                 .diagnosticsEnabled(true)
                 .build(),

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -97,12 +97,12 @@ class ConfigureFragment : Fragment() {
         }
 
         binding.amazonStoreRadioId.setOnCheckedChangeListener { _, isChecked ->
-            // Disable observer mode options if Amazon
-            binding.observerModeCheckbox.isEnabled = !isChecked
+            // Disable finish transaction options if Amazon
+            binding.finishTransactionsCheckbox.isEnabled = !isChecked
 
-            // Toggle observer mode off only if Amazon is checked
+            // Toggle finish transactions on only if Amazon is checked
             if (isChecked) {
-                binding.observerModeCheckbox.isChecked = false
+                binding.finishTransactionsCheckbox.isChecked = true
             }
         }
 
@@ -116,7 +116,7 @@ class ConfigureFragment : Fragment() {
 
         val entitlementVerificationMode = EntitlementVerificationMode.values()[verificationModeIndex]
         val useAmazonStore = binding.storeRadioGroup.checkedRadioButtonId == R.id.amazon_store_radio_id
-        val useObserverMode = binding.observerModeCheckbox.isChecked
+        val finishTransactions = binding.finishTransactionsCheckbox.isChecked
 
         val application = (requireActivity().application as MainApplication)
 
@@ -132,11 +132,11 @@ class ConfigureFragment : Fragment() {
         val configuration = configurationBuilder
             .diagnosticsEnabled(true)
             .entitlementVerificationMode(entitlementVerificationMode)
-            .observerMode(useObserverMode)
+            .finishTransactions(finishTransactions)
             .build()
         Purchases.configure(configuration)
 
-        if (useObserverMode) {
+        if (!finishTransactions) {
             ObserverModeBillingClient.start(application, application.logHandler)
         }
 

--- a/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
@@ -134,8 +134,8 @@
         </RadioGroup>
 
         <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/observer_mode_label"
-                android:text="Observer Mode"
+                android:id="@+id/finish_transactions_label"
+                android:text="Finish transactions"
                 android:textSize="15sp"
                 android:layout_marginTop="20dp"
                 app:layout_constraintTop_toBottomOf="@id/store_label"
@@ -144,10 +144,11 @@
                 android:layout_height="wrap_content"/>
 
         <CheckBox
-                android:id="@+id/observer_mode_checkbox"
-                app:layout_constraintTop_toTopOf="@id/observer_mode_label"
-                app:layout_constraintBottom_toBottomOf="@id/observer_mode_label"
+                android:id="@+id/finish_transactions_checkbox"
+                app:layout_constraintTop_toTopOf="@id/finish_transactions_label"
+                app:layout_constraintBottom_toBottomOf="@id/finish_transactions_label"
                 app:layout_constraintEnd_toEndOf="parent"
+                android:checked="true"
                 android:orientation="horizontal"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"/>
@@ -157,7 +158,7 @@
                 android:text="@string/google_store_is_unavailable"
                 android:textAlignment="textEnd"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/observer_mode_checkbox"
+                app:layout_constraintTop_toBottomOf="@id/finish_transactions_checkbox"
                 app:layout_constraintWidth_percent="0.7"
                 android:visibility="gone"
                 tools:visibility="visible"

--- a/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
@@ -135,7 +135,7 @@
 
         <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/finish_transactions_label"
-                android:text="Finish transactions"
+                android:text="@string/purchases_completed_by"
                 android:textSize="15sp"
                 android:layout_marginTop="20dp"
                 app:layout_constraintTop_toBottomOf="@id/store_label"
@@ -143,22 +143,34 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"/>
 
-        <CheckBox
-                android:id="@+id/finish_transactions_checkbox"
+        <RadioGroup
+                android:id="@+id/purchase_completion_radio_group"
                 app:layout_constraintTop_toTopOf="@id/finish_transactions_label"
                 app:layout_constraintBottom_toBottomOf="@id/finish_transactions_label"
                 app:layout_constraintEnd_toEndOf="parent"
-                android:checked="true"
                 android:orientation="horizontal"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content">
+            <RadioButton
+                    android:id="@+id/completed_by_revenuecat_radio_id"
+                    android:text="@string/revenuecat"
+                    android:checked="true"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+            <RadioButton
+                    android:id="@+id/completed_by_my_app_radio_id"
+                    android:text="@string/my_app"
+                    android:checked="false"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+        </RadioGroup>
 
         <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/google_unavailable_text_view"
                 android:text="@string/google_store_is_unavailable"
                 android:textAlignment="textEnd"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/finish_transactions_checkbox"
+                app:layout_constraintTop_toBottomOf="@id/purchase_completion_radio_group"
                 app:layout_constraintWidth_percent="0.7"
                 android:visibility="gone"
                 tools:visibility="visible"

--- a/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
+++ b/examples/purchase-tester/src/main/res/layout/fragment_configure.xml
@@ -134,7 +134,7 @@
         </RadioGroup>
 
         <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/finish_transactions_label"
+                android:id="@+id/purchase_completion_label"
                 android:text="@string/purchases_completed_by"
                 android:textSize="15sp"
                 android:layout_marginTop="20dp"
@@ -145,8 +145,8 @@
 
         <RadioGroup
                 android:id="@+id/purchase_completion_radio_group"
-                app:layout_constraintTop_toTopOf="@id/finish_transactions_label"
-                app:layout_constraintBottom_toBottomOf="@id/finish_transactions_label"
+                app:layout_constraintTop_toTopOf="@id/purchase_completion_label"
+                app:layout_constraintBottom_toBottomOf="@id/purchase_completion_label"
                 app:layout_constraintEnd_toEndOf="parent"
                 android:orientation="horizontal"
                 android:layout_width="wrap_content"

--- a/examples/purchase-tester/src/main/res/values/strings.xml
+++ b/examples/purchase-tester/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="store">Store</string>
     <string name="google">Google</string>
     <string name="amazon">Amazon</string>
+    <string name="revenuecat">RevenueCat</string>
     <string name="continue_text">Continue</string>
     <string name="loving_cat">😻</string>
     <string name="logs">Logs</string>
@@ -21,4 +22,6 @@
     <string name="proxy">Proxy</string>
     <string name="buy_product">Buy Product</string>
     <string name="find_placement">Find Placement</string>
+    <string name="purchases_completed_by">Purchases are completed by</string>
+    <string name="my_app">My app</string>
 </resources>

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -102,7 +102,8 @@ class Purchases internal constructor(
      *
      * @param [listener] Called when all purchases have been synced with the backend, either successfully or with
      * an error. If no purchases are present, the success function will be called.
-     * @warning This function should only be called if you're migrating to RevenueCat or in observer mode.
+     * @warning This function should only be called if you're migrating to RevenueCat or if you have instructed
+     * `Purchases` not to [finish transactions][finishTransactions].
      * @warning This function could take a relatively long time to execute, depending on the amount of purchases
      * the user has. Consider that when waiting for this operation to complete.
      */
@@ -114,8 +115,9 @@ class Purchases internal constructor(
     }
 
     /**
-     * This method will send a purchase to the RevenueCat backend. This function should only be called if you are
-     * in Amazon observer mode or performing a client side migration of your current users to RevenueCat.
+     * This method will send an Amazon purchase to the RevenueCat backend. This function should only be called if you
+     * have instructed `Purchases` not to [finish transactions][finishTransactions] or when performing a client side
+     * migration of your current users to RevenueCat.
      *
      * The receipt IDs are cached if successfully posted so they are not posted more than once.
      *
@@ -125,7 +127,40 @@ class Purchases internal constructor(
      * @param [isoCurrencyCode] Product's currency code in ISO 4217 format.
      * @param [price] Product's price.
      */
+    @Deprecated(
+        "ObserverMode is a confusing term.",
+        ReplaceWith("syncAmazonPurchase(productID, receiptID, amazonUserID, isoCurrencyCode, price)"),
+    )
     fun syncObserverModeAmazonPurchase(
+        productID: String,
+        receiptID: String,
+        amazonUserID: String,
+        isoCurrencyCode: String?,
+        price: Double?,
+    ) {
+        syncAmazonPurchase(
+            productID = productID,
+            receiptID = receiptID,
+            amazonUserID = amazonUserID,
+            isoCurrencyCode = isoCurrencyCode,
+            price = price,
+        )
+    }
+
+    /**
+     * This method will send an Amazon purchase to the RevenueCat backend. This function should only be called if you
+     * have instructed `Purchases` not to [finish transactions][finishTransactions] or when performing a client side
+     * migration of your current users to RevenueCat.
+     *
+     * The receipt IDs are cached if successfully posted so they are not posted more than once.
+     *
+     * @param [productID] Product ID associated to the purchase.
+     * @param [receiptID] ReceiptId that represents the Amazon purchase.
+     * @param [amazonUserID] Amazon's userID. This parameter will be ignored when syncing a Google purchase.
+     * @param [isoCurrencyCode] Product's currency code in ISO 4217 format.
+     * @param [price] Product's price.
+     */
+    fun syncAmazonPurchase(
         productID: String,
         receiptID: String,
         amazonUserID: String,

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -43,11 +43,32 @@ class Purchases internal constructor(
      * Default to TRUE, set this to FALSE if you are consuming and acknowledging transactions
      * outside of the Purchases SDK.
      */
+    @Deprecated(
+        "\"Finishing transactions\" is not a platform-agnostic term.",
+        ReplaceWith("purchasesAreCompletedBy"),
+    )
     var finishTransactions: Boolean
         @Synchronized get() = purchasesOrchestrator.finishTransactions
 
         @Synchronized set(value) {
             purchasesOrchestrator.finishTransactions = value
+        }
+
+    /**
+     * Default to TRUE, set this to FALSE if you are consuming and acknowledging transactions
+     * outside of the Purchases SDK.
+     */
+    var purchasesAreCompletedBy: PurchasesAreCompletedBy
+        @Synchronized get() =
+            if (purchasesOrchestrator.finishTransactions) {
+                PurchasesAreCompletedBy.REVENUECAT
+            } else PurchasesAreCompletedBy.MY_APP
+
+        @Synchronized set(value) {
+            purchasesOrchestrator.finishTransactions = when (value) {
+                PurchasesAreCompletedBy.REVENUECAT -> true
+                PurchasesAreCompletedBy.MY_APP -> false
+            }
         }
 
     /**
@@ -102,8 +123,8 @@ class Purchases internal constructor(
      *
      * @param [listener] Called when all purchases have been synced with the backend, either successfully or with
      * an error. If no purchases are present, the success function will be called.
-     * @warning This function should only be called if you're migrating to RevenueCat or if you have instructed
-     * `Purchases` not to [finish transactions][finishTransactions].
+     * @warning This function should only be called if you're migrating to RevenueCat or if you have set
+     * [purchasesAreCompletedBy] to [MY_APP][PurchasesAreCompletedBy.MY_APP].
      * @warning This function could take a relatively long time to execute, depending on the amount of purchases
      * the user has. Consider that when waiting for this operation to complete.
      */
@@ -116,7 +137,7 @@ class Purchases internal constructor(
 
     /**
      * This method will send an Amazon purchase to the RevenueCat backend. This function should only be called if you
-     * have instructed `Purchases` not to [finish transactions][finishTransactions] or when performing a client side
+     * have set [purchasesAreCompletedBy] to [MY_APP][PurchasesAreCompletedBy.MY_APP] or when performing a client side
      * migration of your current users to RevenueCat.
      *
      * The receipt IDs are cached if successfully posted so they are not posted more than once.
@@ -149,7 +170,7 @@ class Purchases internal constructor(
 
     /**
      * This method will send an Amazon purchase to the RevenueCat backend. This function should only be called if you
-     * have instructed `Purchases` not to [finish transactions][finishTransactions] or when performing a client side
+     * have set [purchasesAreCompletedBy] to [MY_APP][PurchasesAreCompletedBy.MY_APP] or when performing a client side
      * migration of your current users to RevenueCat.
      *
      * The receipt IDs are cached if successfully posted so they are not posted more than once.

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -149,7 +149,7 @@ class Purchases internal constructor(
      * @param [price] Product's price.
      */
     @Deprecated(
-        "ObserverMode is a confusing term.",
+        "syncObserverModeAmazonPurchase is being deprecated in favor of syncAmazonPurchase.",
         ReplaceWith("syncAmazonPurchase(productID, receiptID, amazonUserID, isoCurrencyCode, price)"),
     )
     fun syncObserverModeAmazonPurchase(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesAreCompletedBy.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesAreCompletedBy.kt
@@ -15,7 +15,7 @@ enum class PurchasesAreCompletedBy {
      * **Note:** failing to acknowledge a purchase within 3 days will lead to Google Play automatically issuing a
      * refund to the user.
      *
-     * For more info, see [revenuecat.com](https://www.revenuecat.com/docs/migrating-to-revenuecat/finishing-transactions)
+     * For more info, see [revenuecat.com](https://docs.revenuecat.com/docs/observer-mode#option-2-client-side)
      * and [developer.android.com](https://developer.android.com/google/play/billing/integrate#process).
      */
     MY_APP,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesAreCompletedBy.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesAreCompletedBy.kt
@@ -1,0 +1,22 @@
+package com.revenuecat.purchases
+
+/**
+ * Modes for completing the purchase process.
+ */
+enum class PurchasesAreCompletedBy {
+    /**
+     * RevenueCat will automatically acknowledge verified purchases. No action is required by you.
+     */
+    REVENUECAT,
+
+    /**
+     * RevenueCat will **not** automatically acknowledge any purchases. You will have to do so manually.
+     *
+     * **Note:** failing to acknowledge a purchase within 3 days will lead to Google Play automatically issuing a
+     * refund to the user.
+     *
+     * For more info, see [revenuecat.com](https://www.revenuecat.com/docs/migrating-to-revenuecat/finishing-transactions)
+     * and [developer.android.com](https://developer.android.com/google/play/billing/integrate#process).
+     */
+    MY_APP,
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases
 
 import android.content.Context
+import com.revenuecat.purchases.PurchasesConfiguration.Builder
 import java.util.concurrent.ExecutorService
 
 /**
@@ -13,6 +14,8 @@ open class PurchasesConfiguration(builder: Builder) {
     val apiKey: String
     val appUserID: String?
     val observerMode: Boolean
+        get() = !finishTransactions
+    val finishTransactions: Boolean
     val showInAppMessagesAutomatically: Boolean
     val service: ExecutorService?
     val store: Store
@@ -24,7 +27,7 @@ open class PurchasesConfiguration(builder: Builder) {
         this.context = builder.context
         this.apiKey = builder.apiKey
         this.appUserID = builder.appUserID
-        this.observerMode = builder.observerMode
+        this.finishTransactions = builder.finishTransactions
         this.service = builder.service
         this.store = builder.store
         this.diagnosticsEnabled = builder.diagnosticsEnabled
@@ -33,6 +36,7 @@ open class PurchasesConfiguration(builder: Builder) {
         this.showInAppMessagesAutomatically = builder.showInAppMessagesAutomatically
     }
 
+    @SuppressWarnings("TooManyFunctions")
     open class Builder(
         @get:JvmSynthetic internal val context: Context,
         @get:JvmSynthetic internal val apiKey: String,
@@ -42,7 +46,7 @@ open class PurchasesConfiguration(builder: Builder) {
         internal var appUserID: String? = null
 
         @set:JvmSynthetic @get:JvmSynthetic
-        internal var observerMode: Boolean = false
+        internal var finishTransactions: Boolean = true
 
         @set:JvmSynthetic @get:JvmSynthetic
         internal var showInAppMessagesAutomatically: Boolean = true
@@ -85,8 +89,18 @@ open class PurchasesConfiguration(builder: Builder) {
          * want to use only RevenueCat's backend. Default is FALSE. If you are on Android and setting this to TRUE,
          * you will have to acknowledge the purchases yourself.
          */
+        @Deprecated("ObserverMode is a confusing term.", ReplaceWith("finishTransactions(!observerMode)"))
         fun observerMode(observerMode: Boolean) = apply {
-            this.observerMode = observerMode
+            this.finishTransactions = !observerMode
+        }
+
+        /**
+         * An optional boolean. Set this to FALSE if you have your own IAP implementation and
+         * want to use only RevenueCat's backend. Default is TRUE. If you are on Android and setting this to FALSE,
+         * you will have to acknowledge the purchases yourself.
+         */
+        fun finishTransactions(finishTransactions: Boolean) = apply {
+            this.finishTransactions = finishTransactions
         }
 
         /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -125,7 +125,7 @@ open class PurchasesConfiguration(builder: Builder) {
          * **Note:** failing to acknowledge a purchase within 3 days will lead to Google Play automatically issuing a
          * refund to the user.
          *
-         * For more info, see [revenuecat.com](https://www.revenuecat.com/docs/migrating-to-revenuecat/finishing-transactions)
+         * For more info, see [revenuecat.com](https://docs.revenuecat.com/docs/observer-mode#option-2-client-side)
          * and [developer.android.com](https://developer.android.com/google/play/billing/integrate#process).
          */
         fun purchasesAreCompletedBy(purchasesAreCompletedBy: PurchasesAreCompletedBy) = apply {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -119,8 +119,8 @@ open class PurchasesConfiguration(builder: Builder) {
         /**
          * An optional setting. Set this to [MY_APP][PurchasesAreCompletedBy.MY_APP] if you have your own IAP
          * implementation and want to use only RevenueCat's backend. Default is
-         * [REVENUECAT][PurchasesAreCompletedBy.REVENUECAT]. If you are on Android and setting this to `MY_APP`, you
-         * will have to acknowledge the purchases yourself.
+         * [REVENUECAT][PurchasesAreCompletedBy.REVENUECAT]. If you are on Android and setting this to
+         * [MY_APP][PurchasesAreCompletedBy.MY_APP], you will have to acknowledge the purchases yourself.
          *
          * **Note:** failing to acknowledge a purchase within 3 days will lead to Google Play automatically issuing a
          * refund to the user.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -15,7 +15,7 @@ open class PurchasesConfiguration(builder: Builder) {
     val appUserID: String?
 
     @Deprecated(
-        "ObserverMode is a confusing term.",
+        "observerMode is being deprecated in favor of purchasesAreCompletedBy.",
         ReplaceWith(
             "purchasesAreCompletedBy == MY_APP",
             "com.revenuecat.purchases.PurchasesAreCompletedBy.MY_APP",
@@ -101,7 +101,7 @@ open class PurchasesConfiguration(builder: Builder) {
          * you will have to acknowledge the purchases yourself.
          */
         @Deprecated(
-            "ObserverMode is a confusing term.",
+            "observerMode() is being deprecated in favor of purchasesAreCompletedBy().",
             ReplaceWith(
                 "purchasesAreCompletedBy(if (observerMode) MY_APP else REVENUECAT)",
                 "com.revenuecat.purchases.PurchasesAreCompletedBy.REVENUECAT",

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -13,6 +13,7 @@ open class PurchasesConfiguration(builder: Builder) {
     val context: Context
     val apiKey: String
     val appUserID: String?
+    
     @Deprecated("ObserverMode is a confusing term.", ReplaceWith("!finishTransactions"))
     val observerMode: Boolean
         get() = !finishTransactions

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -13,7 +13,7 @@ open class PurchasesConfiguration(builder: Builder) {
     val context: Context
     val apiKey: String
     val appUserID: String?
-    
+
     @Deprecated("ObserverMode is a confusing term.", ReplaceWith("!finishTransactions"))
     val observerMode: Boolean
         get() = !finishTransactions

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -13,6 +13,7 @@ open class PurchasesConfiguration(builder: Builder) {
     val context: Context
     val apiKey: String
     val appUserID: String?
+    @Deprecated("ObserverMode is a confusing term.", ReplaceWith("!finishTransactions"))
     val observerMode: Boolean
         get() = !finishTransactions
     val finishTransactions: Boolean

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonStrings.kt
@@ -42,8 +42,9 @@ internal object AmazonStrings {
         "product SKU instead of a subscription term SKU. Make sure you configure the subscription term SKUs " +
         "in the RevenueCat dashboard."
     const val WARNING_AMAZON_OBSERVER_MODE =
-        "Attempting to interact with Amazon App Store with an Amazon Purchases configuration set to not finish " +
-            "transactions won't do anything. Please use syncAmazonPurchase to send purchases to RevenueCat instead."
+        "Attempting to interact with the Amazon App Store while RevenueCat is configured not to complete purchases " +
+            "won't do anything. (See AmazonConfiguration.Builder.purchasesAreCompletedBy().) Please use " +
+            "syncAmazonPurchase to send purchases to RevenueCat instead."
     const val ERROR_TIMEOUT_GETTING_PRODUCT_DATA =
         "Timeout error trying to get Amazon product data for SKUs: %s. Please check that the SKUs are correct."
     const val ERROR_TIMEOUT_GETTING_USER_DATA =

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonStrings.kt
@@ -43,7 +43,7 @@ internal object AmazonStrings {
         "in the RevenueCat dashboard."
     const val WARNING_AMAZON_OBSERVER_MODE =
         "Attempting to interact with Amazon App Store with an Amazon Purchases configuration in observer mode " +
-            "won't do anything. Please use syncObserverModeAmazonPurchase to send purchases to RevenueCat instead."
+            "won't do anything. Please use syncAmazonPurchase to send purchases to RevenueCat instead."
     const val ERROR_TIMEOUT_GETTING_PRODUCT_DATA =
         "Timeout error trying to get Amazon product data for SKUs: %s. Please check that the SKUs are correct."
     const val ERROR_TIMEOUT_GETTING_USER_DATA =

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonStrings.kt
@@ -42,8 +42,8 @@ internal object AmazonStrings {
         "product SKU instead of a subscription term SKU. Make sure you configure the subscription term SKUs " +
         "in the RevenueCat dashboard."
     const val WARNING_AMAZON_OBSERVER_MODE =
-        "Attempting to interact with Amazon App Store with an Amazon Purchases configuration in observer mode " +
-            "won't do anything. Please use syncAmazonPurchase to send purchases to RevenueCat instead."
+        "Attempting to interact with Amazon App Store with an Amazon Purchases configuration set to not finish " +
+            "transactions won't do anything. Please use syncAmazonPurchase to send purchases to RevenueCat instead."
     const val ERROR_TIMEOUT_GETTING_PRODUCT_DATA =
         "Timeout error trying to get Amazon product data for SKUs: %s. Please check that the SKUs are correct."
     const val ERROR_TIMEOUT_GETTING_USER_DATA =

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -32,6 +32,7 @@ class PurchasesConfigurationTest {
         assertThat(purchasesConfiguration.context).isEqualTo(context)
         assertThat(purchasesConfiguration.appUserID).isNull()
         assertThat(purchasesConfiguration.observerMode).isFalse
+        assertThat(purchasesConfiguration.finishTransactions).isTrue
         assertThat(purchasesConfiguration.service).isNull()
         assertThat(purchasesConfiguration.store).isEqualTo(Store.PLAY_STORE)
         assertThat(purchasesConfiguration.diagnosticsEnabled).isFalse

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -51,6 +51,14 @@ class PurchasesConfigurationTest {
     fun `PurchasesConfiguration sets observerMode correctly`() {
         val purchasesConfiguration = builder.observerMode(true).build()
         assertThat(purchasesConfiguration.observerMode).isTrue
+        assertThat(purchasesConfiguration.finishTransactions).isFalse
+    }
+
+    @Test
+    fun `PurchasesConfiguration sets finishTransactions correctly`() {
+        val purchasesConfiguration = builder.finishTransactions(true).build()
+        assertThat(purchasesConfiguration.finishTransactions).isTrue
+        assertThat(purchasesConfiguration.observerMode).isFalse
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -2,6 +2,8 @@ package com.revenuecat.purchases
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.PurchasesAreCompletedBy.MY_APP
+import com.revenuecat.purchases.PurchasesAreCompletedBy.REVENUECAT
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -32,7 +34,7 @@ class PurchasesConfigurationTest {
         assertThat(purchasesConfiguration.context).isEqualTo(context)
         assertThat(purchasesConfiguration.appUserID).isNull()
         assertThat(purchasesConfiguration.observerMode).isFalse
-        assertThat(purchasesConfiguration.finishTransactions).isTrue
+        assertThat(purchasesConfiguration.purchasesAreCompletedBy).isEqualTo(REVENUECAT)
         assertThat(purchasesConfiguration.service).isNull()
         assertThat(purchasesConfiguration.store).isEqualTo(Store.PLAY_STORE)
         assertThat(purchasesConfiguration.diagnosticsEnabled).isFalse
@@ -52,14 +54,14 @@ class PurchasesConfigurationTest {
     fun `PurchasesConfiguration sets observerMode correctly`() {
         val purchasesConfiguration = builder.observerMode(true).build()
         assertThat(purchasesConfiguration.observerMode).isTrue
-        assertThat(purchasesConfiguration.finishTransactions).isFalse
+        assertThat(purchasesConfiguration.purchasesAreCompletedBy).isEqualTo(MY_APP)
     }
 
     @Test
-    fun `PurchasesConfiguration sets finishTransactions correctly`() {
-        val purchasesConfiguration = builder.finishTransactions(true).build()
-        assertThat(purchasesConfiguration.finishTransactions).isTrue
-        assertThat(purchasesConfiguration.observerMode).isFalse
+    fun `PurchasesConfiguration sets purchasesAreCompletedBy correctly`() {
+        val purchasesConfiguration = builder.purchasesAreCompletedBy(MY_APP).build()
+        assertThat(purchasesConfiguration.purchasesAreCompletedBy).isEqualTo(MY_APP)
+        assertThat(purchasesConfiguration.observerMode).isTrue
     }
 
     @Test

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesConfigureTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesConfigureTest.kt
@@ -6,6 +6,8 @@
 package com.revenuecat.purchases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.PurchasesAreCompletedBy.MY_APP
+import com.revenuecat.purchases.PurchasesAreCompletedBy.REVENUECAT
 import com.revenuecat.purchases.common.PlatformInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -48,15 +50,15 @@ internal class PurchasesConfigureTest : BasePurchasesTest() {
     }
 
     @Test
-    fun `Setting finish transactions on propagates to appConfig`() {
-        val builder = PurchasesConfiguration.Builder(mockContext, "api").finishTransactions(true)
+    fun `Setting purchasesAreCompletedBy REVENUECAT propagates to appConfig`() {
+        val builder = PurchasesConfiguration.Builder(mockContext, "api").purchasesAreCompletedBy(REVENUECAT)
         Purchases.configure(builder.build())
         assertThat(Purchases.sharedInstance.purchasesOrchestrator.appConfig.finishTransactions).isTrue
     }
 
     @Test
-    fun `Setting finish transactions off propagates to appConfig`() {
-        val builder = PurchasesConfiguration.Builder(mockContext, "api").finishTransactions(false)
+    fun `Setting purchasesAreCompletedBy MY_APP propagates to appConfig`() {
+        val builder = PurchasesConfiguration.Builder(mockContext, "api").purchasesAreCompletedBy(MY_APP)
         Purchases.configure(builder.build())
         assertThat(Purchases.sharedInstance.purchasesOrchestrator.appConfig.finishTransactions).isFalse
     }

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesConfigureTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesConfigureTest.kt
@@ -48,6 +48,20 @@ internal class PurchasesConfigureTest : BasePurchasesTest() {
     }
 
     @Test
+    fun `Setting finish transactions on propagates to appConfig`() {
+        val builder = PurchasesConfiguration.Builder(mockContext, "api").finishTransactions(true)
+        Purchases.configure(builder.build())
+        assertThat(Purchases.sharedInstance.purchasesOrchestrator.appConfig.finishTransactions).isTrue
+    }
+
+    @Test
+    fun `Setting finish transactions off propagates to appConfig`() {
+        val builder = PurchasesConfiguration.Builder(mockContext, "api").finishTransactions(false)
+        Purchases.configure(builder.build())
+        assertThat(Purchases.sharedInstance.purchasesOrchestrator.appConfig.finishTransactions).isFalse
+    }
+
+    @Test
     fun `Setting store in the configuration sets it on the Purchases instance`() {
         val builder = PurchasesConfiguration.Builder(mockContext, "api").store(Store.PLAY_STORE)
         Purchases.configure(builder.build())

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -764,7 +764,7 @@ internal class PurchasesTest : BasePurchasesTest() {
             mockCache.getPreviouslySentHashedTokens()
         } returns setOf()
 
-        purchases.syncObserverModeAmazonPurchase(
+        purchases.syncAmazonPurchase(
             productID = skuParent,
             receiptID = purchaseToken,
             amazonUserID = amazonUserID,
@@ -821,7 +821,7 @@ internal class PurchasesTest : BasePurchasesTest() {
             }
         }
 
-        purchases.syncObserverModeAmazonPurchase(
+        purchases.syncAmazonPurchase(
             productID = skuParent,
             receiptID = purchaseToken,
             amazonUserID = amazonUserID,
@@ -852,7 +852,7 @@ internal class PurchasesTest : BasePurchasesTest() {
             mockCache.getPreviouslySentHashedTokens()
         } returns setOf(purchaseToken.sha1())
 
-        purchases.syncObserverModeAmazonPurchase(
+        purchases.syncAmazonPurchase(
             productID = skuParent,
             receiptID = purchaseToken,
             amazonUserID = amazonUserID,
@@ -902,7 +902,7 @@ internal class PurchasesTest : BasePurchasesTest() {
             mockCache.getPreviouslySentHashedTokens()
         } returns setOf()
 
-        purchases.syncObserverModeAmazonPurchase(
+        purchases.syncAmazonPurchase(
             productID = skuParent,
             receiptID = purchaseToken,
             amazonUserID = amazonUserID,
@@ -953,7 +953,7 @@ internal class PurchasesTest : BasePurchasesTest() {
             mockCache.getPreviouslySentHashedTokens()
         } returns setOf()
 
-        purchases.syncObserverModeAmazonPurchase(
+        purchases.syncAmazonPurchase(
             productID = skuParent,
             receiptID = purchaseToken,
             amazonUserID = amazonUserID,
@@ -1034,7 +1034,7 @@ internal class PurchasesTest : BasePurchasesTest() {
             mockCache.getPreviouslySentHashedTokens()
         } returns setOf()
 
-        purchases.syncObserverModeAmazonPurchase(
+        purchases.syncAmazonPurchase(
             productID = skuParent,
             receiptID = purchaseToken,
             amazonUserID = amazonUserID,
@@ -1093,7 +1093,7 @@ internal class PurchasesTest : BasePurchasesTest() {
             mockCache.getPreviouslySentHashedTokens()
         } returns setOf()
 
-        purchases.syncObserverModeAmazonPurchase(
+        purchases.syncAmazonPurchase(
             productID = skuParent,
             receiptID = purchaseToken,
             amazonUserID = amazonUserID,


### PR DESCRIPTION
## Changed
- Adds `PurchasesAreCompletedBy` enum.
- Adds `PurchasesConfiguration.Builder.purchasesAreCompletedBy()`
- Deprecates `PurchasesConfiguration.Builder.observerMode()`, with a nice `ReplaceWith` action.
- Adds `Purchases.syncAmazonPurchase()`.
- Deprecates `Purchases.syncObserverModeAmazonPurchase`, with a nice `ReplaceWith` action.
- Deprecates `Purchases.finishTransactions`, with an okay `ReplaceWith` action.
- Adds API tests for `PurchasesAreCompletedBy`.
- Adds API tests for `purchasesAreCompletedBy()`.
- PaywallsTester, PurchaseTester and the MagicWeather samples use `purchasesAreCompletedBy()` instead of `observerMode()`.
- Adds some unit tests for `purchasesAreCompletedBy()`.

## Not changed
This PR does not remove all internal mentions of the terms "observer mode" and "finish transactions" from the codebase. Will do that in a follow-up. 

## Blockers
- [x] Get consensus that this is the route we want to take. 
    - [x] Enum instead of boolean? 👉 enum
    - [x] Deprecate or remove straight away? 👉 deprecate
    - [x] Decide on a target branch (`8.0.0-dev` or `main`). 👉 main
- [x] Wait for `/finishing-transactions` to go live, as it is mentioned in the Magic Weather samples. See https://github.com/RevenueCat/docusaurus/pull/261 👉 moved to another PR: https://github.com/RevenueCat/purchases-android/pull/1721