### PR TITLE
Dispatcher catches and rethrows Throwable instead of Exception to avoid swallowing errors

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Dispatcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Dispatcher.kt
@@ -65,7 +65,7 @@ internal open class Dispatcher(
                 val commandHandlingExceptions = Runnable {
                     try {
                         command.run()
-                    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                    } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
                         errorLog("Exception running command: $e")
                         // We propagate the exception to the main thread to be sure it's not swallowed.
                         mainHandler?.post {


### PR DESCRIPTION
**Note:** this PR is intended as more of a discussion starter, which is why it's a draft.

## Issue
We sometimes come across issues where the SDK seems to hang. This is annoying to investigate, as no error is logged (nor does it crash). See e.g.:
- https://github.com/RevenueCat/react-native-purchases/issues/1088
- [Zendesk: My paywall on android does not load when the app is not in debuggable mode](https://revenuecat.zendesk.com/agent/tickets/47240)

## Cause
I found one cause of hanging while investigating the second issue. Errors can be swallowed by the `Dispatcher`, as it only rethrows `Exception`s. However, not all errors are `Exception`s. An example of an error which is a `Throwable` but not an `Exception` is a [`NoSuchMethodError`](https://developer.android.com/reference/java/lang/NoSuchMethodError).

When such an error happens in an async call and is not caught, the thread dies before the callback can be called, causing the async call to hang. 

## Fix
To truly surface all issues, we should rethrow `Throwable` instead. 

## Discussion
Of course, there is a risk to this, as we might now surface errors that were swallowed before, causing the SDK to crash in new scenarios (where it would likely hang before). I'd like to know your thoughts on this, and how you think we should mitigate. 


