### PR TITLE
Fixes a Paywall Template 7 crash when none of the tiers have any available products.

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
@@ -123,6 +123,10 @@ internal object PackageConfigurationFactory {
             )
         }.filterNotNullValues()
 
+        if (all.isEmpty()) {
+            return Result.failure(PackageConfigurationError("None of the tiers have any available products."))
+        }
+
         val allTierInfos = all.entries.map { (tier, packageInfo) ->
             val tierName = packageInfo.default.localization.tierName
                 ?: return Result.failure(


### PR DESCRIPTION
## Note
There's an equivalent iOS fix here: https://github.com/RevenueCat/purchases-ios/pull/4243.

## Bug
If a Template 7 Paywall is configured to use packages for which the products are not available, it crashes in `PackageConfigurationFactory.kt`, line 142. 

The SDK prints these logs: 
```
Tier Standard has no available products and will be removed from the paywall.
Tier Premium has no available products and will be removed from the paywall.
``` 
After that, no tiers are left anymore, but this case isn't considered.

<details>
  <summary>Stack trace</summary>
  
  ```java
FATAL EXCEPTION: main (Ask Gemini)
Process: com.revenuecat.purchases_sample, PID: 19505
java.util.NoSuchElementException: List is empty.
	at kotlin.collections.CollectionsKt___CollectionsKt.first(_Collections.kt:214)
	at com.revenuecat.purchases.ui.revenuecatui.data.processed.PackageConfigurationFactory.makeMultiTierPackageConfiguration-bMdYcbs(PackageConfigurationFactory.kt:142)
	at com.revenuecat.purchases.ui.revenuecatui.data.processed.PackageConfigurationFactory.createPackageConfiguration-tZkwj4A(PackageConfigurationFactory.kt:63)
	at com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfigurationFactory.create-eH_QyT8(TemplateConfigurationFactory.kt:37)
	at com.revenuecat.purchases.ui.revenuecatui.helpers.OfferingToStateMapperKt.toPaywallState(OfferingToStateMapper.kt:141)
	at com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl.calculateState(PaywallViewModel.kt:380)
	at com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl.access$calculateState(PaywallViewModel.kt:65)
	at com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl$updateState$1.invokeSuspend(PaywallViewModel.kt:342)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.internal.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation.kt:363)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable$default(Cancellable.kt:21)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:88)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:123)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source:1)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:43)
	at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source:1)
	at com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl.updateState(PaywallViewModel.kt:328)
	at com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl.<init>(PaywallViewModel.kt:103)
	at com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl.<init>(PaywallViewModel.kt:67)
	at com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelFactory.create(PaywallViewModelFactory.kt:20)
	at androidx.lifecycle.ViewModelProvider$Factory.create(ViewModelProvider.kt:83)
	at androidx.lifecycle.ViewModelProvider.get(ViewModelProvider.kt:187)
	at androidx.lifecycle.ViewModelProvider.get(ViewModelProvider.kt:153)
	at androidx.lifecycle.viewmodel.compose.ViewModelKt.get(ViewModel.kt:215)
	at androidx.lifecycle.viewmodel.compose.ViewModelKt.viewModel(ViewModel.kt:156)
	at com.revenuecat.purchases.ui.revenuecatui.InternalPaywallKt.getPaywallViewModel(InternalPaywall.kt:315)
	at com.revenuecat.purchases.ui.revenuecatui.InternalPaywallKt.InternalPaywall(InternalPaywall.kt:59)
	at com.revenuecat.purchases.ui.revenuecatui.PaywallKt.Paywall(Paywall.kt:11)
	at com.revenuecat.purchases.kmp.ui.revenuecatui.PaywallKt.Paywall(Paywall.kt:9)
	at com.revenuecat.purchases.kmp.sample.ComposableSingletons$AppKt$lambda-1$1.invoke(App.kt:51)
	at com.revenuecat.purchases.kmp.sample.ComposableSingletons$AppKt$lambda-1$1.invoke(App.kt:26)
	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:109)
	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
	at androidx.compose.runtime.RecomposeScopeImpl.compose(RecomposeScopeImpl.kt:192)
	at androidx.compose.runtime.ComposerImpl.recomposeToGroupEnd(Composer.kt:2556)
	at androidx.compose.runtime.ComposerImpl.skipCurrentGroup(Composer.kt:2827)
	at androidx.compose.runtime.ComposerImpl.doCompose(Composer.kt:3314)
	at androidx.compose.runtime.ComposerImpl.recompose$runtime_release(Composer.kt:3265)
	at androidx.compose.runtime.CompositionImpl.recompose(Composition.kt:940)
	at androidx.compose.runtime.Recomposer.performRecompose(Recomposer.kt:1155) (Ask Gemini)
	at androidx.compose.runtime.Recomposer.access$performRecompose(Recomposer.kt:127)
	at androidx.compose.runtime.Recomposer$runRecomposeAndApplyChanges$2$1.invoke(Recomposer.kt:583)
	at androidx.compose.runtime.Recomposer$runRecomposeAndApplyChanges$2$1.invoke(Recomposer.kt:551)
	at androidx.compose.ui.platform.AndroidUiFrameClock$withFrameNanos$2$callback$1.doFrame(AndroidUiFrameClock.android.kt:41)
	at androidx.compose.ui.platform.AndroidUiDispatcher.performFrameDispatch(AndroidUiDispatcher.android.kt:109)
	at androidx.compose.ui.platform.AndroidUiDispatcher.access$performFrameDispatch(AndroidUiDispatcher.android.kt:41)
	at androidx.compose.ui.platform.AndroidUiDispatcher$dispatchCallback$1.doFrame(AndroidUiDispatcher.android.kt:69)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1337)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1348)
	at android.view.Choreographer.doCallbacks(Choreographer.java:952)
	at android.view.Choreographer.doFrame(Choreographer.java:878)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1322)
	at android.os.Handler.handleCallback(Handler.java:958)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:205)
	at android.os.Looper.loop(Looper.java:294)
	at android.app.ActivityThread.main(ActivityThread.java:8177)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@3170945, Dispatchers.Main.immediate]
  ```
</details>

## Reproducer
In PurchaseTester, using the Main RevenueCat Sample App RevenueCat project, there's a Paywall configured called `template7_crash_android_pr_1834`. Trying to show this Paywall reproduces the crash. This is because the tiers are configured to show the monthly and yearly packages, but only the weekly and lifetime packages are correctly configured for Android in this offering. 

## Fix
The fix implemented in this PR is to check whether we have any tiers left after filtering out those without available products, and returning a `Result.failure()` containing a `PackageConfigurationError`.