### PR TITLE
Fix non-consumables not getting acknowledged

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -371,23 +371,21 @@ internal class BillingWrapper(
                     initiationSource,
                     onConsumed = deviceCache::addSuccessfullyPostedToken,
                 )
-            } else if (finishTransactions) {
+            } else if (finishTransactions && !alreadyAcknowledged) {
                 log(LogIntent.PURCHASE, PurchaseStrings.NOT_CONSUMING_IN_APP_PURCHASE_ACCORDING_TO_BACKEND)
-                acknowledgeIfNeeded(
+                acknowledge(
                     purchase.purchaseToken,
                     initiationSource,
-                    alreadyAcknowledged,
                     onAcknowledged = deviceCache::addSuccessfullyPostedToken,
                 )
             } else {
                 deviceCache.addSuccessfullyPostedToken(purchase.purchaseToken)
             }
         } else {
-            if (finishTransactions) {
-                acknowledgeIfNeeded(
+            if (finishTransactions && !alreadyAcknowledged) {
+                acknowledge(
                     purchase.purchaseToken,
                     initiationSource,
-                    alreadyAcknowledged,
                     onAcknowledged = deviceCache::addSuccessfullyPostedToken,
                 )
             } else {
@@ -422,15 +420,11 @@ internal class BillingWrapper(
         ).run()
     }
 
-    internal fun acknowledgeIfNeeded(
+    internal fun acknowledge(
         token: String,
         initiationSource: PostReceiptInitiationSource,
-        alreadyAcknowledged: Boolean,
         onAcknowledged: (purchaseToken: String) -> Unit,
     ) {
-        if (alreadyAcknowledged) {
-            return
-        }
         log(LogIntent.PURCHASE, PurchaseStrings.ACKNOWLEDGING_PURCHASE.format(token))
         AcknowledgePurchaseUseCase(
             AcknowledgePurchaseUseCaseParams(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -379,8 +379,16 @@ internal class BillingWrapper(
                         LogIntent.PURCHASE,
                         PurchaseStrings.NOT_CONSUMING_IN_APP_PURCHASE_ACCORDING_TO_BACKEND,
                     )
+                    if (!alreadyAcknowledged) {
+                        acknowledge(
+                            purchase.purchaseToken,
+                            initiationSource,
+                            onAcknowledged = deviceCache::addSuccessfullyPostedToken,
+                        )
+                    }
+                } else {
+                    deviceCache.addSuccessfullyPostedToken(purchase.purchaseToken)
                 }
-                deviceCache.addSuccessfullyPostedToken(purchase.purchaseToken)
             }
         } else {
             if (finishTransactions && !alreadyAcknowledged) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -353,19 +353,17 @@ internal class BillingWrapper(
         shouldConsume: Boolean,
         initiationSource: PostReceiptInitiationSource,
     ) {
-        if (purchase.type == ProductType.UNKNOWN) {
-            // Would only get here if the purchase was triggered from outside of the app and there was
+        if (purchase.type == ProductType.UNKNOWN || purchase.purchaseState == PurchaseState.PENDING) {
+            // Product type will be unknown if the purchase was triggered from outside of the app and there was
             // an issue getting the purchase type
-            return
-        }
-        if (purchase.purchaseState == PurchaseState.PENDING) {
-            // PENDING purchases should not be fulfilled
+            // Exit early if purchase type is unknown or purchase is pending
             return
         }
 
         val originalGooglePurchase = purchase.originalGooglePurchase
         val alreadyAcknowledged = originalGooglePurchase?.isAcknowledged ?: false
         val isInAppProduct = purchase.type == ProductType.INAPP
+
         if (isInAppProduct) {
             if (finishTransactions && shouldConsume) {
                 consumePurchase(
@@ -373,28 +371,23 @@ internal class BillingWrapper(
                     initiationSource,
                     onConsumed = deviceCache::addSuccessfullyPostedToken,
                 )
-            } else {
-                if (finishTransactions) {
-                    log(
-                        LogIntent.PURCHASE,
-                        PurchaseStrings.NOT_CONSUMING_IN_APP_PURCHASE_ACCORDING_TO_BACKEND,
-                    )
-                    if (!alreadyAcknowledged) {
-                        acknowledge(
-                            purchase.purchaseToken,
-                            initiationSource,
-                            onAcknowledged = deviceCache::addSuccessfullyPostedToken,
-                        )
-                    }
-                } else {
-                    deviceCache.addSuccessfullyPostedToken(purchase.purchaseToken)
-                }
-            }
-        } else {
-            if (finishTransactions && !alreadyAcknowledged) {
-                acknowledge(
+            } else if (finishTransactions) {
+                log(LogIntent.PURCHASE, PurchaseStrings.NOT_CONSUMING_IN_APP_PURCHASE_ACCORDING_TO_BACKEND)
+                acknowledgeIfNeeded(
                     purchase.purchaseToken,
                     initiationSource,
+                    alreadyAcknowledged,
+                    onAcknowledged = deviceCache::addSuccessfullyPostedToken,
+                )
+            } else {
+                deviceCache.addSuccessfullyPostedToken(purchase.purchaseToken)
+            }
+        } else {
+            if (finishTransactions) {
+                acknowledgeIfNeeded(
+                    purchase.purchaseToken,
+                    initiationSource,
+                    alreadyAcknowledged,
                     onAcknowledged = deviceCache::addSuccessfullyPostedToken,
                 )
             } else {
@@ -429,11 +422,15 @@ internal class BillingWrapper(
         ).run()
     }
 
-    internal fun acknowledge(
+    internal fun acknowledgeIfNeeded(
         token: String,
         initiationSource: PostReceiptInitiationSource,
+        alreadyAcknowledged: Boolean,
         onAcknowledged: (purchaseToken: String) -> Unit,
     ) {
+        if (alreadyAcknowledged) {
+            return
+        }
         log(LogIntent.PURCHASE, PurchaseStrings.ACKNOWLEDGING_PURCHASE.format(token))
         AcknowledgePurchaseUseCase(
             AcknowledgePurchaseUseCaseParams(

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -50,27 +50,13 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
     fun `Acknowledge works`() {
         val token = "token"
 
-        wrapper.acknowledgeIfNeeded(
+        wrapper.acknowledge(
             token,
-            alreadyAcknowledged = false,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
         ) { }
 
         assertThat(capturedAcknowledgePurchaseParams.isCaptured).isTrue
         assertThat(capturedAcknowledgePurchaseParams.captured.purchaseToken).isEqualTo(token)
-    }
-
-    @Test
-    fun `Acknowledge skips if already acknowledged`() {
-        val token = "token"
-
-        wrapper.acknowledgeIfNeeded(
-            token,
-            alreadyAcknowledged = true,
-            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
-        ) { }
-
-        assertThat(capturedAcknowledgePurchaseParams.isCaptured).isFalse()
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -50,13 +50,27 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
     fun `Acknowledge works`() {
         val token = "token"
 
-        wrapper.acknowledge(
+        wrapper.acknowledgeIfNeeded(
             token,
+            alreadyAcknowledged = false,
             initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
         ) { }
 
         assertThat(capturedAcknowledgePurchaseParams.isCaptured).isTrue
         assertThat(capturedAcknowledgePurchaseParams.captured.purchaseToken).isEqualTo(token)
+    }
+
+    @Test
+    fun `Acknowledge skips if already acknowledged`() {
+        val token = "token"
+
+        wrapper.acknowledgeIfNeeded(
+            token,
+            alreadyAcknowledged = true,
+            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+        ) { }
+
+        assertThat(capturedAcknowledgePurchaseParams.isCaptured).isFalse()
     }
 
     @Test


### PR DESCRIPTION
After #1697 , we stopped consuming non-consumables if the backend indicates to not consume them. Non-consumables still need to be acknowledged, otherwise they get refunded, this PR fixes that.

For reference, https://developer.android.com/google/play/billing/integrate#non-consumable-products