### PR TITLE
Fix multi-tier template to allow optional header image

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -70,17 +70,17 @@ private fun PaywallData.validate(): Result<PaywallTemplate> {
                 return Result.failure(PaywallValidationError.MissingTiers)
             }
 
-            // Step 2: Validate all tiers is in colors and images
+            // Step 2: Validate all tiers is in colors
             val tierIds = tiers.map { it.id }.toSet()
             tierIds.getMissingElements(config.colorsByTier?.keys)?.let {
                 return Result.failure(
                     PaywallValidationError.MissingTierConfigurations(it),
                 )
             }
+
+            // Images are optional so just logging if they are missing
             tierIds.getMissingElements(config.imagesByTier?.keys)?.let {
-                return Result.failure(
-                    PaywallValidationError.MissingTierConfigurations(it),
-                )
+                Logger.w("Missing images for tiers $it")
             }
 
             // Step 3: Validate all tiers are in localizations

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -80,7 +80,7 @@ private fun PaywallData.validate(): Result<PaywallTemplate> {
 
             // Images are optional so just logging if they are missing
             tierIds.getMissingElements(config.imagesByTier?.keys)?.let {
-                Logger.w("Missing images for tiers $it")
+                Logger.w("Missing images for tier(s): ${it.joinToString(",")}")
             }
 
             // Step 3: Validate all tiers are in localizations


### PR DESCRIPTION
### Motivation

There was validation that was preventing image from being optional in multi-tier paywall


### Description

- Remove error from being throw when no multi-tier paywall image and do a warning log instead
