### PR TITLE
Keeps the org.json package.

### DIFF
--- a/purchases/consumer-rules.pro
+++ b/purchases/consumer-rules.pro
@@ -54,3 +54,8 @@
 -keep class kotlinx.serialization.internal.ClassValueParametrizedCache$initClassValue$1 { ** computeValue(java.lang.Class); }
 -keep class kotlinx.serialization.internal.ClassValueCache$initClassValue$1 { ** computeValue(java.lang.Class); }
 # END Keep kotlinx.serialization annotations.
+
+# The org.json package is part of the Android framework, so the classes are always available.
+# However, sometimes it gets added to the app's classpath, either explicitly or transitively. When
+# this happens, it becomes susceptible to be shrunk. The following rule avoids that.
+-keep class org.json.* { *; }

--- a/purchases/consumer-rules.pro
+++ b/purchases/consumer-rules.pro
@@ -56,6 +56,6 @@
 # END Keep kotlinx.serialization annotations.
 
 # The org.json package is part of the Android framework, so the classes are always available.
-# However, sometimes it gets added to the app's classpath, either explicitly or transitively. When
+# However, some apps add it to their classpath, either explicitly or transitively. When
 # this happens, it becomes susceptible to be shrunk. The following rule avoids that.
 -keep class org.json.* { *; }


### PR DESCRIPTION
As the title says. This rule will normally have no effect as we don't declare the `org.json:json` dependency, but some apps do (transitively). In that scenario, this rule avoids `NoSuchMethodError`s and `NoSuchFieldError`s. 

**Note:** I gave this the `pr:fix` label, as it will fix the issue reported in [this Zendesk ticket](https://revenuecat.zendesk.com/agent/tickets/47240). Let me know if you think we should give it another label instead.