### PR TITLE
Paywalls: Add bottom padding when there are no buttons in footer

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
@@ -71,7 +71,7 @@ internal fun Footer(
     }
 }
 
-@Suppress("LongParameterList", "LongMethod")
+@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 @Composable
 private fun Footer(
     mode: PaywallMode,
@@ -83,18 +83,31 @@ private fun Footer(
 ) {
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
-
+    val shouldDisplayAllPlansButton = mode == PaywallMode.FOOTER_CONDENSED && allPlansTapped != null
+    val anyButtonDisplayed = shouldDisplayAllPlansButton ||
+        configuration.displayRestorePurchases ||
+        configuration.termsOfServiceURL != null ||
+        configuration.privacyURL != null
+    val bottomMargin = if (anyButtonDisplayed) {
+        0.dp
+    } else {
+        UIConstant.defaultVerticalSpacing * 2
+    }
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(intrinsicSize = IntrinsicSize.Min)
-            .padding(horizontal = UIConstant.defaultHorizontalPadding),
+            .padding(
+                start = UIConstant.defaultHorizontalPadding,
+                end = UIConstant.defaultHorizontalPadding,
+                bottom = bottomMargin,
+            ),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         val color = colors.text1
 
-        if (mode == PaywallMode.FOOTER_CONDENSED && allPlansTapped != null) {
+        if (shouldDisplayAllPlansButton && allPlansTapped != null) {
             Button(
                 color = color,
                 childModifier = childModifier,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -111,6 +111,22 @@ internal object TestData {
         serverDescription = "",
     )
 
+    val template1OfferingNoFooter = Offering(
+        identifier = "Template1",
+        availablePackages = listOf(
+            Packages.monthly,
+        ),
+        metadata = mapOf(),
+        paywall = template1.copy(
+            config = template1.config.copy(
+                displayRestorePurchases = false,
+                termsOfServiceURL = null,
+                privacyURL = null,
+            ),
+        ),
+        serverDescription = "",
+    )
+
     val template2Offering = Offering(
         identifier = "Template2",
         availablePackages = listOf(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -215,6 +215,15 @@ private fun Template1PaywallPreview() {
     )
 }
 
+@Preview(showBackground = true, group = "full_screen")
+@Composable
+private fun Template1NoFooterPaywallPreview() {
+    InternalPaywall(
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
+        viewModel = MockViewModel(offering = TestData.template1OfferingNoFooter),
+    )
+}
+
 @Preview(showBackground = true, group = "footer")
 @Composable
 private fun Template1FooterPaywallPreview() {


### PR DESCRIPTION
### Description
See https://github.com/RevenueCat/purchases-flutter/issues/1078

There is no bottom margin if there is no button present in the footer. This adds a small padding there.

| Before  |  After  |
|---|---|
| ![image](https://github.com/RevenueCat/purchases-android/assets/808417/7e9a9eee-df8f-4c2a-8827-50c5dad3eb4e) | ![image](https://github.com/RevenueCat/purchases-android/assets/808417/d7d04776-348e-4d12-a281-c41ab0fc0c36) | 
