### PR TITLE
Diagnostics: sync only on first activity foregrounded

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -83,7 +83,7 @@ internal class PurchasesOrchestrator constructor(
     var appConfig: AppConfig,
     private val customerInfoHelper: CustomerInfoHelper,
     private val customerInfoUpdateHandler: CustomerInfoUpdateHandler,
-    diagnosticsSynchronizer: DiagnosticsSynchronizer?,
+    private val diagnosticsSynchronizer: DiagnosticsSynchronizer?,
     @get:VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     val offlineEntitlementsManager: OfflineEntitlementsManager,
     private val postReceiptHelper: PostReceiptHelper,
@@ -174,10 +174,6 @@ internal class PurchasesOrchestrator constructor(
         if (!appConfig.dangerousSettings.autoSyncPurchases) {
             log(LogIntent.WARNING, ConfigureStrings.AUTO_SYNC_PURCHASES_DISABLED)
         }
-
-        if (isAndroidNOrNewer()) {
-            diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
-        }
     }
 
     /** @suppress */
@@ -211,6 +207,9 @@ internal class PurchasesOrchestrator constructor(
         synchronizeSubscriberAttributesIfNeeded()
         offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         flushPaywallEvents()
+        if (firstTimeInForeground && isAndroidNOrNewer()) {
+            diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
+        }
     }
 
     override fun onActivityStarted(activity: Activity) {

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -90,11 +90,6 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     @Test
-    fun `diagnostics is synced if needed on constructor`() {
-        verify(exactly = 1) { mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded() }
-    }
-
-    @Test
     fun `when setting up, and passing a appUserID, user is identified`() {
         assertThat(purchases.appUserID).isEqualTo(appUserId)
     }
@@ -1292,6 +1287,25 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
         verify(exactly = 1) {
             mockCache.isCustomerInfoCacheStale(appInBackground = false, appUserID = appUserId)
         }
+    }
+
+    @Test
+    fun `diagnostics is synced on app foregrounded`() {
+        verify(exactly = 0) { mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded() }
+        mockOfferingsManagerAppForeground()
+        Purchases.sharedInstance.purchasesOrchestrator.onAppForegrounded()
+        verify(exactly = 1) { mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded() }
+    }
+
+    @Test
+    fun `diagnostics is synced only on first app foregrounded`() {
+        verify(exactly = 0) { mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded() }
+        mockOfferingsManagerAppForeground()
+        Purchases.sharedInstance.purchasesOrchestrator.onAppForegrounded()
+        verify(exactly = 1) { mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded() }
+        Purchases.sharedInstance.purchasesOrchestrator.onAppForegrounded()
+        Purchases.sharedInstance.purchasesOrchestrator.onAppForegrounded()
+        verify(exactly = 1) { mockDiagnosticsSynchronizer.syncDiagnosticsFileIfNeeded() }
     }
 
     // endregion


### PR DESCRIPTION
### Description
As I was testing some things, I noticed we are syncing diagnostics on SDK initialization, which is ok most times, but we don't want to sync when the app is woken by notifications or alarms. Only when the app is open. This moves the syncing process to avoid those extra requests.