### PR TITLE
Adds X-Is-Debug-Build header

### DIFF
--- a/purchases/src/androidTest/kotlin/com/revenuecat/purchases/purchasesExtensions.kt
+++ b/purchases/src/androidTest/kotlin/com/revenuecat/purchases/purchasesExtensions.kt
@@ -9,7 +9,7 @@ internal fun Purchases.Companion.configure(
     forceServerErrors: Boolean = false,
     forceSigningErrors: Boolean = false,
 ): Purchases {
-    return PurchasesFactory(isDebugBuild = { false }).createPurchases(
+    return PurchasesFactory(isDebugBuild = { true }).createPurchases(
         configuration,
         platformInfo,
         proxyURL,

--- a/purchases/src/androidTest/kotlin/com/revenuecat/purchases/purchasesExtensions.kt
+++ b/purchases/src/androidTest/kotlin/com/revenuecat/purchases/purchasesExtensions.kt
@@ -9,7 +9,7 @@ internal fun Purchases.Companion.configure(
     forceServerErrors: Boolean = false,
     forceSigningErrors: Boolean = false,
 ): Purchases {
-    return PurchasesFactory().createPurchases(
+    return PurchasesFactory(isDebugBuild = { false }).createPurchases(
         configuration,
         platformInfo,
         proxyURL,

--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.models.InAppMessageType
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.strings.ConfigureStrings
+import com.revenuecat.purchases.utils.DefaultIsDebugBuildProvider
 import java.net.URL
 
 /**
@@ -282,7 +283,9 @@ class Purchases internal constructor(
                 .dangerousSettings(DangerousSettings(customEntitlementComputation = true))
                 .pendingTransactionsForPrepaidPlansEnabled(true)
                 .build()
-            return PurchasesFactory().createPurchases(
+            return PurchasesFactory(
+                isDebugBuild = DefaultIsDebugBuildProvider(context),
+            ).createPurchases(
                 configuration,
                 platformInfo,
                 proxyURL,

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -25,6 +25,7 @@ import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.strings.ConfigureStrings
+import com.revenuecat.purchases.utils.DefaultIsDebugBuildProvider
 import java.net.URL
 
 /**
@@ -62,7 +63,9 @@ class Purchases internal constructor(
         @Synchronized get() =
             if (purchasesOrchestrator.finishTransactions) {
                 PurchasesAreCompletedBy.REVENUECAT
-            } else PurchasesAreCompletedBy.MY_APP
+            } else {
+                PurchasesAreCompletedBy.MY_APP
+            }
 
         @Synchronized set(value) {
             purchasesOrchestrator.finishTransactions = when (value) {
@@ -884,7 +887,9 @@ class Purchases internal constructor(
             if (isConfigured) {
                 infoLog(ConfigureStrings.INSTANCE_ALREADY_EXISTS)
             }
-            return PurchasesFactory().createPurchases(
+            return PurchasesFactory(
+                isDebugBuild = DefaultIsDebugBuildProvider(configuration.context),
+            ).createPurchases(
                 configuration,
                 platformInfo,
                 proxyURL,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -42,6 +42,7 @@ import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesPoster
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
 import com.revenuecat.purchases.utils.CoilImageDownloader
 import com.revenuecat.purchases.utils.EventsFileHelper
+import com.revenuecat.purchases.utils.IsDebugBuildProvider
 import com.revenuecat.purchases.utils.OfferingImagePreDownloader
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import java.net.URL
@@ -50,6 +51,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 
 internal class PurchasesFactory(
+    private val isDebugBuild: IsDebugBuildProvider,
     private val apiKeyValidator: APIKeyValidator = APIKeyValidator(),
 ) {
 
@@ -74,7 +76,7 @@ internal class PurchasesFactory(
                 platformInfo,
                 proxyURL,
                 store,
-                isDebugBuild = false, // TODO actually determine this!
+                isDebugBuild(),
                 dangerousSettings,
                 runningIntegrationTests,
                 forceServerErrors,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -74,6 +74,7 @@ internal class PurchasesFactory(
                 platformInfo,
                 proxyURL,
                 store,
+                isDebugBuild = false, // TODO actually determine this!
                 dangerousSettings,
                 runningIntegrationTests,
                 forceServerErrors,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/AppConfig.kt
@@ -16,6 +16,7 @@ internal class AppConfig(
     val platformInfo: PlatformInfo,
     proxyURL: URL?,
     val store: Store,
+    val isDebugBuild: Boolean,
     val dangerousSettings: DangerousSettings = DangerousSettings(autoSyncPurchases = true),
     // Should only be used for tests
     private val runningTests: Boolean = false,
@@ -47,6 +48,7 @@ internal class AppConfig(
     val playStoreVersionName = context.playStoreVersionName
     val playServicesVersionName = context.playServicesVersionName
 
+    @Suppress("CyclomaticComplexMethod")
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -55,6 +57,7 @@ internal class AppConfig(
 
         if (platformInfo != other.platformInfo) return false
         if (store != other.store) return false
+        if (isDebugBuild != other.isDebugBuild) return false
         if (dangerousSettings != other.dangerousSettings) return false
         if (languageTag != other.languageTag) return false
         if (versionName != other.versionName) return false
@@ -71,6 +74,7 @@ internal class AppConfig(
     override fun hashCode(): Int {
         var result = platformInfo.hashCode()
         result = 31 * result + store.hashCode()
+        result = 31 * result + isDebugBuild.hashCode()
         result = 31 * result + dangerousSettings.hashCode()
         result = 31 * result + languageTag.hashCode()
         result = 31 * result + versionName.hashCode()
@@ -87,6 +91,7 @@ internal class AppConfig(
         return "AppConfig(" +
             "platformInfo=$platformInfo, " +
             "store=$store, " +
+            "isDebugBuild=$isDebugBuild, " +
             "dangerousSettings=$dangerousSettings, " +
             "languageTag='$languageTag', " +
             "versionName='$versionName', " +

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -279,6 +279,7 @@ internal class HTTPClient(
             HTTPRequest.POST_PARAMS_HASH to postFieldsToSignHeader,
             "X-Custom-Entitlements-Computation" to if (appConfig.customEntitlementComputation) "true" else null,
             "X-Storefront" to storefrontProvider.getStorefront(),
+            "X-Is-Debug-Build" to appConfig.isDebugBuild.toString(),
         )
             .plus(authenticationHeaders)
             .plus(eTagManager.getETagHeaders(urlPath, shouldSignResponse, refreshETag))

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/IsDebugBuildProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/IsDebugBuildProvider.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.purchases.utils
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+
+internal fun interface IsDebugBuildProvider {
+    operator fun invoke(): Boolean
+}
+
+internal class DefaultIsDebugBuildProvider(context: Context) : IsDebugBuildProvider {
+    private val context: Context = context.applicationContext
+
+    override fun invoke(): Boolean =
+        context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -380,6 +380,7 @@ internal open class BasePurchasesTest {
             platformInfo = PlatformInfo("native", "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,
+            isDebugBuild = false,
             dangerousSettings = DangerousSettings(
                 autoSyncPurchases = autoSync,
                 customEntitlementComputation = customEntitlementComputation,

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCanMakePaymentsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCanMakePaymentsTest.kt
@@ -119,7 +119,8 @@ internal class PurchasesCanMakePaymentsTest : BasePurchasesTest() {
             false,
             PlatformInfo("", null),
             null,
-            Store.AMAZON
+            Store.AMAZON,
+            isDebugBuild = false,
         )
         Purchases.canMakePayments(mockContext, listOf()) {
             assertThat(it).isTrue()

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -27,7 +27,7 @@ class PurchasesFactoryTest {
 
     @Before
     fun setup() {
-        purchasesFactory = PurchasesFactory(isDebugBuild = { false }, apiKeyValidatorMock)
+        purchasesFactory = PurchasesFactory(isDebugBuild = { true }, apiKeyValidatorMock)
 
         every { apiKeyValidatorMock.validateAndLog("fakeApiKey", Store.PLAY_STORE) } just runs
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -27,7 +27,7 @@ class PurchasesFactoryTest {
 
     @Before
     fun setup() {
-        purchasesFactory = PurchasesFactory(apiKeyValidatorMock)
+        purchasesFactory = PurchasesFactory(isDebugBuild = { false }, apiKeyValidatorMock)
 
         every { apiKeyValidatorMock.validateAndLog("fakeApiKey", Store.PLAY_STORE) } just runs
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesLifecycleTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesLifecycleTest.kt
@@ -156,7 +156,8 @@ internal class PurchasesLifecycleTest: BasePurchasesTest() {
             showInAppMessagesAutomatically = showInAppMessagesAutomatically,
             PlatformInfo("", null),
             proxyURL = null,
-            Store.AMAZON
+            Store.AMAZON,
+            isDebugBuild = false,
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/BaseBackendIntegrationTest.kt
@@ -75,6 +75,7 @@ internal abstract class BaseBackendIntegrationTest {
         appConfig = mockk<AppConfig>().apply {
             every { baseURL } returns URL("https://api.revenuecat.com")
             every { store } returns Store.PLAY_STORE
+            every { isDebugBuild } returns true
             every { platformInfo } returns PlatformInfo("test-flavor", version = null)
             every { languageTag } returns "en-US"
             every { versionName } returns "test-version-name"

--- a/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/AppConfigTest.kt
@@ -37,7 +37,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(appConfig.languageTag).isEqualTo(expected)
     }
@@ -55,7 +56,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(appConfig.languageTag).isEqualTo(expected)
     }
@@ -76,7 +78,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(appConfig.versionName).isEqualTo(expected)
     }
@@ -96,7 +99,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(appConfig.versionName).isEqualTo(expected)
     }
@@ -117,7 +121,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(appConfig.packageName).isEqualTo(expected)
     }
@@ -130,7 +135,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(appConfig.showInAppMessagesAutomatically).isFalse
         val appConfig2 = AppConfig(
@@ -139,7 +145,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = true,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(appConfig2.showInAppMessagesAutomatically).isTrue
     }
@@ -152,7 +159,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(appConfig.finishTransactions).isTrue()
     }
@@ -165,7 +173,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(appConfig.finishTransactions).isFalse()
     }
@@ -179,7 +188,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = expected,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(appConfig.baseURL).isEqualTo(expected)
     }
@@ -193,7 +203,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(appConfig.baseURL).isEqualTo(expected)
     }
@@ -206,7 +217,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(appConfig.forceServerErrors).isFalse
     }
@@ -219,7 +231,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(appConfig.forceSigningErrors).isFalse
     }
@@ -233,6 +246,7 @@ class AppConfigTest {
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,
+            isDebugBuild = false,
             dangerousSettings = DangerousSettings(customEntitlementComputation = true)
         )
         assertThat(appConfig.customEntitlementComputation).isTrue
@@ -243,6 +257,7 @@ class AppConfigTest {
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,
+            isDebugBuild = false,
             dangerousSettings = DangerousSettings(customEntitlementComputation = false)
         )
         assertThat(appConfig2.customEntitlementComputation).isFalse
@@ -256,7 +271,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         val y = AppConfig(
             context = mockk(relaxed = true),
@@ -264,7 +280,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
 
         assertThat(x).isEqualTo(y)
@@ -278,7 +295,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         var y = AppConfig(
             context = mockk(relaxed = true),
@@ -286,7 +304,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
 
         assertThat(x).isNotEqualTo(y)
@@ -297,7 +316,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.1.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
 
         assertThat(x).isNotEqualTo(y)
@@ -308,7 +328,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = URL("https://a.com"),
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
 
         assertThat(x).isNotEqualTo(y)
@@ -320,7 +341,20 @@ class AppConfigTest {
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,
+            isDebugBuild = false,
             dangerousSettings = DangerousSettings(autoSyncPurchases = false)
+        )
+
+        assertThat(x).isNotEqualTo(y)
+
+        y = AppConfig(
+            context = mockk(relaxed = true),
+            purchasesAreCompletedBy = REVENUECAT,
+            showInAppMessagesAutomatically = false,
+            platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
+            proxyURL = null,
+            store = Store.PLAY_STORE,
+            isDebugBuild = true,
         )
 
         assertThat(x).isNotEqualTo(y)
@@ -334,7 +368,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         val y = AppConfig(
             context = mockk(relaxed = true),
@@ -342,7 +377,8 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(x.hashCode()).isEqualTo(y.hashCode())
     }
@@ -355,12 +391,14 @@ class AppConfigTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         assertThat(x.toString()).isEqualTo(
             "AppConfig(" +
                 "platformInfo=PlatformInfo(flavor=native, version=3.2.0), " +
                 "store=PLAY_STORE, " +
+                "isDebugBuild=false, " +
                 "dangerousSettings=DangerousSettings(autoSyncPurchases=true, customEntitlementComputation=false), " +
                 "languageTag='', " +
                 "versionName='', " +

--- a/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -6,7 +6,6 @@ import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesAreCompletedBy.REVENUECAT
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.VerificationResult
-import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.networking.ETagManager
 import com.revenuecat.purchases.common.networking.Endpoint
@@ -82,6 +81,7 @@ internal abstract class BaseHTTPClientTest {
         platformInfo: PlatformInfo = expectedPlatformInfo,
         proxyURL: URL? = baseURL,
         store: Store = Store.PLAY_STORE,
+        isDebugBuild: Boolean = false,
         customEntitlementComputation: Boolean = false,
         forceServerErrors: Boolean = false,
         forceSigningErrors: Boolean = false,
@@ -93,6 +93,7 @@ internal abstract class BaseHTTPClientTest {
             platformInfo = platformInfo,
             proxyURL = proxyURL,
             store = store,
+            isDebugBuild = isDebugBuild,
             dangerousSettings = DangerousSettings(customEntitlementComputation = customEntitlementComputation),
             runningTests = true,
             forceServerErrors = forceServerErrors,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -190,6 +190,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         assertThat(request.getHeader("X-Client-Bundle-ID")).isEqualTo("mock-package-name")
         assertThat(request.getHeader("X-Observer-Mode-Enabled")).isEqualTo("false")
         assertThat(request.getHeader("X-Storefront")).isEqualTo("JP")
+        assertThat(request.getHeader("X-Is-Debug-Build")).isEqualTo("false")
     }
 
     @Test
@@ -355,6 +356,22 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         val request = server.takeRequest()
 
         assertThat(request.getHeader("X-Observer-Mode-Enabled")).isEqualTo("true")
+    }
+
+    @Test
+    fun `correctly sets debug header`() {
+        val appConfig = createAppConfig(isDebugBuild = true)
+        client = createClient(appConfig = appConfig)
+        val endpoint = Endpoint.LogIn
+        enqueue(
+            endpoint,
+            HTTPResult.createResult()
+        )
+
+        client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
+        val request = server.takeRequest()
+
+        assertThat(request.getHeader("X-Is-Debug-Build")).isEqualTo("true")
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
@@ -67,7 +67,8 @@ class DiagnosticsTrackerTest {
             showInAppMessagesAutomatically = false,
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
-            store = Store.PLAY_STORE
+            store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         diagnosticsFileHelper = mockk<DiagnosticsFileHelper>().apply {
             every { isDiagnosticsFileTooBig() } returns false

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/IsDebugBuildProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/IsDebugBuildProviderTest.kt
@@ -1,0 +1,44 @@
+package com.revenuecat.purchases.utils
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class IsDebugBuildProviderTest {
+
+
+    @Test
+    fun `Correctly determines non-debug builds`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val isDebugBuild = DefaultIsDebugBuildProvider(context)
+        val expected = false
+        context.applicationInfo.setDebuggable(debuggable = expected)
+
+        val actual = isDebugBuild()
+
+        assert(actual == expected)
+    }
+
+    @Test
+    fun `Correctly determines debug builds`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val isDebugBuild = DefaultIsDebugBuildProvider(context)
+        val expected = true
+        context.applicationInfo.setDebuggable(debuggable = expected)
+
+        val actual = isDebugBuild()
+
+        assert(actual == expected)
+    }
+
+    private fun ApplicationInfo.setDebuggable(debuggable: Boolean) {
+        flags =
+            if (debuggable) flags or ApplicationInfo.FLAG_DEBUGGABLE
+            else flags and ApplicationInfo.FLAG_DEBUGGABLE.inv()
+    }
+
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/IsDebugBuildProviderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/IsDebugBuildProviderTest.kt
@@ -10,7 +10,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class IsDebugBuildProviderTest {
 
-
     @Test
     fun `Correctly determines non-debug builds`() {
         val context = ApplicationProvider.getApplicationContext<Context>()

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -70,6 +70,7 @@ class SubscriberAttributesPurchasesTests {
             platformInfo = PlatformInfo(flavor = "native", version = "3.2.0"),
             proxyURL = null,
             store = Store.PLAY_STORE,
+            isDebugBuild = false,
         )
         val identityManager = mockk<IdentityManager>(relaxed = true).apply {
             every { currentAppUserID } returns appUserId


### PR DESCRIPTION
As the title says. Quite a few changed files. Here's what's new: 

- `AppConfig` has a new `isDebugBuild` property.
- `HTTPClient` reads this property and sets the `X-Is-Debug-Build` header accordingly.
- `PurchasesFactory` uses the new `IsDebugBuildProvider` to determine the `isDebugBuild` property when it creates the `AppConfig`. 
- `AppConfigTest` is adjusted.
- There's a new `HTTPClientTest` case. 
- `IsDebugBuildProviderTest` was added.

iOS implementation: https://github.com/RevenueCat/purchases-ios/pull/4364