### PR TITLE
Fix interaction not disabled during purchases

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -152,8 +152,12 @@ internal class PaywallViewModelImpl(
             Logger.e("Activity is null, not initiating package purchase")
             return
         }
+        if (verifyNoActionInProgressOrStartAction()) {
+            return
+        }
         viewModelScope.launch {
             handlePackagePurchase(activity)
+            finishAction()
         }
     }
 


### PR DESCRIPTION
### Description
This was a regression in #1777, and was reported in #1849 

We weren't marking as an action in progress when performing purchases.