### PR TITLE
[Paywalls] Synchronize paywall events on app backgrounding and after a purchase

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -209,6 +209,7 @@ internal class PurchasesOrchestrator(
         }
         log(LogIntent.DEBUG, ConfigureStrings.APP_BACKGROUNDED)
         synchronizeSubscriberAttributesIfNeeded()
+        flushPaywallEvents()
     }
 
     /** @suppress */
@@ -941,6 +942,9 @@ internal class PurchasesOrchestrator(
                     transactionPostSuccess = callbackPair.first,
                     transactionPostError = callbackPair.second,
                 )
+
+                // Synchronize paywall events after a new purchase
+                flushPaywallEvents()
             }
 
             override fun onPurchasesFailedToUpdate(purchasesError: PurchasesError) {


### PR DESCRIPTION
To improve deliverability of paywall events, try to sync them when the apps is backgrounded and after a new purchase happens.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
