### PR TITLE
Add web redemption parse method for strings to support hybrids

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -116,6 +116,7 @@ final class PurchasesAPI {
         final PurchasesConfiguration configuration = purchases.getCurrentConfiguration();
 
         final WebPurchaseRedemption webPurchaseRedemption1 = Purchases.parseAsWebPurchaseRedemption(intent);
+        final WebPurchaseRedemption webPurchaseRedemption2 = Purchases.parseAsWebPurchaseRedemption("");
     }
 
     static void check(final Purchases purchases, final Map<String, String> attributes) {

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -102,6 +102,7 @@ private class PurchasesAPI {
 
         purchases.redeemWebPurchase(webPurchaseRedemption, redeemWebPurchaseListener)
         val parsedWebPurchaseRedemption: WebPurchaseRedemption? = Purchases.parseAsWebPurchaseRedemption(intent)
+        val parsedWebPurchaseRedemption2: WebPurchaseRedemption? = Purchases.parseAsWebPurchaseRedemption("")
     }
 
     @Suppress("LongMethod", "LongParameterList")

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
@@ -823,6 +824,18 @@ class Purchases internal constructor(
         fun parseAsWebPurchaseRedemption(intent: Intent): WebPurchaseRedemption? {
             val intentData = intent.data ?: return null
             return DeepLinkParser.parseWebPurchaseRedemption(intentData)
+        }
+
+        /**
+         * Given a url string, parses the link and returns a [WebPurchaseRedemption], which can
+         * be used to redeem a web purchase using [Purchases.redeemWebPurchase]
+         * @return A parsed version of the link or null if it's not a valid RevenueCat web purchase redemption link.
+         */
+        @ExperimentalPreviewRevenueCatPurchasesAPI
+        @JvmStatic
+        fun parseAsWebPurchaseRedemption(string: String): WebPurchaseRedemption? {
+            val uri = Uri.parse(string)
+            return DeepLinkParser.parseWebPurchaseRedemption(uri)
         }
 
         /**

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -1511,6 +1511,28 @@ internal class PurchasesTest : BasePurchasesTest() {
         assertThat(receivedError).isEqualTo(expectedError)
     }
 
+    // region parseAsWebPurchaseRedemption
+
+    @Test
+    fun `parseAsWebPurchaseRedemption returns value if a valid web purchase redemption link`() {
+        val redemptionLink = Purchases.parseAsWebPurchaseRedemption("rc-1111://redeem_web_purchase?redemption_token=1234")
+        assertThat(redemptionLink).isNotNull
+    }
+
+    @Test
+    fun `parseAsWebPurchaseRedemption does not return value if not a web purchase redemption link`() {
+        val redemptionLink = Purchases.parseAsWebPurchaseRedemption("rc-1111://another_link?redemption_token=1234")
+        assertThat(redemptionLink).isNull()
+    }
+
+    @Test
+    fun `parseAsWebPurchaseRedemption does not return value if not a link`() {
+        val redemptionLink = Purchases.parseAsWebPurchaseRedemption("invalid_link")
+        assertThat(redemptionLink).isNull()
+    }
+
+    // endregion parseAsWebPurchaseRedemption
+
     // region redeemWebPurchase
 
     @Test


### PR DESCRIPTION
### Description
In order to support the hybrids, getting the url from an intent might not always be easy. This adds an overload to the parsing method so we can obtain the `WebPurchaseRedemption` object from a string URL.