### PR TITLE
Modify intent extension API to parse redemption links to mimick iOS

### DIFF
--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/IntentExtensionsAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/IntentExtensionsAPI.kt
@@ -9,6 +9,6 @@ import com.revenuecat.purchases.asWebPurchaseRedemption
 @Suppress("unused", "UNUSED_VARIABLE")
 private class IntentExtensionsAPI {
     fun check(intent: Intent) {
-        val webPurchaseRedemption: WebPurchaseRedemption? = intent.asWebPurchaseRedemption
+        val webPurchaseRedemption: WebPurchaseRedemption? = intent.asWebPurchaseRedemption()
     }
 }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/IntentExtensionsAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/IntentExtensionsAPI.kt
@@ -3,12 +3,12 @@ package com.revenuecat.apitester.kotlin
 import android.content.Intent
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.WebPurchaseRedemption
-import com.revenuecat.purchases.parseAsWebPurchaseRedemption
+import com.revenuecat.purchases.asWebPurchaseRedemption
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Suppress("unused", "UNUSED_VARIABLE")
 private class IntentExtensionsAPI {
     fun check(intent: Intent) {
-        val webPurchaseRedemption: WebPurchaseRedemption? = intent.parseAsWebPurchaseRedemption()
+        val webPurchaseRedemption: WebPurchaseRedemption? = intent.asWebPurchaseRedemption
     }
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainActivity.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainActivity.kt
@@ -16,13 +16,13 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        webPurchaseRedemption = intent.asWebPurchaseRedemption
+        webPurchaseRedemption = intent.asWebPurchaseRedemption()
     }
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         if (intent != null) {
-            webPurchaseRedemption = intent.asWebPurchaseRedemption
+            webPurchaseRedemption = intent.asWebPurchaseRedemption()
         }
     }
 

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainActivity.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainActivity.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
-import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.WebPurchaseRedemption
 import com.revenuecat.purchases.asWebPurchaseRedemption
 import com.revenuecat.purchases_sample.R

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainActivity.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.WebPurchaseRedemption
+import com.revenuecat.purchases.asWebPurchaseRedemption
 import com.revenuecat.purchases_sample.R
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
@@ -16,13 +17,13 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        webPurchaseRedemption = Purchases.parseAsWebPurchaseRedemption(intent)
+        webPurchaseRedemption = intent.asWebPurchaseRedemption
     }
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         if (intent != null) {
-            webPurchaseRedemption = Purchases.parseAsWebPurchaseRedemption(intent)
+            webPurchaseRedemption = intent.asWebPurchaseRedemption
         }
     }
 

--- a/examples/web-purchase-redemption-sample/src/main/java/com/revenuecat/webpurchaseredemptionsample/MainActivity.kt
+++ b/examples/web-purchase-redemption-sample/src/main/java/com/revenuecat/webpurchaseredemptionsample/MainActivity.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
-import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.WebPurchaseRedemption
 import com.revenuecat.purchases.asWebPurchaseRedemption
 import com.revenuecat.webpurchaseredemptionsample.ui.theme.PurchasesTheme

--- a/examples/web-purchase-redemption-sample/src/main/java/com/revenuecat/webpurchaseredemptionsample/MainActivity.kt
+++ b/examples/web-purchase-redemption-sample/src/main/java/com/revenuecat/webpurchaseredemptionsample/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.WebPurchaseRedemption
+import com.revenuecat.purchases.asWebPurchaseRedemption
 import com.revenuecat.webpurchaseredemptionsample.ui.theme.PurchasesTheme
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
@@ -24,7 +25,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        webPurchaseRedemption = Purchases.parseAsWebPurchaseRedemption(intent)
+        webPurchaseRedemption = intent.asWebPurchaseRedemption
         enableEdgeToEdge()
         setContent {
             PurchasesTheme {
@@ -37,7 +38,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        webPurchaseRedemption = Purchases.parseAsWebPurchaseRedemption(intent)
+        webPurchaseRedemption = intent.asWebPurchaseRedemption
     }
 
     fun clearWebPurchaseRedemption() {

--- a/examples/web-purchase-redemption-sample/src/main/java/com/revenuecat/webpurchaseredemptionsample/MainActivity.kt
+++ b/examples/web-purchase-redemption-sample/src/main/java/com/revenuecat/webpurchaseredemptionsample/MainActivity.kt
@@ -24,7 +24,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        webPurchaseRedemption = intent.asWebPurchaseRedemption
+        webPurchaseRedemption = intent.asWebPurchaseRedemption()
         enableEdgeToEdge()
         setContent {
             PurchasesTheme {
@@ -37,7 +37,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        webPurchaseRedemption = intent.asWebPurchaseRedemption
+        webPurchaseRedemption = intent.asWebPurchaseRedemption()
     }
 
     fun clearWebPurchaseRedemption() {

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/IntentExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/IntentExtensions.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases
 import android.content.Intent
 
 @ExperimentalPreviewRevenueCatPurchasesAPI
-val Intent.asWebPurchaseRedemption: WebPurchaseRedemption?
-    @JvmSynthetic
-    get() = Purchases.parseAsWebPurchaseRedemption(this)
+@JvmSynthetic
+fun Intent.asWebPurchaseRedemption(): WebPurchaseRedemption? {
+    return Purchases.parseAsWebPurchaseRedemption(this)
+}

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/IntentExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/IntentExtensions.kt
@@ -3,7 +3,6 @@ package com.revenuecat.purchases
 import android.content.Intent
 
 @ExperimentalPreviewRevenueCatPurchasesAPI
-@JvmSynthetic
-fun Intent.parseAsWebPurchaseRedemption(): WebPurchaseRedemption? {
-    return Purchases.parseAsWebPurchaseRedemption(this)
-}
+val Intent.asWebPurchaseRedemption: WebPurchaseRedemption?
+    @JvmSynthetic
+    get() = Purchases.parseAsWebPurchaseRedemption(this)

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -803,7 +803,7 @@ class Purchases internal constructor(
 
     /**
      * Redeem a web purchase using a [WebPurchaseRedemption] object obtained
-     * through [Purchases.parseAsWebPurchaseRedemption].
+     * through [Intent.asWebPurchaseRedemption] or [Purchases.parseAsWebPurchaseRedemption].
      */
     @ExperimentalPreviewRevenueCatPurchasesAPI
     fun redeemWebPurchase(webPurchaseRedemption: WebPurchaseRedemption, listener: RedeemWebPurchaseListener) {


### PR DESCRIPTION
### Description
This modifies the `Intent.parseAsWebPurchaseRedemption()` method to `Intent.asWebPurchaseRedemption()` following the naming of the API in the iOS SDK, so we consolidate them. This is a breaking change but this is an experimental API not open to developers yet so it should be safe.