### PR TITLE
Uses `Sequence` instead of `Stream` to avoid errors due to unavailable Java 8 APIs

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/FileHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/FileHelper.kt
@@ -9,7 +9,6 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.InputStreamReader
-import java.util.stream.Stream
 
 internal class FileHelper(
     private val applicationContext: Context,
@@ -34,21 +33,21 @@ internal class FileHelper(
         return file.delete()
     }
 
-    // This is using a lambda with a Stream instead of returning the Stream itself. This is so we keep
-    // the responsibility of closing the bufferedReader to this class. Note that the Stream should
-    // be used synchronously, otherwise the bufferedReader will be closed before the stream is used.
+    // This is using a lambda with a Sequence instead of returning the Sequence itself. This is so we keep
+    // the responsibility of closing the bufferedReader to this class. Note that the Sequence should
+    // be used synchronously, otherwise the bufferedReader will be closed before the Sequence is used.
     @RequiresApi(Build.VERSION_CODES.N)
-    fun readFilePerLines(filePath: String, streamBlock: ((Stream<String>) -> Unit)) {
+    fun readFilePerLines(filePath: String, block: ((Sequence<String>) -> Unit)) {
         openBufferedReader(filePath) { bufferedReader ->
-            streamBlock(bufferedReader.lines())
+            block(bufferedReader.lineSequence())
         }
     }
 
     @RequiresApi(Build.VERSION_CODES.N)
     fun removeFirstLinesFromFile(filePath: String, numberOfLinesToRemove: Int) {
         val textToAppend = StringBuilder()
-        readFilePerLines(filePath) { stream ->
-            stream.skip(numberOfLinesToRemove.toLong()).forEach { line ->
+        readFilePerLines(filePath) { sequence ->
+            sequence.drop(numberOfLinesToRemove).forEach { line ->
                 textToAppend.append(line).append("\n")
             }
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
@@ -10,7 +10,6 @@ import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.verboseLog
 import org.json.JSONObject
 import java.io.IOException
-import java.util.stream.Collectors
 
 /**
  * This class is in charge of syncing all previously tracked diagnostics. All operations will be executed
@@ -32,7 +31,7 @@ internal class DiagnosticsSynchronizer(
         const val MAX_NUMBER_POST_RETRIES = 3
 
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-        const val MAX_EVENTS_TO_SYNC_PER_REQUEST: Long = 200
+        const val MAX_EVENTS_TO_SYNC_PER_REQUEST: Int = 200
 
         fun initializeSharedPreferences(context: Context): SharedPreferences =
             context.getSharedPreferences(
@@ -95,8 +94,8 @@ internal class DiagnosticsSynchronizer(
 
     private fun getEventsToSync(): List<JSONObject> {
         var eventsToSync: List<JSONObject> = emptyList()
-        diagnosticsFileHelper.readFileAsJson { stream ->
-            eventsToSync = stream.limit(MAX_EVENTS_TO_SYNC_PER_REQUEST).collect(Collectors.toList())
+        diagnosticsFileHelper.readFileAsJson { sequence ->
+            eventsToSync = sequence.take(MAX_EVENTS_TO_SYNC_PER_REQUEST).toList()
         }
         return eventsToSync
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEventsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEventsManager.kt
@@ -11,7 +11,6 @@ import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.utils.EventsFileHelper
-import java.util.stream.Collectors
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @RequiresApi(Build.VERSION_CODES.N)
@@ -23,7 +22,7 @@ internal class PaywallEventsManager(
 ) {
     companion object {
         const val PAYWALL_EVENTS_FILE_PATH = "RevenueCat/paywall_event_store/paywall_event_store.jsonl"
-        private const val FLUSH_COUNT = 50L
+        private const val FLUSH_COUNT = 50
     }
 
     @get:Synchronized
@@ -78,9 +77,9 @@ internal class PaywallEventsManager(
     }
 
     private fun getEventsToSync(): List<PaywallStoredEvent?> {
-        var eventsToSync: List<PaywallStoredEvent> = emptyList()
-        fileHelper.readFile { stream ->
-            eventsToSync = stream.limit(FLUSH_COUNT).collect(Collectors.toList())
+        var eventsToSync: List<PaywallStoredEvent?> = emptyList()
+        fileHelper.readFile { sequence ->
+            eventsToSync = sequence.take(FLUSH_COUNT).toList()
         }
         return eventsToSync
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/EventsFileHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/EventsFileHelper.kt
@@ -6,7 +6,6 @@ import com.revenuecat.purchases.common.FileHelper
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.verboseLog
 import org.json.JSONObject
-import java.util.stream.Stream
 
 @RequiresApi(Build.VERSION_CODES.N)
 /**
@@ -24,13 +23,13 @@ internal open class EventsFileHelper<T : Event> (
     }
 
     @Synchronized
-    fun readFile(streamBlock: ((Stream<T>) -> Unit)) {
+    fun readFile(block: ((Sequence<T?>) -> Unit)) {
         val eventDeserializer = eventDeserializer
         if (eventDeserializer == null || fileHelper.fileIsEmpty(filePath)) {
-            streamBlock(Stream.empty())
+            block(emptySequence())
         } else {
-            fileHelper.readFilePerLines(filePath) { stream ->
-                streamBlock(stream.map { line -> mapToEvent(line) })
+            fileHelper.readFilePerLines(filePath) { sequence ->
+                block(sequence.map { line -> mapToEvent(line) })
             }
         }
     }
@@ -39,12 +38,12 @@ internal open class EventsFileHelper<T : Event> (
     // so adding this method to avoid the overhead of converting back to the model, then
     // back again to a JSONObject.
     @Synchronized
-    fun readFileAsJson(streamBlock: ((Stream<JSONObject>) -> Unit)) {
+    fun readFileAsJson(block: ((Sequence<JSONObject>) -> Unit)) {
         if (fileHelper.fileIsEmpty(filePath)) {
-            streamBlock(Stream.empty())
+            block(emptySequence())
         } else {
-            fileHelper.readFilePerLines(filePath) { stream ->
-                streamBlock(stream.map { JSONObject(it) })
+            fileHelper.readFilePerLines(filePath) { sequence ->
+                block(sequence.map { JSONObject(it) })
             }
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/FileHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/FileHelperTest.kt
@@ -137,11 +137,11 @@ class FileHelperTest {
     }
 
     @Test
-    fun `readFilePerLines returns stream with correct content`() {
+    fun `readFilePerLines returns sequence with correct content`() {
         createTestFileWithContents("first line\nsecond line\nthird line\nfourth line")
         val receivedValues = mutableListOf<String>()
-        fileHelper.readFilePerLines(testFilePath) { stream ->
-            stream.forEach {
+        fileHelper.readFilePerLines(testFilePath) { sequence ->
+            sequence.forEach {
                 receivedValues.add(it)
             }
         }
@@ -149,11 +149,11 @@ class FileHelperTest {
     }
 
     @Test
-    fun `readFilePerLines stream can be limited correctly`() {
+    fun `readFilePerLines sequence can be limited correctly`() {
         createTestFileWithContents("first line\nsecond line\nthird line\nfourth line")
         val receivedValues = mutableListOf<String>()
-        fileHelper.readFilePerLines(testFilePath) { stream ->
-            stream.limit(2).forEach {
+        fileHelper.readFilePerLines(testFilePath) { sequence ->
+            sequence.take(2).forEach {
                 receivedValues.add(it)
             }
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
@@ -14,7 +14,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import java.util.stream.Stream
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -76,8 +75,8 @@ class DiagnosticsFileHelperTest {
     fun `readDiagnosticsFile returns empty list if file is empty`() {
         every { fileHelper.fileIsEmpty(diagnosticsFilePath) } returns true
         var resultList: List<JSONObject>? = null
-        diagnosticsFileHelper.readFileAsJson { stream ->
-            resultList = stream.toList()
+        diagnosticsFileHelper.readFileAsJson { sequence ->
+            resultList = sequence.toList()
         }
         verify(exactly = 1) { fileHelper.fileIsEmpty(diagnosticsFilePath) }
         assertThat(resultList).isNotNull
@@ -88,13 +87,13 @@ class DiagnosticsFileHelperTest {
     @Test
     fun `readDiagnosticsFile reads content as json`() {
         every { fileHelper.fileIsEmpty(diagnosticsFilePath) } returns false
-        val streamBlockSlot = slot<((Stream<String>) -> Unit)>()
-        every { fileHelper.readFilePerLines(diagnosticsFilePath, capture(streamBlockSlot)) } answers {
-            streamBlockSlot.captured(Stream.of("{}", "{\"test_key\": \"test_value\"}"))
+        val sequenceBlockSlot = slot<((Sequence<String>) -> Unit)>()
+        every { fileHelper.readFilePerLines(diagnosticsFilePath, capture(sequenceBlockSlot)) } answers {
+            sequenceBlockSlot.captured(sequenceOf("{}", "{\"test_key\": \"test_value\"}"))
         }
         var resultList: List<JSONObject>? = null
-        diagnosticsFileHelper.readFileAsJson { stream ->
-            resultList = stream.toList()
+        diagnosticsFileHelper.readFileAsJson { sequence ->
+            resultList = sequence.toList()
         }
         assertThat(resultList).isNotNull
         assertThat(resultList?.size).isEqualTo(2)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizerTest.kt
@@ -20,7 +20,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.IOException
-import java.util.stream.Stream
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -272,9 +271,9 @@ class DiagnosticsSynchronizerTest {
     }
 
     private fun mockReadDiagnosticsFile(jsons: List<JSONObject>) {
-        val slot = slot<((Stream<JSONObject>) -> Unit)>()
+        val slot = slot<((Sequence<JSONObject>) -> Unit)>()
         every { diagnosticsFileHelper.readFileAsJson(capture(slot)) } answers {
-            slot.captured(jsons.stream())
+            slot.captured(jsons.asSequence())
         }
     }
 }


### PR DESCRIPTION
## Motivation
`Stream` is a Java 8 API, which needs [desugaring](https://developer.android.com/studio/write/java8-support) to function correctly across devices and API levels. This can lead to crashes such as https://github.com/RevenueCat/purchases-flutter/issues/1213, which is only surfacing now because we fixed error-swallowing in https://github.com/RevenueCat/purchases-android/pull/1894.

## Changes
Fortunately, Kotlin's `Sequence` is a near drop-in replacement for `Stream`. This PR implements that replacement.