### PR TITLE
Add `kochava` integration

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -119,6 +119,7 @@ final class PurchasesAPI {
         purchases.setMediaSource("");
         purchases.setCampaign("");
         purchases.setCleverTapID("");
+        purchases.setKochavaDeviceID("");
         purchases.setAdGroup("");
         purchases.setAd("");
         purchases.setKeyword("");

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -167,6 +167,7 @@ private class PurchasesAPI {
             setMediaSource("")
             setCampaign("")
             setCleverTapID("")
+            setKochavaDeviceID("")
             setAdGroup("")
             setAd("")
             setKeyword("")

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -634,6 +634,16 @@ class Purchases internal constructor(
         purchasesOrchestrator.setCleverTapID(cleverTapID)
     }
 
+    /**
+     * Subscriber attribute associated with the Kochava Device ID for the user
+     * Recommended for the RevenueCat Kochava integration
+     *
+     * @param kochavaDeviceID null or an empty string will delete the subscriber attribute.
+     */
+    fun setKochavaDeviceID(kochavaDeviceID: String?) {
+        purchasesOrchestrator.setKochavaDeviceID(kochavaDeviceID)
+    }
+
     // endregion
     // region Campaign parameters
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -708,6 +708,16 @@ internal class PurchasesOrchestrator(
         )
     }
 
+    fun setKochavaDeviceID(kochavaDeviceID: String?) {
+        log(LogIntent.DEBUG, AttributionStrings.METHOD_CALLED.format("setKochavaDeviceID"))
+        subscriberAttributesManager.setAttributionID(
+            SubscriberAttributeKey.AttributionIds.Kochava,
+            kochavaDeviceID,
+            appUserID,
+            application,
+        )
+    }
+
     // endregion
     // region Campaign parameters
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/attribution/AmazonDeviceIdentifiersFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/attribution/AmazonDeviceIdentifiersFetcher.kt
@@ -33,7 +33,7 @@ internal class AmazonDeviceIdentifiersFetcher : DeviceIdentifiersFetcher {
         val deviceIdentifiers = mapOf(
             SubscriberAttributeKey.DeviceIdentifiers.AmazonAdID.backendKey to advertisingID,
             SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey to "true",
-            SubscriberAttributeKey.DeviceIdentifiers.UserAgent.backendKey to "true",
+            SubscriberAttributeKey.DeviceIdentifiers.DeviceVersion.backendKey to "true",
         ).filterNotNullValues()
         completion(deviceIdentifiers)
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/attribution/AmazonDeviceIdentifiersFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/attribution/AmazonDeviceIdentifiersFetcher.kt
@@ -33,6 +33,7 @@ internal class AmazonDeviceIdentifiersFetcher : DeviceIdentifiersFetcher {
         val deviceIdentifiers = mapOf(
             SubscriberAttributeKey.DeviceIdentifiers.AmazonAdID.backendKey to advertisingID,
             SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey to "true",
+            SubscriberAttributeKey.DeviceIdentifiers.UserAgent.backendKey to "true",
         ).filterNotNullValues()
         completion(deviceIdentifiers)
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -266,6 +266,7 @@ internal class HTTPClient(
             "X-Platform-Flavor" to appConfig.platformInfo.flavor,
             "X-Platform-Flavor-Version" to appConfig.platformInfo.version,
             "X-Platform-Version" to Build.VERSION.SDK_INT.toString(),
+            "X-Platform-Device" to Build.MODEL,
             "X-Version" to Config.frameworkVersion,
             "X-Client-Locale" to appConfig.languageTag,
             "X-Client-Version" to appConfig.versionName,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
@@ -29,6 +29,7 @@ internal enum class ReservedSubscriberAttribute(val value: String) {
     ONESIGNAL_USER_ID("\$onesignalUserId"),
     AIRSHIP_CHANNEL_ID("\$airshipChannelId"),
     CLEVER_TAP_ID("\$clevertapId"),
+    KOCHAVA_DEVICE_ID("\$kochavaDeviceId"),
 
     /**
      * Integration IDs
@@ -67,6 +68,7 @@ internal sealed class SubscriberAttributeKey(val backendKey: String) {
         object Facebook : AttributionIds(ReservedSubscriberAttribute.FB_ANON_ID)
         object Mparticle : AttributionIds(ReservedSubscriberAttribute.MPARTICLE_ID)
         object CleverTap : AttributionIds(ReservedSubscriberAttribute.CLEVER_TAP_ID)
+        object Kochava : AttributionIds(ReservedSubscriberAttribute.KOCHAVA_DEVICE_ID)
     }
 
     sealed class IntegrationIds(backendKey: ReservedSubscriberAttribute) : SubscriberAttributeKey(backendKey.value) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
@@ -15,7 +15,7 @@ internal enum class ReservedSubscriberAttribute(val value: String) {
     IDFA("\$idfa"),
     IDFV("\$idfv"),
     IP("\$ip"),
-    USER_AGENT("\$userAgent"),
+    DEVICE_VERSION("\$deviceVersion"),
     GPS_AD_ID("\$gpsAdId"),
     AMAZON_AD_ID("\$amazonAdId"),
 
@@ -60,7 +60,7 @@ internal sealed class SubscriberAttributeKey(val backendKey: String) {
     sealed class DeviceIdentifiers {
         object GPSAdID : SubscriberAttributeKey(ReservedSubscriberAttribute.GPS_AD_ID.value)
         object IP : SubscriberAttributeKey(ReservedSubscriberAttribute.IP.value)
-        object UserAgent : SubscriberAttributeKey(ReservedSubscriberAttribute.USER_AGENT.value)
+        object DeviceVersion : SubscriberAttributeKey(ReservedSubscriberAttribute.DEVICE_VERSION.value)
         object AmazonAdID : SubscriberAttributeKey(ReservedSubscriberAttribute.AMAZON_AD_ID.value)
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
@@ -15,6 +15,7 @@ internal enum class ReservedSubscriberAttribute(val value: String) {
     IDFA("\$idfa"),
     IDFV("\$idfv"),
     IP("\$ip"),
+    USER_AGENT("\$userAgent"),
     GPS_AD_ID("\$gpsAdId"),
     AMAZON_AD_ID("\$amazonAdId"),
 
@@ -59,6 +60,7 @@ internal sealed class SubscriberAttributeKey(val backendKey: String) {
     sealed class DeviceIdentifiers {
         object GPSAdID : SubscriberAttributeKey(ReservedSubscriberAttribute.GPS_AD_ID.value)
         object IP : SubscriberAttributeKey(ReservedSubscriberAttribute.IP.value)
+        object UserAgent : SubscriberAttributeKey(ReservedSubscriberAttribute.USER_AGENT.value)
         object AmazonAdID : SubscriberAttributeKey(ReservedSubscriberAttribute.AMAZON_AD_ID.value)
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcher.kt
@@ -29,7 +29,7 @@ internal class GoogleDeviceIdentifiersFetcher(
             val deviceIdentifiers = mapOf(
                 SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey to advertisingID,
                 SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey to "true",
-                SubscriberAttributeKey.DeviceIdentifiers.UserAgent.backendKey to "true",
+                SubscriberAttributeKey.DeviceIdentifiers.DeviceVersion.backendKey to "true",
             ).filterNotNullValues()
             completion(deviceIdentifiers)
         })

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcher.kt
@@ -29,6 +29,7 @@ internal class GoogleDeviceIdentifiersFetcher(
             val deviceIdentifiers = mapOf(
                 SubscriberAttributeKey.DeviceIdentifiers.GPSAdID.backendKey to advertisingID,
                 SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey to "true",
+                SubscriberAttributeKey.DeviceIdentifiers.UserAgent.backendKey to "true",
             ).filterNotNullValues()
             completion(deviceIdentifiers)
         })

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/attribution/AmazonDeviceIdentifiersFetcherTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/attribution/AmazonDeviceIdentifiersFetcherTests.kt
@@ -123,6 +123,6 @@ class AmazonDeviceIdentifiersFetcherTests {
 
     private fun assertAttributionProperties(identifiers: Map<String, String>) {
         assertThat(identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]).isEqualTo("true")
-        assertThat(identifiers[SubscriberAttributeKey.DeviceIdentifiers.UserAgent.backendKey]).isEqualTo("true")
+        assertThat(identifiers[SubscriberAttributeKey.DeviceIdentifiers.DeviceVersion.backendKey]).isEqualTo("true")
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/attribution/AmazonDeviceIdentifiersFetcherTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/attribution/AmazonDeviceIdentifiersFetcherTests.kt
@@ -53,8 +53,8 @@ class AmazonDeviceIdentifiersFetcherTests {
         }
 
         assertThat(completionCalled).isTrue()
-        assertThat(receivedDeviceIdentifiers.size).isEqualTo(1)
-        assertThat(receivedDeviceIdentifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]).isEqualTo("true")
+        assertThat(receivedDeviceIdentifiers.size).isEqualTo(2)
+        assertAttributionProperties(receivedDeviceIdentifiers)
     }
 
     @Test
@@ -74,10 +74,10 @@ class AmazonDeviceIdentifiersFetcherTests {
         }
 
         assertThat(completionCalled).isTrue()
-        assertThat(receivedDeviceIdentifiers.size).isEqualTo(2)
+        assertThat(receivedDeviceIdentifiers.size).isEqualTo(3)
         assertThat(receivedDeviceIdentifiers[SubscriberAttributeKey.DeviceIdentifiers.AmazonAdID.backendKey])
             .isEqualTo(expectedAmazonAdID)
-        assertThat(receivedDeviceIdentifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]).isEqualTo("true")
+        assertAttributionProperties(receivedDeviceIdentifiers)
     }
 
     @Test
@@ -96,8 +96,8 @@ class AmazonDeviceIdentifiersFetcherTests {
         }
 
         assertThat(completionCalled).isTrue()
-        assertThat(receivedDeviceIdentifiers.size).isEqualTo(1)
-        assertThat(receivedDeviceIdentifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]).isEqualTo("true")
+        assertThat(receivedDeviceIdentifiers.size).isEqualTo(2)
+        assertAttributionProperties(receivedDeviceIdentifiers)
     }
 
     @Test
@@ -117,8 +117,12 @@ class AmazonDeviceIdentifiersFetcherTests {
         }
 
         assertThat(completionCalled).isTrue()
-        assertThat(receivedDeviceIdentifiers.size).isEqualTo(1)
-        assertThat(receivedDeviceIdentifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]).isEqualTo("true")
+        assertThat(receivedDeviceIdentifiers.size).isEqualTo(2)
+        assertAttributionProperties(receivedDeviceIdentifiers)
     }
 
+    private fun assertAttributionProperties(identifiers: Map<String, String>) {
+        assertThat(identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]).isEqualTo("true")
+        assertThat(identifiers[SubscriberAttributeKey.DeviceIdentifiers.UserAgent.backendKey]).isEqualTo("true")
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -180,6 +180,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         assertThat(request.getHeader("Content-Type")).isEqualTo("application/json")
         assertThat(request.getHeader("X-Platform")).isEqualTo("android")
         assertThat(request.getHeader("X-Platform-Version")).isEqualTo("${Build.VERSION.SDK_INT}")
+        assertThat(request.getHeader("X-Platform-Device")).isEqualTo(Build.MODEL)
         assertThat(request.getHeader("X-Platform-Flavor")).isEqualTo(expectedPlatformInfo.flavor)
         assertThat(request.getHeader("X-Platform-Flavor-Version")).isEqualTo(expectedPlatformInfo.version)
         assertThat(request.getHeader("X-Version")).isEqualTo(Config.frameworkVersion)

--- a/purchases/src/test/java/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcherTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcherTests.kt
@@ -41,7 +41,7 @@ class GoogleDeviceIdentifiersFetcherTests {
     }
 
     @Test
-    fun `getDeviceIdentifiers`() {
+    fun getDeviceIdentifiers() {
         val mockContext = mockk<Application>(relaxed = true)
         mockAdvertisingInfo(
             mockContext = mockContext,
@@ -61,7 +61,7 @@ class GoogleDeviceIdentifiersFetcherTests {
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")
 
-            assertContainsUserAgent(identifiers)
+            assertContainsDeviceVersion(identifiers)
         }
 
         assertThat(completionCalled).isTrue()
@@ -89,7 +89,7 @@ class GoogleDeviceIdentifiersFetcherTests {
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")
 
-            assertContainsUserAgent(identifiers)
+            assertContainsDeviceVersion(identifiers)
         }
 
         assertThat(completionCalled).isTrue()
@@ -288,7 +288,7 @@ class GoogleDeviceIdentifiersFetcherTests {
         assertThat(identifiers.containsValue("androidid")).isFalse()
     }
 
-    private fun assertContainsUserAgent(identifiers: Map<String, String>) {
-        assertThat(identifiers[SubscriberAttributeKey.DeviceIdentifiers.UserAgent.backendKey]).isEqualTo("true")
+    private fun assertContainsDeviceVersion(identifiers: Map<String, String>) {
+        assertThat(identifiers[SubscriberAttributeKey.DeviceIdentifiers.DeviceVersion.backendKey]).isEqualTo("true")
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcherTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcherTests.kt
@@ -60,6 +60,8 @@ class GoogleDeviceIdentifiersFetcherTests {
 
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")
+
+            assertContainsUserAgent(identifiers)
         }
 
         assertThat(completionCalled).isTrue()
@@ -86,6 +88,8 @@ class GoogleDeviceIdentifiersFetcherTests {
 
             val ip = identifiers[SubscriberAttributeKey.DeviceIdentifiers.IP.backendKey]
             assertThat(ip).isEqualTo("true")
+
+            assertContainsUserAgent(identifiers)
         }
 
         assertThat(completionCalled).isTrue()
@@ -282,5 +286,9 @@ class GoogleDeviceIdentifiersFetcherTests {
         assertThat(identifiers.containsKey("\$androidId")).isFalse()
         // This value is set by mockAdvertisingInfo(). 
         assertThat(identifiers.containsValue("androidid")).isFalse()
+    }
+
+    private fun assertContainsUserAgent(identifiers: Map<String, String>) {
+        assertThat(identifiers[SubscriberAttributeKey.DeviceIdentifiers.UserAgent.backendKey]).isEqualTo("true")
     }
 }

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -267,6 +267,13 @@ class SubscriberAttributesPurchasesTests {
         }
     }
 
+    @Test
+    fun `setKochavaDeviceID`() {
+        attributionIDTest(SubscriberAttributeKey.AttributionIds.Kochava) { parameter ->
+            underTest.setKochavaDeviceID(parameter)
+        }
+    }
+
     // endregion
 
     // region Integration IDs


### PR DESCRIPTION
### Description
This adds the `kochava` integration.

This brings back the work done in #1829 and picks up the work on #1837 (but renaming it to `$deviceVersion`). Finally, it also adds a new header, `X-Platform-Device` that will contain the model version