### PR TITLE
Remove `force-release-without-waiting-for-tests` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -659,16 +659,9 @@ workflows:
             - run-firebase-tests-purchases-load-shedder-integration-test
             - run-firebase-tests-purchases-custom-entitlement-computation-integration-test
           <<: *release-branches
-      - force-release-without-waiting-for-tests:
-          type: approval
-          <<: *release-branches
       - revenuecat/tag-current-branch:
           requires:
             - hold
-          <<: *release-branches
-      - revenuecat/tag-current-branch:
-          requires:
-            - force-release-without-waiting-for-tests
           <<: *release-branches
       - deploy: *release-tags
       - docs-deploy: *release-tags


### PR DESCRIPTION
This was causing the release PRs to never turn green completely

![CleanShot 2024-05-30 at 16 34 07@2x](https://github.com/RevenueCat/purchases-android/assets/664544/db97d1ca-1f55-4d60-9336-73728681afbd)

Also, it breaks "Rerun from fails" in CircleCI since there's a approval job, which causes the workflow to never fail completely if another job fails. 