### PR TITLE
[Paywalls V2] Add `PurchaseButtonComponent` support

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -76,9 +76,10 @@ internal fun LoadedPaywallComponents(
     }
 
     val config = state.data.componentsConfig.base
-    val style = styleFactory.create(config.stack).getOrThrow()
+    val actionHandler: suspend (PaywallAction) -> Unit = { /* TODO Implement action handler */ }
+    val style = styleFactory.create(config.stack, actionHandler).getOrThrow()
     val footerComponentStyle = config.stickyFooter?.let {
-        styleFactory.createStickyFooterComponentStyle(it).getOrThrow()
+        styleFactory.createStickyFooterComponentStyle(it, actionHandler).getOrThrow()
     }
     val background = config.background.toBackgroundStyle()
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
@@ -1,33 +1,14 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.style
 
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 
 @Immutable
-internal class ButtonComponentStyle private constructor(
+internal class ButtonComponentStyle(
     @get:JvmSynthetic
     val stackComponentStyle: StackComponentStyle,
     @get:JvmSynthetic
     val action: PaywallAction,
     @get:JvmSynthetic
     val actionHandler: suspend (PaywallAction) -> Unit,
-) : ComponentStyle {
-
-    companion object {
-
-        @JvmSynthetic
-        @Composable
-        operator fun invoke(
-            stackComponentStyle: StackComponentStyle,
-            action: PaywallAction,
-            actionHandler: suspend (PaywallAction) -> Unit,
-        ): ButtonComponentStyle {
-            return ButtonComponentStyle(
-                stackComponentStyle = stackComponentStyle,
-                action = action,
-                actionHandler = actionHandler,
-            )
-        }
-    }
-}
+) : ComponentStyle

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentViewTests.kt
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.ui.revenuecatui.assertions.assertNoPixelColorEqu
 import com.revenuecat.purchases.ui.revenuecatui.assertions.assertPixelColorEquals
 import com.revenuecat.purchases.ui.revenuecatui.assertions.assertPixelColorPercentage
 import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState
