### PR TITLE
[CustomerCenter] Adds SubscriptionDetailsView

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -3,6 +3,9 @@ naming:
     active: true
     functionPattern: '[a-zA-Z][a-zA-Z0-9]*'
     ignoreAnnotated: [ 'Composable' ]
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Za-z0-9]*'
 formatting:
   TrailingCommaOnCallSite:
     active: true

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
@@ -1,8 +1,10 @@
 package com.revenuecat.purchases.ui.revenuecatui.customercenter
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
@@ -18,7 +20,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.SubscriptionInformation
@@ -168,12 +169,21 @@ private class SubscriptionInformationProvider : PreviewParameterProvider<Subscri
 }
 
 @Preview(group = "scale = 1", fontScale = 1F)
-@Preview(group = "scale = 2", fontScale = 2F)
+// Unrealistically long device to make the Column fit. Can be removed once Emerge Snapshot Test supports
+// @PreviewParameter.
+@Preview(group = "scale = 2", fontScale = 2F, device = "spec:width=1080px,height=4720px,dpi=440")
 @Composable
-internal fun SubscriptionDetailsView_Preview(
-    @PreviewParameter(SubscriptionInformationProvider::class) details: SubscriptionInformation,
-) {
-    SubscriptionDetailsView(
-        details = details,
-    )
+internal fun SubscriptionDetailsView_Preview() {
+    Column(
+        modifier = Modifier.height(2000.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        // Bit of a roundabout way of using the PreviewParameterProvider, because Emerge Snapshot Test doesn't support
+        // it yet.
+        SubscriptionInformationProvider().values.forEach { details ->
+            SubscriptionDetailsView(
+                details = details,
+            )
+        }
+    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
@@ -2,6 +2,13 @@ package com.revenuecat.purchases.ui.revenuecatui.customercenter
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -9,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.SubscriptionInformation
 
 @Composable
@@ -16,41 +24,67 @@ internal fun SubscriptionDetailsView(
     details: SubscriptionInformation,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier) {
-        Text(text = details.title)
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(all = PaddingContent),
+        ) {
+            Text(
+                text = details.title,
+                style = MaterialTheme.typography.titleMedium,
+            )
 
-        val explanation = remember(details.active, details.willRenew) {
-            when {
-                details.active && details.willRenew -> "This is your subscription with the earliest billing date."
-                details.active -> "This is your subscription with the earliest expiration date."
-                else -> "This subscription has expired."
-            }
-        }
-
-        Text(text = explanation)
-
-        SubscriptionDetailRow(
-            overline = "Billing cycle",
-            text = details.durationTitle,
-        )
-        SubscriptionDetailRow(
-            overline = "Current price",
-            text = details.price,
-        )
-
-        if (details.expirationDateString != null) {
-            val expirationOverline = remember(details.active, details.willRenew) {
+            val explanation = remember(details.active, details.willRenew) {
                 when {
-                    details.active && details.willRenew -> "Next billing date"
-                    details.active -> "Expires"
-                    else -> "Expired"
+                    details.active && details.willRenew -> "This is your subscription with the earliest billing date."
+                    details.active -> "This is your subscription with the earliest expiration date."
+                    else -> "This subscription has expired."
                 }
             }
 
-            SubscriptionDetailRow(
-                overline = expirationOverline,
-                text = details.expirationDateString,
+            Text(
+                text = explanation,
+                color = LocalContentColor.current.copy(alpha = AlphaSecondaryText),
+                style = MaterialTheme.typography.bodySmall,
             )
+
+            Spacer(modifier = Modifier.size(PaddingVertical))
+
+            HorizontalDivider()
+
+            Spacer(modifier = Modifier.size(PaddingVertical))
+
+            SubscriptionDetailRow(
+                overline = "Billing cycle",
+                text = details.durationTitle,
+            )
+
+            Spacer(modifier = Modifier.size(PaddingVertical))
+
+            SubscriptionDetailRow(
+                overline = "Current price",
+                text = details.price,
+            )
+
+            if (details.expirationDateString != null) {
+                val expirationOverline = remember(details.active, details.willRenew) {
+                    when {
+                        details.active && details.willRenew -> "Next billing date"
+                        details.active -> "Expires"
+                        else -> "Expired"
+                    }
+                }
+
+                Spacer(modifier = Modifier.size(PaddingVertical))
+
+                SubscriptionDetailRow(
+                    overline = expirationOverline,
+                    text = details.expirationDateString,
+                )
+            }
         }
     }
 }
@@ -64,11 +98,22 @@ private fun SubscriptionDetailRow(
     Row(modifier) {
         // TODO Icon
         Column {
-            Text(text = overline)
-            Text(text = text)
+            Text(
+                text = overline,
+                color = LocalContentColor.current.copy(alpha = AlphaSecondaryText),
+                style = MaterialTheme.typography.labelSmall,
+            )
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodyMedium,
+            )
         }
     }
 }
+
+private val PaddingVertical = 8.dp
+private val PaddingContent = 16.dp
+private const val AlphaSecondaryText = 0.6f
 
 private class SubscriptionInformationProvider : PreviewParameterProvider<SubscriptionInformation> {
     override val values: Sequence<SubscriptionInformation> = sequenceOf(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
@@ -1,0 +1,113 @@
+package com.revenuecat.purchases.ui.revenuecatui.customercenter
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.SubscriptionInformation
+
+@Composable
+internal fun SubscriptionDetailsView(
+    details: SubscriptionInformation,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier) {
+        Text(text = details.title)
+
+        val explanation = remember(details.active, details.willRenew) {
+            when {
+                details.active && details.willRenew -> "This is your subscription with the earliest billing date."
+                details.active -> "This is your subscription with the earliest expiration date."
+                else -> "This subscription has expired."
+            }
+        }
+
+        Text(text = explanation)
+
+        SubscriptionDetailRow(
+            overline = "Billing cycle",
+            text = details.durationTitle,
+        )
+        SubscriptionDetailRow(
+            overline = "Current price",
+            text = details.price,
+        )
+
+        if (details.expirationDateString != null) {
+            val expirationOverline = remember(details.active, details.willRenew) {
+                when {
+                    details.active && details.willRenew -> "Next billing date"
+                    details.active -> "Expires"
+                    else -> "Expired"
+                }
+            }
+
+            SubscriptionDetailRow(
+                overline = expirationOverline,
+                text = details.expirationDateString,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SubscriptionDetailRow(
+    overline: String,
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier) {
+        // TODO Icon
+        Column {
+            Text(text = overline)
+            Text(text = text)
+        }
+    }
+}
+
+private class SubscriptionInformationProvider : PreviewParameterProvider<SubscriptionInformation> {
+    override val values: Sequence<SubscriptionInformation> = sequenceOf(
+        SubscriptionInformation(
+            title = "Basic",
+            durationTitle = "Monthly",
+            price = "$4.99",
+            expirationDateString = "June 1st, 2024",
+            productIdentifier = "product_id",
+            willRenew = true,
+            active = true,
+        ),
+        SubscriptionInformation(
+            title = "Basic",
+            durationTitle = "Yearly",
+            price = "$49.99",
+            expirationDateString = "June 1st, 2024",
+            productIdentifier = "product_id",
+            willRenew = false,
+            active = true,
+        ),
+        SubscriptionInformation(
+            title = "Basic",
+            durationTitle = "Weekly",
+            price = "$1.99",
+            expirationDateString = "June 1st, 2024",
+            productIdentifier = "product_id",
+            willRenew = false,
+            active = false,
+        ),
+    )
+}
+
+@Preview
+@Composable
+internal fun SubscriptionDetailsView_Preview(
+    @PreviewParameter(SubscriptionInformationProvider::class) details: SubscriptionInformation,
+) {
+    SubscriptionDetailsView(
+        details = details,
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
@@ -6,18 +6,25 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.SubscriptionInformation
+import com.revenuecat.purchases.ui.revenuecatui.icons.CalendarMonth
+import com.revenuecat.purchases.ui.revenuecatui.icons.CurrencyExchange
+import com.revenuecat.purchases.ui.revenuecatui.icons.UniversalCurrencyAlt
 
 @Composable
 internal fun SubscriptionDetailsView(
@@ -58,6 +65,7 @@ internal fun SubscriptionDetailsView(
             Spacer(modifier = Modifier.size(PaddingVertical))
 
             SubscriptionDetailRow(
+                icon = CurrencyExchange,
                 overline = "Billing cycle",
                 text = details.durationTitle,
             )
@@ -65,6 +73,7 @@ internal fun SubscriptionDetailsView(
             Spacer(modifier = Modifier.size(PaddingVertical))
 
             SubscriptionDetailRow(
+                icon = UniversalCurrencyAlt,
                 overline = "Current price",
                 text = details.price,
             )
@@ -81,6 +90,7 @@ internal fun SubscriptionDetailsView(
                 Spacer(modifier = Modifier.size(PaddingVertical))
 
                 SubscriptionDetailRow(
+                    icon = CalendarMonth,
                     overline = expirationOverline,
                     text = details.expirationDateString,
                 )
@@ -91,12 +101,23 @@ internal fun SubscriptionDetailsView(
 
 @Composable
 private fun SubscriptionDetailRow(
+    icon: ImageVector,
     overline: String,
     text: String,
     modifier: Modifier = Modifier,
 ) {
-    Row(modifier) {
-        // TODO Icon
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size((LocalDensity.current.fontScale * SizeIconDp).dp),
+        )
+
+        Spacer(modifier = Modifier.size(PaddingHorizontal))
+
         Column {
             Text(
                 text = overline,
@@ -111,9 +132,11 @@ private fun SubscriptionDetailRow(
     }
 }
 
-private val PaddingVertical = 8.dp
-private val PaddingContent = 16.dp
 private const val AlphaSecondaryText = 0.6f
+private val PaddingContent = 16.dp
+private val PaddingHorizontal = 8.dp
+private val PaddingVertical = 8.dp
+private const val SizeIconDp = 22
 
 private class SubscriptionInformationProvider : PreviewParameterProvider<SubscriptionInformation> {
     override val values: Sequence<SubscriptionInformation> = sequenceOf(
@@ -122,7 +145,6 @@ private class SubscriptionInformationProvider : PreviewParameterProvider<Subscri
             durationTitle = "Monthly",
             price = "$4.99",
             expirationDateString = "June 1st, 2024",
-            productIdentifier = "product_id",
             willRenew = true,
             active = true,
         ),
@@ -131,7 +153,6 @@ private class SubscriptionInformationProvider : PreviewParameterProvider<Subscri
             durationTitle = "Yearly",
             price = "$49.99",
             expirationDateString = "June 1st, 2024",
-            productIdentifier = "product_id",
             willRenew = false,
             active = true,
         ),
@@ -140,14 +161,14 @@ private class SubscriptionInformationProvider : PreviewParameterProvider<Subscri
             durationTitle = "Weekly",
             price = "$1.99",
             expirationDateString = "June 1st, 2024",
-            productIdentifier = "product_id",
             willRenew = false,
             active = false,
         ),
     )
 }
 
-@Preview
+@Preview(group = "scale = 1", fontScale = 1F)
+@Preview(group = "scale = 2", fontScale = 2F)
 @Composable
 internal fun SubscriptionDetailsView_Preview(
     @PreviewParameter(SubscriptionInformationProvider::class) details: SubscriptionInformation,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/SubscriptionInformation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/SubscriptionInformation.kt
@@ -1,0 +1,11 @@
+package com.revenuecat.purchases.ui.revenuecatui.customercenter.data
+
+internal data class SubscriptionInformation(
+    val title: String,
+    val durationTitle: String,
+    val price: String,
+    val expirationDateString: String?,
+    val productIdentifier: String,
+    val willRenew: Boolean,
+    val active: Boolean,
+)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/SubscriptionInformation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/SubscriptionInformation.kt
@@ -5,7 +5,6 @@ internal data class SubscriptionInformation(
     val durationTitle: String,
     val price: String,
     val expirationDateString: String?,
-    val productIdentifier: String,
     val willRenew: Boolean,
     val active: Boolean,
 )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/CalendarMonth.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/CalendarMonth.kt
@@ -1,0 +1,133 @@
+@file:Suppress("MagicNumber", "ObjectPropertyName")
+
+package com.revenuecat.purchases.ui.revenuecatui.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * Exported from [Compose Icons](https://composeicons.com/icons/material-symbols/outlined/calendar_month).
+ */
+internal val CalendarMonth: ImageVector
+    get() {
+        if (_Calendar_month != null) {
+            return _Calendar_month!!
+        }
+        _Calendar_month = ImageVector.Builder(
+            name = "CalendarMonth",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 960f,
+            viewportHeight = 960f,
+        ).apply {
+            path(
+                fill = SolidColor(Color.Black),
+                fillAlpha = 1.0f,
+                stroke = null,
+                strokeAlpha = 1.0f,
+                strokeLineWidth = 1.0f,
+                strokeLineCap = StrokeCap.Butt,
+                strokeLineJoin = StrokeJoin.Miter,
+                strokeLineMiter = 1.0f,
+                pathFillType = PathFillType.NonZero,
+            ) {
+                moveTo(200f, 880f)
+                quadToRelative(-33f, 0f, -56.5f, -23.5f)
+                reflectiveQuadTo(120f, 800f)
+                verticalLineToRelative(-560f)
+                quadToRelative(0f, -33f, 23.5f, -56.5f)
+                reflectiveQuadTo(200f, 160f)
+                horizontalLineToRelative(40f)
+                verticalLineToRelative(-80f)
+                horizontalLineToRelative(80f)
+                verticalLineToRelative(80f)
+                horizontalLineToRelative(320f)
+                verticalLineToRelative(-80f)
+                horizontalLineToRelative(80f)
+                verticalLineToRelative(80f)
+                horizontalLineToRelative(40f)
+                quadToRelative(33f, 0f, 56.5f, 23.5f)
+                reflectiveQuadTo(840f, 240f)
+                verticalLineToRelative(560f)
+                quadToRelative(0f, 33f, -23.5f, 56.5f)
+                reflectiveQuadTo(760f, 880f)
+                close()
+                moveToRelative(0f, -80f)
+                horizontalLineToRelative(560f)
+                verticalLineToRelative(-400f)
+                horizontalLineTo(200f)
+                close()
+                moveToRelative(0f, -480f)
+                horizontalLineToRelative(560f)
+                verticalLineToRelative(-80f)
+                horizontalLineTo(200f)
+                close()
+                moveToRelative(0f, 0f)
+                verticalLineToRelative(-80f)
+                close()
+                moveToRelative(280f, 240f)
+                quadToRelative(-17f, 0f, -28.5f, -11.5f)
+                reflectiveQuadTo(440f, 520f)
+                reflectiveQuadToRelative(11.5f, -28.5f)
+                reflectiveQuadTo(480f, 480f)
+                reflectiveQuadToRelative(28.5f, 11.5f)
+                reflectiveQuadTo(520f, 520f)
+                reflectiveQuadToRelative(-11.5f, 28.5f)
+                reflectiveQuadTo(480f, 560f)
+                moveToRelative(-160f, 0f)
+                quadToRelative(-17f, 0f, -28.5f, -11.5f)
+                reflectiveQuadTo(280f, 520f)
+                reflectiveQuadToRelative(11.5f, -28.5f)
+                reflectiveQuadTo(320f, 480f)
+                reflectiveQuadToRelative(28.5f, 11.5f)
+                reflectiveQuadTo(360f, 520f)
+                reflectiveQuadToRelative(-11.5f, 28.5f)
+                reflectiveQuadTo(320f, 560f)
+                moveToRelative(320f, 0f)
+                quadToRelative(-17f, 0f, -28.5f, -11.5f)
+                reflectiveQuadTo(600f, 520f)
+                reflectiveQuadToRelative(11.5f, -28.5f)
+                reflectiveQuadTo(640f, 480f)
+                reflectiveQuadToRelative(28.5f, 11.5f)
+                reflectiveQuadTo(680f, 520f)
+                reflectiveQuadToRelative(-11.5f, 28.5f)
+                reflectiveQuadTo(640f, 560f)
+                moveTo(480f, 720f)
+                quadToRelative(-17f, 0f, -28.5f, -11.5f)
+                reflectiveQuadTo(440f, 680f)
+                reflectiveQuadToRelative(11.5f, -28.5f)
+                reflectiveQuadTo(480f, 640f)
+                reflectiveQuadToRelative(28.5f, 11.5f)
+                reflectiveQuadTo(520f, 680f)
+                reflectiveQuadToRelative(-11.5f, 28.5f)
+                reflectiveQuadTo(480f, 720f)
+                moveToRelative(-160f, 0f)
+                quadToRelative(-17f, 0f, -28.5f, -11.5f)
+                reflectiveQuadTo(280f, 680f)
+                reflectiveQuadToRelative(11.5f, -28.5f)
+                reflectiveQuadTo(320f, 640f)
+                reflectiveQuadToRelative(28.5f, 11.5f)
+                reflectiveQuadTo(360f, 680f)
+                reflectiveQuadToRelative(-11.5f, 28.5f)
+                reflectiveQuadTo(320f, 720f)
+                moveToRelative(320f, 0f)
+                quadToRelative(-17f, 0f, -28.5f, -11.5f)
+                reflectiveQuadTo(600f, 680f)
+                reflectiveQuadToRelative(11.5f, -28.5f)
+                reflectiveQuadTo(640f, 640f)
+                reflectiveQuadToRelative(28.5f, 11.5f)
+                reflectiveQuadTo(680f, 680f)
+                reflectiveQuadToRelative(-11.5f, 28.5f)
+                reflectiveQuadTo(640f, 720f)
+            }
+        }.build()
+        return _Calendar_month!!
+    }
+
+private var _Calendar_month: ImageVector? = null

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/CurrencyExchange.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/CurrencyExchange.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 
 /**
- * Exported from [Compose Icons](https://composeicons.com/icons/material-symbols/outlined/calendar_month).
+ * Exported from [Compose Icons](https://composeicons.com/icons/material-symbols/outlined/currency_exchange).
  */
 internal val CurrencyExchange: ImageVector
     get() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/CurrencyExchange.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/CurrencyExchange.kt
@@ -1,0 +1,120 @@
+@file:Suppress("MagicNumber", "ObjectPropertyName")
+
+package com.revenuecat.purchases.ui.revenuecatui.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * Exported from [Compose Icons](https://composeicons.com/icons/material-symbols/outlined/calendar_month).
+ */
+internal val CurrencyExchange: ImageVector
+    get() {
+        if (_Currency_exchange != null) {
+            return _Currency_exchange!!
+        }
+        _Currency_exchange = ImageVector.Builder(
+            name = "CurrencyExchange",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 960f,
+            viewportHeight = 960f,
+        ).apply {
+            path(
+                fill = SolidColor(Color.Black),
+                fillAlpha = 1.0f,
+                stroke = null,
+                strokeAlpha = 1.0f,
+                strokeLineWidth = 1.0f,
+                strokeLineCap = StrokeCap.Butt,
+                strokeLineJoin = StrokeJoin.Miter,
+                strokeLineMiter = 1.0f,
+                pathFillType = PathFillType.NonZero,
+            ) {
+                moveTo(480f, 920f)
+                quadToRelative(-112f, 0f, -206f, -51f)
+                reflectiveQuadTo(120f, 733f)
+                verticalLineToRelative(107f)
+                horizontalLineTo(40f)
+                verticalLineToRelative(-240f)
+                horizontalLineToRelative(240f)
+                verticalLineToRelative(80f)
+                horizontalLineToRelative(-99f)
+                quadToRelative(48f, 72f, 126.5f, 116f)
+                reflectiveQuadTo(480f, 840f)
+                quadToRelative(75f, 0f, 140.5f, -28.5f)
+                reflectiveQuadToRelative(114f, -77f)
+                reflectiveQuadToRelative(77f, -114f)
+                reflectiveQuadTo(840f, 480f)
+                horizontalLineToRelative(80f)
+                quadToRelative(0f, 91f, -34.5f, 171f)
+                reflectiveQuadTo(791f, 791f)
+                reflectiveQuadTo(651f, 885.5f)
+                reflectiveQuadTo(480f, 920f)
+                moveToRelative(-36f, -160f)
+                verticalLineToRelative(-52f)
+                quadToRelative(-47f, -11f, -76.5f, -40.5f)
+                reflectiveQuadTo(324f, 590f)
+                lineToRelative(66f, -26f)
+                quadToRelative(12f, 41f, 37.5f, 61.5f)
+                reflectiveQuadTo(486f, 646f)
+                reflectiveQuadToRelative(56.5f, -15.5f)
+                reflectiveQuadTo(566f, 582f)
+                quadToRelative(0f, -29f, -24.5f, -47f)
+                reflectiveQuadTo(454f, 494f)
+                quadToRelative(-59f, -21f, -86.5f, -50f)
+                reflectiveQuadTo(340f, 368f)
+                quadToRelative(0f, -41f, 28.5f, -74.5f)
+                reflectiveQuadTo(446f, 250f)
+                verticalLineToRelative(-50f)
+                horizontalLineToRelative(70f)
+                verticalLineToRelative(50f)
+                quadToRelative(36f, 3f, 65.5f, 29f)
+                reflectiveQuadToRelative(40.5f, 61f)
+                lineToRelative(-64f, 26f)
+                quadToRelative(-8f, -23f, -26f, -38.5f)
+                reflectiveQuadTo(482f, 312f)
+                quadToRelative(-35f, 0f, -53.5f, 15f)
+                reflectiveQuadTo(410f, 368f)
+                reflectiveQuadToRelative(23f, 41f)
+                reflectiveQuadToRelative(83f, 35f)
+                quadToRelative(72f, 26f, 96f, 61f)
+                reflectiveQuadToRelative(24f, 77f)
+                quadToRelative(0f, 29f, -10f, 51f)
+                reflectiveQuadToRelative(-26.5f, 37.5f)
+                reflectiveQuadToRelative(-38.5f, 25f)
+                reflectiveQuadToRelative(-47f, 14.5f)
+                verticalLineToRelative(50f)
+                close()
+                moveTo(40f, 480f)
+                quadToRelative(0f, -91f, 34.5f, -171f)
+                reflectiveQuadTo(169f, 169f)
+                reflectiveQuadToRelative(140f, -94.5f)
+                reflectiveQuadTo(480f, 40f)
+                quadToRelative(112f, 0f, 206f, 51f)
+                reflectiveQuadToRelative(154f, 136f)
+                verticalLineToRelative(-107f)
+                horizontalLineToRelative(80f)
+                verticalLineToRelative(240f)
+                horizontalLineTo(680f)
+                verticalLineToRelative(-80f)
+                horizontalLineToRelative(99f)
+                quadToRelative(-48f, -72f, -126.5f, -116f)
+                reflectiveQuadTo(480f, 120f)
+                quadToRelative(-75f, 0f, -140.5f, 28.5f)
+                reflectiveQuadToRelative(-114f, 77f)
+                reflectiveQuadToRelative(-77f, 114f)
+                reflectiveQuadTo(120f, 480f)
+                close()
+            }
+        }.build()
+        return _Currency_exchange!!
+    }
+
+private var _Currency_exchange: ImageVector? = null

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/UniversalCurrencyAlt.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/UniversalCurrencyAlt.kt
@@ -1,0 +1,81 @@
+@file:Suppress("MagicNumber", "ObjectPropertyName")
+
+package com.revenuecat.purchases.ui.revenuecatui.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * Exported from [Compose Icons](https://composeicons.com/icons/material-symbols/outlined/calendar_month).
+ */
+internal val UniversalCurrencyAlt: ImageVector
+    get() {
+        if (_Universal_currency_alt != null) {
+            return _Universal_currency_alt!!
+        }
+        _Universal_currency_alt = ImageVector.Builder(
+            name = "UniversalCurrencyAlt",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 960f,
+            viewportHeight = 960f,
+        ).apply {
+            path(
+                fill = SolidColor(Color.Black),
+                fillAlpha = 1.0f,
+                stroke = null,
+                strokeAlpha = 1.0f,
+                strokeLineWidth = 1.0f,
+                strokeLineCap = StrokeCap.Butt,
+                strokeLineJoin = StrokeJoin.Miter,
+                strokeLineMiter = 1.0f,
+                pathFillType = PathFillType.NonZero,
+            ) {
+                moveTo(600f, 640f)
+                horizontalLineToRelative(160f)
+                verticalLineToRelative(-160f)
+                horizontalLineToRelative(-60f)
+                verticalLineToRelative(100f)
+                horizontalLineTo(600f)
+                close()
+                moveToRelative(-120f, -40f)
+                quadToRelative(50f, 0f, 85f, -35f)
+                reflectiveQuadToRelative(35f, -85f)
+                reflectiveQuadToRelative(-35f, -85f)
+                reflectiveQuadToRelative(-85f, -35f)
+                reflectiveQuadToRelative(-85f, 35f)
+                reflectiveQuadToRelative(-35f, 85f)
+                reflectiveQuadToRelative(35f, 85f)
+                reflectiveQuadToRelative(85f, 35f)
+                moveTo(200f, 480f)
+                horizontalLineToRelative(60f)
+                verticalLineToRelative(-100f)
+                horizontalLineToRelative(100f)
+                verticalLineToRelative(-60f)
+                horizontalLineTo(200f)
+                close()
+                moveTo(80f, 760f)
+                verticalLineToRelative(-560f)
+                horizontalLineToRelative(800f)
+                verticalLineToRelative(560f)
+                close()
+                moveToRelative(80f, -80f)
+                horizontalLineToRelative(640f)
+                verticalLineToRelative(-400f)
+                horizontalLineTo(160f)
+                close()
+                moveToRelative(0f, 0f)
+                verticalLineToRelative(-400f)
+                close()
+            }
+        }.build()
+        return _Universal_currency_alt!!
+    }
+
+private var _Universal_currency_alt: ImageVector? = null

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/UniversalCurrencyAlt.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/UniversalCurrencyAlt.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 
 /**
- * Exported from [Compose Icons](https://composeicons.com/icons/material-symbols/outlined/calendar_month).
+ * Exported from [Compose Icons](https://composeicons.com/icons/material-symbols/outlined/universal_currency_alt).
  */
 internal val UniversalCurrencyAlt: ImageVector
     get() {


### PR DESCRIPTION
## In this PR

![image](https://github.com/user-attachments/assets/a516dab0-f45b-4109-9ddc-e240c5ef6946)

- A new `SubscriptionDetailsView` ☝️, modelled after the iOS namesake. (The black border is Android Studio's preview UI.)
- Slightly tweaked the `TopLevelPropertyNaming` Detekt rule to allow CamelCase constants, following the Compose guidelines. I modified [Detekt's recommendation](https://detekt.dev/docs/introduction/compose#toplevelpropertynaming-for-compose) to also allow SCREAMING_SNAKE_CASE, as we use that in other parts.

## Not in this PR
- Any logic to display the new `SubscriptionDetailsView`.

I was thinking we can update the design as we go, when we have a better idea of what this is going to look like, but let me know what you think!