### PR TITLE
[Trusted Entitlements] Do not clear CustomerInfo upon enabling Trusted Entitlements

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -58,7 +58,7 @@ internal class IdentityManager(
         val cacheEditor = deviceCache.startEditing()
         deviceCache.cacheAppUserID(appUserIDToUse, cacheEditor)
         subscriberAttributesCache.cleanUpSubscriberAttributeCache(appUserIDToUse, cacheEditor)
-        invalidateCustomerInfoAndETagCacheIfNeeded(appUserIDToUse)
+        invalidateETagCacheIfNeeded(appUserIDToUse)
         cacheEditor.apply()
 
         enqueue {
@@ -146,7 +146,7 @@ internal class IdentityManager(
         }
     }
 
-    private fun invalidateCustomerInfoAndETagCacheIfNeeded(
+    private fun invalidateETagCacheIfNeeded(
         appUserID: String,
     ) {
         if (backend.verificationMode == SignatureVerificationMode.Disabled) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.identity
 
-import android.content.SharedPreferences
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -59,7 +58,7 @@ internal class IdentityManager(
         val cacheEditor = deviceCache.startEditing()
         deviceCache.cacheAppUserID(appUserIDToUse, cacheEditor)
         subscriberAttributesCache.cleanUpSubscriberAttributeCache(appUserIDToUse, cacheEditor)
-        invalidateCustomerInfoAndETagCacheIfNeeded(appUserIDToUse, cacheEditor)
+        invalidateCustomerInfoAndETagCacheIfNeeded(appUserIDToUse)
         cacheEditor.apply()
 
         enqueue {
@@ -149,21 +148,19 @@ internal class IdentityManager(
 
     private fun invalidateCustomerInfoAndETagCacheIfNeeded(
         appUserID: String,
-        cacheEditor: SharedPreferences.Editor,
     ) {
         if (backend.verificationMode == SignatureVerificationMode.Disabled) {
             return
         }
         val cachedCustomerInfo = deviceCache.getCachedCustomerInfo(appUserID)
-        if (shouldInvalidateCustomerInfoAndETagCache(cachedCustomerInfo)) {
-            infoLog(IdentityStrings.INVALIDATING_CACHED_CUSTOMER_INFO)
-            deviceCache.clearCustomerInfoCache(appUserID, cacheEditor)
+        if (shouldInvalidateETagCache(cachedCustomerInfo)) {
+            infoLog(IdentityStrings.INVALIDATING_CACHED_ETAG_CACHE)
             backend.clearCaches()
         }
     }
 
     @Suppress("UnusedPrivateMember", "FunctionOnlyReturningConstant")
-    private fun shouldInvalidateCustomerInfoAndETagCache(customerInfo: CustomerInfo?): Boolean {
+    private fun shouldInvalidateETagCache(customerInfo: CustomerInfo?): Boolean {
         return customerInfo != null &&
             customerInfo.entitlements.verification == VerificationResult.NOT_REQUESTED &&
             backend.verificationMode != SignatureVerificationMode.Disabled

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/IdentityStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/IdentityStrings.kt
@@ -10,8 +10,8 @@ internal object IdentityStrings {
     const val SETTING_NEW_ANON_ID = "Setting new anonymous App User ID - %s"
     const val LOG_OUT_CALLED_ON_ANONYMOUS_USER = "Called logOut but the current user is anonymous"
     const val LOG_OUT_SUCCESSFUL = "Logged out successfully"
-    const val INVALIDATING_CACHED_CUSTOMER_INFO = "Detected unverified cached CustomerInfo but verification " +
-        "is enabled. Invalidating cache."
+    const val INVALIDATING_CACHED_ETAG_CACHE = "Detected unverified cached CustomerInfo but verification " +
+        "is enabled. Invalidating Etag cache."
     const val SWITCHING_USER = "Switching to user %s."
     const val SWITCHING_USER_SAME_APP_USER_ID = "switchUser called with the same appUserID as the current user %s. " +
         "This has no effect."

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -513,7 +513,7 @@ class IdentityManagerTests {
     }
 
     @Test
-    fun `we invalidate customer info and etag caches if verification is informational and cached customer info is not requested`() {
+    fun `we invalidate etag caches if verification is informational and cached customer info is not requested`() {
         val userId = "test-app-user-id"
         setupCustomerInfoCacheInvalidationTest(
             userId,
@@ -523,15 +523,12 @@ class IdentityManagerTests {
         )
         identityManager.configure(userId)
         verify(exactly = 1) {
-            mockDeviceCache.clearCustomerInfoCache(userId, mockEditor)
-        }
-        verify(exactly = 1) {
             mockBackend.clearCaches()
         }
     }
 
     @Test
-    fun `we invalidate customer info and etag caches if verification is enforced and cached customer info is not requested`() {
+    fun `we invalidate etag caches if verification is enforced and cached customer info is not requested`() {
         val userId = "test-app-user-id"
         setupCustomerInfoCacheInvalidationTest(
             userId,
@@ -540,9 +537,6 @@ class IdentityManagerTests {
             true
         )
         identityManager.configure(userId)
-        verify(exactly = 1) {
-            mockDeviceCache.clearCustomerInfoCache(userId, mockEditor)
-        }
         verify(exactly = 1) {
             mockBackend.clearCaches()
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -522,6 +522,9 @@ class IdentityManagerTests {
             true
         )
         identityManager.configure(userId)
+        verify(exactly = 0) {
+            mockDeviceCache.clearCustomerInfoCache(userId, mockEditor)
+        }
         verify(exactly = 1) {
             mockBackend.clearCaches()
         }
@@ -537,6 +540,9 @@ class IdentityManagerTests {
             true
         )
         identityManager.configure(userId)
+        verify(exactly = 0) {
+            mockDeviceCache.clearCustomerInfoCache(userId, mockEditor)
+        }
         verify(exactly = 1) {
             mockBackend.clearCaches()
         }


### PR DESCRIPTION
### Description
Until now, when devs enabled Trusted Entitlements, we would clear the cached `CustomerInfo` and customers would need to refetch the latest value from the server, which could potentially cause delays and/or losing access temporarily.

With this PR, we won't be clearing the cached CustomerInfo anymore. Instead, we would return the cached customer info, which will have a `VerificationResult` of `NOT_REQUESTED`. 

- [ ] Update docs