### PR TITLE
Add `$kochavaDeviceId` attribution convencience method

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -119,6 +119,7 @@ final class PurchasesAPI {
         purchases.setMediaSource("");
         purchases.setCampaign("");
         purchases.setCleverTapID("");
+        purchases.setKochavaDeviceID("");
         purchases.setAdGroup("");
         purchases.setAd("");
         purchases.setKeyword("");

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -167,6 +167,7 @@ private class PurchasesAPI {
             setMediaSource("")
             setCampaign("")
             setCleverTapID("")
+            setKochavaDeviceID("")
             setAdGroup("")
             setAd("")
             setKeyword("")

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -634,6 +634,16 @@ class Purchases internal constructor(
         purchasesOrchestrator.setCleverTapID(cleverTapID)
     }
 
+    /**
+     * Subscriber attribute associated with the Kochava Device ID for the user
+     * Recommended for the RevenueCat Kochava integration
+     *
+     * @param kochavaDeviceID null or an empty string will delete the subscriber attribute.
+     */
+    fun setKochavaDeviceID(kochavaDeviceID: String?) {
+        purchasesOrchestrator.setKochavaDeviceID(kochavaDeviceID)
+    }
+
     // endregion
     // region Campaign parameters
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -708,6 +708,16 @@ internal class PurchasesOrchestrator(
         )
     }
 
+    fun setKochavaDeviceID(kochavaDeviceID: String?) {
+        log(LogIntent.DEBUG, AttributionStrings.METHOD_CALLED.format("setKochavaDeviceID"))
+        subscriberAttributesManager.setAttributionID(
+            SubscriberAttributeKey.AttributionIds.Kochava,
+            kochavaDeviceID,
+            appUserID,
+            application,
+        )
+    }
+
     // endregion
     // region Campaign parameters
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
@@ -29,6 +29,7 @@ internal enum class ReservedSubscriberAttribute(val value: String) {
     ONESIGNAL_USER_ID("\$onesignalUserId"),
     AIRSHIP_CHANNEL_ID("\$airshipChannelId"),
     CLEVER_TAP_ID("\$clevertapId"),
+    KOCHAVA_DEVICE_ID("\$kochavaDeviceId"),
 
     /**
      * Integration IDs
@@ -67,6 +68,7 @@ internal sealed class SubscriberAttributeKey(val backendKey: String) {
         object Facebook : AttributionIds(ReservedSubscriberAttribute.FB_ANON_ID)
         object Mparticle : AttributionIds(ReservedSubscriberAttribute.MPARTICLE_ID)
         object CleverTap : AttributionIds(ReservedSubscriberAttribute.CLEVER_TAP_ID)
+        object Kochava : AttributionIds(ReservedSubscriberAttribute.KOCHAVA_DEVICE_ID)
     }
 
     sealed class IntegrationIds(backendKey: ReservedSubscriberAttribute) : SubscriberAttributeKey(backendKey.value) {

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -267,6 +267,13 @@ class SubscriberAttributesPurchasesTests {
         }
     }
 
+    @Test
+    fun `setKochavaDeviceID`() {
+        attributionIDTest(SubscriberAttributeKey.AttributionIds.Kochava) { parameter ->
+            underTest.setKochavaDeviceID(parameter)
+        }
+    }
+
     // endregion
 
     // region Integration IDs


### PR DESCRIPTION
### Description
This adds a new API `setKochavaDeviceId` that allows to set the kochava device ID required for the Kochava integration. 

Keeping on hold until backend support is added