### PR TITLE
[V5] Change device running nightly integration tests

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -190,6 +190,7 @@ platform :android do
             --app ../purchases/test_artifacts/loadShedderIntegrationTest-app.apk \
             --test ../purchases/test_artifacts/loadShedderIntegrationTest-test.apk \
             --timeout 2m \
+            --device model=panther,version=33,locale=en,orientation=portrait \
             --results-bucket cloud-test-#{google_project_id}"
 
       dir_path = File.join(Dir.home, 'gsutil')


### PR DESCRIPTION
### Description
This changes the device running the nightly load shedder integration tests to a Pixel 7 to hopefully improve the flakyness