### PR TITLE
[Paywalls V2] Improves image previews

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -47,13 +47,14 @@ import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.paywalls.components.properties.FitMode
 import com.revenuecat.purchases.paywalls.components.properties.ImageUrls
 import com.revenuecat.purchases.paywalls.components.properties.Size
-import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
 import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
 import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toContentScale
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.urlsForCurrentTheme
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.aspectRatio
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.overlay
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.rememberColorStyle
@@ -90,6 +91,7 @@ internal fun ImageComponentView(
             urlString = imageState.imageUrls.webp.toString(),
             modifier = modifier
                 .size(imageState.size)
+                .applyIfNotNull(imageState.aspectRatio) { aspectRatio(it) }
                 .applyIfNotNull(overlay) { overlay(it, imageState.shape ?: RectangleShape) }
                 .applyIfNotNull(imageState.shape) { clip(it) },
             placeholderUrlString = imageState.imageUrls.webpLowRes.toString(),
@@ -159,7 +161,13 @@ private class PreviewParametersProvider : PreviewParameterProvider<PreviewParame
         PreviewParameters(
             imageWidth = 1909u,
             imageHeight = 1306u,
-            viewSize = Size(width = SizeConstraint.Fill, height = Fit),
+            viewSize = Size(width = Fill, height = Fit),
+            fitMode = FitMode.FIT,
+        ),
+        PreviewParameters(
+            imageWidth = 1306u,
+            imageHeight = 1909u,
+            viewSize = Size(width = Fit, height = Fill),
             fitMode = FitMode.FIT,
         ),
     )
