### PR TITLE
Stops collecting the ANDROID_ID.

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
@@ -16,7 +16,6 @@ internal enum class ReservedSubscriberAttribute(val value: String) {
     IDFV("\$idfv"),
     IP("\$ip"),
     GPS_AD_ID("\$gpsAdId"),
-    ANDROID_ID("\$androidId"),
     AMAZON_AD_ID("\$amazonAdId"),
 
     /**
@@ -58,7 +57,6 @@ internal sealed class SubscriberAttributeKey(val backendKey: String) {
 
     sealed class DeviceIdentifiers {
         object GPSAdID : SubscriberAttributeKey(ReservedSubscriberAttribute.GPS_AD_ID.value)
-        object AndroidID : SubscriberAttributeKey(ReservedSubscriberAttribute.ANDROID_ID.value)
         object IP : SubscriberAttributeKey(ReservedSubscriberAttribute.IP.value)
         object AmazonAdID : SubscriberAttributeKey(ReservedSubscriberAttribute.AMAZON_AD_ID.value)
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcher.kt
@@ -1,8 +1,6 @@
 package com.revenuecat.purchases.google.attribution
 
-import android.annotation.SuppressLint
 import android.app.Application
-import android.provider.Settings
 import com.google.android.gms.ads.identifier.AdvertisingIdClient
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException
 import com.google.android.gms.common.GooglePlayServicesRepairableException
@@ -28,19 +26,13 @@ internal class GoogleDeviceIdentifiersFetcher(
     ) {
         dispatcher.enqueue({
             val advertisingID: String? = getAdvertisingID(applicationContext)
-            val androidID = getAndroidID(applicationContext)
             val deviceIdentifiers = mapOf(
                 SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey to advertisingID,
-                SubscriberAttributeKey.DeviceIdentifiers.AndroidID.backendKey to androidID,
                 SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey to "true",
             ).filterNotNullValues()
             completion(deviceIdentifiers)
         })
     }
-
-    @SuppressLint("HardwareIds")
-    private fun getAndroidID(applicationContext: Application) =
-        Settings.Secure.getString(applicationContext.contentResolver, Settings.Secure.ANDROID_ID)
 
     private fun getAdvertisingID(applicationContext: Application): String? {
         var advertisingID: String? = null

--- a/purchases/src/test/java/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcherTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcherTests.kt
@@ -56,8 +56,9 @@ class GoogleDeviceIdentifiersFetcherTests {
             assertThat(advertisingID).isNotNull()
             assertThat(advertisingID).isEqualTo("12345")
 
-            val androidID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.AndroidID.backendKey]
-            assertThat(androidID).isEqualTo("androidid")
+            // Assert we don't collect the ANDROID_ID
+            assertThat(identifiers.containsKey("\$androidId")).isFalse()
+            assertThat(identifiers.containsValue("androidid")).isFalse()
 
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")
@@ -83,8 +84,9 @@ class GoogleDeviceIdentifiersFetcherTests {
             val advertisingID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey]
             assertThat(advertisingID).isNull()
 
-            val androidID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.AndroidID.backendKey]
-            assertThat(androidID).isEqualTo("androidid")
+            // Assert we don't collect the ANDROID_ID
+            assertThat(identifiers.containsKey("\$androidId")).isFalse()
+            assertThat(identifiers.containsValue("androidid")).isFalse()
 
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")
@@ -110,8 +112,9 @@ class GoogleDeviceIdentifiersFetcherTests {
             val advertisingID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey]
             assertThat(advertisingID).isNull()
 
-            val androidID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.AndroidID.backendKey]
-            assertThat(androidID).isEqualTo("androidid")
+            // Assert we don't collect the ANDROID_ID
+            assertThat(identifiers.containsKey("\$androidId")).isFalse()
+            assertThat(identifiers.containsValue("androidid")).isFalse()
 
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")
@@ -137,8 +140,9 @@ class GoogleDeviceIdentifiersFetcherTests {
             val advertisingID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey]
             assertThat(advertisingID).isNull()
 
-            val androidID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.AndroidID.backendKey]
-            assertThat(androidID).isEqualTo("androidid")
+            // Assert we don't collect the ANDROID_ID
+            assertThat(identifiers.containsKey("\$androidId")).isFalse()
+            assertThat(identifiers.containsValue("androidid")).isFalse()
 
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")
@@ -163,8 +167,9 @@ class GoogleDeviceIdentifiersFetcherTests {
             val advertisingID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey]
             assertThat(advertisingID).isNull()
 
-            val androidID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.AndroidID.backendKey]
-            assertThat(androidID).isEqualTo("androidid")
+            // Assert we don't collect the ANDROID_ID
+            assertThat(identifiers.containsKey("\$androidId")).isFalse()
+            assertThat(identifiers.containsValue("androidid")).isFalse()
 
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")
@@ -190,8 +195,9 @@ class GoogleDeviceIdentifiersFetcherTests {
             val advertisingID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey]
             assertThat(advertisingID).isNull()
 
-            val androidID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.AndroidID.backendKey]
-            assertThat(androidID).isEqualTo("androidid")
+            // Assert we don't collect the ANDROID_ID
+            assertThat(identifiers.containsKey("\$androidId")).isFalse()
+            assertThat(identifiers.containsValue("androidid")).isFalse()
 
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")
@@ -217,8 +223,9 @@ class GoogleDeviceIdentifiersFetcherTests {
             val advertisingID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey]
             assertThat(advertisingID).isNull()
 
-            val androidID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.AndroidID.backendKey]
-            assertThat(androidID).isEqualTo("androidid")
+            // Assert we don't collect the ANDROID_ID
+            assertThat(identifiers.containsKey("\$androidId")).isFalse()
+            assertThat(identifiers.containsValue("androidid")).isFalse()
 
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")
@@ -244,8 +251,9 @@ class GoogleDeviceIdentifiersFetcherTests {
             val advertisingID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey]
             assertThat(advertisingID).isNull()
 
-            val androidID = identifiers[SubscriberAttributeKey.DeviceIdentifiers.AndroidID.backendKey]
-            assertThat(androidID).isEqualTo("androidid")
+            // Assert we don't collect the ANDROID_ID
+            assertThat(identifiers.containsKey("\$androidId")).isFalse()
+            assertThat(identifiers.containsValue("androidid")).isFalse()
 
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")

--- a/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManagerTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManagerTests.kt
@@ -686,17 +686,12 @@ class SubscriberAttributesManagerTests {
 
         val captured = capturingSlot.captured
         assertThat(captured).isNotNull
-        assertThat(captured.size).isEqualTo(3)
+        assertThat(captured.size).isEqualTo(2)
 
         val gpsAdIdSubscriberAttribute =
             captured[SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey]
         assertThat(gpsAdIdSubscriberAttribute).isNotNull
         assertThat(gpsAdIdSubscriberAttribute!!.value).isEqualTo("12345")
-
-        val androidIDSubscriberAttribute =
-            captured[SubscriberAttributeKey.DeviceIdentifiers.AndroidID.backendKey]
-        assertThat(androidIDSubscriberAttribute).isNotNull
-        assertThat(androidIDSubscriberAttribute!!.value).isEqualTo("androidid")
 
         val ipSubscriberAttribute =
             captured[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
@@ -718,16 +713,11 @@ class SubscriberAttributesManagerTests {
 
         val captured = capturingSlot.captured
         assertThat(captured).isNotNull
-        assertThat(captured.size).isEqualTo(2)
+        assertThat(captured.size).isEqualTo(1)
 
         val gpsAdIdSubscriberAttribute =
             captured[SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey]
         assertThat(gpsAdIdSubscriberAttribute).isNull()
-
-        val androidIDSubscriberAttribute =
-            captured[SubscriberAttributeKey.DeviceIdentifiers.AndroidID.backendKey]
-        assertThat(androidIDSubscriberAttribute).isNotNull
-        assertThat(androidIDSubscriberAttribute!!.value).isEqualTo("androidid")
     }
 
     @Test
@@ -749,17 +739,12 @@ class SubscriberAttributesManagerTests {
 
         val captured = capturingSlot.captured
         assertThat(captured).isNotNull
-        assertThat(captured.size).isEqualTo(4)
+        assertThat(captured.size).isEqualTo(3)
 
         val gpsAdIdSubscriberAttribute =
             captured[SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey]
         assertThat(gpsAdIdSubscriberAttribute).isNotNull
         assertThat(gpsAdIdSubscriberAttribute!!.value).isEqualTo("12345")
-
-        val androidIDSubscriberAttribute =
-            captured[SubscriberAttributeKey.DeviceIdentifiers.AndroidID.backendKey]
-        assertThat(androidIDSubscriberAttribute).isNotNull
-        assertThat(androidIDSubscriberAttribute!!.value).isEqualTo("androidid")
 
         val ipSubscriberAttribute =
             captured[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
@@ -812,7 +797,6 @@ class SubscriberAttributesManagerTests {
             lambda<(Map<String, String>) -> Unit>().captured.also {
                 val deviceIdentifiers = mapOf(
                     SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey to expectedAdID,
-                    SubscriberAttributeKey.DeviceIdentifiers.AndroidID.backendKey to androidID,
                     SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey to "true"
                 ).filterNotNullValues()
                 it.invoke(deviceIdentifiers)


### PR DESCRIPTION
## Changes
### Main
- `GoogleDeviceIdentifiersFetcher` no longer collects the `ANDROID_ID`.
### Others
- Removes `ReservedSubscriberAttribute.ANDROID_ID`.
- Removes `SubscriberAttributeKey.DeviceIdentifiers.AndroidID`.
### Tests
- `GoogleDeviceIdentifiersFetcherTests` asserts the `ANDROID_ID` is not collected.
- `SubscriberAttributesManagerTests` no longer returns the `ANDROID_ID` in its mocked `DeviceIdentifiersFetcher` response. 