### PR TITLE
[Paywalls V2] Minimizes Java API

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
@@ -15,8 +15,8 @@ import kotlinx.serialization.encoding.Encoder
 @Serializable
 @SerialName("button")
 internal data class ButtonComponent(
-    val action: Action,
-    val stack: StackComponent,
+    @get:JvmSynthetic val action: Action,
+    @get:JvmSynthetic val stack: StackComponent,
 ) : PaywallComponent {
 
     @InternalRevenueCatAPI
@@ -31,7 +31,7 @@ internal data class ButtonComponent(
         object NavigateBack : Action
 
         @Serializable
-        data class NavigateTo(val destination: Destination) : Action
+        data class NavigateTo(@get:JvmSynthetic val destination: Destination) : Action
     }
 
     @InternalRevenueCatAPI
@@ -43,13 +43,16 @@ internal data class ButtonComponent(
         object CustomerCenter : Destination
 
         @Serializable
-        data class PrivacyPolicy(val urlLid: String, val method: UrlMethod) : Destination
+        data class PrivacyPolicy(
+            @get:JvmSynthetic val urlLid: String,
+            @get:JvmSynthetic val method: UrlMethod,
+        ) : Destination
 
         @Serializable
-        data class Terms(val urlLid: String, val method: UrlMethod) : Destination
+        data class Terms(@get:JvmSynthetic val urlLid: String, @get:JvmSynthetic val method: UrlMethod) : Destination
 
         @Serializable
-        data class Url(val urlLid: String, val method: UrlMethod) : Destination
+        data class Url(@get:JvmSynthetic val urlLid: String, @get:JvmSynthetic val method: UrlMethod) : Destination
     }
 
     @InternalRevenueCatAPI

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ImageComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ImageComponent.kt
@@ -18,31 +18,45 @@ import kotlinx.serialization.Serializable
 @Serializable
 @SerialName("image")
 internal data class ImageComponent(
+    @get:JvmSynthetic
     val source: ThemeImageUrls,
+    @get:JvmSynthetic
     val size: Size = Size(width = Fill, height = Fit),
+    @get:JvmSynthetic
     @SerialName("override_source_lid")
     val overrideSourceLid: LocalizationKey? = null,
+    @get:JvmSynthetic
     @SerialName("mask_shape")
     val maskShape: MaskShape? = null,
+    @get:JvmSynthetic
     @SerialName("color_overlay")
     val colorOverlay: ColorScheme? = null,
+    @get:JvmSynthetic
     @SerialName("fit_mode")
     val fitMode: FitMode = FIT,
+    @get:JvmSynthetic
     val overrides: ComponentOverrides<PartialImageComponent>? = null,
 ) : PaywallComponent
 
 @InternalRevenueCatAPI
 @Serializable
 internal data class PartialImageComponent(
+    @get:JvmSynthetic
     val visible: Boolean? = true,
+    @get:JvmSynthetic
     val source: ThemeImageUrls? = null,
+    @get:JvmSynthetic
     val size: Size? = null,
+    @get:JvmSynthetic
     @SerialName("override_source_lid")
     val overrideSourceLid: LocalizationKey? = null,
+    @get:JvmSynthetic
     @SerialName("fit_mode")
     val fitMode: FitMode? = null,
+    @get:JvmSynthetic
     @SerialName("mask_shape")
     val maskShape: MaskShape? = null,
+    @get:JvmSynthetic
     @SerialName("color_overlay")
     val colorOverlay: ColorScheme? = null,
 ) : PartialComponent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PackageComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PackageComponent.kt
@@ -8,9 +8,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 @SerialName("package")
 internal data class PackageComponent(
+    @get:JvmSynthetic
     @SerialName("package_id")
     val packageId: String,
+    @get:JvmSynthetic
     @SerialName("is_selected_by_default")
     val isSelectedByDefault: Boolean,
+    @get:JvmSynthetic
     val stack: StackComponent,
 ) : PaywallComponent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PurchaseButtonComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PurchaseButtonComponent.kt
@@ -8,5 +8,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 @SerialName("purchase_button")
 internal data class PurchaseButtonComponent(
-    val stack: StackComponent,
+    @get:JvmSynthetic val stack: StackComponent,
 ) : PaywallComponent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/StackComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/StackComponent.kt
@@ -21,32 +21,53 @@ import kotlinx.serialization.Serializable
 @Serializable
 @SerialName("stack")
 internal data class StackComponent(
+    @get:JvmSynthetic
     val components: List<PaywallComponent>,
+    @get:JvmSynthetic
     val dimension: Dimension = Vertical(CENTER, START),
+    @get:JvmSynthetic
     val size: Size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit),
+    @get:JvmSynthetic
     val spacing: Float? = null,
+    @get:JvmSynthetic
     @SerialName("background_color")
     val backgroundColor: ColorScheme? = null,
+    @get:JvmSynthetic
     val padding: Padding = zero,
+    @get:JvmSynthetic
     val margin: Padding = zero,
+    @get:JvmSynthetic
     val shape: Shape? = null,
+    @get:JvmSynthetic
     val border: Border? = null,
+    @get:JvmSynthetic
     val shadow: Shadow? = null,
+    @get:JvmSynthetic
     val overrides: ComponentOverrides<PartialStackComponent>? = null,
 ) : PaywallComponent
 
 @InternalRevenueCatAPI
 @Serializable
 internal data class PartialStackComponent(
+    @get:JvmSynthetic
     val visible: Boolean? = true,
+    @get:JvmSynthetic
     val dimension: Dimension? = null,
+    @get:JvmSynthetic
     val size: Size? = null,
+    @get:JvmSynthetic
     val spacing: Float? = null,
+    @get:JvmSynthetic
     @SerialName("background_color")
     val backgroundColor: ColorScheme? = null,
+    @get:JvmSynthetic
     val padding: Padding? = null,
+    @get:JvmSynthetic
     val margin: Padding? = null,
+    @get:JvmSynthetic
     val shape: Shape? = null,
+    @get:JvmSynthetic
     val border: Border? = null,
+    @get:JvmSynthetic
     val shadow: Shadow? = null,
 ) : PartialComponent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/StickyFooterComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/StickyFooterComponent.kt
