### PR TITLE
Change android integration test to cover more testable use case

### DIFF
--- a/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -149,6 +149,17 @@ open class BasePurchasesIntegrationTest {
         } answers {
             callbackSlot.captured.invoke(activePurchases)
         }
+
+        val queryAllPurchasesSlot = slot<(List<StoreTransaction>) -> Unit>()
+        every {
+            mockBillingAbstract.queryAllPurchases(
+                testUserId,
+                onReceivePurchaseHistory = capture(queryAllPurchasesSlot),
+                onReceivePurchaseHistoryError = any(),
+            )
+        } answers {
+            queryAllPurchasesSlot.captured.invoke(activePurchases.values.toList())
+        }
     }
 
     protected fun runTestActivityLifecycleScope(

--- a/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/offlineentitlements/OfflineEntitlementsWithInitialRequestsCompletedIntegrationTest.kt
+++ b/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/offlineentitlements/OfflineEntitlementsWithInitialRequestsCompletedIntegrationTest.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.purchaseWith
 import com.revenuecat.purchases.resetSingleton
+import com.revenuecat.purchases.restorePurchasesWith
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Before
@@ -300,7 +301,7 @@ class OfflineEntitlementsWithInitialRequestsCompletedAndNoInitialPurchasesIntegr
     }
 
     @Test
-    fun recoversFromOfflineEntitlementsModeIfGetCustomerInfoSucceeds() {
+    fun recoversFromOfflineEntitlementsModeIfRestoreSucceeds() {
         val storeProduct = StoreProductFactory.createGoogleStoreProduct()
 
         ensureBlockFinishes { latch ->
@@ -319,14 +320,12 @@ class OfflineEntitlementsWithInitialRequestsCompletedAndNoInitialPurchasesIntegr
 
                     Purchases.sharedInstance.forceServerErrors = false
 
-                    Purchases.sharedInstance.getCustomerInfoWith(
-                        CacheFetchPolicy.FETCH_CURRENT,
+                    Purchases.sharedInstance.restorePurchasesWith(
                         onError = {
                             fail("Expected success but got error: $it")
                         },
-                        onSuccess = { customerInfo2 ->
-                            // This is because the token we are using is not a real token to be used in the backend
-                            assertThat(customerInfo2.entitlements.active.keys).containsExactlyInAnyOrderElementsOf(
+                        onSuccess = {
+                            assertThat(it.entitlements.active.keys).containsExactlyInAnyOrderElementsOf(
                                 entitlementsToVerify,
                             )
                             assertAcknowledgePurchaseDidHappen()


### PR DESCRIPTION
### Description
We had a test that verifies that a token gets recognized and entitlements given if the user is offline, then they recover, but that test wasn't working correctly, since the token we used didn't grant any entitlements (was an expired token).

After changing to a proper token, this test started failing because the token was already assigned to a different user and we were posting it with initiation source `unsynced_active_purchases`, which doesn't transfer active purchases, so the entitlement was never granted. In order to properly test that case, we would need a new token every time we run the tests which we currently can't have, since testing with Google Play is bad :(. 

For now, I've changed the test to cover recovery after a restore, which does work as expected. Happy to provide more details as needed!