### PR TITLE
Bump kotlin to 1.8

### DIFF
--- a/api-tester/build.gradle
+++ b/api-tester/build.gradle
@@ -30,7 +30,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0-alpha02'
+        kotlinCompilerExtensionVersion = "1.4.8"
     }
 
     buildFeatures {

--- a/examples/MagicWeatherCompose/app/build.gradle
+++ b/examples/MagicWeatherCompose/app/build.gradle
@@ -53,7 +53,7 @@ android {
         buildConfig true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0-alpha02'
+        kotlinCompilerExtensionVersion = "1.4.8"
     }
     packagingOptions {
         resources {

--- a/examples/paywall-tester/build.gradle
+++ b/examples/paywall-tester/build.gradle
@@ -54,7 +54,7 @@ android {
         enabled = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0-alpha02'
+        kotlinCompilerExtensionVersion = "1.4.8"
     }
     packaging {
         resources {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 agp = "8.1.3"
-kotlin = "1.7.21"
-# Can't update until we use more recent kotlin. 1.5.0 uses Kotlin 1.8.0
-kotlinxSerializationJSON = "1.4.1"
+kotlin = "1.8.22"
+# Can't update until we use more recent kotlin. 1.6.0 uses Kotlin 1.9.0
+kotlinxSerializationJSON = "1.5.1"
 billing = "6.2.1"
 lifecycle = "2.5.0"
 testLibraries = "1.4.0"

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -39,7 +39,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.0-alpha02"
+        kotlinCompilerExtensionVersion = "1.4.8"
     }
     packaging {
         resources {

--- a/ui/debugview/build.gradle
+++ b/ui/debugview/build.gradle
@@ -28,7 +28,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0-alpha02'
+        kotlinCompilerExtensionVersion = "1.4.8"
     }
 }
 

--- a/ui/revenuecatui/build.gradle
+++ b/ui/revenuecatui/build.gradle
@@ -35,7 +35,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0-alpha02'
+        kotlinCompilerExtensionVersion = "1.4.8"
     }
     packaging {
         resources {


### PR DESCRIPTION
Followup on #1706 

Looks like this is the version that's still compatible with most of the hybrids