### PR TITLE
Remove unneeded Android Lollipop version checks

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
@@ -34,7 +34,7 @@ internal class AppConfig(
         get() = runningTests && field
 
     val enableOfflineEntitlements = true
-    val languageTag: String = context.getLocale()?.toBCP47() ?: ""
+    val languageTag: String = context.getLocale()?.toLanguageTag() ?: ""
     val versionName: String = context.versionName ?: ""
     val packageName: String = context.packageName
     var finishTransactions: Boolean = purchasesAreCompletedBy.finishTransactions

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/utils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/utils.kt
@@ -22,57 +22,6 @@ internal fun Context.getLocale(): Locale? =
         resources.configuration.locale
     }
 
-internal fun Locale.toBCP47(): String {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        return toLanguageTag()
-    }
-
-    // we will use a dash as per BCP 47
-    val separator = '-'
-    var language = language
-    var region = country
-    var variant = variant
-
-    // special case for Norwegian Nynorsk since "NY" cannot be a variant as per BCP 47
-    // this goes before the string matching since "NY" wont pass the variant checks
-    if (language == "no" && region == "NO" && variant == "NY") {
-        language = "nn"
-        region = "NO"
-        variant = ""
-    }
-
-    if (language.isEmpty() || !language.matches("\\p{Alpha}{2,8}".toRegex())) {
-        language = "und" // Follow the Locale#toLanguageTag() implementation
-        // which says to return "und" for Undetermined
-    } else if (language == "iw") {
-        language = "he" // correct deprecated "Hebrew"
-    } else if (language == "in") {
-        language = "id" // correct deprecated "Indonesian"
-    } else if (language == "ji") {
-        language = "yi" // correct deprecated "Yiddish"
-    }
-
-    // ensure valid country code, if not well formed, it's omitted
-    if (!region.matches("\\p{Alpha}{2}|\\p{Digit}{3}".toRegex())) {
-        region = ""
-    }
-
-    // variant subtags that begin with a letter must be at least 5 characters long
-    if (!variant.matches("\\p{Alnum}{5,8}|\\p{Digit}\\p{Alnum}{3}".toRegex())) {
-        variant = ""
-    }
-
-    val bcp47Tag = StringBuilder(language)
-    if (region.isNotEmpty()) {
-        bcp47Tag.append(separator).append(region)
-    }
-    if (variant.isNotEmpty()) {
-        bcp47Tag.append(separator).append(variant)
-    }
-
-    return bcp47Tag.toString()
-}
-
 internal fun String.sha1() =
     MessageDigest.getInstance("SHA-1")
         .digest(this.toByteArray()).let {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
@@ -49,13 +49,11 @@ data class PaywallData(
      * and the available locales for this paywall.
      */
     val localizedConfiguration: Pair<Locale, LocalizedConfiguration>
-        @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
         get() {
             return localizedConfiguration(locales = getDefaultLocales())
         }
 
     @VisibleForTesting
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     fun localizedConfiguration(locales: List<Locale>): Pair<Locale, LocalizedConfiguration> {
         for (locale in locales) {
             val localeToCheck = locale.convertToCorrectlyFormattedLocale()
@@ -68,7 +66,6 @@ data class PaywallData(
     }
 
     private val fallbackLocalizedConfiguration: Pair<Locale, LocalizedConfiguration>
-        @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
         get() {
             localization.entries.first().let { localization ->
                 return (localization.key.toLocale() to localization.value)
@@ -80,7 +77,6 @@ data class PaywallData(
      *
      * @return [LocalizedConfiguration] for the given [Locale], if found.
      */
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     fun configForLocale(requiredLocale: Locale): LocalizedConfiguration? {
         return localization[requiredLocale.toString()]
             ?: localization.entries.firstOrNull { (localeKey, _) ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/PaywallData.kt
@@ -1,7 +1,5 @@
 package com.revenuecat.purchases.paywalls
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.utils.convertToCorrectlyFormattedLocale
 import com.revenuecat.purchases.utils.getDefaultLocales

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/LocaleExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/LocaleExtensions.kt
@@ -11,12 +11,10 @@ import java.util.MissingResourceException
 // gives a different result than expected (for example, "es-es" instead of "es").
 // In order to fix that, we convert the string to a locale and we parse that as a locale so the
 // language and country are correctly parsed.
-@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 internal fun Locale.convertToCorrectlyFormattedLocale(): Locale {
     return toString().toLocale()
 }
 
-@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 internal fun String.toLocale(): Locale {
     // Parsing language requires it to be in the form "en-US", even though Locale.toString() returns "en_US"
     return Locale.forLanguageTag(replace("_", "-"))
@@ -27,12 +25,8 @@ internal fun Locale.sharedLanguageCodeWith(locale: Locale): Boolean {
     return try {
         val sameLanguage = isO3Language == locale.isO3Language
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            val sameScript = inferScript() == locale.inferScript()
-            return sameLanguage && sameScript
-        } else {
-            return sameLanguage
-        }
+        val sameScript = inferScript() == locale.inferScript()
+        return sameLanguage && sameScript
     } catch (e: MissingResourceException) {
         errorLog("Locale $this or $locale can't obtain ISO3 language code ($e). Falling back to language.")
         language == locale.language
@@ -46,7 +40,6 @@ fun getDefaultLocales(): List<Locale> {
     return LocaleListCompat.getDefault().toList()
 }
 
-@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 private fun Locale.inferScript(): String {
     if (!script.isNullOrEmpty()) {
         return script

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/LocaleExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/LocaleExtensions.kt
@@ -1,7 +1,5 @@
 package com.revenuecat.purchases.utils
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.core.os.LocaleListCompat
 import com.revenuecat.purchases.common.errorLog
 import java.util.Locale

--- a/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -3,7 +3,6 @@ package com.revenuecat.purchases.common
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.DangerousSettings
-import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesAreCompletedBy.MY_APP
 import com.revenuecat.purchases.PurchasesAreCompletedBy.REVENUECAT
 import com.revenuecat.purchases.Store
@@ -29,9 +28,8 @@ class AppConfigTest {
     fun `languageTag is created successfully`() {
         val expected = "en-US"
         val mockContext = mockk<Context>(relaxed = true)
-        mockkStatic("com.revenuecat.purchases.common.UtilsKt")
         every {
-            mockContext.getLocale()?.toBCP47()
+            mockContext.getLocale()?.toLanguageTag()
         } returns expected
         val appConfig = AppConfig(
             context = mockContext,
@@ -48,9 +46,8 @@ class AppConfigTest {
     fun `languageTag defaults to empty string`() {
         val expected = ""
         val mockContext = mockk<Context>(relaxed = true)
-        mockkStatic("com.revenuecat.purchases.common.UtilsKt")
         every {
-            mockContext.getLocale()?.toBCP47()
+            mockContext.getLocale()?.toLanguageTag()
         } returns null
         val appConfig = AppConfig(
             context = mockContext,
@@ -347,7 +344,7 @@ class AppConfigTest {
             proxyURL = null,
             store = Store.PLAY_STORE
         )
-        assertThat(x.hashCode() == y.hashCode())
+        assertThat(x.hashCode()).isEqualTo(y.hashCode())
     }
 
     @Test


### PR DESCRIPTION
### Description
With version 8.0.0 and BC7, we bumped the min sdk to 21 (since it was required by BC7). This removes some checks we had for versions lower than that which shouldn't happen anymore.