### PR TITLE
Fix crash if activity finished while calculating presentation logic

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -34,6 +34,7 @@ interface PaywallDisplayCallback {
  */
 class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler: PaywallResultHandler) {
     private val activityResultLauncher: ActivityResultLauncher<PaywallActivityArgs>
+
     // We need to know whether the activity is running or finished to avoid launching the paywall
     // after the activity has been destroyed. See https://github.com/RevenueCat/purchases-android/issues/1842.
     // We keep a weak reference to avoid memory leaks.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -200,8 +200,8 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
     private fun isActivityFinishing(): Boolean {
         val activity = weakActivity.get()
         val fragment = weakFragment.get()
-        return (activity == null && fragment?.activity == null)
-            || activity?.isFinishing == true
-            || fragment?.activity?.isFinishing == true
+        return (activity == null && fragment?.activity == null) ||
+            activity?.isFinishing == true ||
+            fragment?.activity?.isFinishing == true
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -191,7 +191,7 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
 
     private fun launchPaywallWithArgs(args: PaywallActivityArgs) {
         if (isActivityFinishing()) {
-            Logger.e("Not displaying paywall because activity/fragment is finishing.")
+            Logger.e("Not displaying paywall because activity/fragment is finishing or has finished.")
             return
         }
         activityResultLauncher.launch(args)
@@ -200,6 +200,8 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
     private fun isActivityFinishing(): Boolean {
         val activity = weakActivity.get()
         val fragment = weakFragment.get()
-        return activity?.isFinishing == true || fragment?.activity?.isFinishing == true
+        return (activity == null && fragment?.activity == null)
+            || activity?.isFinishing == true
+            || fragment?.activity?.isFinishing == true
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -34,6 +34,9 @@ interface PaywallDisplayCallback {
  */
 class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler: PaywallResultHandler) {
     private val activityResultLauncher: ActivityResultLauncher<PaywallActivityArgs>
+    // We need to know whether the activity is running or finished to avoid launching the paywall
+    // after the activity has been destroyed. See https://github.com/RevenueCat/purchases-android/issues/1842.
+    // We keep a weak reference to avoid memory leaks.
     private val weakActivity = WeakReference(resultCaller as? Activity)
     private val weakFragment = WeakReference(resultCaller as? Fragment)
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.fonts.ParcelizableFontProvider
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayBlockForEntitlementIdentifier
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldDisplayPaywall
 import java.lang.ref.WeakReference
@@ -109,8 +110,8 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
         val shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier)
         shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
             paywallDisplayCallback?.onPaywallDisplayResult(shouldDisplay)
-            if (shouldDisplay && !isActivityFinishing()) {
-                activityResultLauncher.launch(
+            if (shouldDisplay) {
+                launchPaywallWithArgs(
                     PaywallActivityArgs(
                         requiredEntitlementIdentifier = requiredEntitlementIdentifier,
                         offeringId = offering?.identifier,
@@ -147,8 +148,8 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
         val shouldDisplayBlock = shouldDisplayBlockForEntitlementIdentifier(requiredEntitlementIdentifier)
         shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
             paywallDisplayCallback?.onPaywallDisplayResult(shouldDisplay)
-            if (shouldDisplay && !isActivityFinishing()) {
-                activityResultLauncher.launch(
+            if (shouldDisplay) {
+                launchPaywallWithArgs(
                     PaywallActivityArgs(
                         requiredEntitlementIdentifier = requiredEntitlementIdentifier,
                         offeringId = offeringIdentifier,
@@ -176,8 +177,8 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
         shouldDisplayBlock: (CustomerInfo) -> Boolean,
     ) {
         shouldDisplayPaywall(shouldDisplayBlock) { shouldDisplay ->
-            if (shouldDisplay && !isActivityFinishing()) {
-                activityResultLauncher.launch(
+            if (shouldDisplay) {
+                launchPaywallWithArgs(
                     PaywallActivityArgs(
                         offeringId = offering?.identifier,
                         fontProvider = fontProvider,
@@ -186,6 +187,14 @@ class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultHandler:
                 )
             }
         }
+    }
+
+    private fun launchPaywallWithArgs(args: PaywallActivityArgs) {
+        if (isActivityFinishing()) {
+            Logger.e("Not displaying paywall because activity/fragment is finishing.")
+            return
+        }
+        activityResultLauncher.launch(args)
     }
 
     private fun isActivityFinishing(): Boolean {


### PR DESCRIPTION
### Description
We got a couple reports of a similar issue:
- https://github.com/RevenueCat/purchases-android/issues/1842
- https://community.revenuecat.com/sdks-51/crash-in-kotlin-4999

Seems that those happened mostly on android TV. While I haven't been able to reproduce normally, I was able to reproduce (with the same stacktrace) by adding an artificial delay between the obtention of the customer info and presenting the paywall when `requiredEntitlementIdentifier` is shown and killing the activity.

This is a possible approach to fixing this.
