### PR TITLE
Save SDK configuration on paywall activity so it can reconfigure automatically

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -100,6 +100,8 @@ final class PurchasesAPI {
         final Store store = purchases.getStore();
 
         final String storefrontCountryCode = purchases.getStorefrontCountryCode();
+
+        final PurchasesConfiguration configuration = purchases.getLatestConfiguration();
     }
 
     static void check(final Purchases purchases, final Map<String, String> attributes) {

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -101,7 +101,7 @@ final class PurchasesAPI {
 
         final String storefrontCountryCode = purchases.getStorefrontCountryCode();
 
-        final PurchasesConfiguration configuration = purchases.getLatestConfiguration();
+        final PurchasesConfiguration configuration = purchases.getCurrentConfiguration();
     }
 
     static void check(final Purchases purchases, final Map<String, String> attributes) {

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -91,7 +91,7 @@ private class PurchasesAPI {
 
         val countryCode = purchases.storefrontCountryCode
 
-        val configuration: PurchasesConfiguration = purchases.latestConfiguration
+        val configuration: PurchasesConfiguration = purchases.currentConfiguration
     }
 
     @Suppress("LongMethod", "LongParameterList")

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -90,6 +90,8 @@ private class PurchasesAPI {
         val store: Store = purchases.store
 
         val countryCode = purchases.storefrontCountryCode
+
+        val configuration: PurchasesConfiguration = purchases.latestConfiguration
     }
 
     @Suppress("LongMethod", "LongParameterList")

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import androidx.annotation.VisibleForTesting
+import com.revenuecat.purchases.common.Config
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.infoLog
@@ -882,7 +883,12 @@ class Purchases internal constructor(
             configuration: PurchasesConfiguration,
         ): Purchases {
             if (isConfigured) {
-                infoLog(ConfigureStrings.INSTANCE_ALREADY_EXISTS)
+                if (backingFieldSharedInstance?.purchasesOrchestrator?.configuration == configuration) {
+                    infoLog(ConfigureStrings.INSTANCE_ALREADY_EXISTS_WITH_SAME_CONFIG)
+                    return sharedInstance
+                } else {
+                    infoLog(ConfigureStrings.INSTANCE_ALREADY_EXISTS)
+                }
             }
             return PurchasesFactory().createPurchases(
                 configuration,

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -41,8 +41,8 @@ class Purchases internal constructor(
     /**
      * The configuration that was used to start Purchases.
      */
-    val configuration: PurchasesConfiguration
-        get() = purchasesOrchestrator.getLatestConfiguration()
+    val latestConfiguration: PurchasesConfiguration
+        get() = purchasesOrchestrator.latestConfiguration
 
     /**
      * Default to TRUE, set this to FALSE if you are consuming and acknowledging transactions
@@ -889,7 +889,7 @@ class Purchases internal constructor(
             configuration: PurchasesConfiguration,
         ): Purchases {
             if (isConfigured) {
-                if (backingFieldSharedInstance?.purchasesOrchestrator?.configuration == configuration) {
+                if (backingFieldSharedInstance?.purchasesOrchestrator?.latestConfiguration == configuration) {
                     infoLog(ConfigureStrings.INSTANCE_ALREADY_EXISTS_WITH_SAME_CONFIG)
                     return sharedInstance
                 } else {

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -38,6 +38,11 @@ import java.net.URL
 class Purchases internal constructor(
     @get:JvmSynthetic internal val purchasesOrchestrator: PurchasesOrchestrator,
 ) : LifecycleDelegate {
+    /**
+     * The configuration that was used to start Purchases.
+     */
+    val configuration: PurchasesConfiguration
+        get() = purchasesOrchestrator.getLatestConfiguration()
 
     /**
      * Default to TRUE, set this to FALSE if you are consuming and acknowledging transactions

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -39,10 +39,10 @@ class Purchases internal constructor(
     @get:JvmSynthetic internal val purchasesOrchestrator: PurchasesOrchestrator,
 ) : LifecycleDelegate {
     /**
-     * The configuration that was used to start Purchases.
+     * The current configuration parameters of the Purchases SDK.
      */
-    val latestConfiguration: PurchasesConfiguration
-        get() = purchasesOrchestrator.latestConfiguration
+    val currentConfiguration: PurchasesConfiguration
+        get() = purchasesOrchestrator.currentConfiguration
 
     /**
      * Default to TRUE, set this to FALSE if you are consuming and acknowledging transactions
@@ -889,7 +889,7 @@ class Purchases internal constructor(
             configuration: PurchasesConfiguration,
         ): Purchases {
             if (isConfigured) {
-                if (backingFieldSharedInstance?.purchasesOrchestrator?.latestConfiguration == configuration) {
+                if (backingFieldSharedInstance?.purchasesOrchestrator?.currentConfiguration == configuration) {
                     infoLog(ConfigureStrings.INSTANCE_ALREADY_EXISTS_WITH_SAME_CONFIG)
                     return sharedInstance
                 } else {

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import androidx.annotation.VisibleForTesting
-import com.revenuecat.purchases.common.Config
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
 import com.revenuecat.purchases.common.infoLog
@@ -63,7 +62,9 @@ class Purchases internal constructor(
         @Synchronized get() =
             if (purchasesOrchestrator.finishTransactions) {
                 PurchasesAreCompletedBy.REVENUECAT
-            } else PurchasesAreCompletedBy.MY_APP
+            } else {
+                PurchasesAreCompletedBy.MY_APP
+            }
 
         @Synchronized set(value) {
             purchasesOrchestrator.finishTransactions = when (value) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/DangerousSettings.kt
@@ -1,8 +1,12 @@
 package com.revenuecat.purchases
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /**
  * Only use a Dangerous Setting if suggested by RevenueCat support team.
  */
+@Parcelize
 data class DangerousSettings internal constructor(
     /**
      * Disable or enable syncing purchases automatically. If this is disabled, RevenueCat will not sync any purchase
@@ -12,6 +16,6 @@ data class DangerousSettings internal constructor(
     val autoSyncPurchases: Boolean = true,
 
     internal val customEntitlementComputation: Boolean = false,
-) {
+) : Parcelable {
     constructor(autoSyncPurchases: Boolean = true) : this(autoSyncPurchases, false)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -36,7 +36,7 @@ open class PurchasesConfiguration(builder: Builder) {
     val pendingTransactionsForPrepaidPlansEnabled: Boolean
 
     init {
-        this.context = builder.context
+        this.context = builder.context.applicationContext
         this.apiKey = builder.apiKey.trim()
         this.appUserID = builder.appUserID
         this.purchasesAreCompletedBy = builder.purchasesAreCompletedBy

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -49,6 +49,8 @@ open class PurchasesConfiguration(builder: Builder) {
         this.pendingTransactionsForPrepaidPlansEnabled = builder.pendingTransactionsForPrepaidPlansEnabled
     }
 
+
+
     @SuppressWarnings("TooManyFunctions")
     open class Builder(
         @get:JvmSynthetic internal val context: Context,
@@ -237,5 +239,41 @@ open class PurchasesConfiguration(builder: Builder) {
         open fun build(): PurchasesConfiguration {
             return PurchasesConfiguration(this)
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as PurchasesConfiguration
+
+        if (context != other.context) return false
+        if (apiKey != other.apiKey) return false
+        if (appUserID != other.appUserID) return false
+        if (purchasesAreCompletedBy != other.purchasesAreCompletedBy) return false
+        if (showInAppMessagesAutomatically != other.showInAppMessagesAutomatically) return false
+        if (service != other.service) return false
+        if (store != other.store) return false
+        if (diagnosticsEnabled != other.diagnosticsEnabled) return false
+        if (dangerousSettings != other.dangerousSettings) return false
+        if (verificationMode != other.verificationMode) return false
+        if (pendingTransactionsForPrepaidPlansEnabled != other.pendingTransactionsForPrepaidPlansEnabled) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = context.hashCode()
+        result = 31 * result + apiKey.hashCode()
+        result = 31 * result + (appUserID?.hashCode() ?: 0)
+        result = 31 * result + purchasesAreCompletedBy.hashCode()
+        result = 31 * result + showInAppMessagesAutomatically.hashCode()
+        result = 31 * result + (service?.hashCode() ?: 0)
+        result = 31 * result + store.hashCode()
+        result = 31 * result + diagnosticsEnabled.hashCode()
+        result = 31 * result + dangerousSettings.hashCode()
+        result = 31 * result + verificationMode.hashCode()
+        result = 31 * result + pendingTransactionsForPrepaidPlansEnabled.hashCode()
+        return result
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -49,6 +49,25 @@ open class PurchasesConfiguration(builder: Builder) {
         this.pendingTransactionsForPrepaidPlansEnabled = builder.pendingTransactionsForPrepaidPlansEnabled
     }
 
+    internal fun copy(
+        appUserID: String? = this.appUserID,
+        service: ExecutorService? = this.service,
+    ): PurchasesConfiguration {
+        var builder = Builder(context, apiKey)
+            .appUserID(appUserID)
+            .purchasesAreCompletedBy(purchasesAreCompletedBy)
+            .store(store)
+            .diagnosticsEnabled(diagnosticsEnabled)
+            .entitlementVerificationMode(verificationMode)
+            .dangerousSettings(dangerousSettings)
+            .showInAppMessagesAutomatically(showInAppMessagesAutomatically)
+            .pendingTransactionsForPrepaidPlansEnabled(pendingTransactionsForPrepaidPlansEnabled)
+        if (service != null) {
+            builder = builder.service(service)
+        }
+        return builder.build()
+    }
+
     @SuppressWarnings("TooManyFunctions")
     open class Builder(
         @get:JvmSynthetic internal val context: Context,
@@ -247,12 +266,10 @@ open class PurchasesConfiguration(builder: Builder) {
 
         other as PurchasesConfiguration
 
-        if (context != other.context) return false
         if (apiKey != other.apiKey) return false
         if (appUserID != other.appUserID) return false
         if (purchasesAreCompletedBy != other.purchasesAreCompletedBy) return false
         if (showInAppMessagesAutomatically != other.showInAppMessagesAutomatically) return false
-        if (service != other.service) return false
         if (store != other.store) return false
         if (diagnosticsEnabled != other.diagnosticsEnabled) return false
         if (dangerousSettings != other.dangerousSettings) return false
@@ -263,12 +280,10 @@ open class PurchasesConfiguration(builder: Builder) {
     }
 
     override fun hashCode(): Int {
-        var result = context.hashCode()
-        result = 31 * result + apiKey.hashCode()
+        var result = apiKey.hashCode()
         result = 31 * result + (appUserID?.hashCode() ?: 0)
         result = 31 * result + purchasesAreCompletedBy.hashCode()
         result = 31 * result + showInAppMessagesAutomatically.hashCode()
-        result = 31 * result + (service?.hashCode() ?: 0)
         result = 31 * result + store.hashCode()
         result = 31 * result + diagnosticsEnabled.hashCode()
         result = 31 * result + dangerousSettings.hashCode()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -49,8 +49,6 @@ open class PurchasesConfiguration(builder: Builder) {
         this.pendingTransactionsForPrepaidPlansEnabled = builder.pendingTransactionsForPrepaidPlansEnabled
     }
 
-
-
     @SuppressWarnings("TooManyFunctions")
     open class Builder(
         @get:JvmSynthetic internal val context: Context,
@@ -119,7 +117,9 @@ open class PurchasesConfiguration(builder: Builder) {
             purchasesAreCompletedBy(
                 if (observerMode) {
                     PurchasesAreCompletedBy.MY_APP
-                } else PurchasesAreCompletedBy.REVENUECAT,
+                } else {
+                    PurchasesAreCompletedBy.REVENUECAT
+                },
             )
         }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -284,7 +284,7 @@ internal class PurchasesFactory(
                 paywallPresentedCache,
                 purchasesStateProvider,
                 dispatcher = dispatcher,
-                configuration = configuration,
+                initialConfiguration = configuration,
             )
 
             return Purchases(purchasesOrchestrator)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -284,6 +284,7 @@ internal class PurchasesFactory(
                 paywallPresentedCache,
                 purchasesStateProvider,
                 dispatcher = dispatcher,
+                configuration = configuration,
             )
 
             return Purchases(purchasesOrchestrator)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -111,7 +111,7 @@ internal class PurchasesOrchestrator(
             purchasesStateCache.purchasesState = value
         }
 
-    val latestConfiguration: PurchasesConfiguration
+    val currentConfiguration: PurchasesConfiguration
         get() = if (initialConfiguration.appUserID == null) {
             initialConfiguration
         } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -101,7 +101,7 @@ internal class PurchasesOrchestrator(
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper()),
     private val dispatcher: Dispatcher,
-    internal val configuration: PurchasesConfiguration,
+    private val initialConfiguration: PurchasesConfiguration,
 ) : LifecycleDelegate, CustomActivityLifecycleHandler {
 
     internal var state: PurchasesState
@@ -109,6 +109,13 @@ internal class PurchasesOrchestrator(
 
         set(value) {
             purchasesStateCache.purchasesState = value
+        }
+
+    val latestConfiguration: PurchasesConfiguration
+        get() = if (initialConfiguration.appUserID == null) {
+            initialConfiguration
+        } else {
+            initialConfiguration.copy(appUserID = this.appUserID)
         }
 
     var finishTransactions: Boolean
@@ -228,10 +235,6 @@ internal class PurchasesOrchestrator(
         if (appConfig.showInAppMessagesAutomatically) {
             showInAppMessagesIfNeeded(activity, InAppMessageType.values().toList())
         }
-    }
-
-    fun getLatestConfiguration(): PurchasesConfiguration {
-        return configuration.copy(appUserID = this.appUserID)
     }
 
     // region Public Methods

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -101,6 +101,7 @@ internal class PurchasesOrchestrator(
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper()),
     private val dispatcher: Dispatcher,
+    internal val configuration: PurchasesConfiguration,
 ) : LifecycleDelegate, CustomActivityLifecycleHandler {
 
     internal var state: PurchasesState

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -230,6 +230,10 @@ internal class PurchasesOrchestrator(
         }
     }
 
+    fun getLatestConfiguration(): PurchasesConfiguration {
+        return configuration.copy(appUserID = this.appUserID)
+    }
+
     // region Public Methods
 
     fun syncAttributesAndOfferingsIfNeeded(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/ConfigureStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/ConfigureStrings.kt
@@ -36,4 +36,6 @@ internal object ConfigureStrings {
         "purchase."
     const val INSTANCE_ALREADY_EXISTS = "Purchases instance already set. " +
         "Did you mean to configure two Purchases objects?"
+    const val INSTANCE_ALREADY_EXISTS_WITH_SAME_CONFIG = "Purchases instance already set with the same configuration. " +
+        "Ignoring duplicate call."
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/ConfigureStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/ConfigureStrings.kt
@@ -36,6 +36,6 @@ internal object ConfigureStrings {
         "purchase."
     const val INSTANCE_ALREADY_EXISTS = "Purchases instance already set. " +
         "Did you mean to configure two Purchases objects?"
-    const val INSTANCE_ALREADY_EXISTS_WITH_SAME_CONFIG = "Purchases instance already set with the same configuration. " +
-        "Ignoring duplicate call."
+    const val INSTANCE_ALREADY_EXISTS_WITH_SAME_CONFIG = "Purchases instance already set with the same " +
+        "configuration. Ignoring duplicate call."
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -408,6 +408,7 @@ internal open class BasePurchasesTest {
             paywallPresentedCache = paywallPresentedCache,
             purchasesStateCache = purchasesStateProvider,
             dispatcher = SyncDispatcher(),
+            configuration = PurchasesConfiguration.Builder(mockContext, "api_key").build()
         )
         purchases = Purchases(purchasesOrchestrator)
         Purchases.sharedInstance = purchases

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -55,7 +55,9 @@ internal open class BasePurchasesTest {
     protected val mockBackend: Backend = mockk()
     protected val mockCache: DeviceCache = mockk()
     protected val updatedCustomerInfoListener: UpdatedCustomerInfoListener = mockk()
-    private val mockApplication = mockk<Application>(relaxed = true)
+    private val mockApplication = mockk<Application>(relaxed = true).apply {
+        every { applicationContext } returns this
+    }
     protected val mockContext = mockk<Context>(relaxed = true).apply {
         every {
             applicationContext
@@ -408,7 +410,7 @@ internal open class BasePurchasesTest {
             paywallPresentedCache = paywallPresentedCache,
             purchasesStateCache = purchasesStateProvider,
             dispatcher = SyncDispatcher(),
-            configuration = PurchasesConfiguration.Builder(mockContext, "api_key").build()
+            initialConfiguration = PurchasesConfiguration.Builder(mockContext, "api_key").build()
         )
         purchases = Purchases(purchasesOrchestrator)
         Purchases.sharedInstance = purchases

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.PurchasesAreCompletedBy.MY_APP
 import com.revenuecat.purchases.PurchasesAreCompletedBy.REVENUECAT
+import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -17,12 +18,15 @@ class PurchasesConfigurationTest {
     private val apiKey = "test-api-key"
 
     private lateinit var context: Context
+    private lateinit var applicationContext: Context
 
     private lateinit var builder: PurchasesConfiguration.Builder
 
     @Before
     fun setup() {
         context = mockk()
+        applicationContext = mockk()
+        every { context.applicationContext } returns applicationContext
 
         builder = PurchasesConfiguration.Builder(context, apiKey)
     }
@@ -31,7 +35,7 @@ class PurchasesConfigurationTest {
     fun `PurchasesConfiguration has expected default parameters`() {
         val purchasesConfiguration = builder.build()
         assertThat(purchasesConfiguration.apiKey).isEqualTo(apiKey)
-        assertThat(purchasesConfiguration.context).isEqualTo(context)
+        assertThat(purchasesConfiguration.context).isEqualTo(applicationContext)
         assertThat(purchasesConfiguration.appUserID).isNull()
         assertThat(purchasesConfiguration.observerMode).isFalse
         assertThat(purchasesConfiguration.purchasesAreCompletedBy).isEqualTo(REVENUECAT)

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -20,7 +20,10 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class PurchasesFactoryTest {
 
-    private val contextMock = mockk<Context>()
+    private val applicationMock = mockk<Context>()
+    private val contextMock = mockk<Context>().apply {
+        every { applicationContext } returns applicationMock
+    }
     private val apiKeyValidatorMock = mockk<APIKeyValidator>()
 
     private lateinit var purchasesFactory: PurchasesFactory
@@ -41,7 +44,7 @@ class PurchasesFactoryTest {
     fun `creating purchase checks context has INTERNET permission`() {
         val configuration = createConfiguration()
         every {
-            contextMock.checkCallingOrSelfPermission(Manifest.permission.INTERNET)
+            applicationMock.checkCallingOrSelfPermission(Manifest.permission.INTERNET)
         } returns PackageManager.PERMISSION_DENIED
         assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
             purchasesFactory.validateConfiguration(configuration)
@@ -52,7 +55,7 @@ class PurchasesFactoryTest {
     fun `creating purchase checks api key is not empty`() {
         val configuration = createConfiguration(testApiKey = "")
         every {
-            contextMock.checkCallingOrSelfPermission(Manifest.permission.INTERNET)
+            applicationMock.checkCallingOrSelfPermission(Manifest.permission.INTERNET)
         } returns PackageManager.PERMISSION_GRANTED
         assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
             purchasesFactory.validateConfiguration(configuration)
@@ -64,10 +67,10 @@ class PurchasesFactoryTest {
         val configuration = createConfiguration()
         val nonApplicationContextMock = mockk<Context>()
         every {
-            contextMock.checkCallingOrSelfPermission(Manifest.permission.INTERNET)
+            applicationMock.checkCallingOrSelfPermission(Manifest.permission.INTERNET)
         } returns PackageManager.PERMISSION_GRANTED
         every {
-            contextMock.applicationContext
+            applicationMock.applicationContext
         } returns nonApplicationContextMock
         assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
             purchasesFactory.validateConfiguration(configuration)
@@ -79,10 +82,10 @@ class PurchasesFactoryTest {
         val configuration = createConfiguration()
         val applicationContextMock = mockk<Application>()
         every {
-            contextMock.checkCallingOrSelfPermission(Manifest.permission.INTERNET)
+            applicationMock.checkCallingOrSelfPermission(Manifest.permission.INTERNET)
         } returns PackageManager.PERMISSION_GRANTED
         every {
-            contextMock.applicationContext
+            applicationMock.applicationContext
         } returns applicationContextMock
         purchasesFactory.validateConfiguration(configuration)
         verify(exactly = 1) { apiKeyValidatorMock.validateAndLog("fakeApiKey", Store.PLAY_STORE) }

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesConfigureTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesConfigureTest.kt
@@ -10,6 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.PurchasesAreCompletedBy.MY_APP
 import com.revenuecat.purchases.PurchasesAreCompletedBy.REVENUECAT
 import com.revenuecat.purchases.common.PlatformInfo
+import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -135,13 +136,13 @@ internal class PurchasesConfigureTest : BasePurchasesTest() {
     }
 
     @Test
-    fun `configurations with different contexts are not equal`() {
+    fun `configurations with different contexts are equal`() {
         val context1 = mockContext
-        val context2 = mockk<Context>()
+        val context2 = mockk<Context>().apply { every { applicationContext } returns mockk() }
         val config1 = PurchasesConfiguration.Builder(context1, "api_key").build()
         val config2 = PurchasesConfiguration.Builder(context2, "api_key").build()
 
-        assertThat(config1).isNotEqualTo(config2)
+        assertThat(config1).isEqualTo(config2)
     }
 
     @Test

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -109,7 +109,7 @@ class SubscriberAttributesPurchasesTests {
             paywallPresentedCache = PaywallPresentedCache(),
             purchasesStateCache = PurchasesStateCache(PurchasesState()),
             dispatcher = SyncDispatcher(),
-            configuration = PurchasesConfiguration.Builder(context, "mock-api-key").build(),
+            initialConfiguration = PurchasesConfiguration.Builder(context, "mock-api-key").build(),
         )
 
         underTest = Purchases(purchasesOrchestrator)

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.PostTransactionWithProductDetailsHelper
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesAreCompletedBy.REVENUECAT
+import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.PurchasesOrchestrator
 import com.revenuecat.purchases.PurchasesState
 import com.revenuecat.purchases.PurchasesStateCache
@@ -84,8 +85,10 @@ class SubscriberAttributesPurchasesTests {
             postTransactionHelper,
         )
 
+        val context = mockk<Application>(relaxed = true).also { applicationMock = it }
+
         val purchasesOrchestrator = PurchasesOrchestrator(
-            application = mockk<Application>(relaxed = true).also { applicationMock = it },
+            application = context,
             backingFieldAppUserID = appUserId,
             backend = backendMock,
             billing = billingWrapperMock,
@@ -106,6 +109,7 @@ class SubscriberAttributesPurchasesTests {
             paywallPresentedCache = PaywallPresentedCache(),
             purchasesStateCache = PurchasesStateCache(PurchasesState()),
             dispatcher = SyncDispatcher(),
+            configuration = PurchasesConfiguration.Builder(context, "mock-api-key").build(),
         )
 
         underTest = Purchases(purchasesOrchestrator)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -74,12 +74,8 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
     ) : Parcelable
 
     private fun getSdkConfigArgs(savedInstanceState: Bundle): SdkConfigArgs? {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            savedInstanceState.getParcelable(SDK_CONFIG_EXTRA, SdkConfigArgs::class.java)
-        } else {
-            @Suppress("DEPRECATION")
-            savedInstanceState.getParcelable(SDK_CONFIG_EXTRA)
-        }
+        @Suppress("DEPRECATION")
+        return savedInstanceState.getParcelable(SDK_CONFIG_EXTRA)
     }
 
     private fun getFontProvider(): FontProvider? {
@@ -183,7 +179,7 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
     private fun configureSdkWithSavedData(savedInstanceState: Bundle) {
         val sdkConfigArgs = getSdkConfigArgs(savedInstanceState)
         if (sdkConfigArgs == null) {
-            Logger.e("TEST: Missing SDK configuration arguments")
+            Logger.e("Missing SDK configuration arguments while restoring PaywallActivity")
             return
         }
         Purchases.configure(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -131,7 +131,7 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
 
     override fun onSaveInstanceState(outState: Bundle) {
         if (Purchases.isConfigured) {
-            val configuration = Purchases.sharedInstance.latestConfiguration
+            val configuration = Purchases.sharedInstance.currentConfiguration
             outState.putParcelable(
                 SDK_CONFIG_EXTRA,
                 SdkConfigArgs(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui.activity
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.Window
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -18,8 +19,14 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.googlefonts.Font
 import androidx.compose.ui.text.googlefonts.GoogleFont
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.DangerousSettings
+import com.revenuecat.purchases.EntitlementVerificationMode
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesAreCompletedBy
+import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
@@ -28,14 +35,18 @@ import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
 import com.revenuecat.purchases.ui.revenuecatui.fonts.GoogleFontProvider
 import com.revenuecat.purchases.ui.revenuecatui.fonts.PaywallFont
 import com.revenuecat.purchases.ui.revenuecatui.fonts.TypographyType
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import kotlinx.parcelize.Parcelize
 
 /**
  * Wrapper activity around [Paywall] that allows using it when you are not using Jetpack Compose directly.
  * It receives the [PaywallActivityArgs] as an extra and returns the [PaywallResult] as a result.
  */
+@Suppress("TooManyFunctions")
 internal class PaywallActivity : ComponentActivity(), PaywallListener {
     companion object {
         const val ARGS_EXTRA = "paywall_args"
+        const val SDK_CONFIG_EXTRA = "sdk_config_args"
 
         const val RESULT_EXTRA = "paywall_result"
     }
@@ -46,6 +57,28 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
         } else {
             @Suppress("DEPRECATION")
             intent.getParcelableExtra(ARGS_EXTRA)
+        }
+    }
+
+    @Parcelize
+    private data class SdkConfigArgs(
+        val apiKey: String,
+        val appUserId: String?,
+        val purchasesAreCompletedBy: PurchasesAreCompletedBy,
+        val showInAppMessagesAutomatically: Boolean,
+        val store: Store,
+        val diagnosticsEnabled: Boolean,
+        val verificationMode: EntitlementVerificationMode,
+        val dangerousSettings: DangerousSettings,
+        val pendingTransactionsForPrepaidPlansEnabled: Boolean,
+    ) : Parcelable
+
+    private fun getSdkConfigArgs(savedInstanceState: Bundle): SdkConfigArgs? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            savedInstanceState.getParcelable(SDK_CONFIG_EXTRA, SdkConfigArgs::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            savedInstanceState.getParcelable(SDK_CONFIG_EXTRA)
         }
     }
 
@@ -79,6 +112,9 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         requestWindowFeature(Window.FEATURE_NO_TITLE)
         super.onCreate(savedInstanceState)
+        if (!Purchases.isConfigured && savedInstanceState != null) {
+            configureSdkWithSavedData(savedInstanceState)
+        }
         val args = getArgs()
         val paywallOptions = PaywallOptions.Builder(dismissRequest = ::finish)
             .setOfferingId(args?.offeringId)
@@ -95,6 +131,27 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
                 }
             }
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        if (Purchases.isConfigured) {
+            val configuration = Purchases.sharedInstance.configuration
+            outState.putParcelable(
+                SDK_CONFIG_EXTRA,
+                SdkConfigArgs(
+                    configuration.apiKey,
+                    configuration.appUserID,
+                    configuration.purchasesAreCompletedBy,
+                    configuration.showInAppMessagesAutomatically,
+                    configuration.store,
+                    configuration.diagnosticsEnabled,
+                    configuration.verificationMode,
+                    configuration.dangerousSettings,
+                    configuration.pendingTransactionsForPrepaidPlansEnabled,
+                ),
+            )
+        }
+        super.onSaveInstanceState(outState)
     }
 
     override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
@@ -121,6 +178,26 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
 
     override fun onRestoreError(error: PurchasesError) {
         setResult(RESULT_OK, createResultIntent(PaywallResult.Error(error)))
+    }
+
+    private fun configureSdkWithSavedData(savedInstanceState: Bundle) {
+        val sdkConfigArgs = getSdkConfigArgs(savedInstanceState)
+        if (sdkConfigArgs == null) {
+            Logger.e("TEST: Missing SDK configuration arguments")
+            return
+        }
+        Purchases.configure(
+            PurchasesConfiguration.Builder(this, sdkConfigArgs.apiKey)
+                .appUserID(sdkConfigArgs.appUserId)
+                .purchasesAreCompletedBy(sdkConfigArgs.purchasesAreCompletedBy)
+                .showInAppMessagesAutomatically(sdkConfigArgs.showInAppMessagesAutomatically)
+                .store(sdkConfigArgs.store)
+                .diagnosticsEnabled(sdkConfigArgs.diagnosticsEnabled)
+                .entitlementVerificationMode(sdkConfigArgs.verificationMode)
+                .dangerousSettings(sdkConfigArgs.dangerousSettings)
+                .pendingTransactionsForPrepaidPlansEnabled(sdkConfigArgs.pendingTransactionsForPrepaidPlansEnabled)
+                .build(),
+        )
     }
 
     private fun createResultIntent(result: PaywallResult): Intent {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -131,7 +131,7 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
 
     override fun onSaveInstanceState(outState: Bundle) {
         if (Purchases.isConfigured) {
-            val configuration = Purchases.sharedInstance.configuration
+            val configuration = Purchases.sharedInstance.latestConfiguration
             outState.putParcelable(
                 SDK_CONFIG_EXTRA,
                 SdkConfigArgs(


### PR DESCRIPTION
### Description
In here we store the latest known state for `Purchases` so we can reconfigure when displaying the `PaywallActivity` and the SDK is not configured. This may happen if the app is killed while displaying the `PaywallActivity`, the developer is not configuring in the application but on an activity and the user returns through the app through the recent apps menu.

Additionally, it includes the changes from #1866 so we avoid reconfiguring the SDK if the configuration parameters are the same.