### PR TITLE
Support ISO8601-2 period durations

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PeriodAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PeriodAPI.java
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.models.Period;
 @SuppressWarnings({"unused", "SpellCheckingInspection"})
 final class PeriodAPI {
     static void check(final Period period) {
+        Period newPeriod = Period.Factory.create("P1M");
         int val = period.getValue();
         Period.Unit unit = period.getUnit();
         String iso8601 = period.getIso8601();

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PeriodAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PeriodAPI.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.models.Period
 @Suppress("unused", "UNUSED_VARIABLE")
 private class PeriodAPI {
     fun check(period: Period) {
+        val newPeriod = Period.create("P1Y")
         with(period) {
             val value: Int = value
             val unit: Period.Unit = unit

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/Period.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/Period.kt
@@ -3,6 +3,16 @@ package com.revenuecat.purchases.models
 import android.os.Parcelable
 import com.revenuecat.purchases.common.errorLog
 import kotlinx.parcelize.Parcelize
+import kotlin.math.roundToInt
+
+private object PeriodConstants {
+    const val DAYS_PER_WEEK = 7.0
+    const val DAYS_PER_MONTH = 30.0
+    const val DAYS_PER_YEAR = 365.0
+    const val WEEKS_PER_YEAR = DAYS_PER_YEAR / DAYS_PER_WEEK
+    const val MONTHS_PER_YEAR = 12.0
+    const val WEEKS_PER_MONTH = DAYS_PER_YEAR / MONTHS_PER_YEAR / DAYS_PER_WEEK
+}
 
 /**
  * Represents subscription or [PricingPhase] billing period
@@ -28,13 +38,6 @@ data class Period(
 ) : Parcelable {
 
     companion object Factory {
-        private const val DAYS_PER_WEEK = 7.0
-        private const val DAYS_PER_MONTH = 30.0
-        private const val DAYS_PER_YEAR = 365.0
-        private const val WEEKS_PER_YEAR = DAYS_PER_YEAR / DAYS_PER_WEEK
-        private const val MONTHS_PER_YEAR = 12.0
-        private const val WEEKS_PER_MONTH = DAYS_PER_YEAR / MONTHS_PER_YEAR / DAYS_PER_WEEK
-
         fun create(iso8601: String): Period {
             val pair = iso8601.toPeriod()
             return Period(pair.first, pair.second, iso8601)
@@ -55,10 +58,10 @@ data class Period(
      */
     internal val valueInWeeks: Double
         get() = when (unit) {
-            Unit.DAY -> value / DAYS_PER_WEEK
+            Unit.DAY -> value / PeriodConstants.DAYS_PER_WEEK
             Unit.WEEK -> value.toDouble()
-            Unit.MONTH -> value.toDouble() * WEEKS_PER_MONTH
-            Unit.YEAR -> value * WEEKS_PER_YEAR
+            Unit.MONTH -> value.toDouble() * PeriodConstants.WEEKS_PER_MONTH
+            Unit.YEAR -> value * PeriodConstants.WEEKS_PER_YEAR
             Unit.UNKNOWN -> {
                 errorLog("Unknown period unit trying to get value in months: $unit")
                 0.0
@@ -70,10 +73,10 @@ data class Period(
      */
     val valueInMonths: Double
         get() = when (unit) {
-            Unit.DAY -> value / DAYS_PER_MONTH
-            Unit.WEEK -> value / WEEKS_PER_MONTH
+            Unit.DAY -> value / PeriodConstants.DAYS_PER_MONTH
+            Unit.WEEK -> value / PeriodConstants.WEEKS_PER_MONTH
             Unit.MONTH -> value.toDouble()
-            Unit.YEAR -> value * MONTHS_PER_YEAR
+            Unit.YEAR -> value * PeriodConstants.MONTHS_PER_YEAR
             Unit.UNKNOWN -> {
                 errorLog("Unknown period unit trying to get value in months: $unit")
                 0.0
@@ -85,9 +88,9 @@ data class Period(
      */
     internal val valueInYears: Double
         get() = when (unit) {
-            Unit.DAY -> value / DAYS_PER_YEAR
-            Unit.WEEK -> value / WEEKS_PER_YEAR
-            Unit.MONTH -> value / MONTHS_PER_YEAR
+            Unit.DAY -> value / PeriodConstants.DAYS_PER_YEAR
+            Unit.WEEK -> value / PeriodConstants.WEEKS_PER_YEAR
+            Unit.MONTH -> value / PeriodConstants.MONTHS_PER_YEAR
             Unit.YEAR -> value.toDouble()
             Unit.UNKNOWN -> {
                 errorLog("Unknown period unit trying to get value in months: $unit")
@@ -115,17 +118,29 @@ private fun String.toPeriod(): Pair<Int, Period.Unit> {
         val weekInt = toInt(week)
         val dayInt = toInt(day)
 
-        return if (yearInt > 0) {
-            Pair(yearInt, Period.Unit.YEAR)
-        } else if (monthInt > 0) {
-            Pair(monthInt, Period.Unit.MONTH)
-        } else if (weekInt > 0) {
-            Pair(weekInt, Period.Unit.WEEK)
-        } else if (dayInt > 0) {
-            Pair(dayInt, Period.Unit.DAY)
-        } else {
-            Pair(0, Period.Unit.UNKNOWN)
+        val smallerUnit = when {
+            dayInt > 0 -> Period.Unit.DAY
+            weekInt > 0 -> Period.Unit.WEEK
+            monthInt > 0 -> Period.Unit.MONTH
+            yearInt > 0 -> Period.Unit.YEAR
+            else -> Period.Unit.UNKNOWN
         }
+
+        val value = when (smallerUnit) {
+            Period.Unit.YEAR -> yearInt.toDouble()
+            Period.Unit.MONTH -> (yearInt * PeriodConstants.MONTHS_PER_YEAR) +
+                monthInt
+            Period.Unit.WEEK -> (yearInt * PeriodConstants.WEEKS_PER_YEAR) +
+                (monthInt * PeriodConstants.WEEKS_PER_MONTH) +
+                weekInt
+            Period.Unit.DAY -> (yearInt * PeriodConstants.DAYS_PER_YEAR) +
+                (monthInt * PeriodConstants.DAYS_PER_MONTH) +
+                (weekInt * PeriodConstants.DAYS_PER_WEEK) +
+                dayInt
+            Period.Unit.UNKNOWN -> 0.0
+        }
+
+        return Pair(value.roundToInt(), smallerUnit)
     }
 
     return Pair(0, Period.Unit.UNKNOWN)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/Period.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/Period.kt
@@ -38,6 +38,13 @@ data class Period(
 ) : Parcelable {
 
     companion object Factory {
+        /**
+         * Creates a [Period] object from an ISO 8601 string. Supports both ISO 8601-1 and ISO 8601-2 formats.
+         * You shouldn't normally need to call this method directly since `Period` objects are created by the SDK.
+         * This can be useful in some cases for testing purposes.
+         *
+         * @param iso8601 The ISO 8601 string to parse
+         */
         fun create(iso8601: String): Period {
             val pair = iso8601.toPeriod()
             return Period(pair.first, pair.second, iso8601)

--- a/purchases/src/test/java/com/revenuecat/purchases/models/PeriodTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/models/PeriodTest.kt
@@ -53,6 +53,22 @@ class PeriodTest {
     }
 
     @Test
+    fun `create period creates expected period class for multiple different units`() {
+        val period = Period.create("P12W6D")
+        assertThat(period.value).isEqualTo(90)
+        assertThat(period.unit).isEqualTo(Period.Unit.DAY)
+        assertThat(period.iso8601).isEqualTo("P12W6D")
+    }
+
+    @Test
+    fun `create period creates expected period class for multiple different units with min unit months`() {
+        val period = Period.create("P2Y6M")
+        assertThat(period.value).isEqualTo(30)
+        assertThat(period.unit).isEqualTo(Period.Unit.MONTH)
+        assertThat(period.iso8601).isEqualTo("P2Y6M")
+    }
+
+    @Test
     fun `valueInMonths is correct for days`() {
         val period = Period.create("P3D")
         assertThat(period.valueInMonths).isCloseTo(0.1, MAX_OFFSET)


### PR DESCRIPTION
### Description
This will fix #1753

In cases where the period we get from the store is in the format ISO8601-2, that is, has multiple units, our current parsing code wouldn't parse it correctly. I changed to use the smaller unit sent from the store and convert it to that unit.