### PR TITLE
Add `subscriptionsByProductIdentifier` to `CustomerInfo`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CustomerInfo.kt
@@ -7,6 +7,7 @@ package com.revenuecat.purchases
 
 import android.net.Uri
 import android.os.Parcelable
+import com.revenuecat.purchases.common.CustomerInfoFactory
 import com.revenuecat.purchases.models.RawDataContainer
 import com.revenuecat.purchases.models.Transaction
 import com.revenuecat.purchases.utils.DateHelper
@@ -39,7 +40,7 @@ import java.util.Date
  */
 @Parcelize
 @TypeParceler<JSONObject, JSONObjectParceler>()
-data class CustomerInfo constructor(
+data class CustomerInfo(
     val entitlements: EntitlementInfos,
     val allExpirationDatesByProduct: Map<String, Date?>,
     val allPurchaseDatesByProduct: Map<String, Date?>,
@@ -113,6 +114,11 @@ data class CustomerInfo constructor(
             }
         }
         nonSubscriptionTransactionList.sortedBy { it.purchaseDate }
+    }
+
+    @IgnoredOnParcel
+    val subscriptionsByProductIdentifier: Map<String, SubscriptionInfo> by lazy {
+        CustomerInfoFactory.parseSubscriptionInfos(subscriberJSONObject, requestDate)
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
@@ -6,6 +6,8 @@ import com.revenuecat.purchases.utils.JSONObjectParceler
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import org.json.JSONObject
 import java.util.Date
 
@@ -173,89 +175,107 @@ data class EntitlementInfo(
 /**
  * Enum of supported stores
  */
+@Serializable
 enum class Store {
     /**
      * For entitlements granted via Apple App Store.
      */
+    @SerialName("app_store")
     APP_STORE,
 
     /**
      * For entitlements granted via Apple Mac App Store.
      */
+    @SerialName("mac_app_store")
     MAC_APP_STORE,
 
     /**
      * For entitlements granted via Google Play Store.
      */
+    @SerialName("play_store")
     PLAY_STORE,
 
     /**
      * For entitlements granted via Stripe.
      */
+    @SerialName("stripe")
     STRIPE,
 
     /**
      * For entitlements granted via a promo in RevenueCat.
      */
+    @SerialName("promotional")
     PROMOTIONAL,
 
     /**
      * For entitlements granted via an unknown store.
      */
+    @SerialName("unknown")
     UNKNOWN_STORE,
 
     /**
      * For entitlements granted via Amazon store.
      */
+    @SerialName("amazon")
     AMAZON,
 
     /**
      * For entitlements granted via RC Billing.
      */
+    @SerialName("rc_billing")
     RC_BILLING,
 
     /**
      * For entitlements granted via RevenueCat's External Purchases API.
      */
+    @SerialName("external")
     EXTERNAL,
 }
 
 /**
  * Enum of supported period types for an entitlement.
  */
+@Serializable
 enum class PeriodType {
     /**
      * If the entitlement is not under an introductory or trial period.
      */
+    @SerialName("normal")
     NORMAL,
 
     /**
      * If the entitlement is under a introductory price period.
      */
+    @SerialName("intro")
     INTRO,
 
     /**
      * If the entitlement is under a trial period.
      */
+    @SerialName("trial")
     TRIAL,
 }
 
 /**
  * Enum of supported ownership types for an entitlement.
  */
+@Serializable
 enum class OwnershipType {
     /**
      * The purchase was made directly by this user.
      */
+    @SerialName("purchased")
     PURCHASED,
 
     /**
      * The purchase has been shared to this user by a family member.
      */
+    @SerialName("family_shared")
     FAMILY_SHARED,
 
     /**
      * The purchase has no or an unknown ownership type.
      */
+    @SerialName("unknown")
     UNKNOWN,
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/SubscriptionInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/SubscriptionInfo.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.utils.DateHelper
 import com.revenuecat.purchases.utils.EntitlementInfoHelper
 import java.util.Date
 
+@SuppressWarnings("LongParameterList")
 class SubscriptionInfo(
     val productIdentifier: String,
     val purchaseDate: Date,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/SubscriptionInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/SubscriptionInfo.kt
@@ -1,0 +1,75 @@
+package com.revenuecat.purchases
+
+import com.revenuecat.purchases.common.responses.SubscriptionInfoResponse
+import com.revenuecat.purchases.utils.DateHelper
+import com.revenuecat.purchases.utils.EntitlementInfoHelper
+import java.util.Date
+
+class SubscriptionInfo(
+    val productIdentifier: String,
+    val purchaseDate: Date,
+    val originalPurchaseDate: Date?,
+    val expiresDate: Date?,
+    val store: Store,
+    val unsubscribeDetectedAt: Date?,
+    val isSandbox: Boolean,
+    val billingIssuesDetectedAt: Date?,
+    val gracePeriodExpiresDate: Date?,
+    val ownershipType: OwnershipType = OwnershipType.UNKNOWN,
+    val periodType: PeriodType,
+    val refundedAt: Date?,
+    val storeTransactionId: String?,
+    val requestDate: Date,
+) {
+
+    val isActive: Boolean = DateHelper.isDateActive(expiresDate, requestDate).isActive
+
+    val willRenew: Boolean = EntitlementInfoHelper.getWillRenew(
+        store,
+        expiresDate,
+        unsubscribeDetectedAt,
+        billingIssuesDetectedAt,
+    )
+
+    override fun toString(): String {
+        return """
+            SubscriptionInfo {
+                purchaseDate: $purchaseDate,
+                originalPurchaseDate: $originalPurchaseDate,
+                expiresDate: $expiresDate,
+                store: $store,
+                isSandbox: $isSandbox,
+                unsubscribeDetectedAt: $unsubscribeDetectedAt,
+                billingIssuesDetectedAt: $billingIssuesDetectedAt,
+                gracePeriodExpiresDate: $gracePeriodExpiresDate,
+                ownershipType: $ownershipType,
+                periodType: $periodType,
+                refundedAt: $refundedAt,
+                storeTransactionId: $storeTransactionId,
+                isActive: $isActive,
+                willRenew: $willRenew
+            }
+        """.trimIndent()
+    }
+
+    internal constructor(
+        productIdentifier: String,
+        requestDate: Date,
+        response: SubscriptionInfoResponse,
+    ) : this(
+        productIdentifier = productIdentifier,
+        requestDate = requestDate,
+        purchaseDate = response.purchaseDate,
+        originalPurchaseDate = response.originalPurchaseDate,
+        expiresDate = response.expiresDate,
+        store = response.store,
+        isSandbox = response.isSandbox,
+        unsubscribeDetectedAt = response.unsubscribeDetectedAt,
+        billingIssuesDetectedAt = response.billingIssuesDetectedAt,
+        gracePeriodExpiresDate = response.gracePeriodExpiresDate,
+        ownershipType = response.ownershipType,
+        periodType = response.periodType,
+        refundedAt = response.refundedAt,
+        storeTransactionId = response.storeTransactionId,
+    )
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/SubscriptionInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/SubscriptionInfo.kt
@@ -5,26 +5,88 @@ import com.revenuecat.purchases.utils.DateHelper
 import com.revenuecat.purchases.utils.EntitlementInfoHelper
 import java.util.Date
 
+/**
+ * Subscription purchases of the Customer.
+ */
 @SuppressWarnings("LongParameterList")
 class SubscriptionInfo(
+    /**
+     * The product identifier.
+     */
     val productIdentifier: String,
+    /**
+     * Date when the last subscription period started.
+     */
     val purchaseDate: Date,
+    /**
+     * Date when this subscription first started. This property does not update with renewals.
+     * This property also does not update for product changes within a subscription group or
+     * re-subscriptions by lapsed subscribers.
+     */
     val originalPurchaseDate: Date?,
+    /**
+     * Date when the subscription expires/expired
+     */
     val expiresDate: Date?,
+    /**
+     * Store where the subscription was purchased.
+     */
     val store: Store,
+    /**
+     * Date when RevenueCat detected that auto-renewal was turned off for this subscription.
+     * Note the subscription may still be active, check the ``expiresDate`` attribute.
+     */
     val unsubscribeDetectedAt: Date?,
+    /**
+     * Whether or not the purchase was made in sandbox mode.
+     */
     val isSandbox: Boolean,
+    /**
+     * Date when RevenueCat detected any billing issues with this subscription.
+     * If and when the billing issue gets resolved, this field is set to nil.
+     * Note the subscription may still be active, check the ``expiresDate`` attribute.
+     */
     val billingIssuesDetectedAt: Date?,
+    /**
+     * Date when any grace period for this subscription expires/expired.
+     * nil if the customer has never been in a grace period.
+     */
     val gracePeriodExpiresDate: Date?,
+    /**
+     * How the Customer received access to this subscription:
+     * - [OwnershipType.PURCHASED]: The customer bought the subscription.
+     * - [OwnershipType.FAMILY_SHARED]: The Customer has access to the product via their family.
+     */
     val ownershipType: OwnershipType = OwnershipType.UNKNOWN,
+    /**
+     * Type of the current subscription period:
+     * - [PeriodType.NORMAL]: The product is in a normal period (default)
+     * - [PeriodType.TRIAL]: The product is in a free trial period
+     * - [PeriodType.INTRO]: The product is in an introductory pricing period
+     */
     val periodType: PeriodType,
+    /**
+     * Date when RevenueCat detected a refund of this subscription.
+     */
     val refundedAt: Date?,
+    /**
+     * The transaction id in the store of the subscription.
+     */
     val storeTransactionId: String?,
-    val requestDate: Date,
+    /**
+     * The date the request was made.
+     */
+    private val requestDate: Date,
 ) {
 
+    /**
+     * Whether the subscription is currently active.
+     */
     val isActive: Boolean = DateHelper.isDateActive(expiresDate, requestDate).isActive
 
+    /**
+     * Whether the subscription will renew at the next billing period.
+     */
     val willRenew: Boolean = EntitlementInfoHelper.getWillRenew(
         store,
         expiresDate,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/CustomerInfoFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/CustomerInfoFactory.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.common.responses.CustomerInfoResponseJsonKeys
 import com.revenuecat.purchases.common.responses.ProductResponseJsonKeys
 import com.revenuecat.purchases.common.responses.SubscriptionInfoResponse
 import com.revenuecat.purchases.utils.Iso8601Utils
+import com.revenuecat.purchases.utils.SerializationException
 import com.revenuecat.purchases.utils.optDate
 import com.revenuecat.purchases.utils.optNullableString
 import kotlinx.serialization.json.Json
@@ -110,8 +111,11 @@ internal object CustomerInfoFactory {
                 )
                 subscriptionMap[productId] = SubscriptionInfo(productId, requestDate, subscriptionInfoResponse)
             }
-        } catch (t: Throwable) {
-            errorLog("Error deserializing subscription information", t)
+        } catch (s: SerializationException) {
+            errorLog("Error deserializing subscription information", s)
+            emptyMap<String, SubscriptionInfo>()
+        } catch (i: IllegalArgumentException) {
+            errorLog("Error deserializing subscription information. The input is not a SubscriptionInfo", i)
             emptyMap<String, SubscriptionInfo>()
         }
         return subscriptionMap

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/EntitlementInfoFactories.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/EntitlementInfoFactories.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.common.responses.EntitlementsResponseJsonKeys
 import com.revenuecat.purchases.common.responses.ProductResponseJsonKeys
 import com.revenuecat.purchases.strings.PurchaseStrings
 import com.revenuecat.purchases.utils.DateHelper
+import com.revenuecat.purchases.utils.EntitlementInfoHelper
 import com.revenuecat.purchases.utils.getDate
 import com.revenuecat.purchases.utils.optDate
 import com.revenuecat.purchases.utils.optNullableString
@@ -92,7 +93,7 @@ internal fun JSONObject.buildEntitlementInfo(
     return EntitlementInfo(
         identifier = identifier,
         isActive = isDateActive(identifier, expirationDate, requestDate),
-        willRenew = getWillRenew(
+        willRenew = EntitlementInfoHelper.getWillRenew(
             store,
             expirationDate,
             unsubscribeDetectedAt,
@@ -126,17 +127,4 @@ private fun isDateActive(
         )
     }
     return dateActive.isActive
-}
-
-private fun getWillRenew(
-    store: Store,
-    expirationDate: Date?,
-    unsubscribeDetectedAt: Date?,
-    billingIssueDetectedAt: Date?,
-): Boolean {
-    val isPromo = store == Store.PROMOTIONAL
-    val isLifetime = expirationDate == null
-    val hasUnsubscribed = unsubscribeDetectedAt != null
-    val hasBillingIssues = billingIssueDetectedAt != null
-    return !(isPromo || isLifetime || hasUnsubscribed || hasBillingIssues)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/responses/SubscriptionInfoResponse.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/responses/SubscriptionInfoResponse.kt
@@ -11,26 +11,30 @@ import java.util.Date
 @Serializable
 @SuppressWarnings("LongParameterList")
 internal class SubscriptionInfoResponse(
-    @SerialName("purchase_date") @Serializable(with = ISO8601DateSerializer::class) val purchaseDate: Date,
-    @SerialName("original_purchase_date") @Serializable(with = ISO8601DateSerializer::class) val originalPurchaseDate:
-    Date?,
-    @SerialName("expires_date") @Serializable(with = ISO8601DateSerializer::class) val expiresDate: Date?,
-    @SerialName("store") val store: Store,
-    @SerialName("is_sandbox") val isSandbox: Boolean,
-    @SerialName("unsubscribe_detected_at") @Serializable(with = ISO8601DateSerializer::class) val unsubscribeDetectedAt:
-    Date?,
-    @SerialName(
-        "billing_issues_detected_at",
-    ) @Serializable(with = ISO8601DateSerializer::class) val billingIssuesDetectedAt:
-    Date?,
-    @SerialName(
-        "grace_period_expires_date",
-    ) @Serializable(with = ISO8601DateSerializer::class) val gracePeriodExpiresDate:
-    Date?,
-    @SerialName("ownership_type") val ownershipType: OwnershipType = OwnershipType.UNKNOWN,
-    @SerialName("period_type") val periodType: PeriodType,
-    @SerialName("refunded_at") @Serializable(with = ISO8601DateSerializer::class) val refundedAt: Date?,
-    @SerialName("store_transaction_id") val storeTransactionId: String?,
+    @SerialName("purchase_date") @Serializable(with = ISO8601DateSerializer::class)
+    val purchaseDate: Date,
+    @SerialName("original_purchase_date") @Serializable(with = ISO8601DateSerializer::class)
+    val originalPurchaseDate: Date?,
+    @SerialName("expires_date") @Serializable(with = ISO8601DateSerializer::class)
+    val expiresDate: Date?,
+    @SerialName("store")
+    val store: Store,
+    @SerialName("is_sandbox")
+    val isSandbox: Boolean,
+    @SerialName("unsubscribe_detected_at") @Serializable(with = ISO8601DateSerializer::class)
+    val unsubscribeDetectedAt: Date?,
+    @SerialName("billing_issues_detected_at") @Serializable(with = ISO8601DateSerializer::class)
+    val billingIssuesDetectedAt: Date?,
+    @SerialName("grace_period_expires_date") @Serializable(with = ISO8601DateSerializer::class)
+    val gracePeriodExpiresDate: Date?,
+    @SerialName("ownership_type")
+    val ownershipType: OwnershipType = OwnershipType.UNKNOWN,
+    @SerialName("period_type")
+    val periodType: PeriodType,
+    @SerialName("refunded_at") @Serializable(with = ISO8601DateSerializer::class)
+    val refundedAt: Date?,
+    @SerialName("store_transaction_id")
+    val storeTransactionId: String?,
 ) {
 
     override fun toString(): String {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/responses/SubscriptionInfoResponse.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/responses/SubscriptionInfoResponse.kt
@@ -3,30 +3,33 @@ package com.revenuecat.purchases.common.responses
 import com.revenuecat.purchases.OwnershipType
 import com.revenuecat.purchases.PeriodType
 import com.revenuecat.purchases.Store
-import com.revenuecat.purchases.utils.serializers.ISO8601Serializer
+import com.revenuecat.purchases.utils.serializers.ISO8601DateSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.util.Date
 
 @Serializable
+@SuppressWarnings("LongParameterList")
 internal class SubscriptionInfoResponse(
-    @SerialName("purchase_date") @Serializable(with = ISO8601Serializer::class) val purchaseDate: Date,
-    @SerialName("original_purchase_date") @Serializable(with = ISO8601Serializer::class) val originalPurchaseDate:
+    @SerialName("purchase_date") @Serializable(with = ISO8601DateSerializer::class) val purchaseDate: Date,
+    @SerialName("original_purchase_date") @Serializable(with = ISO8601DateSerializer::class) val originalPurchaseDate:
     Date?,
-    @SerialName("expires_date") @Serializable(with = ISO8601Serializer::class) val expiresDate: Date?,
+    @SerialName("expires_date") @Serializable(with = ISO8601DateSerializer::class) val expiresDate: Date?,
     @SerialName("store") val store: Store,
     @SerialName("is_sandbox") val isSandbox: Boolean,
-    @SerialName("unsubscribe_detected_at") @Serializable(with = ISO8601Serializer::class) val unsubscribeDetectedAt:
+    @SerialName("unsubscribe_detected_at") @Serializable(with = ISO8601DateSerializer::class) val unsubscribeDetectedAt:
     Date?,
     @SerialName(
         "billing_issues_detected_at",
-    ) @Serializable(with = ISO8601Serializer::class) val billingIssuesDetectedAt:
+    ) @Serializable(with = ISO8601DateSerializer::class) val billingIssuesDetectedAt:
     Date?,
-    @SerialName("grace_period_expires_date") @Serializable(with = ISO8601Serializer::class) val gracePeriodExpiresDate:
+    @SerialName(
+        "grace_period_expires_date",
+    ) @Serializable(with = ISO8601DateSerializer::class) val gracePeriodExpiresDate:
     Date?,
     @SerialName("ownership_type") val ownershipType: OwnershipType = OwnershipType.UNKNOWN,
     @SerialName("period_type") val periodType: PeriodType,
-    @SerialName("refunded_at") @Serializable(with = ISO8601Serializer::class) val refundedAt: Date?,
+    @SerialName("refunded_at") @Serializable(with = ISO8601DateSerializer::class) val refundedAt: Date?,
     @SerialName("store_transaction_id") val storeTransactionId: String?,
 ) {
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/responses/SubscriptionInfoResponse.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/responses/SubscriptionInfoResponse.kt
@@ -1,0 +1,51 @@
+package com.revenuecat.purchases.common.responses
+
+import com.revenuecat.purchases.OwnershipType
+import com.revenuecat.purchases.PeriodType
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.utils.serializers.ISO8601Serializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.util.Date
+
+@Serializable
+internal class SubscriptionInfoResponse(
+    @SerialName("purchase_date") @Serializable(with = ISO8601Serializer::class) val purchaseDate: Date,
+    @SerialName("original_purchase_date") @Serializable(with = ISO8601Serializer::class) val originalPurchaseDate:
+    Date?,
+    @SerialName("expires_date") @Serializable(with = ISO8601Serializer::class) val expiresDate: Date?,
+    @SerialName("store") val store: Store,
+    @SerialName("is_sandbox") val isSandbox: Boolean,
+    @SerialName("unsubscribe_detected_at") @Serializable(with = ISO8601Serializer::class) val unsubscribeDetectedAt:
+    Date?,
+    @SerialName(
+        "billing_issues_detected_at",
+    ) @Serializable(with = ISO8601Serializer::class) val billingIssuesDetectedAt:
+    Date?,
+    @SerialName("grace_period_expires_date") @Serializable(with = ISO8601Serializer::class) val gracePeriodExpiresDate:
+    Date?,
+    @SerialName("ownership_type") val ownershipType: OwnershipType = OwnershipType.UNKNOWN,
+    @SerialName("period_type") val periodType: PeriodType,
+    @SerialName("refunded_at") @Serializable(with = ISO8601Serializer::class) val refundedAt: Date?,
+    @SerialName("store_transaction_id") val storeTransactionId: String?,
+) {
+
+    override fun toString(): String {
+        return """
+            SubscriptionInfo {
+                purchaseDate: $purchaseDate,
+                originalPurchaseDate: $originalPurchaseDate,
+                expiresDate: $expiresDate,
+                store: $store,
+                isSandbox: $isSandbox,
+                unsubscribeDetectedAt: $unsubscribeDetectedAt,
+                billingIssuesDetectedAt: $billingIssuesDetectedAt,
+                gracePeriodExpiresDate: $gracePeriodExpiresDate,
+                ownershipType: $ownershipType,
+                periodType: $periodType,
+                refundedAt: $refundedAt,
+                storeTransactionId: $storeTransactionId,
+            }
+        """.trimIndent()
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/EntitlementInfoHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/EntitlementInfoHelper.kt
@@ -1,0 +1,23 @@
+package com.revenuecat.purchases.utils
+
+import com.revenuecat.purchases.Store
+import java.util.Date
+
+internal class EntitlementInfoHelper private constructor() {
+
+    companion object {
+
+        fun getWillRenew(
+            store: Store,
+            expirationDate: Date?,
+            unsubscribeDetectedAt: Date?,
+            billingIssueDetectedAt: Date?,
+        ): Boolean {
+            val isPromo = store == Store.PROMOTIONAL
+            val isLifetime = expirationDate == null
+            val hasUnsubscribed = unsubscribeDetectedAt != null
+            val hasBillingIssues = billingIssueDetectedAt != null
+            return !(isPromo || isLifetime || hasUnsubscribed || hasBillingIssues)
+        }
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/EntitlementInfoHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/EntitlementInfoHelper.kt
@@ -3,21 +3,18 @@ package com.revenuecat.purchases.utils
 import com.revenuecat.purchases.Store
 import java.util.Date
 
-internal class EntitlementInfoHelper private constructor() {
+internal object EntitlementInfoHelper {
 
-    companion object {
-
-        fun getWillRenew(
-            store: Store,
-            expirationDate: Date?,
-            unsubscribeDetectedAt: Date?,
-            billingIssueDetectedAt: Date?,
-        ): Boolean {
-            val isPromo = store == Store.PROMOTIONAL
-            val isLifetime = expirationDate == null
-            val hasUnsubscribed = unsubscribeDetectedAt != null
-            val hasBillingIssues = billingIssueDetectedAt != null
-            return !(isPromo || isLifetime || hasUnsubscribed || hasBillingIssues)
-        }
+    fun getWillRenew(
+        store: Store,
+        expirationDate: Date?,
+        unsubscribeDetectedAt: Date?,
+        billingIssueDetectedAt: Date?,
+    ): Boolean {
+        val isPromo = store == Store.PROMOTIONAL
+        val isLifetime = expirationDate == null
+        val hasUnsubscribed = unsubscribeDetectedAt != null
+        val hasBillingIssues = billingIssueDetectedAt != null
+        return !(isPromo || isLifetime || hasUnsubscribed || hasBillingIssues)
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/ISO8601DateSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/ISO8601DateSerializer.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import java.util.Date
 
-internal object ISO8601Serializer : KSerializer<Date> {
+internal object ISO8601DateSerializer : KSerializer<Date> {
 
     override val descriptor: SerialDescriptor
         get() = PrimitiveSerialDescriptor("Date", PrimitiveKind.STRING)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/ISO8601DateSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/ISO8601DateSerializer.kt
@@ -1,0 +1,26 @@
+package com.revenuecat.purchases.utils.serializers
+
+import com.revenuecat.purchases.utils.Iso8601Utils
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.util.Date
+
+internal object ISO8601Serializer : KSerializer<Date> {
+
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("Date", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): Date {
+        val isoDateString = decoder.decodeString()
+        return Iso8601Utils.parse(isoDateString)
+    }
+
+    override fun serialize(encoder: Encoder, value: Date) {
+        val isoDateString = Iso8601Utils.format(value)
+        encoder.encodeString(isoDateString)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/EntitlementInfoHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/EntitlementInfoHelperTest.kt
@@ -20,7 +20,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class CustomerInfoHelperTest {
+class EntitlementInfoHelperTest {
 
     private val mockCache = mockk<DeviceCache>()
     private val mockBackend = mockk<Backend>()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/CustomerInfoTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/CustomerInfoTest.kt
@@ -367,7 +367,6 @@ class CustomerInfoTest {
         assertThat(proSubscription.periodType).isEqualTo(PeriodType.NORMAL)
         assertThat(proSubscription.refundedAt).isNull()
         assertThat(proSubscription.storeTransactionId).isEqualTo("GPA.3394-7009-4518-41945..6")
-        assertThat(proSubscription.requestDate).isEqualTo(Iso8601Utils.parse("2019-08-16T10:30:42Z"))
         assertThat(proSubscription.isActive).isTrue()
         assertThat(proSubscription.willRenew).isTrue()
 
@@ -386,7 +385,6 @@ class CustomerInfoTest {
         assertThat(basicSubscription.periodType).isEqualTo(PeriodType.NORMAL)
         assertThat(basicSubscription.refundedAt).isNull()
         assertThat(basicSubscription.storeTransactionId).isEqualTo("GPA.3394-7009-4518-41945..8")
-        assertThat(basicSubscription.requestDate).isEqualTo(Iso8601Utils.parse("2019-08-16T10:30:42Z"))
         assertThat(basicSubscription.isActive).isFalse()
         assertThat(basicSubscription.willRenew).isFalse()
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/CustomerInfoTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/CustomerInfoTest.kt
@@ -8,6 +8,10 @@ package com.revenuecat.purchases.common
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.OwnershipType
+import com.revenuecat.purchases.PeriodType
+import com.revenuecat.purchases.Store
+import com.revenuecat.purchases.utils.Iso8601Utils
 import com.revenuecat.purchases.utils.Responses
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONException
@@ -42,7 +46,6 @@ class CustomerInfoTest {
         assertThat(emptyCustomerInfo.latestExpirationDate).isNull()
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun `Given a full response with non subscription SKUs, all SKUs are parsed properly`() {
         val info = fullCustomerInfo
@@ -342,5 +345,82 @@ class CustomerInfoTest {
         assertThat(fullCustomerInfo.allPurchaseDatesByProduct["100_coins_pack"]).isNotNull
         assertThat(fullCustomerInfo.allPurchaseDatesByProduct["7_extra_lives"]).isNotNull
         assertThat(fullCustomerInfo.allPurchaseDatesByProduct["lifetime_access"]).isNotNull
+    }
+
+    @Test
+    fun `Test subscriptionsByProductIdentifier`() {
+        assertThat(fullCustomerInfo.subscriptionsByProductIdentifier).isNotEmpty
+        assertThat(fullCustomerInfo.subscriptionsByProductIdentifier.size).isEqualTo(2)
+
+        val proSubscription = fullCustomerInfo.subscriptionsByProductIdentifier["pro"]
+        assertThat(proSubscription).isNotNull
+        assertThat(proSubscription!!.productIdentifier).isEqualTo("pro")
+        assertThat(proSubscription.purchaseDate).isEqualTo(Iso8601Utils.parse("2019-07-26T23:45:40Z"))
+        assertThat(proSubscription.originalPurchaseDate).isEqualTo(Iso8601Utils.parse("2019-07-26T23:30:41Z"))
+        assertThat(proSubscription.expiresDate).isEqualTo(Iso8601Utils.parse("2100-04-06T20:54:45.975000Z"))
+        assertThat(proSubscription.store).isEqualTo(Store.APP_STORE)
+        assertThat(proSubscription.unsubscribeDetectedAt).isNull()
+        assertThat(proSubscription.isSandbox).isTrue()
+        assertThat(proSubscription.billingIssuesDetectedAt).isNull()
+        assertThat(proSubscription.gracePeriodExpiresDate).isNull()
+        assertThat(proSubscription.ownershipType).isEqualTo(OwnershipType.PURCHASED)
+        assertThat(proSubscription.periodType).isEqualTo(PeriodType.NORMAL)
+        assertThat(proSubscription.refundedAt).isNull()
+        assertThat(proSubscription.storeTransactionId).isEqualTo("GPA.3394-7009-4518-41945..6")
+        assertThat(proSubscription.requestDate).isEqualTo(Iso8601Utils.parse("2019-08-16T10:30:42Z"))
+        assertThat(proSubscription.isActive).isTrue()
+        assertThat(proSubscription.willRenew).isTrue()
+
+        val basicSubscription = fullCustomerInfo.subscriptionsByProductIdentifier["basic"]
+        assertThat(basicSubscription).isNotNull
+        assertThat(basicSubscription!!.productIdentifier).isEqualTo("basic")
+        assertThat(basicSubscription.purchaseDate).isEqualTo(Iso8601Utils.parse("2019-07-26T23:45:40Z"))
+        assertThat(basicSubscription.originalPurchaseDate).isEqualTo(Iso8601Utils.parse("2019-07-26T23:30:41Z"))
+        assertThat(basicSubscription.expiresDate).isEqualTo(Iso8601Utils.parse("1990-08-30T02:40:36Z"))
+        assertThat(basicSubscription.store).isEqualTo(Store.APP_STORE)
+        assertThat(basicSubscription.unsubscribeDetectedAt).isEqualTo(Iso8601Utils.parse("2023-07-26T23:45:40Z"))
+        assertThat(basicSubscription.isSandbox).isTrue()
+        assertThat(basicSubscription.billingIssuesDetectedAt).isNull()
+        assertThat(basicSubscription.gracePeriodExpiresDate).isNull()
+        assertThat(basicSubscription.ownershipType).isEqualTo(OwnershipType.PURCHASED)
+        assertThat(basicSubscription.periodType).isEqualTo(PeriodType.NORMAL)
+        assertThat(basicSubscription.refundedAt).isNull()
+        assertThat(basicSubscription.storeTransactionId).isEqualTo("GPA.3394-7009-4518-41945..8")
+        assertThat(basicSubscription.requestDate).isEqualTo(Iso8601Utils.parse("2019-08-16T10:30:42Z"))
+        assertThat(basicSubscription.isActive).isFalse()
+        assertThat(basicSubscription.willRenew).isFalse()
+    }
+
+    @Test
+    fun `Test subscriptionsByProductIdentifier nullable dates`() {
+        val jsonObject = JSONObject(Responses.validFullPurchaserResponse)
+        val subscriber = jsonObject.getJSONObject("subscriber")
+        val subscriptions = subscriber.getJSONObject("subscriptions")
+
+        val proSubscriptionJSON = subscriptions.getJSONObject("pro")
+        proSubscriptionJSON.put("unsubscribe_detected_at", "2023-07-26T23:45:40Z")
+        proSubscriptionJSON.put("billing_issues_detected_at", "2019-07-26T23:45:40Z")
+        proSubscriptionJSON.put("grace_period_expires_date", "2019-07-25T23:45:40Z")
+        proSubscriptionJSON.put("refunded_at", "2019-07-24T23:45:40Z")
+
+        subscriptions.put("pro", proSubscriptionJSON)
+        subscriber.put("subscriptions", subscriptions)
+        jsonObject.put("subscriber", subscriber)
+
+        val customerInfo = createCustomerInfo(jsonObject)
+
+        assertThat(customerInfo.subscriptionsByProductIdentifier).isNotEmpty
+        assertThat(customerInfo.subscriptionsByProductIdentifier.size).isEqualTo(2)
+
+        val proSubscription = customerInfo.subscriptionsByProductIdentifier["pro"]
+        assertThat(proSubscription).isNotNull
+        assertThat(proSubscription!!.productIdentifier).isEqualTo("pro")
+        assertThat(proSubscription.purchaseDate).isEqualTo(Iso8601Utils.parse("2019-07-26T23:45:40Z"))
+        assertThat(proSubscription.originalPurchaseDate).isEqualTo(Iso8601Utils.parse("2019-07-26T23:30:41Z"))
+        assertThat(proSubscription.expiresDate).isEqualTo(Iso8601Utils.parse("2100-04-06T20:54:45.975000Z"))
+        assertThat(proSubscription.unsubscribeDetectedAt).isEqualTo(Iso8601Utils.parse("2023-07-26T23:45:40Z"))
+        assertThat(proSubscription.billingIssuesDetectedAt).isEqualTo(Iso8601Utils.parse("2019-07-26T23:45:40Z"))
+        assertThat(proSubscription.gracePeriodExpiresDate).isEqualTo(Iso8601Utils.parse("2019-07-25T23:45:40Z"))
+        assertThat(proSubscription.refundedAt).isEqualTo(Iso8601Utils.parse("2019-07-24T23:45:40Z"))
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/Responses.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/Responses.kt
@@ -78,24 +78,34 @@ object Responses {
                     "subscriptions": {
                       "pro": {
                         "billing_issues_detected_at": null,
+                        "grace_period_expires_date": null,
+                        "auto_resume_date": null,
                         "is_sandbox": true,
                         "original_purchase_date": "2019-07-26T23:30:41Z",
                         "purchase_date": "2019-07-26T23:45:40Z",
                         "product_plan_identifier": "monthly",
                         "store": "app_store",
                         "unsubscribe_detected_at": null,
+                        "refunded_at": null,
                         "expires_date": "${Iso8601Utils.format(oneMonthFreeTrialExpirationDate)}",
+                        "ownership_type": "purchased",
+                        "store_transaction_id" : "GPA.3394-7009-4518-41945..6",
                         "period_type": "normal"
                       },
                       "basic": {
                         "billing_issues_detected_at": null,
+                        "grace_period_expires_date": null,
+                        "auto_resume_date": null,
                         "is_sandbox": true,
                         "original_purchase_date": "2019-07-26T23:30:41Z",
                         "purchase_date": "2019-07-26T23:45:40Z",
                         "product_plan_identifier": "monthly",
                         "store": "app_store",
-                        "unsubscribe_detected_at": null,
+                        "unsubscribe_detected_at": "2023-07-26T23:45:40Z",
+                        "refunded_at": null,
                         "period_type": "normal",
+                        "ownership_type": "purchased",
+                        "store_transaction_id" : "GPA.3394-7009-4518-41945..8",
                         "expires_date": "${Iso8601Utils.format(threeMonthFreeTrialExpirationDate)}"
                       }
                     },


### PR DESCRIPTION
We had more information we were not exposing in the CustomerInfo JSON

This PR adds `CustomerInfo.subscriptionsByProductIdentifier` which has some useful information for devs that don't use the entitlements system

https://github.com/RevenueCat/purchases-ios/pull/4508