### PR TITLE
Fix purchase tester offerings not reloading

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingCardAdapter.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OfferingCardAdapter.kt
@@ -20,12 +20,6 @@ class OfferingCardAdapter(
         return OfferingViewHolder(binding)
     }
 
-    fun update(offerings: List<Offering>, currentOffering: Offering?) {
-        this.offerings = offerings
-        this.currentOffering = currentOffering
-        this.notifyDataSetChanged()
-    }
-
     override fun getItemCount(): Int = offerings.size
 
     override fun onBindViewHolder(holder: OfferingViewHolder, position: Int) {

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -92,8 +92,6 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
         Purchases.sharedInstance.getOfferingsWith(::showError, ::populateOfferings)
     }
 
-    private var adapter: OfferingCardAdapter? = null
-
     private fun populateOfferings(offerings: Offerings) {
         if (offerings.all.isEmpty()) {
             binding.offeringHeader.text = "No Offerings"
@@ -105,15 +103,13 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
             it.identifier != currentOffering?.identifier
         }
 
-        this.adapter?.update(allOfferings, currentOffering) ?: run {
-            this.adapter = OfferingCardAdapter(
-                allOfferings,
-                currentOffering,
-                this,
-            )
-            binding.overviewOfferingsRecycler.layoutManager = LinearLayoutManager(requireContext())
-            binding.overviewOfferingsRecycler.adapter = this.adapter
-        }
+        val adapter = OfferingCardAdapter(
+            allOfferings,
+            currentOffering,
+            this,
+        )
+        binding.overviewOfferingsRecycler.layoutManager = LinearLayoutManager(requireContext())
+        binding.overviewOfferingsRecycler.adapter = adapter
     }
 
     override fun onOfferingClicked(cardView: View, offering: Offering) {


### PR DESCRIPTION
### Description
I've run into some issues with purchase tester for a while where the offerings were not updated after changing screens or purchasing. This simplifies the reloading so it loads always. There might be more performant options, but considering this is a test app, I didn't want to dedicate too much time to it.