### PR TITLE
Attempt to fix ANRs by moving some tasks during configure to background

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -95,10 +95,6 @@ internal class PurchasesFactory(
                 createEventsExecutor(),
                 runningIntegrationTests = runningIntegrationTests,
             )
-            val identityManagerDispatcher = Dispatcher(
-                createDefaultExecutor(),
-                runningIntegrationTests = runningIntegrationTests,
-            )
 
             var diagnosticsFileHelper: DiagnosticsFileHelper? = null
             var diagnosticsHelper: DiagnosticsHelper? = null
@@ -183,7 +179,7 @@ internal class PurchasesFactory(
                 offeringsCache,
                 backend,
                 offlineEntitlementsManager,
-                identityManagerDispatcher,
+                dispatcher,
             )
 
             val customerInfoUpdateHandler = CustomerInfoUpdateHandler(
@@ -290,6 +286,7 @@ internal class PurchasesFactory(
                 createPaywallEventsManager(application, identityManager, eventsDispatcher, backend),
                 paywallPresentedCache,
                 purchasesStateProvider,
+                dispatcher,
             )
 
             return Purchases(purchasesOrchestrator)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -95,6 +95,10 @@ internal class PurchasesFactory(
                 createEventsExecutor(),
                 runningIntegrationTests = runningIntegrationTests,
             )
+            val identityManagerDispatcher = Dispatcher(
+                createDefaultExecutor(),
+                runningIntegrationTests = runningIntegrationTests,
+            )
 
             var diagnosticsFileHelper: DiagnosticsFileHelper? = null
             var diagnosticsHelper: DiagnosticsHelper? = null
@@ -179,6 +183,7 @@ internal class PurchasesFactory(
                 offeringsCache,
                 backend,
                 offlineEntitlementsManager,
+                identityManagerDispatcher,
             )
 
             val customerInfoUpdateHandler = CustomerInfoUpdateHandler(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -286,7 +286,7 @@ internal class PurchasesFactory(
                 createPaywallEventsManager(application, identityManager, eventsDispatcher, backend),
                 paywallPresentedCache,
                 purchasesStateProvider,
-                dispatcher,
+                dispatcher = dispatcher,
             )
 
             return Purchases(purchasesOrchestrator)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -73,7 +73,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.seconds
 
 @Suppress("LongParameterList", "LargeClass", "TooManyFunctions")
-internal class PurchasesOrchestrator constructor(
+internal class PurchasesOrchestrator(
     private val application: Application,
     backingFieldAppUserID: String?,
     private val backend: Backend,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -780,7 +780,6 @@ internal class PurchasesOrchestrator(
     //endregion
 
     // region Private Methods
-    @Synchronized
     private fun enqueue(command: () -> Unit) {
         dispatcher.enqueue({ command() }, Delay.NONE)
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -16,6 +16,8 @@ import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.Config
 import com.revenuecat.purchases.common.Constants
+import com.revenuecat.purchases.common.Delay
+import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.ReceiptInfo
@@ -97,6 +99,7 @@ internal class PurchasesOrchestrator(
     private val purchasesStateCache: PurchasesStateCache,
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper()),
+    private val dispatcher: Dispatcher,
 ) : LifecycleDelegate, CustomActivityLifecycleHandler {
 
     internal var state: PurchasesState
@@ -194,22 +197,24 @@ internal class PurchasesOrchestrator(
             state = state.copy(appInBackground = false, firstTimeInForeground = false)
         }
         log(LogIntent.DEBUG, ConfigureStrings.APP_FOREGROUNDED)
-        if (shouldRefreshCustomerInfo(firstTimeInForeground)) {
-            log(LogIntent.DEBUG, CustomerInfoStrings.CUSTOMERINFO_STALE_UPDATING_FOREGROUND)
-            customerInfoHelper.retrieveCustomerInfo(
-                identityManager.currentAppUserID,
-                fetchPolicy = CacheFetchPolicy.FETCH_CURRENT,
-                appInBackground = false,
-                allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
-            )
-        }
-        offeringsManager.onAppForeground(identityManager.currentAppUserID)
-        postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount)
-        synchronizeSubscriberAttributesIfNeeded()
-        offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
-        flushPaywallEvents()
-        if (firstTimeInForeground && isAndroidNOrNewer()) {
-            diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
+        enqueue {
+            if (shouldRefreshCustomerInfo(firstTimeInForeground)) {
+                log(LogIntent.DEBUG, CustomerInfoStrings.CUSTOMERINFO_STALE_UPDATING_FOREGROUND)
+                customerInfoHelper.retrieveCustomerInfo(
+                    identityManager.currentAppUserID,
+                    fetchPolicy = CacheFetchPolicy.FETCH_CURRENT,
+                    appInBackground = false,
+                    allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
+                )
+            }
+            offeringsManager.onAppForeground(identityManager.currentAppUserID)
+            postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount)
+            synchronizeSubscriberAttributesIfNeeded()
+            offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
+            flushPaywallEvents()
+            if (firstTimeInForeground && isAndroidNOrNewer()) {
+                diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
+            }
         }
     }
 
@@ -775,6 +780,10 @@ internal class PurchasesOrchestrator(
     //endregion
 
     // region Private Methods
+    @Synchronized
+    private fun enqueue(command: () -> Unit) {
+        dispatcher.enqueue({ command() }, Delay.NONE)
+    }
 
     private fun shouldRefreshCustomerInfo(firstTimeInForeground: Boolean): Boolean {
         return !appConfig.customEntitlementComputation &&

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -64,6 +64,10 @@ internal open class DeviceCache(
 
     private val offeringsResponseCacheKey: String by lazy { "$apiKeyPrefix.offeringsResponse" }
 
+    fun startEditing(): SharedPreferences.Editor {
+        return preferences.edit()
+    }
+
     // region app user id
 
     @Synchronized
@@ -74,7 +78,15 @@ internal open class DeviceCache(
 
     @Synchronized
     fun cacheAppUserID(appUserID: String) {
-        preferences.edit().putString(appUserIDCacheKey, appUserID).apply()
+        cacheAppUserID(appUserID, preferences.edit()).apply()
+    }
+
+    @Synchronized
+    fun cacheAppUserID(
+        appUserID: String,
+        cacheEditor: SharedPreferences.Editor,
+    ): SharedPreferences.Editor {
+        return cacheEditor.putString(appUserIDCacheKey, appUserID)
     }
 
     @Synchronized
@@ -168,9 +180,17 @@ internal open class DeviceCache(
     @Synchronized
     fun clearCustomerInfoCache(appUserID: String) {
         val editor = preferences.edit()
+        clearCustomerInfoCache(appUserID, editor)
+        editor.apply()
+    }
+
+    @Synchronized
+    fun clearCustomerInfoCache(
+        appUserID: String,
+        editor: SharedPreferences.Editor,
+    ) {
         editor.clearCustomerInfoCacheTimestamp(appUserID)
         editor.remove(customerInfoCacheKey(appUserID))
-        editor.apply()
     }
 
     @Synchronized

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -78,7 +78,7 @@ internal class OfflineEntitlementsManager(
                     warnLog(OfflineEntitlementsStrings.USING_OFFLINE_ENTITLEMENTS_CUSTOMER_INFO)
                     diagnosticsTracker?.trackEnteredOfflineEntitlementsMode()
                     _offlineCustomerInfo = customerInfo
-                    deviceCache.getCachedAppUserID()?.let { deviceCache.clearCustomerInfoCache(it) }
+                    deviceCache.getCachedAppUserID()?.let { deviceCache.clearCustomerInfoCache(it, cacheEditor) }
                     val callbacks = offlineCustomerInfoCallbackCache.remove(appUserId)
                     callbacks?.forEach { (onSuccess, _) ->
                         onSuccess(customerInfo)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -78,7 +78,7 @@ internal class OfflineEntitlementsManager(
                     warnLog(OfflineEntitlementsStrings.USING_OFFLINE_ENTITLEMENTS_CUSTOMER_INFO)
                     diagnosticsTracker?.trackEnteredOfflineEntitlementsMode()
                     _offlineCustomerInfo = customerInfo
-                    deviceCache.getCachedAppUserID()?.let { deviceCache.clearCustomerInfoCache(it, cacheEditor) }
+                    deviceCache.getCachedAppUserID()?.let { deviceCache.clearCustomerInfoCache(it) }
                     val callbacks = offlineCustomerInfoCallbackCache.remove(appUserId)
                     callbacks?.forEach { (onSuccess, _) ->
                         onSuccess(customerInfo)

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -33,6 +33,7 @@ import com.revenuecat.purchases.paywalls.PaywallPresentedCache
 import com.revenuecat.purchases.paywalls.events.PaywallEventsManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.utils.STUB_PRODUCT_IDENTIFIER
+import com.revenuecat.purchases.utils.SyncDispatcher
 import com.revenuecat.purchases.utils.createMockOneTimeProductDetails
 import com.revenuecat.purchases.utils.stubGooglePurchase
 import com.revenuecat.purchases.utils.stubPurchaseHistoryRecord
@@ -406,6 +407,7 @@ internal open class BasePurchasesTest {
             paywallEventsManager = mockPaywallEventsManager,
             paywallPresentedCache = paywallPresentedCache,
             purchasesStateCache = purchasesStateProvider,
+            dispatcher = SyncDispatcher(),
         )
         purchases = Purchases(purchasesOrchestrator)
         Purchases.sharedInstance = purchases

--- a/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesDeviceCacheTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesDeviceCacheTests.kt
@@ -336,7 +336,7 @@ class SubscriberAttributesDeviceCacheTests {
 
         mockNotEmptyCache(expectedAttributes)
 
-        underTest.cleanUpSubscriberAttributeCache(appUserID)
+        underTest.cleanUpSubscriberAttributeCache(appUserID, mockEditor)
 
         verify(exactly = 0) { mockEditor.remove(any()) }
         assertCapturedEqualsExpected(mapOf(appUserID to expectedAttributes))
@@ -368,7 +368,7 @@ class SubscriberAttributesDeviceCacheTests {
             userThree to createMapOfUnsyncedAttributes()
         )
         mockNotEmptyCacheMultipleUsers(cacheContents)
-        underTest.cleanUpSubscriberAttributeCache(appUserID)
+        underTest.cleanUpSubscriberAttributeCache(appUserID, mockEditor)
 
         verify(exactly = 1) {
             mockEditor.remove(underTest.legacySubscriberAttributesCacheKey(userOne))
@@ -417,7 +417,7 @@ class SubscriberAttributesDeviceCacheTests {
         )
         mockNotEmptyCacheMultipleUsers(cacheContents)
 
-        underTest.cleanUpSubscriberAttributeCache(appUserID)
+        underTest.cleanUpSubscriberAttributeCache(appUserID, mockEditor)
 
         verify(exactly = 1) {
             mockEditor.remove(underTest.legacySubscriberAttributesCacheKey(userOne))
@@ -458,7 +458,7 @@ class SubscriberAttributesDeviceCacheTests {
         )
         mockEmptyLegacyCache()
         mockNotEmptyCacheMultipleUsers(cacheContents)
-        underTest.cleanUpSubscriberAttributeCache(appUserID)
+        underTest.cleanUpSubscriberAttributeCache(appUserID, mockEditor)
         assertCapturedEqualsExpected(
             mapOf(
                 appUserID to expectedAttributes

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -105,6 +105,7 @@ class SubscriberAttributesPurchasesTests {
             paywallEventsManager = null,
             paywallPresentedCache = PaywallPresentedCache(),
             purchasesStateCache = PurchasesStateCache(PurchasesState()),
+            dispatcher = SyncDispatcher(),
         )
 
         underTest = Purchases(purchasesOrchestrator)


### PR DESCRIPTION
## Description
This PR addresses a significant number of ANRs (Application Not Responding errors) reported, such as in issue #1629.

## Problem
The method `IdentityManager.configure` is currently running on the main thread and accessing `SharedPreferences`. Accessing `SharedPreferences` can be costly, especially if the XML file storing the preferences is large. This cost is particularly high during the initial accesses, as the XML file needs to be read and parsed, which can block the main thread and lead to ANRs.

## Solution
**Custom Dispatcher**: This PR introduces a custom dispatcher to the `IdentityManager`, allowing configure to run on a background thread. By moving this operation off the main thread, we avoid blocking it with the potentially expensive SharedPreferences access.
**Main Thread Optimization**: The remaining setup in `PurchasesOrchestrator` has been deferred to execute after configure completes, ensuring the main thread remains unblocked and improving overall app responsiveness.

## Notes
While this fix should mitigate the reported ANRs, it's possible there are other underlying causes contributing to these issues. This PR serves as a good initial step towards improving performance.