### PR TITLE
[Paywalls V2] Adds borders and image backgrounds

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/Background.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/Background.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 
 @InternalRevenueCatAPI
 @Serializable
-internal sealed interface Background {
+sealed interface Background {
     @Serializable
     @SerialName("color")
     data class Color(@get:JvmSynthetic val value: ColorScheme) : Background

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/ColorScheme.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/ColorScheme.kt
@@ -1,0 +1,11 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.ktx
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+
+internal val ColorScheme.colorsForCurrentTheme: ColorInfo
+    @Composable get() = if (isSystemInDarkTheme()) dark ?: light else light

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/ThemeImageUrls.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/ThemeImageUrls.kt
@@ -1,0 +1,11 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.ktx
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import com.revenuecat.purchases.paywalls.components.properties.ImageUrls
+import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
+
+internal val ThemeImageUrls.urlsForCurrentTheme: ImageUrls
+    @Composable get() = if (isSystemInDarkTheme()) dark ?: light else light

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Background.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Background.kt
@@ -5,8 +5,11 @@ package com.revenuecat.purchases.ui.revenuecatui.components.modifier
 import androidx.compose.foundation.background
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.paint
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
 
 @JvmSynthetic
@@ -16,6 +19,17 @@ internal fun Modifier.background(
     shape: Shape = RectangleShape,
 ): Modifier =
     when (color) {
-        is ColorStyle.Solid -> background(color.color, shape)
-        is ColorStyle.Gradient -> background(color.brush, shape, alpha = 1f)
+        is ColorStyle.Solid -> this then background(color.color, shape)
+        is ColorStyle.Gradient -> this then background(color.brush, shape, alpha = 1f)
+    }
+
+@JvmSynthetic
+@Stable
+internal fun Modifier.background(
+    background: BackgroundStyle,
+    shape: Shape = RectangleShape,
+): Modifier =
+    when (background) {
+        is BackgroundStyle.Color -> this then background(color = background.color, shape = shape)
+        is BackgroundStyle.Image -> this then paint(background.painter) then clip(shape)
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Border.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Border.kt
@@ -1,0 +1,179 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.modifier
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.BorderStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.toColorStyle
+
+@JvmSynthetic
+@Stable
+internal fun Modifier.border(
+    border: BorderStyle,
+    shape: Shape = RectangleShape,
+): Modifier =
+    when (border.color) {
+        is ColorStyle.Solid -> this then border(width = border.width, color = border.color.color, shape = shape)
+        is ColorStyle.Gradient -> this then border(width = border.width, brush = border.color.brush, shape = shape)
+    }
+
+@Suppress("MagicNumber")
+@Preview("Solid")
+@Composable
+private fun Border_Preview_Solid() {
+    Box(
+        modifier = Modifier
+            .requiredSize(100.dp)
+            .background(Color.Red)
+            .border(
+                border = BorderStyle(
+                    width = 10.dp,
+                    color = ColorStyle.Solid(color = Color.Blue),
+                ),
+            ),
+    )
+}
+
+@Suppress("MagicNumber")
+@Preview("SolidThin")
+@Composable
+private fun Border_Preview_SolidThin() {
+    Box(
+        modifier = Modifier
+            .requiredSize(100.dp)
+            .background(Color.Red)
+            .border(
+                border = BorderStyle(
+                    width = 2.dp,
+                    color = ColorStyle.Solid(color = Color.Blue),
+                ),
+            ),
+    )
+}
+
+@Suppress("MagicNumber")
+@Preview("SolidCircle")
+@Composable
+private fun Border_Preview_SolidCircle() {
+    Box(
+        modifier = Modifier
+            .requiredSize(100.dp)
+            .background(Color.Red)
+            .border(
+                border = BorderStyle(
+                    width = 10.dp,
+                    color = ColorStyle.Solid(color = Color.Blue),
+                ),
+                shape = CircleShape,
+            ),
+    )
+}
+
+@Preview("LinearGradientSquare")
+@Composable
+private fun Border_Preview_LinearGradientSquare() {
+    Border_Preview_LinearGradient(shape = RectangleShape)
+}
+
+@Preview("LinearGradientCircle")
+@Composable
+private fun Border_Preview_LinearGradientCircle() {
+    Border_Preview_LinearGradient(shape = CircleShape)
+}
+
+@Preview("RadialGradientSquare")
+@Composable
+private fun Border_Preview_RadialGradientSquare() {
+    Border_Preview_RadialGradient(shape = RectangleShape)
+}
+
+@Preview("RadialGradientCircle")
+@Composable
+private fun Border_Preview_RadialGradientCircle() {
+    Border_Preview_RadialGradient(shape = CircleShape)
+}
+
+@Suppress("MagicNumber")
+@Composable
+private fun Border_Preview_LinearGradient(shape: Shape) {
+    Box(
+        modifier = Modifier
+            .requiredSize(100.dp)
+            .background(Color.Red)
+            .border(
+                border = BorderStyle(
+                    width = 10.dp,
+                    color = ColorScheme(
+                        light = ColorInfo.Gradient.Linear(
+                            degrees = -45f,
+                            points = listOf(
+                                ColorInfo.Gradient.Point(
+                                    color = Color.Cyan.toArgb(),
+                                    percent = 0.1f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color(red = 0x00, green = 0x66, blue = 0xff).toArgb(),
+                                    percent = 0.3f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color(red = 0xA0, green = 0x00, blue = 0xA0).toArgb(),
+                                    percent = 0.8f,
+                                ),
+                            ),
+                        ),
+                    ).toColorStyle(),
+                ),
+                shape = shape,
+            ),
+    )
+}
+
+@Suppress("MagicNumber")
+@Composable
+private fun Border_Preview_RadialGradient(shape: Shape) {
+    Box(
+        modifier = Modifier
+            .requiredSize(100.dp)
+            .background(Color.Red)
+            .border(
+                border = BorderStyle(
+                    width = 10.dp,
+                    color = ColorScheme(
+                        light = ColorInfo.Gradient.Radial(
+                            points = listOf(
+                                ColorInfo.Gradient.Point(
+                                    color = Color.Cyan.toArgb(),
+                                    percent = 0.8f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color(red = 0x00, green = 0x66, blue = 0xff).toArgb(),
+                                    percent = 0.9f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color(red = 0xA0, green = 0x00, blue = 0xA0).toArgb(),
+                                    percent = 0.96f,
+                                ),
+                            ),
+                        ),
+                    ).toColorStyle(),
+                ),
+                shape = shape,
+            ),
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/BackgroundStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/BackgroundStyle.kt
@@ -1,0 +1,134 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.properties
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.revenuecat.purchases.paywalls.components.common.Background
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.urlsForCurrentTheme
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
+
+/**
+ * Ready to use background properties for the current theme.
+ */
+internal sealed interface BackgroundStyle {
+    @JvmInline
+    value class Color(@JvmSynthetic val color: ColorStyle) : BackgroundStyle
+
+    @JvmInline
+    value class Image(@JvmSynthetic val painter: Painter) : BackgroundStyle
+}
+
+@JvmSynthetic
+@Composable
+internal fun Background.toBackgroundStyle(): BackgroundStyle =
+    when (this) {
+        is Background.Color -> BackgroundStyle.Color(color = value.toColorStyle())
+        is Background.Image -> {
+            val imageUrls = value.urlsForCurrentTheme
+            BackgroundStyle.Image(
+                painter = rememberAsyncImagePainter(
+                    model = imageUrls.webp,
+                    placeholder = rememberAsyncImagePainter(
+                        model = imageUrls.webpLowRes,
+                        error = null,
+                        fallback = null,
+                        contentScale = ContentScale.Crop,
+                    ),
+                    error = null,
+                    fallback = null,
+                    contentScale = ContentScale.Crop,
+                ),
+            )
+        }
+    }
+
+@Preview
+@Composable
+private fun Background_Preview_ColorHex() {
+    Box(
+        modifier = Modifier
+            .requiredSize(100.dp)
+            .background(
+                Background.Color(
+                    ColorScheme(
+                        light = ColorInfo.Hex(Color.Red.toArgb()),
+                    ),
+                ).toBackgroundStyle(),
+            ),
+    )
+}
+
+@Preview
+@Composable
+private fun Background_Preview_ColorGradientLinear() {
+    Box(
+        modifier = Modifier
+            .requiredSize(100.dp)
+            .background(
+                Background.Color(
+                    ColorScheme(
+                        light = ColorInfo.Gradient.Linear(
+                            degrees = 0f,
+                            points = listOf(
+                                ColorInfo.Gradient.Point(
+                                    color = Color.Red.toArgb(),
+                                    percent = 0f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color.Green.toArgb(),
+                                    percent = 0.5f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color.Blue.toArgb(),
+                                    percent = 1f,
+                                ),
+                            ),
+                        ),
+                    ),
+                ).toBackgroundStyle(),
+            ),
+    )
+}
+
+@Preview
+@Composable
+private fun Background_Preview_ColorGradientRadial() {
+    Box(
+        modifier = Modifier
+            .requiredSize(100.dp)
+            .background(
+                Background.Color(
+                    ColorScheme(
+                        light = ColorInfo.Gradient.Radial(
+                            points = listOf(
+                                ColorInfo.Gradient.Point(
+                                    color = Color.Red.toArgb(),
+                                    percent = 0f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color.Green.toArgb(),
+                                    percent = 0.5f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color.Blue.toArgb(),
+                                    percent = 1f,
+                                ),
+                            ),
+                        ),
+                    ),
+                ).toBackgroundStyle(),
+            ),
+    )
+}
+
+// We cannot use a network image in Compose previews, so we don't have a preview for Background.Image.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/BorderStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/BorderStyle.kt
@@ -1,0 +1,13 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.properties
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.unit.Dp
+
+/**
+ * Ready to use border properties for the current theme.
+ */
+@Immutable
+internal data class BorderStyle(
+    @get:JvmSynthetic val width: Dp,
+    @get:JvmSynthetic val color: ColorStyle,
+)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.properties
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.runtime.Composable
@@ -20,6 +19,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.colorsForCurrentTheme
 import dev.drewhamilton.poko.Poko
 import kotlin.math.abs
 import kotlin.math.cos
@@ -41,9 +41,7 @@ internal sealed interface ColorStyle {
 @JvmSynthetic
 @Composable
 internal fun ColorScheme.toColorStyle(): ColorStyle {
-    val colorInfo = if (isSystemInDarkTheme()) dark ?: light else light
-
-    return when (colorInfo) {
+    return when (val colorInfo = colorsForCurrentTheme) {
         is ColorInfo.Alias -> TODO("Color aliases are not yet implemented.")
         is ColorInfo.Hex -> ColorStyle.Solid(Color(color = colorInfo.value))
         is ColorInfo.Gradient -> ColorStyle.Gradient(


### PR DESCRIPTION
As the title says. Supports gradient borders because why not. Also adds a `ColorScheme.colorsForCurrentTheme` extension in the same spirit as `ThemeImageUrls.urlsForCurrentTheme`. 