### PR TITLE
Adds the baseline file to the Detekt IntelliJ plugin settings.

### DIFF
--- a/.idea/detekt.xml
+++ b/.idea/detekt.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DetektPluginSettings">
+    <option name="baselinePath" value="$PROJECT_DIR$/config/detekt/detekt-baseline.xml" />
     <option name="configurationFiles">
       <list>
         <option value="$PROJECT_DIR$/config/detekt/detekt.yml" />


### PR DESCRIPTION
As the title says. Previously discussed here: https://github.com/RevenueCat/purchases-android/pull/1796#discussion_r1695021333