### PR TITLE
Add Emerge snapshot testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -648,6 +648,7 @@ workflows:
       - run-backend-integration-tests
       - verify-revenuecatui-snapshots
       - run-revenuecatui-ui-tests
+      - emerge_purchases_ui_snapshot_tests
       - verify_debug_view_snapshot_tests: *release-branches
       - integration-tests-build: *release-branches
       - purchases-integration-tests-build: *release-branches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -513,6 +513,21 @@ jobs:
             bundle exec fastlane android verify_debug_view_snapshot_tests
       - android/save-build-cache
 
+  emerge_purchases_ui_snapshot_tests:
+    description: "Emerge purchases ui snapshot tests"
+    <<: *android-executor
+    steps:
+      - checkout
+      - install-sdkman
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
+      - android/restore-build-cache
+      - run:
+          name: Build and run purchases ui snapshot tests
+          command: |
+            bundle exec fastlane android emerge_purchases_ui_snapshot_tests
+      - android/save-build-cache
+
   run-firebase-tests:
     description: "Run integration tests for Android in Firebase. Variant latestDependencies"
     executor: gcp-cli/google

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
     alias libs.plugins.kover apply false
     alias libs.plugins.detekt
     alias libs.plugins.dependencyGraph
+    alias libs.plugins.emerge apply false
 //    Removing from here gives an error
 //    The request for this plugin could not be satisfied because the plugin is already on the classpath with an
 //    unknown version, so compatibility cannot be checked.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,6 +65,11 @@ platform :android do
     gradle(task: "ui:debugview:recordPaparazziDebug")
   end
 
+  desc "Emerge snapshot tests"
+  lane :emerge_purchases_ui_snapshot_tests do
+    gradle(task: ":test-apps:testpurchasesuiandroidcompatibility:emergeUploadSnapshotBundleDebug")
+  end
+
   desc "Replaces version numbers, updates changelog and creates PR"
   lane :bump do |options|
     bump_version_update_changelog_create_pr(

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -47,6 +47,14 @@ Verify snapshot tests for the debug view library
 
 Record/Update snapshots for tests in the debug view library
 
+### android emerge_purchases_ui_snapshot_tests
+
+```sh
+[bundle exec] fastlane android emerge_purchases_ui_snapshot_tests
+```
+
+Run snapshot tests for the purchases UI library
+
 ### android bump
 
 ```sh

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,8 @@ commonmark = "0.21.0"
 activity-compose = "1.7.2"
 fragment = "1.6.1"
 hamcrest = "1.3"
+emergeGradlePlugin = "3.1.2"
+emergeSnapshots = "1.1.3"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -48,6 +50,7 @@ androidx-navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", ver
 dependencyGraph = { id = "com.savvasdalkitsis.module-dependency-graph", version.ref = "dependencyGraph" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id ="org.jetbrains.dokka", version.ref = "dokka"}
+emerge = { id = "com.emergetools.android", version.ref = "emergeGradlePlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
@@ -93,6 +96,8 @@ billing = { module = "com.android.billingclient:billing" , version.ref = "billin
 
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 detekt-compose = { module = "io.nlopez.compose.rules:detekt", version.ref = "detektRulesCompose" }
+
+emerge-snapshots = { module = "com.emergetools.snapshots:snapshots", version.ref = "emergeSnapshots" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJSON"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,8 +40,8 @@ commonmark = "0.21.0"
 activity-compose = "1.7.2"
 fragment = "1.6.1"
 hamcrest = "1.3"
-emergeGradlePlugin = "3.1.2"
-emergeSnapshots = "1.1.3"
+emergeGradlePlugin = "4.0.0"
+emergeSnapshots = "1.2.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -50,7 +50,20 @@ android {
 }
 
 emerge {
+    // TODO: RevenueCat to set from CircleCi variables
     apiToken.set(System.getenv("EMERGE_API_TOKEN"))
+
+    vcs {
+        // TODO: RevenueCat to set from CircleCi variables
+        sha.set("")
+        // TODO: RevenueCat to set from CircleCi variables
+        // Should skip setting for main branch uploads
+        baseSha.set("")
+        gitHub {
+            repoName.set("purchases-android")
+            repoOwner.set("RevenueCat")
+        }
+    }
 }
 
 dependencies {

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -54,8 +54,7 @@ emerge {
     apiToken.set(System.getenv("EMERGE_API_TOKEN"))
 
     vcs {
-        // TODO: RevenueCat to set from CircleCi variables
-        sha.set("")
+        sha.set(System.getenv("CIRCLE_SHA1"))
         // TODO: RevenueCat to set from CircleCi variables
         // Should skip setting for main branch uploads
         baseSha.set("")

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.emerge)
 }
 
 android {
@@ -48,9 +49,15 @@ android {
     }
 }
 
+emerge {
+    apiToken.set(System.getenv("EMERGE_API_TOKEN"))
+}
+
 dependencies {
     implementation(project(":purchases"))
     implementation(project(":ui:revenuecatui"))
+
+    androidTestImplementation(libs.emerge.snapshots)
 
     implementation(platform(libs.kotlin.bom))
     implementation(libs.androidx.core)


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Adds Emerge snapshots to purchases UI, as RevenueCat has expressed interest and we figured we'd make the process easier 😄 .

### Description
Adds the basic integration necessary for getting up and running with Emerge snapshots:

- Adds the Emerge gradle plugin to the `testpurchasesuiandroidcompatibility` module.
  - Worth noting that Emerge requires the plugin to be set on an `application` module vs a library module. @tonidero had mentioned that the Previews we want to snapshot are in `:ui:revenuecatui`. Given that this application module depends directly on the `:ui:revenuecatui` module and snapshots use a debug variant, all code should be present from that module, giving Emerge all `@Previews` automatically.
- Adds what I believe is the necessary fastlane/CircleCI setup to invoke snapshots, but my experience here is a bit more limited.
- Updates Compose BOM from `2023.05.01` to `2024.06.00`, as Emerge snapshots rely on compose foundation, which can't be resolved without an update. Happy to help test this!

For the best usage, we recommend running snapshots on every commit - all PR commits and main commits. Emerge will run & snapshot all `@Preview` annotated functions, storing the generated snapshots based on the `sha` of that upload. 

If the commit has a valid `baseSha` set and we have snapshots for that `baseSha`, we'll automatically compare the snapshots and let you know if there's any visual changes directly on the PR. See our [snapshot docs](https://docs.emergetools.com/docs/snapshot-testing) for all functionality!

Remaining tasks for RevenueCat to implement to complete this:
- [ ] Connect the Emerge GitHub app ([docs](https://docs.emergetools.com/docs/github)). This allows us to post status checks on PRs, letting you know when a visual change has occurred.
- [ ] Add the `EMERGE_API_TOKEN` as a GitHub secret
- [ ] Wire up CircleCI variables to see the `sha` & `baseSha` in the Emerge gradle plugin config block. These are what we use for [diffing snapshots](https://docs.emergetools.com/docs/continuous-integration).
- [ ] Validate the fastlane/CircleCI setup I added is correct and what is intended.
