### PR TITLE
Add `$userAgent` tracking for attribution networks

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/attribution/AmazonDeviceIdentifiersFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/attribution/AmazonDeviceIdentifiersFetcher.kt
@@ -33,6 +33,7 @@ internal class AmazonDeviceIdentifiersFetcher : DeviceIdentifiersFetcher {
         val deviceIdentifiers = mapOf(
             SubscriberAttributeKey.DeviceIdentifiers.AmazonAdID.backendKey to advertisingID,
             SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey to "true",
+            SubscriberAttributeKey.DeviceIdentifiers.UserAgent.backendKey to "true",
         ).filterNotNullValues()
         completion(deviceIdentifiers)
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
@@ -15,6 +15,7 @@ internal enum class ReservedSubscriberAttribute(val value: String) {
     IDFA("\$idfa"),
     IDFV("\$idfv"),
     IP("\$ip"),
+    USER_AGENT("\$userAgent"),
     GPS_AD_ID("\$gpsAdId"),
     AMAZON_AD_ID("\$amazonAdId"),
 
@@ -59,6 +60,7 @@ internal sealed class SubscriberAttributeKey(val backendKey: String) {
     sealed class DeviceIdentifiers {
         object GPSAdID : SubscriberAttributeKey(ReservedSubscriberAttribute.GPS_AD_ID.value)
         object IP : SubscriberAttributeKey(ReservedSubscriberAttribute.IP.value)
+        object UserAgent : SubscriberAttributeKey(ReservedSubscriberAttribute.USER_AGENT.value)
         object AmazonAdID : SubscriberAttributeKey(ReservedSubscriberAttribute.AMAZON_AD_ID.value)
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcher.kt
@@ -29,6 +29,7 @@ internal class GoogleDeviceIdentifiersFetcher(
             val deviceIdentifiers = mapOf(
                 SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey to advertisingID,
                 SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey to "true",
+                SubscriberAttributeKey.DeviceIdentifiers.UserAgent.backendKey to "true",
             ).filterNotNullValues()
             completion(deviceIdentifiers)
         })

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/attribution/AmazonDeviceIdentifiersFetcherTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/attribution/AmazonDeviceIdentifiersFetcherTests.kt
@@ -53,8 +53,8 @@ class AmazonDeviceIdentifiersFetcherTests {
         }
 
         assertThat(completionCalled).isTrue()
-        assertThat(receivedDeviceIdentifiers.size).isEqualTo(1)
-        assertThat(receivedDeviceIdentifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]).isEqualTo("true")
+        assertThat(receivedDeviceIdentifiers.size).isEqualTo(2)
+        assertAttributionProperties(receivedDeviceIdentifiers)
     }
 
     @Test
@@ -74,10 +74,10 @@ class AmazonDeviceIdentifiersFetcherTests {
         }
 
         assertThat(completionCalled).isTrue()
-        assertThat(receivedDeviceIdentifiers.size).isEqualTo(2)
+        assertThat(receivedDeviceIdentifiers.size).isEqualTo(3)
         assertThat(receivedDeviceIdentifiers[SubscriberAttributeKey.DeviceIdentifiers.AmazonAdID.backendKey])
             .isEqualTo(expectedAmazonAdID)
-        assertThat(receivedDeviceIdentifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]).isEqualTo("true")
+        assertAttributionProperties(receivedDeviceIdentifiers)
     }
 
     @Test
@@ -96,8 +96,8 @@ class AmazonDeviceIdentifiersFetcherTests {
         }
 
         assertThat(completionCalled).isTrue()
-        assertThat(receivedDeviceIdentifiers.size).isEqualTo(1)
-        assertThat(receivedDeviceIdentifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]).isEqualTo("true")
+        assertThat(receivedDeviceIdentifiers.size).isEqualTo(2)
+        assertAttributionProperties(receivedDeviceIdentifiers)
     }
 
     @Test
@@ -117,8 +117,12 @@ class AmazonDeviceIdentifiersFetcherTests {
         }
 
         assertThat(completionCalled).isTrue()
-        assertThat(receivedDeviceIdentifiers.size).isEqualTo(1)
-        assertThat(receivedDeviceIdentifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]).isEqualTo("true")
+        assertThat(receivedDeviceIdentifiers.size).isEqualTo(2)
+        assertAttributionProperties(receivedDeviceIdentifiers)
     }
 
+    private fun assertAttributionProperties(identifiers: Map<String, String>) {
+        assertThat(identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]).isEqualTo("true")
+        assertThat(identifiers[SubscriberAttributeKey.DeviceIdentifiers.UserAgent.backendKey]).isEqualTo("true")
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcherTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcherTests.kt
@@ -60,6 +60,8 @@ class GoogleDeviceIdentifiersFetcherTests {
 
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")
+
+            assertContainsUserAgent(identifiers)
         }
 
         assertThat(completionCalled).isTrue()
@@ -86,6 +88,8 @@ class GoogleDeviceIdentifiersFetcherTests {
 
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")
+
+            assertContainsUserAgent(identifiers)
         }
 
         assertThat(completionCalled).isTrue()
@@ -282,5 +286,9 @@ class GoogleDeviceIdentifiersFetcherTests {
         assertThat(identifiers.containsKey("\$androidId")).isFalse()
         // This value is set by mockAdvertisingInfo(). 
         assertThat(identifiers.containsValue("androidid")).isFalse()
+    }
+
+    private fun assertContainsUserAgent(identifiers: Map<String, String>) {
+        assertThat(identifiers[SubscriberAttributeKey.DeviceIdentifiers.UserAgent.backendKey]).isEqualTo("true")
     }
 }


### PR DESCRIPTION
### Description
This will set up a new property `$userAgent` set to `"true"` when using any attribution network method. When this is set, the backend will know to collect the user agent. 

This is a follow-up for the Kochava PR: #1829 

- [ ] Holding until backend has been deployed