### PR TITLE
Bump kotlin to 1.8 in MagicWeatherCompose

### DIFF
--- a/examples/MagicWeatherCompose/gradle/libs.versions.toml
+++ b/examples/MagicWeatherCompose/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.1.3"
 androidxNavigation = "2.5.3"
-kotlin = "1.7.21"
+kotlin = "1.8.22"
 purchases = "7.12.0-SNAPSHOT"
 lifecycle = "2.5.0"
 androidxCore = "1.10.1"


### PR DESCRIPTION
Build was failing because the compose compiler we use in MagicWeatherCompose is incompatible with 1.7.21. Upgraded to 1.8.22 to match the rest of the projects