### PR TITLE
[Paywalls V2] Add support for markdown in text component

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
@@ -2,10 +2,10 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components.text
 
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fi
 import com.revenuecat.purchases.ui.revenuecatui.components.ColorStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
+import com.revenuecat.purchases.ui.revenuecatui.composables.Markdown
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 
 @Composable
@@ -47,7 +48,7 @@ private fun TextComponentView(
     }
 
     if (style.visible) {
-        Text(
+        Markdown(
             text = style.text,
             modifier = modifier
                 .size(style.size, horizontalAlignment = style.horizontalAlignment)
@@ -58,6 +59,7 @@ private fun TextComponentView(
             fontSize = style.fontSize,
             fontWeight = style.fontWeight,
             fontFamily = style.fontFamily,
+            horizontalAlignment = style.horizontalAlignment,
             textAlign = style.textAlign,
             style = textStyle,
         )
@@ -156,6 +158,18 @@ private fun TextComponentView_Preview_Customizations() {
             backgroundColor = ColorScheme(light = ColorInfo.Hex(Color(red = 0xde, green = 0xde, blue = 0xde).toArgb())),
             padding = Padding(top = 10.0, bottom = 10.0, leading = 20.0, trailing = 20.0),
             margin = Padding(top = 20.0, bottom = 20.0, leading = 10.0, trailing = 10.0),
+        ),
+    )
+}
+
+@Preview(name = "Default")
+@Composable
+private fun TextComponentView_Preview_Markdown() {
+    TextComponentView(
+        style = previewTextComponentStyle(
+            text = "Hello, **bold**, *italic* or _italic2_ with ~strikethrough~ and `monospace`. " +
+                "Click [here](https://revenuecat.com)",
+            color = ColorScheme(light = ColorInfo.Hex(Color.Black.toArgb())),
         ),
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IntroEligibilityStateView.kt
@@ -45,6 +45,7 @@ internal fun IntroEligibilityStateView(
             fontWeight = fontWeight,
             textAlign = textAlign,
             allowLinks = allowLinks,
+            textFillMaxWidth = true,
             modifier = modifier,
         )
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Markdown.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Markdown.kt
@@ -62,6 +62,11 @@ private val parser = Parser.builder()
     .extensions(listOf(StrikethroughExtension.create()))
     .build()
 
+/**
+ * @param allowLinks If true, links will be decorated and clickable.
+ * @param textFillMaxWidth If true, the text will fill the maximum width available. This was used by paywalls V1 and
+ * left to avoid unintended UI changes.
+ */
 @SuppressWarnings("LongParameterList")
 @Composable
 internal fun Markdown(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -98,6 +98,7 @@ private fun ColumnScope.Template1MainContent(state: PaywallState.Loaded) {
                 fontWeight = FontWeight.Black,
                 textAlign = TextAlign.Center,
                 color = colors.text1,
+                textFillMaxWidth = true,
                 modifier = Modifier
                     .padding(
                         horizontal = UIConstant.defaultHorizontalPadding,
@@ -114,6 +115,7 @@ private fun ColumnScope.Template1MainContent(state: PaywallState.Loaded) {
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.Normal,
                     textAlign = TextAlign.Center,
+                    textFillMaxWidth = true,
                     modifier = Modifier
                         .padding(
                             horizontal = UIConstant.defaultHorizontalPadding,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -268,6 +268,7 @@ private fun Title(
         textAlign = textAlign,
         text = state.selectedLocalization.title,
         color = state.templateConfiguration.getCurrentColors().text1,
+        textFillMaxWidth = true,
         modifier = childModifier,
     )
 }
@@ -284,6 +285,7 @@ private fun Subtitle(
         textAlign = textAlign,
         text = state.selectedLocalization.subtitle ?: "",
         color = state.templateConfiguration.getCurrentColors().text1,
+        textFillMaxWidth = true,
         modifier = childModifier,
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
@@ -156,6 +156,7 @@ private fun Title(
         textAlign = TextAlign.Center,
         text = state.selectedLocalization.title,
         color = state.templateConfiguration.getCurrentColors().text1,
+        textFillMaxWidth = true,
     )
 }
 
@@ -222,6 +223,7 @@ private fun Feature(
                 textAlign = TextAlign.Start,
                 text = feature.title,
                 color = colors.text1,
+                textFillMaxWidth = true,
             )
             feature.content?.let { content ->
                 Markdown(
@@ -230,6 +232,7 @@ private fun Feature(
                     textAlign = TextAlign.Start,
                     text = content,
                     color = colors.text2,
+                    textFillMaxWidth = true,
                 )
             }
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template4.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template4.kt
@@ -163,6 +163,7 @@ private fun Template4MainContent(
                 textAlign = TextAlign.Center,
                 text = localizedConfig.title,
                 color = colors.text1,
+                textFillMaxWidth = true,
                 modifier = Modifier.padding(horizontal = UIConstant.defaultHorizontalPadding),
             )
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
@@ -247,6 +247,7 @@ private fun ColumnScope.Title(
         textAlign = TextAlign.Start,
         text = state.selectedLocalization.title,
         color = state.templateConfiguration.getCurrentColors().text1,
+        textFillMaxWidth = true,
         modifier = Modifier
             .fillMaxWidth(),
     )
@@ -301,6 +302,7 @@ private fun Feature(
                 textAlign = TextAlign.Start,
                 text = feature.title,
                 color = colors.text1,
+                textFillMaxWidth = true,
             )
             feature.content?.let { content ->
                 Markdown(
@@ -309,6 +311,7 @@ private fun Feature(
                     textAlign = TextAlign.Start,
                     text = content,
                     color = colors.text2,
+                    textFillMaxWidth = true,
                 )
             }
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template7.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template7.kt
@@ -347,6 +347,7 @@ private fun ColumnScope.Title(
         textAlign = TextAlign.Center,
         text = localization.title,
         color = colorForTier.text1,
+        textFillMaxWidth = true,
         modifier = Modifier
             .fillMaxWidth(),
     )
@@ -421,6 +422,7 @@ private fun Feature(
                 textAlign = TextAlign.Start,
                 text = feature.title,
                 color = colors.text1,
+                textFillMaxWidth = true,
             )
             feature.content?.let { content ->
                 Markdown(
@@ -429,6 +431,7 @@ private fun Feature(
                     textAlign = TextAlign.Start,
                     text = content,
                     color = colors.text2,
+                    textFillMaxWidth = true,
                 )
             }
         }


### PR DESCRIPTION
### Description
This adds support for Markdown inside the text component of paywalls V2. Here you can see the text component previews before (top) and after (bottom)
<img width="870" alt="Screenshot 2024-12-02 at 18 32 43" src="https://github.com/user-attachments/assets/20064aaa-a4c7-43ed-b471-cc9071d6c944">
