### PR TITLE
Expose `InstallmentsInfo` in `SubscriptionOption`

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/InstallmentsInfoAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/InstallmentsInfoAPI.java
@@ -1,0 +1,23 @@
+package com.revenuecat.apitester.java;
+
+import com.revenuecat.purchases.models.GoogleInstallmentsInfo;
+import com.revenuecat.purchases.models.InstallmentsInfo;
+
+@SuppressWarnings({"unused"})
+final class InstallmentsInfoAPI {
+    static void check(final InstallmentsInfo installmentsInfo) {
+        int commitmentPaymentsCount = installmentsInfo.getCommitmentPaymentsCount();
+        int subsequentCommitmentPaymentsCount = installmentsInfo.getSubsequentCommitmentPaymentsCount();
+    }
+
+    static void checkGoogleInstallmentsInfo(final GoogleInstallmentsInfo googleInstallmentsInfo) {
+        check(googleInstallmentsInfo);
+        int commitmentPaymentsCount = googleInstallmentsInfo.getCommitmentPaymentsCount();
+        int subsequentCommitmentPaymentsCount = googleInstallmentsInfo.getSubsequentCommitmentPaymentsCount();
+
+        GoogleInstallmentsInfo constructedGoogleInstallmentsInfo = new GoogleInstallmentsInfo(
+                commitmentPaymentsCount,
+                subsequentCommitmentPaymentsCount
+        );
+    }
+}

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/InstallmentsInfoAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/InstallmentsInfoAPI.java
@@ -7,17 +7,17 @@ import com.revenuecat.purchases.models.InstallmentsInfo;
 final class InstallmentsInfoAPI {
     static void check(final InstallmentsInfo installmentsInfo) {
         int commitmentPaymentsCount = installmentsInfo.getCommitmentPaymentsCount();
-        int subsequentCommitmentPaymentsCount = installmentsInfo.getSubsequentCommitmentPaymentsCount();
+        int renewalCommitmentPaymentsCount = installmentsInfo.getRenewalCommitmentPaymentsCount();
     }
 
     static void checkGoogleInstallmentsInfo(final GoogleInstallmentsInfo googleInstallmentsInfo) {
         check(googleInstallmentsInfo);
         int commitmentPaymentsCount = googleInstallmentsInfo.getCommitmentPaymentsCount();
-        int subsequentCommitmentPaymentsCount = googleInstallmentsInfo.getSubsequentCommitmentPaymentsCount();
+        int renewalCommitmentPaymentsCount = googleInstallmentsInfo.getRenewalCommitmentPaymentsCount();
 
         GoogleInstallmentsInfo constructedGoogleInstallmentsInfo = new GoogleInstallmentsInfo(
                 commitmentPaymentsCount,
-                subsequentCommitmentPaymentsCount
+                renewalCommitmentPaymentsCount
         );
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/SubscriptionOptionAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/SubscriptionOptionAPI.java
@@ -2,7 +2,9 @@ package com.revenuecat.apitester.java;
 
 import com.android.billingclient.api.ProductDetails;
 import com.revenuecat.purchases.PresentedOfferingContext;
+import com.revenuecat.purchases.models.GoogleInstallmentsInfo;
 import com.revenuecat.purchases.models.GoogleSubscriptionOption;
+import com.revenuecat.purchases.models.InstallmentsInfo;
 import com.revenuecat.purchases.models.PricingPhase;
 import com.revenuecat.purchases.models.PurchasingData;
 import com.revenuecat.purchases.models.SubscriptionOption;
@@ -21,6 +23,7 @@ final class SubscriptionOptionAPI {
         PurchasingData purchasingData = subscriptionOption.getPurchasingData();
         String id = subscriptionOption.getId();
         Boolean isPrepaid = subscriptionOption.isPrepaid();
+        InstallmentsInfo installmentsInfo = subscriptionOption.getInstallmentsInfo();
     }
 
     static void checkGoogleSubscriptionOption(GoogleSubscriptionOption googleSubscriptionOption) {
@@ -30,6 +33,7 @@ final class SubscriptionOptionAPI {
         String offerId = googleSubscriptionOption.getOfferId();
         String offerToken = googleSubscriptionOption.getOfferToken();
         ProductDetails productDetails = googleSubscriptionOption.getProductDetails();
+        GoogleInstallmentsInfo installmentsInfo = googleSubscriptionOption.getInstallmentsInfo();
 
         GoogleSubscriptionOption constructedGoogleSubOption = new GoogleSubscriptionOption(
                 productId,
@@ -61,6 +65,18 @@ final class SubscriptionOptionAPI {
                 productDetails,
                 offerToken,
                 googleSubscriptionOption.getPresentedOfferingContext()
+        );
+
+        GoogleSubscriptionOption constructedGoogleSubOptionWithInstallmentsInfo = new GoogleSubscriptionOption(
+                productId,
+                basePlanId,
+                offerId,
+                googleSubscriptionOption.getPricingPhases(),
+                googleSubscriptionOption.getTags(),
+                productDetails,
+                offerToken,
+                googleSubscriptionOption.getPresentedOfferingContext(),
+                installmentsInfo
         );
     }
 

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/InstallmentsInfoAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/InstallmentsInfoAPI.kt
@@ -1,0 +1,23 @@
+package com.revenuecat.apitester.kotlin
+
+import com.revenuecat.purchases.models.GoogleInstallmentsInfo
+import com.revenuecat.purchases.models.InstallmentsInfo
+
+@Suppress("unused", "UNUSED_VARIABLE")
+private class InstallmentsInfoAPI {
+    fun checkInstallmentsInfo(installmentsInfo: InstallmentsInfo) {
+        val commitmentPaymentsCount: Int = installmentsInfo.commitmentPaymentsCount
+        val subsequentCommitmentPaymentsCount: Int = installmentsInfo.subsequentCommitmentPaymentsCount
+    }
+
+    fun checkGoogleInstallmentsInfo(googleInstallmentsInfo: GoogleInstallmentsInfo) {
+        checkInstallmentsInfo(googleInstallmentsInfo)
+        val commitmentPaymentsCount: Int = googleInstallmentsInfo.commitmentPaymentsCount
+        val subsequentCommitmentPaymentsCount: Int = googleInstallmentsInfo.subsequentCommitmentPaymentsCount
+
+        val newGoogleInstallmentsInfo = GoogleInstallmentsInfo(
+            commitmentPaymentsCount,
+            subsequentCommitmentPaymentsCount,
+        )
+    }
+}

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/InstallmentsInfoAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/InstallmentsInfoAPI.kt
@@ -7,17 +7,17 @@ import com.revenuecat.purchases.models.InstallmentsInfo
 private class InstallmentsInfoAPI {
     fun checkInstallmentsInfo(installmentsInfo: InstallmentsInfo) {
         val commitmentPaymentsCount: Int = installmentsInfo.commitmentPaymentsCount
-        val subsequentCommitmentPaymentsCount: Int = installmentsInfo.subsequentCommitmentPaymentsCount
+        val renewalCommitmentPaymentsCount: Int = installmentsInfo.renewalCommitmentPaymentsCount
     }
 
     fun checkGoogleInstallmentsInfo(googleInstallmentsInfo: GoogleInstallmentsInfo) {
         checkInstallmentsInfo(googleInstallmentsInfo)
         val commitmentPaymentsCount: Int = googleInstallmentsInfo.commitmentPaymentsCount
-        val subsequentCommitmentPaymentsCount: Int = googleInstallmentsInfo.subsequentCommitmentPaymentsCount
+        val renewalCommitmentPaymentsCount: Int = googleInstallmentsInfo.renewalCommitmentPaymentsCount
 
         val newGoogleInstallmentsInfo = GoogleInstallmentsInfo(
             commitmentPaymentsCount,
-            subsequentCommitmentPaymentsCount,
+            renewalCommitmentPaymentsCount,
         )
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/SubscriptionOptionAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/SubscriptionOptionAPI.kt
@@ -1,7 +1,9 @@
 package com.revenuecat.apitester.kotlin
 
 import com.revenuecat.purchases.PresentedOfferingContext
+import com.revenuecat.purchases.models.GoogleInstallmentsInfo
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
+import com.revenuecat.purchases.models.InstallmentsInfo
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.SubscriptionOption
 
@@ -14,6 +16,7 @@ private class SubscriptionOptionAPI {
         val presentedOfferingId: String? = subscriptionOption.presentedOfferingIdentifier
         val presentedOfferingContext: PresentedOfferingContext? = subscriptionOption.presentedOfferingContext
         val isPrepaid: Boolean = subscriptionOption.isPrepaid
+        val installmentsInfo: InstallmentsInfo? = subscriptionOption.installmentsInfo
     }
 
     fun checkGoogleSubscriptionOption(googleSubscriptionOption: GoogleSubscriptionOption) {
@@ -23,6 +26,7 @@ private class SubscriptionOptionAPI {
         val offerId = googleSubscriptionOption.offerId
         val offerToken = googleSubscriptionOption.offerToken
         val productDetails = googleSubscriptionOption.productDetails
+        val installmentsInfo: GoogleInstallmentsInfo? = googleSubscriptionOption.installmentsInfo
 
         val subscriptionOption = GoogleSubscriptionOption(
             productId,
@@ -65,6 +69,18 @@ private class SubscriptionOptionAPI {
             productDetails,
             offerToken,
             null,
+        )
+
+        val subscriptionOptionWithInstallmentsInfo = GoogleSubscriptionOption(
+            productId,
+            basePlanId,
+            offerId,
+            googleSubscriptionOption.pricingPhases,
+            googleSubscriptionOption.tags,
+            productDetails,
+            offerToken,
+            presentedOfferingContext = null,
+            installmentsInfo,
         )
     }
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/SubscriptionOptionExtensions.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/SubscriptionOptionExtensions.kt
@@ -9,5 +9,16 @@ fun SubscriptionOption.toButtonString(isDefault: Boolean): String {
         val cycles = pricingPhase.billingCycleCount
         "\t[$formatted, $iso, $cycles cycles]"
     }
-    return "${if (isDefault) "DEFAULT\n" else ""} PricingPhases = [\n$pricingPhasesString\n],\nTags = $tags"
+    val installmentsString = installmentsInfo?.let { installmentsInfo ->
+        val commitmentPaymentsCount = installmentsInfo.commitmentPaymentsCount
+        val subsequentCommitmentPaymentsCount = installmentsInfo.subsequentCommitmentPaymentsCount
+        "\nInstallmentsInfo = [" +
+            "\n\tCommitment: $commitmentPaymentsCount," +
+            "\n\tSubsequent: $subsequentCommitmentPaymentsCount" +
+            "\n]"
+    }
+    return "${if (isDefault) "DEFAULT\n" else ""} " +
+        "PricingPhases = [\n$pricingPhasesString\n],\n" +
+        "Tags = $tags" +
+        if (installmentsString != null) ",$installmentsString" else ""
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/SubscriptionOptionExtensions.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/SubscriptionOptionExtensions.kt
@@ -11,10 +11,10 @@ fun SubscriptionOption.toButtonString(isDefault: Boolean): String {
     }
     val installmentsString = installmentsInfo?.let { installmentsInfo ->
         val commitmentPaymentsCount = installmentsInfo.commitmentPaymentsCount
-        val subsequentCommitmentPaymentsCount = installmentsInfo.subsequentCommitmentPaymentsCount
+        val renewalCommitmentPaymentsCount = installmentsInfo.renewalCommitmentPaymentsCount
         "\nInstallmentsInfo = [" +
             "\n\tCommitment: $commitmentPaymentsCount," +
-            "\n\tSubsequent: $subsequentCommitmentPaymentsCount" +
+            "\n\tRenewal: $renewalCommitmentPaymentsCount" +
             "\n]"
     }
     return "${if (isDefault) "DEFAULT\n" else ""} " +

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/subscriptionOptionConversions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/subscriptionOptionConversions.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.google
 
 import com.android.billingclient.api.ProductDetails
+import com.revenuecat.purchases.models.GoogleInstallmentsInfo
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
 
 internal fun ProductDetails.SubscriptionOfferDetails.toSubscriptionOption(
@@ -16,6 +17,8 @@ internal fun ProductDetails.SubscriptionOfferDetails.toSubscriptionOption(
         offerTags,
         productDetails,
         offerToken,
+        presentedOfferingContext = null,
+        installmentPlanDetails?.installmentsInfo,
     )
 }
 
@@ -24,3 +27,9 @@ internal val ProductDetails.SubscriptionOfferDetails.subscriptionBillingPeriod: 
 
 internal val ProductDetails.SubscriptionOfferDetails.isBasePlan: Boolean
     get() = this.pricingPhases.pricingPhaseList.size == 1
+
+private val ProductDetails.InstallmentPlanDetails.installmentsInfo: GoogleInstallmentsInfo
+    get() = GoogleInstallmentsInfo(
+        installmentPlanCommitmentPaymentsCount,
+        subsequentInstallmentPlanCommitmentPaymentsCount,
+    )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleInstallmentsInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleInstallmentsInfo.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.purchases.models
+
+/**
+ * Type containing information of Google Play installment subscriptions
+ */
+data class GoogleInstallmentsInfo(
+    /**
+     * Number of payments the customer commits to in order to purchase the subscription.
+     */
+    override val commitmentPaymentsCount: Int,
+    /**
+     * After the commitment payments are made, the number of payments the user commits to upon a renewal.
+     */
+    override val subsequentCommitmentPaymentsCount: Int,
+) : InstallmentsInfo

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleInstallmentsInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleInstallmentsInfo.kt
@@ -11,5 +11,5 @@ data class GoogleInstallmentsInfo(
     /**
      * After the commitment payments are made, the number of payments the user commits to upon a renewal.
      */
-    override val subsequentCommitmentPaymentsCount: Int,
+    override val renewalCommitmentPaymentsCount: Int,
 ) : InstallmentsInfo

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleSubscriptionOption.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleSubscriptionOption.kt
@@ -54,6 +54,12 @@ data class GoogleSubscriptionOption @JvmOverloads constructor(
      * or on restores/syncs.
      */
     override val presentedOfferingContext: PresentedOfferingContext? = null,
+
+    /**
+     * For installment subscriptions, the details of the installment plan the customer commits to.
+     * Null for non-installment subscriptions.
+     */
+    override val installmentsInfo: GoogleInstallmentsInfo? = null,
 ) : SubscriptionOption {
 
     @Deprecated(
@@ -96,6 +102,7 @@ data class GoogleSubscriptionOption @JvmOverloads constructor(
             subscriptionOption.productDetails,
             subscriptionOption.offerToken,
             presentedOfferingContext,
+            subscriptionOption.installmentsInfo,
         )
 
     override val id: String

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/InstallmentsInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/InstallmentsInfo.kt
@@ -1,0 +1,16 @@
+package com.revenuecat.purchases.models
+
+/**
+ * Type containing information of installment subscriptions. Currently only supported in Google Play.
+ */
+interface InstallmentsInfo {
+    /**
+     * Number of payments the customer commits to in order to purchase the subscription.
+     */
+    val commitmentPaymentsCount: Int
+
+    /**
+     * After the commitment payments are made, the number of payments the user commits to upon a renewal.
+     */
+    val subsequentCommitmentPaymentsCount: Int
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/InstallmentsInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/InstallmentsInfo.kt
@@ -10,7 +10,7 @@ interface InstallmentsInfo {
     val commitmentPaymentsCount: Int
 
     /**
-     * After the commitment payments are made, the number of payments the user commits to upon a renewal.
+     * After the commitment payments are complete, the number of payments the user commits to upon a renewal.
      */
-    val subsequentCommitmentPaymentsCount: Int
+    val renewalCommitmentPaymentsCount: Int
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/SubscriptionOption.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/SubscriptionOption.kt
@@ -93,4 +93,11 @@ interface SubscriptionOption {
         }
 
     val purchasingData: PurchasingData
+
+    /**
+     * For installment subscriptions, the details of the installment plan the customer commits to.
+     * Null for non-installment subscriptions.
+     * Installment plans are only available for Google Play subscriptions.
+     */
+    val installmentsInfo: InstallmentsInfo?
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/TestStoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/TestStoreProduct.kt
@@ -125,6 +125,7 @@ private class TestSubscriptionOption(
     override val presentedOfferingContext: PresentedOfferingContext = PresentedOfferingContext(
         offeringIdentifier = "offering",
     ),
+    override val installmentsInfo: InstallmentsInfo? = null,
 ) : SubscriptionOption {
     override val id: String
         get() = if (pricingPhases.size == 1) basePlanId else "$basePlanId:testOfferId"

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1154,7 +1154,7 @@ class BillingWrapperTest {
         val subscriptionOption = storeProduct.subscriptionOptions!!.first()
         assertThat(subscriptionOption.installmentsInfo).isNotNull
         assertThat(subscriptionOption.installmentsInfo?.commitmentPaymentsCount).isEqualTo(3)
-        assertThat(subscriptionOption.installmentsInfo?.subsequentCommitmentPaymentsCount).isEqualTo(1)
+        assertThat(subscriptionOption.installmentsInfo?.renewalCommitmentPaymentsCount).isEqualTo(1)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -36,6 +36,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.sha256
 import com.revenuecat.purchases.models.GoogleReplacementMode
 import com.revenuecat.purchases.models.InAppMessageType
+import com.revenuecat.purchases.models.InstallmentsInfo
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
@@ -47,10 +48,12 @@ import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.SubscriptionOptions
 import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.utils.createMockProductDetailsNoOffers
+import com.revenuecat.purchases.utils.mockInstallmentPlandetails
 import com.revenuecat.purchases.utils.mockOneTimePurchaseOfferDetails
 import com.revenuecat.purchases.utils.mockProductDetails
 import com.revenuecat.purchases.utils.mockQueryPurchaseHistory
 import com.revenuecat.purchases.utils.mockQueryPurchasesAsync
+import com.revenuecat.purchases.utils.mockSubscriptionOfferDetails
 import com.revenuecat.purchases.utils.stubGooglePurchase
 import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
 import com.revenuecat.purchases.utils.verifyQueryPurchaseHistoryCalledWithType
@@ -777,6 +780,9 @@ class BillingWrapperTest {
                     override val productType: ProductType
                         get() = ProductType.SUBS
                 }
+
+            override val installmentsInfo: InstallmentsInfo?
+                get() = null
         }
 
         wrapper.makePurchaseAsync(
@@ -835,6 +841,8 @@ class BillingWrapperTest {
                         get() = null
                     override val purchasingData: PurchasingData
                         get() = purchasingData
+                    override val installmentsInfo: InstallmentsInfo?
+                        get() = null
                 }
             override val purchasingData: PurchasingData
                 get() = purchasingData
@@ -1132,6 +1140,21 @@ class BillingWrapperTest {
 
         assertThat(slot.captured.size).isOne
         assertThat(slot.captured[0].subscriptionOptionId).isEqualTo(subscriptionOption.id)
+    }
+
+    @Test
+    fun `installment plan details are properly forwarded`() {
+        val productDetails = mockProductDetails(subscriptionOfferDetails = listOf(
+            mockSubscriptionOfferDetails(installmentDetails = mockInstallmentPlandetails())
+        ))
+        val storeProduct = productDetails.toStoreProduct(
+            productDetails.subscriptionOfferDetails!!
+        )!!
+        assertThat(storeProduct.subscriptionOptions?.size).isOne
+        val subscriptionOption = storeProduct.subscriptionOptions!!.first()
+        assertThat(subscriptionOption.installmentsInfo).isNotNull
+        assertThat(subscriptionOption.installmentsInfo?.commitmentPaymentsCount).isEqualTo(3)
+        assertThat(subscriptionOption.installmentsInfo?.subsequentCommitmentPaymentsCount).isEqualTo(1)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/billingClientStubs.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/billingClientStubs.kt
@@ -78,11 +78,11 @@ fun mockSubscriptionOfferDetails(
 
 fun mockInstallmentPlandetails(
     commitmentPaymentsCount: Int = 3,
-    subsequentCommitmentPaymentsCount: Int = 1,
+    renewalCommitmentPaymentsCount: Int = 1,
 ): InstallmentPlanDetails {
     return mockk<InstallmentPlanDetails>().apply {
         every { installmentPlanCommitmentPaymentsCount } returns commitmentPaymentsCount
-        every { subsequentInstallmentPlanCommitmentPaymentsCount } returns subsequentCommitmentPaymentsCount
+        every { subsequentInstallmentPlanCommitmentPaymentsCount } returns renewalCommitmentPaymentsCount
     }
 }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/billingClientStubs.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/billingClientStubs.kt
@@ -5,6 +5,7 @@ package com.revenuecat.purchases.utils
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.ProductDetails.InstallmentPlanDetails
 import com.android.billingclient.api.ProductDetails.OneTimePurchaseOfferDetails
 import com.android.billingclient.api.ProductDetails.PricingPhase
 import com.android.billingclient.api.ProductDetails.RecurrenceMode
@@ -63,6 +64,7 @@ fun mockSubscriptionOfferDetails(
     offerId: String = "mock-offer-id",
     basePlanId: String = "mock-base-plan-id",
     pricingPhases: List<PricingPhase> = listOf(mockPricingPhase()),
+    installmentDetails: ProductDetails.InstallmentPlanDetails? = null,
 ): SubscriptionOfferDetails = mockk<SubscriptionOfferDetails>().apply {
     every { offerTags } returns tags
     every { offerToken } returns token
@@ -70,6 +72,17 @@ fun mockSubscriptionOfferDetails(
     every { getBasePlanId() } returns basePlanId
     every { getPricingPhases() } returns mockk<ProductDetails.PricingPhases>().apply {
         every { pricingPhaseList } returns pricingPhases
+    }
+    every { installmentPlanDetails } returns installmentDetails
+}
+
+fun mockInstallmentPlandetails(
+    commitmentPaymentsCount: Int = 3,
+    subsequentCommitmentPaymentsCount: Int = 1,
+): InstallmentPlanDetails {
+    return mockk<InstallmentPlanDetails>().apply {
+        every { installmentPlanCommitmentPaymentsCount } returns commitmentPaymentsCount
+        every { subsequentInstallmentPlanCommitmentPaymentsCount } returns subsequentCommitmentPaymentsCount
     }
 }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.common.MICROS_MULTIPLIER
+import com.revenuecat.purchases.models.InstallmentsInfo
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
@@ -224,6 +225,7 @@ fun stubSubscriptionOption(
     duration: Period = Period(1, Period.Unit.MONTH, "P1M"),
     pricingPhases: List<PricingPhase> = listOf(stubPricingPhase(billingPeriod = duration)),
     presentedOfferingContext: PresentedOfferingContext? = null,
+    installmentsInfo: InstallmentsInfo? = null,
 ): SubscriptionOption = object : SubscriptionOption {
     override val id: String
         get() = id
@@ -239,6 +241,8 @@ fun stubSubscriptionOption(
         get() = StubPurchasingData(
             productId = productId,
         )
+    override val installmentsInfo: InstallmentsInfo?
+        get() = installmentsInfo
 }
 
 fun stubFreeTrialPricingPhase(

--- a/ui/debugview/src/main/kotlin/com/revenuecat/purchases/ui/debugview/models/TestModels.kt
+++ b/ui/debugview/src/main/kotlin/com/revenuecat/purchases/ui/debugview/models/TestModels.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.models.InstallmentsInfo
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
@@ -50,6 +51,8 @@ internal val testOffering: Offering
                 get() = PresentedOfferingContext("offering_id")
             override val purchasingData: PurchasingData
                 get() = purchasingData
+            override val installmentsInfo: InstallmentsInfo?
+                get() = null
         }
         val subscriptionOptions = SubscriptionOptions(listOf(subscriptionOption))
         val storeProduct = object : StoreProduct {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PackageExtensionsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PackageExtensionsTest.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui.extensions
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PresentedOfferingContext
+import com.revenuecat.purchases.models.InstallmentsInfo
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
@@ -58,6 +59,8 @@ class PackageExtensionsTest {
                         get() = PresentedOfferingContext("offering_id")
                     override val purchasingData: PurchasingData
                         get() = mockk()
+                    override val installmentsInfo: InstallmentsInfo?
+                        get() = null
                 }
             }
         }


### PR DESCRIPTION
### Description
This exposes the info for installment plans so developers can use it. The new API looks like:
- New `InstallmentsInfo` interface with `commitmentPaymentsCount` and `subsequentCommitmentPaymentsCount` fields.
- New `GoogleInstallmentsInfo` data class implementing previous interface.
- New method in `SubscriptionOption`/`GoogleSubscriptionOption` exposing the installments info.

