### PR TITLE
[Paywalls V2] Add `Badge`'s `edgeToEdge` `Top`/`Bottom` alignment style layout

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/CornerRadiuses.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/CornerRadiuses.kt
@@ -42,4 +42,13 @@ class CornerRadiuses(
 
         @get:JvmSynthetic val default = zero
     }
+
+    fun copy(
+        topLeading: Double = this.topLeading,
+        topTrailing: Double = this.topTrailing,
+        bottomLeading: Double = this.bottomLeading,
+        bottomTrailing: Double = this.bottomTrailing,
+    ): CornerRadiuses {
+        return CornerRadiuses(topLeading, topTrailing, bottomLeading, bottomTrailing)
+    }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/CornerRadiuses.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/CornerRadiuses.kt
@@ -43,6 +43,8 @@ class CornerRadiuses(
         @get:JvmSynthetic val default = zero
     }
 
+    constructor(all: Double) : this(all, all, all, all)
+
     fun copy(
         topLeading: Double = this.topLeading,
         topTrailing: Double = this.topTrailing,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -36,6 +36,7 @@ import com.revenuecat.purchases.paywalls.components.properties.FontWeight
 import com.revenuecat.purchases.paywalls.components.properties.HorizontalAlignment
 import com.revenuecat.purchases.paywalls.components.properties.Padding
 import com.revenuecat.purchases.paywalls.components.properties.Shadow
+import com.revenuecat.purchases.paywalls.components.properties.Shape
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
@@ -123,12 +124,7 @@ private fun previewButtonComponentStyle(
         padding = PaddingValues(all = 16.dp),
         margin = PaddingValues(all = 16.dp),
         shape = RoundedCornerShape(size = 20.dp),
-        cornerRadiuses = CornerRadiuses(
-            topLeading = 20.0,
-            topTrailing = 20.0,
-            bottomLeading = 20.0,
-            bottomTrailing = 20.0,
-        ),
+        rcShape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
         border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
         shadow = Shadow(
             color = ColorScheme(ColorInfo.Hex(Color.Black.toArgb())),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -4,7 +4,6 @@ package com.revenuecat.purchases.ui.revenuecatui.components.button
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -122,8 +121,7 @@ private fun previewButtonComponentStyle(
         backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
         padding = PaddingValues(all = 16.dp),
         margin = PaddingValues(all = 16.dp),
-        shape = RoundedCornerShape(size = 20.dp),
-        rcShape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
+        shape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
         border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
         shadow = Shadow(
             color = ColorScheme(ColorInfo.Hex(Color.Black.toArgb())),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -28,6 +28,7 @@ import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.properties.Border
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.CornerRadiuses
 import com.revenuecat.purchases.paywalls.components.properties.Dimension
 import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution.START
 import com.revenuecat.purchases.paywalls.components.properties.FontSize
@@ -122,6 +123,12 @@ private fun previewButtonComponentStyle(
         padding = PaddingValues(all = 16.dp),
         margin = PaddingValues(all = 16.dp),
         shape = RoundedCornerShape(size = 20.dp),
+        cornerRadiuses = CornerRadiuses(
+            topLeading = 20.0,
+            topTrailing = 20.0,
+            bottomLeading = 20.0,
+            bottomTrailing = 20.0,
+        ),
         border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
         shadow = Shadow(
             color = ColorScheme(ColorInfo.Hex(Color.Black.toArgb())),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
@@ -105,8 +105,8 @@ internal class StackComponentState(
     val shape by derivedStateOf { presentedPartial?.partial?.shape?.toShape() ?: style.shape }
 
     @get:JvmSynthetic
-    val cornerRadiuses by derivedStateOf {
-        (presentedPartial?.partial?.shape as? Shape.Rectangle)?.corners ?: style.cornerRadiuses
+    val rcShape by derivedStateOf {
+        (presentedPartial?.partial?.shape as? Shape.Rectangle)?.corners ?: style.rcShape
     }
 
     @get:JvmSynthetic

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowWidthSizeClass
 import com.revenuecat.purchases.Package
-import com.revenuecat.purchases.paywalls.components.properties.Shape
 import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState
 import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition
 import com.revenuecat.purchases.ui.revenuecatui.components.buildPresentedPartial
@@ -106,9 +105,7 @@ internal class StackComponentState(
     val shape by derivedStateOf { presentedPartial?.partial?.shape?.toShape() ?: style.shape }
 
     @get:JvmSynthetic
-    val rcShape by derivedStateOf {
-        (presentedPartial?.partial?.shape as? Shape.Rectangle)?.corners ?: style.rcShape
-    }
+    val rcShape by derivedStateOf { presentedPartial?.partial?.shape ?: style.rcShape }
 
     @get:JvmSynthetic
     val border by derivedStateOf { presentedPartial?.partial?.border ?: style.border }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
@@ -17,7 +17,6 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState
 import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition
 import com.revenuecat.purchases.ui.revenuecatui.components.buildPresentedPartial
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toPaddingValues
-import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toShape
 import com.revenuecat.purchases.ui.revenuecatui.components.style.BadgeStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
@@ -102,10 +101,7 @@ internal class StackComponentState(
     val margin by derivedStateOf { presentedPartial?.partial?.margin?.toPaddingValues() ?: style.margin }
 
     @get:JvmSynthetic
-    val shape by derivedStateOf { presentedPartial?.partial?.shape?.toShape() ?: style.shape }
-
-    @get:JvmSynthetic
-    val rcShape by derivedStateOf { presentedPartial?.partial?.shape ?: style.rcShape }
+    val shape by derivedStateOf { presentedPartial?.partial?.shape ?: style.shape }
 
     @get:JvmSynthetic
     val border by derivedStateOf { presentedPartial?.partial?.border ?: style.border }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowWidthSizeClass
+import com.revenuecat.purchases.paywalls.components.properties.Shape
 import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState
 import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition
 import com.revenuecat.purchases.ui.revenuecatui.components.buildPresentedPartial
@@ -102,6 +103,11 @@ internal class StackComponentState(
 
     @get:JvmSynthetic
     val shape by derivedStateOf { presentedPartial?.partial?.shape?.toShape() ?: style.shape }
+
+    @get:JvmSynthetic
+    val cornerRadiuses by derivedStateOf {
+        (presentedPartial?.partial?.shape as? Shape.Rectangle)?.corners ?: style.cornerRadiuses
+    }
 
     @get:JvmSynthetic
     val border by derivedStateOf { presentedPartial?.partial?.border ?: style.border }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -7,31 +7,28 @@ import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.layout
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.paywalls.components.StackComponent
@@ -94,6 +91,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.toComponentsPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.validatePaywallComponentsDataOrNull
 import java.net.URL
 import kotlin.math.roundToInt
+import androidx.compose.ui.geometry.Size as ComposeSize
 
 @Suppress("LongMethod")
 @Composable
@@ -132,7 +130,7 @@ internal fun StackComponentView(
                         stackState,
                         state,
                         badge.stackStyle,
-                        badge.alignment,
+                        badge.alignment.isTop,
                         clickHandler,
                         modifier,
                         selected,
@@ -166,107 +164,113 @@ private fun StackWithOverlaidBadge(
     }
 }
 
+/**
+ * @param topBadge Whether the badge should be placed on the top or bottom of the stack.
+ */
 @Suppress("LongMethod", "LongParameterList", "CyclomaticComplexMethod")
 @Composable
 private fun StackWithEdgeToEdgeBadge(
     stackState: StackComponentState,
     state: PaywallState.Loaded.Components,
     badgeStack: StackComponentStyle,
-    alignment: TwoDimensionalAlignment,
+    topBadge: Boolean,
     clickHandler: suspend (PaywallAction) -> Unit,
     modifier: Modifier = Modifier,
     selected: Boolean = false,
 ) {
-    var badgeHeight by remember {
-        mutableIntStateOf(0)
-    }
-    val badgeHeightDp = with(LocalDensity.current) { badgeHeight.toDp() }
-    val badge = @Composable {
-        StackComponentView(
-            // The background and border is applied to the parent container so we null it out here.
-            // We make the badge use all the available width without increasing the size of the main content.
-            badgeStack.copy(
-                backgroundColor = null,
-                size = Size(width = Fill, height = badgeStack.size.height),
-                border = null,
-                margin = PaddingValues(0.dp),
-            ),
-            state,
-            clickHandler,
-            selected = selected,
-            modifier = Modifier.onGloballyPositioned {
-                badgeHeight = it.size.height
-            },
-        )
-    }
-    val mainContent = @Composable {
-        MainStackComponent(
-            stackState,
-            state,
-            clickHandler,
-            selected = selected,
-        )
-    }
-    val backgroundColorStyle = badgeStack.backgroundColor?.let { rememberColorStyle(scheme = it) }
-    val borderStyle = badgeStack.border?.let { rememberBorderStyle(border = it) }
-    val shadowStyle = badgeStack.shadow?.let { rememberShadowStyle(shadow = it) }
-    val backgroundShape = badgeStack.cornerRadiuses?.let { cornerRadiuses ->
-        val filteredCornerRadiuses = when (alignment) {
-            TwoDimensionalAlignment.TOP_LEADING,
-            TwoDimensionalAlignment.TOP,
-            TwoDimensionalAlignment.TOP_TRAILING,
-            -> cornerRadiuses.copy(bottomLeading = 0.0, bottomTrailing = 0.0)
-            TwoDimensionalAlignment.BOTTOM_LEADING,
-            TwoDimensionalAlignment.BOTTOM,
-            TwoDimensionalAlignment.BOTTOM_TRAILING,
-            -> cornerRadiuses.copy(topLeading = 0.0, topTrailing = 0.0)
-            else -> cornerRadiuses
-        }
-        Shape.Rectangle(filteredCornerRadiuses).toShape()
-    }
+    SubcomposeLayout(
+        modifier = modifier,
+    ) { constraints ->
+        // Subcompose and measure the stack
+        val stackMeasurable = subcompose("stack") {
+            MainStackComponent(
+                stackState,
+                state,
+                clickHandler,
+                selected = selected,
+            )
+        }.first()
+        val stackPlaceable = stackMeasurable.measure(constraints)
 
-    val backgroundModifier = remember(badgeStack, backgroundColorStyle, borderStyle, shadowStyle) {
-        Modifier
-            .padding(badgeStack.margin)
-            .applyIfNotNull(backgroundColorStyle) { background(it, backgroundShape ?: RectangleShape) }
-            .applyIfNotNull(backgroundShape) { clip(it) }
-            .applyIfNotNull(borderStyle) { border(it, badgeStack.shape) }
-    }
+        // Subcompose and measure the badge
+        val badgeMeasurable = subcompose("badge") {
+            StackComponentView(
+                // The background and border is applied to the parent container so we null it out here.
+                // We make the badge use all the available width without increasing the size of the main content.
+                badgeStack.copy(
+                    backgroundColor = null,
+                    size = Size(width = Fill, height = badgeStack.size.height),
+                    border = null,
+                    margin = PaddingValues(0.dp),
+                ),
+                state,
+                clickHandler,
+                selected = selected,
+            )
+        }.first()
+        val badgePlaceable = badgeMeasurable.measure(constraints)
 
-    val backgroundHeight by remember(stackState.cornerRadiuses, badgeHeightDp) {
-        derivedStateOf {
-            stackState.cornerRadiuses?.let {
-                badgeHeightDp + maxOf(it.topLeading, it.topTrailing, it.bottomLeading, it.bottomTrailing).dp
-            } ?: badgeHeightDp
-        }
-    }
-    Box(modifier = modifier.width(IntrinsicSize.Min)) {
-        Box(
-            modifier = Modifier
-                .align(alignment.toAlignment())
-                .fillMaxWidth()
-                .height(backgroundHeight)
-                .then(backgroundModifier),
+        // Decide the final size of this layout
+        val totalWidth = stackPlaceable.width
+        val totalHeight = stackPlaceable.height + badgePlaceable.height
+
+        // Subcompose the background
+        val backgroundMeasurable = subcompose("background") {
+            val backgroundColorStyle = badgeStack.backgroundColor?.let { rememberColorStyle(scheme = it) }
+            val borderStyle = badgeStack.border?.let { rememberBorderStyle(border = it) }
+            val shadowStyle = badgeStack.shadow?.let { rememberShadowStyle(shadow = it) }
+            val backgroundShape = when (badgeStack.shape) {
+                is RoundedCornerShape -> {
+                    // We have to make sure our badge uses absolute corner sizes. If it's using relative corner sizes,
+                    // i.e. pill-shaped, we need to use the stack to calculate the absolute size to use.
+                    RoundedCornerShape(
+                        topStart = badgeStack.shape.topStart.makeAbsolute(stackPlaceable, LocalDensity.current),
+                        topEnd = badgeStack.shape.topEnd.makeAbsolute(stackPlaceable, LocalDensity.current),
+                        bottomEnd = badgeStack.shape.bottomEnd.makeAbsolute(stackPlaceable, LocalDensity.current),
+                        bottomStart = badgeStack.shape.bottomStart.makeAbsolute(stackPlaceable, LocalDensity.current),
+                    )
+                }
+                RectangleShape -> RectangleShape
+                else -> RectangleShape
+            }
+
+            val backgroundModifier = remember(badgeStack, backgroundColorStyle, borderStyle, shadowStyle) {
+                Modifier
+                    .padding(badgeStack.margin)
+                    .applyIfNotNull(backgroundColorStyle) { background(it, backgroundShape) }
+                    .applyIfNotNull(backgroundShape) { clip(it) }
+                    .applyIfNotNull(borderStyle) { border(it, badgeStack.shape) }
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .then(backgroundModifier),
+            )
+        }.first()
+        val backgroundPlaceable = backgroundMeasurable.measure(
+            // We know exactly how big this needs to be.
+            Constraints.fixed(width = totalWidth, height = totalHeight),
         )
-        Column {
-            when (alignment) {
-                TwoDimensionalAlignment.TOP_LEADING,
-                TwoDimensionalAlignment.TOP,
-                TwoDimensionalAlignment.TOP_TRAILING,
-                -> {
-                    badge()
-                    mainContent()
-                }
-                TwoDimensionalAlignment.BOTTOM_LEADING,
-                TwoDimensionalAlignment.BOTTOM,
-                TwoDimensionalAlignment.BOTTOM_TRAILING,
-                -> {
-                    mainContent()
-                    badge()
-                }
-                else -> {
-                    mainContent()
-                }
+
+        // Lay it all out
+        layout(totalWidth, totalHeight) {
+            backgroundPlaceable.placeRelative(0, 0)
+
+            var yPosition = 0
+
+            if (topBadge) {
+                badgePlaceable.placeRelative(x = 0, y = yPosition)
+                yPosition += badgePlaceable.height
+
+                stackPlaceable.placeRelative(x = 0, y = yPosition)
+                yPosition += stackPlaceable.height
+            } else {
+                stackPlaceable.placeRelative(x = 0, y = yPosition)
+                yPosition += stackPlaceable.height
+
+                badgePlaceable.placeRelative(x = 0, y = yPosition)
+                yPosition += badgePlaceable.height
             }
         }
     }
@@ -371,6 +375,42 @@ private fun MainStackComponent(
     }
 }
 
+/**
+ * Make this CornerSize absolute, based on the provided [placeable]. This is useful for turning relative
+ * (percentage-based) corners into absolute ones.
+ */
+private fun CornerSize.makeAbsolute(placeable: Placeable, density: Density) =
+    makeAbsolute(
+        shapeSize = ComposeSize(
+            width = placeable.width.toFloat(),
+            height = placeable.height.toFloat(),
+        ),
+        density = density,
+    )
+
+/**
+ * Make this CornerSize absolute, based on the provided [shapeSize]. This is useful for turning relative
+ * (percentage-based) corners into absolute ones.
+ */
+private fun CornerSize.makeAbsolute(shapeSize: ComposeSize, density: Density) =
+    CornerSize(size = toPx(shapeSize, density))
+
+private val TwoDimensionalAlignment.isTop: Boolean
+    get() = when (this) {
+        TwoDimensionalAlignment.TOP_LEADING,
+        TwoDimensionalAlignment.TOP,
+        TwoDimensionalAlignment.TOP_TRAILING,
+        -> true
+
+        TwoDimensionalAlignment.CENTER,
+        TwoDimensionalAlignment.LEADING,
+        TwoDimensionalAlignment.TRAILING,
+        TwoDimensionalAlignment.BOTTOM,
+        TwoDimensionalAlignment.BOTTOM_LEADING,
+        TwoDimensionalAlignment.BOTTOM_TRAILING,
+        -> false
+    }
+
 private fun getOverlaidBadgeOffsetY(height: Int, alignment: TwoDimensionalAlignment) =
     when (alignment) {
         TwoDimensionalAlignment.CENTER,
@@ -448,6 +488,14 @@ private fun StackComponentView_Preview_Overlay_Badge(
     Box(
         modifier = Modifier.padding(all = 32.dp),
     ) {
+        val badgeShape = Shape.Rectangle(
+            corners = CornerRadiuses(
+                topLeading = 20.0,
+                topTrailing = 20.0,
+                bottomLeading = 20.0,
+                bottomTrailing = 20.0,
+            ),
+        )
         StackComponentView(
             style = StackComponentStyle(
                 children = previewChildren(),
@@ -468,7 +516,7 @@ private fun StackComponentView_Preview_Overlay_Badge(
                 ),
                 border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
                 shadow = null,
-                badge = previewBadge(Badge.Style.Overlay, alignment),
+                badge = previewBadge(Badge.Style.Overlay, alignment, badgeShape),
                 overrides = null,
             ),
             state = previewEmptyState(),
@@ -485,6 +533,14 @@ private fun StackComponentView_Preview_EdgeToEdge_Badge(
     Box(
         modifier = Modifier.padding(all = 32.dp),
     ) {
+        val badgeShape = Shape.Rectangle(
+            corners = CornerRadiuses(
+                topLeading = 20.0,
+                topTrailing = 20.0,
+                bottomLeading = 20.0,
+                bottomTrailing = 20.0,
+            ),
+        )
         StackComponentView(
             style = StackComponentStyle(
                 children = previewChildren(),
@@ -505,7 +561,39 @@ private fun StackComponentView_Preview_EdgeToEdge_Badge(
                 ),
                 border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
                 shadow = null,
-                badge = previewBadge(Badge.Style.EdgeToEdge, alignment),
+                badge = previewBadge(Badge.Style.EdgeToEdge, alignment, badgeShape),
+                overrides = null,
+            ),
+            state = previewEmptyState(),
+            clickHandler = { },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun StackComponentView_Preview_Pill_EdgeToEdge_Badge(
+    @PreviewParameter(BadgeAlignmentProvider::class) alignment: TwoDimensionalAlignment,
+) {
+    Box(
+        modifier = Modifier.padding(all = 32.dp),
+    ) {
+        StackComponentView(
+            style = StackComponentStyle(
+                children = previewChildren(),
+                dimension = Dimension.Vertical(alignment = HorizontalAlignment.CENTER, distribution = START),
+                size = Size(width = Fixed(200u), height = Fit),
+                spacing = 16.dp,
+                backgroundColor = ColorScheme(
+                    light = ColorInfo.Hex(Color.Red.toArgb()),
+                ),
+                padding = PaddingValues(all = 0.dp),
+                margin = PaddingValues(all = 0.dp),
+                shape = RoundedCornerShape(percent = 50),
+                cornerRadiuses = null,
+                border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
+                shadow = null,
+                badge = previewBadge(Badge.Style.EdgeToEdge, alignment, Shape.Pill),
                 overrides = null,
             ),
             state = previewEmptyState(),
@@ -808,7 +896,7 @@ private fun previewEmptyState(): PaywallState.Loaded.Components {
     return offering.toComponentsPaywallState(validated)
 }
 
-private fun previewBadge(style: Badge.Style, alignment: TwoDimensionalAlignment): BadgeStyle {
+private fun previewBadge(style: Badge.Style, alignment: TwoDimensionalAlignment, shape: Shape): BadgeStyle {
     return BadgeStyle(
         stackStyle = StackComponentStyle(
             children = listOf(
@@ -847,13 +935,11 @@ private fun previewBadge(style: Badge.Style, alignment: TwoDimensionalAlignment)
             ),
             padding = PaddingValues(all = 0.dp),
             margin = PaddingValues(all = 0.dp),
-            shape = RoundedCornerShape(size = 20.dp),
-            cornerRadiuses = CornerRadiuses(
-                topLeading = 20.0,
-                topTrailing = 20.0,
-                bottomLeading = 20.0,
-                bottomTrailing = 20.0,
-            ),
+            shape = shape.toShape(),
+            cornerRadiuses = when (shape) {
+                is Shape.Rectangle -> shape.corners
+                is Shape.Pill -> null
+            },
             border = null,
             shadow = null,
             badge = null,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -198,13 +198,26 @@ private fun StackWithEdgeToEdgeBadge(
         }.first()
         val badgePlaceable = badgeMeasurable.measure(constraints)
         val badgeHeight = badgePlaceable.height
-        // We are extending the background to the half of the height of the stack so it covers all rounded corners cases
-        val halfStackHeight = stackPlaceable.height / 2
+
+        val backgroundCornerRadiusExtension = when (stackState.rcShape) {
+            is Shape.Pill -> stackPlaceable.height / 2
+            is Shape.Rectangle -> {
+                (
+                    (stackState.rcShape as? Shape.Rectangle)?.let { rcShape ->
+                        if (topBadge) {
+                            maxOf(rcShape.corners?.topLeading ?: 0.0, rcShape.corners?.topTrailing ?: 0.0)
+                        } else {
+                            maxOf(rcShape.corners?.bottomLeading ?: 0.0, rcShape.corners?.bottomTrailing ?: 0.0)
+                        }
+                    } ?: 0.0
+                    ).dp.toPx().roundToInt()
+            }
+        }
 
         // Decide the final size of this layout
         val totalWidth = stackPlaceable.width
         val totalHeight = stackPlaceable.height + badgeHeight
-        val backgroundHeight = badgeHeight + halfStackHeight
+        val backgroundHeight = badgeHeight + backgroundCornerRadiusExtension
 
         // Subcompose the background
         val backgroundMeasurable = subcompose("background") {
@@ -258,7 +271,7 @@ private fun StackWithEdgeToEdgeBadge(
             if (topBadge) {
                 backgroundPlaceable.placeRelative(0, 0)
             } else {
-                backgroundPlaceable.placeRelative(0, halfStackHeight)
+                backgroundPlaceable.placeRelative(0, totalHeight - backgroundHeight)
             }
 
             var yPosition = 0

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -210,7 +210,7 @@ private fun StackWithEdgeToEdgeBadge(
     val backgroundColorStyle = badgeStack.backgroundColor?.let { rememberColorStyle(scheme = it) }
     val borderStyle = badgeStack.border?.let { rememberBorderStyle(border = it) }
     val shadowStyle = badgeStack.shadow?.let { rememberShadowStyle(shadow = it) }
-    val shape = badgeStack.cornerRadiuses?.let { cornerRadiuses ->
+    val backgroundShape = badgeStack.cornerRadiuses?.let { cornerRadiuses ->
         val filteredCornerRadiuses = when (alignment) {
             TwoDimensionalAlignment.TOP_LEADING,
             TwoDimensionalAlignment.TOP,
@@ -228,8 +228,8 @@ private fun StackWithEdgeToEdgeBadge(
     val backgroundModifier = remember(badgeStack, backgroundColorStyle, borderStyle, shadowStyle) {
         Modifier
             .padding(badgeStack.margin)
-            .applyIfNotNull(backgroundColorStyle) { background(it, shape ?: RectangleShape) }
-            .applyIfNotNull(shape) { clip(it) }
+            .applyIfNotNull(backgroundColorStyle) { background(it, backgroundShape ?: RectangleShape) }
+            .applyIfNotNull(backgroundShape) { clip(it) }
             .applyIfNotNull(borderStyle) { border(it, badgeStack.shape) }
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -381,7 +381,7 @@ private val TwoDimensionalAlignment.isTop: Boolean
         TwoDimensionalAlignment.TOP_LEADING,
         TwoDimensionalAlignment.TOP,
         TwoDimensionalAlignment.TOP_TRAILING,
-            -> true
+        -> true
 
         TwoDimensionalAlignment.CENTER,
         TwoDimensionalAlignment.LEADING,
@@ -389,7 +389,7 @@ private val TwoDimensionalAlignment.isTop: Boolean
         TwoDimensionalAlignment.BOTTOM,
         TwoDimensionalAlignment.BOTTOM_LEADING,
         TwoDimensionalAlignment.BOTTOM_TRAILING,
-            -> false
+        -> false
     }
 
 /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
@@ -64,6 +64,7 @@ internal class StackComponentStyle(
         border: Border? = this.border,
         shadow: Shadow? = this.shadow,
         badge: BadgeStyle? = this.badge,
+        rcPackage: Package? = this.rcPackage,
         overrides: PresentedOverrides<PresentedStackPartial>? = this.overrides,
     ): StackComponentStyle = StackComponentStyle(
         children = children,
@@ -78,6 +79,7 @@ internal class StackComponentStyle(
         border = border,
         shadow = shadow,
         badge = badge,
+        rcPackage = rcPackage,
         overrides = overrides,
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
@@ -6,12 +6,12 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import com.revenuecat.purchases.paywalls.components.properties.Border
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
-import com.revenuecat.purchases.paywalls.components.properties.CornerRadiuses
 import com.revenuecat.purchases.paywalls.components.properties.Dimension
 import com.revenuecat.purchases.paywalls.components.properties.Shadow
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedOverrides
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedStackPartial
+import com.revenuecat.purchases.paywalls.components.properties.Shape as RcShape
 
 @Suppress("LongParameterList")
 @Immutable
@@ -33,7 +33,7 @@ internal class StackComponentStyle(
     @get:JvmSynthetic
     val shape: Shape,
     @get:JvmSynthetic
-    val cornerRadiuses: CornerRadiuses?,
+    val rcShape: RcShape,
     @get:JvmSynthetic
     val border: Border?,
     @get:JvmSynthetic
@@ -53,7 +53,7 @@ internal class StackComponentStyle(
         padding: PaddingValues = this.padding,
         margin: PaddingValues = this.margin,
         shape: Shape = this.shape,
-        cornerRadiuses: CornerRadiuses? = this.cornerRadiuses,
+        rcShape: RcShape = this.rcShape,
         border: Border? = this.border,
         shadow: Shadow? = this.shadow,
         badge: BadgeStyle? = this.badge,
@@ -67,7 +67,7 @@ internal class StackComponentStyle(
         padding = padding,
         margin = margin,
         shape = shape,
-        cornerRadiuses = cornerRadiuses,
+        rcShape = rcShape,
         border = border,
         shadow = shadow,
         badge = badge,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
@@ -16,7 +16,7 @@ import com.revenuecat.purchases.paywalls.components.properties.Shape as RcShape
 
 @Suppress("LongParameterList")
 @Immutable
-internal class StackComponentStyle(
+internal data class StackComponentStyle(
     @get:JvmSynthetic
     val children: List<ComponentStyle>,
     @get:JvmSynthetic
@@ -49,37 +49,4 @@ internal class StackComponentStyle(
     val rcPackage: Package?,
     @get:JvmSynthetic
     val overrides: PresentedOverrides<PresentedStackPartial>?,
-) : ComponentStyle {
-    @JvmSynthetic
-    internal fun copy(
-        children: List<ComponentStyle> = this.children,
-        dimension: Dimension = this.dimension,
-        size: Size = this.size,
-        spacing: Dp = this.spacing,
-        backgroundColor: ColorScheme? = this.backgroundColor,
-        padding: PaddingValues = this.padding,
-        margin: PaddingValues = this.margin,
-        shape: Shape = this.shape,
-        rcShape: RcShape = this.rcShape,
-        border: Border? = this.border,
-        shadow: Shadow? = this.shadow,
-        badge: BadgeStyle? = this.badge,
-        rcPackage: Package? = this.rcPackage,
-        overrides: PresentedOverrides<PresentedStackPartial>? = this.overrides,
-    ): StackComponentStyle = StackComponentStyle(
-        children = children,
-        dimension = dimension,
-        size = size,
-        spacing = spacing,
-        backgroundColor = backgroundColor,
-        padding = padding,
-        margin = margin,
-        shape = shape,
-        rcShape = rcShape,
-        border = border,
-        shadow = shadow,
-        badge = badge,
-        rcPackage = rcPackage,
-        overrides = overrides,
-    )
-}
+) : ComponentStyle

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import com.revenuecat.purchases.paywalls.components.properties.Border
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.CornerRadiuses
 import com.revenuecat.purchases.paywalls.components.properties.Dimension
 import com.revenuecat.purchases.paywalls.components.properties.Shadow
 import com.revenuecat.purchases.paywalls.components.properties.Size
@@ -32,6 +33,8 @@ internal class StackComponentStyle(
     @get:JvmSynthetic
     val shape: Shape,
     @get:JvmSynthetic
+    val cornerRadiuses: CornerRadiuses?,
+    @get:JvmSynthetic
     val border: Border?,
     @get:JvmSynthetic
     val shadow: Shadow?,
@@ -50,6 +53,7 @@ internal class StackComponentStyle(
         padding: PaddingValues = this.padding,
         margin: PaddingValues = this.margin,
         shape: Shape = this.shape,
+        cornerRadiuses: CornerRadiuses? = this.cornerRadiuses,
         border: Border? = this.border,
         shadow: Shadow? = this.shadow,
         badge: BadgeStyle? = this.badge,
@@ -63,6 +67,7 @@ internal class StackComponentStyle(
         padding = padding,
         margin = margin,
         shape = shape,
+        cornerRadiuses = cornerRadiuses,
         border = border,
         shadow = shadow,
         badge = badge,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
@@ -39,4 +39,33 @@ internal class StackComponentStyle(
     val badge: BadgeStyle?,
     @get:JvmSynthetic
     val overrides: PresentedOverrides<PresentedStackPartial>?,
-) : ComponentStyle
+) : ComponentStyle {
+    @JvmSynthetic
+    internal fun copy(
+        children: List<ComponentStyle> = this.children,
+        dimension: Dimension = this.dimension,
+        size: Size = this.size,
+        spacing: Dp = this.spacing,
+        backgroundColor: ColorScheme? = this.backgroundColor,
+        padding: PaddingValues = this.padding,
+        margin: PaddingValues = this.margin,
+        shape: Shape = this.shape,
+        border: Border? = this.border,
+        shadow: Shadow? = this.shadow,
+        badge: BadgeStyle? = this.badge,
+        overrides: PresentedOverrides<PresentedStackPartial>? = this.overrides,
+    ): StackComponentStyle = StackComponentStyle(
+        children = children,
+        dimension = dimension,
+        size = size,
+        spacing = spacing,
+        backgroundColor = backgroundColor,
+        padding = padding,
+        margin = margin,
+        shape = shape,
+        border = border,
+        shadow = shadow,
+        badge = badge,
+        overrides = overrides,
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
@@ -2,17 +2,16 @@ package com.revenuecat.purchases.ui.revenuecatui.components.style
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Immutable
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.components.properties.Border
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.paywalls.components.properties.Dimension
 import com.revenuecat.purchases.paywalls.components.properties.Shadow
+import com.revenuecat.purchases.paywalls.components.properties.Shape
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedOverrides
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedStackPartial
-import com.revenuecat.purchases.paywalls.components.properties.Shape as RcShape
 
 @Suppress("LongParameterList")
 @Immutable
@@ -33,8 +32,6 @@ internal data class StackComponentStyle(
     val margin: PaddingValues,
     @get:JvmSynthetic
     val shape: Shape,
-    @get:JvmSynthetic
-    val rcShape: RcShape,
     @get:JvmSynthetic
     val border: Border?,
     @get:JvmSynthetic

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.style
 
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
@@ -52,7 +51,6 @@ internal class StyleFactory(
 
     private companion object {
         private const val DEFAULT_SPACING = 0f
-        private val DEFAULT_SHAPE = RectangleShape
     }
 
     fun create(
@@ -190,8 +188,7 @@ internal class StyleFactory(
             backgroundColor = component.backgroundColor,
             padding = component.padding.toPaddingValues(),
             margin = component.margin.toPaddingValues(),
-            shape = component.shape?.toShape() ?: DEFAULT_SHAPE,
-            rcShape = component.shape ?: Shape.Rectangle(),
+            shape = component.shape ?: Shape.Rectangle(),
             border = component.border,
             shadow = component.shadow,
             badge = badge,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -181,7 +181,7 @@ internal class StyleFactory(
             padding = component.padding.toPaddingValues(),
             margin = component.margin.toPaddingValues(),
             shape = component.shape?.toShape() ?: DEFAULT_SHAPE,
-            cornerRadiuses = (component.shape as? Shape.Rectangle)?.corners,
+            rcShape = component.shape ?: Shape.Rectangle(),
             border = component.border,
             shadow = component.shadow,
             badge = badge,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.paywalls.components.StickyFooterComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.properties.Shape
 import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
 import com.revenuecat.purchases.ui.revenuecatui.components.LocalizedTextPartial
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedImagePartial
@@ -180,6 +181,7 @@ internal class StyleFactory(
             padding = component.padding.toPaddingValues(),
             margin = component.margin.toPaddingValues(),
             shape = component.shape?.toShape() ?: DEFAULT_SHAPE,
+            cornerRadiuses = (component.shape as? Shape.Rectangle)?.corners,
             border = component.border,
             shadow = component.shadow,
             badge = badge,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.paywalls.components.properties.Border
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.CornerRadiuses
 import com.revenuecat.purchases.paywalls.components.properties.Dimension
 import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution.START
 import com.revenuecat.purchases.paywalls.components.properties.FontSize
@@ -92,6 +93,12 @@ class ButtonComponentViewTests {
                     padding = PaddingValues(all = 16.dp),
                     margin = PaddingValues(all = 16.dp),
                     shape = RoundedCornerShape(size = 20.dp),
+                    cornerRadiuses = CornerRadiuses(
+                        topLeading = 20.0,
+                        topTrailing = 20.0,
+                        bottomLeading = 20.0,
+                        bottomTrailing = 20.0,
+                    ),
                     border = Border(width = 2.0, color = ColorScheme(ColorInfo.Hex(Color.Blue.toArgb()))),
                     shadow = Shadow(
                         color = ColorScheme(ColorInfo.Hex(Color.Black.toArgb())),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
@@ -94,8 +94,7 @@ class ButtonComponentViewTests {
                     backgroundColor = ColorScheme(ColorInfo.Hex(Color.Red.toArgb())),
                     padding = PaddingValues(all = 16.dp),
                     margin = PaddingValues(all = 16.dp),
-                    shape = RoundedCornerShape(size = 20.dp),
-                    rcShape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
+                    shape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
                     border = Border(width = 2.0, color = ColorScheme(ColorInfo.Hex(Color.Blue.toArgb()))),
                     shadow = Shadow(
                         color = ColorScheme(ColorInfo.Hex(Color.Black.toArgb())),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
@@ -30,6 +30,7 @@ import com.revenuecat.purchases.paywalls.components.properties.FontWeight
 import com.revenuecat.purchases.paywalls.components.properties.HorizontalAlignment.CENTER
 import com.revenuecat.purchases.paywalls.components.properties.Padding
 import com.revenuecat.purchases.paywalls.components.properties.Shadow
+import com.revenuecat.purchases.paywalls.components.properties.Shape
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
@@ -93,12 +94,7 @@ class ButtonComponentViewTests {
                     padding = PaddingValues(all = 16.dp),
                     margin = PaddingValues(all = 16.dp),
                     shape = RoundedCornerShape(size = 20.dp),
-                    cornerRadiuses = CornerRadiuses(
-                        topLeading = 20.0,
-                        topTrailing = 20.0,
-                        bottomLeading = 20.0,
-                        bottomTrailing = 20.0,
-                    ),
+                    rcShape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
                     border = Border(width = 2.0, color = ColorScheme(ColorInfo.Hex(Color.Blue.toArgb()))),
                     shadow = Shadow(
                         color = ColorScheme(ColorInfo.Hex(Color.Black.toArgb())),


### PR DESCRIPTION
### Description
Follow-up to #2009 
This PR adds the `edgeToEdge` top/bottom style for badges.
<img width="911" alt="image" src="https://github.com/user-attachments/assets/a2722e94-8bd1-4867-a8a6-0edfceac2ed6" />

