### PR TITLE
[CustomerCenter] Add `CustomerCenterBottomSheet` 

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
@@ -28,12 +29,15 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.ui.debugview.DebugRevenueCatBottomSheet
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 @Composable
 fun AppInfoScreen(viewModel: AppInfoScreenViewModel = viewModel<AppInfoScreenViewModelImpl>()) {
     var isDebugBottomSheetVisible by remember { mutableStateOf(false) }
+    var isCustomerCenterBottomSheetVisible by remember { mutableStateOf(false) }
     var showLogInDialog by remember { mutableStateOf(false) }
 
     Column(
@@ -52,6 +56,9 @@ fun AppInfoScreen(viewModel: AppInfoScreenViewModel = viewModel<AppInfoScreenVie
         Button(onClick = { isDebugBottomSheetVisible = true }) {
             Text(text = "Show debug view")
         }
+        Button(onClick = { isCustomerCenterBottomSheetVisible = true }) {
+            Text(text = "Show customer center bottom sheet")
+        }
     }
 
     if (showLogInDialog) {
@@ -64,6 +71,16 @@ fun AppInfoScreen(viewModel: AppInfoScreenViewModel = viewModel<AppInfoScreenVie
         isVisible = isDebugBottomSheetVisible,
         onDismissCallback = { isDebugBottomSheetVisible = false },
     )
+
+    // CustomerCenter WIP: Uncomment once access to CustomerCenter is public.
+//    if (isCustomerCenterBottomSheetVisible) {
+//        val customerCenterSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+//
+//        CustomerCenterBottomSheet(
+//            onDismissRequest = { isCustomerCenterBottomSheetVisible = false },
+//            sheetState = customerCenterSheetState,
+//        )
+//    }
 }
 
 @Composable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterBottomSheet.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterBottomSheet.kt
@@ -1,0 +1,62 @@
+package com.revenuecat.purchases.ui.revenuecatui.customercenter
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+
+/**
+ * Composable offering a bottom sheet Customer Center UI configured from the RevenueCat dashboard.
+ */
+@ExperimentalPreviewRevenueCatUIPurchasesAPI
+@ExperimentalMaterial3Api
+@Composable
+// CustomerCenter WIP: Make public when ready
+internal fun CustomerCenterBottomSheet(
+    onDismissRequest: () -> Unit,
+    sheetState: SheetState,
+) {
+    CustomerCenterBottomSheetScaffold(
+        onDismissRequest,
+        sheetState,
+    ) {
+        InternalCustomerCenter()
+    }
+}
+
+private const val CUSTOMER_CENTER_BOTTOM_SHEET_MAX_HEIGHT_PERCENTAGE = 0.9f
+
+@ExperimentalMaterial3Api
+@Composable
+private fun CustomerCenterBottomSheetScaffold(
+    onDismissRequest: () -> Unit,
+    sheetState: SheetState,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = Modifier.fillMaxHeight(CUSTOMER_CENTER_BOTTOM_SHEET_MAX_HEIGHT_PERCENTAGE),
+        sheetState = sheetState,
+    ) {
+        content()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview
+@Composable
+internal fun CustomerCenterBottomSheetPreview() {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    CustomerCenterBottomSheetScaffold(
+        onDismissRequest = {},
+        sheetState = sheetState,
+    ) {
+        InternalCustomerCenter(getCustomerCenterViewModel(previewPurchases))
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -111,7 +111,7 @@ internal fun CustomerCenterLoadedPreview() {
 }
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
-private val previewPurchases = object : PurchasesType {
+internal val previewPurchases = object : PurchasesType {
     override suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult {
         error("Not implemented for preview")
     }


### PR DESCRIPTION
### Description
This adds a new composable `CustomerCenterBottomSheet` as an entry point for the customer center. This basically wraps the `CustomerCenter` composable into a bottom sheet, for convenience.
Additionally, it has some commented out code to display this bottom sheet in the paywall tester app. Need to make public the composables and uncomment to test it.