### PR TITLE
[EXTERNAL] Add Emerge snapshot testing (#1785) by @rbro112

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -513,6 +513,21 @@ jobs:
             bundle exec fastlane android verify_debug_view_snapshot_tests
       - android/save-build-cache
 
+  emerge_purchases_ui_snapshot_tests:
+    description: "Emerge purchases ui snapshot tests"
+    <<: *android-executor
+    steps:
+      - checkout
+      - install-sdkman
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
+      - android/restore-build-cache
+      - run:
+          name: Build and run purchases ui snapshot tests
+          command: |
+            bundle exec fastlane android emerge_purchases_ui_snapshot_tests
+      - android/save-build-cache
+
   run-firebase-tests:
     description: "Run integration tests for Android in Firebase. Variant latestDependencies"
     executor: gcp-cli/google
@@ -633,6 +648,7 @@ workflows:
       - run-backend-integration-tests
       - verify-revenuecatui-snapshots
       - run-revenuecatui-ui-tests
+      - emerge_purchases_ui_snapshot_tests
       - verify_debug_view_snapshot_tests: *release-branches
       - integration-tests-build: *release-branches
       - purchases-integration-tests-build: *release-branches

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
     alias libs.plugins.kover apply false
     alias libs.plugins.detekt
     alias libs.plugins.dependencyGraph
+    alias libs.plugins.emerge apply false
 //    Removing from here gives an error
 //    The request for this plugin could not be satisfied because the plugin is already on the classpath with an
 //    unknown version, so compatibility cannot be checked.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,6 +65,11 @@ platform :android do
     gradle(task: "ui:debugview:recordPaparazziDebug")
   end
 
+  desc "Emerge snapshot tests"
+  lane :emerge_purchases_ui_snapshot_tests do
+    gradle(task: ":test-apps:testpurchasesuiandroidcompatibility:emergeUploadSnapshotBundleDebug")
+  end
+
   desc "Replaces version numbers, updates changelog and creates PR"
   lane :bump do |options|
     bump_version_update_changelog_create_pr(

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -47,6 +47,14 @@ Verify snapshot tests for the debug view library
 
 Record/Update snapshots for tests in the debug view library
 
+### android emerge_purchases_ui_snapshot_tests
+
+```sh
+[bundle exec] fastlane android emerge_purchases_ui_snapshot_tests
+```
+
+Run snapshot tests for the purchases UI library
+
 ### android bump
 
 ```sh

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,8 @@ commonmark = "0.21.0"
 activity-compose = "1.7.2"
 fragment = "1.6.1"
 hamcrest = "1.3"
+emergeGradlePlugin = "4.0.0"
+emergeSnapshots = "1.2.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -48,6 +50,7 @@ androidx-navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", ver
 dependencyGraph = { id = "com.savvasdalkitsis.module-dependency-graph", version.ref = "dependencyGraph" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id ="org.jetbrains.dokka", version.ref = "dokka"}
+emerge = { id = "com.emergetools.android", version.ref = "emergeGradlePlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
@@ -93,6 +96,8 @@ billing = { module = "com.android.billingclient:billing" , version.ref = "billin
 
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 detekt-compose = { module = "io.nlopez.compose.rules:detekt", version.ref = "detektRulesCompose" }
+
+emerge-snapshots = { module = "com.emergetools.snapshots:snapshots", version.ref = "emergeSnapshots" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJSON"}

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.emerge)
 }
 
 android {
@@ -48,9 +49,27 @@ android {
     }
 }
 
+emerge {
+    // TODO: RevenueCat to set from CircleCi variables
+    apiToken.set(System.getenv("EMERGE_API_TOKEN"))
+
+    vcs {
+        sha.set(System.getenv("CIRCLE_SHA1"))
+        // TODO: RevenueCat to set from CircleCi variables
+        // Should skip setting for main branch uploads
+        baseSha.set("")
+        gitHub {
+            repoName.set("purchases-android")
+            repoOwner.set("RevenueCat")
+        }
+    }
+}
+
 dependencies {
     implementation(project(":purchases"))
     implementation(project(":ui:revenuecatui"))
+
+    androidTestImplementation(libs.emerge.snapshots)
 
     implementation(platform(libs.kotlin.bom))
     implementation(libs.androidx.core)

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -50,12 +50,11 @@ android {
 }
 
 emerge {
-    // TODO: RevenueCat to set from CircleCi variables
     apiToken.set(System.getenv("EMERGE_API_TOKEN"))
 
     vcs {
         sha.set(System.getenv("CIRCLE_SHA1"))
-        // TODO: RevenueCat to set from CircleCi variables
+        // WIP: Set from CircleCi variables
         // Should skip setting for main branch uploads
         baseSha.set("")
         gitHub {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallFooter.kt
@@ -6,14 +6,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 
 /**
  * Composable offering a minified screen Paywall UI configured from the RevenueCat dashboard.
@@ -61,34 +56,4 @@ fun PaywallFooter(
             paywallComposable()
         }
     }
-}
-
-@Suppress("MagicNumber")
-@Preview(showBackground = true)
-@Composable
-private fun PaywallFooterPreview() {
-    PaywallFooter(
-        options = PaywallOptions.Builder(dismissRequest = {}).build(),
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
-                .padding(it),
-        ) {
-            // TODO-PAYWALLS: Implement an actual sample paywall
-            for (i in 1..50) {
-                Text(text = "Main content $i")
-            }
-        }
-    }
-}
-
-@Suppress("MagicNumber")
-@Preview(showBackground = true)
-@Composable
-private fun PaywallFooterNoContentPreview() {
-    PaywallFooter(
-        options = PaywallOptions.Builder(dismissRequest = {}).build(),
-    )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Markdown.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Markdown.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import org.commonmark.ext.gfm.strikethrough.Strikethrough
@@ -73,7 +74,13 @@ internal fun Markdown(
     val root = parser.parse(text) as Document
 
     val density = LocalDensity.current
-    val paragraphPadding = with(density) { style.lineHeight.toDp() }
+    val paragraphPadding = with(density) {
+        if (style.lineHeight.type == TextUnitType.Sp) {
+            style.lineHeight.toDp()
+        } else {
+            0.dp
+        }
+    }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(paragraphPadding),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallDataExtensions.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.PaywallColor
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
+import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
@@ -123,10 +124,8 @@ private fun getThemeColors(currentColorScheme: ColorScheme): PaywallData.Configu
 
 private fun Color.asPaywallColor(): PaywallColor = PaywallColor(colorInt = this.toArgb())
 
-@Preview(showBackground = true, locale = "en-rUS")
-@Preview(showBackground = true, locale = "es-rES")
 @Composable
-internal fun DefaultPaywallPreview() {
+private fun getDefaultPreviewOffering(): Offering {
     val availablePackages = listOf(
         TestData.Packages.weekly,
         TestData.Packages.monthly,
@@ -137,15 +136,39 @@ internal fun DefaultPaywallPreview() {
         MaterialTheme.colorScheme,
         MockResourceProvider(),
     )
-    val template2Offering = Offering(
+    return Offering(
         identifier = "Template2",
         availablePackages = availablePackages,
         metadata = mapOf(),
         paywall = paywallData,
         serverDescription = "",
     )
+}
+
+@Preview(showBackground = true, locale = "en-rUS")
+@Preview(showBackground = true, locale = "es-rES")
+@Composable
+internal fun DefaultPaywallPreview() {
     InternalPaywall(
         options = PaywallOptions.Builder(dismissRequest = {}).build(),
-        viewModel = MockViewModel(offering = template2Offering),
+        viewModel = MockViewModel(offering = getDefaultPreviewOffering()),
+    )
+}
+
+@Preview(showBackground = true, locale = "en-rUS", group = "footer")
+@Composable
+internal fun DefaultPaywallFooterPreview() {
+    InternalPaywall(
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
+        viewModel = MockViewModel(mode = PaywallMode.FOOTER, offering = getDefaultPreviewOffering()),
+    )
+}
+
+@Preview(showBackground = true, locale = "en-rUS", group = "footer")
+@Composable
+internal fun DefaultPaywallFooterCondensedPreview() {
+    InternalPaywall(
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
+        viewModel = MockViewModel(mode = PaywallMode.FOOTER_CONDENSED, offering = getDefaultPreviewOffering()),
     )
 }


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Adds Emerge snapshots to purchases UI, as RevenueCat has expressed interest and we figured we'd make the process easier 😄 .

### Description
Adds the basic integration necessary for getting up and running with Emerge snapshots:

- Adds the Emerge gradle plugin to the `testpurchasesuiandroidcompatibility` module.
- Worth noting that Emerge requires the plugin to be set on an `application` module vs a library module. @tonidero had mentioned that the Previews we want to snapshot are in `:ui:revenuecatui`. Given that this application module depends directly on the `:ui:revenuecatui` module and snapshots use a debug variant, all code should be present from that module, giving Emerge all `@Previews` automatically.
- Adds what I believe is the necessary fastlane/CircleCI setup to invoke snapshots, but my experience here is a bit more limited.
- Updates Compose BOM from `2023.05.01` to `2024.06.00`, as Emerge snapshots rely on compose foundation, which can't be resolved without an update. Happy to help test this!

For the best usage, we recommend running snapshots on every commit - all PR commits and main commits. Emerge will run & snapshot all `@Preview` annotated functions, storing the generated snapshots based on the `sha` of that upload.

If the commit has a valid `baseSha` set and we have snapshots for that `baseSha`, we'll automatically compare the snapshots and let you know if there's any visual changes directly on the PR. See our [snapshot docs](https://docs.emergetools.com/docs/snapshot-testing) for all functionality!

Remaining tasks to implement to complete this:
- [ ] Wire up CircleCI variables to see the `sha` & `baseSha` in the Emerge gradle plugin config block. These are what we use for [diffing snapshots](https://docs.emergetools.com/docs/continuous-integration). Will do this in follow up PRs

Contributed by @rbro112 in #1785
