### PR TITLE
Makes `ITEM_NOT_OWNED` message more clear when restoring and acknowledging/consuming

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -415,13 +415,8 @@ internal class BillingWrapper(
                 appInBackground,
             ),
             onReceive = onConsumed,
-            onError = { error ->
+            onError = { _ ->
                 // TODO-retry: if ITEM_NOT_OWNED queryPurchasesAsync
-                log(
-                    LogIntent.GOOGLE_ERROR,
-                    PurchaseStrings.CONSUMING_PURCHASE_ERROR
-                        .format(error.underlyingErrorMessage),
-                )
             },
             ::withConnectedClient,
             ::executeRequestOnUIThread,
@@ -441,13 +436,8 @@ internal class BillingWrapper(
                 appInBackground,
             ),
             onReceive = onAcknowledged,
-            { error ->
+            { _ ->
                 // TODO-retry: if ITEM_NOT_OWNED queryPurchasesAsync
-                log(
-                    LogIntent.GOOGLE_ERROR,
-                    PurchaseStrings.ACKNOWLEDGING_PURCHASE_ERROR
-                        .format(error.underlyingErrorMessage),
-                )
             },
             ::withConnectedClient,
             ::executeRequestOnUIThread,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCase.kt
@@ -44,19 +44,20 @@ internal class AcknowledgePurchaseUseCase(
                 processResult(
                     billingResult,
                     useCaseParams.purchaseToken,
-                    onError = {
+                    onError = { errorBillingResult ->
                         val underlyingErrorMessage: String
-                        if (it.responseCode == BillingClient.BillingResponseCode.ITEM_NOT_OWNED &&
+                        if (errorBillingResult.responseCode == BillingClient.BillingResponseCode.ITEM_NOT_OWNED &&
                             useCaseParams.initiationSource == PostReceiptInitiationSource.RESTORE
                         ) {
                             underlyingErrorMessage = PurchaseStrings.ACKNOWLEDGING_PURCHASE_ERROR_RESTORE
                             log(LogIntent.GOOGLE_WARNING, underlyingErrorMessage)
                         } else {
-                            underlyingErrorMessage = "$errorMessage - ${billingResult.toHumanReadableDescription()}"
+                            underlyingErrorMessage =
+                                "$errorMessage - ${errorBillingResult.toHumanReadableDescription()}"
                             log(LogIntent.GOOGLE_ERROR, underlyingErrorMessage)
                         }
                         onError(
-                            billingResult.responseCode.billingResponseToPurchasesError(underlyingErrorMessage),
+                            errorBillingResult.responseCode.billingResponseToPurchasesError(underlyingErrorMessage),
                         )
                     },
                 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCase.kt
@@ -5,7 +5,6 @@ import com.android.billingclient.api.BillingClient
 import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.PurchasesErrorCallback
 import com.revenuecat.purchases.common.LogIntent
-import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
 import com.revenuecat.purchases.google.toHumanReadableDescription
@@ -57,9 +56,7 @@ internal class AcknowledgePurchaseUseCase(
                             log(LogIntent.GOOGLE_ERROR, underlyingErrorMessage)
                         }
                         onError(
-                            billingResult.responseCode.billingResponseToPurchasesError(
-                                underlyingErrorMessage,
-                            ).also { errorLog(it) },
+                            billingResult.responseCode.billingResponseToPurchasesError(underlyingErrorMessage),
                         )
                     },
                 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCase.kt
@@ -45,19 +45,20 @@ internal class ConsumePurchaseUseCase(
                 processResult(
                     billingResult,
                     purchaseToken,
-                    onError = {
+                    onError = { errorBillingResult ->
                         val underlyingErrorMessage: String
-                        if (it.responseCode == BillingClient.BillingResponseCode.ITEM_NOT_OWNED &&
+                        if (errorBillingResult.responseCode == BillingClient.BillingResponseCode.ITEM_NOT_OWNED &&
                             useCaseParams.initiationSource == PostReceiptInitiationSource.RESTORE
                         ) {
                             underlyingErrorMessage = PurchaseStrings.CONSUMING_PURCHASE_ERROR_RESTORE
                             log(LogIntent.GOOGLE_WARNING, underlyingErrorMessage)
                         } else {
-                            underlyingErrorMessage = "$errorMessage - ${billingResult.toHumanReadableDescription()}"
+                            underlyingErrorMessage =
+                                "$errorMessage - ${errorBillingResult.toHumanReadableDescription()}"
                             log(LogIntent.GOOGLE_ERROR, underlyingErrorMessage)
                         }
                         onError(
-                            billingResult.responseCode.billingResponseToPurchasesError(underlyingErrorMessage),
+                            errorBillingResult.responseCode.billingResponseToPurchasesError(underlyingErrorMessage),
                         )
                     },
                 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCase.kt
@@ -4,6 +4,11 @@ import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.ConsumeParams
 import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.PurchasesErrorCallback
+import com.revenuecat.purchases.common.LogIntent
+import com.revenuecat.purchases.common.log
+import com.revenuecat.purchases.google.billingResponseToPurchasesError
+import com.revenuecat.purchases.google.toHumanReadableDescription
+import com.revenuecat.purchases.strings.PurchaseStrings
 
 internal class ConsumePurchaseUseCaseParams(
     val purchaseToken: String,
@@ -24,6 +29,7 @@ internal class ConsumePurchaseUseCase(
             PostReceiptInitiationSource.RESTORE,
             PostReceiptInitiationSource.PURCHASE,
             -> false
+
             PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES -> true
         }
 
@@ -35,7 +41,27 @@ internal class ConsumePurchaseUseCase(
             val consumeParams = ConsumeParams.newBuilder()
                 .setPurchaseToken(useCaseParams.purchaseToken)
                 .build()
-            consumeAsync(consumeParams, ::processResult)
+            consumeAsync(consumeParams) { billingResult, purchaseToken ->
+                processResult(
+                    billingResult,
+                    purchaseToken,
+                    onError = {
+                        val underlyingErrorMessage: String
+                        if (it.responseCode == BillingClient.BillingResponseCode.ITEM_NOT_OWNED &&
+                            useCaseParams.initiationSource == PostReceiptInitiationSource.RESTORE
+                        ) {
+                            underlyingErrorMessage = PurchaseStrings.CONSUMING_PURCHASE_ERROR_RESTORE
+                            log(LogIntent.GOOGLE_WARNING, underlyingErrorMessage)
+                        } else {
+                            underlyingErrorMessage = "$errorMessage - ${billingResult.toHumanReadableDescription()}"
+                            log(LogIntent.GOOGLE_ERROR, underlyingErrorMessage)
+                        }
+                        onError(
+                            billingResult.responseCode.billingResponseToPurchasesError(underlyingErrorMessage),
+                        )
+                    },
+                )
+            }
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/PurchaseStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/PurchaseStrings.kt
@@ -4,11 +4,13 @@ internal object PurchaseStrings {
     const val ACKNOWLEDGING_PURCHASE = "Acknowledging purchase with token %s"
     const val ACKNOWLEDGING_PURCHASE_ERROR = "Error acknowledging purchase. Will retry next queryPurchases. %s"
     const val ACKNOWLEDGING_PURCHASE_ERROR_RESTORE = "Couldn't acknowledge purchase after restoring it, this most " +
-        "likely means the subscription has expired already or the product has already been consumed."
+        "likely means the subscription has expired already or the product has already been acknowledged."
     const val BILLING_CLIENT_NOT_CONNECTED = "Skipping updating pending purchase queue since " +
         "BillingClient is not connected yet."
     const val CONSUMING_PURCHASE = "Consuming purchase with token %s"
     const val CONSUMING_PURCHASE_ERROR = "Error consuming purchase. Will retry next queryPurchases. %s"
+    const val CONSUMING_PURCHASE_ERROR_RESTORE = "Couldn't consume purchase after restoring it, this most likely " +
+        "means the product has already been consumed."
     const val NOT_CONSUMING_IN_APP_PURCHASE_ACCORDING_TO_BACKEND = "Not consuming in-app purchase according to" +
         " server configuration. This is expected for non-consumable products. The user won't be able to purchase this" +
         " product again."

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/PurchaseStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/PurchaseStrings.kt
@@ -3,6 +3,8 @@ package com.revenuecat.purchases.strings
 internal object PurchaseStrings {
     const val ACKNOWLEDGING_PURCHASE = "Acknowledging purchase with token %s"
     const val ACKNOWLEDGING_PURCHASE_ERROR = "Error acknowledging purchase. Will retry next queryPurchases. %s"
+    const val ACKNOWLEDGING_PURCHASE_ERROR_RESTORE = "Couldn't acknowledge purchase after restoring it, this most " +
+        "likely means the subscription has expired already or the product has already been consumed."
     const val BILLING_CLIENT_NOT_CONNECTED = "Skipping updating pending purchase queue since " +
         "BillingClient is not connected yet."
     const val CONSUMING_PURCHASE = "Consuming purchase with token %s"

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -390,7 +390,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
     }
 
     @Test
-    fun `ITEM_NOT_OWNED when restoring  has special error message`() {
+    fun `ITEM_NOT_OWNED when restoring has special error message`() {
         val slot = slot<AcknowledgePurchaseResponseListener>()
         val acknowledgeStubbing = every {
             mockClient.acknowledgePurchase(

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.google.toStoreTransaction
 import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.strings.PurchaseStrings
 import com.revenuecat.purchases.utils.stubGooglePurchase
 import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
 import io.mockk.Runs
@@ -386,6 +387,52 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         verify(exactly = 1) {
             mockDeviceCache.addSuccessfullyPostedToken(token)
         }
+    }
+
+    @Test
+    fun `ITEM_NOT_OWNED when restoring  has special error message`() {
+        val slot = slot<AcknowledgePurchaseResponseListener>()
+        val acknowledgeStubbing = every {
+            mockClient.acknowledgePurchase(
+                any(),
+                capture(slot),
+            )
+        }
+        var receivedError: PurchasesError? = null
+        var timesRetried = 0
+        val useCase = AcknowledgePurchaseUseCase(
+            AcknowledgePurchaseUseCaseParams(
+                "purchaseToken",
+                PostReceiptInitiationSource.RESTORE,
+                appInBackground = false,
+            ),
+            { _ ->
+                Assertions.fail("shouldn't be success")
+            },
+            { error ->
+                receivedError = error
+            },
+            withConnectedClient = {
+                timesRetried++
+                it.invoke(mockClient)
+            },
+            executeRequestOnUIThread = { _, request ->
+                acknowledgeStubbing answers {
+                    slot.captured.onAcknowledgePurchaseResponse(
+                        BillingClient.BillingResponseCode.ITEM_NOT_OWNED.buildResult(),
+                    )
+                }
+
+                request(null)
+            },
+        )
+
+        useCase.run()
+
+        assertThat(timesRetried).isEqualTo(1)
+        assertThat(receivedError).isNotNull
+        assertThat(receivedError!!.code).isEqualTo(PurchasesErrorCode.PurchaseNotAllowedError)
+        assertThat(receivedError!!.underlyingErrorMessage).isEqualTo(PurchaseStrings.ACKNOWLEDGING_PURCHASE_ERROR_RESTORE)
     }
 
     // region retries


### PR DESCRIPTION
Cleans up logs when acknowledging or consuming and getting an `ITEM_NOT_OWNED`. Also removed some duplication of the logs

-------

Before:
![CleanShot 2024-06-19 at 12 30 21@2x](https://github.com/RevenueCat/purchases-android/assets/664544/81ea65f7-2d26-4211-9c9b-ba355ad3e82e)

After:
![CleanShot 2024-06-19 at 12 29 26@2x](https://github.com/RevenueCat/purchases-android/assets/664544/57d3ad6f-45f1-413d-9ae9-0b041a1f3c67)