+import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StyleFactory
@@ -49,6 +50,7 @@ class StackComponentViewTests {
     val composeTestRule = createComposeRule()
 
     private lateinit var styleFactory: StyleFactory
+    private val actionHandler: (PaywallAction) -> Unit = {}
 
     @Before
     fun setup() {
@@ -78,7 +80,7 @@ class StackComponentViewTests {
         themeChangingTest(
             arrange = {
                 // We don't want to recreate the entire tree every time the theme, or any other state, changes.
-                styleFactory.create(component).getOrThrow() as StackComponentStyle
+                styleFactory.create(component, actionHandler).getOrThrow() as StackComponentStyle
             },
             act = { StackComponentView(style = it, state = state, modifier = Modifier.testTag("stack")) },
             assert = { theme ->
@@ -125,7 +127,7 @@ class StackComponentViewTests {
                 borderWidthPx = with(LocalDensity.current) { borderWidthDp.dp.roundToPx() }
                 sizePx = with(LocalDensity.current) { sizeDp.dp.roundToPx() }
                 // We don't want to recreate the entire tree every time the theme, or any other state, changes.
-                styleFactory.create(component).getOrThrow() as StackComponentStyle
+                styleFactory.create(component, actionHandler).getOrThrow() as StackComponentStyle
             },
             act = { StackComponentView(style = it, state = state, modifier = Modifier.testTag("stack")) },
             assert = { theme ->
@@ -179,7 +181,7 @@ class StackComponentViewTests {
         themeChangingTest(
             arrange = {
                 // We don't want to recreate the entire tree every time the theme, or any other state, changes.
-                styleFactory.create(component).getOrThrow() as StackComponentStyle
+                styleFactory.create(component, actionHandler).getOrThrow() as StackComponentStyle
             },
             act = {
                 // An outer box, because a shadow draws outside the Composable's bounds.

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -58,7 +58,7 @@ class StyleFactoryTests {
         )
 
         // Act
-        val result = styleFactory.create(textComponent)
+        val result = styleFactory.create(textComponent, {})
 
         // Assert
         assertThat(result).isInstanceOf(Result.Success::class.java)
@@ -86,7 +86,7 @@ class StyleFactoryTests {
             )
 
             // Act
-            val result = styleFactory.create(stackComponent)
+            val result = styleFactory.create(stackComponent, {})
 
             // Assert
             assertThat(result).isInstanceOf(Result.Success::class.java)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewTests.kt
@@ -34,6 +34,7 @@ import com.revenuecat.purchases.ui.revenuecatui.assertions.assertPixelColorEqual
 import com.revenuecat.purchases.ui.revenuecatui.assertions.assertPixelColorPercentage
 import com.revenuecat.purchases.ui.revenuecatui.assertions.assertTextColorEquals
 import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState
+import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StyleFactory
 import com.revenuecat.purchases.ui.revenuecatui.components.style.TextComponentStyle
@@ -70,6 +71,7 @@ class TextComponentViewTests {
         ineligibleLocalizationKey to LocalizationData.Text(expectedTextIneligible),
         eligibleLocalizationKey to LocalizationData.Text(expectedTextEligible),
     )
+    private val actionHandler: (PaywallAction) -> Unit = {}
     private lateinit var styleFactory: StyleFactory
 
     @Before
@@ -99,7 +101,7 @@ class TextComponentViewTests {
         themeChangingTest(
             arrange = {
                 // We don't want to recreate the entire tree every time the theme, or any other state, changes.
-                styleFactory.create(component).getOrThrow() as TextComponentStyle
+                styleFactory.create(component, actionHandler).getOrThrow() as TextComponentStyle
             },
             act = { TextComponentView(style = it, state = state) },
             assert = { theme ->
@@ -140,7 +142,7 @@ class TextComponentViewTests {
         themeChangingTest(
             arrange = {
                 // We don't want to recreate the entire tree every time the theme, or any other state, changes.
-                styleFactory.create(component).getOrThrow() as TextComponentStyle
+                styleFactory.create(component, actionHandler).getOrThrow() as TextComponentStyle
             },
             act = { TextComponentView(style = it, state = state) },
             assert = { theme ->
@@ -174,8 +176,14 @@ class TextComponentViewTests {
         val smallTextComponent = TextComponent(text = textId, color = color, fontSize = FontSize.BODY_S, size = size)
         val state = FakePaywallState(largeTextComponent, smallTextComponent)
         setContent {
-            val largeTextStyle = styleFactory.create(largeTextComponent).getOrThrow() as TextComponentStyle
-            val smallTextStyle = styleFactory.create(smallTextComponent).getOrThrow() as TextComponentStyle
+            val largeTextStyle = styleFactory.create(
+                largeTextComponent,
+                actionHandler,
+            ).getOrThrow() as TextComponentStyle
+            val smallTextStyle = styleFactory.create(
+                smallTextComponent,
+                actionHandler,
+            ).getOrThrow() as TextComponentStyle
 
             // Act
             MaterialTheme {
@@ -225,7 +233,7 @@ class TextComponentViewTests {
             )
         )
         val state = FakePaywallState(component)
-        val style = styleFactory.create(component).getOrThrow() as TextComponentStyle
+        val style = styleFactory.create(component, actionHandler).getOrThrow() as TextComponentStyle
 
         // Act
         setContent {
@@ -272,7 +280,7 @@ class TextComponentViewTests {
             )
         )
         val state = FakePaywallState(component)
-        val style = styleFactory.create(component).getOrThrow() as TextComponentStyle
+        val style = styleFactory.create(component, actionHandler).getOrThrow() as TextComponentStyle
 
         // Act
         setContent { TextComponentView(style = style, state = state) }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewWindowTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewWindowTests.kt
@@ -103,7 +103,7 @@ internal class TextComponentViewWindowTests {
             componentState = ComponentViewState.DEFAULT,
             localizationDictionary = localizationDictionary,
         )
-        val style = styleFactory.create(component).getOrThrow() as TextComponentStyle
+        val style = styleFactory.create(component) {}.getOrThrow() as TextComponentStyle
     }
 
     @GraphicsMode(GraphicsMode.Mode.NATIVE)


### PR DESCRIPTION
### Description
Adds support for the `PurchaseButtonComponent`, which maps to a normal `ButtonComponentView` for now. We also pass action and actionhandler from the style factory, which might also change once we move more logic to the VM.