### PR TITLE
[EXTERNAL] Wireup Emerge gradle plugin config for PR snapshot diffs (#1841) by @rbro112

### DIFF
--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -54,9 +54,17 @@ emerge {
 
     vcs {
         sha.set(System.getenv("CIRCLE_SHA1"))
-        // WIP: Set from CircleCi variables
-        // Should skip setting for main branch uploads
-        baseSha.set("")
+        val prUrl = System.getenv("CIRCLE_PULL_REQUEST")
+        if (!prUrl.isNullOrEmpty()) {
+            val prNum = prUrl.split("/").lastOrNull()
+            if (!prNum.isNullOrEmpty()) {
+                prNumber.set(prNum)
+            }
+            // baseSha will be set automatically by Emerge gradle plugin for PRs
+        } else {
+            // Explicitly skip baseSha setting for main branch as it could trigger unexpected main branch comparison.
+            baseSha.set("")
+        }
         gitHub {
             repoName.set("purchases-android")
             repoOwner.set("RevenueCat")

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -54,15 +54,14 @@ emerge {
 
     vcs {
         sha.set(System.getenv("CIRCLE_SHA1"))
-        val prUrl = System.getenv("CIRCLE_PULL_REQUEST")
-        if (!prUrl.isNullOrEmpty()) {
-            val prNum = prUrl.split("/").lastOrNull()
-            if (!prNum.isNullOrEmpty()) {
-                prNumber.set(prNum)
-            }
-            // baseSha will be set automatically by Emerge gradle plugin for PRs
+        val prNum = System.getenv("CIRCLE_PULL_REQUEST")
+            .takeUnless { prUrl -> prUrl.isNullOrEmpty() }
+            ?.takeIf { prUrl -> prUrl.contains('/') }
+            ?.split('/')
+            ?.lastOrNull()
+        if (prNum != null) {
+            prNumber.set(prNum)
         } else {
-            // Explicitly skip baseSha setting for main branch as it could trigger unexpected main branch comparison.
             baseSha.set("")
         }
         gitHub {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PaywallIcon.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PaywallIcon.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.composables
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,7 +15,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.ui.revenuecatui.R
-import kotlin.random.Random
 
 @Composable
 internal fun PaywallIcon(
@@ -151,18 +151,9 @@ internal enum class PaywallIconName {
 internal fun PaywallIconPreview() {
     val icons = PaywallIconName.values()
 
-    @Suppress("MagicNumber")
-    fun randomColor(): Color {
-        return Color(
-            red = Random.nextInt(0, 256),
-            green = Random.nextInt(0, 256),
-            blue = Random.nextInt(0, 256),
-        )
-    }
-
     LazyVerticalGrid(columns = GridCells.Adaptive(40.dp)) {
         items(icons.size) {
-            Box(modifier = Modifier.background(randomColor())) {
+            Box(modifier = Modifier.background(Color.White).border(1.dp, Color.Black)) {
                 PaywallIcon(icon = icons[it], tintColor = Color.Black)
             }
         }


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Attempts to wire up Emerge gradle plugin configuration for getting snapshot diffs on PRs as a follow up from
https://github.com/RevenueCat/purchases-android/pull/1831. Emerge diffs using Git information (sha/base sha), so we just need to set the baseSha to the proper `main` branch sha the PR is based off.

### Description
Wires up two notable config items from Emerge plugin to enable diffing:

- `baseSha` for finding the proper base build to diff against. Emerge sets this implicitly from Git info (when `baseSha` is not explicitly set), which I believe should work here since CircleCI is doing a standard checkout.
- I couldn't find a base sha variable in https://circleci.com/docs/variables/, but I believe our implicit setting should handle.
- The gradle plugin code that sets this is [here](https://github.com/EmergeTools/emerge-android/blob/6fd459f3718fb7e908a0b856df645d677bfb76ea/gradle-plugin/plugin/src/main/kotlin/com/emergetools/android/gradle/util/Git.kt#L15).
- `prNumber` to link to the PR from Emerge's UI/wire up approvals (should you choose to use them!)

This PR makes it so if `CIRCLE_PULL_REQUEST` is set, the baseSha is implicitly set, and the PR URL (`CIRCLE_PULL_REQUEST`) is used to set the `prNumber`. Otherwise, `baseSha` is explicitly set to `""` to avoid diffs on the main branch.

Contributed by @rbro112 in #1841 
