### PR TITLE
Catch `NoSuchMethodError` on Ads library

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcher.kt
@@ -79,6 +79,11 @@ internal class GoogleDeviceIdentifiersFetcher(
                 AttributionStrings.NULL_EXCEPTION_WHEN_FETCHING_ADVERTISING_IDENTIFIER
                     .format(e.localizedMessage),
             )
+        } catch (e: NoSuchMethodError) {
+            log(
+                LogIntent.GOOGLE_ERROR,
+                AttributionStrings.NO_SUCH_METHOD_WHEN_FETCHING_ADVERTISING_IDENTIFIER,
+            )
         }
         return advertisingID
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/attribution/GoogleDeviceIdentifiersFetcher.kt
@@ -79,7 +79,7 @@ internal class GoogleDeviceIdentifiersFetcher(
                 AttributionStrings.NULL_EXCEPTION_WHEN_FETCHING_ADVERTISING_IDENTIFIER
                     .format(e.localizedMessage),
             )
-        } catch (e: NoSuchMethodError) {
+        } catch (@Suppress("SwallowedException") e: NoSuchMethodError) {
             log(
                 LogIntent.GOOGLE_ERROR,
                 AttributionStrings.NO_SUCH_METHOD_WHEN_FETCHING_ADVERTISING_IDENTIFIER,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/AttributionStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/AttributionStrings.kt
@@ -16,6 +16,8 @@ internal object AttributionStrings {
         "identifier. Message: %s"
     const val NULL_EXCEPTION_WHEN_FETCHING_ADVERTISING_IDENTIFIER = "NullPointerException when getting advertising " +
         "identifier. Message: %s"
+    const val NO_SUCH_METHOD_WHEN_FETCHING_ADVERTISING_IDENTIFIER = "NoSuchMethodError when getting advertising " +
+        "identifier. com.google.android.gms.ads library is not available."
     const val MARKING_ATTRIBUTES_SYNCED = "Marking the following attributes as synced for App User ID: %s"
     const val METHOD_CALLED = "%s called"
     const val NO_SUBSCRIBER_ATTRIBUTES_TO_SYNCHRONIZE = "No subscriber attributes to synchronize."


### PR DESCRIPTION
Reported in https://github.com/RevenueCat/purchases-android/issues/1913

Looks like https://github.com/RevenueCat/purchases-android/commit/84874c940d3e2f60c87455db36760a36fb9dc704 surfaced this issue and might be the cause for many hangs in React Native