### PR TITLE
[WEB-1757] Handle new backend error codes that may show in the redemption endpoint

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
@@ -27,8 +27,12 @@ internal enum class BackendErrorCode(val value: Int) {
     BackendPlayStoreGenericError(7231),
     BackendUserIneligibleForPromoOffer(7232),
     BackendInvalidAppleSubscriptionKey(7234),
+    BackendCouldNotCreateAlias(7255),
+    BackendInvalidAppUserId(7256),
     BackendInvalidSubscriberAttributes(7263),
     BackendInvalidSubscriberAttributesBody(7264),
+    BackendSubscriberAttributesAreBeingUpdated(7629),
+    BackendRequestAlreadyInProgress(7638),
     BackendProductIDsMalformed(7662),
     BackendInvalidWebRedemptionToken(7849),
     BackendPurchaseBelongsToOtherUser(7852),
@@ -84,7 +88,9 @@ private fun BackendErrorCode.toPurchasesErrorCode(): PurchasesErrorCode {
         BackendErrorCode.BackendInvalidPaymentModeOrIntroPriceNotProvided,
         BackendErrorCode.BackendProductIdForGoogleReceiptNotProvided,
         -> PurchasesErrorCode.PurchaseInvalidError
-        BackendErrorCode.BackendEmptyAppUserId -> PurchasesErrorCode.InvalidAppUserIdError
+        BackendErrorCode.BackendEmptyAppUserId,
+        BackendErrorCode.BackendInvalidAppUserId,
+        -> PurchasesErrorCode.InvalidAppUserIdError
         BackendErrorCode.BackendPlayStoreQuotaExceeded -> PurchasesErrorCode.StoreProblemError
         BackendErrorCode.BackendPlayStoreInvalidPackageName,
         BackendErrorCode.BackendInvalidPlatform,
@@ -99,6 +105,10 @@ private fun BackendErrorCode.toPurchasesErrorCode(): PurchasesErrorCode {
         BackendErrorCode.BackendBadRequest,
         BackendErrorCode.BackendInternalServerError,
         -> PurchasesErrorCode.UnexpectedBackendResponseError
+        BackendErrorCode.BackendRequestAlreadyInProgress,
+        BackendErrorCode.BackendSubscriberAttributesAreBeingUpdated,
+        -> PurchasesErrorCode.OperationAlreadyInProgressError
+        BackendErrorCode.BackendCouldNotCreateAlias -> PurchasesErrorCode.ConfigurationError
         BackendErrorCode.BackendProductIDsMalformed -> PurchasesErrorCode.UnsupportedError
         BackendErrorCode.BackendInvalidWebRedemptionToken -> PurchasesErrorCode.PurchaseInvalidError
         BackendErrorCode.BackendPurchaseBelongsToOtherUser -> PurchasesErrorCode.ProductAlreadyPurchasedError


### PR DESCRIPTION
### Description
Currently these error codes would display in the API as "UnknownBackendError". This performs some better processing of these error codes.
