### PR TITLE
Fixes artifact consolidation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,11 +182,6 @@ jobs:
           name: Run Tests
           command: ./gradlew lint test
       - run:
-          name: Consolidate artifacts
-          command: |
-              mkdir -p build/test-results/
-              find . -type f -regex ".*/build/test-results/.*xml" -exec cp --parents {} build/test-results/ \;
-      - run:
           name: Kover HTML
           command: ./gradlew purchases:koverHtmlReportDefaultsRelease
       - run:
@@ -195,6 +190,11 @@ jobs:
       - codecov/upload:
           file: purchases/build/reports/kover/reportDefaultsRelease.xml
       - android/save-build-cache
+      - run:
+          name: Consolidate artifacts
+          command: |
+            mkdir -p build/reports/
+            find . -type f -path "*/build/reports/*" | grep -v 'paparazzi' | xargs -I {} cp --parents {} build/reports/
       - store_artifacts:
           path: build/reports
       - run:


### PR DESCRIPTION
As the title says. I noticed artifacts were not being uploaded to CircleCI.

## However
Do we even want this? It's a lot. I already excluded  `paparrazi`. We can also exclude `kover` maybe because we have codecov. That would still be quite a lot though. 