### PR TITLE
Adds the Detekt IntelliJ plugin settings to version control.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ vendor/
 
 # Snapshots repo folder
 purchases-android-snapshots
+
+# Make sure we share the same Detekt IntelliJ plugin settings
+!.idea/detekt.xml

--- a/.idea/detekt.xml
+++ b/.idea/detekt.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DetektPluginSettings">
+    <option name="configurationFiles">
+      <list>
+        <option value="$PROJECT_DIR$/config/detekt/detekt.yml" />
+      </list>
+    </option>
+    <option name="enableDetekt" value="true" />
+  </component>
+</project>


### PR DESCRIPTION
As the title says. The [Detekt IntelliJ plugin](https://plugins.jetbrains.com/plugin/10761-detekt) requires some manual setup. If every team member has to do that individually, there's a higher chance of discrepancies and errors. 