@@ -188,7 +196,11 @@ private fun ImageComponentView_Preview(
 @Composable
 private fun ImageComponentView_Preview_SmallerContainer() {
     val themeImageUrls = previewThemeImageUrls(widthPx = 400u, heightPx = 400u)
-    Box(modifier = Modifier.height(200.dp).background(ComposeColor.Blue)) {
+    Box(
+        modifier = Modifier
+            .height(200.dp)
+            .background(ComposeColor.Blue),
+    ) {
         ImageComponentView(
             style = previewImageComponentStyle(
                 themeImageUrls = themeImageUrls,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -1,8 +1,17 @@
 @file:JvmSynthetic
+@file:Suppress("TooManyFunctions")
 
 package com.revenuecat.purchases.ui.revenuecatui.components.image
 
+import android.graphics.Bitmap
+import android.graphics.Bitmap.Config
+import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import androidx.annotation.ColorInt
+import androidx.annotation.DrawableRes
+import androidx.annotation.Px
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
@@ -12,9 +21,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import androidx.core.graphics.component1
+import androidx.core.graphics.component2
+import androidx.core.graphics.component3
+import androidx.core.graphics.component4
+import coil.ImageLoader
+import coil.decode.DataSource
+import coil.request.SuccessResult
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
@@ -30,9 +48,12 @@ import com.revenuecat.purchases.paywalls.components.properties.FitMode
 import com.revenuecat.purchases.paywalls.components.properties.ImageUrls
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
 import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
 import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toContentScale
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.urlsForCurrentTheme
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.overlay
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.rememberColorStyle
@@ -54,6 +75,7 @@ internal fun ImageComponentView(
     state: PaywallState.Loaded.Components,
     modifier: Modifier = Modifier,
     selected: Boolean = false,
+    previewImageLoader: ImageLoader? = null,
 ) {
     // Get an ImageComponentState that calculates the overridden properties we should use.
     val imageState = rememberUpdatedImageComponentState(
@@ -72,46 +94,92 @@ internal fun ImageComponentView(
                 .applyIfNotNull(imageState.shape) { clip(it) },
             placeholderUrlString = imageState.imageUrls.webpLowRes.toString(),
             contentScale = imageState.contentScale,
-            imagePreview = R.drawable.android,
+            previewImageLoader = previewImageLoader,
         )
     }
 }
 
-@Preview
-@Composable
-private fun ImageComponentView_Preview_Default() {
-    Box(modifier = Modifier.background(ComposeColor.Red)) {
-        ImageComponentView(
-            style = previewImageComponentStyle(),
-            state = previewEmptyState(),
-        )
-    }
+private class PreviewParameters(
+    @Px val imageWidth: UInt,
+    @Px val imageHeight: UInt,
+    val viewSize: Size,
+    val fitMode: FitMode,
+)
+
+private class PreviewParametersProvider : PreviewParameterProvider<PreviewParameters> {
+    override val values: Sequence<PreviewParameters> = sequenceOf(
+        PreviewParameters(
+            imageWidth = 100u,
+            imageHeight = 100u,
+            viewSize = Size(width = Fixed(200u), height = Fixed(200u)),
+            fitMode = FitMode.FILL,
+        ),
+        PreviewParameters(
+            imageWidth = 100u,
+            imageHeight = 100u,
+            viewSize = Size(width = Fixed(200u), height = Fixed(200u)),
+            fitMode = FitMode.FIT,
+        ),
+        PreviewParameters(
+            imageWidth = 100u,
+            imageHeight = 100u,
+            viewSize = Size(width = Fixed(200u), height = Fixed(50u)),
+            fitMode = FitMode.FILL,
+        ),
+        PreviewParameters(
+            imageWidth = 100u,
+            imageHeight = 100u,
+            viewSize = Size(width = Fixed(200u), height = Fixed(50u)),
+            fitMode = FitMode.FIT,
+        ),
+        PreviewParameters(
+            imageWidth = 100u,
+            imageHeight = 100u,
+            viewSize = Size(width = Fixed(50u), height = Fixed(200u)),
+            fitMode = FitMode.FILL,
+        ),
+        PreviewParameters(
+            imageWidth = 100u,
+            imageHeight = 100u,
+            viewSize = Size(width = Fixed(50u), height = Fixed(200u)),
+            fitMode = FitMode.FIT,
+        ),
+        PreviewParameters(
+            imageWidth = 100u,
+            imageHeight = 100u,
+            viewSize = Size(width = Fixed(72u), height = Fit),
+            fitMode = FitMode.FILL,
+        ),
+        PreviewParameters(
+            imageWidth = 100u,
+            imageHeight = 100u,
+            viewSize = Size(width = Fit, height = Fixed(72u)),
+            fitMode = FitMode.FILL,
+        ),
+        PreviewParameters(
+            imageWidth = 1909u,
+            imageHeight = 1306u,
+            viewSize = Size(width = SizeConstraint.Fill, height = Fit),
+            fitMode = FitMode.FIT,
+        ),
+    )
 }
 
 @Preview
 @Composable
-private fun ImageComponentView_Preview_FixedWidthFitHeight() {
+private fun ImageComponentView_Preview(
+    @PreviewParameter(PreviewParametersProvider::class) parameters: PreviewParameters,
+) {
+    val themeImageUrls = previewThemeImageUrls(widthPx = parameters.imageWidth, heightPx = parameters.imageHeight)
     Box(modifier = Modifier.background(ComposeColor.Red)) {
         ImageComponentView(
             style = previewImageComponentStyle(
-                size = Size(width = SizeConstraint.Fixed(72u), height = SizeConstraint.Fit),
-                contentScale = FitMode.FILL.toContentScale(),
+                themeImageUrls = themeImageUrls,
+                size = parameters.viewSize,
+                fitMode = parameters.fitMode,
             ),
             state = previewEmptyState(),
-        )
-    }
-}
-
-@Preview
-@Composable
-private fun ImageComponentView_Preview_FitWidthFixedHeight() {
-    Box(modifier = Modifier.background(ComposeColor.Red)) {
-        ImageComponentView(
-            style = previewImageComponentStyle(
-                size = Size(width = SizeConstraint.Fit, height = SizeConstraint.Fixed(72u)),
-                contentScale = FitMode.FILL.toContentScale(),
-            ),
-            state = previewEmptyState(),
+            previewImageLoader = previewImageLoader(themeImageUrls),
         )
     }
 }
@@ -119,10 +187,16 @@ private fun ImageComponentView_Preview_FitWidthFixedHeight() {
 @Preview
 @Composable
 private fun ImageComponentView_Preview_SmallerContainer() {
-    Box(modifier = Modifier.height(200.dp).background(ComposeColor.Red)) {
+    val themeImageUrls = previewThemeImageUrls(widthPx = 400u, heightPx = 400u)
+    Box(modifier = Modifier.height(200.dp).background(ComposeColor.Blue)) {
         ImageComponentView(
-            style = previewImageComponentStyle(),
+            style = previewImageComponentStyle(
+                themeImageUrls = themeImageUrls,
+                size = Size(width = Fixed(400u), height = Fixed(400u)),
+                fitMode = FitMode.FIT,
+            ),
             state = previewEmptyState(),
+            previewImageLoader = previewImageLoader(themeImageUrls),
         )
     }
 }
@@ -131,9 +205,13 @@ private fun ImageComponentView_Preview_SmallerContainer() {
 @Preview
 @Composable
 private fun ImageComponentView_Preview_LinearGradient() {
+    val themeImageUrls = previewThemeImageUrls(widthPx = 100u, heightPx = 100u)
     Box(modifier = Modifier.background(ComposeColor.Red)) {
         ImageComponentView(
             style = previewImageComponentStyle(
+                themeImageUrls = themeImageUrls,
+                size = Size(width = Fixed(400u), height = Fit),
+                fitMode = FitMode.FIT,
                 overlay = ColorScheme(
                     light = ColorInfo.Gradient.Linear(
                         degrees = -90f,
@@ -163,9 +241,13 @@ private fun ImageComponentView_Preview_LinearGradient() {
 @Preview
 @Composable
 private fun ImageComponentView_Preview_RadialGradient() {
+    val themeImageUrls = previewThemeImageUrls(widthPx = 100u, heightPx = 100u)
     Box(modifier = Modifier.background(ComposeColor.Red)) {
         ImageComponentView(
             style = previewImageComponentStyle(
+                themeImageUrls = themeImageUrls,
+                size = Size(width = Fixed(400u), height = Fit),
+                fitMode = FitMode.FIT,
                 overlay = ColorScheme(
                     light = ColorInfo.Gradient.Radial(
                         listOf(
@@ -193,17 +275,16 @@ private fun ImageComponentView_Preview_RadialGradient() {
 @Suppress("LongParameterList")
 @Composable
 private fun previewImageComponentStyle(
-    url: URL = URL("https://sample-videos.com/img/Sample-jpg-image-5mb.jpg"),
-    lowResURL: URL = URL("https://assets.pawwalls.com/954459_1701163461.jpg"),
-    size: Size = Size(width = SizeConstraint.Fixed(400u), height = SizeConstraint.Fit),
-    contentScale: ContentScale = ContentScale.Fit,
+    themeImageUrls: ThemeImageUrls,
+    size: Size,
+    fitMode: FitMode,
     overlay: ColorScheme? = null,
 ) = ImageComponentStyle(
-    sources = nonEmptyMapOf(LocaleId("en_US") to ThemeImageUrls(light = ImageUrls(url, url, lowResURL, 1000u, 1000u))),
+    sources = nonEmptyMapOf(LocaleId("en_US") to themeImageUrls),
     size = size,
     shape = RoundedCornerShape(20.dp, 20.dp, 20.dp, 20.dp),
     overlay = overlay,
-    contentScale = contentScale,
+    contentScale = fitMode.toContentScale(),
     overrides = null,
 )
 
@@ -235,4 +316,81 @@ private fun previewEmptyState(): PaywallState.Loaded.Components {
     )
     val validated = offering.validatePaywallComponentsDataOrNull()?.getOrThrow()!!
     return offering.toComponentsPaywallState(validated)
+}
+
+@Composable
+private fun previewImageLoader(themeImageUrls: ThemeImageUrls) =
+    previewImageLoader(imageUrls = themeImageUrls.urlsForCurrentTheme)
+
+@Composable
+private fun previewImageLoader(
+    imageUrls: ImageUrls,
+    @DrawableRes resource: Int = R.drawable.android,
+): ImageLoader {
+    val context = LocalContext.current
+    return ImageLoader.Builder(context)
+        .components {
+            add { chain ->
+                SuccessResult(
+                    drawable = BitmapDrawable(
+                        chain.request.context.resources,
+                        context.getDrawable(resource)!!.toBitmap(
+                            width = imageUrls.width,
+                            height = imageUrls.height,
+                            // Create a deterministic color from the URL and size.
+                            background = with(imageUrls) { "$original:$width$height".toRgbColor() },
+                        ),
+                    ),
+                    request = chain.request,
+                    dataSource = DataSource.MEMORY,
+                )
+            }
+        }
+        .build()
+}
+
+private fun previewThemeImageUrls(widthPx: UInt, heightPx: UInt): ThemeImageUrls =
+    ThemeImageUrls(
+        light = ImageUrls(
+            original = URL("https://preview"),
+            webp = URL("https://preview"),
+            webpLowRes = URL("https://preview"),
+            width = widthPx,
+            height = heightPx,
+        ),
+    )
+
+/**
+ * Converts this drawable to a bitmap with a [background].
+ */
+@Suppress("DestructuringDeclarationWithTooManyEntries")
+fun Drawable.toBitmap(
+    @Px width: UInt,
+    @Px height: UInt,
+    @ColorInt background: Int,
+): Bitmap {
+    val (oldLeft, oldTop, oldRight, oldBottom) = bounds
+
+    val bitmap = Bitmap.createBitmap(width.toInt(), height.toInt(), Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+
+    canvas.drawColor(background)
+
+    setBounds(0, 0, width.toInt(), height.toInt())
+    draw(canvas)
+    setBounds(oldLeft, oldTop, oldRight, oldBottom)
+
+    return bitmap
+}
+
+@Suppress("MagicNumber")
+private fun String.toRgbColor(): Int {
+    val hash = hashCode()
+    // Use the hash to generate ARGB color components
+    val r = (hash shr 16 and 0xFF)
+    val g = (hash shr 8 and 0xFF)
+    val b = (hash and 0xFF)
+
+    // Combine the components into a color integer with full opacity (alpha = 255)
+    return 0xFF000000.toInt() or (r shl 16) or (g shl 8) or b
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -217,7 +217,7 @@ private fun ImageComponentView_Preview_SmallerContainer() {
 @Preview
 @Composable
 private fun ImageComponentView_Preview_LinearGradient() {
-    val themeImageUrls = previewThemeImageUrls(widthPx = 100u, heightPx = 100u)
+    val themeImageUrls = previewThemeImageUrls(widthPx = 400u, heightPx = 400u)
     Box(modifier = Modifier.background(ComposeColor.Red)) {
         ImageComponentView(
             style = previewImageComponentStyle(
@@ -245,6 +245,7 @@ private fun ImageComponentView_Preview_LinearGradient() {
                 ),
             ),
             state = previewEmptyState(),
+            previewImageLoader = previewImageLoader(themeImageUrls),
         )
     }
 }
@@ -253,7 +254,7 @@ private fun ImageComponentView_Preview_LinearGradient() {
 @Preview
 @Composable
 private fun ImageComponentView_Preview_RadialGradient() {
-    val themeImageUrls = previewThemeImageUrls(widthPx = 100u, heightPx = 100u)
+    val themeImageUrls = previewThemeImageUrls(widthPx = 400u, heightPx = 400u)
     Box(modifier = Modifier.background(ComposeColor.Red)) {
         ImageComponentView(
             style = previewImageComponentStyle(
@@ -280,6 +281,7 @@ private fun ImageComponentView_Preview_RadialGradient() {
                 ),
             ),
             state = previewEmptyState(),
+            previewImageLoader = previewImageLoader(themeImageUrls),
         )
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/AspectRatio.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/AspectRatio.kt
@@ -1,0 +1,26 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components.modifier
+
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import dev.drewhamilton.poko.Poko
+
+@Poko
+@Immutable
+internal class AspectRatio(
+    @get:JvmSynthetic val ratio: Float,
+    @get:JvmSynthetic val matchHeightConstraintsFirst: Boolean,
+)
+
+@JvmSynthetic
+@Stable
+internal fun Modifier.aspectRatio(
+    aspectRatio: AspectRatio,
+): Modifier =
+    this then Modifier.aspectRatio(
+        ratio = aspectRatio.ratio,
+        matchHeightConstraintsFirst = aspectRatio.matchHeightConstraintsFirst,
+    )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.composables
 
 import android.content.Context
+import android.graphics.drawable.Drawable
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -11,6 +12,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.withSave
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -21,12 +28,16 @@ import coil.compose.rememberAsyncImagePainter
 import coil.disk.DiskCache
 import coil.memory.MemoryCache
 import coil.request.CachePolicy
+import coil.request.ErrorResult
 import coil.request.ImageRequest
+import coil.request.SuccessResult
 import coil.transform.Transformation
 import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
+import kotlinx.coroutines.runBlocking
+import kotlin.math.roundToInt
 
 @SuppressWarnings("LongParameterList")
 @Composable
@@ -37,7 +48,6 @@ internal fun LocalImage(
     contentDescription: String? = null,
     transformation: Transformation? = null,
     alpha: Float = 1f,
-    @DrawableRes imagePreview: Int? = null,
 ) {
     Image(
         source = ImageSource.Local(resource),
@@ -47,7 +57,7 @@ internal fun LocalImage(
         contentDescription = contentDescription,
         transformation = transformation,
         alpha = alpha,
-        imagePreview = imagePreview,
+        previewImageLoader = null,
     )
 }
 
@@ -65,7 +75,7 @@ internal fun RemoteImage(
     contentDescription: String? = null,
     transformation: Transformation? = null,
     alpha: Float = 1f,
-    @DrawableRes imagePreview: Int? = null,
+    previewImageLoader: ImageLoader? = null,
 ) {
     Image(
         source = ImageSource.Remote(urlString),
@@ -75,7 +85,7 @@ internal fun RemoteImage(
         contentDescription = contentDescription,
         transformation = transformation,
         alpha = alpha,
-        imagePreview = imagePreview,
+        previewImageLoader = previewImageLoader,
     )
 }
 
@@ -100,16 +110,17 @@ private fun Image(
     contentDescription: String?,
     transformation: Transformation?,
     alpha: Float,
-    @DrawableRes imagePreview: Int?,
+    previewImageLoader: ImageLoader?,
 ) {
     // Previews don't support images
-    if (isInPreviewMode() && imagePreview == null) {
+    val isInPreviewMode = isInPreviewMode()
+    if (isInPreviewMode && previewImageLoader == null) {
         return ImageForPreviews(modifier)
     }
 
     var useCache by remember { mutableStateOf(true) }
     val applicationContext = LocalContext.current.applicationContext
-    val imageLoader = remember(useCache) {
+    val imageLoader = previewImageLoader.takeIf { isInPreviewMode } ?: remember(useCache) {
         applicationContext.getRevenueCatUIImageLoader(readCache = useCache)
     }
 
@@ -129,7 +140,6 @@ private fun Image(
             modifier = modifier,
             contentScale = contentScale,
             alpha = alpha,
-            imagePreview = imagePreview,
             onError = {
                 Logger.w("Image failed to load. Will try again disabling cache")
                 useCache = false
@@ -145,7 +155,6 @@ private fun Image(
             modifier = modifier,
             contentScale = contentScale,
             alpha = alpha,
-            imagePreview = imagePreview,
         )
     }
 }
@@ -161,7 +170,6 @@ private fun AsyncImage(
     contentScale: ContentScale,
     contentDescription: String?,
     alpha: Float,
-    @DrawableRes imagePreview: Int? = null,
     onError: ((AsyncImagePainter.State.Error) -> Unit)? = null,
 ) {
     AsyncImage(
@@ -170,7 +178,14 @@ private fun AsyncImage(
         placeholder = placeholderSource?.let {
             rememberAsyncImagePainter(
                 model = it.data,
-                placeholder = if (isInPreviewMode() && imagePreview != null) painterResource(imagePreview) else null,
+                placeholder = if (isInPreviewMode()) {
+                    when (val result = runBlocking { imageLoader.execute(imageRequest) }) {
+                        is SuccessResult -> DrawablePainter(result.drawable)
+                        is ErrorResult -> throw result.throwable
+                    }
+                } else {
+                    null
+                },
                 imageLoader = imageLoader,
                 contentScale = contentScale,
                 onError = { errorState ->
@@ -228,4 +243,36 @@ private fun Context.getRevenueCatUIImageLoader(readCache: Boolean): ImageLoader 
         .diskCachePolicy(cachePolicy)
         .memoryCachePolicy(cachePolicy)
         .build()
+}
+
+/**
+ * This is loosely based on [Accompanist's Drawable Painter](https://google.github.io/accompanist/drawablepainter/).
+ * This is not production-quality code and should only be used for Previews. If we ever have a need for this, it's
+ * better to use the Accompanist Drawable Painter library directly.
+ */
+private class DrawablePainter(
+    private val drawable: Drawable,
+) : Painter() {
+
+    override fun DrawScope.onDraw() {
+        drawIntoCanvas { canvas ->
+            // Update the Drawable's bounds
+            drawable.setBounds(0, 0, size.width.roundToInt(), size.height.roundToInt())
+
+            canvas.withSave {
+                drawable.draw(canvas.nativeCanvas)
+            }
+        }
+    }
+
+    override val intrinsicSize: Size = drawable.intrinsicSize
+
+    private val Drawable.intrinsicSize: Size
+        get() = when {
+            // Only return a finite size if the drawable has an intrinsic size
+            intrinsicWidth >= 0 && intrinsicHeight >= 0 -> {
+                Size(width = intrinsicWidth.toFloat(), height = intrinsicHeight.toFloat())
+            }
+            else -> Size.Unspecified
+        }
 }


### PR DESCRIPTION
## Motivation
The current mechanisms to show remote images in Compose Previews did not allow us to specify the size of the remote image. The replacement image was a solid color or a vector drawable, both of which resize uniformly to the view they're displayed in. However, in the real world, Paywalls V2 will receive images with a fixed size. We needed a way to preview resizing and scaling behavior with these kinds of images.

## Description
This PR adds a new `previewImageLoader` parameter, which can be used to return whatever kind of image we want. This is then used in `ImageComponentView` previews to check its behavior for images with a fixed size. It's slightly hacky, but the upside is that it will only run in the preview environment. The alternative approach involves updating to Coil 3 (https://github.com/RevenueCat/purchases-android/pull/2028), but that bumps Kotlin to 2.0.21. So that's left for a later date. 

This PR also fixes a rendering bug when the width is `Fill` and the height is `Fit`, by introducing an `aspectRatio` modifier. These size constraints are often used for header images. The changes to the preview mechanism allowed us to write a regression "test" (preview) for this.

## Note
This changes some existing previews for `ImageComponentView`, since the preview image is now no longer scaled uniformly.
