### PR TITLE
Set INFORMATIONAL trusted entitlements mode as the default in the purchase tester app

### DIFF
--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -44,6 +44,7 @@ class ConfigureFragment : Fragment() {
             android.R.layout.simple_spinner_item,
             EntitlementVerificationMode.values(),
         )
+        binding.verificationOptionsInput.setSelection(EntitlementVerificationMode.INFORMATIONAL.ordinal)
         setupSupportedStoresRadioButtons()
 
         lifecycleScope.launch {


### PR DESCRIPTION
### Description
Enabling trusted entitlement seems like a more sensible default for our test app.