@@ -8,5 +8,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 @SerialName("sticky_footer")
 internal data class StickyFooterComponent(
+    @get:JvmSynthetic
     val stack: StackComponent,
 ) : PaywallComponent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/TextComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/TextComponent.kt
@@ -26,22 +26,33 @@ import kotlinx.serialization.Serializable
 class TextComponent
 @Suppress("LongParameterList")
 internal constructor(
+    @get:JvmSynthetic
     @SerialName("text_lid")
     val text: LocalizationKey,
+    @get:JvmSynthetic
     val color: ColorScheme,
+    @get:JvmSynthetic
     @SerialName("background_color")
     val backgroundColor: ColorScheme? = null,
+    @get:JvmSynthetic
     @SerialName("font_name")
     val fontName: String? = null,
+    @get:JvmSynthetic
     @SerialName("font_weight")
     val fontWeight: FontWeight = REGULAR,
+    @get:JvmSynthetic
     @SerialName("font_size")
     val fontSize: FontSize = BODY_M,
+    @get:JvmSynthetic
     @SerialName("horizontal_alignment")
     val horizontalAlignment: HorizontalAlignment = CENTER,
+    @get:JvmSynthetic
     val size: Size = Size(width = Fill, height = Fit),
+    @get:JvmSynthetic
     val padding: Padding = zero,
+    @get:JvmSynthetic
     val margin: Padding = zero,
+    @get:JvmSynthetic
     val overrides: ComponentOverrides<PartialTextComponent>? = null,
 ) : PaywallComponent
 
