### PR TITLE
[Paywalls] Fix `RemoteImage` flicker on activity changes

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
@@ -93,7 +93,7 @@ private fun Image(
 
     var useCache by remember { mutableStateOf(true) }
     val applicationContext = LocalContext.current.applicationContext
-    val imageLoader = remember(applicationContext, useCache) {
+    val imageLoader = remember(useCache) {
         applicationContext.getRevenueCatUIImageLoader(readCache = useCache)
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -93,7 +92,10 @@ private fun Image(
     }
 
     var useCache by remember { mutableStateOf(true) }
-    val imageLoader = LocalContext.current.getRevenueCatUIImageLoader(readCache = useCache)
+    val applicationContext = LocalContext.current.applicationContext
+    val imageLoader = remember(applicationContext, useCache) {
+        applicationContext.getRevenueCatUIImageLoader(readCache = useCache)
+    }
 
     val imageRequest = ImageRequest.Builder(LocalContext.current)
         .data(source.data)
@@ -181,8 +183,6 @@ private const val PAYWALL_IMAGE_CACHE_FOLDER = "revenuecatui_cache"
  *
  * @param readCache: set to false to ignore cache for reading, but allow overwriting with updated image.
  */
-@Composable
-@ReadOnlyComposable
 private fun Context.getRevenueCatUIImageLoader(readCache: Boolean): ImageLoader {
     val cachePolicy = if (readCache) CachePolicy.ENABLED else CachePolicy.WRITE_ONLY
 


### PR DESCRIPTION
### Description
We were seeing some flickering in the paywall images when the activity was paused/started. This seems to have been caused because the loader was recreated every time. The loader only actually uses a reference to the application context, so we can just change it to avoid that recreation and store a reference to the image loader.