### PR TITLE
Convert error message property into computed property

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases
 
 import android.os.Parcelable
-import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import java.io.Serializable
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
@@ -24,8 +24,8 @@ class PurchasesError(
     }
 
     // Message explaining the error
-    @IgnoredOnParcel
-    val message: String = code.description
+    val message: String
+        get() = code.description
 
     override fun toString(): String {
         return "PurchasesError(code=$code, underlyingErrorMessage=$underlyingErrorMessage, message='$message')"


### PR DESCRIPTION
### Description
Addressing #2037

This makes it so the message is not part of the serialization, since it's not needed