@@ -51,21 +62,32 @@ internal constructor(
 class PartialTextComponent
 @Suppress("LongParameterList")
 internal constructor(
+    @get:JvmSynthetic
     val visible: Boolean? = true,
+    @get:JvmSynthetic
     @SerialName("text_lid")
     val text: LocalizationKey? = null,
+    @get:JvmSynthetic
     val color: ColorScheme? = null,
+    @get:JvmSynthetic
     @SerialName("background_color")
     val backgroundColor: ColorScheme? = null,
+    @get:JvmSynthetic
     @SerialName("font_name")
     val fontName: String? = null,
+    @get:JvmSynthetic
     @SerialName("font_weight")
     val fontWeight: FontWeight? = null,
+    @get:JvmSynthetic
     @SerialName("font_size")
     val fontSize: FontSize? = null,
+    @get:JvmSynthetic
     @SerialName("horizontal_alignment")
     val horizontalAlignment: HorizontalAlignment? = null,
+    @get:JvmSynthetic
     val size: Size? = null,
+    @get:JvmSynthetic
     val padding: Padding? = null,
+    @get:JvmSynthetic
     val margin: Padding? = null,
 ) : PartialComponent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/Background.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/Background.kt
@@ -11,9 +11,9 @@ import kotlinx.serialization.Serializable
 internal sealed interface Background {
     @Serializable
     @SerialName("color")
-    data class Color(val value: ColorScheme) : Background
+    data class Color(@get:JvmSynthetic val value: ColorScheme) : Background
 
     @Serializable
     @SerialName("image")
-    data class Image(val value: ThemeImageUrls) : Background
+    data class Image(@get:JvmSynthetic val value: ThemeImageUrls) : Background
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverrides.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverrides.kt
@@ -9,23 +9,23 @@ import kotlinx.serialization.Serializable
 @Poko
 @Serializable
 class ComponentOverrides<T : PartialComponent> internal constructor(
-    val introOffer: T? = null,
-    val states: ComponentStates<T>? = null,
-    val conditions: ComponentConditions<T>? = null,
+    @get:JvmSynthetic val introOffer: T? = null,
+    @get:JvmSynthetic val states: ComponentStates<T>? = null,
+    @get:JvmSynthetic val conditions: ComponentConditions<T>? = null,
 )
 
 @InternalRevenueCatAPI
 @Poko
 @Serializable
 class ComponentStates<T : PartialComponent> internal constructor(
-    val selected: T? = null,
+    @get:JvmSynthetic val selected: T? = null,
 )
 
 @InternalRevenueCatAPI
 @Poko
 @Serializable
 class ComponentConditions<T : PartialComponent> internal constructor(
-    val compact: T? = null,
-    val medium: T? = null,
-    val expanded: T? = null,
+    @get:JvmSynthetic val compact: T? = null,
+    @get:JvmSynthetic val medium: T? = null,
+    @get:JvmSynthetic val expanded: T? = null,
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentsConfig.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentsConfig.kt
@@ -9,14 +9,15 @@ import kotlinx.serialization.Serializable
 @InternalRevenueCatAPI
 @Serializable
 internal data class ComponentsConfig(
-    val base: PaywallComponentsConfig,
+    @get:JvmSynthetic val base: PaywallComponentsConfig,
 )
 
 @InternalRevenueCatAPI
 @Serializable
 internal data class PaywallComponentsConfig(
-    val stack: StackComponent,
-    val background: Background,
+    @get:JvmSynthetic val stack: StackComponent,
+    @get:JvmSynthetic val background: Background,
+    @get:JvmSynthetic
     @SerialName("sticky_footer")
     val stickyFooter: StickyFooterComponent? = null,
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/Localization.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/Localization.kt
@@ -16,12 +16,12 @@ import kotlinx.serialization.encoding.Encoder
 @InternalRevenueCatAPI
 @Serializable
 @JvmInline
-internal value class LocaleId(val value: String)
+internal value class LocaleId(@get:JvmSynthetic val value: String)
 
 @InternalRevenueCatAPI
 @Serializable
 @JvmInline
-value class LocalizationKey internal constructor(val value: String)
+value class LocalizationKey internal constructor(@get:JvmSynthetic val value: String)
 
 @InternalRevenueCatAPI
 internal typealias LocalizationDictionary = Map<LocalizationKey, LocalizationData>
@@ -34,11 +34,11 @@ internal typealias LocalizationDictionary = Map<LocalizationKey, LocalizationDat
 internal sealed interface LocalizationData {
     @Serializable
     @JvmInline
-    value class Text(val value: String) : LocalizationData
+    value class Text(@get:JvmSynthetic val value: String) : LocalizationData
 
     @Serializable
     @JvmInline
-    value class Image(val value: ThemeImageUrls) : LocalizationData
+    value class Image(@get:JvmSynthetic val value: ThemeImageUrls) : LocalizationData
 }
 
 @OptIn(InternalRevenueCatAPI::class)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/PaywallComponentsData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/PaywallComponentsData.kt
@@ -9,16 +9,22 @@ import java.net.URL
 @InternalRevenueCatAPI
 @Serializable
 internal data class PaywallComponentsData(
+    @get:JvmSynthetic
     @SerialName("template_name")
     val templateName: String,
+    @get:JvmSynthetic
     @Serializable(with = URLSerializer::class)
     @SerialName("asset_base_url")
     val assetBaseURL: URL,
+    @get:JvmSynthetic
     @SerialName("components_config")
     val componentsConfig: ComponentsConfig,
+    @get:JvmSynthetic
     @SerialName("components_localizations")
     val componentsLocalizations: Map<LocaleId, LocalizationDictionary>,
+    @get:JvmSynthetic
     @SerialName("default_locale")
     val defaultLocaleIdentifier: LocaleId,
+    @get:JvmSynthetic
     val revision: Int = 0,
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Border.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Border.kt
@@ -6,6 +6,8 @@ import kotlinx.serialization.Serializable
 @InternalRevenueCatAPI
 @Serializable
 internal data class Border(
+    @get:JvmSynthetic
     val color: ColorScheme,
+    @get:JvmSynthetic
     val width: Double,
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/ColorInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/ColorInfo.kt
@@ -20,6 +20,7 @@ sealed interface ColorInfo {
     @Serializable
     @SerialName("hex")
     class Hex internal constructor(
+        @get:JvmSynthetic
         @Serializable(with = RgbaStringArgbColorIntDeserializer::class)
         @ColorInt
         val value: Int,
@@ -28,7 +29,7 @@ sealed interface ColorInfo {
     @Poko
     @Serializable
     @SerialName("alias")
-    class Alias internal constructor(val value: String) : ColorInfo
+    class Alias internal constructor(@get:JvmSynthetic val value: String) : ColorInfo
 
     sealed interface Gradient : ColorInfo {
 
@@ -36,15 +37,15 @@ sealed interface ColorInfo {
         @Serializable
         @SerialName("linear")
         class Linear internal constructor(
-            val degrees: Float,
-            val points: List<Point>,
+            @get:JvmSynthetic val degrees: Float,
+            @get:JvmSynthetic val points: List<Point>,
         ) : Gradient
 
         @Poko
         @Serializable
         @SerialName("radial")
         class Radial internal constructor(
-            val points: List<Point>,
+            @get:JvmSynthetic val points: List<Point>,
         ) : Gradient
 
         /**
@@ -55,8 +56,8 @@ sealed interface ColorInfo {
         class Point internal constructor(
             @Serializable(with = RgbaStringArgbColorIntDeserializer::class)
             @ColorInt
-            val color: Int,
-            val percent: Float,
+            @get:JvmSynthetic val color: Int,
+            @get:JvmSynthetic val percent: Float,
         )
     }
 }
@@ -65,8 +66,8 @@ sealed interface ColorInfo {
 @Poko
 @Serializable
 class ColorScheme internal constructor(
-    val light: ColorInfo,
-    val dark: ColorInfo? = null,
+    @get:JvmSynthetic val light: ColorInfo,
+    @get:JvmSynthetic val dark: ColorInfo? = null,
 )
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/CornerRadiuses.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/CornerRadiuses.kt
@@ -13,26 +13,31 @@ internal data class CornerRadiuses(
     /**
      * The top-leading, or top-start, corner radius, in dp.
      */
+    @get:JvmSynthetic
     @SerialName("top_leading")
     val topLeading: Double,
     /**
      * The top-trailing, or top-end, corner radius, in dp.
      */
+    @get:JvmSynthetic
     @SerialName("top_trailing")
     val topTrailing: Double,
     /**
      * The bottom-leading, or bottom-start, corner radius, in dp.
      */
+    @get:JvmSynthetic
     @SerialName("bottom_leading")
     val bottomLeading: Double,
     /**
      * The bottom-trailing, or bottom-end, corner radius, in dp.
      */
+    @get:JvmSynthetic
     @SerialName("bottom_trailing")
     val bottomTrailing: Double,
 ) {
     companion object {
-        val zero = CornerRadiuses(0.0, 0.0, 0.0, 0.0)
-        val default = zero
+        @get:JvmSynthetic val zero = CornerRadiuses(0.0, 0.0, 0.0, 0.0)
+
+        @get:JvmSynthetic val default = zero
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Dimension.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Dimension.kt
@@ -11,20 +11,20 @@ internal sealed interface Dimension {
     @Serializable
     @SerialName("vertical")
     data class Vertical(
-        val alignment: HorizontalAlignment,
-        val distribution: FlexDistribution,
+        @get:JvmSynthetic val alignment: HorizontalAlignment,
+        @get:JvmSynthetic val distribution: FlexDistribution,
     ) : Dimension
 
     @Serializable
     @SerialName("horizontal")
     data class Horizontal(
-        val alignment: VerticalAlignment,
-        val distribution: FlexDistribution,
+        @get:JvmSynthetic val alignment: VerticalAlignment,
+        @get:JvmSynthetic val distribution: FlexDistribution,
     ) : Dimension
 
     @Serializable
     @SerialName("zlayer")
     data class ZLayer(
-        val alignment: TwoDimensionalAlignment,
+        @get:JvmSynthetic val alignment: TwoDimensionalAlignment,
     ) : Dimension
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/ImageUrls.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/ImageUrls.kt
@@ -9,20 +9,25 @@ import java.net.URL
 @InternalRevenueCatAPI
 @Serializable
 internal data class ImageUrls internal constructor(
+    @get:JvmSynthetic
     @Serializable(with = URLSerializer::class)
     val original: URL,
+    @get:JvmSynthetic
     @Serializable(with = URLSerializer::class)
     val webp: URL,
+    @get:JvmSynthetic
     @SerialName("webp_low_res")
     @Serializable(with = URLSerializer::class)
     val webpLowRes: URL,
+    @get:JvmSynthetic
     val width: UInt,
+    @get:JvmSynthetic
     val height: UInt,
 )
 
 @InternalRevenueCatAPI
 @Serializable
 internal data class ThemeImageUrls internal constructor(
-    val light: ImageUrls,
-    val dark: ImageUrls? = null,
+    @get:JvmSynthetic val light: ImageUrls,
+    @get:JvmSynthetic val dark: ImageUrls? = null,
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/MaskShape.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/MaskShape.kt
@@ -11,7 +11,7 @@ internal sealed interface MaskShape {
     @Serializable
     @SerialName("rectangle")
     data class Rectangle(
-        val corners: CornerRadiuses? = null,
+        @get:JvmSynthetic val corners: CornerRadiuses? = null,
     ) : MaskShape
 
     @Serializable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Padding.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Padding.kt
@@ -14,19 +14,19 @@ class Padding internal constructor(
     /**
      * The top padding, in dp.
      */
-    val top: Double,
+    @get:JvmSynthetic val top: Double,
     /**
      * The bottom padding, in dp.
      */
-    val bottom: Double,
+    @get:JvmSynthetic val bottom: Double,
     /**
      * The leading, or start, padding, in dp.
      */
-    val leading: Double,
+    @get:JvmSynthetic val leading: Double,
     /**
      * The trailing, or end, padding, in dp.
      */
-    val trailing: Double,
+    @get:JvmSynthetic val trailing: Double,
 ) {
     internal companion object {
         @get:JvmSynthetic

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Shadow.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Shadow.kt
@@ -6,8 +6,8 @@ import kotlinx.serialization.Serializable
 @InternalRevenueCatAPI
 @Serializable
 internal data class Shadow(
-    val color: ColorScheme,
-    val radius: Double,
-    val x: Double,
-    val y: Double,
+    @get:JvmSynthetic val color: ColorScheme,
+    @get:JvmSynthetic val radius: Double,
+    @get:JvmSynthetic val x: Double,
+    @get:JvmSynthetic val y: Double,
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Shape.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Shape.kt
@@ -11,7 +11,7 @@ internal sealed interface Shape {
     @Serializable
     @SerialName("rectangle")
     data class Rectangle(
-        val corners: CornerRadiuses? = null,
+        @get:JvmSynthetic val corners: CornerRadiuses? = null,
     ) : Shape
 
     @Serializable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Size.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Size.kt
@@ -9,8 +9,8 @@ import kotlinx.serialization.Serializable
 @Poko
 @Serializable
 class Size internal constructor(
-    val width: SizeConstraint,
-    val height: SizeConstraint,
+    @get:JvmSynthetic val width: SizeConstraint,
+    @get:JvmSynthetic val height: SizeConstraint,
 )
 
 @InternalRevenueCatAPI
@@ -29,6 +29,6 @@ sealed interface SizeConstraint {
     @Serializable
     @SerialName("fixed")
     class Fixed internal constructor(
-        val value: UInt,
+        @get:JvmSynthetic val value: UInt,
     ) : SizeConstraint
 }


### PR DESCRIPTION
Adds `@JvmSynthetic` to all public and internal Paywall Components fields to minimize the Java API. (Kotlin's `internal` visibility becomes `public` in Java.)