### PR TITLE
[Trusted Entitlements] Enable `Trusted Entitlements` by default

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementVerificationMode.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementVerificationMode.kt
@@ -31,7 +31,7 @@ enum class EntitlementVerificationMode {
          * Default entitlement verification mode.
          */
         val default: EntitlementVerificationMode
-            get() = DISABLED
+            get() = INFORMATIONAL
     }
 
     val isEnabled: Boolean

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -42,7 +42,7 @@ class PurchasesConfigurationTest {
         assertThat(purchasesConfiguration.service).isNull()
         assertThat(purchasesConfiguration.store).isEqualTo(Store.PLAY_STORE)
         assertThat(purchasesConfiguration.diagnosticsEnabled).isFalse
-        assertThat(purchasesConfiguration.verificationMode).isEqualTo(EntitlementVerificationMode.DISABLED)
+        assertThat(purchasesConfiguration.verificationMode).isEqualTo(EntitlementVerificationMode.INFORMATIONAL)
         assertThat(purchasesConfiguration.dangerousSettings).isEqualTo(DangerousSettings(autoSyncPurchases = true))
         assertThat(purchasesConfiguration.showInAppMessagesAutomatically).isTrue
         assertThat(purchasesConfiguration.pendingTransactionsForPrepaidPlansEnabled).isFalse


### PR DESCRIPTION
### Description
This enables Trusted Entitlements by default. Behavior won't change for devs not check the verification result, but this will make it much easier to use in the future, as all SDK versions have it enabled.

This should be merged after #2049.