### PR TITLE
Migrates to Coil 3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ material = "1.6.0"
 adsIdentifier = "17.0.1"
 viewmodelCompose = "2.4.0"
 paparrazzi = "1.3.1"
-coil = "2.4.0"
+coil = "3.0.4"
 window = "1.1.0"
 commonmark = "0.21.0"
 activity-compose = "1.9.3"
@@ -140,9 +140,9 @@ compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 window = { module = "androidx.window:window", version.ref = "window" }
 window-core = { module = "androidx.window:window-core", version.ref = "window" }
 
-coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
-coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coil" }
-coil-test = { module = "io.coil-kt:coil-test", version.ref = "coil" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
+coil-test = { module = "io.coil-kt.coil3:coil-test", version.ref = "coil" }
 
 commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
 commonmark-strikethrough = { module = "org.commonmark:commonmark-ext-gfm-strikethrough", version.ref = "commonmark" }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CoilImageDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CoilImageDownloader.kt
@@ -2,9 +2,10 @@ package com.revenuecat.purchases.utils
 
 import android.content.Context
 import android.net.Uri
-import coil.ImageLoader
-import coil.disk.DiskCache
-import coil.request.ImageRequest
+import coil3.ImageLoader
+import coil3.disk.DiskCache
+import coil3.disk.directory
+import coil3.request.ImageRequest
 
 // Note: these values have to match those in RemoteImage
 private const val MAX_CACHE_SIZE_BYTES = 25 * 1024 * 1024L // 25 MB

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.annotation.ExperimentalCoilApi
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
@@ -40,6 +41,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.ImageComponentS
 import com.revenuecat.purchases.ui.revenuecatui.composables.RemoteImage
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.extensions.applyIfNotNull
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PreviewImagesAsDrawableResource
 import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
 import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toComponentsPaywallState
@@ -72,121 +74,138 @@ internal fun ImageComponentView(
                 .applyIfNotNull(imageState.shape) { clip(it) },
             placeholderUrlString = imageState.imageUrls.webpLowRes.toString(),
             contentScale = imageState.contentScale,
-            imagePreview = R.drawable.android,
         )
     }
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Preview
 @Composable
 private fun ImageComponentView_Preview_Default() {
-    Box(modifier = Modifier.background(ComposeColor.Red)) {
-        ImageComponentView(
-            style = previewImageComponentStyle(),
-            state = previewEmptyState(),
-        )
+    PreviewImagesAsDrawableResource(R.drawable.android) {
+        Box(modifier = Modifier.background(ComposeColor.Red)) {
+            ImageComponentView(
+                style = previewImageComponentStyle(),
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Preview
 @Composable
 private fun ImageComponentView_Preview_FixedWidthFitHeight() {
-    Box(modifier = Modifier.background(ComposeColor.Red)) {
-        ImageComponentView(
-            style = previewImageComponentStyle(
-                size = Size(width = SizeConstraint.Fixed(72u), height = SizeConstraint.Fit),
-                contentScale = FitMode.FILL.toContentScale(),
-            ),
-            state = previewEmptyState(),
-        )
+    PreviewImagesAsDrawableResource(R.drawable.android) {
+        Box(modifier = Modifier.background(ComposeColor.Red)) {
+            ImageComponentView(
+                style = previewImageComponentStyle(
+                    size = Size(width = SizeConstraint.Fixed(72u), height = SizeConstraint.Fit),
+                    contentScale = FitMode.FILL.toContentScale(),
+                ),
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Preview
 @Composable
 private fun ImageComponentView_Preview_FitWidthFixedHeight() {
-    Box(modifier = Modifier.background(ComposeColor.Red)) {
-        ImageComponentView(
-            style = previewImageComponentStyle(
-                size = Size(width = SizeConstraint.Fit, height = SizeConstraint.Fixed(72u)),
-                contentScale = FitMode.FILL.toContentScale(),
-            ),
-            state = previewEmptyState(),
-        )
+    PreviewImagesAsDrawableResource(R.drawable.android) {
+        Box(modifier = Modifier.background(ComposeColor.Red)) {
+            ImageComponentView(
+                style = previewImageComponentStyle(
+                    size = Size(width = SizeConstraint.Fit, height = SizeConstraint.Fixed(72u)),
+                    contentScale = FitMode.FILL.toContentScale(),
+                ),
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Preview
 @Composable
 private fun ImageComponentView_Preview_SmallerContainer() {
-    Box(modifier = Modifier.height(200.dp).background(ComposeColor.Red)) {
-        ImageComponentView(
-            style = previewImageComponentStyle(),
-            state = previewEmptyState(),
-        )
+    PreviewImagesAsDrawableResource(R.drawable.android) {
+        Box(modifier = Modifier.height(200.dp).background(ComposeColor.Red)) {
+            ImageComponentView(
+                style = previewImageComponentStyle(),
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Suppress("MagicNumber")
 @Preview
 @Composable
 private fun ImageComponentView_Preview_LinearGradient() {
-    Box(modifier = Modifier.background(ComposeColor.Red)) {
-        ImageComponentView(
-            style = previewImageComponentStyle(
-                overlay = ColorScheme(
-                    light = ColorInfo.Gradient.Linear(
-                        degrees = -90f,
-                        points = listOf(
-                            ColorInfo.Gradient.Point(
-                                color = Color.parseColor("#88FF0000"),
-                                percent = 0f,
-                            ),
-                            ColorInfo.Gradient.Point(
-                                color = Color.parseColor("#8800FF00"),
-                                percent = 0.5f,
-                            ),
-                            ColorInfo.Gradient.Point(
-                                color = Color.parseColor("#880000FF"),
-                                percent = 1f,
+    PreviewImagesAsDrawableResource(R.drawable.android) {
+        Box(modifier = Modifier.background(ComposeColor.Red)) {
+            ImageComponentView(
+                style = previewImageComponentStyle(
+                    overlay = ColorScheme(
+                        light = ColorInfo.Gradient.Linear(
+                            degrees = -90f,
+                            points = listOf(
+                                ColorInfo.Gradient.Point(
+                                    color = Color.parseColor("#88FF0000"),
+                                    percent = 0f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color.parseColor("#8800FF00"),
+                                    percent = 0.5f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color.parseColor("#880000FF"),
+                                    percent = 1f,
+                                ),
                             ),
                         ),
                     ),
                 ),
-            ),
-            state = previewEmptyState(),
-        )
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Suppress("MagicNumber")
 @Preview
 @Composable
 private fun ImageComponentView_Preview_RadialGradient() {
-    Box(modifier = Modifier.background(ComposeColor.Red)) {
-        ImageComponentView(
-            style = previewImageComponentStyle(
-                overlay = ColorScheme(
-                    light = ColorInfo.Gradient.Radial(
-                        listOf(
-                            ColorInfo.Gradient.Point(
-                                color = Color.parseColor("#88FF0000"),
-                                percent = 0f,
-                            ),
-                            ColorInfo.Gradient.Point(
-                                color = Color.parseColor("#8800FF00"),
-                                percent = 0.5f,
-                            ),
-                            ColorInfo.Gradient.Point(
-                                color = Color.parseColor("#880000FF"),
-                                percent = 1f,
+    PreviewImagesAsDrawableResource(R.drawable.android) {
+        Box(modifier = Modifier.background(ComposeColor.Red)) {
+            ImageComponentView(
+                style = previewImageComponentStyle(
+                    overlay = ColorScheme(
+                        light = ColorInfo.Gradient.Radial(
+                            listOf(
+                                ColorInfo.Gradient.Point(
+                                    color = Color.parseColor("#88FF0000"),
+                                    percent = 0f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color.parseColor("#8800FF00"),
+                                    percent = 0.5f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color.parseColor("#880000FF"),
+                                    percent = 1f,
+                                ),
                             ),
                         ),
                     ),
                 ),
-            ),
-            state = previewEmptyState(),
-        )
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/BackgroundStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/BackgroundStyle.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.rememberAsyncImagePainter
+import coil3.compose.rememberAsyncImagePainter
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IconImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/IconImage.kt
@@ -3,14 +3,10 @@ package com.revenuecat.purchases.ui.revenuecatui.composables
 import android.graphics.Bitmap
 import android.net.Uri
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -22,9 +18,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.drawable.toBitmap
+import coil3.annotation.ExperimentalCoilApi
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.extensions.defaultAppIconPlaceholder
-import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PreviewImagesAsPrimaryColor
 
 @Composable
 internal fun IconImage(
@@ -39,13 +36,7 @@ internal fun IconImage(
                 .aspectRatio(ratio = 1f)
                 .widthIn(max = maxWidth)
                 .clip(RoundedCornerShape(iconCornerRadius))
-            if (isInPreviewMode()) {
-                Box(
-                    modifier = modifier
-                        .background(color = MaterialTheme.colorScheme.primary)
-                        .size(maxWidth),
-                )
-            } else if (uri.toString().contains(PaywallData.defaultAppIconPlaceholder)) {
+            if (uri.toString().contains(PaywallData.defaultAppIconPlaceholder)) {
                 AppIcon(modifier = modifier)
             } else {
                 RemoteImage(
@@ -76,12 +67,15 @@ private fun AppIcon(
     )
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Preview
 @Composable
 private fun IconImagePreview() {
-    IconImage(
-        uri = Uri.parse("https://assets.pawwalls.com/icon.jpg"),
-        maxWidth = 140.dp,
-        iconCornerRadius = 16.dp,
-    )
+    PreviewImagesAsPrimaryColor {
+        IconImage(
+            uri = Uri.parse("https://assets.pawwalls.com/icon.jpg"),
+            maxWidth = 140.dp,
+            iconCornerRadius = 16.dp,
+        )
+    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
@@ -2,9 +2,6 @@ package com.revenuecat.purchases.ui.revenuecatui.composables
 
 import android.content.Context
 import androidx.annotation.DrawableRes
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -13,7 +10,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import coil3.ImageLoader
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
@@ -26,10 +22,8 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.request.transformations
 import coil3.transform.Transformation
-import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
-import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
 
 @SuppressWarnings("LongParameterList")
 @Composable
@@ -40,7 +34,6 @@ internal fun LocalImage(
     contentDescription: String? = null,
     transformation: Transformation? = null,
     alpha: Float = 1f,
-    @DrawableRes imagePreview: Int? = null,
 ) {
     Image(
         source = ImageSource.Local(resource),
@@ -50,14 +43,9 @@ internal fun LocalImage(
         contentDescription = contentDescription,
         transformation = transformation,
         alpha = alpha,
-        imagePreview = imagePreview,
     )
 }
 
-/**
- * @param supportImagePreview: set to false to not show any image in previews and just a colored box. This is to avoid
- * modifying Paywalls V1 previews.
- */
 @SuppressWarnings("LongParameterList")
 @Composable
 internal fun RemoteImage(
@@ -68,7 +56,6 @@ internal fun RemoteImage(
     contentDescription: String? = null,
     transformation: Transformation? = null,
     alpha: Float = 1f,
-    @DrawableRes imagePreview: Int? = null,
 ) {
     Image(
         source = ImageSource.Remote(urlString),
@@ -78,7 +65,6 @@ internal fun RemoteImage(
         contentDescription = contentDescription,
         transformation = transformation,
         alpha = alpha,
-        imagePreview = imagePreview,
     )
 }
 
@@ -103,13 +89,7 @@ private fun Image(
     contentDescription: String?,
     transformation: Transformation?,
     alpha: Float,
-    @DrawableRes imagePreview: Int?,
 ) {
-    // Previews don't support images
-    if (isInPreviewMode() && imagePreview == null) {
-        return ImageForPreviews(modifier)
-    }
-
     var useCache by remember { mutableStateOf(true) }
     val applicationContext = LocalContext.current.applicationContext
     val imageLoader = remember(useCache) {
@@ -132,7 +112,6 @@ private fun Image(
             modifier = modifier,
             contentScale = contentScale,
             alpha = alpha,
-            imagePreview = imagePreview,
             onError = {
                 Logger.w("Image failed to load. Will try again disabling cache")
                 useCache = false
@@ -148,7 +127,6 @@ private fun Image(
             modifier = modifier,
             contentScale = contentScale,
             alpha = alpha,
-            imagePreview = imagePreview,
         )
     }
 }
@@ -164,7 +142,6 @@ private fun AsyncImage(
     contentScale: ContentScale,
     contentDescription: String?,
     alpha: Float,
-    @DrawableRes imagePreview: Int? = null,
     onError: ((AsyncImagePainter.State.Error) -> Unit)? = null,
 ) {
     AsyncImage(
@@ -173,14 +150,13 @@ private fun AsyncImage(
         placeholder = placeholderSource?.let {
             rememberAsyncImagePainter(
                 model = it.data,
-                placeholder = if (isInPreviewMode() && imagePreview != null) painterResource(imagePreview) else null,
                 imageLoader = imageLoader,
                 contentScale = contentScale,
                 onError = { errorState ->
                     Logger.e("Error loading placeholder image", errorState.result.throwable)
                 },
             )
-        } ?: if (isInPreviewMode()) painterResource(R.drawable.android) else null,
+        },
         imageLoader = imageLoader,
         modifier = modifier,
         contentScale = contentScale,
@@ -194,13 +170,6 @@ private fun AsyncImage(
             Logger.e(error, it.result.throwable)
             onError?.invoke(it)
         },
-    )
-}
-
-@Composable
-private fun ImageForPreviews(modifier: Modifier) {
-    Box(
-        modifier = modifier.background(MaterialTheme.colorScheme.primary),
     )
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
@@ -14,15 +14,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import coil.ImageLoader
-import coil.compose.AsyncImage
-import coil.compose.AsyncImagePainter
-import coil.compose.rememberAsyncImagePainter
-import coil.disk.DiskCache
-import coil.memory.MemoryCache
-import coil.request.CachePolicy
-import coil.request.ImageRequest
-import coil.transform.Transformation
+import coil3.ImageLoader
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.compose.rememberAsyncImagePainter
+import coil3.disk.DiskCache
+import coil3.disk.directory
+import coil3.memory.MemoryCache
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.request.transformations
+import coil3.transform.Transformation
 import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
@@ -222,7 +225,8 @@ private fun Context.getRevenueCatUIImageLoader(readCache: Boolean): ImageLoader 
                 .build()
         }
         .memoryCache(
-            MemoryCache.Builder(this)
+            MemoryCache.Builder()
+                .maxSizePercent(this)
                 .build(),
         )
         .diskCachePolicy(cachePolicy)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/BlurTransformation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/BlurTransformation.kt
@@ -5,8 +5,8 @@ import android.renderscript.Element
 import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicBlur
 import androidx.annotation.VisibleForTesting
-import coil.size.Size
-import coil.transform.Transformation
+import coil3.size.Size
+import coil3.transform.Transformation
 import kotlin.math.min
 import kotlin.math.roundToInt
 
@@ -21,7 +21,7 @@ import kotlin.math.roundToInt
 internal class BlurTransformation(
     private val context: Context,
     private val radius: Float,
-) : Transformation {
+) : Transformation() {
     override val cacheKey: String = "${javaClass.name}-$radius"
 
     override suspend fun transform(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PreviewImages.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PreviewImages.kt
@@ -1,0 +1,53 @@
+package com.revenuecat.purchases.ui.revenuecatui.helpers
+
+import android.graphics.drawable.ColorDrawable
+import androidx.annotation.DrawableRes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import coil3.annotation.ExperimentalCoilApi
+import coil3.asImage
+import coil3.compose.AsyncImagePreviewHandler
+import coil3.compose.LocalAsyncImagePreviewHandler
+import com.revenuecat.purchases.InternalRevenueCatAPI
+
+/**
+ * **For Compose Previews only.**
+ *
+ * Replaces all images in the [content] with the provided [color].
+ */
+@InternalRevenueCatAPI
+@ExperimentalCoilApi
+@Composable
+internal fun PreviewImagesAsColor(color: Color, content: @Composable () -> Unit) {
+    val previewHandler = AsyncImagePreviewHandler { ColorDrawable(color.toArgb()).asImage() }
+    CompositionLocalProvider(LocalAsyncImagePreviewHandler provides previewHandler, content)
+}
+
+/**
+ * **For Compose Previews only.**
+ *
+ * Replaces all images in the [content] with the current Material 3 theme's primary color.
+ */
+@InternalRevenueCatAPI
+@ExperimentalCoilApi
+@Composable
+internal fun PreviewImagesAsPrimaryColor(content: @Composable () -> Unit) =
+    PreviewImagesAsColor(MaterialTheme.colorScheme.primary, content)
+
+/**
+ * **For Compose Previews only.**
+ *
+ * Replaces all images in the [content] with the provided Drawable [resource].
+ */
+@InternalRevenueCatAPI
+@ExperimentalCoilApi
+@Composable
+internal fun PreviewImagesAsDrawableResource(@DrawableRes resource: Int, content: @Composable () -> Unit) {
+    val context = LocalContext.current
+    val previewHandler = AsyncImagePreviewHandler { context.getDrawable(resource)?.asImage() }
+    CompositionLocalProvider(LocalAsyncImagePreviewHandler provides previewHandler, content)
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template1.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import coil3.annotation.ExperimentalCoilApi
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -55,6 +56,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PreviewImagesAsPrimaryColor
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldUseLandscapeLayout
 
 @Composable
@@ -201,6 +203,7 @@ private object Template1UIConstants {
     const val circleScaleLanscape = 8.0f
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Preview(showBackground = true, group = "full_screen")
 @Preview(
     showBackground = true,
@@ -213,19 +216,24 @@ private object Template1UIConstants {
 @Preview(showBackground = true, device = Devices.NEXUS_10, group = "full_screen")
 @Composable
 private fun Template1PaywallPreview() {
-    InternalPaywall(
-        options = PaywallOptions.Builder(dismissRequest = {}).build(),
-        viewModel = MockViewModel(offering = TestData.template1Offering),
-    )
+    PreviewImagesAsPrimaryColor {
+        InternalPaywall(
+            options = PaywallOptions.Builder(dismissRequest = {}).build(),
+            viewModel = MockViewModel(offering = TestData.template1Offering),
+        )
+    }
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Preview(showBackground = true, group = "full_screen")
 @Composable
 private fun Template1NoFooterPaywallPreview() {
-    InternalPaywall(
-        options = PaywallOptions.Builder(dismissRequest = {}).build(),
-        viewModel = MockViewModel(offering = TestData.template1OfferingNoFooter),
-    )
+    PreviewImagesAsPrimaryColor {
+        InternalPaywall(
+            options = PaywallOptions.Builder(dismissRequest = {}).build(),
+            viewModel = MockViewModel(offering = TestData.template1OfferingNoFooter),
+        )
+    }
 }
 
 @Preview(showBackground = true, group = "footer")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template2.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.annotation.ExperimentalCoilApi
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -72,6 +73,7 @@ import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 import com.revenuecat.purchases.ui.revenuecatui.extensions.packageButtonActionInProgressOpacityAnimation
 import com.revenuecat.purchases.ui.revenuecatui.extensions.packageButtonColorAnimation
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PreviewImagesAsPrimaryColor
 import com.revenuecat.purchases.ui.revenuecatui.helpers.TestTag
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldUseLandscapeLayout
 
@@ -430,6 +432,7 @@ private fun CheckmarkBox(isSelected: Boolean, colors: TemplateConfiguration.Colo
     }
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Preview(showBackground = true, locale = "en-rUS", group = "full-screen", name = "Portrait")
 @Preview(
     showBackground = true,
@@ -444,10 +447,12 @@ private fun CheckmarkBox(isSelected: Boolean, colors: TemplateConfiguration.Colo
 @Preview(showBackground = true, device = Devices.NEXUS_10, group = "full-screen")
 @Composable
 private fun Template2PaywallPreview() {
-    InternalPaywall(
-        options = PaywallOptions.Builder(dismissRequest = {}).build(),
-        viewModel = MockViewModel(offering = TestData.template2Offering),
-    )
+    PreviewImagesAsPrimaryColor {
+        InternalPaywall(
+            options = PaywallOptions.Builder(dismissRequest = {}).build(),
+            viewModel = MockViewModel(offering = TestData.template2Offering),
+        )
+    }
 }
 
 @Preview(showBackground = true, locale = "en-rUS", group = "footer")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import coil3.annotation.ExperimentalCoilApi
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
@@ -47,6 +48,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfigura
 import com.revenuecat.purchases.ui.revenuecatui.data.selectedLocalization
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PreviewImagesAsPrimaryColor
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldUseLandscapeLayout
 
 private object Template3UIConstants {
@@ -242,6 +244,7 @@ private fun Feature(
     }
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Preview(locale = "en-rUS", showBackground = true, group = "full_screen", name = "Portrait")
 @Preview(
     locale = "en-rUS",
@@ -256,10 +259,12 @@ private fun Feature(
 @Preview(showBackground = true, device = Devices.NEXUS_10, group = "full_screen")
 @Composable
 private fun Template3Preview() {
-    InternalPaywall(
-        options = PaywallOptions.Builder(dismissRequest = {}).build(),
-        viewModel = MockViewModel(offering = TestData.template3Offering),
-    )
+    PreviewImagesAsPrimaryColor {
+        InternalPaywall(
+            options = PaywallOptions.Builder(dismissRequest = {}).build(),
+            viewModel = MockViewModel(offering = TestData.template3Offering),
+        )
+    }
 }
 
 @Preview(showBackground = true, group = "footer")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template4.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template4.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import coil3.annotation.ExperimentalCoilApi
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -83,6 +84,7 @@ import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 import com.revenuecat.purchases.ui.revenuecatui.extensions.packageButtonActionInProgressOpacityAnimation
 import com.revenuecat.purchases.ui.revenuecatui.extensions.packageButtonColorAnimation
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PreviewImagesAsPrimaryColor
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldUseLandscapeLayout
 import kotlin.math.min
 
@@ -448,6 +450,7 @@ private fun CheckmarkBox(
     }
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Preview(showBackground = true, locale = "en-rUS", group = "full_screen")
 @Preview(
     showBackground = true,
@@ -462,10 +465,12 @@ private fun CheckmarkBox(
 @Preview(showBackground = true, device = Devices.NEXUS_10, group = "full_screen")
 @Composable
 private fun Template4PaywallPreview() {
-    InternalPaywall(
-        options = PaywallOptions.Builder(dismissRequest = {}).build(),
-        viewModel = MockViewModel(offering = TestData.template4Offering),
-    )
+    PreviewImagesAsPrimaryColor {
+        InternalPaywall(
+            options = PaywallOptions.Builder(dismissRequest = {}).build(),
+            viewModel = MockViewModel(offering = TestData.template4Offering),
+        )
+    }
 }
 
 @Preview(showBackground = true, locale = "en-rUS", group = "footer")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template5.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.annotation.ExperimentalCoilApi
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallMode
@@ -77,6 +78,7 @@ import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 import com.revenuecat.purchases.ui.revenuecatui.extensions.packageButtonActionInProgressOpacityAnimation
 import com.revenuecat.purchases.ui.revenuecatui.extensions.packageButtonColorAnimation
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PreviewImagesAsPrimaryColor
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldUseLandscapeLayout
 
 private object Template5UIConstants {
@@ -508,6 +510,7 @@ private val TemplateConfiguration.Colors.selectedDiscountText: Color
 private val TemplateConfiguration.Colors.unselectedDiscountText: Color
     get() = this.text3
 
+@OptIn(ExperimentalCoilApi::class)
 @Preview(showBackground = true, locale = "en-rUS", group = "full_screen")
 @Preview(
     showBackground = true,
@@ -523,10 +526,12 @@ private val TemplateConfiguration.Colors.unselectedDiscountText: Color
 @Preview(showBackground = true, device = Devices.NEXUS_10, group = "full_screen")
 @Composable
 private fun Template5PaywallPreview() {
-    InternalPaywall(
-        options = PaywallOptions.Builder(dismissRequest = {}).build(),
-        viewModel = MockViewModel(offering = TestData.template5Offering),
-    )
+    PreviewImagesAsPrimaryColor {
+        InternalPaywall(
+            options = PaywallOptions.Builder(dismissRequest = {}).build(),
+            viewModel = MockViewModel(offering = TestData.template5Offering),
+        )
+    }
 }
 
 @Preview(showBackground = true, locale = "en-rUS", group = "footer")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template7.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template7.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.annotation.ExperimentalCoilApi
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.InternalPaywall
@@ -80,6 +81,7 @@ import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 import com.revenuecat.purchases.ui.revenuecatui.extensions.packageButtonActionInProgressOpacityAnimation
 import com.revenuecat.purchases.ui.revenuecatui.extensions.packageButtonColorAnimation
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PreviewImagesAsPrimaryColor
 import com.revenuecat.purchases.ui.revenuecatui.helpers.shouldUseLandscapeLayout
 
 private object Template7UIConstants {
@@ -648,7 +650,7 @@ private val TemplateConfiguration.Colors.selectedDiscountText: Color
 private val TemplateConfiguration.Colors.unselectedDiscountText: Color
     get() = this.text3
 
-@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
+@OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class, ExperimentalCoilApi::class)
 @Preview(showBackground = true, locale = "en-rUS", group = "full_screen")
 @Preview(
     showBackground = true,
@@ -664,10 +666,12 @@ private val TemplateConfiguration.Colors.unselectedDiscountText: Color
 @Preview(showBackground = true, device = Devices.NEXUS_10, group = "full_screen")
 @Composable
 private fun Template7PaywallPreview() {
-    InternalPaywall(
-        options = PaywallOptions.Builder(dismissRequest = {}).build(),
-        viewModel = MockViewModel(offering = TestData.template7Offering),
-    )
+    PreviewImagesAsPrimaryColor {
+        InternalPaywall(
+            options = PaywallOptions.Builder(dismissRequest = {}).build(),
+            viewModel = MockViewModel(offering = TestData.template7Offering),
+        )
+    }
 }
 
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/BackgroundTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/BackgroundTests.kt
@@ -24,10 +24,11 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import coil.Coil
-import coil.ImageLoader
-import coil.annotation.ExperimentalCoilApi
-import coil.test.FakeImageLoaderEngine
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.annotation.DelicateCoilApi
+import coil3.test.FakeImageLoaderEngine
+import coil3.test.intercept
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
@@ -51,7 +52,7 @@ import java.net.URL
 
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(shadows = [ShadowPixelCopy::class], sdk = [26])
-@OptIn(ExperimentalCoilApi::class)
+@OptIn(DelicateCoilApi::class)
 @RunWith(AndroidJUnit4::class)
 class BackgroundTests {
 
@@ -74,12 +75,12 @@ class BackgroundTests {
             .components { add(engine) }
             .build()
 
-        Coil.setImageLoader(imageLoader)
+        SingletonImageLoader.setUnsafe(imageLoader)
     }
 
     @After
     fun teardown() {
-        Coil.reset()
+        SingletonImageLoader.reset()
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR updates Coil to 3.0.4. The maven coordinates have changed wrt Coil 2, which means there should be no binary incompatibility issues. For reference, the official migration docs are [here](https://coil-kt.github.io/coil/upgrading_to_coil3/).
- https://github.com/RevenueCat/purchases-android/commit/c34a6d9f5eb2ae27a57bdb5989f1d72ed3b3955c Migrates the code base to Coil 3.0.4. This is mostly a version bump + changing imports.
- https://github.com/RevenueCat/purchases-android/commit/191d7b956b8610e135d6f5a7db9540f7e96f749d Migrates all previews to make use of the new `PreviewHandler` mechanism. Check out `ImagePreviews.kt`. 

## Motivation
The main motivation is Coil's new `PreviewHandler` mechanism. This gives us great control over the images used in Compose previews. This comes in handy when creating previews for the Paywalls V2 image component, as it should handle various sizes and fit modes correctly. This automatically protects us against regressions in combination with Emerge Snapshots. 
