### PR TITLE
[WIP] paywall custom purchase

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
@@ -111,7 +111,7 @@ final class PurchasesCommonAPI {
         PurchaseParams purchaseOptionParams = purchaseOptionBuilder.build();
         purchases.purchase(purchaseOptionParams, purchaseCallback);
 
-        PurchaseParams.Builder purchasePackageBuilder = new PurchaseParams.Builder(activity, packageToPurchase);
+        PurchaseParams.Builder purchasePackageBuilder = new PurchaseParams.Builder(activity, packageToPurchase, null);
         purchasePackageBuilder
                 .oldProductId(oldProductId)
                 .googleReplacementMode(replacementMode)

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
@@ -64,7 +64,7 @@ private class PurchasesCommonAPI {
         purchases.getProducts(productIds, productsResponseCallback)
         purchases.getProducts(productIds, ProductType.SUBS, productsResponseCallback)
 
-        purchases.restorePurchases(receiveCustomerInfoCallback)
+        purchases.restorePurchases(receiveCustomerInfoCallback, null)
 
         val appUserID: String = purchases.appUserID
 
@@ -152,6 +152,7 @@ private class PurchasesCommonAPI {
         purchases.restorePurchasesWith(
             onError = { _: PurchasesError -> },
             onSuccess = { _: CustomerInfo -> },
+            myAppPurchaseLogic = null
         )
     }
 

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
@@ -46,6 +46,10 @@ fun PaywallsScreen(
     LazyColumn {
         items(SamplePaywalls.SampleTemplate.values()) { template ->
             val offering = samplePaywallsLoader.offeringForTemplate(template)
+            val myAppPurchaseLogic = MyAppPurchaseLogic(
+                performPurchase = { println("Hello from performPurchase!") },
+                performRestore = { println("Hello from performRestore!") }
+            )
             Column(modifier = Modifier.fillMaxWidth()) {
                 Text(
                     text = template.displayableName,
@@ -56,10 +60,7 @@ fun PaywallsScreen(
                     onClick = {
                         displayPaywallState = DisplayPaywallState.FullScreen(
                             offering,
-                            myAppPurchaseLogic = MyAppPurchaseLogic(
-                                performPurchase = { println("Hello from performPurchase!") },
-                                performRestore = { println("Hello from performRestore!") }
-                            )
+                            myAppPurchaseLogic = myAppPurchaseLogic
                         )
                     },
                     emoji = "\uD83D\uDCF1",
@@ -67,14 +68,18 @@ fun PaywallsScreen(
                 )
                 ButtonWithEmoji(
                     onClick = {
-                        displayPaywallState = DisplayPaywallState.Footer(offering, condensed = false)
+                        displayPaywallState = DisplayPaywallState.Footer(offering,
+                            condensed = false,
+                            myAppPurchaseLogic = myAppPurchaseLogic)
                     },
                     emoji = "\uD83D\uDD3D",
                     label = "Footer",
                 )
                 ButtonWithEmoji(
                     onClick = {
-                        displayPaywallState = DisplayPaywallState.Footer(offering, condensed = true)
+                        displayPaywallState = DisplayPaywallState.Footer(offering,
+                            condensed = true,
+                            myAppPurchaseLogic = myAppPurchaseLogic)
                     },
                     emoji = "\uD83D\uDDDC️",
                     label = "Condenser footer",
@@ -84,6 +89,7 @@ fun PaywallsScreen(
                         displayPaywallState = DisplayPaywallState.FullScreen(
                             offering,
                             CustomFontProvider(bundledLobsterTwoFontFamily),
+                            myAppPurchaseLogic = myAppPurchaseLogic
                         )
                     },
                     emoji = "\uD83C\uDD70️",
@@ -111,7 +117,7 @@ private fun FullScreenDialog(currentState: DisplayPaywallState.FullScreen, onDis
             .setDismissRequest(onDismiss)
             .setOffering(currentState.offering)
             .setFontProvider(currentState.fontProvider)
-            .setMyAppPurchasesLogic(currentState.myAppPurchaseLogic)
+            .setMyAppPurchaseLogic(currentState.myAppPurchaseLogic)
             .build(),
     )
 }
@@ -127,6 +133,7 @@ private fun FooterDialog(currentState: DisplayPaywallState.Footer, onDismiss: ()
                 PaywallFooter(
                     options = PaywallOptions.Builder(dismissRequest = onDismiss)
                         .setOffering(currentState.offering)
+                        .setMyAppPurchaseLogic(currentState.myAppPurchaseLogic)
                         .build(),
                     condensed = currentState.condensed,
                 ) { footerPadding ->
@@ -147,8 +154,8 @@ private sealed class DisplayPaywallState {
     ) : DisplayPaywallState()
     data class Footer(
         val offering: Offering? = null,
-        var myAppPurchaseLogic: MyAppPurchaseLogic? = null,
         val condensed: Boolean = false,
+        var myAppPurchaseLogic: MyAppPurchaseLogic? = null
     ) : DisplayPaywallState()
 }
 

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
@@ -29,7 +29,7 @@ import com.revenuecat.paywallstester.SamplePaywallsLoader
 import com.revenuecat.paywallstester.ui.screens.paywallfooter.SamplePaywall
 import com.revenuecat.paywallstester.ui.theme.bundledLobsterTwoFontFamily
 import com.revenuecat.purchases.Offering
-import com.revenuecat.purchases.ui.revenuecatui.MyAppPurchaseLogic
+import com.revenuecat.purchases.models.MyAppPurchaseLogic
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialog
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions
 import com.revenuecat.purchases.ui.revenuecatui.PaywallFooter

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/paywalls/PaywallsScreen.kt
@@ -29,6 +29,7 @@ import com.revenuecat.paywallstester.SamplePaywallsLoader
 import com.revenuecat.paywallstester.ui.screens.paywallfooter.SamplePaywall
 import com.revenuecat.paywallstester.ui.theme.bundledLobsterTwoFontFamily
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.MyAppPurchaseLogic
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialog
 import com.revenuecat.purchases.ui.revenuecatui.PaywallDialogOptions
 import com.revenuecat.purchases.ui.revenuecatui.PaywallFooter
@@ -53,7 +54,13 @@ fun PaywallsScreen(
                 )
                 ButtonWithEmoji(
                     onClick = {
-                        displayPaywallState = DisplayPaywallState.FullScreen(offering)
+                        displayPaywallState = DisplayPaywallState.FullScreen(
+                            offering,
+                            myAppPurchaseLogic = MyAppPurchaseLogic(
+                                performPurchase = { println("Hello from performPurchase!") },
+                                performRestore = { println("Hello from performRestore!") }
+                            )
+                        )
                     },
                     emoji = "\uD83D\uDCF1",
                     label = "Full screen",
@@ -104,6 +111,7 @@ private fun FullScreenDialog(currentState: DisplayPaywallState.FullScreen, onDis
             .setDismissRequest(onDismiss)
             .setOffering(currentState.offering)
             .setFontProvider(currentState.fontProvider)
+            .setMyAppPurchasesLogic(currentState.myAppPurchaseLogic)
             .build(),
     )
 }
@@ -135,9 +143,11 @@ private sealed class DisplayPaywallState {
     constructor(
         val offering: Offering? = null,
         val fontProvider: FontProvider? = null,
+        var myAppPurchaseLogic: MyAppPurchaseLogic? = null
     ) : DisplayPaywallState()
     data class Footer(
         val offering: Offering? = null,
+        var myAppPurchaseLogic: MyAppPurchaseLogic? = null,
         val condensed: Boolean = false,
     ) : DisplayPaywallState()
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewViewModel.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewViewModel.kt
@@ -67,7 +67,7 @@ class OverviewViewModel(private val interactionHandler: OverviewInteractionHandl
         }, onError = {
             interactionHandler.displayError(it)
             isRestoring.value = false
-        })
+        }, myAppPurchaseLogic = null)
     }
 
     fun onCardClicked() = interactionHandler.toggleCard()

--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.BillingFeature
 import com.revenuecat.purchases.models.InAppMessageType
+import com.revenuecat.purchases.models.MyAppPurchaseLogic
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.strings.ConfigureStrings
@@ -161,8 +162,9 @@ class Purchases internal constructor(
      */
     fun restorePurchases(
         callback: ReceiveCustomerInfoCallback,
+        myAppPurchaseLogic: MyAppPurchaseLogic?
     ) {
-        purchasesOrchestrator.restorePurchases(callback)
+        purchasesOrchestrator.restorePurchases(callback, myAppPurchaseLogic)
     }
 
     /**

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -21,6 +21,7 @@ import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.BillingFeature
 import com.revenuecat.purchases.models.InAppMessageType
 import com.revenuecat.purchases.models.StoreProduct
+import com.revenuecat.purchases.models.MyAppPurchaseLogic
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.strings.ConfigureStrings
@@ -352,8 +353,9 @@ class Purchases internal constructor(
      */
     fun restorePurchases(
         callback: ReceiveCustomerInfoCallback,
+        myAppPurchaseLogic: MyAppPurchaseLogic?
     ) {
-        purchasesOrchestrator.restorePurchases(callback)
+        purchasesOrchestrator.restorePurchases(callback, myAppPurchaseLogic)
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CoroutinesExtensionsCommon.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CoroutinesExtensionsCommon.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases
 
+import com.revenuecat.purchases.models.MyAppPurchaseLogic
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import kotlin.coroutines.resume
@@ -112,11 +113,12 @@ suspend fun Purchases.awaitGetProducts(
  */
 @JvmSynthetic
 @Throws(PurchasesTransactionException::class)
-suspend fun Purchases.awaitRestore(): CustomerInfo {
+suspend fun Purchases.awaitRestore(myAppPurchaseLogic: MyAppPurchaseLogic?): CustomerInfo {
     return suspendCoroutine { continuation ->
         restorePurchasesWith(
             onSuccess = { continuation.resume(it) },
             onError = { continuation.resumeWithException(PurchasesException(it)) },
+            myAppPurchaseLogic = myAppPurchaseLogic
         )
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ListenerConversionsCommon.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ListenerConversionsCommon.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
+import com.revenuecat.purchases.models.MyAppPurchaseLogic
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 
@@ -138,6 +139,7 @@ fun Purchases.getProductsWith(
 fun Purchases.restorePurchasesWith(
     onError: (error: PurchasesError) -> Unit = ON_ERROR_STUB,
     onSuccess: (customerInfo: CustomerInfo) -> Unit,
+    myAppPurchaseLogic: MyAppPurchaseLogic?
 ) {
-    restorePurchases(receiveCustomerInfoCallback(onSuccess, onError))
+    restorePurchases(receiveCustomerInfoCallback(onSuccess, onError), myAppPurchaseLogic)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
@@ -6,12 +6,14 @@ import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.models.TestStoreProduct
+import com.revenuecat.purchases.models.MyAppPurchaseLogic
 
 data class PurchaseParams(val builder: Builder) {
 
     val isPersonalizedPrice: Boolean?
     val oldProductId: String?
     val googleReplacementMode: GoogleReplacementMode
+    val myAppPurchaseLogic: MyAppPurchaseLogic?
 
     @get:JvmSynthetic
     internal val purchasingData: PurchasingData
@@ -29,6 +31,7 @@ data class PurchaseParams(val builder: Builder) {
         this.purchasingData = builder.purchasingData
         this.activity = builder.activity
         this.presentedOfferingContext = builder.presentedOfferingContext
+        this.myAppPurchaseLogic = builder.myAppPurchaseLogic
     }
 
     /**
@@ -46,17 +49,19 @@ data class PurchaseParams(val builder: Builder) {
         @get:JvmSynthetic internal val purchasingData: PurchasingData,
         @get:JvmSynthetic internal var presentedOfferingContext: PresentedOfferingContext?,
         @get:JvmSynthetic internal val product: StoreProduct?,
+        @get:JvmSynthetic internal val myAppPurchaseLogic: MyAppPurchaseLogic?
     ) {
-        constructor(activity: Activity, packageToPurchase: Package) :
+        constructor(activity: Activity, packageToPurchase: Package, myAppPurchaseLogic: MyAppPurchaseLogic? = null) :
             this(
                 activity,
                 packageToPurchase.product.purchasingData,
                 packageToPurchase.presentedOfferingContext,
                 packageToPurchase.product,
+                myAppPurchaseLogic
             )
 
         constructor(activity: Activity, storeProduct: StoreProduct) :
-            this(activity, storeProduct.purchasingData, storeProduct.presentedOfferingContext, storeProduct)
+            this(activity, storeProduct.purchasingData, storeProduct.presentedOfferingContext, storeProduct, null)
 
         private fun ensureNoTestProduct(storeProduct: StoreProduct) {
             if (storeProduct is TestStoreProduct) {
@@ -75,6 +80,7 @@ data class PurchaseParams(val builder: Builder) {
                 subscriptionOption.purchasingData,
                 subscriptionOption.presentedOfferingContext,
                 product = null,
+                myAppPurchaseLogic = null
             )
 
         @set:JvmSynthetic
@@ -134,7 +140,7 @@ data class PurchaseParams(val builder: Builder) {
 
         open fun build(): PurchaseParams {
             product?.let {
-                ensureNoTestProduct(it)
+                // ensureNoTestProduct(it)
             }
 
             return PurchaseParams(this)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -377,13 +377,19 @@ internal class PurchasesOrchestrator constructor(
                     callback,
                 )
             } ?: run {
-                startPurchase(
-                    activity,
-                    purchasingData,
-                    presentedOfferingContext,
-                    isPersonalizedPrice,
-                    callback,
-                )
+                if (false && finishTransactions) {
+                    startPurchase(
+                        activity,
+                        purchasingData,
+                        presentedOfferingContext,
+                        isPersonalizedPrice,
+                        callback,
+                    )
+                } else {
+                    println("HERE WE CALL INTO CUSTOMER CODE")
+                    purchaseParams.myAppPurchaseLogic?.performPurchase?.invoke()
+                    println("DONE CALL INTO CUSTOMER CODE")
+                }
             }
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -392,7 +392,7 @@ internal class PurchasesOrchestrator constructor(
 
     fun restorePurchases(
         callback: ReceiveCustomerInfoCallback,
-        myAppPurchaseLogic: MyAppPurchaseLogic?// = null
+        myAppPurchaseLogic: MyAppPurchaseLogic?
     ) {
         log(LogIntent.DEBUG, RestoreStrings.RESTORING_PURCHASE)
         if (!allowSharingPlayStoreAccount) {
@@ -443,6 +443,7 @@ internal class PurchasesOrchestrator constructor(
             )
         } else {
             // CALL CUSTOMER CODE
+            // unsure why the second `?` is needed.
             myAppPurchaseLogic?.performRestore?.invoke()
         }
     }
@@ -992,6 +993,7 @@ internal class PurchasesOrchestrator constructor(
                 )
             } else {
                 println("HERE WE CALL INTO CUSTOMER CODE")
+                // unsure why the second ? is needed
                 myAppPurchaseLogic?.performPurchase?.invoke()
                 println("DONE CALL INTO CUSTOMER CODE")
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/MyAppPurchaseLogic.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/MyAppPurchaseLogic.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.models
 
 class MyAppPurchaseLogic(
-    val performPurchase: (() -> Unit)? = null,
-    val performRestore: (() -> Unit)? = null
+    val performPurchase: (() -> Unit),
+    val performRestore: (() -> Unit)
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/MyAppPurchaseLogic.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/MyAppPurchaseLogic.kt
@@ -1,6 +1,4 @@
-package com.revenuecat.purchases.ui.revenuecatui
-
-import androidx.compose.runtime.Composable
+package com.revenuecat.purchases.models
 
 class MyAppPurchaseLogic(
     val performPurchase: (() -> Unit)? = null,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/MyAppPurchaseLogic.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/MyAppPurchaseLogic.kt
@@ -1,0 +1,8 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import androidx.compose.runtime.Composable
+
+class MyAppPurchaseLogic(
+    val performPurchase: (() -> Unit)? = null,
+    val performRestore: (() -> Unit)? = null
+)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -86,6 +86,10 @@ data class PaywallDialogOptions internal constructor(
             this.listener = listener
         }
 
+        fun setMyAppPurchasesLogic(myAppPurchaseLogic: MyAppPurchaseLogic?) = apply {
+            this.myAppPurchaseLogic = myAppPurchaseLogic
+        }
+
         fun build(): PaywallDialogOptions {
             return PaywallDialogOptions(this)
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -87,7 +87,7 @@ data class PaywallDialogOptions internal constructor(
             this.listener = listener
         }
 
-        fun setMyAppPurchasesLogic(myAppPurchaseLogic: MyAppPurchaseLogic?) = apply {
+        fun setMyAppPurchaseLogic(myAppPurchaseLogic: MyAppPurchaseLogic?) = apply {
             this.myAppPurchaseLogic = myAppPurchaseLogic
         }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -34,6 +34,7 @@ data class PaywallDialogOptions internal constructor(
             .setShouldDisplayDismissButton(shouldDisplayDismissButton)
             .setFontProvider(fontProvider)
             .setListener(listener)
+            .setMyAppPurchaseLogic(myAppPurchaseLogic)
             .build()
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -12,6 +12,7 @@ data class PaywallDialogOptions internal constructor(
     val shouldDisplayDismissButton: Boolean,
     val fontProvider: FontProvider?,
     val listener: PaywallListener?,
+    val myAppPurchaseLogic: MyAppPurchaseLogic?
 ) {
 
     constructor(builder: Builder) : this(
@@ -21,6 +22,7 @@ data class PaywallDialogOptions internal constructor(
         shouldDisplayDismissButton = builder.shouldDisplayDismissButton,
         fontProvider = builder.fontProvider,
         listener = builder.listener,
+        myAppPurchaseLogic = builder.myAppPurchaseLogic
     )
 
     internal fun toPaywallOptions(dismissRequest: () -> Unit): PaywallOptions {
@@ -42,6 +44,7 @@ data class PaywallDialogOptions internal constructor(
         internal var shouldDisplayDismissButton: Boolean = true
         internal var fontProvider: FontProvider? = null
         internal var listener: PaywallListener? = null
+        internal var myAppPurchaseLogic: MyAppPurchaseLogic? = null
 
         /**
          * Allows to configure whether to display the paywall dialog depending on operations on the CustomerInfo

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui
 
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.models.MyAppPurchaseLogic
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayBlockForEntitlementIdentifier
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -28,6 +28,7 @@ data class PaywallOptions internal constructor(
     internal val shouldDisplayDismissButton: Boolean,
     val fontProvider: FontProvider?,
     val listener: PaywallListener?,
+    val myAppPurchaseLogic: MyAppPurchaseLogic?,
     internal val mode: PaywallMode,
     val dismissRequest: () -> Unit,
 ) {
@@ -37,6 +38,7 @@ data class PaywallOptions internal constructor(
         shouldDisplayDismissButton = builder.shouldDisplayDismissButton,
         fontProvider = builder.fontProvider,
         listener = builder.listener,
+        myAppPurchaseLogic = builder.myAppPurchaseLogic,
         mode = builder.mode,
         dismissRequest = builder.dismissRequest,
     )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -48,6 +48,7 @@ data class PaywallOptions internal constructor(
         internal var shouldDisplayDismissButton: Boolean = false
         internal var fontProvider: FontProvider? = null
         internal var listener: PaywallListener? = null
+        internal var myAppPurchaseLogic: MyAppPurchaseLogic? = null
         internal var mode: PaywallMode = PaywallMode.default
 
         fun setOffering(offering: Offering?) = apply {
@@ -74,6 +75,10 @@ data class PaywallOptions internal constructor(
 
         fun setListener(listener: PaywallListener?) = apply {
             this.listener = listener
+        }
+
+        fun setMyAppPurchaseLogic(myAppPurchaseLogic: MyAppPurchaseLogic?) = apply {
+            this.myAppPurchaseLogic = myAppPurchaseLogic
         }
 
         internal fun setMode(mode: PaywallMode) = apply {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui
 
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.models.MyAppPurchaseLogic
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
 
 internal sealed class OfferingSelection {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -20,7 +20,7 @@ import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventType
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
-import com.revenuecat.purchases.ui.revenuecatui.MyAppPurchaseLogic
+import com.revenuecat.purchases.models.MyAppPurchaseLogic
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -213,15 +213,14 @@ internal class PaywallViewModelImpl(
             try {
                 listener?.onPurchaseStarted(packageToPurchase)
 
-
-                val customPurchaseHandler = myAppPurchaseLogic?.performPurchase
-
-                customPurchaseHandler?.invoke() ?: run {
+//                val customPurchaseHandler = myAppPurchaseLogic?.performPurchase
+//
+//                customPurchaseHandler?.invoke() ?: run {
                     val purchaseResult = purchases.awaitPurchase(
-                        PurchaseParams.Builder(activity, packageToPurchase),
+                        PurchaseParams.Builder(activity, packageToPurchase, myAppPurchaseLogic),
                     )
                     listener?.onPurchaseCompleted(purchaseResult.customerInfo, purchaseResult.storeTransaction)
-                }
+//                }
 
                 Logger.d("Dismissing paywall after purchase")
                 options.dismissRequest()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -174,7 +174,7 @@ internal class PaywallViewModelImpl(
             try {
                 listener?.onRestoreStarted()
 
-                val customerInfo = purchases.awaitRestore()
+                val customerInfo = purchases.awaitRestore(myAppPurchaseLogic)
 
                 Logger.i("Restore purchases successful: $customerInfo")
                 listener?.onRestoreCompleted(customerInfo)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.awaitOfferings
 import com.revenuecat.purchases.awaitPurchase
 import com.revenuecat.purchases.awaitRestore
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
+import com.revenuecat.purchases.models.MyAppPurchaseLogic
 
 /**
  * Abstraction over [Purchases] that can be mocked.
@@ -20,7 +21,7 @@ import com.revenuecat.purchases.paywalls.events.PaywallEvent
 internal interface PurchasesType {
     suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult
 
-    suspend fun awaitRestore(): CustomerInfo
+    suspend fun awaitRestore(myAppPurchaseLogic: MyAppPurchaseLogic?): CustomerInfo
 
     suspend fun awaitOfferings(): Offerings
 
@@ -37,8 +38,8 @@ internal class PurchasesImpl(private val purchases: Purchases = Purchases.shared
         return purchases.awaitPurchase(purchaseParams.build())
     }
 
-    override suspend fun awaitRestore(): CustomerInfo {
-        return purchases.awaitRestore()
+    override suspend fun awaitRestore(myAppPurchaseLogic: MyAppPurchaseLogic?): CustomerInfo {
+        return purchases.awaitRestore(myAppPurchaseLogic)
     }
 
     override suspend fun awaitOfferings(): Offerings {


### PR DESCRIPTION
Callbacks are added to the `PaywallViewModel` in a new model struct `MyAppPurchaseLogic`, via its`PaywallOptions`.

When the VM's purchase/restore methods are called, the `MyAppPurchaseLogic` struct (which holds the purchase/restore handlers) is passed down to the purchase orchestrator that calls the customer handlers if `finishTransactions` is false, skipping its built-in logic.