### PR TITLE
Increase integration test timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -656,15 +656,13 @@ workflows:
       - run-revenuecatui-ui-tests
       - emerge_purchases_ui_snapshot_tests
       - verify_debug_view_snapshot_tests: *release-branches
-      - integration-tests-build: *release-branches
-      - purchases-integration-tests-build: *release-branches
-      - run-firebase-tests-purchases-custom-entitlement-computation-integration-test:
-          <<: *release-branches
+      - integration-tests-build
+      - purchases-integration-tests-build
+      - run-firebase-tests-purchases-custom-entitlement-computation-integration-test
       - run-firebase-tests-purchases-integration-test:
           requires:
             - purchases-integration-tests-build
       - run-firebase-tests-purchases-load-shedder-integration-test:
-          <<: *release-branches
           context:
             - slack-secrets
       - run-firebase-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -656,13 +656,15 @@ workflows:
       - run-revenuecatui-ui-tests
       - emerge_purchases_ui_snapshot_tests
       - verify_debug_view_snapshot_tests: *release-branches
-      - integration-tests-build
-      - purchases-integration-tests-build
-      - run-firebase-tests-purchases-custom-entitlement-computation-integration-test
+      - integration-tests-build: *release-branches
+      - purchases-integration-tests-build: *release-branches
+      - run-firebase-tests-purchases-custom-entitlement-computation-integration-test:
+          <<: *release-branches
       - run-firebase-tests-purchases-integration-test:
           requires:
             - purchases-integration-tests-build
       - run-firebase-tests-purchases-load-shedder-integration-test:
+          <<: *release-branches
           context:
             - slack-secrets
       - run-firebase-tests:

--- a/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -44,7 +44,7 @@ open class BasePurchasesIntegrationTest {
     protected open val initialForceServerErrors: Boolean = false
     protected open val initialForceSigningErrors: Boolean = false
 
-    protected val testTimeout = 5.seconds
+    protected val testTimeout = 10.seconds
     protected val currentTimestamp = Date().time
     protected val testUserId = "android-integration-test-$currentTimestamp"
     protected val proxyUrl = Constants.proxyUrl.takeIf { it != "NO_PROXY_URL" }


### PR DESCRIPTION
### Description
Integration tests have been failing pretty frequently. From some tests, it seems that verifying the purchase token in the backend after a while takes a bit longer, which makes it frequently go over the timeout limit of 5s set for purchasing. This increases the timeout so it has time to finish the purchase on those situations.