### PR TITLE
Add extra error cases for web purchases redemptions

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.PurchasesAreCompletedBy;
 import com.revenuecat.purchases.PurchasesConfiguration;
 import com.revenuecat.purchases.PurchasesError;
 import com.revenuecat.purchases.Store;
+import com.revenuecat.purchases.WebPurchaseRedemption;
 import com.revenuecat.purchases.amazon.AmazonConfiguration;
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback;
 import com.revenuecat.purchases.interfaces.LogInCallback;
@@ -35,7 +36,7 @@ import java.util.concurrent.ExecutorService;
 final class PurchasesAPI {
     static void check(
             final Purchases purchases,
-            final Purchases.DeepLink.WebPurchaseRedemption deepLink,
+            final WebPurchaseRedemption webPurchaseRedemption,
             final RedeemWebPurchaseListener redeemWebPurchaseListener,
             final Intent intent
             ) {
@@ -95,7 +96,7 @@ final class PurchasesAPI {
         purchases.getCustomerInfo(receiveCustomerInfoListener);
         purchases.getCustomerInfo(CacheFetchPolicy.CACHED_OR_FETCHED, receiveCustomerInfoListener);
         purchases.getAmazonLWAConsentStatus(getAmazonLWAContentStatusCallback);
-        purchases.redeemWebPurchase(deepLink, redeemWebPurchaseListener);
+        purchases.redeemWebPurchase(webPurchaseRedemption, redeemWebPurchaseListener);
 
         purchases.restorePurchases(receiveCustomerInfoListener);
         purchases.invalidateCustomerInfoCache();
@@ -114,7 +115,7 @@ final class PurchasesAPI {
 
         final PurchasesConfiguration configuration = purchases.getCurrentConfiguration();
 
-        final Purchases.DeepLink parsedDeepLink = Purchases.parseAsDeepLink(intent);
+        final WebPurchaseRedemption webPurchaseRedemption1 = Purchases.parseAsWebPurchaseRedemption(intent);
     }
 
     static void check(final Purchases purchases, final Map<String, String> attributes) {

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/RedeemWebPurchaseListenerAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/RedeemWebPurchaseListenerAPI.java
@@ -20,6 +20,13 @@ final class RedeemWebPurchaseListenerAPI {
             CustomerInfo customerInfo = ((RedeemWebPurchaseListener.Result.Success) result).getCustomerInfo();
         } else if (result instanceof RedeemWebPurchaseListener.Result.Error) {
             PurchasesError error = ((RedeemWebPurchaseListener.Result.Error) result).getError();
+        } else if (result instanceof RedeemWebPurchaseListener.Result.InvalidToken) {
+            return;
+        } else if (result instanceof RedeemWebPurchaseListener.Result.AlreadyRedeemed) {
+            return;
+        } else if (result instanceof RedeemWebPurchaseListener.Result.Expired) {
+            String obfuscatedEmail = ((RedeemWebPurchaseListener.Result.Expired) result).getObfuscatedEmail();
+            Boolean wasEmailSent = ((RedeemWebPurchaseListener.Result.Expired) result).getWasEmailSent();
         }
 
         boolean isSuccess = result.isSuccess();

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/RedeemWebPurchaseListenerAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/RedeemWebPurchaseListenerAPI.java
@@ -26,7 +26,6 @@ final class RedeemWebPurchaseListenerAPI {
             return;
         } else if (result instanceof RedeemWebPurchaseListener.Result.Expired) {
             String obfuscatedEmail = ((RedeemWebPurchaseListener.Result.Expired) result).getObfuscatedEmail();
-            Boolean wasEmailSent = ((RedeemWebPurchaseListener.Result.Expired) result).getWasEmailSent();
         }
 
         boolean isSuccess = result.isSuccess();

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/IntentExtensionsAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/IntentExtensionsAPI.kt
@@ -2,13 +2,13 @@ package com.revenuecat.apitester.kotlin
 
 import android.content.Intent
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
-import com.revenuecat.purchases.Purchases
-import com.revenuecat.purchases.parseAsDeepLink
+import com.revenuecat.purchases.WebPurchaseRedemption
+import com.revenuecat.purchases.parseAsWebPurchaseRedemption
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Suppress("unused", "UNUSED_VARIABLE")
 private class IntentExtensionsAPI {
     fun check(intent: Intent) {
-        val deepLink: Purchases.DeepLink? = intent.parseAsDeepLink()
+        val webPurchaseRedemption: WebPurchaseRedemption? = intent.parseAsWebPurchaseRedemption()
     }
 }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesConfiguration
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.WebPurchaseRedemption
 import com.revenuecat.purchases.amazon.AmazonConfiguration
 import com.revenuecat.purchases.awaitCustomerCenterConfigData
 import com.revenuecat.purchases.awaitCustomerInfo
@@ -45,7 +46,7 @@ private class PurchasesAPI {
     @SuppressWarnings("LongParameterList")
     fun check(
         purchases: Purchases,
-        deepLink: Purchases.DeepLink.WebPurchaseRedemption,
+        webPurchaseRedemption: WebPurchaseRedemption,
         redeemWebPurchaseListener: RedeemWebPurchaseListener,
         intent: Intent,
     ) {
@@ -99,14 +100,8 @@ private class PurchasesAPI {
 
         val configuration: PurchasesConfiguration = purchases.currentConfiguration
 
-        purchases.redeemWebPurchase(deepLink, redeemWebPurchaseListener)
-        val parsedDeepLink: Purchases.DeepLink? = Purchases.parseAsDeepLink(intent)
-    }
-
-    fun checkDeepLink(deepLink: Purchases.DeepLink): Boolean {
-        when (deepLink) {
-            is Purchases.DeepLink.WebPurchaseRedemption -> return true
-        }
+        purchases.redeemWebPurchase(webPurchaseRedemption, redeemWebPurchaseListener)
+        val parsedWebPurchaseRedemption: WebPurchaseRedemption? = Purchases.parseAsWebPurchaseRedemption(intent)
     }
 
     @Suppress("LongMethod", "LongParameterList")

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/RedeemWebPurchaseListenerAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/RedeemWebPurchaseListenerAPI.kt
@@ -35,7 +35,6 @@ private class RedeemWebPurchaseListenerAPI {
             }
             is RedeemWebPurchaseListener.Result.Expired -> {
                 val obfuscatedEmail: String = result.obfuscatedEmail
-                val emailSent: Boolean = result.wasEmailSent
                 return false
             }
         }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/RedeemWebPurchaseListenerAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/RedeemWebPurchaseListenerAPI.kt
@@ -6,7 +6,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.interfaces.RedeemWebPurchaseListener
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
-@Suppress("unused", "UNUSED_VARIABLE")
+@Suppress("unused", "UNUSED_VARIABLE", "ReturnCount")
 private class RedeemWebPurchaseListenerAPI {
     fun checkListener(
         redeemWebPurchaseListener: RedeemWebPurchaseListener,
@@ -25,6 +25,17 @@ private class RedeemWebPurchaseListenerAPI {
             }
             is RedeemWebPurchaseListener.Result.Error -> {
                 val error: PurchasesError = result.error
+                return false
+            }
+            is RedeemWebPurchaseListener.Result.InvalidToken -> {
+                return false
+            }
+            is RedeemWebPurchaseListener.Result.AlreadyRedeemed -> {
+                return false
+            }
+            is RedeemWebPurchaseListener.Result.Expired -> {
+                val obfuscatedEmail: String = result.obfuscatedEmail
+                val emailSent: Boolean = result.wasEmailSent
                 return false
             }
         }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainActivity.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainActivity.kt
@@ -5,27 +5,28 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.WebPurchaseRedemption
 import com.revenuecat.purchases_sample.R
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 class MainActivity : AppCompatActivity() {
 
-    internal var rcDeepLink: Purchases.DeepLink? = null
+    internal var webPurchaseRedemption: WebPurchaseRedemption? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        rcDeepLink = Purchases.parseAsDeepLink(intent)
+        webPurchaseRedemption = Purchases.parseAsWebPurchaseRedemption(intent)
     }
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         if (intent != null) {
-            rcDeepLink = Purchases.parseAsDeepLink(intent)
+            webPurchaseRedemption = Purchases.parseAsWebPurchaseRedemption(intent)
         }
     }
 
-    fun clearDeepLink() {
-        rcDeepLink = null
+    fun clearWebPurchaseRedemption() {
+        webPurchaseRedemption = null
     }
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -120,33 +120,31 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
         super.onResume()
 
         val activity = requireActivity() as MainActivity
-        val deepLink = activity.rcDeepLink ?: return
-        if (deepLink is Purchases.DeepLink.WebPurchaseRedemption) {
-            activity.clearDeepLink()
-            Purchases.sharedInstance.redeemWebPurchase(deepLink) { result ->
-                when (result) {
-                    is RedeemWebPurchaseListener.Result.Success -> {
-                        showToast("Successfully redeemed web purchase. Updating customer info.")
+        val webPurchaseRedemption = activity.webPurchaseRedemption ?: return
+        activity.clearWebPurchaseRedemption()
+        Purchases.sharedInstance.redeemWebPurchase(webPurchaseRedemption) { result ->
+            when (result) {
+                is RedeemWebPurchaseListener.Result.Success -> {
+                    showToast("Successfully redeemed web purchase. Updating customer info.")
+                }
+                is RedeemWebPurchaseListener.Result.Error -> {
+                    showUserError(requireActivity(), result.error)
+                }
+                RedeemWebPurchaseListener.Result.InvalidToken -> {
+                    showToast("Invalid web redemption token. Please check your link.")
+                }
+                RedeemWebPurchaseListener.Result.AlreadyRedeemed -> {
+                    showToast("Web purchase already redeemed. Ignoring.")
+                }
+                is RedeemWebPurchaseListener.Result.Expired -> {
+                    val message = if (result.wasEmailSent) {
+                        "Web purchase redemption token expired. " +
+                            "An email with a new one was sent to ${result.obfuscatedEmail}."
+                    } else {
+                        "Web purchase redemption token expired. " +
+                            "A new one was previously sent to ${result.obfuscatedEmail}."
                     }
-                    is RedeemWebPurchaseListener.Result.Error -> {
-                        showUserError(requireActivity(), result.error)
-                    }
-                    RedeemWebPurchaseListener.Result.InvalidToken -> {
-                        showToast("Invalid web redemption token. Please check your link.")
-                    }
-                    RedeemWebPurchaseListener.Result.AlreadyRedeemed -> {
-                        showToast("Web purchase already redeemed. Ignoring.")
-                    }
-                    is RedeemWebPurchaseListener.Result.Expired -> {
-                        val message = if (result.wasEmailSent) {
-                            "Web purchase redemption token expired. " +
-                                "An email with a new one was sent to ${result.obfuscatedEmail}."
-                        } else {
-                            "Web purchase redemption token expired. " +
-                                "A new one was previously sent to ${result.obfuscatedEmail}."
-                        }
-                        showToast(message)
-                    }
+                    showToast(message)
                 }
             }
         }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -131,6 +131,22 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
                     is RedeemWebPurchaseListener.Result.Error -> {
                         showUserError(requireActivity(), result.error)
                     }
+                    RedeemWebPurchaseListener.Result.InvalidToken -> {
+                        showToast("Invalid web redemption token. Please check your link.")
+                    }
+                    RedeemWebPurchaseListener.Result.AlreadyRedeemed -> {
+                        showToast("Web purchase already redeemed. Ignoring.")
+                    }
+                    is RedeemWebPurchaseListener.Result.Expired -> {
+                        val message = if (result.wasEmailSent) {
+                            "Web purchase redemption token expired. " +
+                                "An email with a new one was sent to ${result.obfuscatedEmail}."
+                        } else {
+                            "Web purchase redemption token expired. " +
+                                "A new one was previously sent to ${result.obfuscatedEmail}."
+                        }
+                        showToast(message)
+                    }
                 }
             }
         }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -137,8 +137,10 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
                     showToast("Web purchase already redeemed. Ignoring.")
                 }
                 is RedeemWebPurchaseListener.Result.Expired -> {
-                    showToast("Web purchase redemption token expired. " +
-                        "An email with a new one was sent to ${result.obfuscatedEmail}.")
+                    showToast(
+                        "Web purchase redemption token expired. " +
+                            "An email with a new one was sent to ${result.obfuscatedEmail}.",
+                    )
                 }
             }
         }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -137,14 +137,8 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
                     showToast("Web purchase already redeemed. Ignoring.")
                 }
                 is RedeemWebPurchaseListener.Result.Expired -> {
-                    val message = if (result.wasEmailSent) {
-                        "Web purchase redemption token expired. " +
-                            "An email with a new one was sent to ${result.obfuscatedEmail}."
-                    } else {
-                        "Web purchase redemption token expired. " +
-                            "A new one was previously sent to ${result.obfuscatedEmail}."
-                    }
-                    showToast(message)
+                    showToast("Web purchase redemption token expired. " +
+                        "An email with a new one was sent to ${result.obfuscatedEmail}.")
                 }
             }
         }

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/IntentExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/IntentExtensions.kt
@@ -4,6 +4,6 @@ import android.content.Intent
 
 @ExperimentalPreviewRevenueCatPurchasesAPI
 @JvmSynthetic
-fun Intent.parseAsDeepLink(): Purchases.DeepLink? {
-    return Purchases.parseAsDeepLink(this)
+fun Intent.parseAsWebPurchaseRedemption(): WebPurchaseRedemption? {
+    return Purchases.parseAsWebPurchaseRedemption(this)
 }

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -802,38 +802,27 @@ class Purchases internal constructor(
     // endregion
 
     /**
-     * Redeem a web purchase using a [DeepLink.WebPurchaseRedemption] object obtained
-     * through [Purchases.parseAsDeepLink].
+     * Redeem a web purchase using a [WebPurchaseRedemption] object obtained
+     * through [Purchases.parseAsWebPurchaseRedemption].
      */
     @ExperimentalPreviewRevenueCatPurchasesAPI
-    fun redeemWebPurchase(webPurchaseRedemption: DeepLink.WebPurchaseRedemption, listener: RedeemWebPurchaseListener) {
+    fun redeemWebPurchase(webPurchaseRedemption: WebPurchaseRedemption, listener: RedeemWebPurchaseListener) {
         purchasesOrchestrator.redeemWebPurchase(webPurchaseRedemption, listener)
-    }
-
-    /**
-     * Represents a valid RevenueCat deep link.
-     */
-    @ExperimentalPreviewRevenueCatPurchasesAPI
-    sealed interface DeepLink {
-        /**
-         * Represents a web redemption link, that can be redeemed using [Purchases.redeemWebPurchase]
-         */
-        class WebPurchaseRedemption internal constructor(internal val redemptionToken: String) : DeepLink
     }
 
     // region Static
     companion object {
 
         /**
-         * Given an intent, parses the deep link if any and returns a parsed version of it.
-         * Currently supports web redemption links.
-         * @return A parsed version of the deep link or null if it's not a valid RevenueCat deep link.
+         * Given an intent, parses the associated link if any and returns a [WebPurchaseRedemption], which can
+         * be used to redeem a web purchase using [Purchases.redeemWebPurchase]
+         * @return A parsed version of the link or null if it's not a valid RevenueCat web purchase redemption link.
          */
         @ExperimentalPreviewRevenueCatPurchasesAPI
         @JvmStatic
-        fun parseAsDeepLink(intent: Intent): DeepLink? {
+        fun parseAsWebPurchaseRedemption(intent: Intent): WebPurchaseRedemption? {
             val intentData = intent.data ?: return null
-            return DeepLinkParser.parseDeepLink(intentData)
+            return DeepLinkParser.parseWebPurchaseRedemption(intentData)
         }
 
         /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -249,7 +249,7 @@ internal class PurchasesOrchestrator(
 
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     fun redeemWebPurchase(
-        webPurchaseRedemption: Purchases.DeepLink.WebPurchaseRedemption,
+        webPurchaseRedemption: WebPurchaseRedemption,
         listener: RedeemWebPurchaseListener,
     ) {
         webPurchaseRedemptionHelper.handleRedeemWebPurchase(webPurchaseRedemption, listener)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/WebPurchaseRedemption.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/WebPurchaseRedemption.kt
@@ -1,0 +1,9 @@
+package com.revenuecat.purchases
+
+/**
+ * Represents a web redemption link, that can be redeemed using [Purchases.redeemWebPurchase]
+ */
+@ExperimentalPreviewRevenueCatPurchasesAPI
+class WebPurchaseRedemption internal constructor(
+    internal val redemptionToken: String,
+)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -708,12 +708,11 @@ internal class Backend(
                                 val resultBody = result.body
                                 val redemptionError = resultBody.optJSONObject("purchase_redemption_error_info")
                                 val obfuscatedEmail = redemptionError?.optString("obfuscated_email")
-                                val emailSent = redemptionError?.optBoolean("was_email_sent")
-                                if (obfuscatedEmail == null || emailSent == null) {
+                                if (obfuscatedEmail == null) {
                                     errorLog("Error parsing expired redemption token response: $resultBody")
                                     callback(RedeemWebPurchaseListener.Result.Error(result.toPurchasesError()))
                                 } else {
-                                    callback(RedeemWebPurchaseListener.Result.Expired(obfuscatedEmail, emailSent))
+                                    callback(RedeemWebPurchaseListener.Result.Expired(obfuscatedEmail))
                                 }
                             }
                             BackendErrorCode.BackendWebPurchaseAlreadyRedeemed.value -> {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
@@ -8,7 +8,7 @@ import org.json.JSONException
 import java.io.IOException
 
 @SuppressWarnings("MagicNumber")
-private enum class BackendErrorCode(val value: Int) {
+internal enum class BackendErrorCode(val value: Int) {
     BackendInvalidPlatform(7000),
     BackendStoreProblem(7101),
     BackendCannotTransferPurchase(7102),
@@ -30,6 +30,9 @@ private enum class BackendErrorCode(val value: Int) {
     BackendInvalidSubscriberAttributes(7263),
     BackendInvalidSubscriberAttributesBody(7264),
     BackendProductIDsMalformed(7662),
+    BackendInvalidWebRedemptionToken(7849),
+    BackendWebPurchaseAlreadyRedeemed(7852),
+    BackendExpiredWebRedemptionToken(7853),
     ;
 
     companion object {
@@ -97,6 +100,9 @@ private fun BackendErrorCode.toPurchasesErrorCode(): PurchasesErrorCode {
         BackendErrorCode.BackendInternalServerError,
         -> PurchasesErrorCode.UnexpectedBackendResponseError
         BackendErrorCode.BackendProductIDsMalformed -> PurchasesErrorCode.UnsupportedError
+        BackendErrorCode.BackendInvalidWebRedemptionToken -> PurchasesErrorCode.PurchaseInvalidError
+        BackendErrorCode.BackendWebPurchaseAlreadyRedeemed -> PurchasesErrorCode.ProductAlreadyPurchasedError
+        BackendErrorCode.BackendExpiredWebRedemptionToken -> PurchasesErrorCode.PurchaseInvalidError
     }
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCHTTPStatusCodes.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/RCHTTPStatusCodes.kt
@@ -6,6 +6,7 @@ internal object RCHTTPStatusCodes {
     const val UNSUCCESSFUL = 300
     const val NOT_MODIFIED = 304
     const val BAD_REQUEST = 400
+    const val FORBIDDEN = 403
     const val NOT_FOUND = 404
     const val ERROR = 500
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/deeplinks/DeepLinkParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/deeplinks/DeepLinkParser.kt
@@ -2,7 +2,7 @@ package com.revenuecat.purchases.deeplinks
 
 import android.net.Uri
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
-import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.WebPurchaseRedemption
 import com.revenuecat.purchases.common.debugLog
 
 internal object DeepLinkParser {
@@ -10,14 +10,14 @@ internal object DeepLinkParser {
 
     @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
     @Suppress("ReturnCount")
-    fun parseDeepLink(data: Uri): Purchases.DeepLink? {
+    fun parseWebPurchaseRedemption(data: Uri): WebPurchaseRedemption? {
         if (data.host == REDEEM_WEB_PURCHASE_HOST) {
             val redemptionToken = data.getQueryParameter("redemption_token")
             if (redemptionToken.isNullOrBlank()) {
                 debugLog("Redemption token is missing web redemption deep link. Ignoring.")
                 return null
             }
-            return Purchases.DeepLink.WebPurchaseRedemption(redemptionToken)
+            return WebPurchaseRedemption(redemptionToken)
         } else {
             debugLog("Unrecognized deep link host: ${data.host}. Ignoring")
             return null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelper.kt
@@ -28,15 +28,19 @@ internal class WebPurchaseRedemptionHelper(
         backend.postRedeemWebPurchase(
             identityManager.currentAppUserID,
             deepLink.redemptionToken,
-            onErrorHandler = {
-                errorLog("Error redeeming web purchase: $it")
-                dispatchResult(listener, RedeemWebPurchaseListener.Result.Error(it))
-            },
-            onSuccessHandler = {
-                debugLog("Successfully redeemed web purchase. Updating customer info.")
-                offlineEntitlementsManager.resetOfflineCustomerInfoCache()
-                customerInfoUpdateHandler.cacheAndNotifyListeners(it)
-                dispatchResult(listener, RedeemWebPurchaseListener.Result.Success(it))
+            onResultHandler = { result ->
+                when (result) {
+                    is RedeemWebPurchaseListener.Result.Success -> {
+                        debugLog("Successfully redeemed web purchase. Updating customer info.")
+                        offlineEntitlementsManager.resetOfflineCustomerInfoCache()
+                        customerInfoUpdateHandler.cacheAndNotifyListeners(result.customerInfo)
+                        dispatchResult(listener, result)
+                    }
+                    else -> {
+                        errorLog("Error redeeming web purchase: $result")
+                        dispatchResult(listener, result)
+                    }
+                }
             },
         )
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelper.kt
@@ -4,7 +4,7 @@ import android.os.Handler
 import android.os.Looper
 import com.revenuecat.purchases.CustomerInfoUpdateHandler
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
-import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.WebPurchaseRedemption
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
@@ -21,13 +21,13 @@ internal class WebPurchaseRedemptionHelper(
     private val mainHandler: Handler? = Handler(Looper.getMainLooper()),
 ) {
     fun handleRedeemWebPurchase(
-        deepLink: Purchases.DeepLink.WebPurchaseRedemption,
+        webPurchaseRedemption: WebPurchaseRedemption,
         listener: RedeemWebPurchaseListener,
     ) {
         debugLog("Starting web purchase redemption.")
         backend.postRedeemWebPurchase(
             identityManager.currentAppUserID,
-            deepLink.redemptionToken,
+            webPurchaseRedemption.redemptionToken,
             onResultHandler = { result ->
                 when (result) {
                     is RedeemWebPurchaseListener.Result.Success -> {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
@@ -24,6 +24,24 @@ class PurchasesError(
     override fun toString(): String {
         return "PurchasesError(code=$code, underlyingErrorMessage=$underlyingErrorMessage, message='$message')"
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as PurchasesError
+
+        if (code != other.code) return false
+        if (underlyingErrorMessage != other.underlyingErrorMessage) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = code.hashCode()
+        result = 31 * result + (underlyingErrorMessage?.hashCode() ?: 0)
+        return result
+    }
 }
 
 @SuppressWarnings("MagicNumber")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/RedeemWebPurchaseListener.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/RedeemWebPurchaseListener.kt
@@ -13,8 +13,32 @@ fun interface RedeemWebPurchaseListener {
      * Result of the redemption of a RevenueCat Web purchase.
      */
     sealed class Result {
+        /**
+         * Indicates that the web purchase was redeemed successfully.
+         */
         data class Success(val customerInfo: CustomerInfo) : Result()
+
+        /**
+         * Indicates that an unknown error occurred during the redemption.
+         */
         data class Error(val error: PurchasesError) : Result()
+
+        /**
+         * Indicates that the redemption token is invalid.
+         */
+        object InvalidToken : Result()
+
+        /**
+         * Indicates that the redemption token has expired. An email with a new redemption token
+         * might be sent depending on the value of [wasEmailSent].
+         * The email where it will be sent is indicated by the [obfuscatedEmail].
+         */
+        data class Expired(val obfuscatedEmail: String, val wasEmailSent: Boolean) : Result()
+
+        /**
+         * Indicates that the web purchase has already been redeemed and can't be redeemed again.
+         */
+        object AlreadyRedeemed : Result()
 
         /**
          * Whether the redemption was successful or not.
@@ -23,6 +47,9 @@ fun interface RedeemWebPurchaseListener {
             get() = when (this) {
                 is Success -> true
                 is Error -> false
+                InvalidToken -> false
+                is Expired -> false
+                AlreadyRedeemed -> false
             }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/RedeemWebPurchaseListener.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/RedeemWebPurchaseListener.kt
@@ -30,10 +30,10 @@ fun interface RedeemWebPurchaseListener {
 
         /**
          * Indicates that the redemption token has expired. An email with a new redemption token
-         * might be sent depending on the value of [wasEmailSent].
+         * might be sent if a new one wasn't already sent recently.
          * The email where it will be sent is indicated by the [obfuscatedEmail].
          */
-        data class Expired(val obfuscatedEmail: String, val wasEmailSent: Boolean) : Result()
+        data class Expired(val obfuscatedEmail: String) : Result()
 
         /**
          * Indicates that the web purchase has already been redeemed and can't be redeemed again.

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendRedeemWebPurchaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendRedeemWebPurchaseTest.kt
@@ -119,8 +119,10 @@ class BackendRedeemWebPurchaseTest {
             {
                 "code": 7853,
                 "message": "The link has expired.",
-                "email": "t***@r******t.com",
-                "was_email_sent": true
+                "purchase_redemption_error_info": {
+                   "obfuscated_email": "t***@r******t.com",
+                   "was_email_sent": true
+                }
             }
         """.trimIndent()
         mockHttpResult(responseCode = RCHTTPStatusCodes.FORBIDDEN, responseBody = responseBody)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendRedeemWebPurchaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendRedeemWebPurchaseTest.kt
@@ -31,6 +31,7 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @RunWith(AndroidJUnit4::class)
 class BackendRedeemWebPurchaseTest {
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendRedeemWebPurchaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendRedeemWebPurchaseTest.kt
@@ -120,14 +120,13 @@ class BackendRedeemWebPurchaseTest {
                 "code": 7853,
                 "message": "The link has expired.",
                 "purchase_redemption_error_info": {
-                   "obfuscated_email": "t***@r******t.com",
-                   "was_email_sent": true
+                   "obfuscated_email": "t***@r******t.com"
                 }
             }
         """.trimIndent()
         mockHttpResult(responseCode = RCHTTPStatusCodes.FORBIDDEN, responseBody = responseBody)
         performPostAndExpectResult(
-            RedeemWebPurchaseListener.Result.Expired(obfuscatedEmail = "t***@r******t.com", wasEmailSent = true)
+            RedeemWebPurchaseListener.Result.Expired(obfuscatedEmail = "t***@r******t.com")
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelperTest.kt
@@ -4,9 +4,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.CustomerInfoUpdateHandler
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
-import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.WebPurchaseRedemption
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.identity.IdentityManager
@@ -28,7 +28,7 @@ class WebPurchaseRedemptionHelperTest {
 
     private val userId = "test-user-id"
     private val redemptionToken = "test-redemption-token"
-    private val deepLink = Purchases.DeepLink.WebPurchaseRedemption(redemptionToken)
+    private val webPurchaseRedemption = WebPurchaseRedemption(redemptionToken)
 
     private lateinit var customerInfo: CustomerInfo
 
@@ -63,7 +63,7 @@ class WebPurchaseRedemptionHelperTest {
     fun `handleRedeemWebPurchase posts token and returns success`() {
         mockBackendResult()
         var result: RedeemWebPurchaseListener.Result? = null
-        webPurchaseRedemptionHelper.handleRedeemWebPurchase(deepLink) {
+        webPurchaseRedemptionHelper.handleRedeemWebPurchase(webPurchaseRedemption) {
             result = it
         }
         assertTrue(result is RedeemWebPurchaseListener.Result.Success)
@@ -73,14 +73,14 @@ class WebPurchaseRedemptionHelperTest {
     @Test
     fun `handleRedeemWebPurchase posts token and resets offline entitlements cache on success`() {
         mockBackendResult()
-        webPurchaseRedemptionHelper.handleRedeemWebPurchase(deepLink) {}
+        webPurchaseRedemptionHelper.handleRedeemWebPurchase(webPurchaseRedemption) {}
         verify(exactly = 1) { offlineEntitlementsManager.resetOfflineCustomerInfoCache() }
     }
 
     @Test
     fun `handleRedeemWebPurchase posts token and notifies listener on success`() {
         mockBackendResult()
-        webPurchaseRedemptionHelper.handleRedeemWebPurchase(deepLink) {}
+        webPurchaseRedemptionHelper.handleRedeemWebPurchase(webPurchaseRedemption) {}
         verify(exactly = 1) { customerInfoUpdateHandler.cacheAndNotifyListeners(customerInfo) }
     }
 
@@ -89,7 +89,7 @@ class WebPurchaseRedemptionHelperTest {
         val expectedError = PurchasesError(PurchasesErrorCode.UnknownBackendError)
         mockBackendResult(result = RedeemWebPurchaseListener.Result.Error(expectedError))
         var result: RedeemWebPurchaseListener.Result? = null
-        webPurchaseRedemptionHelper.handleRedeemWebPurchase(deepLink) {
+        webPurchaseRedemptionHelper.handleRedeemWebPurchase(webPurchaseRedemption) {
             result = it
         }
         assertTrue(result is RedeemWebPurchaseListener.Result.Error)
@@ -102,7 +102,7 @@ class WebPurchaseRedemptionHelperTest {
     fun `handleRedeemWebPurchase posts token and returns already redeemed`() {
         mockBackendResult(result = RedeemWebPurchaseListener.Result.AlreadyRedeemed)
         var result: RedeemWebPurchaseListener.Result? = null
-        webPurchaseRedemptionHelper.handleRedeemWebPurchase(deepLink) {
+        webPurchaseRedemptionHelper.handleRedeemWebPurchase(webPurchaseRedemption) {
             result = it
         }
         assertTrue(result is RedeemWebPurchaseListener.Result.AlreadyRedeemed)
@@ -115,7 +115,7 @@ class WebPurchaseRedemptionHelperTest {
         val expectedResult = RedeemWebPurchaseListener.Result.Expired("test-email", wasEmailSent = false)
         mockBackendResult(expectedResult)
         var result: RedeemWebPurchaseListener.Result? = null
-        webPurchaseRedemptionHelper.handleRedeemWebPurchase(deepLink) {
+        webPurchaseRedemptionHelper.handleRedeemWebPurchase(webPurchaseRedemption) {
             result = it
         }
         assertThat(result).isEqualTo(expectedResult)
@@ -128,7 +128,7 @@ class WebPurchaseRedemptionHelperTest {
         val expectedResult = RedeemWebPurchaseListener.Result.InvalidToken
         mockBackendResult(expectedResult)
         var result: RedeemWebPurchaseListener.Result? = null
-        webPurchaseRedemptionHelper.handleRedeemWebPurchase(deepLink) {
+        webPurchaseRedemptionHelper.handleRedeemWebPurchase(webPurchaseRedemption) {
             result = it
         }
         assertThat(result).isEqualTo(expectedResult)

--- a/purchases/src/test/java/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelperTest.kt
@@ -112,7 +112,7 @@ class WebPurchaseRedemptionHelperTest {
 
     @Test
     fun `handleRedeemWebPurchase posts token and returns token expired`() {
-        val expectedResult = RedeemWebPurchaseListener.Result.Expired("test-email", wasEmailSent = false)
+        val expectedResult = RedeemWebPurchaseListener.Result.Expired("test-email")
         mockBackendResult(expectedResult)
         var result: RedeemWebPurchaseListener.Result? = null
         webPurchaseRedemptionHelper.handleRedeemWebPurchase(webPurchaseRedemption) {

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -1515,7 +1515,7 @@ internal class PurchasesTest : BasePurchasesTest() {
 
     @Test
     fun `redeemWebPurchase is successful if helper returns success`() {
-        val redemptionLink = Purchases.DeepLink.WebPurchaseRedemption("redemption_token")
+        val redemptionLink = WebPurchaseRedemption("redemption_token")
         val slot = slot<RedeemWebPurchaseListener>()
         every { mockWebPurchasesRedemptionHelper.handleRedeemWebPurchase(redemptionLink, capture(slot)) } answers {
             slot.captured.handleResult(RedeemWebPurchaseListener.Result.Success(mockInfo))
@@ -1529,7 +1529,7 @@ internal class PurchasesTest : BasePurchasesTest() {
 
     @Test
     fun `redeemWebPurchase errors if helper returns error`() {
-        val redemptionLink = Purchases.DeepLink.WebPurchaseRedemption("redemption_token")
+        val redemptionLink = WebPurchaseRedemption("redemption_token")
         val slot = slot<RedeemWebPurchaseListener>()
         val expectedError = PurchasesError(PurchasesErrorCode.UnknownBackendError)
         every { mockWebPurchasesRedemptionHelper.handleRedeemWebPurchase(redemptionLink, capture(slot)) } answers {


### PR DESCRIPTION
### Description
This adds some new result types to a web purchase redemption:
- InvalidToken
- AlreadyRedeemed
- Expired. This one includes additional information like the obfuscated email where a new token was/will be sent and whether that email was sent.

This falls behind the experimental APIs introduced in #1889 

Additionally, this renames `parseAsDeepLink` to `parseAsWebPurchaseRedemption` and removes the `DeepLink` type. This is a breaking change, but should be ok since the API is marked as experimental and not usable still by any customers.