### PR TITLE
[Paywalls V2] Adds `PaywallComponentsData` to `Offering`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
@@ -6,6 +6,7 @@
 package com.revenuecat.purchases
 
 import com.revenuecat.purchases.paywalls.PaywallData
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 
 /**
  * An offering is a collection of [Package] available for the user to purchase.
@@ -15,12 +16,17 @@ import com.revenuecat.purchases.paywalls.PaywallData
  * @property availablePackages Array of [Package] objects available for purchase.
  * @property metadata Offering metadata defined in RevenueCat dashboard.
  */
-data class Offering @JvmOverloads constructor(
+data class Offering
+@OptIn(InternalRevenueCatAPI::class)
+@JvmOverloads
+constructor(
     val identifier: String,
     val serverDescription: String,
     val metadata: Map<String, Any>,
     val availablePackages: List<Package>,
     val paywall: PaywallData? = null,
+    @InternalRevenueCatAPI
+    val paywallComponents: PaywallComponentsData? = null,
 ) {
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
@@ -16,6 +16,7 @@ import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
  * @property availablePackages Array of [Package] objects available for purchase.
  * @property metadata Offering metadata defined in RevenueCat dashboard.
  */
+@Suppress("UnsafeOptInUsageError")
 data class Offering
 @OptIn(InternalRevenueCatAPI::class)
 @JvmOverloads

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -33,7 +33,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvi
 import com.revenuecat.purchases.ui.revenuecatui.extensions.createDefault
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ResourceProvider
 import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
-import com.revenuecat.purchases.ui.revenuecatui.helpers.toPaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.toLegacyPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toResourceProvider
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template2
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -62,7 +62,7 @@ internal fun LoadingPaywall(
         paywall = paywallData,
     )
 
-    val state = offering.toPaywallState(
+    val state = offering.toLegacyPaywallState(
         variableDataProvider = VariableDataProvider(
             resourceProvider,
             isInPreviewMode(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -31,7 +31,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.testdata.templates.template
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.templates.template7
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.templates.template7CustomPackages
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ResourceProvider
-import com.revenuecat.purchases.ui.revenuecatui.helpers.toPaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.toLegacyPaywallState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -441,7 +441,7 @@ internal class MockViewModel(
     }
 
     private val _state = MutableStateFlow(
-        offering.toPaywallState(
+        offering.toLegacyPaywallState(
             variableDataProvider = VariableDataProvider(resourceProvider),
             activelySubscribedProductIdentifiers = setOf(),
             nonSubscriptionProductIdentifiers = setOf(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui.helpers
 import androidx.compose.material3.ColorScheme
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.paywalls.PaywallData
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.composables.PaywallIconName
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
@@ -18,12 +19,12 @@ import com.revenuecat.purchases.ui.revenuecatui.extensions.defaultTemplate
 import kotlin.Result
 
 @Suppress("ReturnCount")
-internal fun Offering.validatedPaywall(
+internal fun Offering.validatedLegacyPaywall(
     currentColorScheme: ColorScheme,
     resourceProvider: ResourceProvider,
-): PaywallValidationResult {
+): PaywallValidationResult.Legacy {
     val paywallData = this.paywall
-        ?: return PaywallValidationResult(
+        ?: return PaywallValidationResult.Legacy(
             PaywallData.createDefault(
                 availablePackages,
                 currentColorScheme,
@@ -34,7 +35,7 @@ internal fun Offering.validatedPaywall(
         )
 
     val template = paywallData.validate().getOrElse {
-        return PaywallValidationResult(
+        return PaywallValidationResult.Legacy(
             PaywallData.createDefaultForIdentifiers(
                 paywallData.config.packageIds,
                 currentColorScheme,
@@ -44,7 +45,7 @@ internal fun Offering.validatedPaywall(
             it as PaywallValidationError,
         )
     }
-    return PaywallValidationResult(
+    return PaywallValidationResult.Legacy(
         paywallData,
         template,
     )
@@ -129,7 +130,7 @@ private fun PaywallData.LocalizedConfiguration.validate(): PaywallValidationErro
 }
 
 @Suppress("ReturnCount", "TooGenericExceptionCaught", "LongParameterList")
-internal fun Offering.toPaywallState(
+internal fun Offering.toLegacyPaywallState(
     variableDataProvider: VariableDataProvider,
     activelySubscribedProductIdentifiers: Set<String>,
     nonSubscriptionProductIdentifiers: Set<String>,
@@ -160,6 +161,12 @@ internal fun Offering.toPaywallState(
         shouldDisplayDismissButton = shouldDisplayDismissButton,
     )
 }
+
+internal fun Offering.toComponentsPaywallState(validatedPaywallData: PaywallComponentsData): PaywallState =
+    PaywallState.Loaded.Components(
+        offering = this,
+        data = validatedPaywallData,
+    )
 
 /**
  * Returns an error if any of the variables are invalid, or null if they're all valid

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallValidationResult.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallValidationResult.kt
@@ -1,11 +1,21 @@
 package com.revenuecat.purchases.ui.revenuecatui.helpers
 
 import com.revenuecat.purchases.paywalls.PaywallData
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.errors.PaywallValidationError
 
-internal data class PaywallValidationResult(
-    val displayablePaywall: PaywallData,
-    val template: PaywallTemplate,
-    val error: PaywallValidationError? = null,
-)
+internal sealed interface PaywallValidationResult {
+    val error: PaywallValidationError?
+
+    data class Legacy(
+        val displayablePaywall: PaywallData,
+        val template: PaywallTemplate,
+        override val error: PaywallValidationError? = null,
+    ) : PaywallValidationResult
+
+    data class Components(
+        val displayablePaywall: PaywallComponentsData,
+        override val error: PaywallValidationError? = null,
+    ) : PaywallValidationResult
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/LegacyPaywallDataValidationTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/LegacyPaywallDataValidationTest.kt
@@ -7,7 +7,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockResourceProvid
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.errors.PaywallValidationError
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
-import com.revenuecat.purchases.ui.revenuecatui.helpers.validatedPaywall
+import com.revenuecat.purchases.ui.revenuecatui.helpers.validatedLegacyPaywall
 import io.mockk.mockkObject
 import io.mockk.verify
 import kotlinx.serialization.json.Json
@@ -17,7 +17,7 @@ import org.junit.runner.RunWith
 import java.io.File
 
 @RunWith(AndroidJUnit4::class)
-class PaywallDataValidationTest {
+class LegacyPaywallDataValidationTest {
 
     @Test
     fun `Validate an offering without paywall`() {
@@ -231,7 +231,7 @@ class PaywallDataValidationTest {
         )
     }
 
-    private fun getPaywallValidationResult(offering: Offering) = offering.validatedPaywall(
+    private fun getPaywallValidationResult(offering: Offering) = offering.validatedLegacyPaywall(
         currentColorScheme = TestData.Constants.currentColorScheme,
         resourceProvider = MockResourceProvider()
     )


### PR DESCRIPTION
## Main changes
- Adds `PaywallComponentsData` to `Offering`.
- `OfferingParser` parses `paywall_components` into `PaywallComponentsData`.
- `PaywallViewModel` emits `PaywallState.Loaded.Components` if it encounters an `Offering` with `PaywallComponentsData`

## Other changes 
- `PaywallValidationResult` is a `sealed interface` now.
- Renames a few existing functions to indicate they handle the "legacy" `PaywallData`.
- Renames `PaywallDataValidationTest` to `LegacyPaywallDataValidationTest`. 