### PR TITLE
Use trimmed API key

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -14,9 +14,6 @@ open class PurchasesConfiguration(builder: Builder) {
     val apiKey: String
     val appUserID: String?
 
-    internal val trimmedApiKey: String
-        get() = apiKey.trim()
-
     @Deprecated(
         "observerMode is being deprecated in favor of purchasesAreCompletedBy.",
         ReplaceWith(
@@ -40,7 +37,7 @@ open class PurchasesConfiguration(builder: Builder) {
 
     init {
         this.context = builder.context
-        this.apiKey = builder.apiKey
+        this.apiKey = builder.apiKey.trim()
         this.appUserID = builder.appUserID
         this.purchasesAreCompletedBy = builder.purchasesAreCompletedBy
         this.service = builder.service

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -14,6 +14,9 @@ open class PurchasesConfiguration(builder: Builder) {
     val apiKey: String
     val appUserID: String?
 
+    internal val trimmedApiKey: String
+        get() = apiKey.trim()
+
     @Deprecated(
         "observerMode is being deprecated in favor of purchasesAreCompletedBy.",
         ReplaceWith(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -116,12 +116,12 @@ internal class PurchasesFactory(
             val signatureVerificationMode = SignatureVerificationMode.fromEntitlementVerificationMode(
                 verificationMode,
             )
-            val signingManager = SigningManager(signatureVerificationMode, appConfig, apiKey)
+            val signingManager = SigningManager(signatureVerificationMode, appConfig, trimmedApiKey)
 
-            val cache = DeviceCache(prefs, apiKey)
+            val cache = DeviceCache(prefs, trimmedApiKey)
 
             val httpClient = HTTPClient(appConfig, eTagManager, diagnosticsTracker, signingManager, cache)
-            val backendHelper = BackendHelper(apiKey, backendDispatcher, appConfig, httpClient)
+            val backendHelper = BackendHelper(trimmedApiKey, backendDispatcher, appConfig, httpClient)
             val backend = Backend(
                 appConfig,
                 backendDispatcher,
@@ -324,11 +324,11 @@ internal class PurchasesFactory(
                 "Purchases requires INTERNET permission."
             }
 
-            require(apiKey.isNotBlank()) { "API key must be set. Get this from the RevenueCat web app" }
+            require(trimmedApiKey.isNotBlank()) { "API key must be set. Get this from the RevenueCat web app" }
 
             require(context.applicationContext is Application) { "Needs an application context." }
 
-            apiKeyValidator.validateAndLog(apiKey, store)
+            apiKeyValidator.validateAndLog(trimmedApiKey, store)
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -116,12 +116,12 @@ internal class PurchasesFactory(
             val signatureVerificationMode = SignatureVerificationMode.fromEntitlementVerificationMode(
                 verificationMode,
             )
-            val signingManager = SigningManager(signatureVerificationMode, appConfig, trimmedApiKey)
+            val signingManager = SigningManager(signatureVerificationMode, appConfig, apiKey)
 
-            val cache = DeviceCache(prefs, trimmedApiKey)
+            val cache = DeviceCache(prefs, apiKey)
 
             val httpClient = HTTPClient(appConfig, eTagManager, diagnosticsTracker, signingManager, cache)
-            val backendHelper = BackendHelper(trimmedApiKey, backendDispatcher, appConfig, httpClient)
+            val backendHelper = BackendHelper(apiKey, backendDispatcher, appConfig, httpClient)
             val backend = Backend(
                 appConfig,
                 backendDispatcher,
@@ -324,11 +324,11 @@ internal class PurchasesFactory(
                 "Purchases requires INTERNET permission."
             }
 
-            require(trimmedApiKey.isNotBlank()) { "API key must be set. Get this from the RevenueCat web app" }
+            require(apiKey.isNotBlank()) { "API key must be set. Get this from the RevenueCat web app" }
 
             require(context.applicationContext is Application) { "Needs an application context." }
 
-            apiKeyValidator.validateAndLog(trimmedApiKey, store)
+            apiKeyValidator.validateAndLog(apiKey, store)
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -110,4 +110,11 @@ class PurchasesConfigurationTest {
         val purchasesConfiguration = builder.dangerousSettings(dangerousSettings).build()
         assertThat(purchasesConfiguration.dangerousSettings).isEqualTo(dangerousSettings)
     }
+
+    @Test
+    fun `PurchasesConfiguration trimmedApiKey has correct value`() {
+        val purchasesConfiguration = PurchasesConfiguration.Builder(context, "  test-api-key  ").build()
+        assertThat(purchasesConfiguration.apiKey).isEqualTo("  test-api-key  ")
+        assertThat(purchasesConfiguration.trimmedApiKey).isEqualTo("test-api-key")
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -112,9 +112,8 @@ class PurchasesConfigurationTest {
     }
 
     @Test
-    fun `PurchasesConfiguration trimmedApiKey has correct value`() {
+    fun `PurchasesConfiguration trims api key`() {
         val purchasesConfiguration = PurchasesConfiguration.Builder(context, "  test-api-key  ").build()
-        assertThat(purchasesConfiguration.apiKey).isEqualTo("  test-api-key  ")
-        assertThat(purchasesConfiguration.trimmedApiKey).isEqualTo("test-api-key")
+        assertThat(purchasesConfiguration.apiKey).isEqualTo("test-api-key")
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -89,11 +89,9 @@ class PurchasesFactoryTest {
     }
 
     private fun createConfiguration(testApiKey: String = "fakeApiKey"): PurchasesConfiguration {
-        return mockk<PurchasesConfiguration>().apply {
-            every { context } returns contextMock
-            every { apiKey } returns testApiKey
-            every { appUserID } returns "appUserID"
-            every { store } returns Store.PLAY_STORE
-        }
+        return PurchasesConfiguration.Builder(contextMock, testApiKey)
+            .appUserID("appUserID")
+            .store(Store.PLAY_STORE)
+            .build()
     }
 }


### PR DESCRIPTION
### Description
I noticed that trusted entitlements may fail if passing an API key with extra whitespaces. This is because it's part of the data we are verifying and the backend uses the trimmed version so there is a mismatch. This trims the API key we use in the SDK, so it matches what the backend uses in those cases. Any real API key shouldn't contain any whitespaces so I think it should be fine but lmk what you think
