### PR TITLE
Use correct product context with `DEFERRED` purchases

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -1020,6 +1020,8 @@ internal class PurchasesOrchestrator constructor(
             }
 
             if (!state.purchaseCallbacksByProductId.containsKey(purchasingData.productId)) {
+                // When using DEFERRED proration mode, callback needs to be associated with the *old* product we are
+                // switching from, because the transaction we receive on successful purchase is for the old product.
                 val productId =
                     if (googleReplacementMode == GoogleReplacementMode.DEFERRED) {
                         oldProductId

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -92,7 +92,8 @@ internal class BillingWrapper(
     @Volatile
     var billingClient: BillingClient? = null
 
-    private val purchaseContext = mutableMapOf<String, PurchaseContext>()
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val purchaseContext = mutableMapOf<String, PurchaseContext>()
 
     private val serviceRequests =
         ConcurrentLinkedQueue<Pair<(connectionError: PurchasesError?) -> Unit, Long?>>()
@@ -266,7 +267,12 @@ internal class BillingWrapper(
         }
 
         synchronized(this@BillingWrapper) {
-            val productId = googlePurchasingData.productId
+            // When using DEFERRED proration mode, callback needs to be associated with the *old* product we are
+            // switching from, because the transaction we receive on successful purchase is for the old product.
+            val productId =
+                if (replaceProductInfo?.replacementMode == GoogleReplacementMode.DEFERRED) {
+                    replaceProductInfo.oldPurchase.productIds.first()
+                } else googlePurchasingData.productId
             purchaseContext[productId] = PurchaseContext(
                 googlePurchasingData.productType,
                 presentedOfferingContext,


### PR DESCRIPTION
### Description
Another followup to #1751 and #1764 

When making `DEFERRED` purchases, Google returns the result using the old product id. We need to cache all the context information using the old product id so we can attribute it correctly. 