### PR TITLE
[Paywalls V2] Add more image component previews to test parent being smaller than image size

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -5,6 +5,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components.image
 import android.graphics.Color
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -18,6 +19,7 @@ import com.revenuecat.purchases.paywalls.components.properties.ImageUrls
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
+import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.urlsForCurrentTheme
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.overlay
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
@@ -44,6 +46,7 @@ internal fun ImageComponentView(
                 .applyIfNotNull(style.shape) { clip(it) },
             placeholderUrlString = currentUrls.webpLowRes.toString(),
             contentScale = style.contentScale,
+            imagePreview = R.drawable.android,
         )
     }
 }
@@ -52,6 +55,16 @@ internal fun ImageComponentView(
 @Composable
 private fun ImageComponentView_Preview_Default() {
     Box(modifier = Modifier.background(ComposeColor.Red)) {
+        ImageComponentView(
+            style = previewImageComponentStyle(),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ImageComponentView_Preview_SmallerContainer() {
+    Box(modifier = Modifier.height(200.dp).background(ComposeColor.Red)) {
         ImageComponentView(
             style = previewImageComponentStyle(),
         )
@@ -103,7 +116,7 @@ private fun previewImageComponentStyle(
     lowResURL: URL = URL("https://assets.pawwalls.com/954459_1701163461.jpg"),
     visible: Boolean = true,
     size: Size = Size(width = SizeConstraint.Fixed(400u), height = SizeConstraint.Fit),
-    contentScale: ContentScale = ContentScale.Crop,
+    contentScale: ContentScale = ContentScale.Fit,
     overlay: ColorStyle? = null,
 ) = ImageComponentStyle(
     visible = visible,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
@@ -37,6 +37,7 @@ internal fun LocalImage(
     contentDescription: String? = null,
     transformation: Transformation? = null,
     alpha: Float = 1f,
+    @DrawableRes imagePreview: Int? = null,
 ) {
     Image(
         source = ImageSource.Local(resource),
@@ -46,9 +47,14 @@ internal fun LocalImage(
         contentDescription = contentDescription,
         transformation = transformation,
         alpha = alpha,
+        imagePreview = imagePreview,
     )
 }
 
+/**
+ * @param supportImagePreview: set to false to not show any image in previews and just a colored box. This is to avoid
+ * modifying Paywalls V1 previews.
+ */
 @SuppressWarnings("LongParameterList")
 @Composable
 internal fun RemoteImage(
@@ -59,6 +65,7 @@ internal fun RemoteImage(
     contentDescription: String? = null,
     transformation: Transformation? = null,
     alpha: Float = 1f,
+    @DrawableRes imagePreview: Int? = null,
 ) {
     Image(
         source = ImageSource.Remote(urlString),
@@ -68,6 +75,7 @@ internal fun RemoteImage(
         contentDescription = contentDescription,
         transformation = transformation,
         alpha = alpha,
+        imagePreview = imagePreview,
     )
 }
 
@@ -92,9 +100,10 @@ private fun Image(
     contentDescription: String?,
     transformation: Transformation?,
     alpha: Float,
+    @DrawableRes imagePreview: Int?,
 ) {
     // Previews don't support images
-    if (isInPreviewMode()) {
+    if (isInPreviewMode() && imagePreview == null) {
         return ImageForPreviews(modifier)
     }
 
@@ -120,6 +129,7 @@ private fun Image(
             modifier = modifier,
             contentScale = contentScale,
             alpha = alpha,
+            imagePreview = imagePreview,
             onError = {
                 Logger.w("Image failed to load. Will try again disabling cache")
                 useCache = false
@@ -135,6 +145,7 @@ private fun Image(
             modifier = modifier,
             contentScale = contentScale,
             alpha = alpha,
+            imagePreview = imagePreview,
         )
     }
 }
@@ -150,6 +161,7 @@ private fun AsyncImage(
     contentScale: ContentScale,
     contentDescription: String?,
     alpha: Float,
+    @DrawableRes imagePreview: Int? = null,
     onError: ((AsyncImagePainter.State.Error) -> Unit)? = null,
 ) {
     AsyncImage(
@@ -158,7 +170,7 @@ private fun AsyncImage(
         placeholder = placeholderSource?.let {
             rememberAsyncImagePainter(
                 model = it.data,
-                placeholder = if (isInPreviewMode()) painterResource(R.drawable.android) else null,
+                placeholder = if (isInPreviewMode() && imagePreview != null) painterResource(imagePreview) else null,
                 imageLoader = imageLoader,
                 contentScale = contentScale,
                 onError = { errorState ->


### PR DESCRIPTION
### Description
This has 2 main changes:
- Adds one more preview for `ImageComponentView` that verifies how it looks when the dimension size is `Fit` (which translates to the image size) but the parent is smaller than the image.
- Adds one more parameter to `RemoteImage` and `LocalImage` that allows to set an optional preview resource drawable.