### PR TITLE
Call callbacks on `DEFERRED` purchases

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -1020,7 +1020,10 @@ internal class PurchasesOrchestrator constructor(
             }
 
             if (!state.purchaseCallbacksByProductId.containsKey(purchasingData.productId)) {
-                val productId = purchasingData.productId
+                val productId =
+                    if (googleReplacementMode == GoogleReplacementMode.DEFERRED) {
+                        oldProductId
+                    } else purchasingData.productId
                 val mapOfProductIdToListener = mapOf(productId to purchaseCallback)
                 state = state.copy(
                     purchaseCallbacksByProductId = state.purchaseCallbacksByProductId + mapOfProductIdToListener,

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -250,6 +250,50 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     @Test
+    fun `when making a deferred product change, completion is called with the transaction for the old product`() {
+        val newProductId = listOf("newproduct")
+        val storeProduct = mockStoreProduct(newProductId, newProductId, ProductType.SUBS)
+        val oldPurchase = mockPurchaseFound()
+        mockQueryingProductDetails(oldPurchase.productIds.first(), ProductType.SUBS, null)
+        every {
+            mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(
+                oldPurchase, any(), isRestore = false, appUserId, initiationSource, captureLambda(), any(),
+            )
+        } answers {
+            lambda<SuccessfulPurchaseCallback>().captured.invoke(oldPurchase, mockk())
+        }
+        val productChangeParams = getPurchaseParams(
+            storeProduct.first().subscriptionOptions!!.first(),
+            oldPurchase.productIds.first(),
+            googleReplacementMode = GoogleReplacementMode.DEFERRED,
+        )
+        var callCount = 0
+        purchases.purchaseWith(
+            productChangeParams,
+            onError = { _, _ ->
+                fail("should be successful")
+            },
+            onSuccess = { purchase, _ ->
+                callCount++
+                assertThat(purchase).isEqualTo(oldPurchase)
+            }
+        )
+        capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(listOf(oldPurchase))
+        assertThat(callCount).isEqualTo(1)
+        verify(exactly = 1) {
+            mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(
+                purchase = oldPurchase,
+                storeProduct = any(),
+                isRestore = false,
+                appUserID = appUserId,
+                initiationSource = initiationSource,
+                onSuccess = any(),
+                onError = any()
+            )
+        }
+    }
+
+    @Test
     fun `upgrade defaults to ProrationMode IMMEDIATE_WITHOUT_PRORATION`() {
         val productId = "gold"
         val oldSubId = "oldSubID"


### PR DESCRIPTION
### Description
Followup to #1751.

We were not calling the callbacks on DEFERRED purchases. This fixes that so DEFERRED purchases work correctly