### PR TITLE
[EXTERNAL] Wireup Emerge gradle plugin config for PR snapshot diffs

### DIFF
--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -50,7 +50,6 @@ android {
 }
 
 emerge {
-    // TODO: RevenueCat to set from CircleCi variables
     apiToken.set(System.getenv("EMERGE_API_TOKEN"))
 
     vcs {

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -54,11 +54,15 @@ emerge {
 
     vcs {
         sha.set(System.getenv("CIRCLE_SHA1"))
-        val circleCiBaseSha = System.getenv("CIRCLE_MERGE_BASE")
-        if (!circleCiBaseSha.isNullOrBlank()) {
-            baseSha.set(circleCiBaseSha)
+        val prUrl = System.getenv("CIRCLE_PULL_REQUEST")
+        if (!prUrl.isNullOrEmpty()) {
+            val prNum = prUrl.split("/").lastOrNull()
+            if (!prNum.isNullOrEmpty()) {
+                prNumber.set(prNum)
+            }
+            // baseSha will be set automatically by Emerge gradle plugin for PRs
         } else {
-            // Should skip setting for main branch uploads
+            // Explicitly skip baseSha setting for main branch as it could trigger unexpected main branch comparison.
             baseSha.set("")
         }
         gitHub {

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -50,13 +50,18 @@ android {
 }
 
 emerge {
+    // TODO: RevenueCat to set from CircleCi variables
     apiToken.set(System.getenv("EMERGE_API_TOKEN"))
 
     vcs {
         sha.set(System.getenv("CIRCLE_SHA1"))
-        // WIP: Set from CircleCi variables
-        // Should skip setting for main branch uploads
-        baseSha.set("")
+        val circleCiBaseSha = System.getenv("CIRCLE_MERGE_BASE")
+        if (!circleCiBaseSha.isNullOrBlank()) {
+            baseSha.set(circleCiBaseSha)
+        } else {
+            // Should skip setting for main branch uploads
+            baseSha.set("")
+        }
         gitHub {
             repoName.set("purchases-android")
             repoOwner.set("RevenueCat")


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Attempts to wire up Emerge gradle plugin configuration for getting snapshot diffs on PRs as a follow up from https://github.com/RevenueCat/purchases-android/pull/1831. Emerge diffs using Git information (sha/base sha), so we just need to set the baseSha to the proper `main` branch sha the PR is based off. 

### Description
Wires up two notable config items from Emerge plugin to enable diffing:

- `baseSha` for finding the proper base build to diff against. Emerge sets this implicitly from Git info (when `baseSha` is not explicitly set), which I believe should work here since CircleCI is doing a standard checkout. 
  - I couldn't find a base sha variable in https://circleci.com/docs/variables/, but I believe our implicit setting should handle.
  - The gradle plugin code that sets this is [here](https://github.com/EmergeTools/emerge-android/blob/6fd459f3718fb7e908a0b856df645d677bfb76ea/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Git.kt#L15).
- `prNumber` to link to the PR from Emerge's UI/wire up approvals (should you choose to use them!) 

This PR makes it so if `CIRCLE_PULL_REQUEST` is set, the baseSha is implicitly set, and the PR URL (`CIRCLE_PULL_REQUEST`) is used to set the `prNumber`. Otherwise, `baseSha` is explicitly set to `""` to avoid diffs on the main branch.