### PR TITLE
[CustomerCenter] Add networking layer and models

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -15,9 +15,7 @@ import com.revenuecat.purchases.PurchasesConfiguration;
 import com.revenuecat.purchases.PurchasesError;
 import com.revenuecat.purchases.Store;
 import com.revenuecat.purchases.amazon.AmazonConfiguration;
-import com.revenuecat.purchases.customercenter.CustomerCenterConfigData;
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback;
-import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback;
 import com.revenuecat.purchases.interfaces.LogInCallback;
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback;
 import com.revenuecat.purchases.interfaces.SyncAttributesAndOfferingsCallback;
@@ -78,16 +76,6 @@ final class PurchasesAPI {
             }
         };
 
-        final GetCustomerCenterConfigCallback getCustomerCenterConfigCallback = new GetCustomerCenterConfigCallback() {
-            @Override
-            public void onError(@NonNull PurchasesError error) {
-            }
-
-            @Override
-            public void onSuccess(@NonNull CustomerCenterConfigData customerCenterConfig) {
-            }
-        };
-
         purchases.syncAttributesAndOfferingsIfNeeded(syncAttributesAndOfferingsCallback);
         purchases.syncPurchases();
         purchases.syncPurchases(syncPurchasesCallback);
@@ -97,7 +85,6 @@ final class PurchasesAPI {
         purchases.getCustomerInfo(receiveCustomerInfoListener);
         purchases.getCustomerInfo(CacheFetchPolicy.CACHED_OR_FETCHED, receiveCustomerInfoListener);
         purchases.getAmazonLWAConsentStatus(getAmazonLWAContentStatusCallback);
-        purchases.getCustomerCenterConfigData(getCustomerCenterConfigCallback);
 
         purchases.restorePurchases(receiveCustomerInfoListener);
         purchases.invalidateCustomerInfoCache();

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -15,7 +15,9 @@ import com.revenuecat.purchases.PurchasesConfiguration;
 import com.revenuecat.purchases.PurchasesError;
 import com.revenuecat.purchases.Store;
 import com.revenuecat.purchases.amazon.AmazonConfiguration;
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData;
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback;
+import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback;
 import com.revenuecat.purchases.interfaces.LogInCallback;
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback;
 import com.revenuecat.purchases.interfaces.SyncAttributesAndOfferingsCallback;
@@ -76,6 +78,16 @@ final class PurchasesAPI {
             }
         };
 
+        final GetCustomerCenterConfigCallback getCustomerCenterConfigCallback = new GetCustomerCenterConfigCallback() {
+            @Override
+            public void onError(@NonNull PurchasesError error) {
+            }
+
+            @Override
+            public void onSuccess(@NonNull CustomerCenterConfigData customerCenterConfig) {
+            }
+        };
+
         purchases.syncAttributesAndOfferingsIfNeeded(syncAttributesAndOfferingsCallback);
         purchases.syncPurchases();
         purchases.syncPurchases(syncPurchasesCallback);
