### PR TITLE
WebPurchaseRedemption: Rename `AlreadyRedeemed` result to `PurchaseBelongsToOtherUser`

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/RedeemWebPurchaseListenerAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/RedeemWebPurchaseListenerAPI.java
@@ -22,7 +22,7 @@ final class RedeemWebPurchaseListenerAPI {
             PurchasesError error = ((RedeemWebPurchaseListener.Result.Error) result).getError();
         } else if (result instanceof RedeemWebPurchaseListener.Result.InvalidToken) {
             return;
-        } else if (result instanceof RedeemWebPurchaseListener.Result.AlreadyRedeemed) {
+        } else if (result instanceof RedeemWebPurchaseListener.Result.PurchaseBelongsToOtherUser) {
             return;
         } else if (result instanceof RedeemWebPurchaseListener.Result.Expired) {
             String obfuscatedEmail = ((RedeemWebPurchaseListener.Result.Expired) result).getObfuscatedEmail();

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/RedeemWebPurchaseListenerAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/RedeemWebPurchaseListenerAPI.kt
@@ -30,7 +30,7 @@ private class RedeemWebPurchaseListenerAPI {
             is RedeemWebPurchaseListener.Result.InvalidToken -> {
                 return false
             }
-            is RedeemWebPurchaseListener.Result.AlreadyRedeemed -> {
+            is RedeemWebPurchaseListener.Result.PurchaseBelongsToOtherUser -> {
                 return false
             }
             is RedeemWebPurchaseListener.Result.Expired -> {

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/OverviewFragment.kt
@@ -133,8 +133,8 @@ class OverviewFragment : Fragment(), OfferingCardAdapter.OfferingCardAdapterList
                 RedeemWebPurchaseListener.Result.InvalidToken -> {
                     showToast("Invalid web redemption token. Please check your link.")
                 }
-                RedeemWebPurchaseListener.Result.AlreadyRedeemed -> {
-                    showToast("Web purchase already redeemed. Ignoring.")
+                RedeemWebPurchaseListener.Result.PurchaseBelongsToOtherUser -> {
+                    showToast("Web purchase belongs to a different user. Ignoring.")
                 }
                 is RedeemWebPurchaseListener.Result.Expired -> {
                     showToast(

--- a/examples/web-purchase-redemption-sample/src/main/java/com/revenuecat/webpurchaseredemptionsample/Content.kt
+++ b/examples/web-purchase-redemption-sample/src/main/java/com/revenuecat/webpurchaseredemptionsample/Content.kt
@@ -119,8 +119,8 @@ fun WebRedemption(onSuccess: (CustomerInfo) -> Unit) {
                         onSuccess(result.customerInfo)
                         "Successfully redeemed purchase!"
                     }
-                    RedeemWebPurchaseListener.Result.AlreadyRedeemed ->
-                        "Purchase already redeemed. Nothing to do."
+                    RedeemWebPurchaseListener.Result.PurchaseBelongsToOtherUser ->
+                        "Purchase already belongs to a different user."
                     is RedeemWebPurchaseListener.Result.Error ->
                         "Error redeeming purchase: ${result.error.message}"
                     is RedeemWebPurchaseListener.Result.Expired ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -712,7 +712,7 @@ internal class Backend(
                                     callback(RedeemWebPurchaseListener.Result.Expired(obfuscatedEmail))
                                 }
                             }
-                            BackendErrorCode.BackendPurchaseBelongsToDifferentUser.value -> {
+                            BackendErrorCode.BackendPurchaseBelongsToOtherUser.value -> {
                                 callback(RedeemWebPurchaseListener.Result.PurchaseBelongsToOtherUser)
                             }
                             else -> {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -712,8 +712,8 @@ internal class Backend(
                                     callback(RedeemWebPurchaseListener.Result.Expired(obfuscatedEmail))
                                 }
                             }
-                            BackendErrorCode.BackendWebPurchaseAlreadyRedeemed.value -> {
-                                callback(RedeemWebPurchaseListener.Result.AlreadyRedeemed)
+                            BackendErrorCode.BackendPurchaseBelongsToDifferentUser.value -> {
+                                callback(RedeemWebPurchaseListener.Result.PurchaseBelongsToOtherUser)
                             }
                             else -> {
                                 callback(RedeemWebPurchaseListener.Result.Error(result.toPurchasesError()))

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
@@ -31,7 +31,7 @@ internal enum class BackendErrorCode(val value: Int) {
     BackendInvalidSubscriberAttributesBody(7264),
     BackendProductIDsMalformed(7662),
     BackendInvalidWebRedemptionToken(7849),
-    BackendWebPurchaseAlreadyRedeemed(7852),
+    BackendPurchaseBelongsToDifferentUser(7852),
     BackendExpiredWebRedemptionToken(7853),
     ;
 
@@ -101,7 +101,7 @@ private fun BackendErrorCode.toPurchasesErrorCode(): PurchasesErrorCode {
         -> PurchasesErrorCode.UnexpectedBackendResponseError
         BackendErrorCode.BackendProductIDsMalformed -> PurchasesErrorCode.UnsupportedError
         BackendErrorCode.BackendInvalidWebRedemptionToken -> PurchasesErrorCode.PurchaseInvalidError
-        BackendErrorCode.BackendWebPurchaseAlreadyRedeemed -> PurchasesErrorCode.ProductAlreadyPurchasedError
+        BackendErrorCode.BackendPurchaseBelongsToDifferentUser -> PurchasesErrorCode.ProductAlreadyPurchasedError
         BackendErrorCode.BackendExpiredWebRedemptionToken -> PurchasesErrorCode.PurchaseInvalidError
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
@@ -31,7 +31,7 @@ internal enum class BackendErrorCode(val value: Int) {
     BackendInvalidSubscriberAttributesBody(7264),
     BackendProductIDsMalformed(7662),
     BackendInvalidWebRedemptionToken(7849),
-    BackendPurchaseBelongsToDifferentUser(7852),
+    BackendPurchaseBelongsToOtherUser(7852),
     BackendExpiredWebRedemptionToken(7853),
     ;
 
@@ -101,7 +101,7 @@ private fun BackendErrorCode.toPurchasesErrorCode(): PurchasesErrorCode {
         -> PurchasesErrorCode.UnexpectedBackendResponseError
         BackendErrorCode.BackendProductIDsMalformed -> PurchasesErrorCode.UnsupportedError
         BackendErrorCode.BackendInvalidWebRedemptionToken -> PurchasesErrorCode.PurchaseInvalidError
-        BackendErrorCode.BackendPurchaseBelongsToDifferentUser -> PurchasesErrorCode.ProductAlreadyPurchasedError
+        BackendErrorCode.BackendPurchaseBelongsToOtherUser -> PurchasesErrorCode.ProductAlreadyPurchasedError
         BackendErrorCode.BackendExpiredWebRedemptionToken -> PurchasesErrorCode.PurchaseInvalidError
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/RedeemWebPurchaseListener.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/RedeemWebPurchaseListener.kt
@@ -36,9 +36,9 @@ fun interface RedeemWebPurchaseListener {
         data class Expired(val obfuscatedEmail: String) : Result()
 
         /**
-         * Indicates that the web purchase has already been redeemed and can't be redeemed again.
+         * Indicates that the redemption couldn't be performed because the purchase belongs to a different user.
          */
-        object AlreadyRedeemed : Result()
+        object PurchaseBelongsToOtherUser : Result()
 
         /**
          * Whether the redemption was successful or not.
@@ -49,7 +49,7 @@ fun interface RedeemWebPurchaseListener {
                 is Error -> false
                 InvalidToken -> false
                 is Expired -> false
-                AlreadyRedeemed -> false
+                PurchaseBelongsToOtherUser -> false
             }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendRedeemWebPurchaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendRedeemWebPurchaseTest.kt
@@ -103,7 +103,7 @@ class BackendRedeemWebPurchaseTest {
     }
 
     @Test
-    fun `postRedeemWebPurchase errors with already redeemed token if backend returns that code`() {
+    fun `postRedeemWebPurchase errors with purchase belongs to other user if backend returns that code`() {
         val responseBody = """
             {
                 "code": 7852,
@@ -111,7 +111,7 @@ class BackendRedeemWebPurchaseTest {
             }
         """.trimIndent()
         mockHttpResult(responseCode = RCHTTPStatusCodes.FORBIDDEN, responseBody = responseBody)
-        performPostAndExpectResult(RedeemWebPurchaseListener.Result.AlreadyRedeemed)
+        performPostAndExpectResult(RedeemWebPurchaseListener.Result.PurchaseBelongsToOtherUser)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/deeplinks/WebPurchaseRedemptionHelperTest.kt
@@ -99,13 +99,13 @@ class WebPurchaseRedemptionHelperTest {
     }
 
     @Test
-    fun `handleRedeemWebPurchase posts token and returns already redeemed`() {
-        mockBackendResult(result = RedeemWebPurchaseListener.Result.AlreadyRedeemed)
+    fun `handleRedeemWebPurchase posts token and returns belongs to other user`() {
+        mockBackendResult(result = RedeemWebPurchaseListener.Result.PurchaseBelongsToOtherUser)
         var result: RedeemWebPurchaseListener.Result? = null
         webPurchaseRedemptionHelper.handleRedeemWebPurchase(webPurchaseRedemption) {
             result = it
         }
-        assertTrue(result is RedeemWebPurchaseListener.Result.AlreadyRedeemed)
+        assertTrue(result is RedeemWebPurchaseListener.Result.PurchaseBelongsToOtherUser)
         verify(exactly = 0) { offlineEntitlementsManager.resetOfflineCustomerInfoCache() }
         verify(exactly = 0) { customerInfoUpdateHandler.cacheAndNotifyListeners(any()) }
     }


### PR DESCRIPTION
### Description
We decided to rename this redemption result value to better represent the meaning of the result. Note that the API is marked as experimental and the feature is still not enabled in our backend, so it should be ok to rename it.