### PR TITLE
Support pending prepaid purchases

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
@@ -146,7 +146,7 @@ final class PurchasesCommonAPI {
                 .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
                 .showInAppMessagesAutomatically(true)
                 .store(Store.APP_STORE)
-                .pendingPrepaidSubscriptionsEnabled(true)
+                .pendingTransactionsForPrepaidPlansEnabled(true)
                 .build();
 
         final Boolean showInAppMessagesAutomatically = build.getShowInAppMessagesAutomatically();

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
@@ -146,6 +146,7 @@ final class PurchasesCommonAPI {
                 .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
                 .showInAppMessagesAutomatically(true)
                 .store(Store.APP_STORE)
+                .pendingPrepaidSubscriptionsEnabled(true)
                 .build();
 
         final Boolean showInAppMessagesAutomatically = build.getShowInAppMessagesAutomatically();

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
@@ -190,7 +190,7 @@ private class PurchasesCommonAPI {
             .diagnosticsEnabled(true)
             .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
             .store(Store.PLAY_STORE)
-            .pendingPrepaidSubscriptionsEnabled(true)
+            .pendingTransactionsForPrepaidPlansEnabled(true)
             .build()
 
         val showInAppMessagesAutomatically: Boolean = build.showInAppMessagesAutomatically

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
@@ -190,6 +190,7 @@ private class PurchasesCommonAPI {
             .diagnosticsEnabled(true)
             .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
             .store(Store.PLAY_STORE)
+            .pendingPrepaidSubscriptionsEnabled(true)
             .build()
 
         val showInAppMessagesAutomatically: Boolean = build.showInAppMessagesAutomatically

--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -277,6 +277,7 @@ class Purchases internal constructor(
             val configuration = PurchasesConfiguration.Builder(context, apiKey)
                 .appUserID(appUserID)
                 .dangerousSettings(DangerousSettings(customEntitlementComputation = true))
+                .pendingTransactionsForPrepaidPlansEnabled(true)
                 .build()
             return PurchasesFactory().createPurchases(
                 configuration,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
@@ -20,9 +20,10 @@ internal object BillingFactory {
         observerMode: Boolean,
         diagnosticsTrackerIfEnabled: DiagnosticsTracker?,
         stateProvider: PurchasesStateProvider,
+        pendingPrepaidSubscriptionsEnabled: Boolean,
     ) = when (store) {
         Store.PLAY_STORE -> BillingWrapper(
-            BillingWrapper.ClientFactory(application),
+            BillingWrapper.ClientFactory(application, pendingPrepaidSubscriptionsEnabled),
             Handler(application.mainLooper),
             cache,
             diagnosticsTrackerIfEnabled,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
@@ -20,10 +20,10 @@ internal object BillingFactory {
         observerMode: Boolean,
         diagnosticsTrackerIfEnabled: DiagnosticsTracker?,
         stateProvider: PurchasesStateProvider,
-        pendingPrepaidSubscriptionsEnabled: Boolean,
+        pendingTransactionsForPrepaidPlansEnabled: Boolean,
     ) = when (store) {
         Store.PLAY_STORE -> BillingWrapper(
-            BillingWrapper.ClientFactory(application, pendingPrepaidSubscriptionsEnabled),
+            BillingWrapper.ClientFactory(application, pendingTransactionsForPrepaidPlansEnabled),
             Handler(application.mainLooper),
             cache,
             diagnosticsTrackerIfEnabled,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -19,7 +19,7 @@ open class PurchasesConfiguration(builder: Builder) {
     val diagnosticsEnabled: Boolean
     val dangerousSettings: DangerousSettings
     val verificationMode: EntitlementVerificationMode
-    val pendingPrepaidSubscriptionsEnabled: Boolean
+    val pendingTransactionsForPrepaidPlansEnabled: Boolean
 
     init {
         this.context = builder.context
@@ -32,7 +32,7 @@ open class PurchasesConfiguration(builder: Builder) {
         this.verificationMode = builder.verificationMode
         this.dangerousSettings = builder.dangerousSettings
         this.showInAppMessagesAutomatically = builder.showInAppMessagesAutomatically
-        this.pendingPrepaidSubscriptionsEnabled = builder.pendingPrepaidSubscriptionsEnabled
+        this.pendingTransactionsForPrepaidPlansEnabled = builder.pendingTransactionsForPrepaidPlansEnabled
     }
 
     @Suppress("TooManyFunctions")
@@ -66,7 +66,7 @@ open class PurchasesConfiguration(builder: Builder) {
         internal var dangerousSettings: DangerousSettings = DangerousSettings()
 
         @set:JvmSynthetic @get:JvmSynthetic
-        internal var pendingPrepaidSubscriptionsEnabled: Boolean = true
+        internal var pendingTransactionsForPrepaidPlansEnabled: Boolean = false
 
         /**
          * A unique id for identifying the user
@@ -180,12 +180,12 @@ open class PurchasesConfiguration(builder: Builder) {
         }
 
         /**
-         * Disable this setting if you don't want to allow pending purchases for prepaid subscriptions (only supported
+         * Enable this setting if you want to allow pending purchases for prepaid subscriptions (only supported
          * in Google Play). Note that entitlements are not granted until payment is done.
-         * Default is enabled.
+         * Default is disabled.
          */
-        fun pendingPrepaidSubscriptionsEnabled(pendingPrepaidSubscriptionsEnabled: Boolean) = apply {
-            this.pendingPrepaidSubscriptionsEnabled = pendingPrepaidSubscriptionsEnabled
+        fun pendingTransactionsForPrepaidPlansEnabled(pendingTransactionsForPrepaidPlansEnabled: Boolean) = apply {
+            this.pendingTransactionsForPrepaidPlansEnabled = pendingTransactionsForPrepaidPlansEnabled
         }
 
         /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -19,6 +19,7 @@ open class PurchasesConfiguration(builder: Builder) {
     val diagnosticsEnabled: Boolean
     val dangerousSettings: DangerousSettings
     val verificationMode: EntitlementVerificationMode
+    val pendingPrepaidSubscriptionsEnabled: Boolean
 
     init {
         this.context = builder.context
@@ -31,8 +32,10 @@ open class PurchasesConfiguration(builder: Builder) {
         this.verificationMode = builder.verificationMode
         this.dangerousSettings = builder.dangerousSettings
         this.showInAppMessagesAutomatically = builder.showInAppMessagesAutomatically
+        this.pendingPrepaidSubscriptionsEnabled = builder.pendingPrepaidSubscriptionsEnabled
     }
 
+    @Suppress("TooManyFunctions")
     open class Builder(
         @get:JvmSynthetic internal val context: Context,
         @get:JvmSynthetic internal val apiKey: String,
@@ -61,6 +64,9 @@ open class PurchasesConfiguration(builder: Builder) {
 
         @set:JvmSynthetic @get:JvmSynthetic
         internal var dangerousSettings: DangerousSettings = DangerousSettings()
+
+        @set:JvmSynthetic @get:JvmSynthetic
+        internal var pendingPrepaidSubscriptionsEnabled: Boolean = true
 
         /**
          * A unique id for identifying the user
@@ -171,6 +177,15 @@ open class PurchasesConfiguration(builder: Builder) {
          */
         fun dangerousSettings(dangerousSettings: DangerousSettings) = apply {
             this.dangerousSettings = dangerousSettings
+        }
+
+        /**
+         * Disable this setting if you don't want to allow pending purchases for prepaid subscriptions (only supported
+         * in Google Play). Note that entitlements are not granted until payment is done.
+         * Default is enabled.
+         */
+        fun pendingPrepaidSubscriptionsEnabled(pendingPrepaidSubscriptionsEnabled: Boolean) = apply {
+            this.pendingPrepaidSubscriptionsEnabled = pendingPrepaidSubscriptionsEnabled
         }
 
         /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -141,6 +141,7 @@ internal class PurchasesFactory(
                 observerMode,
                 diagnosticsTracker,
                 purchasesStateProvider,
+                pendingPrepaidSubscriptionsEnabled,
             )
 
             val subscriberAttributesPoster = SubscriberAttributesPoster(backendHelper)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -141,7 +141,7 @@ internal class PurchasesFactory(
                 observerMode,
                 diagnosticsTracker,
                 purchasesStateProvider,
-                pendingPrepaidSubscriptionsEnabled,
+                pendingTransactionsForPrepaidPlansEnabled,
             )
 
             val subscriberAttributesPoster = SubscriberAttributesPoster(backendHelper)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -107,12 +107,12 @@ internal class BillingWrapper(
     val appInBackground: Boolean
         get() = purchasesStateProvider.purchasesState.appInBackground
 
-    class ClientFactory(private val context: Context) {
+    class ClientFactory(private val context: Context, private val pendingPrepaidSubscriptionsEnabled: Boolean) {
         @UiThread
         fun buildClient(listener: com.android.billingclient.api.PurchasesUpdatedListener): BillingClient {
             val pendingPurchaseParams = PendingPurchasesParams.newBuilder()
                 .enableOneTimeProducts()
-                .enablePrepaidPlans()
+                .apply { if (pendingPrepaidSubscriptionsEnabled) enablePrepaidPlans() }
                 .build()
             return BillingClient.newBuilder(context).enablePendingPurchases(pendingPurchaseParams).setListener(listener)
                 .build()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -107,12 +107,15 @@ internal class BillingWrapper(
     val appInBackground: Boolean
         get() = purchasesStateProvider.purchasesState.appInBackground
 
-    class ClientFactory(private val context: Context, private val pendingPrepaidSubscriptionsEnabled: Boolean) {
+    class ClientFactory(
+        private val context: Context,
+        private val pendingTransactionsForPrepaidPlansEnabled: Boolean,
+    ) {
         @UiThread
         fun buildClient(listener: com.android.billingclient.api.PurchasesUpdatedListener): BillingClient {
             val pendingPurchaseParams = PendingPurchasesParams.newBuilder()
                 .enableOneTimeProducts()
-                .apply { if (pendingPrepaidSubscriptionsEnabled) enablePrepaidPlans() }
+                .apply { if (pendingTransactionsForPrepaidPlansEnabled) enablePrepaidPlans() }
                 .build()
             return BillingClient.newBuilder(context).enablePendingPurchases(pendingPurchaseParams).setListener(listener)
                 .build()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -16,6 +16,7 @@ import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.InAppMessageParams
 import com.android.billingclient.api.InAppMessageResult
+import com.android.billingclient.api.PendingPurchasesParams
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryRecord
 import com.android.billingclient.api.PurchasesUpdatedListener
@@ -109,7 +110,11 @@ internal class BillingWrapper(
     class ClientFactory(private val context: Context) {
         @UiThread
         fun buildClient(listener: com.android.billingclient.api.PurchasesUpdatedListener): BillingClient {
-            return BillingClient.newBuilder(context).enablePendingPurchases().setListener(listener)
+            val pendingPurchaseParams = PendingPurchasesParams.newBuilder()
+                .enableOneTimeProducts()
+                .enablePrepaidPlans()
+                .build()
+            return BillingClient.newBuilder(context).enablePendingPurchases(pendingPurchaseParams).setListener(listener)
                 .build()
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
@@ -27,7 +27,7 @@ class BillingFactoryTest {
             observerMode = false,
             mockDiagnosticsTracker,
             PurchasesStateCache(PurchasesState()),
-            pendingPrepaidSubscriptionsEnabled = true,
+            pendingTransactionsForPrepaidPlansEnabled = true,
         )
     }
 
@@ -45,7 +45,7 @@ class BillingFactoryTest {
             observerMode = false,
             diagnosticsTrackerIfEnabled = null,
             PurchasesStateCache(PurchasesState()),
-            pendingPrepaidSubscriptionsEnabled = true,
+            pendingTransactionsForPrepaidPlansEnabled = true,
         )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
@@ -26,7 +26,8 @@ class BillingFactoryTest {
             mockCache,
             observerMode = false,
             mockDiagnosticsTracker,
-            PurchasesStateCache(PurchasesState())
+            PurchasesStateCache(PurchasesState()),
+            pendingPrepaidSubscriptionsEnabled = true,
         )
     }
 
@@ -43,7 +44,8 @@ class BillingFactoryTest {
             mockCache,
             observerMode = false,
             diagnosticsTrackerIfEnabled = null,
-            PurchasesStateCache(PurchasesState())
+            PurchasesStateCache(PurchasesState()),
+            pendingPrepaidSubscriptionsEnabled = true,
         )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -38,6 +38,7 @@ class PurchasesConfigurationTest {
         assertThat(purchasesConfiguration.verificationMode).isEqualTo(EntitlementVerificationMode.DISABLED)
         assertThat(purchasesConfiguration.dangerousSettings).isEqualTo(DangerousSettings(autoSyncPurchases = true))
         assertThat(purchasesConfiguration.showInAppMessagesAutomatically).isTrue
+        assertThat(purchasesConfiguration.pendingTransactionsForPrepaidPlansEnabled).isFalse
     }
 
     @Test
@@ -84,6 +85,12 @@ class PurchasesConfigurationTest {
             EntitlementVerificationMode.INFORMATIONAL
         ).build()
         assertThat(purchasesConfiguration.verificationMode).isEqualTo(EntitlementVerificationMode.INFORMATIONAL)
+    }
+
+    @Test
+    fun `PurchasesConfiguration sets pending prepaid support enabled correctly`() {
+        val purchasesConfiguration = builder.pendingTransactionsForPrepaidPlansEnabled(true).build()
+        assertThat(purchasesConfiguration.pendingTransactionsForPrepaidPlansEnabled).isTrue
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
@@ -31,7 +31,8 @@ class BillingFactoryAmazonTest {
             mockCache,
             observerMode = false,
             mockDiagnosticsTracker,
-            stateProvider = PurchasesStateCache(PurchasesState())
+            stateProvider = PurchasesStateCache(PurchasesState()),
+            pendingPrepaidSubscriptionsEnabled = true,
         )
     }
 
@@ -48,7 +49,8 @@ class BillingFactoryAmazonTest {
             mockCache,
             observerMode = false,
             diagnosticsTrackerIfEnabled = null,
-            stateProvider = PurchasesStateCache(PurchasesState())
+            stateProvider = PurchasesStateCache(PurchasesState()),
+            pendingPrepaidSubscriptionsEnabled = true,
         )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
@@ -32,7 +32,7 @@ class BillingFactoryAmazonTest {
             observerMode = false,
             mockDiagnosticsTracker,
             stateProvider = PurchasesStateCache(PurchasesState()),
-            pendingPrepaidSubscriptionsEnabled = true,
+            pendingTransactionsForPrepaidPlansEnabled = true,
         )
     }
 
@@ -50,7 +50,7 @@ class BillingFactoryAmazonTest {
             observerMode = false,
             diagnosticsTrackerIfEnabled = null,
             stateProvider = PurchasesStateCache(PurchasesState()),
-            pendingPrepaidSubscriptionsEnabled = true,
+            pendingTransactionsForPrepaidPlansEnabled = true,
         )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -15,6 +15,7 @@ import com.android.billingclient.api.ConsumeResponseListener
 import com.android.billingclient.api.InAppMessageResponseListener
 import com.android.billingclient.api.InAppMessageResult
 import com.android.billingclient.api.InAppMessageResult.InAppMessageResponseCode
+import com.android.billingclient.api.PendingPurchasesParams
 import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.ProductDetailsResponseListener
 import com.android.billingclient.api.PurchasesUpdatedListener
@@ -1135,16 +1136,38 @@ class BillingWrapperTest {
     }
 
     @Test
-    fun `When building the BillingClient enabledPendingPurchases is called`() {
+    fun `When building the BillingClient enabledPendingPurchases for OTP and prepaid are called`() {
         val context = mockk<Context>()
         mockkStatic(BillingClient::class)
+        mockkStatic(PendingPurchasesParams::class)
         val mockBuilder = mockk<BillingClient.Builder>(relaxed = true)
         every {
             BillingClient.newBuilder(context)
         } returns mockBuilder
+        val mockPendingParamsBuilder = mockk<PendingPurchasesParams.Builder>(relaxed = true)
+        val mockPendingParams = mockk<PendingPurchasesParams>()
+        every {
+            PendingPurchasesParams.newBuilder()
+        } returns mockPendingParamsBuilder
+        every {
+            mockPendingParamsBuilder.enableOneTimeProducts()
+        } returns mockPendingParamsBuilder
+        every {
+            mockPendingParamsBuilder.enablePrepaidPlans()
+        } returns mockPendingParamsBuilder
+        every {
+            mockPendingParamsBuilder.build()
+        } returns mockPendingParams
         BillingWrapper.ClientFactory(context).buildClient(mockk())
+
         verify(exactly = 1) {
-            mockBuilder.enablePendingPurchases()
+            mockPendingParamsBuilder.enableOneTimeProducts()
+        }
+        verify(exactly = 1) {
+            mockPendingParamsBuilder.enablePrepaidPlans()
+        }
+        verify(exactly = 1) {
+            mockBuilder.enablePendingPurchases(mockPendingParams)
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1158,12 +1158,48 @@ class BillingWrapperTest {
         every {
             mockPendingParamsBuilder.build()
         } returns mockPendingParams
-        BillingWrapper.ClientFactory(context).buildClient(mockk())
+        BillingWrapper.ClientFactory(context, pendingPrepaidSubscriptionsEnabled = true).buildClient(mockk())
 
         verify(exactly = 1) {
             mockPendingParamsBuilder.enableOneTimeProducts()
         }
         verify(exactly = 1) {
+            mockPendingParamsBuilder.enablePrepaidPlans()
+        }
+        verify(exactly = 1) {
+            mockBuilder.enablePendingPurchases(mockPendingParams)
+        }
+    }
+
+    @Test
+    fun `Can disable pending prepaid subs`() {
+        val context = mockk<Context>()
+        mockkStatic(BillingClient::class)
+        mockkStatic(PendingPurchasesParams::class)
+        val mockBuilder = mockk<BillingClient.Builder>(relaxed = true)
+        every {
+            BillingClient.newBuilder(context)
+        } returns mockBuilder
+        val mockPendingParamsBuilder = mockk<PendingPurchasesParams.Builder>(relaxed = true)
+        val mockPendingParams = mockk<PendingPurchasesParams>()
+        every {
+            PendingPurchasesParams.newBuilder()
+        } returns mockPendingParamsBuilder
+        every {
+            mockPendingParamsBuilder.enableOneTimeProducts()
+        } returns mockPendingParamsBuilder
+        every {
+            mockPendingParamsBuilder.enablePrepaidPlans()
+        } returns mockPendingParamsBuilder
+        every {
+            mockPendingParamsBuilder.build()
+        } returns mockPendingParams
+        BillingWrapper.ClientFactory(context, pendingPrepaidSubscriptionsEnabled = false).buildClient(mockk())
+
+        verify(exactly = 1) {
+            mockPendingParamsBuilder.enableOneTimeProducts()
+        }
+        verify(exactly = 0) {
             mockPendingParamsBuilder.enablePrepaidPlans()
         }
         verify(exactly = 1) {

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1158,7 +1158,7 @@ class BillingWrapperTest {
         every {
             mockPendingParamsBuilder.build()
         } returns mockPendingParams
-        BillingWrapper.ClientFactory(context, pendingPrepaidSubscriptionsEnabled = true).buildClient(mockk())
+        BillingWrapper.ClientFactory(context, pendingTransactionsForPrepaidPlansEnabled = true).buildClient(mockk())
 
         verify(exactly = 1) {
             mockPendingParamsBuilder.enableOneTimeProducts()
@@ -1194,7 +1194,7 @@ class BillingWrapperTest {
         every {
             mockPendingParamsBuilder.build()
         } returns mockPendingParams
-        BillingWrapper.ClientFactory(context, pendingPrepaidSubscriptionsEnabled = false).buildClient(mockk())
+        BillingWrapper.ClientFactory(context, pendingTransactionsForPrepaidPlansEnabled = false).buildClient(mockk())
 
         verify(exactly = 1) {
             mockPendingParamsBuilder.enableOneTimeProducts()


### PR DESCRIPTION
### Description
PR to support pending prepaid purchase as a new feature added in BC7. This will be enabled by default but can be disabled through an option in `PurchasesConfiguration`: `pendingTransactionsForPrepaidPlansEnabled `.