@@ -85,6 +97,7 @@ final class PurchasesAPI {
         purchases.getCustomerInfo(receiveCustomerInfoListener);
         purchases.getCustomerInfo(CacheFetchPolicy.CACHED_OR_FETCHED, receiveCustomerInfoListener);
         purchases.getAmazonLWAConsentStatus(getAmazonLWAContentStatusCallback);
+        purchases.getCustomerCenterConfigData(getCustomerCenterConfigCallback);
 
         purchases.restorePurchases(receiveCustomerInfoListener);
         purchases.invalidateCustomerInfoCache();

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -24,10 +24,8 @@ import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.data.LogInResult
 import com.revenuecat.purchases.getAmazonLWAConsentStatus
 import com.revenuecat.purchases.getAmazonLWAConsentStatusWith
-import com.revenuecat.purchases.getCustomerCenterConfigDataWith
 import com.revenuecat.purchases.getCustomerInfoWith
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback
-import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.SyncAttributesAndOfferingsCallback
@@ -65,10 +63,6 @@ private class PurchasesAPI {
             override fun onSuccess(status: AmazonLWAConsentStatus) {}
             override fun onError(error: PurchasesError) {}
         }
-        val getCustomerCenterConfigCallback = object : GetCustomerCenterConfigCallback {
-            override fun onSuccess(customerCenterConfig: CustomerCenterConfigData) {}
-            override fun onError(error: PurchasesError) {}
-        }
 
         purchases.syncAttributesAndOfferingsIfNeeded(syncAttributesAndOfferingsCallback)
         purchases.getAmazonLWAConsentStatus(getAmazonLWAConsentStatusCallback)
@@ -96,8 +90,6 @@ private class PurchasesAPI {
         val store: Store = purchases.store
 
         val countryCode = purchases.storefrontCountryCode
-
-        purchases.getCustomerCenterConfigData(getCustomerCenterConfigCallback)
     }
 
     @Suppress("LongMethod", "LongParameterList")
@@ -139,10 +131,6 @@ private class PurchasesAPI {
         purchases.getAmazonLWAConsentStatusWith(
             onError = { _: PurchasesError -> },
             onSuccess = { _: AmazonLWAConsentStatus -> },
-        )
-        purchases.getCustomerCenterConfigDataWith(
-            onError = { _: PurchasesError -> },
-            onSuccess = { _: CustomerCenterConfigData -> },
         )
     }
 

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -13,17 +13,21 @@ import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.amazon.AmazonConfiguration
+import com.revenuecat.purchases.awaitCustomerCenterConfigData
 import com.revenuecat.purchases.awaitCustomerInfo
 import com.revenuecat.purchases.awaitLogIn
 import com.revenuecat.purchases.awaitLogOut
 import com.revenuecat.purchases.awaitRestore
 import com.revenuecat.purchases.awaitSyncAttributesAndOfferingsIfNeeded
 import com.revenuecat.purchases.awaitSyncPurchases
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.data.LogInResult
 import com.revenuecat.purchases.getAmazonLWAConsentStatus
 import com.revenuecat.purchases.getAmazonLWAConsentStatusWith
+import com.revenuecat.purchases.getCustomerCenterConfigDataWith
 import com.revenuecat.purchases.getCustomerInfoWith
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback
+import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.SyncAttributesAndOfferingsCallback
@@ -61,6 +65,10 @@ private class PurchasesAPI {
             override fun onSuccess(status: AmazonLWAConsentStatus) {}
             override fun onError(error: PurchasesError) {}
         }
+        val getCustomerCenterConfigCallback = object : GetCustomerCenterConfigCallback {
+            override fun onSuccess(customerCenterConfig: CustomerCenterConfigData) {}
+            override fun onError(error: PurchasesError) {}
+        }
 
         purchases.syncAttributesAndOfferingsIfNeeded(syncAttributesAndOfferingsCallback)
         purchases.getAmazonLWAConsentStatus(getAmazonLWAConsentStatusCallback)
@@ -88,6 +96,8 @@ private class PurchasesAPI {
         val store: Store = purchases.store
 
         val countryCode = purchases.storefrontCountryCode
+
+        purchases.getCustomerCenterConfigData(getCustomerCenterConfigCallback)
     }
 
     @Suppress("LongMethod", "LongParameterList")
@@ -130,6 +140,10 @@ private class PurchasesAPI {
             onError = { _: PurchasesError -> },
             onSuccess = { _: AmazonLWAConsentStatus -> },
         )
+        purchases.getCustomerCenterConfigDataWith(
+            onError = { _: PurchasesError -> },
+            onSuccess = { _: CustomerCenterConfigData -> },
+        )
     }
 
     suspend fun checkCoroutines(
@@ -145,6 +159,7 @@ private class PurchasesAPI {
         val customerInfo5: CustomerInfo = purchases.awaitSyncPurchases()
         var offerings: Offerings = purchases.awaitSyncAttributesAndOfferingsIfNeeded()
         var consentStatus: AmazonLWAConsentStatus = purchases.getAmazonLWAConsentStatus()
+        var customerCenterConfigData: CustomerCenterConfigData = purchases.awaitCustomerCenterConfigData()
     }
 
     fun check(purchases: Purchases, attributes: Map<String, String>) {

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -134,6 +134,7 @@ private class PurchasesAPI {
         )
     }
 
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     suspend fun checkCoroutines(
         purchases: Purchases,
     ) {

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.interfaces.Callback
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback
+import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
@@ -460,6 +461,15 @@ class Purchases internal constructor(
     @JvmSynthetic
     fun track(paywallEvent: PaywallEvent) {
         purchasesOrchestrator.track(paywallEvent)
+    }
+
+    /**
+     * Used by `RevenueCatUI` to get the customer center config data.
+     */
+    fun getCustomerCenterConfigData(
+        callback: GetCustomerCenterConfigCallback,
+    ) {
+        purchasesOrchestrator.getCustomerCenterConfig(callback)
     }
 
     // region Subscriber Attributes

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -463,10 +463,8 @@ class Purchases internal constructor(
         purchasesOrchestrator.track(paywallEvent)
     }
 
-    /**
-     * Used by `RevenueCatUI` to get the customer center config data.
-     */
-    fun getCustomerCenterConfigData(
+    // Kept internal since it's not meant for public usage.
+    internal fun getCustomerCenterConfigData(
         callback: GetCustomerCenterConfigCallback,
     ) {
         purchasesOrchestrator.getCustomerCenterConfig(callback)

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases
 import com.revenuecat.purchases.CacheFetchPolicy.CACHED_OR_FETCHED
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.data.LogInResult
+import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -160,9 +161,14 @@ suspend fun Purchases.getAmazonLWAConsentStatus(): AmazonLWAConsentStatus {
 @Throws(PurchasesException::class)
 suspend fun Purchases.awaitCustomerCenterConfigData(): CustomerCenterConfigData {
     return suspendCoroutine { continuation ->
-        getCustomerCenterConfigDataWith(
-            onError = { continuation.resumeWithException(PurchasesException(it)) },
-            onSuccess = continuation::resume,
-        )
+        getCustomerCenterConfigData(object : GetCustomerCenterConfigCallback {
+            override fun onSuccess(customerCenterConfig: CustomerCenterConfigData) {
+                continuation.resume(customerCenterConfig)
+            }
+
+            override fun onError(error: PurchasesError) {
+                continuation.resumeWithException(PurchasesException(error))
+            }
+        })
     }
 }

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
@@ -159,6 +159,7 @@ suspend fun Purchases.getAmazonLWAConsentStatus(): AmazonLWAConsentStatus {
  */
 @JvmSynthetic
 @Throws(PurchasesException::class)
+@ExperimentalPreviewRevenueCatPurchasesAPI
 suspend fun Purchases.awaitCustomerCenterConfigData(): CustomerCenterConfigData {
     return suspendCoroutine { continuation ->
         getCustomerCenterConfigData(object : GetCustomerCenterConfigCallback {

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases
 
 import com.revenuecat.purchases.CacheFetchPolicy.CACHED_OR_FETCHED
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.data.LogInResult
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -103,7 +104,7 @@ suspend fun Purchases.awaitSyncPurchases(): CustomerInfo {
  * This method is rate limited to 5 calls per minute. It will log a warning and return offerings cache when reached.
  *
  * Refer to [the guide](https://www.revenuecat.com/docs/tools/targeting) for more targeting information
- * For more offerings information, see [getOfferings]
+ * For more offerings information, see [Purchases.getOfferings]
  *
  * Coroutine friendly version of [Purchases.syncAttributesAndOfferingsIfNeeded].
  *
@@ -144,6 +145,24 @@ suspend fun Purchases.getAmazonLWAConsentStatus(): AmazonLWAConsentStatus {
         getAmazonLWAConsentStatusWith(
             onSuccess = continuation::resume,
             onError = { continuation.resumeWithException(PurchasesException(it)) },
+        )
+    }
+}
+
+/**
+ * Gets the current user's [CustomerCenterConfigData]. Used by RevenueCatUI to present the customer center.
+ *
+ * @throws [PurchasesException] with the first [PurchasesError] if there's an error getting the customer center
+ * config data.
+ * @returns The [CustomerCenterConfigData] for the current user.
+ */
+@JvmSynthetic
+@Throws(PurchasesException::class)
+suspend fun Purchases.awaitCustomerCenterConfigData(): CustomerCenterConfigData {
+    return suspendCoroutine { continuation ->
+        getCustomerCenterConfigDataWith(
+            onError = { continuation.resumeWithException(PurchasesException(it)) },
+            onSuccess = continuation::resume,
         )
     }
 }

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -1,7 +1,9 @@
 package com.revenuecat.purchases
 
 import android.app.Activity
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback
+import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.ProductChangeCallback
 import com.revenuecat.purchases.interfaces.SyncAttributesAndOfferingsCallback
@@ -68,6 +70,19 @@ internal fun getAmazonLWAConsentStatusListener(
 ) = object : GetAmazonLWAConsentStatusCallback {
     override fun onSuccess(consentStatus: AmazonLWAConsentStatus) {
         onSuccess(consentStatus)
+    }
+
+    override fun onError(error: PurchasesError) {
+        onError(error)
+    }
+}
+
+internal fun getCustomerCenterConfigDataListener(
+    onSuccess: (CustomerCenterConfigData) -> Unit,
+    onError: (PurchasesError) -> Unit,
+) = object : GetCustomerCenterConfigCallback {
+    override fun onSuccess(customerCenterConfig: CustomerCenterConfigData) {
+        onSuccess(customerCenterConfig)
     }
 
     override fun onError(error: PurchasesError) {
@@ -205,7 +220,7 @@ fun Purchases.syncPurchasesWith(
  * This method is rate limited to 5 calls per minute. It will log a warning and return offerings cache when reached.
  *
  * Refer to [the guide](https://www.revenuecat.com/docs/tools/targeting) for more targeting information
- * For more offerings information, see [getOfferings]
+ * For more offerings information, see [Purchases.getOfferings]
  *
  * @param [onError] Called when there was an error syncing attributes or fetching offerings. Will return the first error
  * found syncing the purchases.
@@ -238,6 +253,16 @@ fun Purchases.getAmazonLWAConsentStatusWith(
     onSuccess: (AmazonLWAConsentStatus) -> Unit,
 ) {
     getAmazonLWAConsentStatus(getAmazonLWAConsentStatusListener(onSuccess, onError))
+}
+
+/**
+ * Gets the [CustomerCenterConfigData] for the current user. Used by RevenueCatUI to present the CustomerCenter.
+ */
+fun Purchases.getCustomerCenterConfigDataWith(
+    onError: (error: PurchasesError) -> Unit = ON_ERROR_STUB,
+    onSuccess: (CustomerCenterConfigData) -> Unit,
+) {
+    getCustomerCenterConfigData(getCustomerCenterConfigDataListener(onSuccess, onError))
 }
 
 // region Deprecated

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -255,16 +255,6 @@ fun Purchases.getAmazonLWAConsentStatusWith(
     getAmazonLWAConsentStatus(getAmazonLWAConsentStatusListener(onSuccess, onError))
 }
 
-/**
- * Gets the [CustomerCenterConfigData] for the current user. Used by RevenueCatUI to present the CustomerCenter.
- */
-fun Purchases.getCustomerCenterConfigDataWith(
-    onError: (error: PurchasesError) -> Unit = ON_ERROR_STUB,
-    onSuccess: (CustomerCenterConfigData) -> Unit,
-) {
-    getCustomerCenterConfigData(getCustomerCenterConfigDataListener(onSuccess, onError))
-}
-
 // region Deprecated
 
 /**

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -77,6 +77,7 @@ internal fun getAmazonLWAConsentStatusListener(
     }
 }
 
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal fun getCustomerCenterConfigDataListener(
     onSuccess: (CustomerCenterConfigData) -> Unit,
     onError: (PurchasesError) -> Unit,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -38,6 +38,7 @@ import com.revenuecat.purchases.google.isSuccessful
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.interfaces.Callback
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback
+import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.ProductChangeCallback
@@ -560,6 +561,18 @@ internal class PurchasesOrchestrator(
         if (isAndroidNOrNewer()) {
             paywallEventsManager?.track(paywallEvent)
         }
+    }
+
+    fun getCustomerCenterConfig(callback: GetCustomerCenterConfigCallback) {
+        backend.getCustomerCenterConfig(
+            identityManager.currentAppUserID,
+            onSuccessHandler = { config ->
+                callback.onSuccess(config)
+            },
+            onErrorHandler = { error ->
+                callback.onError(error)
+            },
+        )
     }
 
     // region Subscriber Attributes

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -563,6 +563,7 @@ internal class PurchasesOrchestrator(
         }
     }
 
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     fun getCustomerCenterConfig(callback: GetCustomerCenterConfigCallback) {
         backend.getCustomerCenterConfig(
             identityManager.currentAppUserID,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -72,6 +73,7 @@ internal typealias PaywallEventsCallback = Pair<() -> Unit, (PurchasesError, Boo
 /** @suppress */
 internal typealias ProductEntitlementCallback = Pair<(ProductEntitlementMapping) -> Unit, (PurchasesError) -> Unit>
 
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal typealias CustomerCenterCallback = Pair<(CustomerCenterConfigData) -> Unit, (PurchasesError) -> Unit>
 
 internal enum class PostReceiptErrorHandlingBehavior {
@@ -80,6 +82,7 @@ internal enum class PostReceiptErrorHandlingBehavior {
     SHOULD_NOT_CONSUME,
 }
 
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Suppress("TooManyFunctions")
 internal class Backend(
     private val appConfig: AppConfig,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -627,7 +627,6 @@ internal class Backend(
                 }?.forEach { (onSuccessHandler, onErrorHandler) ->
                     if (result.isSuccessful()) {
                         try {
-                            errorLog("Received customer center config: ${result.payload}")
                             val customerCenterRoot = json.decodeFromString<CustomerCenterRoot>(
                                 result.payload,
                             )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -5,7 +5,6 @@
 
 package com.revenuecat.purchases.common
 
-import android.content.res.Resources
 import android.os.Build
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.Store
@@ -47,6 +46,7 @@ internal class HTTPClient(
     private val storefrontProvider: StorefrontProvider,
     private val dateProvider: DateProvider = DefaultDateProvider(),
     private val mapConverter: MapConverter = MapConverter(),
+    private val localeProvider: LocaleProvider = DefaultLocaleProvider(),
 ) {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal companion object {
@@ -270,7 +270,7 @@ internal class HTTPClient(
             "X-Platform-Device" to Build.MODEL,
             "X-Platform-Brand" to Build.BRAND,
             "X-Version" to Config.frameworkVersion,
-            "X-Preferred-Locales" to getXPreferredLocalesHeader(),
+            "X-Preferred-Locales" to localeProvider.currentLocalesLanguageTags,
             "X-Client-Locale" to appConfig.languageTag,
             "X-Client-Version" to appConfig.versionName,
             "X-Client-Bundle-ID" to appConfig.packageName,
@@ -302,15 +302,6 @@ internal class HTTPClient(
     private fun getXPlatformHeader() = when (appConfig.store) {
         Store.AMAZON -> "amazon"
         else -> "android"
-    }
-
-    private fun getXPreferredLocalesHeader(): String {
-        val locales = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            Resources.getSystem().configuration.locales.toLanguageTags()
-        } else {
-            Resources.getSystem().configuration.locale.toLanguageTag()
-        }
-        return locales.replace('-', '_')
     }
 
     private fun verifyResponse(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -5,6 +5,7 @@
 
 package com.revenuecat.purchases.common
 
+import android.content.res.Resources
 import android.os.Build
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.Store
@@ -269,6 +270,7 @@ internal class HTTPClient(
             "X-Platform-Device" to Build.MODEL,
             "X-Platform-Brand" to Build.BRAND,
             "X-Version" to Config.frameworkVersion,
+            "X-Preferred-Locales" to getXPreferredLocalesHeader(),
             "X-Client-Locale" to appConfig.languageTag,
             "X-Client-Version" to appConfig.versionName,
             "X-Client-Bundle-ID" to appConfig.packageName,
@@ -300,6 +302,15 @@ internal class HTTPClient(
     private fun getXPlatformHeader() = when (appConfig.store) {
         Store.AMAZON -> "amazon"
         else -> "android"
+    }
+
+    private fun getXPreferredLocalesHeader(): String {
+        val locales = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            Resources.getSystem().configuration.locales.toLanguageTags()
+        } else {
+            Resources.getSystem().configuration.locale.toLanguageTag()
+        }
+        return locales.replace('-', '_')
     }
 
     private fun verifyResponse(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/LocaleProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/LocaleProvider.kt
@@ -1,13 +1,12 @@
 package com.revenuecat.purchases.common
 
-import android.os.LocaleList
 import androidx.core.os.LocaleListCompat
 
 internal interface LocaleProvider {
     val currentLocalesLanguageTags: String
 }
 
-internal class DefaultLocaleProvider: LocaleProvider {
+internal class DefaultLocaleProvider : LocaleProvider {
     override val currentLocalesLanguageTags: String
         get() = LocaleListCompat.getDefault().toLanguageTags()
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/LocaleProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/LocaleProvider.kt
@@ -1,0 +1,13 @@
+package com.revenuecat.purchases.common
+
+import android.os.LocaleList
+import androidx.core.os.LocaleListCompat
+
+internal interface LocaleProvider {
+    val currentLocalesLanguageTags: String
+}
+
+internal class DefaultLocaleProvider: LocaleProvider {
+    override val currentLocalesLanguageTags: String
+        get() = LocaleListCompat.getDefault().toLanguageTags()
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -34,6 +34,12 @@ internal sealed class Endpoint(val pathTemplate: String, val name: String) {
     object GetProductEntitlementMapping : Endpoint("/product_entitlement_mapping", "get_product_entitlement_mapping") {
         override fun getPath() = pathTemplate
     }
+    data class GetCustomerCenterConfig(val userId: String) : Endpoint(
+        "/customercenter/%s",
+        "get_customer_center_config",
+    ) {
+        override fun getPath() = pathTemplate.format(Uri.encode(userId))
+    }
 
     val supportsSignatureVerification: Boolean
         get() = when (this) {
@@ -48,6 +54,7 @@ internal sealed class Endpoint(val pathTemplate: String, val name: String) {
             is PostAttributes,
             PostDiagnostics,
             PostPaywallEvents,
+            is GetCustomerCenterConfig,
             ->
                 false
         }
@@ -65,6 +72,7 @@ internal sealed class Endpoint(val pathTemplate: String, val name: String) {
             PostDiagnostics,
             PostPaywallEvents,
             GetProductEntitlementMapping,
+            is GetCustomerCenterConfig,
             ->
                 false
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -6,6 +6,8 @@ import kotlinx.serialization.Serializable
 
 typealias RCColor = PaywallColor
 
+private const val hashCodeMultiplier = 31
+
 @Serializable
 internal class CustomerCenterRoot(
     @SerialName("customer_center") val customerCenter: CustomerCenterConfigData,
@@ -159,6 +161,24 @@ class CustomerCenterConfigData(
         fun commonLocalizedString(key: CommonLocalizedString): String {
             return localizedStrings[key.name.lowercase()] ?: key.defaultValue
         }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as Localization
+
+            if (locale != other.locale) return false
+            if (localizedStrings != other.localizedStrings) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = locale.hashCode()
+            result = hashCodeMultiplier * result + localizedStrings.hashCode()
+            return result
+        }
     }
 
     @Serializable
@@ -178,7 +198,29 @@ class CustomerCenterConfigData(
                 val eligible: Boolean,
                 val title: String,
                 val subtitle: String,
-            ) : PathDetail()
+            ) : PathDetail() {
+                override fun equals(other: Any?): Boolean {
+                    if (this === other) return true
+                    if (javaClass != other?.javaClass) return false
+
+                    other as PromotionalOffer
+
+                    if (androidOfferId != other.androidOfferId) return false
+                    if (eligible != other.eligible) return false
+                    if (title != other.title) return false
+                    if (subtitle != other.subtitle) return false
+
+                    return true
+                }
+
+                override fun hashCode(): Int {
+                    var result = androidOfferId.hashCode()
+                    result = hashCodeMultiplier * result + eligible.hashCode()
+                    result = hashCodeMultiplier * result + title.hashCode()
+                    result = hashCodeMultiplier * result + subtitle.hashCode()
+                    return result
+                }
+            }
 
             @Serializable
             class FeedbackSurvey(
@@ -190,7 +232,45 @@ class CustomerCenterConfigData(
                     val id: String,
                     val title: String,
                     @SerialName("promotional_offer") val promotionalOffer: PromotionalOffer? = null,
-                )
+                ) {
+                    override fun equals(other: Any?): Boolean {
+                        if (this === other) return true
+                        if (javaClass != other?.javaClass) return false
+
+                        other as Option
+
+                        if (id != other.id) return false
+                        if (title != other.title) return false
+                        if (promotionalOffer != other.promotionalOffer) return false
+
+                        return true
+                    }
+
+                    override fun hashCode(): Int {
+                        var result = id.hashCode()
+                        result = 31 * result + title.hashCode()
+                        result = 31 * result + (promotionalOffer?.hashCode() ?: 0)
+                        return result
+                    }
+                }
+
+                override fun equals(other: Any?): Boolean {
+                    if (this === other) return true
+                    if (javaClass != other?.javaClass) return false
+
+                    other as FeedbackSurvey
+
+                    if (title != other.title) return false
+                    if (options != other.options) return false
+
+                    return true
+                }
+
+                override fun hashCode(): Int {
+                    var result = title.hashCode()
+                    result = hashCodeMultiplier * result + options.hashCode()
+                    return result
+                }
             }
         }
 
@@ -211,6 +291,30 @@ class CustomerCenterConfigData(
             @SerialName("UNKNOWN")
             UNKNOWN,
         }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as HelpPath
+
+            if (id != other.id) return false
+            if (title != other.title) return false
+            if (type != other.type) return false
+            if (promotionalOffer != other.promotionalOffer) return false
+            if (feedbackSurvey != other.feedbackSurvey) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = id.hashCode()
+            result = hashCodeMultiplier * result + title.hashCode()
+            result = hashCodeMultiplier * result + type.hashCode()
+            result = hashCodeMultiplier * result + (promotionalOffer?.hashCode() ?: 0)
+            result = hashCodeMultiplier * result + (feedbackSurvey?.hashCode() ?: 0)
+            return result
+        }
     }
 
     @Serializable
@@ -230,7 +334,49 @@ class CustomerCenterConfigData(
             val buttonTextColor: RCColor? = null,
             @SerialName("button_background_color") @Serializable(with = PaywallColor.Serializer::class)
             val buttonBackgroundColor: RCColor? = null,
-        )
+        ) {
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (javaClass != other?.javaClass) return false
+
+                other as ColorInformation
+
+                if (accentColor != other.accentColor) return false
+                if (textColor != other.textColor) return false
+                if (backgroundColor != other.backgroundColor) return false
+                if (buttonTextColor != other.buttonTextColor) return false
+                if (buttonBackgroundColor != other.buttonBackgroundColor) return false
+
+                return true
+            }
+
+            override fun hashCode(): Int {
+                var result = accentColor?.hashCode() ?: 0
+                result = hashCodeMultiplier * result + (textColor?.hashCode() ?: 0)
+                result = hashCodeMultiplier * result + (backgroundColor?.hashCode() ?: 0)
+                result = hashCodeMultiplier * result + (buttonTextColor?.hashCode() ?: 0)
+                result = hashCodeMultiplier * result + (buttonBackgroundColor?.hashCode() ?: 0)
+                return result
+            }
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as Appearance
+
+            if (light != other.light) return false
+            if (dark != other.dark) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = light?.hashCode() ?: 0
+            result = hashCodeMultiplier * result + (dark?.hashCode() ?: 0)
+            return result
+        }
     }
 
     @Serializable
@@ -251,10 +397,72 @@ class CustomerCenterConfigData(
             @SerialName("UNKNOWN")
             UNKNOWN,
         }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as Screen
+
+            if (type != other.type) return false
+            if (title != other.title) return false
+            if (subtitle != other.subtitle) return false
+            if (paths != other.paths) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = type.hashCode()
+            result = hashCodeMultiplier * result + title.hashCode()
+            result = hashCodeMultiplier * result + (subtitle?.hashCode() ?: 0)
+            result = hashCodeMultiplier * result + paths.hashCode()
+            return result
+        }
     }
 
     @Serializable
     class Support(
         val email: String? = null,
-    )
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as Support
+
+            return email == other.email
+        }
+
+        override fun hashCode(): Int {
+            return email?.hashCode() ?: 0
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as CustomerCenterConfigData
+
+        if (screens.keys != other.screens.keys) return false
+        for (key in screens.keys) {
+            if (screens[key] != other.screens[key]) return false
+        }
+        if (appearance != other.appearance) return false
+        if (localization != other.localization) return false
+        if (support != other.support) return false
+        if (lastPublishedAppVersion != other.lastPublishedAppVersion) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = screens.hashCode()
+        result = hashCodeMultiplier * result + appearance.hashCode()
+        result = hashCodeMultiplier * result + localization.hashCode()
+        result = hashCodeMultiplier * result + support.hashCode()
+        result = hashCodeMultiplier * result + (lastPublishedAppVersion?.hashCode() ?: 0)
+        return result
+    }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -198,19 +198,10 @@ data class CustomerCenterConfigData(
 
         @Serializable
         enum class PathType {
-            @SerialName("MISSING_PURCHASE")
             MISSING_PURCHASE,
-
-            @SerialName("REFUND_REQUEST")
             REFUND_REQUEST,
-
-            @SerialName("CHANGE_PLANS")
             CHANGE_PLANS,
-
-            @SerialName("CANCEL")
             CANCEL,
-
-            @SerialName("UNKNOWN")
             UNKNOWN,
         }
     }
@@ -244,13 +235,8 @@ data class CustomerCenterConfigData(
     ) {
         @Serializable
         enum class ScreenType {
-            @SerialName("MANAGEMENT")
             MANAGEMENT,
-
-            @SerialName("NO_ACTIVE")
             NO_ACTIVE,
-
-            @SerialName("UNKNOWN")
             UNKNOWN,
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -445,10 +445,7 @@ class CustomerCenterConfigData(
 
         other as CustomerCenterConfigData
 
-        if (screens.keys != other.screens.keys) return false
-        for (key in screens.keys) {
-            if (screens[key] != other.screens[key]) return false
-        }
+        if (screens != other.screens) return false
         if (appearance != other.appearance) return false
         if (localization != other.localization) return false
         if (support != other.support) return false

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -1,0 +1,260 @@
+package com.revenuecat.purchases.customercenter
+
+import com.revenuecat.purchases.paywalls.PaywallColor
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+typealias RCColor = PaywallColor
+
+@Serializable
+internal class CustomerCenterRoot(
+    @SerialName("customer_center") val customerCenter: CustomerCenterConfigData,
+)
+
+@Serializable
+class CustomerCenterConfigData(
+    @Serializable(with = ScreenMapSerializer::class) val screens: Map<Screen.ScreenType, Screen>,
+    val appearance: Appearance,
+    val localization: Localization,
+    val support: Support,
+    @SerialName("last_published_app_version") val lastPublishedAppVersion: String? = null,
+) {
+    @Serializable
+    class Localization(
+        val locale: String,
+        @SerialName("localized_strings") val localizedStrings: Map<String, String>,
+    ) {
+        @Serializable
+        enum class CommonLocalizedString {
+            @SerialName("no_thanks")
+            NO_THANKS,
+
+            @SerialName("no_subscriptions_found")
+            NO_SUBSCRIPTIONS_FOUND,
+
+            @SerialName("try_check_restore")
+            TRY_CHECK_RESTORE,
+
+            @SerialName("restore_purchases")
+            RESTORE_PURCHASES,
+
+            @SerialName("cancel")
+            CANCEL,
+
+            @SerialName("billing_cycle")
+            BILLING_CYCLE,
+
+            @SerialName("current_price")
+            CURRENT_PRICE,
+
+            @SerialName("expired")
+            EXPIRED,
+
+            @SerialName("expires")
+            EXPIRES,
+
+            @SerialName("next_billing_date")
+            NEXT_BILLING_DATE,
+
+            @SerialName("refund_canceled")
+            REFUND_CANCELED,
+
+            @SerialName("refund_error_generic")
+            REFUND_ERROR_GENERIC,
+
+            @SerialName("refund_granted")
+            REFUND_GRANTED,
+
+            @SerialName("refund_status")
+            REFUND_STATUS,
+
+            @SerialName("sub_earliest_expiration")
+            SUB_EARLIEST_EXPIRATION,
+
+            @SerialName("sub_earliest_renewal")
+            SUB_EARLIEST_RENEWAL,
+
+            @SerialName("sub_expired")
+            SUB_EXPIRED,
+
+            @SerialName("contact_support")
+            CONTACT_SUPPORT,
+
+            @SerialName("default_body")
+            DEFAULT_BODY,
+
+            @SerialName("default_subject")
+            DEFAULT_SUBJECT,
+
+            @SerialName("dismiss")
+            DISMISS,
+
+            @SerialName("update_warning_title")
+            UPDATE_WARNING_TITLE,
+
+            @SerialName("update_warning_description")
+            UPDATE_WARNING_DESCRIPTION,
+
+            @SerialName("update_warning_update")
+            UPDATE_WARNING_UPDATE,
+
+            @SerialName("update_warning_ignore")
+            UPDATE_WARNING_IGNORE,
+
+            @SerialName("please_contact_support")
+            PLEASE_CONTACT_SUPPORT_TO_MANAGE,
+
+            @SerialName("apple_subscription_manage")
+            APPLE_SUBSCRIPTION_MANAGE,
+
+            @SerialName("google_subscription_manage")
+            GOOGLE_SUBSCRIPTION_MANAGE,
+
+            @SerialName("amazon_subscription_manage")
+            AMAZON_SUBSCRIPTION_MANAGE,
+
+            @SerialName("platform_mismatch")
+            PLATFORM_MISMATCH,
+            ;
+
+            val defaultValue: String
+                get() = when (this) {
+                    NO_THANKS -> "No, thanks"
+                    NO_SUBSCRIPTIONS_FOUND -> "No Subscriptions found"
+                    TRY_CHECK_RESTORE -> "We can try checking your Apple account for any previous purchases"
+                    RESTORE_PURCHASES -> "Restore purchases"
+                    CANCEL -> "Cancel"
+                    BILLING_CYCLE -> "Billing cycle"
+                    CURRENT_PRICE -> "Current price"
+                    EXPIRED -> "Expired"
+                    EXPIRES -> "Expires"
+                    NEXT_BILLING_DATE -> "Next billing date"
+                    REFUND_CANCELED -> "Refund canceled"
+                    REFUND_ERROR_GENERIC -> "An error occurred while processing the refund request. Please try again."
+                    REFUND_GRANTED -> "Refund granted successfully!"
+                    REFUND_STATUS -> "Refund status"
+                    SUB_EARLIEST_EXPIRATION -> "This is your subscription with the earliest expiration date."
+                    SUB_EARLIEST_RENEWAL -> "This is your subscription with the earliest billing date."
+                    SUB_EXPIRED -> "This subscription has expired."
+                    CONTACT_SUPPORT -> "Contact support"
+                    DEFAULT_BODY -> "Please describe your issue or question."
+                    DEFAULT_SUBJECT -> "Support Request"
+                    DISMISS -> "Dismiss"
+                    UPDATE_WARNING_TITLE -> "Update available"
+                    UPDATE_WARNING_DESCRIPTION ->
+                        "Downloading the latest version of the app may help solve the problem."
+                    UPDATE_WARNING_UPDATE -> "Update"
+                    UPDATE_WARNING_IGNORE -> "Continue"
+                    PLATFORM_MISMATCH -> "Platform mismatch"
+                    PLEASE_CONTACT_SUPPORT_TO_MANAGE -> "Please contact support to manage your subscription."
+                    APPLE_SUBSCRIPTION_MANAGE ->
+                        "You can manage your subscription by using the App Store app on an Apple device."
+                    GOOGLE_SUBSCRIPTION_MANAGE ->
+                        "You can manage your subscription by using the Play Store app on an Android device"
+                    AMAZON_SUBSCRIPTION_MANAGE ->
+                        "You can manage your subscription in the Amazon Appstore app on an Amazon device."
+                }
+        }
+
+        fun commonLocalizedString(key: CommonLocalizedString): String {
+            return localizedStrings[key.name.lowercase()] ?: key.defaultValue
+        }
+    }
+
+    @Serializable
+    class HelpPath(
+        val id: String,
+        val title: String,
+        val type: PathType,
+        @SerialName("promotional_offer") val promotionalOffer: PathDetail.PromotionalOffer? = null,
+        @SerialName("feedback_survey") val feedbackSurvey: PathDetail.FeedbackSurvey? = null,
+    ) {
+        @Serializable
+        sealed class PathDetail {
+            @Serializable
+            class PromotionalOffer(
+                // WIP: Rename this field name to a new android id
+                @SerialName("ios_offer_id") val androidOfferId: String,
+                val eligible: Boolean,
+                val title: String,
+                val subtitle: String,
+            ) : PathDetail()
+
+            @Serializable
+            class FeedbackSurvey(
+                val title: String,
+                val options: List<Option>,
+            ) : PathDetail() {
+                @Serializable
+                class Option(
+                    val id: String,
+                    val title: String,
+                    @SerialName("promotional_offer") val promotionalOffer: PromotionalOffer? = null,
+                )
+            }
+        }
+
+        @Serializable
+        enum class PathType {
+            @SerialName("MISSING_PURCHASE")
+            MISSING_PURCHASE,
+
+            @SerialName("REFUND_REQUEST")
+            REFUND_REQUEST,
+
+            @SerialName("CHANGE_PLANS")
+            CHANGE_PLANS,
+
+            @SerialName("CANCEL")
+            CANCEL,
+
+            @SerialName("UNKNOWN")
+            UNKNOWN,
+        }
+    }
+
+    @Serializable
+    class Appearance(
+        val light: ColorInformation? = null,
+        val dark: ColorInformation? = null,
+    ) {
+        @Serializable
+        class ColorInformation(
+            @SerialName("accent_color") @Serializable(with = PaywallColor.Serializer::class)
+            val accentColor: RCColor? = null,
+            @SerialName("text_color") @Serializable(with = PaywallColor.Serializer::class)
+            val textColor: RCColor? = null,
+            @SerialName("background_color") @Serializable(with = PaywallColor.Serializer::class)
+            val backgroundColor: RCColor? = null,
+            @SerialName("button_text_color") @Serializable(with = PaywallColor.Serializer::class)
+            val buttonTextColor: RCColor? = null,
+            @SerialName("button_background_color") @Serializable(with = PaywallColor.Serializer::class)
+            val buttonBackgroundColor: RCColor? = null,
+        )
+    }
+
+    @Serializable
+    class Screen(
+        val type: ScreenType,
+        val title: String,
+        val subtitle: String? = null,
+        val paths: List<HelpPath>,
+    ) {
+        @Serializable
+        enum class ScreenType {
+            @SerialName("MANAGEMENT")
+            MANAGEMENT,
+
+            @SerialName("NO_ACTIVE")
+            NO_ACTIVE,
+
+            @SerialName("UNKNOWN")
+            UNKNOWN,
+        }
+    }
+
+    @Serializable
+    class Support(
+        val email: String? = null,
+    )
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 
 typealias RCColor = PaywallColor
 
-private const val hashCodeMultiplier = 31
+private const val HASH_CODE_MULTIPLIER = 31
 
 @Serializable
 internal class CustomerCenterRoot(
@@ -176,7 +176,7 @@ class CustomerCenterConfigData(
 
         override fun hashCode(): Int {
             var result = locale.hashCode()
-            result = hashCodeMultiplier * result + localizedStrings.hashCode()
+            result = HASH_CODE_MULTIPLIER * result + localizedStrings.hashCode()
             return result
         }
     }
@@ -215,9 +215,9 @@ class CustomerCenterConfigData(
 
                 override fun hashCode(): Int {
                     var result = androidOfferId.hashCode()
-                    result = hashCodeMultiplier * result + eligible.hashCode()
-                    result = hashCodeMultiplier * result + title.hashCode()
-                    result = hashCodeMultiplier * result + subtitle.hashCode()
+                    result = HASH_CODE_MULTIPLIER * result + eligible.hashCode()
+                    result = HASH_CODE_MULTIPLIER * result + title.hashCode()
+                    result = HASH_CODE_MULTIPLIER * result + subtitle.hashCode()
                     return result
                 }
             }
@@ -268,7 +268,7 @@ class CustomerCenterConfigData(
 
                 override fun hashCode(): Int {
                     var result = title.hashCode()
-                    result = hashCodeMultiplier * result + options.hashCode()
+                    result = HASH_CODE_MULTIPLIER * result + options.hashCode()
                     return result
                 }
             }
@@ -309,10 +309,10 @@ class CustomerCenterConfigData(
 
         override fun hashCode(): Int {
             var result = id.hashCode()
-            result = hashCodeMultiplier * result + title.hashCode()
-            result = hashCodeMultiplier * result + type.hashCode()
-            result = hashCodeMultiplier * result + (promotionalOffer?.hashCode() ?: 0)
-            result = hashCodeMultiplier * result + (feedbackSurvey?.hashCode() ?: 0)
+            result = HASH_CODE_MULTIPLIER * result + title.hashCode()
+            result = HASH_CODE_MULTIPLIER * result + type.hashCode()
+            result = HASH_CODE_MULTIPLIER * result + (promotionalOffer?.hashCode() ?: 0)
+            result = HASH_CODE_MULTIPLIER * result + (feedbackSurvey?.hashCode() ?: 0)
             return result
         }
     }
@@ -352,10 +352,10 @@ class CustomerCenterConfigData(
 
             override fun hashCode(): Int {
                 var result = accentColor?.hashCode() ?: 0
-                result = hashCodeMultiplier * result + (textColor?.hashCode() ?: 0)
-                result = hashCodeMultiplier * result + (backgroundColor?.hashCode() ?: 0)
-                result = hashCodeMultiplier * result + (buttonTextColor?.hashCode() ?: 0)
-                result = hashCodeMultiplier * result + (buttonBackgroundColor?.hashCode() ?: 0)
+                result = HASH_CODE_MULTIPLIER * result + (textColor?.hashCode() ?: 0)
+                result = HASH_CODE_MULTIPLIER * result + (backgroundColor?.hashCode() ?: 0)
+                result = HASH_CODE_MULTIPLIER * result + (buttonTextColor?.hashCode() ?: 0)
+                result = HASH_CODE_MULTIPLIER * result + (buttonBackgroundColor?.hashCode() ?: 0)
                 return result
             }
         }
@@ -374,7 +374,7 @@ class CustomerCenterConfigData(
 
         override fun hashCode(): Int {
             var result = light?.hashCode() ?: 0
-            result = hashCodeMultiplier * result + (dark?.hashCode() ?: 0)
+            result = HASH_CODE_MULTIPLIER * result + (dark?.hashCode() ?: 0)
             return result
         }
     }
@@ -414,9 +414,9 @@ class CustomerCenterConfigData(
 
         override fun hashCode(): Int {
             var result = type.hashCode()
-            result = hashCodeMultiplier * result + title.hashCode()
-            result = hashCodeMultiplier * result + (subtitle?.hashCode() ?: 0)
-            result = hashCodeMultiplier * result + paths.hashCode()
+            result = HASH_CODE_MULTIPLIER * result + title.hashCode()
+            result = HASH_CODE_MULTIPLIER * result + (subtitle?.hashCode() ?: 0)
+            result = HASH_CODE_MULTIPLIER * result + paths.hashCode()
             return result
         }
     }
@@ -459,10 +459,10 @@ class CustomerCenterConfigData(
 
     override fun hashCode(): Int {
         var result = screens.hashCode()
-        result = hashCodeMultiplier * result + appearance.hashCode()
-        result = hashCodeMultiplier * result + localization.hashCode()
-        result = hashCodeMultiplier * result + support.hashCode()
-        result = hashCodeMultiplier * result + (lastPublishedAppVersion?.hashCode() ?: 0)
+        result = HASH_CODE_MULTIPLIER * result + appearance.hashCode()
+        result = HASH_CODE_MULTIPLIER * result + localization.hashCode()
+        result = HASH_CODE_MULTIPLIER * result + support.hashCode()
+        result = HASH_CODE_MULTIPLIER * result + (lastPublishedAppVersion?.hashCode() ?: 0)
         return result
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -14,7 +14,7 @@ internal class CustomerCenterRoot(
 )
 
 @Serializable
-class CustomerCenterConfigData(
+data class CustomerCenterConfigData(
     @Serializable(with = ScreenMapSerializer::class) val screens: Map<Screen.ScreenType, Screen>,
     val appearance: Appearance,
     val localization: Localization,
@@ -22,7 +22,7 @@ class CustomerCenterConfigData(
     @SerialName("last_published_app_version") val lastPublishedAppVersion: String? = null,
 ) {
     @Serializable
-    class Localization(
+    data class Localization(
         val locale: String,
         @SerialName("localized_strings") val localizedStrings: Map<String, String>,
     ) {
@@ -161,28 +161,10 @@ class CustomerCenterConfigData(
         fun commonLocalizedString(key: CommonLocalizedString): String {
             return localizedStrings[key.name.lowercase()] ?: key.defaultValue
         }
-
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (javaClass != other?.javaClass) return false
-
-            other as Localization
-
-            if (locale != other.locale) return false
-            if (localizedStrings != other.localizedStrings) return false
-
-            return true
-        }
-
-        override fun hashCode(): Int {
-            var result = locale.hashCode()
-            result = HASH_CODE_MULTIPLIER * result + localizedStrings.hashCode()
-            return result
-        }
     }
 
     @Serializable
-    class HelpPath(
+    data class HelpPath(
         val id: String,
         val title: String,
         val type: PathType,
@@ -192,85 +174,25 @@ class CustomerCenterConfigData(
         @Serializable
         sealed class PathDetail {
             @Serializable
-            class PromotionalOffer(
+            data class PromotionalOffer(
                 // WIP: Rename this field name to a new android id
                 @SerialName("ios_offer_id") val androidOfferId: String,
                 val eligible: Boolean,
                 val title: String,
                 val subtitle: String,
-            ) : PathDetail() {
-                override fun equals(other: Any?): Boolean {
-                    if (this === other) return true
-                    if (javaClass != other?.javaClass) return false
-
-                    other as PromotionalOffer
-
-                    if (androidOfferId != other.androidOfferId) return false
-                    if (eligible != other.eligible) return false
-                    if (title != other.title) return false
-                    if (subtitle != other.subtitle) return false
-
-                    return true
-                }
-
-                override fun hashCode(): Int {
-                    var result = androidOfferId.hashCode()
-                    result = HASH_CODE_MULTIPLIER * result + eligible.hashCode()
-                    result = HASH_CODE_MULTIPLIER * result + title.hashCode()
-                    result = HASH_CODE_MULTIPLIER * result + subtitle.hashCode()
-                    return result
-                }
-            }
+            ) : PathDetail()
 
             @Serializable
-            class FeedbackSurvey(
+            data class FeedbackSurvey(
                 val title: String,
                 val options: List<Option>,
             ) : PathDetail() {
                 @Serializable
-                class Option(
+                data class Option(
                     val id: String,
                     val title: String,
                     @SerialName("promotional_offer") val promotionalOffer: PromotionalOffer? = null,
-                ) {
-                    override fun equals(other: Any?): Boolean {
-                        if (this === other) return true
-                        if (javaClass != other?.javaClass) return false
-
-                        other as Option
-
-                        if (id != other.id) return false
-                        if (title != other.title) return false
-                        if (promotionalOffer != other.promotionalOffer) return false
-
-                        return true
-                    }
-
-                    override fun hashCode(): Int {
-                        var result = id.hashCode()
-                        result = 31 * result + title.hashCode()
-                        result = 31 * result + (promotionalOffer?.hashCode() ?: 0)
-                        return result
-                    }
-                }
-
-                override fun equals(other: Any?): Boolean {
-                    if (this === other) return true
-                    if (javaClass != other?.javaClass) return false
-
-                    other as FeedbackSurvey
-
-                    if (title != other.title) return false
-                    if (options != other.options) return false
-
-                    return true
-                }
-
-                override fun hashCode(): Int {
-                    var result = title.hashCode()
-                    result = HASH_CODE_MULTIPLIER * result + options.hashCode()
-                    return result
-                }
+                )
             }
         }
 
@@ -291,39 +213,15 @@ class CustomerCenterConfigData(
             @SerialName("UNKNOWN")
             UNKNOWN,
         }
-
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (javaClass != other?.javaClass) return false
-
-            other as HelpPath
-
-            if (id != other.id) return false
-            if (title != other.title) return false
-            if (type != other.type) return false
-            if (promotionalOffer != other.promotionalOffer) return false
-            if (feedbackSurvey != other.feedbackSurvey) return false
-
-            return true
-        }
-
-        override fun hashCode(): Int {
-            var result = id.hashCode()
-            result = HASH_CODE_MULTIPLIER * result + title.hashCode()
-            result = HASH_CODE_MULTIPLIER * result + type.hashCode()
-            result = HASH_CODE_MULTIPLIER * result + (promotionalOffer?.hashCode() ?: 0)
-            result = HASH_CODE_MULTIPLIER * result + (feedbackSurvey?.hashCode() ?: 0)
-            return result
-        }
     }
 
     @Serializable
-    class Appearance(
+    data class Appearance(
         val light: ColorInformation? = null,
         val dark: ColorInformation? = null,
     ) {
         @Serializable
-        class ColorInformation(
+        data class ColorInformation(
             @SerialName("accent_color") @Serializable(with = PaywallColor.Serializer::class)
             val accentColor: RCColor? = null,
             @SerialName("text_color") @Serializable(with = PaywallColor.Serializer::class)
@@ -334,53 +232,11 @@ class CustomerCenterConfigData(
             val buttonTextColor: RCColor? = null,
             @SerialName("button_background_color") @Serializable(with = PaywallColor.Serializer::class)
             val buttonBackgroundColor: RCColor? = null,
-        ) {
-            override fun equals(other: Any?): Boolean {
-                if (this === other) return true
-                if (javaClass != other?.javaClass) return false
-
-                other as ColorInformation
-
-                if (accentColor != other.accentColor) return false
-                if (textColor != other.textColor) return false
-                if (backgroundColor != other.backgroundColor) return false
-                if (buttonTextColor != other.buttonTextColor) return false
-                if (buttonBackgroundColor != other.buttonBackgroundColor) return false
-
-                return true
-            }
-
-            override fun hashCode(): Int {
-                var result = accentColor?.hashCode() ?: 0
-                result = HASH_CODE_MULTIPLIER * result + (textColor?.hashCode() ?: 0)
-                result = HASH_CODE_MULTIPLIER * result + (backgroundColor?.hashCode() ?: 0)
-                result = HASH_CODE_MULTIPLIER * result + (buttonTextColor?.hashCode() ?: 0)
-                result = HASH_CODE_MULTIPLIER * result + (buttonBackgroundColor?.hashCode() ?: 0)
-                return result
-            }
-        }
-
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (javaClass != other?.javaClass) return false
-
-            other as Appearance
-
-            if (light != other.light) return false
-            if (dark != other.dark) return false
-
-            return true
-        }
-
-        override fun hashCode(): Int {
-            var result = light?.hashCode() ?: 0
-            result = HASH_CODE_MULTIPLIER * result + (dark?.hashCode() ?: 0)
-            return result
-        }
+        )
     }
 
     @Serializable
-    class Screen(
+    data class Screen(
         val type: ScreenType,
         val title: String,
         val subtitle: String? = null,
@@ -397,69 +253,10 @@ class CustomerCenterConfigData(
             @SerialName("UNKNOWN")
             UNKNOWN,
         }
-
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (javaClass != other?.javaClass) return false
-
-            other as Screen
-
-            if (type != other.type) return false
-            if (title != other.title) return false
-            if (subtitle != other.subtitle) return false
-            if (paths != other.paths) return false
-
-            return true
-        }
-
-        override fun hashCode(): Int {
-            var result = type.hashCode()
-            result = HASH_CODE_MULTIPLIER * result + title.hashCode()
-            result = HASH_CODE_MULTIPLIER * result + (subtitle?.hashCode() ?: 0)
-            result = HASH_CODE_MULTIPLIER * result + paths.hashCode()
-            return result
-        }
     }
 
     @Serializable
-    class Support(
+    data class Support(
         val email: String? = null,
-    ) {
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (javaClass != other?.javaClass) return false
-
-            other as Support
-
-            return email == other.email
-        }
-
-        override fun hashCode(): Int {
-            return email?.hashCode() ?: 0
-        }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as CustomerCenterConfigData
-
-        if (screens != other.screens) return false
-        if (appearance != other.appearance) return false
-        if (localization != other.localization) return false
-        if (support != other.support) return false
-        if (lastPublishedAppVersion != other.lastPublishedAppVersion) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = screens.hashCode()
-        result = HASH_CODE_MULTIPLIER * result + appearance.hashCode()
-        result = HASH_CODE_MULTIPLIER * result + localization.hashCode()
-        result = HASH_CODE_MULTIPLIER * result + support.hashCode()
-        result = HASH_CODE_MULTIPLIER * result + (lastPublishedAppVersion?.hashCode() ?: 0)
-        return result
-    }
+    )
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.customercenter
 
+import com.revenuecat.purchases.paywalls.EmptyStringToNullSerializer
 import com.revenuecat.purchases.paywalls.PaywallColor
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -17,7 +18,9 @@ data class CustomerCenterConfigData(
     val appearance: Appearance,
     val localization: Localization,
     val support: Support,
-    @SerialName("last_published_app_version") val lastPublishedAppVersion: String? = null,
+    @SerialName("last_published_app_version")
+    @Serializable(with = EmptyStringToNullSerializer::class)
+    val lastPublishedAppVersion: String? = null,
 ) {
     @Serializable
     data class Localization(
@@ -252,7 +255,7 @@ data class CustomerCenterConfigData(
     data class Screen(
         val type: ScreenType,
         val title: String,
-        val subtitle: String? = null,
+        @Serializable(with = EmptyStringToNullSerializer::class) val subtitle: String? = null,
         val paths: List<HelpPath>,
     ) {
         @Serializable
@@ -265,6 +268,6 @@ data class CustomerCenterConfigData(
 
     @Serializable
     data class Support(
-        val email: String? = null,
+        @Serializable(with = EmptyStringToNullSerializer::class) val email: String? = null,
     )
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -6,8 +6,6 @@ import kotlinx.serialization.Serializable
 
 typealias RCColor = PaywallColor
 
-private const val HASH_CODE_MULTIPLIER = 31
-
 @Serializable
 internal class CustomerCenterRoot(
     @SerialName("customer_center") val customerCenter: CustomerCenterConfigData,
@@ -117,6 +115,21 @@ data class CustomerCenterConfigData(
 
             @SerialName("platform_mismatch")
             PLATFORM_MISMATCH,
+
+            @SerialName("going_to_check_purchases")
+            GOING_TO_CHECK_PURCHASES,
+
+            @SerialName("check_past_purchases")
+            CHECK_PAST_PURCHASES,
+
+            @SerialName("purchases_recovered")
+            PURCHASES_RECOVERED,
+
+            @SerialName("purchases_recovered_explanation")
+            PURCHASES_RECOVERED_EXPLANATION,
+
+            @SerialName("purchases_not_recovered")
+            PURCHASES_NOT_RECOVERED,
             ;
 
             val defaultValue: String
@@ -155,6 +168,15 @@ data class CustomerCenterConfigData(
                         "You can manage your subscription by using the Play Store app on an Android device"
                     AMAZON_SUBSCRIPTION_MANAGE ->
                         "You can manage your subscription in the Amazon Appstore app on an Amazon device."
+                    GOING_TO_CHECK_PURCHASES ->
+                        "Let’s take a look! We’re going to check your account for missing purchases."
+                    CHECK_PAST_PURCHASES -> "Check past purchases"
+                    PURCHASES_RECOVERED -> "Purchases recovered!"
+                    PURCHASES_RECOVERED_EXPLANATION ->
+                        "We applied the previously purchased items to your account. Sorry for the inconvenience."
+                    PURCHASES_NOT_RECOVERED ->
+                        "We couldn't find any additional purchases under this account. " +
+                            "Contact support for assistance if you think this is an error."
                 }
         }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.customercenter
 
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.paywalls.EmptyStringToNullSerializer
 import com.revenuecat.purchases.paywalls.PaywallColor
 import kotlinx.serialization.SerialName
@@ -7,11 +8,13 @@ import kotlinx.serialization.Serializable
 
 typealias RCColor = PaywallColor
 
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Serializable
 internal class CustomerCenterRoot(
     @SerialName("customer_center") val customerCenter: CustomerCenterConfigData,
 )
 
+@ExperimentalPreviewRevenueCatPurchasesAPI
 @Serializable
 data class CustomerCenterConfigData(
     @Serializable(with = ScreenMapSerializer::class) val screens: Map<Screen.ScreenType, Screen>,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -203,8 +203,7 @@ data class CustomerCenterConfigData(
         sealed class PathDetail {
             @Serializable
             data class PromotionalOffer(
-                // WIP: Rename this field name to a new android id
-                @SerialName("ios_offer_id") val androidOfferId: String,
+                @SerialName("android_offer_id") val androidOfferId: String,
                 val eligible: Boolean,
                 val title: String,
                 val subtitle: String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -102,7 +102,7 @@ class CustomerCenterConfigData(
             UPDATE_WARNING_IGNORE,
 
             @SerialName("please_contact_support")
-            PLEASE_CONTACT_SUPPORT_TO_MANAGE,
+            PLEASE_CONTACT_SUPPORT,
 
             @SerialName("apple_subscription_manage")
             APPLE_SUBSCRIPTION_MANAGE,
@@ -146,7 +146,7 @@ class CustomerCenterConfigData(
                     UPDATE_WARNING_UPDATE -> "Update"
                     UPDATE_WARNING_IGNORE -> "Continue"
                     PLATFORM_MISMATCH -> "Platform mismatch"
-                    PLEASE_CONTACT_SUPPORT_TO_MANAGE -> "Please contact support to manage your subscription."
+                    PLEASE_CONTACT_SUPPORT -> "Please contact support to manage your subscription."
                     APPLE_SUBSCRIPTION_MANAGE ->
                         "You can manage your subscription by using the App Store app on an Apple device."
                     GOOGLE_SUBSCRIPTION_MANAGE ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/ScreenMapSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/ScreenMapSerializer.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.customercenter
 
-import com.revenuecat.purchases.common.warnLog
+import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Screen
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Screen.ScreenType
 import kotlinx.serialization.KSerializer
@@ -24,7 +24,7 @@ internal object ScreenMapSerializer : KSerializer<Map<ScreenType, Screen>> {
                 val enumKey = ScreenType.valueOf(key)
                 map[enumKey] = jsonInput.json.decodeFromJsonElement(Screen.serializer(), value)
             } catch (_: IllegalArgumentException) {
-                warnLog("Unknown CustomerCenter ScreenType: $key. Ignoring.")
+                debugLog("Unknown CustomerCenter ScreenType: $key. Ignoring.")
             }
         }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/ScreenMapSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/ScreenMapSerializer.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.customercenter
 
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Screen
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Screen.ScreenType
@@ -11,6 +12,7 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.jsonObject
 
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal object ScreenMapSerializer : KSerializer<Map<ScreenType, Screen>> {
     override val descriptor: SerialDescriptor = MapSerializer(ScreenType.serializer(), Screen.serializer()).descriptor
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/ScreenMapSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/ScreenMapSerializer.kt
@@ -1,0 +1,37 @@
+package com.revenuecat.purchases.customercenter
+
+import com.revenuecat.purchases.common.warnLog
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Screen
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Screen.ScreenType
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.jsonObject
+
+internal object ScreenMapSerializer : KSerializer<Map<ScreenType, Screen>> {
+    override val descriptor: SerialDescriptor = MapSerializer(ScreenType.serializer(), Screen.serializer()).descriptor
+
+    override fun deserialize(decoder: Decoder): Map<ScreenType, Screen> {
+        val map = mutableMapOf<ScreenType, Screen>()
+        val jsonInput = decoder as? JsonDecoder ?: error("Can be deserialized only by JSON")
+        val jsonObject = jsonInput.decodeJsonElement().jsonObject
+
+        jsonObject.forEach { (key, value) ->
+            try {
+                val enumKey = ScreenType.valueOf(key)
+                map[enumKey] = jsonInput.json.decodeFromJsonElement(Screen.serializer(), value)
+            } catch (_: IllegalArgumentException) {
+                warnLog("Unknown CustomerCenter ScreenType: $key. Ignoring.")
+            }
+        }
+
+        return map
+    }
+
+    override fun serialize(encoder: Encoder, value: Map<ScreenType, Screen>) {
+        MapSerializer(ScreenType.serializer(), Screen.serializer()).serialize(encoder, value)
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetCustomerCenterConfigCallback.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetCustomerCenterConfigCallback.kt
@@ -1,0 +1,18 @@
+package com.revenuecat.purchases.interfaces
+
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
+
+interface GetCustomerCenterConfigCallback {
+    /**
+     * Will be called after the call has completed.
+     * @param customerCenterConfig config for the customer center to be created
+     */
+    fun onSuccess(customerCenterConfig: CustomerCenterConfigData)
+
+    /**
+     * Will be called after the call has completed with an error.
+     * @param error A [PurchasesError] containing the reason for the failure of the call
+     */
+    fun onError(error: PurchasesError)
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetCustomerCenterConfigCallback.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetCustomerCenterConfigCallback.kt
@@ -1,9 +1,11 @@
 package com.revenuecat.purchases.interfaces
 
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 
 // Kept internal since it's not meant for public usage.
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal interface GetCustomerCenterConfigCallback {
     /**
      * Will be called after the call has completed.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetCustomerCenterConfigCallback.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetCustomerCenterConfigCallback.kt
@@ -3,7 +3,8 @@ package com.revenuecat.purchases.interfaces
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 
-interface GetCustomerCenterConfigCallback {
+// Kept internal since it's not meant for public usage.
+internal interface GetCustomerCenterConfigCallback {
     /**
      * Will be called after the call has completed.
      * @param customerCenterConfig config for the customer center to be created

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -219,14 +219,14 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
         if (customerCenterConfigData == null) {
             error("Expected customer center config data")
         }
-        customerCenterConfigData?.let { customerCenterConfigData->
-            val managementScreen = customerCenterConfigData.screens[CustomerCenterConfigData.Screen.ScreenType.MANAGEMENT] ?: fail("Expected management screen")
-            val noActiveScreen = customerCenterConfigData.screens[CustomerCenterConfigData.Screen.ScreenType.NO_ACTIVE] ?: fail("Expected no active screen")
+        customerCenterConfigData?.let {
+            val managementScreen = it.screens[CustomerCenterConfigData.Screen.ScreenType.MANAGEMENT] ?: fail("Expected management screen")
+            val noActiveScreen = it.screens[CustomerCenterConfigData.Screen.ScreenType.NO_ACTIVE] ?: fail("Expected no active screen")
             assertThat(managementScreen.type).isEqualTo(CustomerCenterConfigData.Screen.ScreenType.MANAGEMENT)
             assertThat(managementScreen.paths.size).isEqualTo(4)
             val expectedLocalizationKeys = CustomerCenterConfigData.Localization.CommonLocalizedString.values().map { it.name.lowercase() }.toTypedArray()
-            assertThat(customerCenterConfigData.localization.localizedStrings.keys).contains(*expectedLocalizationKeys)
-            assertThat(customerCenterConfigData.support.email).isNull()
+            assertThat(it.localization.localizedStrings.keys).contains(*expectedLocalizationKeys)
+            assertThat(it.support.email).isNull()
         }
 
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -201,6 +201,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
         assertSigningNotPerformed()
     }
 
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     @Test
     fun `can get customer center config data`() {
         var customerCenterConfigData: CustomerCenterConfigData? = null

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetCustomerCenterConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetCustomerCenterConfigTest.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common.backend
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.AppConfig
@@ -33,6 +34,7 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @RunWith(AndroidJUnit4::class)
 class BackendGetCustomerCenterConfigTest {
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetCustomerCenterConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetCustomerCenterConfigTest.kt
@@ -241,8 +241,8 @@ class BackendGetCustomerCenterConfigTest {
     }
 
     @Test
-    fun `given multiple getCustomerInfo calls for same subscriber same body, only one is triggered`() {
-        mockHttpResult()
+    fun `given multiple getCustomerCenterConfig calls for same subscriber same body, only one is triggered`() {
+        mockHttpResult(delayMs = 200)
         val lock = CountDownLatch(2)
         asyncBackend.getCustomerCenterConfig("test-user-id",
             onSuccessHandler = {
@@ -260,7 +260,7 @@ class BackendGetCustomerCenterConfigTest {
                 fail("Expected success. Got error: $it")
             },
         )
-        lock.await(10.seconds.inWholeSeconds, TimeUnit.SECONDS)
+        lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             httpClient.performRequest(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetCustomerCenterConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetCustomerCenterConfigTest.kt
@@ -1,0 +1,315 @@
+package com.revenuecat.purchases.common.backend
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.VerificationResult
+import com.revenuecat.purchases.common.AppConfig
+import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.BackendHelper
+import com.revenuecat.purchases.common.Dispatcher
+import com.revenuecat.purchases.common.HTTPClient
+import com.revenuecat.purchases.common.SyncDispatcher
+import com.revenuecat.purchases.common.networking.Endpoint
+import com.revenuecat.purchases.common.networking.HTTPResult
+import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.HelpPath
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Screen
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Screen.ScreenType
+import com.revenuecat.purchases.customercenter.RCColor
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.net.URL
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
+
+@RunWith(AndroidJUnit4::class)
+class BackendGetCustomerCenterConfigTest {
+
+    private val mockBaseURL = URL("http://mock-api-test.revenuecat.com/")
+    private val MOCK_RESPONSE_FILENAME = "get_customer_center_config_success.json"
+
+    private lateinit var appConfig: AppConfig
+    private lateinit var httpClient: HTTPClient
+
+    private lateinit var backend: Backend
+    private lateinit var asyncBackend: Backend
+
+    private val expectedCustomerCenterConfigData = CustomerCenterConfigData(
+        screens = mapOf(
+            ScreenType.MANAGEMENT to Screen(
+                type = Screen.ScreenType.MANAGEMENT,
+                title = "How can we help?",
+                paths = listOf(
+                    HelpPath(
+                        id = "ownmsldfow",
+                        title = "Didn't receive purchase",
+                        type = HelpPath.PathType.MISSING_PURCHASE
+                    ),
+                    HelpPath(
+                        id = "nwodkdnfaoeb",
+                        title = "Request a refund",
+                        type = HelpPath.PathType.REFUND_REQUEST,
+                        promotionalOffer = HelpPath.PathDetail.PromotionalOffer(
+                            androidOfferId = "rc-refund-offer",
+                            eligible = true,
+                            title = "Wait!",
+                            subtitle = "Before you go, here's a one-time offer to continue at a discount."
+                        )
+                    ),
+                    HelpPath(
+                        id = "nfoaiodifj9",
+                        title = "Change plans",
+                        type = HelpPath.PathType.CHANGE_PLANS
+                    ),
+                    HelpPath(
+                        id = "jnkasldfhas",
+                        title = "Cancel subscription",
+                        type = HelpPath.PathType.CANCEL,
+                        feedbackSurvey = HelpPath.PathDetail.FeedbackSurvey(
+                            title = "Why are you cancelling?",
+                            options = listOf(
+                                HelpPath.PathDetail.FeedbackSurvey.Option(
+                                    id = "cancel_survey_too_expensive",
+                                    title = "Too expensive",
+                                    promotionalOffer = HelpPath.PathDetail.PromotionalOffer(
+                                        androidOfferId = "rc-cancel-offer",
+                                        eligible = true,
+                                        title = "Wait!",
+                                        subtitle = "Before you go, here's a one-time offer to continue at a discount."
+                                    )
+                                ),
+                                HelpPath.PathDetail.FeedbackSurvey.Option(
+                                    id = "cancel_survey_usage",
+                                    title = "Don't use the app",
+                                    promotionalOffer = HelpPath.PathDetail.PromotionalOffer(
+                                        androidOfferId = "rc-cancel-offer",
+                                        eligible = true,
+                                        title = "Wait!",
+                                        subtitle = "Before you go, here's a one-time offer to continue at a discount."
+                                    )
+                                ),
+                                HelpPath.PathDetail.FeedbackSurvey.Option(
+                                    id = "cancel_survey_mistake",
+                                    title = "Bought by mistake"
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            Screen.ScreenType.NO_ACTIVE to Screen(
+                type = Screen.ScreenType.NO_ACTIVE,
+                title = "No subscriptions found",
+                subtitle = "You currently have no active subscriptions",
+                paths = listOf(
+                    HelpPath(
+                        id = "9q9719171o",
+                        title = "Check purchases",
+                        type = HelpPath.PathType.MISSING_PURCHASE
+                    )
+                )
+            )
+        ),
+        appearance = CustomerCenterConfigData.Appearance(
+            light = CustomerCenterConfigData.Appearance.ColorInformation(
+                accentColor = RCColor("#a28339"),
+                textColor = RCColor("#000000"),
+                backgroundColor = RCColor("#ffffff"),
+                buttonTextColor = RCColor("#ffffff"),
+                buttonBackgroundColor = RCColor("#000000")
+            ),
+            dark = CustomerCenterConfigData.Appearance.ColorInformation(
+                accentColor = RCColor("#F4A900"),
+                textColor = RCColor("#ffffff"),
+                backgroundColor = RCColor("#000000"),
+                buttonTextColor = RCColor("#000000"),
+                buttonBackgroundColor = RCColor("#ffffff")
+            )
+        ),
+        localization = CustomerCenterConfigData.Localization(
+            locale = "en",
+            localizedStrings = mapOf(
+                "amazon_subscription_manage" to "You can manage your subscription in the Amazon Appstore app on an Amazon device.",
+                "apple_subscription_manage" to "You can manage your subscription by using the App Store app on an Apple device.",
+                "billing_cycle" to "Billing cycle",
+                "cancel" to "Cancel",
+                "check_past_purchases" to "Check past purchases",
+                "contact_support" to "Contact support",
+                "current_price" to "Current price",
+                "default_body" to "Please describe your issue or question.",
+                "default_subject" to "Support Request",
+                "dismiss" to "Dismiss",
+                "expired" to "Expired",
+                "expires" to "Expires",
+                "going_to_check_purchases" to "Let\u2019s take a look! We\u2019re going to check your account for missing purchases.",
+                "google_subscription_manage" to "You can manage your subscription by using the Play Store app on an Android device.",
+                "next_billing_date" to "Next billing date",
+                "no_subscriptions_found" to "No Subscriptions found",
+                "no_thanks" to "No, thanks",
+                "platform_mismatch" to "Platform mismatch",
+                "please_contact_support" to "Please contact support to manage your subscription.",
+                "purchases_not_recovered" to "We couldn't find any additional purchases under this account. Contact support for assistance if you think this is an error.",
+                "purchases_recovered" to "Purchases recovered!",
+                "purchases_recovered_explanation" to "We applied the previously purchased items to your account. Sorry for the inconvenience.",
+                "refund_canceled" to "Refund canceled",
+                "refund_error_generic" to "An error occurred while processing the refund request. Please try again.",
+                "refund_granted" to "Refund granted successfully!",
+                "refund_status" to "Refund status",
+                "restore_purchases" to "Restore purchases",
+                "sub_earliest_expiration" to "This is your subscription with the earliest expiration date.",
+                "sub_earliest_renewal" to "This is your subscription with the earliest billing date.",
+                "sub_expired" to "This subscription has expired.",
+                "try_check_restore" to "We can try checking your Apple account for any previous purchases",
+                "update_warning_description" to "Downloading the latest version of the app may help solve the problem.",
+                "update_warning_ignore" to "Continue",
+                "update_warning_title" to "Update available",
+                "update_warning_update" to "Update",
+            )
+        ),
+        support = CustomerCenterConfigData.Support(
+            email = "support@revenuecat.com"
+        ),
+        lastPublishedAppVersion = null
+    )
+
+    @Before
+    fun setUp() {
+        appConfig = mockk<AppConfig>().apply {
+            every { baseURL } returns mockBaseURL
+            every { customEntitlementComputation } returns false
+        }
+        httpClient = mockk()
+        val backendHelper = BackendHelper("TEST_API_KEY", SyncDispatcher(), appConfig, httpClient)
+
+        val asyncDispatcher1 = createAsyncDispatcher()
+        val asyncDispatcher2 = createAsyncDispatcher()
+
+        val asyncBackendHelper = BackendHelper("TEST_API_KEY", asyncDispatcher1, appConfig, httpClient)
+
+        backend = Backend(
+            appConfig,
+            SyncDispatcher(),
+            SyncDispatcher(),
+            httpClient,
+            backendHelper,
+        )
+
+        asyncBackend = Backend(
+            appConfig,
+            asyncDispatcher1,
+            asyncDispatcher2,
+            httpClient,
+            asyncBackendHelper,
+        )
+    }
+
+    @Test
+    fun `getCustomerCenterConfigData gets correctly`() {
+        mockHttpResult()
+        var customerCenterConfigData: CustomerCenterConfigData? = null
+        backend.getCustomerCenterConfig(
+            appUserID = "test-user-id",
+            onSuccessHandler = { customerCenterConfigData = it },
+            onErrorHandler = { error -> fail("Expected success. Got error: $error") },
+        )
+        assertThat(customerCenterConfigData).isEqualTo(expectedCustomerCenterConfigData)
+        val expectedLocalizationKeys = CustomerCenterConfigData.Localization.CommonLocalizedString.values().map { it.name.lowercase() }.toTypedArray()
+        assertThat(customerCenterConfigData!!.localization.localizedStrings.keys).contains(*expectedLocalizationKeys)
+    }
+
+    @Test
+    fun `getCustomerCenterConfigData errors propagate correctly`() {
+        mockHttpResult(responseCode = RCHTTPStatusCodes.ERROR)
+        var obtainedError: PurchasesError? = null
+        backend.getCustomerCenterConfig(
+            appUserID = "test-user-id",
+            onSuccessHandler = { fail("Expected error. Got success") },
+            onErrorHandler = { error -> obtainedError = error },
+        )
+        assertThat(obtainedError).isNotNull
+    }
+
+    @Test
+    fun `given multiple getCustomerInfo calls for same subscriber same body, only one is triggered`() {
+        mockHttpResult()
+        val lock = CountDownLatch(2)
+        asyncBackend.getCustomerCenterConfig("test-user-id",
+            onSuccessHandler = {
+                lock.countDown()
+            },
+            onErrorHandler = {
+                fail("Expected success. Got error: $it")
+            },
+        )
+        asyncBackend.getCustomerCenterConfig("test-user-id",
+            onSuccessHandler = {
+                lock.countDown()
+            },
+            onErrorHandler = {
+                fail("Expected success. Got error: $it")
+            },
+        )
+        lock.await(10.seconds.inWholeSeconds, TimeUnit.SECONDS)
+        assertThat(lock.count).isEqualTo(0)
+        verify(exactly = 1) {
+            httpClient.performRequest(
+                mockBaseURL,
+                Endpoint.GetCustomerCenterConfig("test-user-id"),
+                body = null,
+                postFieldsToSign = null,
+                any()
+            )
+        }
+    }
+
+    private fun mockHttpResult(
+        responseCode: Int = RCHTTPStatusCodes.SUCCESS,
+        delayMs: Long? = null
+    ) {
+        every {
+            httpClient.performRequest(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } answers {
+            if (delayMs != null) {
+                Thread.sleep(delayMs)
+            }
+            HTTPResult(
+                responseCode,
+                loadJSON(MOCK_RESPONSE_FILENAME),
+                HTTPResult.Origin.BACKEND,
+                requestDate = null,
+                VerificationResult.NOT_REQUESTED
+            )
+        }
+    }
+
+    private fun createAsyncDispatcher(): Dispatcher {
+        return Dispatcher(
+            ThreadPoolExecutor(
+                1,
+                2,
+                0,
+                TimeUnit.MILLISECONDS,
+                LinkedBlockingQueue()
+            )
+        )
+    }
+
+    private fun loadJSON(jsonFileName: String) = File(javaClass.classLoader!!.getResource(jsonFileName).file).readText()
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
@@ -15,12 +15,10 @@ import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
 import com.revenuecat.purchases.paywalls.events.PaywallBackendEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventRequest
 import com.revenuecat.purchases.paywalls.events.PaywallEventType
-import com.revenuecat.purchases.paywalls.events.PaywallEventsManager
 import com.revenuecat.purchases.utils.asMap
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.encodeToJsonElement
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
@@ -28,7 +26,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
-import java.net.URL
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor

--- a/purchases/src/test/java/com/revenuecat/purchases/customercenter/CustomerCenterConfigDataTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/customercenter/CustomerCenterConfigDataTest.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.customercenter
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.common.Backend
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -8,6 +9,7 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.File
 
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
 class CustomerCenterConfigDataTest {

--- a/purchases/src/test/java/com/revenuecat/purchases/customercenter/CustomerCenterConfigDataTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/customercenter/CustomerCenterConfigDataTest.kt
@@ -1,0 +1,153 @@
+package com.revenuecat.purchases.customercenter
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.Backend
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class CustomerCenterConfigDataTest {
+
+    @Test
+    fun `CustomerCenterConfigData creation and equality`() {
+        val configData1 = createSampleConfigData()
+        val configData2 = createSampleConfigData()
+        val configData3 = CustomerCenterConfigData(
+            appearance = CustomerCenterConfigData.Appearance(
+                light = CustomerCenterConfigData.Appearance.ColorInformation(
+                    accentColor = RCColor("#FF0000"),
+                    textColor = RCColor("#000000")
+                ),
+                dark = CustomerCenterConfigData.Appearance.ColorInformation(
+                    accentColor = RCColor("#00FF00"),
+                    textColor = RCColor("#FFFFFF")
+                )
+            ),
+            screens = mapOf(
+                CustomerCenterConfigData.Screen.ScreenType.MANAGEMENT to CustomerCenterConfigData.Screen(
+                    type = CustomerCenterConfigData.Screen.ScreenType.MANAGEMENT,
+                    title = "Management Screen",
+                    subtitle = "Manage your subscription",
+                    paths = listOf(
+                        CustomerCenterConfigData.HelpPath(
+                            id = "path1",
+                            title = "Path 1",
+                            type = CustomerCenterConfigData.HelpPath.PathType.CANCEL
+                        )
+                    )
+                )
+            ),
+            support = CustomerCenterConfigData.Support(email = "test@revenuecat.com"),
+            localization = CustomerCenterConfigData.Localization(
+                locale = "en",
+                localizedStrings = mapOf(
+                    "no_thanks" to "No, thanks",
+                    "cancel" to "Cancel"
+                )
+            )
+        )
+
+        assertThat(configData1).isEqualTo(configData2)
+        assertThat(configData1.hashCode()).isEqualTo(configData2.hashCode())
+        assertThat(configData1).isNotEqualTo(configData3)
+        assertThat(configData1.hashCode()).isNotEqualTo(configData3.hashCode())
+    }
+
+    @Test
+    fun `Localization returns correct localized strings and default for those not found`() {
+        val localization = CustomerCenterConfigData.Localization(
+            locale = "en",
+            localizedStrings = mapOf(
+                "no_thanks" to "No, thanks",
+                "cancel" to "Cancel"
+            )
+        )
+
+        assertThat(localization.commonLocalizedString(CustomerCenterConfigData.Localization.CommonLocalizedString.NO_THANKS))
+            .isEqualTo("No, thanks")
+        assertThat(localization.commonLocalizedString(CustomerCenterConfigData.Localization.CommonLocalizedString.CANCEL))
+            .isEqualTo("Cancel")
+        assertThat(localization.commonLocalizedString(CustomerCenterConfigData.Localization.CommonLocalizedString.RESTORE_PURCHASES))
+            .isEqualTo("Restore purchases")
+    }
+
+    @Test
+    fun `HelpPath properties are correctly set`() {
+        val helpPath = CustomerCenterConfigData.HelpPath(
+            id = "test_id",
+            title = "Test Title",
+            type = CustomerCenterConfigData.HelpPath.PathType.MISSING_PURCHASE,
+            promotionalOffer = CustomerCenterConfigData.HelpPath.PathDetail.PromotionalOffer(
+                androidOfferId = "offer_id",
+                eligible = true,
+                title = "Offer Title",
+                subtitle = "Offer Subtitle"
+            )
+        )
+
+        assertThat(helpPath.id).isEqualTo("test_id")
+        assertThat(helpPath.title).isEqualTo("Test Title")
+        assertThat(helpPath.type).isEqualTo(CustomerCenterConfigData.HelpPath.PathType.MISSING_PURCHASE)
+        assertThat(helpPath.promotionalOffer).isNotNull
+        assertThat(helpPath.feedbackSurvey).isNull()
+    }
+
+    @Test
+    fun `Appearance color information is correctly set`() {
+        val appearance = CustomerCenterConfigData.Appearance(
+            light = CustomerCenterConfigData.Appearance.ColorInformation(
+                accentColor = RCColor("#FF0000"),
+                textColor = RCColor("#000000")
+            ),
+            dark = CustomerCenterConfigData.Appearance.ColorInformation(
+                accentColor = RCColor("#00FF00"),
+                textColor = RCColor("#FFFFFF")
+            )
+        )
+
+        assertThat(appearance.light).isNotNull
+        assertThat(appearance.dark).isNotNull
+        assertThat(appearance.light?.accentColor).isEqualTo(RCColor("#FF0000"))
+        assertThat(appearance.dark?.accentColor).isEqualTo(RCColor("#00FF00"))
+    }
+
+    @Test
+    fun `Screen properties are correctly set`() {
+        val screen = CustomerCenterConfigData.Screen(
+            type = CustomerCenterConfigData.Screen.ScreenType.MANAGEMENT,
+            title = "Management Screen",
+            subtitle = "Manage your subscription",
+            paths = listOf(
+                CustomerCenterConfigData.HelpPath(
+                    id = "path1",
+                    title = "Path 1",
+                    type = CustomerCenterConfigData.HelpPath.PathType.CANCEL
+                )
+            )
+        )
+
+        assertThat(screen.type).isEqualTo(CustomerCenterConfigData.Screen.ScreenType.MANAGEMENT)
+        assertThat(screen.title).isEqualTo("Management Screen")
+        assertThat(screen.subtitle).isEqualTo("Manage your subscription")
+        assertThat(screen.paths).hasSize(1)
+    }
+
+    @Test
+    fun `Support email is correctly set`() {
+        val support = CustomerCenterConfigData.Support(email = "support@example.com")
+        assertThat(support.email).isEqualTo("support@example.com")
+    }
+
+    private fun createSampleConfigData(): CustomerCenterConfigData {
+        return Backend.json.decodeFromString(
+            CustomerCenterRoot.serializer(),
+            loadTestJSON()
+        ).customerCenter
+    }
+
+    private fun loadTestJSON() = File(javaClass.classLoader!!.getResource("get_customer_center_config_success.json").file).readText()
+}

--- a/purchases/src/test/resources/get_customer_center_config_success.json
+++ b/purchases/src/test/resources/get_customer_center_config_success.json
@@ -1,0 +1,140 @@
+{
+  "customer_center":{
+    "appearance":{
+      "dark":{
+        "accent_color":"#F4A900",
+        "background_color":"#000000",
+        "button_background_color":"#ffffff",
+        "button_text_color":"#000000",
+        "text_color":"#ffffff"
+      },
+      "light":{
+        "accent_color":"#a28339",
+        "background_color":"#ffffff",
+        "button_background_color":"#000000",
+        "button_text_color":"#ffffff",
+        "text_color":"#000000"
+      }
+    },
+    "localization":{
+      "locale":"en",
+      "localized_strings":{
+        "amazon_subscription_manage":"You can manage your subscription in the Amazon Appstore app on an Amazon device.",
+        "apple_subscription_manage":"You can manage your subscription by using the App Store app on an Apple device.",
+        "billing_cycle":"Billing cycle",
+        "cancel":"Cancel",
+        "check_past_purchases":"Check past purchases",
+        "contact_support":"Contact support",
+        "current_price":"Current price",
+        "default_body":"Please describe your issue or question.",
+        "default_subject":"Support Request",
+        "dismiss":"Dismiss",
+        "expired":"Expired",
+        "expires":"Expires",
+        "going_to_check_purchases":"Let\u2019s take a look! We\u2019re going to check your account for missing purchases.",
+        "google_subscription_manage":"You can manage your subscription by using the Play Store app on an Android device.",
+        "next_billing_date":"Next billing date",
+        "no_subscriptions_found":"No Subscriptions found",
+        "no_thanks":"No, thanks",
+        "platform_mismatch":"Platform mismatch",
+        "please_contact_support":"Please contact support to manage your subscription.",
+        "purchases_not_recovered":"We couldn't find any additional purchases under this account. Contact support for assistance if you think this is an error.",
+        "purchases_recovered":"Purchases recovered!",
+        "purchases_recovered_explanation":"We applied the previously purchased items to your account. Sorry for the inconvenience.",
+        "refund_canceled":"Refund canceled",
+        "refund_error_generic":"An error occurred while processing the refund request. Please try again.",
+        "refund_granted":"Refund granted successfully!",
+        "refund_status":"Refund status",
+        "restore_purchases":"Restore purchases",
+        "sub_earliest_expiration":"This is your subscription with the earliest expiration date.",
+        "sub_earliest_renewal":"This is your subscription with the earliest billing date.",
+        "sub_expired":"This subscription has expired.",
+        "try_check_restore":"We can try checking your Apple account for any previous purchases",
+        "update_warning_description":"Downloading the latest version of the app may help solve the problem.",
+        "update_warning_ignore":"Continue",
+        "update_warning_title":"Update available",
+        "update_warning_update":"Update"
+      }
+    },
+    "screens":{
+      "MANAGEMENT":{
+        "paths":[
+          {
+            "id":"ownmsldfow",
+            "title":"Didn't receive purchase",
+            "type":"MISSING_PURCHASE"
+          },
+          {
+            "id":"nwodkdnfaoeb",
+            "promotional_offer":{
+              "eligible":true,
+              "ios_offer_id":"rc-refund-offer",
+              "subtitle":"Before you go, here's a one-time offer to continue at a discount.",
+              "title":"Wait!"
+            },
+            "title":"Request a refund",
+            "type":"REFUND_REQUEST"
+          },
+          {
+            "id":"nfoaiodifj9",
+            "title":"Change plans",
+            "type":"CHANGE_PLANS"
+          },
+          {
+            "feedback_survey":{
+              "options":[
+                {
+                  "id":"cancel_survey_too_expensive",
+                  "promotional_offer":{
+                    "eligible":true,
+                    "ios_offer_id":"rc-cancel-offer",
+                    "subtitle":"Before you go, here's a one-time offer to continue at a discount.",
+                    "title":"Wait!"
+                  },
+                  "title":"Too expensive"
+                },
+                {
+                  "id":"cancel_survey_usage",
+                  "promotional_offer":{
+                    "eligible":true,
+                    "ios_offer_id":"rc-cancel-offer",
+                    "subtitle":"Before you go, here's a one-time offer to continue at a discount.",
+                    "title":"Wait!"
+                  },
+                  "title":"Don't use the app"
+                },
+                {
+                  "id":"cancel_survey_mistake",
+                  "title":"Bought by mistake"
+                }
+              ],
+              "title":"Why are you cancelling?"
+            },
+            "id":"jnkasldfhas",
+            "title":"Cancel subscription",
+            "type":"CANCEL"
+          }
+        ],
+        "title":"How can we help?",
+        "type":"MANAGEMENT"
+      },
+      "NO_ACTIVE":{
+        "paths":[
+          {
+            "id":"9q9719171o",
+            "title":"Check purchases",
+            "type":"MISSING_PURCHASE"
+          }
+        ],
+        "subtitle":"You currently have no active subscriptions",
+        "title":"No subscriptions found",
+        "type":"NO_ACTIVE"
+      }
+    },
+    "support":{
+      "email":"support@revenuecat.com"
+    }
+  },
+  "itunes_track_id":null,
+  "last_published_app_version":null
+}

--- a/purchases/src/test/resources/get_customer_center_config_success.json
+++ b/purchases/src/test/resources/get_customer_center_config_success.json
@@ -68,7 +68,7 @@
             "id":"nwodkdnfaoeb",
             "promotional_offer":{
               "eligible":true,
-              "ios_offer_id":"rc-refund-offer",
+              "android_offer_id":"rc-refund-offer",
               "subtitle":"Before you go, here's a one-time offer to continue at a discount.",
               "title":"Wait!"
             },
@@ -87,7 +87,7 @@
                   "id":"cancel_survey_too_expensive",
                   "promotional_offer":{
                     "eligible":true,
-                    "ios_offer_id":"rc-cancel-offer",
+                    "android_offer_id":"rc-cancel-offer",
                     "subtitle":"Before you go, here's a one-time offer to continue at a discount.",
                     "title":"Wait!"
                   },
@@ -97,7 +97,7 @@
                   "id":"cancel_survey_usage",
                   "promotional_offer":{
                     "eligible":true,
-                    "ios_offer_id":"rc-cancel-offer",
+                    "android_offer_id":"rc-cancel-offer",
                     "subtitle":"Before you go, here's a one-time offer to continue at a discount.",
                     "title":"Wait!"
                   },

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -15,6 +15,7 @@ import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.google.toInAppStoreProduct
 import com.revenuecat.purchases.google.toStoreProduct
+import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
@@ -1464,14 +1465,15 @@ internal class PurchasesTest : BasePurchasesTest() {
         }
 
         var receivedData: CustomerCenterConfigData? = null
-        purchases.getCustomerCenterConfigDataWith(
-            onError = {
+        purchases.getCustomerCenterConfigData(object : GetCustomerCenterConfigCallback {
+            override fun onError(error: PurchasesError) {
                 fail("should be success")
-            },
-            onSuccess = {
-                receivedData = it
-            },
-        )
+            }
+
+            override fun onSuccess(customerCenterConfig: CustomerCenterConfigData) {
+                receivedData = customerCenterConfig
+            }
+        })
 
         assertThat(receivedData).isEqualTo(expectedData)
     }
@@ -1493,14 +1495,15 @@ internal class PurchasesTest : BasePurchasesTest() {
         }
 
         var receivedError: PurchasesError? = null
-        purchases.getCustomerCenterConfigDataWith(
-            onError = {
-                receivedError = it
-            },
-            onSuccess = {
+        purchases.getCustomerCenterConfigData(object : GetCustomerCenterConfigCallback {
+            override fun onError(error: PurchasesError) {
+                receivedError = error
+            }
+
+            override fun onSuccess(customerCenterConfig: CustomerCenterConfigData) {
                 fail("should be error")
-            },
-        )
+            }
+        })
 
         assertThat(receivedError).isEqualTo(expectedError)
     }


### PR DESCRIPTION
### Description
- Adds networking layer and models to `RevenueCat` to support the new CustomerCenter.
- Adds a new `X-Preferred-Locales` header.
- Adds a new `Purchases.getCustomerCenterConfigData` method to access the data from `RevenueCatUI`
