### PR TITLE
Add `DEFERRED` replacement mode

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/GoogleReplacementModeAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/GoogleReplacementModeAPI.java
@@ -10,6 +10,7 @@ final class GoogleReplacementModeAPI {
             case WITH_TIME_PRORATION:
             case CHARGE_FULL_PRICE:
             case CHARGE_PRORATED_PRICE:
+            case DEFERRED:
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/GoogleReplacementModeAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/GoogleReplacementModeAPI.kt
@@ -10,6 +10,7 @@ private class GoogleReplacementModeAPI {
             GoogleReplacementMode.WITH_TIME_PRORATION,
             GoogleReplacementMode.CHARGE_FULL_PRICE,
             GoogleReplacementMode.CHARGE_PRORATED_PRICE,
+            GoogleReplacementMode.DEFERRED,
             -> {}
         }.exhaustive
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -669,6 +669,7 @@ private enum class LegacyProrationMode {
     IMMEDIATE_WITH_TIME_PRORATION,
     IMMEDIATE_AND_CHARGE_FULL_PRICE,
     IMMEDIATE_AND_CHARGE_PRORATED_PRICE,
+    DEFERRED,
 }
 
 private val GoogleReplacementMode.asLegacyProrationMode: LegacyProrationMode
@@ -677,4 +678,5 @@ private val GoogleReplacementMode.asLegacyProrationMode: LegacyProrationMode
         GoogleReplacementMode.WITH_TIME_PRORATION -> LegacyProrationMode.IMMEDIATE_WITH_TIME_PRORATION
         GoogleReplacementMode.CHARGE_FULL_PRICE -> LegacyProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE
         GoogleReplacementMode.CHARGE_PRORATED_PRICE -> LegacyProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE
+        GoogleReplacementMode.DEFERRED -> LegacyProrationMode.DEFERRED
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleReplacementMode.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleReplacementMode.kt
@@ -56,6 +56,9 @@ enum class GoogleReplacementMode(
      * On May 1st, Samwise is charged $36 for his new subscription tier and another $36 on May 1 of each year following.
      */
     CHARGE_PRORATED_PRICE(BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.CHARGE_PRORATED_PRICE),
+
+    // WIP: ADD DOCS
+    DEFERRED(BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.DEFERRED),
     ;
 
     override fun describeContents(): Int {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleReplacementMode.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleReplacementMode.kt
@@ -57,7 +57,12 @@ enum class GoogleReplacementMode(
      */
     CHARGE_PRORATED_PRICE(BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.CHARGE_PRORATED_PRICE),
 
-    // WIP: ADD DOCS
+    /**
+     * Replacement takes effect when the old plan expires, and the new price will be charged at the same time.
+     *
+     * Example: Samwise's Tier 1 subscription continues until it expires on April 30. On May 1st, the
+     * Tier 2 subscription takes effect, and Samwise is charged $36 for his new subscription tier.
+     */
     DEFERRED(BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.DEFERRED),
     ;
 


### PR DESCRIPTION
### Description
Deferred replacement mode was removed in V7 of the SDK. This brings it back.
