### PR TITLE
Handle `IllegalArgumentException` when opening a Uri in the paywalls

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Footer.kt
@@ -1,5 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.composables
 
+import android.content.ActivityNotFoundException
+import android.content.Context
 import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
@@ -28,6 +30,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.semantics
@@ -144,11 +147,7 @@ private fun Footer(
                 R.string.terms_and_conditions,
                 R.string.terms,
             ) {
-                uriHandler.openUriOrElse(it.toString()) {
-                    val msg = context.getString(R.string.no_browser_cannot_open_link)
-                    Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
-                    Logger.w(msg)
-                }
+                openURL(context, uriHandler, it)
             }
 
             if (configuration.privacyURL != null) {
@@ -163,11 +162,7 @@ private fun Footer(
                 R.string.privacy_policy,
                 R.string.privacy,
             ) {
-                uriHandler.openUriOrElse(it.toString()) {
-                    val msg = context.getString(R.string.no_browser_cannot_open_link)
-                    Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
-                    Logger.w(msg)
-                }
+                openURL(context, uriHandler, it)
             }
         }
     }
@@ -259,6 +254,18 @@ private fun RowScope.Button(
 private object FooterConstants {
     @ReadOnlyComposable @Composable
     fun style(): TextStyle = MaterialTheme.typography.bodySmall
+}
+
+private fun openURL(context: Context, uriHandler: UriHandler, url: URL) {
+    uriHandler.openUriOrElse(url.toString()) { exception ->
+        val msg = if (exception is ActivityNotFoundException) {
+            context.getString(R.string.no_browser_cannot_open_link)
+        } else {
+            context.getString(R.string.cannot_open_link)
+        }
+        Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+        Logger.w(msg)
+    }
 }
 
 @Preview(showBackground = true)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/UriHandlerExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/UriHandlerExtensions.kt
@@ -7,10 +7,12 @@ import androidx.compose.ui.platform.UriHandler
  * Opens the given [uri] in a browser. If no browser is installed, [fallbackAction] is called.
  */
 @Suppress("SwallowedException")
-fun UriHandler.openUriOrElse(uri: String, fallbackAction: () -> Unit) {
+fun UriHandler.openUriOrElse(uri: String, fallbackAction: (e: Exception) -> Unit) {
     try {
         openUri(uri)
     } catch (e: ActivityNotFoundException) {
-        fallbackAction()
+        fallbackAction(e)
+    } catch (e: IllegalArgumentException) {
+        fallbackAction(e)
     }
 }

--- a/ui/revenuecatui/src/main/res/values-ar/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ar/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">يكمل</string>
     <string name="default_offer_details_with_intro_offer">ابدأ الفترة التجريبية التي تبلغ {{ sub_offer_duration }}، ثم {{ Total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">لم يتم تثبيت المتصفح. تعذر فتح الرابط.</string>
+    <string name="cannot_open_link">الرابط غير صالح. لم يتمكن من الفتح.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-bg/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-bg/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">продължи</string>
     <string name="default_offer_details_with_intro_offer">Започнете своя пробен период от {{ sub_offer_duration }}, след което {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Няма инсталиран браузър. Връзката не може да бъде отворена.</string>
+    <string name="cannot_open_link">Невалиден линк. Не може да бъде отворен.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-ca/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ca/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Continua</string>
     <string name="default_offer_details_with_intro_offer">Inicieu la vostra prova de {{ sub_offer_duration }} i després {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">No hi ha cap navegador instal·lat. No s\'ha pogut obrir l\'enllaç.</string>
+    <string name="cannot_open_link">Enllaç no vàlid. No s’ha pogut obrir.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-cs/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-cs/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Pokračovat</string>
     <string name="default_offer_details_with_intro_offer">Začněte {{ sub_offer_duration }} zkušební období, poté {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Není nainstalován prohlížeč. Odkaz nelze otevřít.</string>
+    <string name="cannot_open_link">Odkaz je neplatný. Nelze otevřít.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-da/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-da/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Blive ved</string>
     <string name="default_offer_details_with_intro_offer">Start din prøveperiode på {{ sub_offer_duration }} og derefter {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Ingen browser installeret. Link kunne ikke åbnes.</string>
+    <string name="cannot_open_link">Ugyldigt link. Kunne ikke åbnes.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-de/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-de/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Weitermachen</string>
     <string name="default_offer_details_with_intro_offer">Starten Sie Ihre Testversion für {{ sub_offer_duration }} und dann für {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Kein Browser installiert. Link konnte nicht geöffnet werden.</string>
+    <string name="cannot_open_link">Ungültiger Link. Konnte nicht geöffnet werden.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-el/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-el/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Να συνεχίσει</string>
     <string name="default_offer_details_with_intro_offer">Ξεκινήστε τη δοκιμή {{ sub_offer_duration }} και μετά {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Δεν είναι εγκατεστημένος περιηγητής. Ο σύνδεσμος δεν μπόρεσε να ανοιχτεί.</string>
+    <string name="cannot_open_link">Μη έγκυρος σύνδεσμος. Δεν μπόρεσε να ανοιχτεί.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-es/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-es/strings.xml
@@ -19,4 +19,5 @@
     <string name="weekly">Semanalmente</string>
     <string name="lifetime">Toda la vida</string>
     <string name="no_browser_cannot_open_link">No hay navegador instalado. No se pudo abrir el enlace.</string>
+    <string name="cannot_open_link">Enlace inválido. No se pudo abrir.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-fi/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-fi/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Jatkaa</string>
     <string name="default_offer_details_with_intro_offer">Aloita {{ sub_offer_duration }} -kokeilu ja sitten {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Selainta ei ole asennettu. Linkkiä ei voitu avata.</string>
+    <string name="cannot_open_link">Virheellinen linkki. Ei voitu avata.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-fr/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-fr/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Continuer</string>
     <string name="default_offer_details_with_intro_offer">Démarrez votre essai de {{ sub_offer_duration }}, puis de {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Aucun navigateur installé. Le lien n\'a pas pu être ouvert.</string>
+    <string name="cannot_open_link">Lien invalide. Impossible à ouvrir.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-he/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-he/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">לְהַמשִׁיך</string>
     <string name="default_offer_details_with_intro_offer">התחל את תקופת הניסיון של {{ sub_offer_duration }} ולאחר מכן {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">אין דפדפן מותקן. לא ניתן לפתוח את הקישור.</string>
+    <string name="cannot_open_link">הקישור אינו חוקי. לא ניתן לפתוח.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-hi/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-hi/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">जारी रखना</string>
     <string name="default_offer_details_with_intro_offer">अपना {{sub_offer_duration }} परीक्षण शुरू करें, फिर {{ total_price_and_per_month }}।</string>
     <string name="no_browser_cannot_open_link">ब्राउज़र स्थापित नहीं है। लिंक नहीं खोला जा सका।</string>
+    <string name="cannot_open_link">" लिंक अमान्य है। इसे खोला नहीं जा सका।"</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-hr/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-hr/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Nastaviti</string>
     <string name="default_offer_details_with_intro_offer">Započnite probno razdoblje od {{ sub_offer_duration }}, a zatim {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Nije instaliran preglednik. Veza se nije mogla otvoriti.</string>
+    <string name="cannot_open_link">Nevažeća poveznica. Nije moguće otvoriti.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-hu/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-hu/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Folytatni</string>
     <string name="default_offer_details_with_intro_offer">Indítsa el a {{ sub_offer_duration }} próbaidőszakot, majd {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Nincs böngésző telepítve. A linket nem sikerült megnyitni.</string>
+    <string name="cannot_open_link">Érvénytelen link. Nem sikerült megnyitni.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-id/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-id/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Melanjutkan</string>
     <string name="default_offer_details_with_intro_offer">Mulai uji coba {{ sub_offer_duration }} Anda, lalu {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Tidak ada browser yang terpasang. Tautan tidak bisa dibuka.</string>
+    <string name="cannot_open_link">Tautan tidak valid. Tidak dapat dibuka.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-it/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-it/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Continua</string>
     <string name="default_offer_details_with_intro_offer">Inizia la tua prova di {{ sub_offer_duration }}, poi {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Nessun browser installato. Il link non può essere aperto.</string>
+    <string name="cannot_open_link">Link non valido. Impossibile aprire.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-ja/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ja/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">続く</string>
     <string name="default_offer_details_with_intro_offer">{{ sub_offer_duration }} トライアルを開始してから、{{ total_price_and_per_month }} を開始してください。</string>
     <string name="no_browser_cannot_open_link">ブラウザがインストールされていません。リンクを開くことができませんでした。</string>
+    <string name="cannot_open_link">リンクが無効です。開くことができませんでした。</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-kk/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-kk/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Жалғастыру</string>
     <string name="default_offer_details_with_intro_offer">{{ sub_offer_duration }} сынақ нұсқасын бастаңыз, содан кейін {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Шолғыш орнатылмаған. Сілтеме ашылмады.</string>
+    <string name="cannot_open_link">Сілтеме жарамсыз. Ашылмады.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-ko/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ko/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">계속하다</string>
     <string name="default_offer_details_with_intro_offer">{{ sub_offer_duration }} 무료 체험을 시작한 후 {{ total_price_and_per_month }}를 시작하세요.</string>
     <string name="no_browser_cannot_open_link">브라우저가 설치되어 있지 않습니다. 링크를 열 수 없습니다.</string>
+    <string name="cannot_open_link">링크가 유효하지 않습니다. 열 수 없습니다.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-ms/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ms/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">teruskan</string>
     <string name="default_offer_details_with_intro_offer">Mulakan percubaan {{ sub_offer_duration }} anda, kemudian {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Tiada pelayar dipasang. Pautan tidak dapat dibuka.</string>
+    <string name="cannot_open_link">Pautan tidak sah. Tidak dapat dibuka.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-nl/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-nl/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Doorgaan</string>
     <string name="default_offer_details_with_intro_offer">Start uw proefperiode van {{ sub_offer_duration }} en daarna {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Geen browser geïnstalleerd. Link kon niet worden geopend.</string>
+    <string name="cannot_open_link">Ongeldige link. Kon niet worden geopend.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-no/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-no/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Fortsette</string>
     <string name="default_offer_details_with_intro_offer">Start prøveperioden på {{ sub_offer_duration }}, og deretter {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Ingen nettleser installert. Lenken kunne ikke åpnes.</string>
+    <string name="cannot_open_link">Ugyldig lenke. Kunne ikke åpnes.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-pl/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-pl/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Kontynuować</string>
     <string name="default_offer_details_with_intro_offer">Rozpocznij okres próbny {{ sub_offer_duration }}, a następnie {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Brak zainstalowanej przeglądarki. Link nie mógł zostać otwarty.</string>
+    <string name="cannot_open_link">Nieprawidłowy link. Nie można otworzyć.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-pt/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-pt/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Continuar</string>
     <string name="default_offer_details_with_intro_offer">Comece sua avaliação de {{ sub_offer_duration }} e depois {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Nenhum navegador instalado. O link não pôde ser aberto.</string>
+    <string name="cannot_open_link">Link inválido. Não foi possível abrir.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-ro/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ro/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Continua</string>
     <string name="default_offer_details_with_intro_offer">Începeți perioada de încercare de {{ sub_offer_duration }}, apoi {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Niciun browser instalat. Linkul nu a putut fi deschis.</string>
+    <string name="cannot_open_link">Link invalid. Nu a putut fi deschis.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-ru/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-ru/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Продолжить</string>
     <string name="default_offer_details_with_intro_offer">Начните пробную версию на {{ sub_offer_duration }}, затем {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Браузер не установлен. Ссылка не может быть открыта.</string>
+    <string name="cannot_open_link">Неверная ссылка. Не удалось открыть.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-sk/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-sk/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">ďalej</string>
     <string name="default_offer_details_with_intro_offer">Začnite skúšobnú verziu {{ sub_offer_duration }}, potom {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Nie je nainštalovaný prehliadač. Odkaz sa nepodarilo otvoriť.</string>
+    <string name="cannot_open_link">Neplatný odkaz. Nedalo sa otvoriť.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-sv/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-sv/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Fortsätta</string>
     <string name="default_offer_details_with_intro_offer">Starta din provperiod på {{ sub_offer_duration }} och sedan {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Ingen webbläsare installerad. Länken kunde inte öppnas.</string>
+    <string name="cannot_open_link">Ogiltig länk. Kunde inte öppnas.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-th/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-th/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">ดำเนินการต่อ</string>
     <string name="default_offer_details_with_intro_offer">เริ่มทดลองใช้ {{ sub_offer_duration }} จากนั้นจ่ายเป็น {{ Total_price_and_per_month }}</string>
     <string name="no_browser_cannot_open_link">ไม่ได้ติดตั้งเบราว์เซอร์ ลิงก์ไม่สามารถเปิดได้</string>
+    <string name="cannot_open_link">ลิงก์ไม่ถูกต้อง ไม่สามารถเปิดได้</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-tr/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-tr/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Devam et</string>
     <string name="default_offer_details_with_intro_offer">{{ sub_offer_duration }} denemenizi başlatın, ardından {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Yüklü bir tarayıcı yok. Bağlantı açılamadı.</string>
+    <string name="cannot_open_link">Geçersiz bağlantı. Açılamadı.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-uk/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-uk/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Продовжити</string>
     <string name="default_offer_details_with_intro_offer">Розпочніть {{ sub_offer_duration }} пробний період, а потім {{ total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Браузер не встановлено. Посилання не вдалося відкрити.</string>
+    <string name="cannot_open_link">Недійсне посилання. Не вдалося відкрити.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-vi/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-vi/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">Tiếp tục</string>
     <string name="default_offer_details_with_intro_offer">Bắt đầu dùng thử {{ sub_offer_duration }}, sau đó là {{ Total_price_and_per_month }}.</string>
     <string name="no_browser_cannot_open_link">Không có trình duyệt nào được cài đặt. Liên kết không thể mở được.</string>
+    <string name="cannot_open_link">Liên kết không hợp lệ. Không thể mở được.</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-zh-rHK/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-zh-rHK/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">繼續</string>
     <string name="default_offer_details_with_intro_offer">試用期{{ sub_offer_duration }}，屆滿後{{ total_price_and_per_month }}。</string>
     <string name="no_browser_cannot_open_link">未安裝瀏覽器。連結無法打開。</string>
+    <string name="cannot_open_link">連結無效，無法開啟</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-zh-rTW/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-zh-rTW/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">繼續</string>
     <string name="default_offer_details_with_intro_offer">試用期{{ sub_offer_duration }}，屆滿後{{ total_price_and_per_month }}。</string>
     <string name="no_browser_cannot_open_link">未安裝瀏覽器。連結無法打開。</string>
+    <string name="cannot_open_link">連結無效，無法開啟。</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values-zh/strings.xml
+++ b/ui/revenuecatui/src/main/res/values-zh/strings.xml
@@ -19,4 +19,5 @@
     <string name="continue_cta">继续</string>
     <string name="default_offer_details_with_intro_offer">试用期{{ sub_offer_duration }}，届满后{{ total_price_and_per_month }}。</string>
     <string name="no_browser_cannot_open_link">未安装浏览器。链接无法打开。</string>
+    <string name="cannot_open_link">链接无效，无法打开。</string>
 </resources>

--- a/ui/revenuecatui/src/main/res/values/strings.xml
+++ b/ui/revenuecatui/src/main/res/values/strings.xml
@@ -19,4 +19,5 @@
     <string name="weekly">Weekly</string>
     <string name="lifetime">Lifetime</string>
     <string name="no_browser_cannot_open_link">No browser installed. Link could not be opened.</string>
+    <string name="cannot_open_link">Link invalid. Could not be opened.</string>
 </resources>


### PR DESCRIPTION
### Description
Looking at the [docs](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/AndroidUriHandler#openUri(kotlin.String)), the `openUri` method, may throw an `IllegalArgumentException` if the link is invalid.

I haven't been able to reproduce this error, getting an `ActivityNotFoundException` instead when the link is invalid... Seems this may be something device related. In any case, we should also handle these exceptions according to the docs and fail gracefully.