### PR TITLE
[Fix] Consider a network error as not successfully synced for paywall events

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -524,7 +524,7 @@ internal class Backend(
                 synchronized(this@Backend) {
                     paywallEventsCallbacks.remove(paywallEventRequest.cacheKey)
                 }?.forEach { (_, onErrorHandler) ->
-                    onErrorHandler(error, true)
+                    onErrorHandler(error, false)
                 }
             }
 


### PR DESCRIPTION

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation

While investigating missing impression events, I found a possible logic issue on Android where we are considering a network error as "successfully synced" and hence deleting any pending events.