### PR TITLE
[Paywalls V2] Adds a `FLAG_PAYWALL_COMPONENTS` build flag

### DIFF
--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -36,6 +36,14 @@ android {
             resources.excludes.add("META-INF/LICENSE.md")
             resources.excludes.add("META-INF/LICENSE-notice.md")
         }
+
+        Properties properties = new Properties()
+        properties.load(project.rootProject.file('local.properties').newDataInputStream())
+        buildConfigField(
+                "boolean",
+                "FLAG_PAYWALL_COMPONENTS",
+                properties.getOrDefault("revenuecat.flag.paywallComponents", "false")
+        )
     }
 
     testOptions {

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -38,7 +38,8 @@ android {
         }
 
         Properties properties = new Properties()
-        properties.load(project.rootProject.file('local.properties').newDataInputStream())
+        def localProperties = project.rootProject.file('local.properties')
+        if (localProperties.exists()) properties.load(localProperties.newDataInputStream())
         buildConfigField(
                 "boolean",
                 "FLAG_PAYWALL_COMPONENTS",

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.PresentedOfferingContext
+import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
@@ -119,17 +120,20 @@ internal abstract class OfferingParser {
             }
         }
 
-        val paywallComponentsDataJson = offeringJson.optJSONObject("paywall_components")
-
         @Suppress("TooGenericExceptionCaught")
-        val paywallComponentsData: PaywallComponentsData? = paywallComponentsDataJson?.let {
-            try {
-                json.decodeFromString<PaywallComponentsData>(it.toString())
-            } catch (e: Throwable) {
-                errorLog("Error deserializing paywall components data", e)
+        val paywallComponentsData: PaywallComponentsData? =
+            if (BuildConfig.FLAG_PAYWALL_COMPONENTS) {
+                offeringJson.optJSONObject("paywall_components")?.let {
+                    try {
+                        json.decodeFromString<PaywallComponentsData>(it.toString())
+                    } catch (e: Throwable) {
+                        errorLog("Error deserializing paywall components data", e)
+                        null
+                    }
+                }
+            } else {
                 null
             }
-        }
 
         return if (availablePackages.isNotEmpty()) {
             Offering(


### PR DESCRIPTION
## Description
Since the iOS closed beta is coming up, I thought it'd be good to be extra careful about parsing the `paywall_components` JSON, as more people will soon have the ability to create those via the dashboard.

## How to
To enable, add the following line to your `local.properties` file in the root of the repo:
```properties
revenuecat.flag.paywallComponents=true
```

To disable, set it to false, or remove the line entirely. 