### PR TITLE
[CustomerCenter] Fix help path deserializing when unknown type

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -258,7 +258,7 @@ data class CustomerCenterConfigData(
         val type: ScreenType,
         val title: String,
         @Serializable(with = EmptyStringToNullSerializer::class) val subtitle: String? = null,
-        val paths: List<HelpPath>,
+        @Serializable(with = HelpPathsSerializer::class) val paths: List<HelpPath>,
     ) {
         @Serializable
         enum class ScreenType {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/HelpPathsSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/HelpPathsSerializer.kt
@@ -2,11 +2,8 @@ package com.revenuecat.purchases.customercenter
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.common.debugLog
-import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Screen
-import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Screen.ScreenType
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
@@ -15,7 +12,9 @@ import kotlinx.serialization.json.jsonArray
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal object HelpPathsSerializer : KSerializer<List<CustomerCenterConfigData.HelpPath>> {
-    override val descriptor: SerialDescriptor = MapSerializer(ScreenType.serializer(), Screen.serializer()).descriptor
+    override val descriptor: SerialDescriptor = ListSerializer(
+        CustomerCenterConfigData.HelpPath.serializer(),
+    ).descriptor
 
     override fun deserialize(decoder: Decoder): List<CustomerCenterConfigData.HelpPath> {
         val list = mutableListOf<CustomerCenterConfigData.HelpPath>()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/HelpPathsSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/HelpPathsSerializer.kt
@@ -12,7 +12,6 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 internal object HelpPathsSerializer : KSerializer<List<CustomerCenterConfigData.HelpPath>> {
@@ -25,7 +24,9 @@ internal object HelpPathsSerializer : KSerializer<List<CustomerCenterConfigData.
 
         jsonArray.forEach { jsonElement ->
             try {
-                list.add(jsonInput.json.decodeFromJsonElement(CustomerCenterConfigData.HelpPath.serializer(), jsonElement))
+                list.add(
+                    jsonInput.json.decodeFromJsonElement(CustomerCenterConfigData.HelpPath.serializer(), jsonElement),
+                )
             } catch (e: IllegalArgumentException) {
                 debugLog("Issue deserializing CustomerCenter HelpPath. Ignoring. Error: $e")
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/HelpPathsSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/HelpPathsSerializer.kt
@@ -1,0 +1,40 @@
+package com.revenuecat.purchases.customercenter
+
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Screen
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Screen.ScreenType
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+internal object HelpPathsSerializer : KSerializer<List<CustomerCenterConfigData.HelpPath>> {
+    override val descriptor: SerialDescriptor = MapSerializer(ScreenType.serializer(), Screen.serializer()).descriptor
+
+    override fun deserialize(decoder: Decoder): List<CustomerCenterConfigData.HelpPath> {
+        val list = mutableListOf<CustomerCenterConfigData.HelpPath>()
+        val jsonInput = decoder as? JsonDecoder ?: error("Can be deserialized only by JSON")
+        val jsonArray = jsonInput.decodeJsonElement().jsonArray
+
+        jsonArray.forEach { jsonElement ->
+            try {
+                list.add(jsonInput.json.decodeFromJsonElement(CustomerCenterConfigData.HelpPath.serializer(), jsonElement))
+            } catch (e: IllegalArgumentException) {
+                debugLog("Issue deserializing CustomerCenter HelpPath. Ignoring. Error: $e")
+            }
+        }
+
+        return list
+    }
+
+    override fun serialize(encoder: Encoder, value: List<CustomerCenterConfigData.HelpPath>) {
+        ListSerializer(CustomerCenterConfigData.HelpPath.serializer()).serialize(encoder, value)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/customercenter/CustomerCenterConfigDataTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/customercenter/CustomerCenterConfigDataTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.common.Backend
 import org.assertj.core.api.Assertions.assertThat
+import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
@@ -148,6 +149,36 @@ class CustomerCenterConfigDataTest {
         return Backend.json.decodeFromString(
             CustomerCenterRoot.serializer(),
             loadTestJSON()
+        ).customerCenter
+    }
+
+    @Test
+    fun `can parse json with unknown screen types`() {
+        val json = JSONObject(loadTestJSON())
+        val screens = json.getJSONObject("customer_center").getJSONObject("screens")
+        screens.put("random_screen_id", screens.getJSONObject("MANAGEMENT"))
+        val configData = createSampleConfigData(json.toString())
+        assertThat(configData.screens).hasSize(2)
+    }
+
+    @Test
+    fun `can parse json with unknown path types`() {
+        val json = JSONObject(loadTestJSON())
+        val managementScreenPaths = json
+            .getJSONObject("customer_center")
+            .getJSONObject("screens")
+            .getJSONObject("MANAGEMENT")
+            .getJSONArray("paths")
+        val firstPathClone = JSONObject(managementScreenPaths.getJSONObject(0).toString())
+        managementScreenPaths.put(firstPathClone.put("type", "UNKNOWN_PATH_TYPE"))
+        val configData = createSampleConfigData(json.toString())
+        assertThat(configData.screens[CustomerCenterConfigData.Screen.ScreenType.MANAGEMENT]!!.paths).hasSize(4)
+    }
+
+    private fun createSampleConfigData(json: String = loadTestJSON()): CustomerCenterConfigData {
+        return Backend.json.decodeFromString(
+            CustomerCenterRoot.serializer(),
+            json,
         ).customerCenter
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/customercenter/CustomerCenterConfigDataTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/customercenter/CustomerCenterConfigDataTest.kt
@@ -145,13 +145,6 @@ class CustomerCenterConfigDataTest {
         assertThat(support.email).isEqualTo("support@example.com")
     }
 
-    private fun createSampleConfigData(): CustomerCenterConfigData {
-        return Backend.json.decodeFromString(
-            CustomerCenterRoot.serializer(),
-            loadTestJSON()
-        ).customerCenter
-    }
-
     @Test
     fun `can parse json with unknown screen types`() {
         val json = JSONObject(loadTestJSON())


### PR DESCRIPTION
### Description
While testing one thing I noticed we were not handling unknown help path types. This basically caused the whole screen to not be deserialized, since we catch deserialization issues at that level, but we can do better than that and just not deserialize the unknown path type.