### PR TITLE
[Diagnostics] Send backend_error_code in http request failures if available

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -240,6 +240,7 @@ internal class HTTPClient(
                 responseTime,
                 requestWasError,
                 responseCode,
+                callResult?.backendErrorCode,
                 origin,
                 verificationResult,
             )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.strings.OfflineEntitlementsStrings
+import com.revenuecat.purchases.utils.filterNotNullValues
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import java.io.IOException
 import kotlin.time.Duration
@@ -31,6 +32,7 @@ internal class DiagnosticsTracker(
         const val ENDPOINT_NAME_KEY = "endpoint_name"
         const val SUCCESSFUL_KEY = "successful"
         const val RESPONSE_CODE_KEY = "response_code"
+        const val BACKEND_ERROR_CODE_KEY = "backend_error_code"
         const val ETAG_HIT_KEY = "etag_hit"
         const val VERIFICATION_RESULT_KEY = "verification_result"
         const val RESPONSE_TIME_MILLIS_KEY = "response_time_millis"
@@ -45,6 +47,7 @@ internal class DiagnosticsTracker(
         responseTime: Duration,
         wasSuccessful: Boolean,
         responseCode: Int,
+        backendErrorCode: Int?,
         resultOrigin: HTTPResult.Origin?,
         verificationResult: VerificationResult,
     ) {
@@ -57,9 +60,10 @@ internal class DiagnosticsTracker(
                     RESPONSE_TIME_MILLIS_KEY to responseTime.inWholeMilliseconds,
                     SUCCESSFUL_KEY to wasSuccessful,
                     RESPONSE_CODE_KEY to responseCode,
+                    BACKEND_ERROR_CODE_KEY to backendErrorCode,
                     ETAG_HIT_KEY to eTagHit,
                     VERIFICATION_RESULT_KEY to verificationResult.name,
-                ),
+                ).filterNotNullValues(),
             ),
         )
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
@@ -58,8 +58,8 @@ private fun BackendErrorCode.toPurchasesError(underlyingErrorMessage: String) =
     PurchasesError(this.toPurchasesErrorCode(), underlyingErrorMessage)
 
 internal fun HTTPResult.toPurchasesError(): PurchasesError {
-    val errorCode = if (body.has("code")) body.get("code") as Int else null
-    val errorMessage = if (body.has("message")) body.get("message") as String else ""
+    val errorCode = backendErrorCode
+    val errorMessage = backendErrorMessage ?: ""
 
     return errorCode?.let { BackendErrorCode.valueOf(it) }?.toPurchasesError(errorMessage)
         ?: PurchasesError(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPResult.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/HTTPResult.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common.networking
 
 import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.isSuccessful
 import org.json.JSONObject
 import java.util.Date
 
@@ -50,6 +51,15 @@ internal data class HTTPResult(
     }
 
     val body: JSONObject = payload.takeIf { it.isNotBlank() }?.let { JSONObject(it) } ?: JSONObject()
+
+    val backendErrorCode: Int? = if (!isSuccessful()) body.optInt("code").takeIf { it > 0 } else null
+    val backendErrorMessage: String? = if (!isSuccessful()) {
+        body.optString(
+            "message",
+        ).takeIf { it.isNotBlank() }
+    } else {
+        null
+    }
 
     fun serialize(): String {
         val jsonObject = JSONObject().apply {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
@@ -147,6 +147,7 @@ class DiagnosticsTrackerTest {
             1234L.milliseconds,
             true,
             200,
+            null,
             HTTPResult.Origin.CACHE,
             VerificationResult.NOT_REQUESTED
         )
@@ -164,6 +165,7 @@ class DiagnosticsTrackerTest {
             "response_time_millis" to 1234L,
             "successful" to true,
             "response_code" to 200,
+            "backend_error_code" to 1234,
             "etag_hit" to false,
             "verification_result" to "NOT_REQUESTED"
         )
@@ -173,6 +175,7 @@ class DiagnosticsTrackerTest {
             1234L.milliseconds,
             true,
             200,
+            1234,
             HTTPResult.Origin.BACKEND,
             VerificationResult.NOT_REQUESTED
         )


### PR DESCRIPTION
### Description
This adds a new property to the `http_request_performed` diagnostics event including information of any backend provided error codes if any.

- [x] Hold until backend support has been deployed.