### PR TITLE
Update test lane to require active entitlements

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -244,9 +244,7 @@ platform :android do
         google_purchase_token: ENV['GOOGLE_PURCHASE_TOKEN'],
         product_id_to_purchase: ENV['PRODUCT_ID_TO_PURCHASE'],
         base_plan_id_to_purchase: ENV['BASE_PLAN_ID_TO_PURCHASE'],
-        # We default to empty active entitlements since we are using an expired token for these integration tests.
-        # So no active entitlements will be returned by our servers.
-        active_entitlements_to_verify: ENV['ACTIVE_ENTITLEMENTS_TO_VERIFY'] || '',
+        active_entitlements_to_verify: ENV['ACTIVE_ENTITLEMENTS_TO_VERIFY'],
     )
   end
 


### PR DESCRIPTION
### Description
Now we have an active token in production that won't expire, so we can require an active entitlement for integration tests. We just need to update some ENVs in CI. This is just a cleanup