### PR TITLE
Removes `@RequiresApi(N)` from `FileHelper` and related classes

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -5,8 +5,6 @@
 
 package com.revenuecat.purchases.common
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
@@ -494,7 +492,6 @@ internal class Backend(
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.N)
     fun postPaywallEvents(
         paywallEventRequest: PaywallEventRequest,
         onSuccessHandler: () -> Unit,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/FileHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/FileHelper.kt
@@ -1,8 +1,6 @@
 package com.revenuecat.purchases.common
 
 import android.content.Context
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.revenuecat.purchases.utils.sizeInKB
 import java.io.BufferedReader
 import java.io.File
@@ -36,14 +34,12 @@ internal class FileHelper(
     // This is using a lambda with a Sequence instead of returning the Sequence itself. This is so we keep
     // the responsibility of closing the bufferedReader to this class. Note that the Sequence should
     // be used synchronously, otherwise the bufferedReader will be closed before the Sequence is used.
-    @RequiresApi(Build.VERSION_CODES.N)
     fun readFilePerLines(filePath: String, block: ((Sequence<String>) -> Unit)) {
         openBufferedReader(filePath) { bufferedReader ->
             block(bufferedReader.lineSequence())
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.N)
     fun removeFirstLinesFromFile(filePath: String, numberOfLinesToRemove: Int) {
         val textToAppend = StringBuilder()
         readFilePerLines(filePath) { sequence ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsHelper.kt
@@ -2,8 +2,6 @@ package com.revenuecat.purchases.common.diagnostics
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 
 internal class DiagnosticsHelper(
@@ -22,7 +20,6 @@ internal class DiagnosticsHelper(
             )
     }
 
-    @RequiresApi(Build.VERSION_CODES.N)
     fun resetDiagnosticsStatus() {
         clearConsecutiveNumberOfErrors()
         diagnosticsFileHelper.deleteFile()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
@@ -2,8 +2,6 @@ package com.revenuecat.purchases.common.diagnostics
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.Dispatcher
@@ -18,7 +16,6 @@ import java.io.IOException
  *
  * If syncing diagnostics fails multiple times, we will delete any stored diagnostics data and start again.
  */
-@RequiresApi(Build.VERSION_CODES.N)
 internal class DiagnosticsSynchronizer(
     private val diagnosticsHelper: DiagnosticsHelper,
     private val diagnosticsFileHelper: DiagnosticsFileHelper,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEventsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEventsManager.kt
@@ -1,7 +1,5 @@
 package com.revenuecat.purchases.paywalls.events
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.Delay
@@ -13,7 +11,6 @@ import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.utils.EventsFileHelper
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
-@RequiresApi(Build.VERSION_CODES.N)
 internal class PaywallEventsManager(
     private val fileHelper: EventsFileHelper<PaywallStoredEvent>,
     private val identityManager: IdentityManager,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/EventsFileHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/EventsFileHelper.kt
@@ -1,13 +1,10 @@
 package com.revenuecat.purchases.utils
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.revenuecat.purchases.common.FileHelper
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.verboseLog
 import org.json.JSONObject
 
-@RequiresApi(Build.VERSION_CODES.N)
 /**
  * Class to handle file operations for event types like PaywallEvents and Diagnostics.
  * When [eventDeserializer] is null, [readFile] with the deserialized type won't return any events.


### PR DESCRIPTION
As the title says. Just a bit of cleanup as these annotations are no longer needed. They were probably added because we were using `Stream`, but our collective memory is fuzzy. (We're no longer using `Stream` as of #1943.)