### PR TITLE
[Paywalls V2] Add `edgeToEdge` badge trailing/leading style layout

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/CornerRadiuses.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/CornerRadiuses.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases.paywalls.components.properties
 
 import androidx.annotation.IntRange
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.common.errorLog
 import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -118,11 +117,6 @@ internal object CornerRadiusesSerializer : KSerializer<CornerRadiuses> {
      * are done with that serializer.
      */
     override fun deserialize(decoder: Decoder): CornerRadiuses {
-        return try {
-            decoder.decodeSerializableValue(serializer)
-        } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
-            errorLog("Failed to deserialize CornerRadiuses", e)
-            CornerRadiuses.Dp.zero
-        }
+        return decoder.decodeSerializableValue(serializer)
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/CornerRadiuses.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/CornerRadiuses.kt
@@ -1,56 +1,127 @@
 package com.revenuecat.purchases.paywalls.components.properties
 
+import androidx.annotation.IntRange
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-/**
- * Contains radius values for 4 corners, in dp.
- */
 @InternalRevenueCatAPI
-@Poko
 @Serializable
-class CornerRadiuses(
-    /**
-     * The top-leading, or top-start, corner radius, in dp.
-     */
-    @get:JvmSynthetic
-    @SerialName("top_leading")
-    val topLeading: Double,
-    /**
-     * The top-trailing, or top-end, corner radius, in dp.
-     */
-    @get:JvmSynthetic
-    @SerialName("top_trailing")
-    val topTrailing: Double,
-    /**
-     * The bottom-leading, or bottom-start, corner radius, in dp.
-     */
-    @get:JvmSynthetic
-    @SerialName("bottom_leading")
-    val bottomLeading: Double,
-    /**
-     * The bottom-trailing, or bottom-end, corner radius, in dp.
-     */
-    @get:JvmSynthetic
-    @SerialName("bottom_trailing")
-    val bottomTrailing: Double,
-) {
-    companion object {
-        @get:JvmSynthetic val zero = CornerRadiuses(0.0, 0.0, 0.0, 0.0)
+sealed interface CornerRadiuses {
 
-        @get:JvmSynthetic val default = zero
+    /**
+     * Contains radius values for 4 corners, in dp.
+     */
+    @Poko
+    @Serializable
+    class Dp(
+        /**
+         * The top-leading, or top-start, corner radius, in dp.
+         */
+        @get:JvmSynthetic
+        @SerialName("top_leading")
+        val topLeading: Double,
+        /**
+         * The top-trailing, or top-end, corner radius, in dp.
+         */
+        @get:JvmSynthetic
+        @SerialName("top_trailing")
+        val topTrailing: Double,
+        /**
+         * The bottom-leading, or bottom-start, corner radius, in dp.
+         */
+        @get:JvmSynthetic
+        @SerialName("bottom_leading")
+        val bottomLeading: Double,
+        /**
+         * The bottom-trailing, or bottom-end, corner radius, in dp.
+         */
+        @get:JvmSynthetic
+        @SerialName("bottom_trailing")
+        val bottomTrailing: Double,
+    ) : CornerRadiuses {
+        companion object {
+            @get:JvmSynthetic val zero = Dp(0.0, 0.0, 0.0, 0.0)
+
+            @get:JvmSynthetic val default = zero
+        }
+
+        constructor(all: Double) : this(all, all, all, all)
+
+        fun copy(
+            topLeading: Double = this.topLeading,
+            topTrailing: Double = this.topTrailing,
+            bottomLeading: Double = this.bottomLeading,
+            bottomTrailing: Double = this.bottomTrailing,
+        ): Dp {
+            return Dp(topLeading, topTrailing, bottomLeading, bottomTrailing)
+        }
     }
 
-    constructor(all: Double) : this(all, all, all, all)
+    /**
+     * Contains radius values for 4 corners, in percentages.
+     */
+    @Poko
+    @Serializable
+    class Percentage(
+        /**
+         * The top-leading, or top-start, corner radius, in percentage [0-100].
+         */
+        @get:JvmSynthetic
+        @IntRange(from = 0, to = 100)
+        @SerialName("top_leading")
+        val topLeading: Int,
+        /**
+         * The top-trailing, or top-end, corner radius, in percentage [0-100].
+         */
+        @get:JvmSynthetic
+        @IntRange(from = 0, to = 100)
+        @SerialName("top_trailing")
+        val topTrailing: Int,
+        /**
+         * The bottom-leading, or bottom-start, corner radius, in percentage [0-100].
+         */
+        @get:JvmSynthetic
+        @IntRange(from = 0, to = 100)
+        @SerialName("bottom_leading")
+        val bottomLeading: Int,
+        /**
+         * The bottom-trailing, or bottom-end, corner radius, in percentage [0-100].
+         */
+        @get:JvmSynthetic
+        @IntRange(from = 0, to = 100)
+        @SerialName("bottom_trailing")
+        val bottomTrailing: Int,
+    ) : CornerRadiuses {
 
-    fun copy(
-        topLeading: Double = this.topLeading,
-        topTrailing: Double = this.topTrailing,
-        bottomLeading: Double = this.bottomLeading,
-        bottomTrailing: Double = this.bottomTrailing,
-    ): CornerRadiuses {
-        return CornerRadiuses(topLeading, topTrailing, bottomLeading, bottomTrailing)
+        constructor(all: Int) : this(all, all, all, all)
+    }
+}
+
+@OptIn(InternalRevenueCatAPI::class, ExperimentalSerializationApi::class)
+internal object CornerRadiusesSerializer : KSerializer<CornerRadiuses?> {
+    override val descriptor: SerialDescriptor = CornerRadiuses.Dp.serializer().descriptor
+
+    override fun serialize(encoder: Encoder, value: CornerRadiuses?) {
+        when (value) {
+            is CornerRadiuses.Dp -> encoder.encodeSerializableValue(CornerRadiuses.Dp.serializer(), value)
+            is CornerRadiuses.Percentage ->
+                encoder.encodeSerializableValue(CornerRadiuses.Percentage.serializer(), value)
+            null -> encoder.encodeNull()
+        }
+    }
+
+    /**
+     * For now, the backend will always return corner radiuses in Dp, so this will assume all serializations
+     * are done with that serializer.
+     */
+    override fun deserialize(decoder: Decoder): CornerRadiuses? {
+        return decoder.decodeNullableSerializableValue(CornerRadiuses.Dp.serializer())
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/MaskShape.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/MaskShape.kt
@@ -13,7 +13,7 @@ sealed interface MaskShape {
     @Serializable
     @SerialName("rectangle")
     class Rectangle(
-        @get:JvmSynthetic val corners: CornerRadiuses? = null,
+        @get:JvmSynthetic @Serializable(with = CornerRadiusesSerializer::class) val corners: CornerRadiuses? = null,
     ) : MaskShape
 
     @Serializable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/MaskShape.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/MaskShape.kt
@@ -14,7 +14,6 @@ sealed interface MaskShape {
     @SerialName("rectangle")
     class Rectangle(
         @get:JvmSynthetic
-        @Serializable
         val corners: CornerRadiuses? = null,
     ) : MaskShape
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/MaskShape.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/MaskShape.kt
@@ -15,7 +15,7 @@ sealed interface MaskShape {
     class Rectangle(
         @get:JvmSynthetic
         @Serializable
-        val corners: CornerRadiuses = CornerRadiuses.Dp.zero,
+        val corners: CornerRadiuses? = null,
     ) : MaskShape
 
     @Serializable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/MaskShape.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/MaskShape.kt
@@ -13,7 +13,9 @@ sealed interface MaskShape {
     @Serializable
     @SerialName("rectangle")
     class Rectangle(
-        @get:JvmSynthetic @Serializable(with = CornerRadiusesSerializer::class) val corners: CornerRadiuses? = null,
+        @get:JvmSynthetic
+        @Serializable
+        val corners: CornerRadiuses = CornerRadiuses.Dp.zero,
     ) : MaskShape
 
     @Serializable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Shape.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Shape.kt
@@ -13,10 +13,16 @@ sealed interface Shape {
     @Poko
     @SerialName("rectangle")
     class Rectangle(
-        @get:JvmSynthetic val corners: CornerRadiuses? = null,
+        @get:JvmSynthetic @Serializable(with = CornerRadiusesSerializer::class) val corners: CornerRadiuses? = null,
     ) : Shape
 
     @Serializable
     @SerialName("pill")
     object Pill : Shape
+
+    val cornerRadiuses: CornerRadiuses
+        get() = when (this) {
+            is Rectangle -> corners ?: CornerRadiuses.Dp.zero
+            else -> CornerRadiuses.Percentage(all = 50)
+        }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Shape.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Shape.kt
@@ -9,11 +9,17 @@ import kotlinx.serialization.Serializable
 @Serializable
 sealed interface Shape {
 
+    companion object {
+        private val pillCornerRadiuses = CornerRadiuses.Percentage(all = 50)
+    }
+
     @Serializable
     @Poko
     @SerialName("rectangle")
     class Rectangle(
-        @get:JvmSynthetic @Serializable(with = CornerRadiusesSerializer::class) val corners: CornerRadiuses? = null,
+        @get:JvmSynthetic
+        @Serializable
+        val corners: CornerRadiuses = CornerRadiuses.Dp.zero,
     ) : Shape
 
     @Serializable
@@ -22,7 +28,7 @@ sealed interface Shape {
 
     val cornerRadiuses: CornerRadiuses
         get() = when (this) {
-            is Rectangle -> corners ?: CornerRadiuses.Dp.zero
-            else -> CornerRadiuses.Percentage(all = 50)
+            is Rectangle -> corners
+            else -> pillCornerRadiuses
         }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Shape.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Shape.kt
@@ -18,7 +18,6 @@ sealed interface Shape {
     @SerialName("rectangle")
     class Rectangle(
         @get:JvmSynthetic
-        @Serializable
         val corners: CornerRadiuses? = null,
     ) : Shape
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Shape.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/Shape.kt
@@ -19,7 +19,7 @@ sealed interface Shape {
     class Rectangle(
         @get:JvmSynthetic
         @Serializable
-        val corners: CornerRadiuses = CornerRadiuses.Dp.zero,
+        val corners: CornerRadiuses? = null,
     ) : Shape
 
     @Serializable
@@ -28,7 +28,7 @@ sealed interface Shape {
 
     val cornerRadiuses: CornerRadiuses
         get() = when (this) {
-            is Rectangle -> corners
+            is Rectangle -> corners ?: CornerRadiuses.Dp.zero
             else -> pillCornerRadiuses
         }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ImageComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ImageComponentTests.kt
@@ -103,7 +103,7 @@ internal class ImageComponentTests {
                             size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit),
                             overrideSourceLid = LocalizationKey("abc123"),
                             maskShape = MaskShape.Rectangle(
-                                corners = CornerRadiuses(
+                                corners = CornerRadiuses.Dp(
                                     topLeading = 3.0,
                                     topTrailing = 4.0,
                                     bottomLeading = 1.0,
@@ -252,7 +252,7 @@ internal class ImageComponentTests {
                             overrideSourceLid = LocalizationKey("abc123"),
                             fitMode = FitMode.FILL,
                             maskShape = MaskShape.Rectangle(
-                                corners = CornerRadiuses(
+                                corners = CornerRadiuses.Dp(
                                     topLeading = 3.0,
                                     topTrailing = 4.0,
                                     bottomLeading = 1.0,

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/CornerRadiusesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/CornerRadiusesTests.kt
@@ -12,7 +12,7 @@ internal class CornerRadiusesTests(@Suppress("UNUSED_PARAMETER") name: String, p
     class Args(
         @Language("json")
         val json: String,
-        val expected: CornerRadiuses,
+        val expected: CornerRadiuses.Dp,
     )
 
     companion object {
@@ -32,7 +32,7 @@ internal class CornerRadiusesTests(@Suppress("UNUSED_PARAMETER") name: String, p
                           "bottom_trailing": 4
                         }
                         """.trimIndent(),
-                    expected = CornerRadiuses(
+                    expected = CornerRadiuses.Dp(
                         topLeading = 1.0,
                         topTrailing = 2.0,
                         bottomLeading = 3.0,
@@ -51,7 +51,7 @@ internal class CornerRadiusesTests(@Suppress("UNUSED_PARAMETER") name: String, p
                           "bottom_trailing": 4.5
                         }
                         """.trimIndent(),
-                    expected = CornerRadiuses(
+                    expected = CornerRadiuses.Dp(
                         topLeading = 1.2,
                         topTrailing = 2.3,
                         bottomLeading = 3.4,
@@ -65,7 +65,7 @@ internal class CornerRadiusesTests(@Suppress("UNUSED_PARAMETER") name: String, p
     @Test
     fun `Should properly deserialize CornerRadiuses`() {
         // Arrange, Act
-        val actual = OfferingParser.json.decodeFromString<CornerRadiuses>(args.json)
+        val actual = OfferingParser.json.decodeFromString<CornerRadiuses.Dp>(args.json)
 
         // Assert
         assert(actual == args.expected)

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/MaskShapeTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/MaskShapeTests.kt
@@ -4,9 +4,9 @@ import com.revenuecat.purchases.common.OfferingParser
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.ParameterizedRobolectricTestRunner
+import org.junit.runners.Parameterized
 
-@RunWith(ParameterizedRobolectricTestRunner::class)
+@RunWith(Parameterized::class)
 internal class MaskShapeTests(@Suppress("UNUSED_PARAMETER") name: String, private val args: Args) {
 
     class Args(
@@ -19,7 +19,7 @@ internal class MaskShapeTests(@Suppress("UNUSED_PARAMETER") name: String, privat
 
         @Suppress("LongMethod")
         @JvmStatic
-        @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
+        @Parameterized.Parameters(name = "{0}")
         fun parameters(): Collection<*> = listOf(
             arrayOf(
                 "rectangle - corners present",

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/MaskShapeTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/MaskShapeTests.kt
@@ -36,7 +36,7 @@ internal class MaskShapeTests(@Suppress("UNUSED_PARAMETER") name: String, privat
                         }
                         """.trimIndent(),
                     expected = MaskShape.Rectangle(
-                        corners = CornerRadiuses(
+                        corners = CornerRadiuses.Dp(
                             topLeading = 1.0,
                             topTrailing = 2.0,
                             bottomLeading = 3.0,

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/MaskShapeTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/MaskShapeTests.kt
@@ -4,9 +4,9 @@ import com.revenuecat.purchases.common.OfferingParser
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
+import org.robolectric.ParameterizedRobolectricTestRunner
 
-@RunWith(Parameterized::class)
+@RunWith(ParameterizedRobolectricTestRunner::class)
 internal class MaskShapeTests(@Suppress("UNUSED_PARAMETER") name: String, private val args: Args) {
 
     class Args(
@@ -19,7 +19,7 @@ internal class MaskShapeTests(@Suppress("UNUSED_PARAMETER") name: String, privat
 
         @Suppress("LongMethod")
         @JvmStatic
-        @Parameterized.Parameters(name = "{0}")
+        @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
         fun parameters(): Collection<*> = listOf(
             arrayOf(
                 "rectangle - corners present",
@@ -53,9 +53,7 @@ internal class MaskShapeTests(@Suppress("UNUSED_PARAMETER") name: String, privat
                           "type": "rectangle"
                         }
                         """.trimIndent(),
-                    expected = MaskShape.Rectangle(
-                        corners = null
-                    )
+                    expected = MaskShape.Rectangle()
                 )
             ),
             arrayOf(
@@ -67,9 +65,7 @@ internal class MaskShapeTests(@Suppress("UNUSED_PARAMETER") name: String, privat
                           "type": "rectangle"
                         }
                         """.trimIndent(),
-                    expected = MaskShape.Rectangle(
-                        corners = null
-                    )
+                    expected = MaskShape.Rectangle()
                 )
             ),
             arrayOf(

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/ShapeTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/ShapeTests.kt
@@ -36,7 +36,7 @@ internal class ShapeTests(@Suppress("UNUSED_PARAMETER") name: String, private va
                         }
                         """.trimIndent(),
                     expected = Shape.Rectangle(
-                        corners = CornerRadiuses(
+                        corners = CornerRadiuses.Dp(
                             topLeading = 1.0,
                             topTrailing = 2.0,
                             bottomLeading = 3.0,

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/ShapeTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/ShapeTests.kt
@@ -4,9 +4,9 @@ import com.revenuecat.purchases.common.OfferingParser
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
+import org.robolectric.ParameterizedRobolectricTestRunner
 
-@RunWith(Parameterized::class)
+@RunWith(ParameterizedRobolectricTestRunner::class)
 internal class ShapeTests(@Suppress("UNUSED_PARAMETER") name: String, private val args: Args) {
 
     class Args(
@@ -19,7 +19,7 @@ internal class ShapeTests(@Suppress("UNUSED_PARAMETER") name: String, private va
 
         @Suppress("LongMethod")
         @JvmStatic
-        @Parameterized.Parameters(name = "{0}")
+        @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
         fun parameters(): Collection<*> = listOf(
             arrayOf(
                 "rectangle - corners present",
@@ -53,9 +53,7 @@ internal class ShapeTests(@Suppress("UNUSED_PARAMETER") name: String, private va
                           "type": "rectangle"
                         }
                         """.trimIndent(),
-                    expected = Shape.Rectangle(
-                        corners = null
-                    )
+                    expected = Shape.Rectangle()
                 )
             ),
             arrayOf(
@@ -67,9 +65,7 @@ internal class ShapeTests(@Suppress("UNUSED_PARAMETER") name: String, private va
                           "type": "rectangle"
                         }
                         """.trimIndent(),
-                    expected = Shape.Rectangle(
-                        corners = null
-                    )
+                    expected = Shape.Rectangle()
                 )
             ),
             arrayOf(

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/ShapeTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/ShapeTests.kt
@@ -4,9 +4,10 @@ import com.revenuecat.purchases.common.OfferingParser
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import org.robolectric.ParameterizedRobolectricTestRunner
 
-@RunWith(ParameterizedRobolectricTestRunner::class)
+@RunWith(Parameterized::class)
 internal class ShapeTests(@Suppress("UNUSED_PARAMETER") name: String, private val args: Args) {
 
     class Args(
@@ -19,7 +20,7 @@ internal class ShapeTests(@Suppress("UNUSED_PARAMETER") name: String, private va
 
         @Suppress("LongMethod")
         @JvmStatic
-        @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
+        @Parameterized.Parameters(name = "{0}")
         fun parameters(): Collection<*> = listOf(
             arrayOf(
                 "rectangle - corners present",

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/ShapeTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/ShapeTests.kt
@@ -5,7 +5,6 @@ import org.intellij.lang.annotations.Language
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import org.robolectric.ParameterizedRobolectricTestRunner
 
 @RunWith(Parameterized::class)
 internal class ShapeTests(@Suppress("UNUSED_PARAMETER") name: String, private val args: Args) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -124,7 +124,7 @@ private fun LoadedPaywallComponents_Preview() {
                         dimension = Vertical(alignment = CENTER, distribution = START),
                         backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.White.toArgb())),
                         shape = Shape.Rectangle(
-                            corners = CornerRadiuses(
+                            corners = CornerRadiuses.Dp(
                                 topLeading = 10.0,
                                 topTrailing = 10.0,
                                 bottomLeading = 0.0,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -121,7 +121,7 @@ private fun previewButtonComponentStyle(
         backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
         padding = PaddingValues(all = 16.dp),
         margin = PaddingValues(all = 16.dp),
-        shape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
+        shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
         border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
         shadow = Shadow(
             color = ColorScheme(ColorInfo.Hex(Color.Black.toArgb())),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/Shape.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/Shape.kt
@@ -8,34 +8,17 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.paywalls.components.properties.CornerRadiuses
 import com.revenuecat.purchases.paywalls.components.properties.MaskShape
 import com.revenuecat.purchases.paywalls.components.properties.Shape as RcShape
 
 @JvmSynthetic
-internal fun RcShape.toShape(): Shape =
-    when (this) {
-        is RcShape.Rectangle -> corners?.run {
-            RoundedCornerShape(
-                topStart = topLeading.dp,
-                topEnd = topTrailing.dp,
-                bottomEnd = bottomTrailing.dp,
-                bottomStart = bottomLeading.dp,
-            )
-        } ?: RectangleShape
-        is RcShape.Pill -> RoundedCornerShape(percent = 50)
-    }
+internal fun RcShape.toShape(): Shape = cornerRadiuses.convertCornerRadiusesToShape()
 
 @JvmSynthetic
 internal fun MaskShape.toShape(): Shape =
     when (this) {
-        is MaskShape.Rectangle -> corners?.run {
-            RoundedCornerShape(
-                topStart = topLeading.dp,
-                topEnd = topTrailing.dp,
-                bottomEnd = bottomTrailing.dp,
-                bottomStart = bottomLeading.dp,
-            )
-        } ?: RectangleShape
+        is MaskShape.Rectangle -> corners?.convertCornerRadiusesToShape() ?: RectangleShape
 
         is MaskShape.Pill -> RoundedCornerShape(percent = 50)
         is MaskShape.Concave -> GenericShape { size, _ ->
@@ -57,3 +40,18 @@ internal fun MaskShape.toShape(): Shape =
         }
         is MaskShape.Circle -> CircleShape
     }
+
+private fun CornerRadiuses.convertCornerRadiusesToShape(): Shape = when (this) {
+    is CornerRadiuses.Percentage -> RoundedCornerShape(
+        topStartPercent = topLeading,
+        topEndPercent = topTrailing,
+        bottomEndPercent = bottomTrailing,
+        bottomStartPercent = bottomLeading,
+    )
+    is CornerRadiuses.Dp -> RoundedCornerShape(
+        topStart = topLeading.dp,
+        topEnd = topTrailing.dp,
+        bottomEnd = bottomTrailing.dp,
+        bottomStart = bottomLeading.dp,
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -21,12 +21,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.layout
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -219,18 +217,15 @@ private fun StackWithLongEdgeToEdgeBadge(
         }.first()
         val badgePlaceable = badgeMeasurable.measure(constraints)
         val badgeHeight = badgePlaceable.height
-
-        val backgroundCornerRadiusExtension = when (stackState.shape) {
-            is Shape.Pill -> stackPlaceable.height / 2
-            is Shape.Rectangle -> {
+        val backgroundCornerRadiusExtension = when (val stackCornerRadiuses = stackState.shape.cornerRadiuses) {
+            is CornerRadiuses.Percentage -> stackPlaceable.height / 2
+            is CornerRadiuses.Dp -> {
                 (
-                    (stackState.shape as? Shape.Rectangle)?.let { rcShape ->
-                        if (topBadge) {
-                            maxOf(rcShape.corners?.topLeading ?: 0.0, rcShape.corners?.topTrailing ?: 0.0)
-                        } else {
-                            maxOf(rcShape.corners?.bottomLeading ?: 0.0, rcShape.corners?.bottomTrailing ?: 0.0)
-                        }
-                    } ?: 0.0
+                    if (topBadge) {
+                        maxOf(stackCornerRadiuses.topLeading, stackCornerRadiuses.topTrailing)
+                    } else {
+                        maxOf(stackCornerRadiuses.bottomLeading, stackCornerRadiuses.bottomTrailing)
+                    }
                     ).dp.roundToPx()
             }
         }
@@ -245,44 +240,36 @@ private fun StackWithLongEdgeToEdgeBadge(
             val backgroundColorStyle = badgeStack.backgroundColor?.let { rememberColorStyle(scheme = it) }
             val borderStyle = badgeStack.border?.let { rememberBorderStyle(border = it) }
             val shadowStyle = badgeStack.shadow?.let { rememberShadowStyle(shadow = it) }
-            val backgroundShape = when (badgeStack.shape) {
-                is Shape.Pill -> {
-                    // We have to make sure our badge uses absolute corner sizes. If it's using relative corner sizes,
-                    // i.e. pill-shaped, we need to use the stack to calculate the absolute size to use.
-                    (badgeStack.shape.toShape() as? RoundedCornerShape)?.let { shape ->
-                        if (topBadge) {
-                            RoundedCornerShape(
-                                topStart = shape.topStart.makeAbsolute(stackPlaceable, LocalDensity.current),
-                                topEnd = shape.topEnd.makeAbsolute(stackPlaceable, LocalDensity.current),
-                                bottomEnd = CornerSize(0.dp),
-                                bottomStart = CornerSize(0.dp),
-                            )
-                        } else {
-                            RoundedCornerShape(
-                                topStart = CornerSize(0.dp),
-                                topEnd = CornerSize(0.dp),
-                                bottomEnd = shape.bottomEnd.makeAbsolute(stackPlaceable, LocalDensity.current),
-                                bottomStart = shape.bottomStart.makeAbsolute(stackPlaceable, LocalDensity.current),
-                            )
-                        }
-                    } ?: RectangleShape
+            val backgroundShape = when (val badgeCornerRadiuses = badgeStack.shape.cornerRadiuses) {
+                is CornerRadiuses.Percentage -> {
+                    if (topBadge) {
+                        RoundedCornerShape(
+                            topStartPercent = badgeCornerRadiuses.topLeading,
+                            topEndPercent = badgeCornerRadiuses.topTrailing,
+                        )
+                    } else {
+                        RoundedCornerShape(
+                            bottomEndPercent = badgeCornerRadiuses.bottomTrailing,
+                            bottomStartPercent = badgeCornerRadiuses.bottomLeading,
+                        )
+                    }
                 }
-                is Shape.Rectangle -> if (topBadge) {
+                is CornerRadiuses.Dp -> if (topBadge) {
                     Shape.Rectangle(
-                        corners = CornerRadiuses(
-                            topLeading = badgeStack.shape.corners?.topLeading ?: 0.0,
-                            topTrailing = badgeStack.shape.corners?.topTrailing ?: 0.0,
+                        corners = CornerRadiuses.Dp(
+                            topLeading = badgeCornerRadiuses.topLeading,
+                            topTrailing = badgeCornerRadiuses.topTrailing,
                             bottomLeading = 0.0,
                             bottomTrailing = 0.0,
                         ),
                     ).toShape()
                 } else {
                     Shape.Rectangle(
-                        corners = CornerRadiuses(
+                        corners = CornerRadiuses.Dp(
                             topLeading = 0.0,
                             topTrailing = 0.0,
-                            bottomLeading = badgeStack.shape.corners?.bottomLeading ?: 0.0,
-                            bottomTrailing = badgeStack.shape.corners?.bottomTrailing ?: 0.0,
+                            bottomLeading = badgeCornerRadiuses.bottomLeading,
+                            bottomTrailing = badgeCornerRadiuses.bottomTrailing,
                         ),
                     ).toShape()
                 }
@@ -334,7 +321,7 @@ private fun StackWithLongEdgeToEdgeBadge(
     }
 }
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LongMethod")
 @Composable
 private fun StackWithShortEdgeToEdgeBadge(
     stackState: StackComponentState,
@@ -344,40 +331,69 @@ private fun StackWithShortEdgeToEdgeBadge(
     clickHandler: suspend (PaywallAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val badgeRectangleCorners = (badgeStack.shape as? Shape.Rectangle)?.corners
-        ?: CornerRadiuses(all = 20.0) // For pill badge shape default to a "medium" rounded corner.
-    val badgeShape = Shape.Rectangle(
-        corners = when (alignment) {
-            TwoDimensionalAlignment.TOP_LEADING -> CornerRadiuses(
-                topLeading = 0.0,
-                topTrailing = 0.0,
-                bottomLeading = 0.0,
-                bottomTrailing = badgeRectangleCorners.bottomTrailing,
-            )
-            TwoDimensionalAlignment.TOP_TRAILING -> CornerRadiuses(
-                topLeading = 0.0,
-                topTrailing = 0.0,
-                bottomLeading = badgeRectangleCorners.bottomLeading,
-                bottomTrailing = 0.0,
-            )
-            TwoDimensionalAlignment.BOTTOM_LEADING -> CornerRadiuses(
-                topLeading = 0.0,
-                topTrailing = badgeRectangleCorners.topTrailing,
-                bottomLeading = 0.0,
-                bottomTrailing = 0.0,
-            )
-            TwoDimensionalAlignment.BOTTOM_TRAILING -> CornerRadiuses(
-                topLeading = badgeRectangleCorners.topLeading,
-                topTrailing = 0.0,
-                bottomLeading = 0.0,
-                bottomTrailing = 0.0,
-            )
-            else -> CornerRadiuses(all = 0.0)
-        },
-    )
+    val adjustedCornerRadiuses: CornerRadiuses = when (val badgeRectangleCorners = badgeStack.shape.cornerRadiuses) {
+        is CornerRadiuses.Percentage -> {
+            when (alignment) {
+                TwoDimensionalAlignment.TOP_LEADING -> CornerRadiuses.Percentage(
+                    topLeading = 0,
+                    topTrailing = 0,
+                    bottomLeading = 0,
+                    bottomTrailing = badgeRectangleCorners.bottomTrailing,
+                )
+                TwoDimensionalAlignment.TOP_TRAILING -> CornerRadiuses.Percentage(
+                    topLeading = 0,
+                    topTrailing = 0,
+                    bottomLeading = badgeRectangleCorners.bottomLeading,
+                    bottomTrailing = 0,
+                )
+                TwoDimensionalAlignment.BOTTOM_LEADING -> CornerRadiuses.Percentage(
+                    topLeading = 0,
+                    topTrailing = badgeRectangleCorners.topTrailing,
+                    bottomLeading = 0,
+                    bottomTrailing = 0,
+                )
+                TwoDimensionalAlignment.BOTTOM_TRAILING -> CornerRadiuses.Percentage(
+                    topLeading = badgeRectangleCorners.topLeading,
+                    topTrailing = 0,
+                    bottomLeading = 0,
+                    bottomTrailing = 0,
+                )
+                else -> CornerRadiuses.Percentage(all = 0)
+            }
+        }
+        is CornerRadiuses.Dp -> {
+            when (alignment) {
+                TwoDimensionalAlignment.TOP_LEADING -> CornerRadiuses.Dp(
+                    topLeading = 0.0,
+                    topTrailing = 0.0,
+                    bottomLeading = 0.0,
+                    bottomTrailing = badgeRectangleCorners.bottomTrailing,
+                )
+                TwoDimensionalAlignment.TOP_TRAILING -> CornerRadiuses.Dp(
+                    topLeading = 0.0,
+                    topTrailing = 0.0,
+                    bottomLeading = badgeRectangleCorners.bottomLeading,
+                    bottomTrailing = 0.0,
+                )
+                TwoDimensionalAlignment.BOTTOM_LEADING -> CornerRadiuses.Dp(
+                    topLeading = 0.0,
+                    topTrailing = badgeRectangleCorners.topTrailing,
+                    bottomLeading = 0.0,
+                    bottomTrailing = 0.0,
+                )
+                TwoDimensionalAlignment.BOTTOM_TRAILING -> CornerRadiuses.Dp(
+                    topLeading = badgeRectangleCorners.topLeading,
+                    topTrailing = 0.0,
+                    bottomLeading = 0.0,
+                    bottomTrailing = 0.0,
+                )
+                else -> CornerRadiuses.Dp(all = 0.0)
+            }
+        }
+    }
     MainStackComponent(stackState, state, clickHandler, modifier) {
         StackComponentView(
-            badgeStack.copy(shape = badgeShape),
+            badgeStack.copy(shape = Shape.Rectangle(adjustedCornerRadiuses)),
             state,
             clickHandler,
             modifier = Modifier.align(alignment.toAlignment()),
@@ -616,7 +632,7 @@ private fun StackComponentView_Preview_Vertical() {
                 ),
                 padding = PaddingValues(all = 16.dp),
                 margin = PaddingValues(all = 16.dp),
-                shape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
+                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
                 border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
                 shadow = Shadow(
                     color = ColorScheme(ColorInfo.Hex(Color.Black.toArgb())),
@@ -654,7 +670,7 @@ private fun StackComponentView_Preview_Overlay_Badge(
         modifier = Modifier.padding(all = 32.dp),
     ) {
         val badgeShape = Shape.Rectangle(
-            corners = CornerRadiuses(
+            corners = CornerRadiuses.Dp(
                 topLeading = 20.0,
                 topTrailing = 20.0,
                 bottomLeading = 20.0,
@@ -675,7 +691,7 @@ private fun StackComponentView_Preview_Overlay_Badge(
                 ),
                 padding = PaddingValues(all = 12.dp),
                 margin = PaddingValues(all = 0.dp),
-                shape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
+                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
                 border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
                 shadow = null,
                 badge = previewBadge(Badge.Style.Overlay, alignment, badgeShape),
@@ -697,7 +713,7 @@ private fun StackComponentView_Preview_EdgeToEdge_Badge(
         modifier = Modifier.padding(all = 32.dp),
     ) {
         val badgeShape = Shape.Rectangle(
-            corners = CornerRadiuses(
+            corners = CornerRadiuses.Dp(
                 topLeading = 20.0,
                 topTrailing = 20.0,
                 bottomLeading = 20.0,
@@ -718,7 +734,7 @@ private fun StackComponentView_Preview_EdgeToEdge_Badge(
                 ),
                 padding = PaddingValues(all = 0.dp),
                 margin = PaddingValues(all = 0.dp),
-                shape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
+                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
                 border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
                 shadow = null,
                 badge = previewBadge(Badge.Style.EdgeToEdge, alignment, badgeShape),
@@ -775,7 +791,7 @@ private fun StackComponentView_Preview_Nested_Badge(
         modifier = Modifier.padding(all = 32.dp),
     ) {
         val badgeShape = Shape.Rectangle(
-            corners = CornerRadiuses(
+            corners = CornerRadiuses.Dp(
                 topLeading = 20.0,
                 topTrailing = 20.0,
                 bottomLeading = 20.0,
@@ -796,7 +812,7 @@ private fun StackComponentView_Preview_Nested_Badge(
                 ),
                 padding = PaddingValues(all = 0.dp),
                 margin = PaddingValues(all = 0.dp),
-                shape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
+                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
                 border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Yellow.toArgb()))),
                 shadow = null,
                 badge = previewBadge(Badge.Style.Nested, alignment, badgeShape),
@@ -831,7 +847,7 @@ private fun StackComponentView_Preview_Horizontal() {
                 ),
                 padding = PaddingValues(all = 16.dp),
                 margin = PaddingValues(all = 16.dp),
-                shape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
+                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
                 border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
                 shadow = Shadow(
                     color = ColorScheme(ColorInfo.Hex(Color.Black.toArgb())),
@@ -909,7 +925,7 @@ private fun StackComponentView_Preview_ZLayer() {
                 ),
                 padding = PaddingValues(all = 16.dp),
                 margin = PaddingValues(all = 16.dp),
-                shape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
+                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
                 border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
                 shadow = Shadow(
                     color = ColorScheme(ColorInfo.Hex(Color.Black.toArgb())),
@@ -1187,7 +1203,7 @@ private fun previewBadge(style: Badge.Style, alignment: TwoDimensionalAlignment,
                     padding = Padding(
                         top = 8.0,
                         bottom = 8.0,
-                        leading = 8.0,
+                        leading = 32.0,
                         trailing = 8.0,
                     ).toPaddingValues(),
                     margin = Padding(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -126,14 +126,28 @@ internal fun StackComponentView(
                 }
 
                 Badge.Style.EdgeToEdge -> {
-                    StackWithEdgeToEdgeBadge(
-                        stackState,
-                        state,
-                        badge.stackStyle,
-                        badge.alignment.isTop,
-                        clickHandler,
-                        modifier,
-                    )
+                    when (badge.alignment) {
+                        TwoDimensionalAlignment.TOP,
+                        TwoDimensionalAlignment.BOTTOM
+                        -> StackWithLongEdgeToEdgeBadge(
+                            stackState,
+                            state,
+                            badge.stackStyle,
+                            badge.alignment.isTop,
+                            clickHandler,
+                            modifier,
+                        )
+                        else
+                        -> StackWithShortEdgeToEdgeBadge(
+                            stackState,
+                            state,
+                            badge.stackStyle,
+                            badge.alignment,
+                            clickHandler,
+                            modifier,
+                        )
+                    }
+
                 }
 
                 Badge.Style.Nested -> {
@@ -167,7 +181,7 @@ private fun StackWithOverlaidBadge(
  */
 @Suppress("LongMethod", "LongParameterList", "CyclomaticComplexMethod")
 @Composable
-private fun StackWithEdgeToEdgeBadge(
+private fun StackWithLongEdgeToEdgeBadge(
     stackState: StackComponentState,
     state: PaywallState.Loaded.Components,
     badgeStack: StackComponentStyle,
@@ -317,6 +331,55 @@ private fun StackWithEdgeToEdgeBadge(
                 yPosition += badgePlaceable.height
             }
         }
+    }
+}
+
+@Composable
+private fun StackWithShortEdgeToEdgeBadge(
+    stackState: StackComponentState,
+    state: PaywallState.Loaded.Components,
+    badgeStack: StackComponentStyle,
+    alignment: TwoDimensionalAlignment,
+    clickHandler: suspend (PaywallAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val stackStateRectangleCorners = (stackState.shape as? Shape.Rectangle)?.corners ?: CornerRadiuses(all = 0.0)
+    val adjustedCorners = when (alignment) {
+        TwoDimensionalAlignment.TOP_LEADING -> CornerRadiuses(
+            topLeading = stackStateRectangleCorners.topLeading,
+            topTrailing = 0.0,
+            bottomLeading = 0.0,
+            bottomTrailing = stackStateRectangleCorners.bottomTrailing,
+        )
+        TwoDimensionalAlignment.TOP_TRAILING -> CornerRadiuses(
+            topLeading = 0.0,
+            topTrailing = stackStateRectangleCorners.topTrailing,
+            bottomLeading = stackStateRectangleCorners.bottomLeading,
+            bottomTrailing = 0.0,
+        )
+        TwoDimensionalAlignment.BOTTOM_LEADING -> CornerRadiuses(
+            topLeading = 0.0,
+            topTrailing = stackStateRectangleCorners.topTrailing,
+            bottomLeading = stackStateRectangleCorners.bottomLeading,
+            bottomTrailing = 0.0,
+        )
+        TwoDimensionalAlignment.BOTTOM_TRAILING -> CornerRadiuses(
+            topLeading = stackStateRectangleCorners.topLeading,
+            topTrailing = 0.0,
+            bottomLeading = 0.0,
+            bottomTrailing = stackStateRectangleCorners.bottomTrailing,
+        )
+        else -> CornerRadiuses(all = 0.0)
+    }
+    val badgeShape = Shape.Rectangle(corners = adjustedCorners)
+    Box(modifier = modifier) {
+        MainStackComponent(stackState, state, clickHandler)
+        StackComponentView(
+            badgeStack.copy(shape = badgeShape),
+            state,
+            clickHandler,
+            modifier = Modifier.align(alignment.toAlignment()),
+        )
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -1203,7 +1203,7 @@ private fun previewBadge(style: Badge.Style, alignment: TwoDimensionalAlignment,
                     padding = Padding(
                         top = 8.0,
                         bottom = 8.0,
-                        leading = 32.0,
+                        leading = 8.0,
                         trailing = 8.0,
                     ).toPaddingValues(),
                     margin = Padding(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -492,6 +492,7 @@ private fun MainStackComponent(
 
     val outerShapeModifier = remember(backgroundColorStyle, shadowStyle) {
         Modifier
+            .padding(stackState.margin)
             .applyIfNotNull(shadowStyle) { shadow(it, composeShape) }
             .applyIfNotNull(backgroundColorStyle) { background(it, composeShape) }
             .clip(composeShape)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases.ui.revenuecatui.components.button
 
 import android.os.LocaleList
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.test.assertHasClickAction
@@ -94,7 +93,7 @@ class ButtonComponentViewTests {
                     backgroundColor = ColorScheme(ColorInfo.Hex(Color.Red.toArgb())),
                     padding = PaddingValues(all = 16.dp),
                     margin = PaddingValues(all = 16.dp),
-                    shape = Shape.Rectangle(CornerRadiuses(all = 20.0)),
+                    shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
                     border = Border(width = 2.0, color = ColorScheme(ColorInfo.Hex(Color.Blue.toArgb()))),
                     shadow = Shadow(
                         color = ColorScheme(ColorInfo.Hex(Color.Black.toArgb())),


### PR DESCRIPTION
### Description
This adds the remaining `edgeToEdge` style layouts for the badge, including leading and trailing

<img width="1135" alt="image" src="https://github.com/user-attachments/assets/5c569151-ffca-47c4-b519-4badf2328e98" />
