### PR TITLE
Add retries upon Google's SERVICE_UNAVAILABLE error when app in foreground

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/durationExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/durationExtensions.kt
@@ -6,3 +6,7 @@ import kotlin.time.Duration
 internal fun Duration.Companion.between(startTime: Date, endTime: Date): Duration {
     return (endTime.time - startTime.time).milliseconds
 }
+
+internal fun min(duration1: Duration, duration2: Duration): Duration {
+    return if (duration1 < duration2) duration1 else duration2
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/BillingClientUseCase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/BillingClientUseCase.kt
@@ -72,7 +72,7 @@ internal abstract class BillingClientUseCase<T>(
             }
 
             BillingResponse.ServiceUnavailable -> {
-                backoffOrErrorIfUseInSession(onError, billingResult)
+                backoffOrErrorIfManyRetries(onError, billingResult)
             }
 
             BillingResponse.NetworkError,
@@ -125,19 +125,14 @@ internal abstract class BillingClientUseCase<T>(
         }
     }
 
-    private fun backoffOrErrorIfUseInSession(
+    private fun backoffOrErrorIfManyRetries(
         onError: (BillingResult) -> Unit,
         billingResult: BillingResult,
     ) {
-        if (useCaseParams.appInBackground) {
-            log(LogIntent.GOOGLE_WARNING, BillingStrings.BILLING_SERVICE_UNAVAILABLE_BACKGROUND)
-            if (retryBackoffMilliseconds < RETRY_TIMER_MAX_TIME_MILLISECONDS) {
-                retryWithBackoff()
-            } else {
-                onError(billingResult)
-            }
+        log(LogIntent.GOOGLE_WARNING, BillingStrings.BILLING_SERVICE_UNAVAILABLE.format(useCaseParams.appInBackground))
+        if (retryBackoffMilliseconds < RETRY_TIMER_MAX_TIME_MILLISECONDS) {
+            retryWithBackoff()
         } else {
-            log(LogIntent.GOOGLE_ERROR, BillingStrings.BILLING_SERVICE_UNAVAILABLE_FOREGROUND)
             onError(billingResult)
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/BillingClientUseCase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/BillingClientUseCase.kt
@@ -7,20 +7,23 @@ import com.revenuecat.purchases.PurchasesErrorCallback
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.common.min
 import com.revenuecat.purchases.google.BillingResponse
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
 import com.revenuecat.purchases.google.toHumanReadableDescription
 import com.revenuecat.purchases.strings.BillingStrings
 import java.io.PrintWriter
 import java.io.StringWriter
-import kotlin.math.min
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 internal typealias ExecuteRequestOnUIThreadFunction = (delayInMillis: Long, onError: (PurchasesError?) -> Unit) -> Unit
 
 private const val MAX_RETRIES_DEFAULT = 3
-private const val RETRY_TIMER_START_MILLISECONDS = 878L // So it gets close to 15 minutes in last retry
-internal const val RETRY_TIMER_MAX_TIME_MILLISECONDS = 1000L * 60L * 15L // 15 minutes
-internal const val RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND = 1000L * 4L // 4 seconds
+private val RETRY_TIMER_START = 878.milliseconds // So it gets close to 15 minutes in last retry
+internal val RETRY_TIMER_MAX_TIME = 15.minutes
+internal val RETRY_TIMER_SERVICE_UNAVAILABLE_MAX_TIME_FOREGROUND = 4.seconds
 
 internal interface UseCaseParams {
     val appInBackground: Boolean
@@ -38,7 +41,7 @@ internal abstract class BillingClientUseCase<T>(
 
     private val maxRetries: Int = MAX_RETRIES_DEFAULT
     private var retryAttempt: Int = 0
-    private var retryBackoffMilliseconds = RETRY_TIMER_START_MILLISECONDS
+    private var retryBackoff = RETRY_TIMER_START
 
     fun run(
         delayMilliseconds: Long = 0,
@@ -63,7 +66,7 @@ internal abstract class BillingClientUseCase<T>(
     ) {
         when (BillingResponse.fromCode(billingResult.responseCode)) {
             BillingResponse.OK -> {
-                retryBackoffMilliseconds = RETRY_TIMER_START_MILLISECONDS
+                retryBackoff = RETRY_TIMER_START
                 onSuccess(response)
             }
 
@@ -116,7 +119,7 @@ internal abstract class BillingClientUseCase<T>(
         onError: (BillingResult) -> Unit,
         billingResult: BillingResult,
     ) {
-        if (backoffForNetworkErrors && retryBackoffMilliseconds < RETRY_TIMER_MAX_TIME_MILLISECONDS) {
+        if (backoffForNetworkErrors && retryBackoff < RETRY_TIMER_MAX_TIME) {
             retryWithBackoff()
         } else if (!backoffForNetworkErrors && retryAttempt < maxRetries) {
             retryAttempt++
@@ -132,11 +135,11 @@ internal abstract class BillingClientUseCase<T>(
     ) {
         log(LogIntent.GOOGLE_WARNING, BillingStrings.BILLING_SERVICE_UNAVAILABLE.format(useCaseParams.appInBackground))
         val maxBackoff = if (useCaseParams.appInBackground) {
-            RETRY_TIMER_MAX_TIME_MILLISECONDS
+            RETRY_TIMER_MAX_TIME
         } else {
-            RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND
+            RETRY_TIMER_SERVICE_UNAVAILABLE_MAX_TIME_FOREGROUND
         }
-        if (retryBackoffMilliseconds < maxBackoff) {
+        if (retryBackoff < maxBackoff) {
             retryWithBackoff()
         } else {
             onError(billingResult)
@@ -144,12 +147,12 @@ internal abstract class BillingClientUseCase<T>(
     }
 
     private fun retryWithBackoff() {
-        retryBackoffMilliseconds.let { currentDelayMilliseconds ->
-            retryBackoffMilliseconds = min(
-                retryBackoffMilliseconds * 2,
-                RETRY_TIMER_MAX_TIME_MILLISECONDS,
+        retryBackoff.let { currentDelay ->
+            retryBackoff = min(
+                retryBackoff * 2,
+                RETRY_TIMER_MAX_TIME,
             )
-            run(currentDelayMilliseconds)
+            run(currentDelay.inWholeMilliseconds)
         }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/BillingClientUseCase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/BillingClientUseCase.kt
@@ -76,7 +76,7 @@ internal abstract class BillingClientUseCase<T>(
             }
 
             BillingResponse.ServiceUnavailable -> {
-                backoffOrErrorIfManyRetries(onError, billingResult)
+                backoffOrErrorIfServiceUnavailable(onError, billingResult)
             }
 
             BillingResponse.NetworkError,
@@ -129,7 +129,7 @@ internal abstract class BillingClientUseCase<T>(
         }
     }
 
-    private fun backoffOrErrorIfManyRetries(
+    private fun backoffOrErrorIfServiceUnavailable(
         onError: (BillingResult) -> Unit,
         billingResult: BillingResult,
     ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -42,7 +42,5 @@ internal object BillingStrings {
     const val BILLING_COUNTRY_CODE = "Billing connected with country code: %s"
     const val BILLING_STOREFRONT_CACHING = "Setting storefront cache to %s"
     const val BILLING_STOREFRONT_NULL_FROM_CACHE = "Getting storefront from cache was null."
-    const val BILLING_SERVICE_UNAVAILABLE_FOREGROUND = "Billing is unavailable. App is in foreground. Won't retry."
-    const val BILLING_SERVICE_UNAVAILABLE_BACKGROUND = "Billing is unavailable. App is in background, will retry with" +
-        "backoff."
+    const val BILLING_SERVICE_UNAVAILABLE = "Billing is unavailable. Will retry with backoff. App is in background: %s"
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -587,7 +587,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(capturedDelays.size).isEqualTo(12)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.NetworkError)
     }
@@ -723,7 +723,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(capturedDelays.size).isEqualTo(12)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -859,7 +859,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(capturedDelays.size).isEqualTo(12)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -907,7 +907,8 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(timesRetried).isEqualTo(4)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
+        assertThat(capturedDelays.last())
+            .isCloseTo(RETRY_TIMER_SERVICE_UNAVAILABLE_MAX_TIME_FOREGROUND.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -953,7 +954,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(capturedDelays.size).isEqualTo(12)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -1001,7 +1002,8 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(timesRetried).isEqualTo(4)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
+        assertThat(capturedDelays.last())
+            .isCloseTo(RETRY_TIMER_SERVICE_UNAVAILABLE_MAX_TIME_FOREGROUND.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -1047,7 +1049,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(capturedDelays.size).isEqualTo(12)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -1095,7 +1097,8 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(timesRetried).isEqualTo(4)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
+        assertThat(capturedDelays.last())
+            .isCloseTo(RETRY_TIMER_SERVICE_UNAVAILABLE_MAX_TIME_FOREGROUND.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -865,7 +865,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
     }
 
     @Test
-    fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session for restores`() {
+    fun `If service returns SERVICE_UNAVAILABLE, retry with backoff a few times then error if user in session for restores`() {
         val slot = slot<AcknowledgePurchaseResponseListener>()
         val acknowledgeStubbing = every {
             mockClient.acknowledgePurchase(
@@ -875,6 +875,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
+        val capturedDelays = mutableListOf<Long>()
         val useCase = AcknowledgePurchaseUseCase(
             AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
@@ -891,7 +892,8 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 timesRetried++
                 it.invoke(mockClient)
             },
-            executeRequestOnUIThread = { _, request ->
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
                 acknowledgeStubbing answers {
                     slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
@@ -904,7 +906,8 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
         useCase.run()
 
-        assertThat(timesRetried).isEqualTo(1)
+        assertThat(timesRetried).isEqualTo(4)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -956,7 +959,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
     }
 
     @Test
-    fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session for purchases`() {
+    fun `If service returns SERVICE_UNAVAILABLE, retries with backoff a few times then error if user in session for purchases`() {
         val slot = slot<AcknowledgePurchaseResponseListener>()
         val acknowledgeStubbing = every {
             mockClient.acknowledgePurchase(
@@ -966,6 +969,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
+        val capturedDelays = mutableListOf<Long>()
         val useCase = AcknowledgePurchaseUseCase(
             AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
@@ -982,7 +986,8 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 timesRetried++
                 it.invoke(mockClient)
             },
-            executeRequestOnUIThread = { _, request ->
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
                 acknowledgeStubbing answers {
                     slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
@@ -995,7 +1000,8 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
         useCase.run()
 
-        assertThat(timesRetried).isEqualTo(1)
+        assertThat(timesRetried).isEqualTo(4)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -1047,7 +1053,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
     }
 
     @Test
-    fun `If SERVICE_UNAVAILABLE, error if user in session acking unsynced active purchases`() {
+    fun `If SERVICE_UNAVAILABLE, retries with backoff a few times then error if user in session acking unsynced active purchases`() {
         val slot = slot<AcknowledgePurchaseResponseListener>()
         val acknowledgeStubbing = every {
             mockClient.acknowledgePurchase(
@@ -1057,6 +1063,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
+        val capturedDelays = mutableListOf<Long>()
         val useCase = AcknowledgePurchaseUseCase(
             AcknowledgePurchaseUseCaseParams(
                 "purchaseToken",
@@ -1073,7 +1080,8 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 timesRetried++
                 it.invoke(mockClient)
             },
-            executeRequestOnUIThread = { _, request ->
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
                 acknowledgeStubbing answers {
                     slot.captured.onAcknowledgePurchaseResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
@@ -1086,7 +1094,8 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
         useCase.run()
 
-        assertThat(timesRetried).isEqualTo(1)
+        assertThat(timesRetried).isEqualTo(4)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCaseTest.kt
@@ -564,7 +564,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(capturedDelays.size).isEqualTo(12)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.NetworkError)
     }
@@ -703,7 +703,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(capturedDelays.size).isEqualTo(12)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -842,7 +842,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(capturedDelays.size).isEqualTo(12)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -891,7 +891,8 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(timesRetried).isEqualTo(4)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
+        assertThat(capturedDelays.last())
+            .isCloseTo(RETRY_TIMER_SERVICE_UNAVAILABLE_MAX_TIME_FOREGROUND.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -938,7 +939,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(capturedDelays.size).isEqualTo(12)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -987,7 +988,8 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(timesRetried).isEqualTo(4)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
+        assertThat(capturedDelays.last())
+            .isCloseTo(RETRY_TIMER_SERVICE_UNAVAILABLE_MAX_TIME_FOREGROUND.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -1034,7 +1036,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(capturedDelays.size).isEqualTo(12)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -1083,7 +1085,8 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(timesRetried).isEqualTo(4)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
+        assertThat(capturedDelays.last())
+            .isCloseTo(RETRY_TIMER_SERVICE_UNAVAILABLE_MAX_TIME_FOREGROUND.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCaseTest.kt
@@ -848,7 +848,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
     }
 
     @Test
-    fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session for restores`() {
+    fun `If service returns SERVICE_UNAVAILABLE, retry with backoff a few times then error if user in session for restores`() {
         val slot = slot<ConsumeResponseListener>()
         val consumeStubbing = every {
             mockClient.consumeAsync(
@@ -858,6 +858,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
+        val capturedDelays = mutableListOf<Long>()
         val useCase = ConsumePurchaseUseCase(
             ConsumePurchaseUseCaseParams(
                 "purchaseToken",
@@ -874,7 +875,8 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 timesRetried++
                 it.invoke(mockClient)
             },
-            executeRequestOnUIThread = { _, request ->
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
                 consumeStubbing answers {
                     slot.captured.onConsumeResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
@@ -888,7 +890,8 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
         useCase.run()
 
-        assertThat(timesRetried).isEqualTo(1)
+        assertThat(timesRetried).isEqualTo(4)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -941,7 +944,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
     }
 
     @Test
-    fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session for purchases`() {
+    fun `If service returns SERVICE_UNAVAILABLE, retry with backoff a few times then error if user in session for purchases`() {
         val slot = slot<ConsumeResponseListener>()
         val consumeStubbing = every {
             mockClient.consumeAsync(
@@ -951,6 +954,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
+        val capturedDelays = mutableListOf<Long>()
         val useCase = ConsumePurchaseUseCase(
             ConsumePurchaseUseCaseParams(
                 "purchaseToken",
@@ -967,7 +971,8 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 timesRetried++
                 it.invoke(mockClient)
             },
-            executeRequestOnUIThread = { _, request ->
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
                 consumeStubbing answers {
                     slot.captured.onConsumeResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
@@ -981,7 +986,8 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
         useCase.run()
 
-        assertThat(timesRetried).isEqualTo(1)
+        assertThat(timesRetried).isEqualTo(4)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -1034,7 +1040,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
     }
 
     @Test
-    fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session for unsynced active purchases`() {
+    fun `If service returns SERVICE_UNAVAILABLE, retry with backoff a few times then error if user in session for unsynced active purchases`() {
         val slot = slot<ConsumeResponseListener>()
         val consumeStubbing = every {
             mockClient.consumeAsync(
@@ -1044,6 +1050,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
+        val capturedDelays = mutableListOf<Long>()
         val useCase = ConsumePurchaseUseCase(
             ConsumePurchaseUseCaseParams(
                 "purchaseToken",
@@ -1060,7 +1067,8 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
                 timesRetried++
                 it.invoke(mockClient)
             },
-            executeRequestOnUIThread = { _, request ->
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
                 consumeStubbing answers {
                     slot.captured.onConsumeResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
@@ -1074,7 +1082,8 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
 
         useCase.run()
 
-        assertThat(timesRetried).isEqualTo(1)
+        assertThat(timesRetried).isEqualTo(4)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryProductDetailsUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryProductDetailsUseCaseTest.kt
@@ -383,7 +383,7 @@ internal class QueryProductDetailsUseCaseTest: BaseBillingUseCaseTest() {
     }
 
     @Test
-    fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session`() {
+    fun `If service returns SERVICE_UNAVAILABLE, retry with backoff a few times then error if user in session`() {
         val slot = slot<ProductDetailsResponseListener>()
         val queryProductDetailsStubbing = every {
             mockClient.queryProductDetailsAsync(
@@ -394,6 +394,7 @@ internal class QueryProductDetailsUseCaseTest: BaseBillingUseCaseTest() {
         val productIDs = setOf("product_a")
         var receivedError: PurchasesError? = null
         var timesRetried = 0
+        val capturedDelays = mutableListOf<Long>()
         val useCase = QueryProductDetailsUseCase(
             QueryProductDetailsUseCaseParams(
                 mockDateProvider,
@@ -412,7 +413,8 @@ internal class QueryProductDetailsUseCaseTest: BaseBillingUseCaseTest() {
                 timesRetried++
                 it.invoke(mockClient)
             },
-            executeRequestOnUIThread = { _, request ->
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
                 queryProductDetailsStubbing answers {
                     slot.captured.onProductDetailsResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
@@ -426,7 +428,8 @@ internal class QueryProductDetailsUseCaseTest: BaseBillingUseCaseTest() {
 
         useCase.run()
 
-        assertThat(timesRetried).isEqualTo(1)
+        assertThat(timesRetried).isEqualTo(4)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryProductDetailsUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryProductDetailsUseCaseTest.kt
@@ -377,7 +377,7 @@ internal class QueryProductDetailsUseCaseTest: BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(capturedDelays.size).isEqualTo(12)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -429,7 +429,8 @@ internal class QueryProductDetailsUseCaseTest: BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(timesRetried).isEqualTo(4)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
+        assertThat(capturedDelays.last())
+            .isCloseTo(RETRY_TIMER_SERVICE_UNAVAILABLE_MAX_TIME_FOREGROUND.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
@@ -497,7 +497,8 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(timesRetried).isEqualTo(4)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
+        assertThat(capturedDelays.last())
+            .isCloseTo(RETRY_TIMER_SERVICE_UNAVAILABLE_MAX_TIME_FOREGROUND.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -545,7 +546,7 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
         useCase.run()
 
         assertThat(capturedDelays.size).isEqualTo(12)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchaseHistoryUseCaseTest.kt
@@ -453,7 +453,7 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
     }
 
     @Test
-    fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session`() {
+    fun `If service returns SERVICE_UNAVAILABLE, retry with backoff a few times then error if user in session`() {
         val slot = slot<PurchaseHistoryResponseListener>()
         val queryPurchaseHistoryStubbing = every {
             mockClient.queryPurchaseHistoryAsync(
@@ -463,6 +463,7 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
+        val capturedDelays = mutableListOf<Long>()
         val useCase = QueryPurchaseHistoryUseCase(
             QueryPurchaseHistoryUseCaseParams(
                 mockDateProvider,
@@ -480,7 +481,8 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
                 timesRetried++
                 it.invoke(mockClient)
             },
-            executeRequestOnUIThread = { _, request ->
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
                 queryPurchaseHistoryStubbing answers {
                     slot.captured.onPurchaseHistoryResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
@@ -494,7 +496,8 @@ internal class QueryPurchaseHistoryUseCaseTest: BaseBillingUseCaseTest() {
 
         useCase.run()
 
-        assertThat(timesRetried).isEqualTo(1)
+        assertThat(timesRetried).isEqualTo(4)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchasesByTypeUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchasesByTypeUseCaseTest.kt
@@ -10,14 +10,11 @@ import com.android.billingclient.api.QueryPurchasesParams
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
-import com.revenuecat.purchases.common.sha1
-import com.revenuecat.purchases.google.BillingWrapperTest
 import com.revenuecat.purchases.google.buildQueryPurchasesParams
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.utils.mockQueryPurchasesAsync
 import com.revenuecat.purchases.utils.stubGooglePurchase
 import io.mockk.every
-import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import io.mockk.verifySequence
@@ -29,9 +26,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.util.Date
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 
 @RunWith(AndroidJUnit4::class)
@@ -333,7 +327,8 @@ internal class QueryPurchasesByTypeUseCaseTest : BaseBillingUseCaseTest() {
         ).run()
 
         assertThat(timesRetried).isEqualTo(4)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
+        assertThat(capturedDelays.last())
+            .isCloseTo(RETRY_TIMER_SERVICE_UNAVAILABLE_MAX_TIME_FOREGROUND.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -379,7 +374,7 @@ internal class QueryPurchasesByTypeUseCaseTest : BaseBillingUseCaseTest() {
         ).run()
 
         assertThat(capturedDelays.size).isEqualTo(12)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchasesByTypeUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchasesByTypeUseCaseTest.kt
@@ -291,7 +291,7 @@ internal class QueryPurchasesByTypeUseCaseTest : BaseBillingUseCaseTest() {
     }
 
     @Test
-    fun `If service returns SERVICE_UNAVAILABLE, don't retry and error if user in session`() {
+    fun `If service returns SERVICE_UNAVAILABLE, retry with backoff a few times then error if user in session`() {
         val slot = slot<PurchasesResponseListener>()
         val queryPurchasesStubbing = every {
             mockClient.queryPurchasesAsync(
@@ -301,6 +301,7 @@ internal class QueryPurchasesByTypeUseCaseTest : BaseBillingUseCaseTest() {
         }
         var receivedError: PurchasesError? = null
         var timesRetried = 0
+        val capturedDelays = mutableListOf<Long>()
         QueryPurchasesByTypeUseCase(
             QueryPurchasesByTypeUseCaseParams(
                 mockDateProvider,
@@ -318,7 +319,8 @@ internal class QueryPurchasesByTypeUseCaseTest : BaseBillingUseCaseTest() {
                 timesRetried++
                 it.invoke(mockClient)
             },
-            executeRequestOnUIThread = { _, request ->
+            executeRequestOnUIThread = { delay, request ->
+                capturedDelays.add(delay)
                 queryPurchasesStubbing answers {
                     slot.captured.onQueryPurchasesResponse(
                         BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE.buildResult(),
@@ -330,7 +332,8 @@ internal class QueryPurchasesByTypeUseCaseTest : BaseBillingUseCaseTest() {
             },
         ).run()
 
-        assertThat(timesRetried).isEqualTo(1)
+        assertThat(timesRetried).isEqualTo(4)
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchasesUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/QueryPurchasesUseCaseTest.kt
@@ -522,7 +522,8 @@ internal class QueryPurchasesUseCaseTest : BaseBillingUseCaseTest() {
         ).run()
 
         assertThat(timesRetried).isEqualTo(5)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS_FOREGROUND, Offset.offset(1000L))
+        assertThat(capturedDelays.last())
+            .isCloseTo(RETRY_TIMER_SERVICE_UNAVAILABLE_MAX_TIME_FOREGROUND.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
@@ -567,7 +568,7 @@ internal class QueryPurchasesUseCaseTest : BaseBillingUseCaseTest() {
         ).run()
 
         assertThat(capturedDelays.size).isEqualTo(13)
-        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME_MILLISECONDS, Offset.offset(1000L))
+        assertThat(capturedDelays.last()).isCloseTo(RETRY_TIMER_MAX_TIME.inWholeMilliseconds, Offset.offset(1000L))
         assertThat(receivedError).isNotNull
         assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }


### PR DESCRIPTION
### Description
We detected this error could happen consistently when acknowledging pending prepaid purchases after payment is performed when the app is closed. This adds some retries to this error, but much smaller than the one that we have when the app is in background (15min vs 4 seconds).