### PR TITLE
Updates Gradle (8.9), AGP (8.5.1) and maven.publish (0.28.0)

### DIFF
--- a/examples/CustomEntitlementComputationSample/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/CustomEntitlementComputationSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jun 06 20:13:30 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/MagicWeather/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/MagicWeather/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip

--- a/examples/MagicWeatherCompose/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/MagicWeatherCompose/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jun 06 20:13:30 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.1.3"
+agp = "8.5.1"
 kotlin = "1.8.22"
 # Can't update until we use more recent kotlin. 1.6.0 uses Kotlin 1.9.0
 kotlinxSerializationJSON = "1.5.1"
@@ -22,7 +22,7 @@ dokka = "1.8.10"
 androidxCore = "1.8.0"
 dependencyGraph = "0.9"
 kover = "0.7.0"
-mavenPublish = "0.22.0"
+mavenPublish = "0.28.0"
 multidex = "2.0.1"
 recyclerview = "1.2.1"
 amazon = "3.0.5"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip


### PR DESCRIPTION
As the title says. 

Gradle was at 8.0 and needed to at least be 8.1. for maven.publish 0.28.0, so I updated to the latest.
There was no requirement to update AGP, but from experience it is good to keep that somewhat in sync with Gradle, so went with the latest here too. 