### PR TITLE
Fixes crash if no browser is installed

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,6 +106,7 @@ okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.
 playServices-ads-identifier = { module = "com.google.android.gms:play-services-ads-identifier", version.ref = "adsIdentifier" }
 
 robolectric = { module = "org.robolectric:robolectric", version.ref = "roboelectric" }
+hamcrest-core = { module = "org.hamcrest:hamcrest-core", version = "1.3" }
 
 tink = { module = "com.google.crypto.tink:tink-android", version.ref = "tink" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ window = "1.1.0"
 commonmark = "0.21.0"
 activity-compose = "1.7.2"
 fragment = "1.6.1"
+hamcrest = "1.3"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -106,7 +107,7 @@ okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.
 playServices-ads-identifier = { module = "com.google.android.gms:play-services-ads-identifier", version.ref = "adsIdentifier" }
 
 robolectric = { module = "org.robolectric:robolectric", version.ref = "roboelectric" }
-hamcrest-core = { module = "org.hamcrest:hamcrest-core", version = "1.3" }
+hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest" }
 
 tink = { module = "com.google.crypto.tink:tink-android", version.ref = "tink" }
 

--- a/ui/revenuecatui/build.gradle
+++ b/ui/revenuecatui/build.gradle
@@ -44,6 +44,12 @@ android {
         resources.excludes.add("META-INF/LICENSE.md")
         resources.excludes.add("META-INF/LICENSE-notice.md")
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -76,6 +82,8 @@ dependencies {
     testImplementation libs.bundles.test
     testImplementation libs.coroutines.test
     testImplementation libs.kotlinx.serialization.json
+    testImplementation libs.androidx.test.compose
+    testImplementation libs.hamcrest.core
 
     androidTestImplementation libs.assertJ
     androidTestImplementation libs.mockk.android

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
@@ -45,6 +45,8 @@ import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfigura
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.templates.template2
+import com.revenuecat.purchases.ui.revenuecatui.extensions.openUriOrElse
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import java.net.URL
 
 @Composable
@@ -67,7 +69,7 @@ internal fun Footer(
     }
 }
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LongMethod")
 @Composable
 private fun Footer(
     mode: PaywallMode,
@@ -124,7 +126,11 @@ private fun Footer(
                 childModifier = childModifier,
                 R.string.terms_and_conditions,
                 R.string.terms,
-            ) { uriHandler.openUri(it.toString()) }
+            ) {
+                uriHandler.openUriOrElse(it.toString()) {
+                    Logger.w("No browser installed. Terms and conditions could not be opened.")
+                }
+            }
 
             if (configuration.privacyURL != null) {
                 Separator(color = color)
@@ -137,7 +143,11 @@ private fun Footer(
                 childModifier = childModifier,
                 R.string.privacy_policy,
                 R.string.privacy,
-            ) { uriHandler.openUri(it.toString()) }
+            ) {
+                uriHandler.openUriOrElse(it.toString()) {
+                    Logger.w("No browser installed. Privacy policy could not be opened.")
+                }
+            }
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/UriHandlerExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/UriHandlerExtensions.kt
@@ -1,0 +1,16 @@
+package com.revenuecat.purchases.ui.revenuecatui.extensions
+
+import android.content.ActivityNotFoundException
+import androidx.compose.ui.platform.UriHandler
+
+/**
+ * Opens the given [uri] in a browser. If no browser is installed, [fallbackAction] is called.
+ */
+@Suppress("SwallowedException")
+fun UriHandler.openUriOrElse(uri: String, fallbackAction: () -> Unit) {
+    try {
+        openUri(uri)
+    } catch (e: ActivityNotFoundException) {
+        fallbackAction()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/FooterLinksNoBrowserTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/FooterLinksNoBrowserTest.kt
@@ -1,0 +1,109 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import android.app.Application
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.net.Uri
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+@RunWith(RobolectricTestRunner::class)
+class FooterLinksNoBrowserTest {
+
+    @get:Rule(order = 1)
+    val addActivityToRobolectricRule = object : TestWatcher() {
+        override fun starting(description: Description?) {
+            super.starting(description)
+            val appContext: Application = getApplicationContext()
+            val activityInfo = ActivityInfo().apply {
+                name = IntentResolvingActivity::class.java.name
+                packageName = appContext.packageName
+            }
+            shadowOf(appContext.packageManager).addOrUpdateActivity(activityInfo)
+        }
+    }
+
+    @get:Rule(order = 2)
+    internal val composeTestRule = createAndroidComposeRule<IntentResolvingActivity>()
+
+    private lateinit var viewModel: MockViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = MockViewModel(offering = TestData.template2Offering, shouldErrorOnUnsupportedMethods = false)
+    }
+
+    @Test
+    fun `Clicking Terms without a browser should not crash`() {
+        // Arrange
+        assertNoBrowser()
+        setUpUI()
+
+        // Act, Assert
+        composeTestRule
+            .onNodeWithText("Terms and conditions")
+            .performClick()
+    }
+
+    @Test
+    fun `Clicking Privacy without a browser should not crash`() {
+        // Arrange
+        assertNoBrowser()
+        setUpUI()
+
+        // Act, Assert
+        composeTestRule
+            .onNodeWithText("Privacy policy")
+            .performClick()
+    }
+
+    private fun setUpUI() {
+        composeTestRule.setContent {
+            InternalPaywall(
+                options = PaywallOptions.Builder { Assert.fail("Should not be dismissed") }.build(),
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    /**
+     * Asserts that our environment has no browser installed.
+     */
+    private fun assertNoBrowser() {
+        val implicitBrowserIntent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.google.com/"))
+
+        assertThatExceptionOfType(ActivityNotFoundException::class.java)
+            .isThrownBy { composeTestRule.activity.startActivity(implicitBrowserIntent) }
+    }
+}
+
+/**
+ * An Activity that actually resolves Intents. Normally Robolectric doesn't do this.
+ */
+internal class IntentResolvingActivity : ComponentActivity() {
+
+    override fun startActivity(intent: Intent) {
+        val packageManager = getApplicationContext<Context>().packageManager
+        if (intent.resolveActivity(packageManager) != null) super.startActivity(intent)
+        else throw ActivityNotFoundException("No Activity to handle Intent: $intent")
+    }
+
+}


### PR DESCRIPTION
## Changes
### Main
- Adds `UriHandler.openUriOrElse()`, inspired by the stdlib's `Map.getOrElse()`.
- Uses `openUriOrElse()` in the `Footer` to log a warning if there's no browser installed.
### Tests
- Adds `FooterLinksNoBrowserTest`.

Closes #1723 
