### PR TITLE
Allow repurchasing custom packages

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
@@ -346,8 +346,10 @@ private fun Package.currentlySubscribed(
     PackageType.WEEKLY,
     -> activelySubscribedProductIdentifiers.contains(product.id)
 
-    PackageType.LIFETIME, PackageType.CUSTOM,
+    PackageType.LIFETIME,
     -> nonSubscriptionProductIdentifiers.contains(product.id)
 
-    PackageType.UNKNOWN -> false
+    PackageType.CUSTOM,
+    PackageType.UNKNOWN,
+    -> false
 }


### PR DESCRIPTION
### Description
Allow repurchasing custom packages, independently of what the user is already subscribed to/purchased. Now that we support non-consumables in Android, as long as the product is marked as non-consumable we won't consume it and Google will stop repurchasing if needed, so this is safe to do now.