### PR TITLE
Fix multiple paywalls display issues

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -175,6 +175,7 @@ internal fun getPaywallViewModel(
 ): PaywallViewModel {
     val applicationContext = LocalContext.current.applicationContext
     val viewModel = viewModel<PaywallViewModelImpl>(
+        key = options.dataHash,
         factory = PaywallViewModelFactory(
             applicationContext.toResourceProvider(),
             options,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -46,6 +46,9 @@ data class PaywallOptions internal constructor(
         dismissRequest = builder.dismissRequest,
     )
 
+    // This hash is used to determine if the paywall should use a different view model.
+    // Not using hashCode/equals because the listener may change in some rerenders and we don't want to change
+    // the view model in those cases.
     internal val dataHash: String = run {
         var result = offeringSelection.offeringIdentifier.hashCode()
         result = hashMultiplier * result + shouldDisplayDismissButton.hashCode()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -32,6 +32,9 @@ data class PaywallOptions internal constructor(
     internal val mode: PaywallMode,
     val dismissRequest: () -> Unit,
 ) {
+    companion object {
+        private const val hashMultiplier = 31
+    }
 
     constructor(builder: Builder) : this(
         offeringSelection = builder.offeringSelection,
@@ -42,6 +45,13 @@ data class PaywallOptions internal constructor(
         mode = builder.mode,
         dismissRequest = builder.dismissRequest,
     )
+
+    internal val dataHash: String = run {
+        var result = offeringSelection.offeringIdentifier.hashCode()
+        result = hashMultiplier * result + shouldDisplayDismissButton.hashCode()
+        result = hashMultiplier * result + mode.hashCode()
+        result.toString()
+    }
 
     class Builder(
         internal val dismissRequest: () -> Unit,


### PR DESCRIPTION
### Description
This is an approach to fix DENG-955

If trying to display multiple paywalls at the same time, all paywalls would currently share the same view model. This caused that all of them would be exactly the same, which was not great for some use cases. This adds a key to the view model injection using the paywall options view model hash code. This means we will have one view model for each combination of paywall options parameters.

![image](https://github.com/user-attachments/assets/0d9d860e-9db9-4d51-a590-cf4de3fed42b)
