### PR TITLE
[Paywalls V2] Implements `Convex` and `Concave` image masks

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -15,7 +15,6 @@ import androidx.annotation.Px
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -44,8 +43,10 @@ import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConf
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.CornerRadiuses
 import com.revenuecat.purchases.paywalls.components.properties.FitMode
 import com.revenuecat.purchases.paywalls.components.properties.ImageUrls
+import com.revenuecat.purchases.paywalls.components.properties.MaskShape
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
@@ -53,6 +54,7 @@ import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fi
 import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
 import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toContentScale
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toShape
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.urlsForCurrentTheme
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.aspectRatio
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.overlay
@@ -183,6 +185,14 @@ private fun ImageComponentView_Preview(
                 themeImageUrls = themeImageUrls,
                 size = parameters.viewSize,
                 fitMode = parameters.fitMode,
+                shape = MaskShape.Rectangle(
+                    corners = CornerRadiuses(
+                        topLeading = 20.0,
+                        topTrailing = 20.0,
+                        bottomLeading = 20.0,
+                        bottomTrailing = 20.0,
+                    ),
+                ),
             ),
             state = previewEmptyState(),
             previewImageLoader = previewImageLoader(themeImageUrls),
@@ -204,6 +214,14 @@ private fun ImageComponentView_Preview_SmallerContainer() {
                 themeImageUrls = themeImageUrls,
                 size = Size(width = Fixed(400u), height = Fixed(400u)),
                 fitMode = FitMode.FIT,
+                shape = MaskShape.Rectangle(
+                    corners = CornerRadiuses(
+                        topLeading = 20.0,
+                        topTrailing = 20.0,
+                        bottomLeading = 20.0,
+                        bottomTrailing = 20.0,
+                    ),
+                ),
             ),
             state = previewEmptyState(),
             previewImageLoader = previewImageLoader(themeImageUrls),
@@ -222,6 +240,14 @@ private fun ImageComponentView_Preview_LinearGradient() {
                 themeImageUrls = themeImageUrls,
                 size = Size(width = Fixed(400u), height = Fit),
                 fitMode = FitMode.FIT,
+                shape = MaskShape.Rectangle(
+                    corners = CornerRadiuses(
+                        topLeading = 20.0,
+                        topTrailing = 20.0,
+                        bottomLeading = 20.0,
+                        bottomTrailing = 20.0,
+                    ),
+                ),
                 overlay = ColorScheme(
                     light = ColorInfo.Gradient.Linear(
                         degrees = -90f,
@@ -259,6 +285,14 @@ private fun ImageComponentView_Preview_RadialGradient() {
                 themeImageUrls = themeImageUrls,
                 size = Size(width = Fixed(400u), height = Fit),
                 fitMode = FitMode.FIT,
+                shape = MaskShape.Rectangle(
+                    corners = CornerRadiuses(
+                        topLeading = 20.0,
+                        topTrailing = 20.0,
+                        bottomLeading = 20.0,
+                        bottomTrailing = 20.0,
+                    ),
+                ),
                 overlay = ColorScheme(
                     light = ColorInfo.Gradient.Radial(
                         listOf(
@@ -284,17 +318,55 @@ private fun ImageComponentView_Preview_RadialGradient() {
     }
 }
 
+private class MaskShapeProvider : PreviewParameterProvider<MaskShape> {
+    override val values: Sequence<MaskShape> = sequenceOf(
+        MaskShape.Rectangle(
+            corners = CornerRadiuses(
+                topLeading = 30.0,
+                topTrailing = 50.0,
+                bottomLeading = 20.0,
+                bottomTrailing = 40.0,
+            ),
+        ),
+        MaskShape.Pill,
+        MaskShape.Concave,
+        MaskShape.Convex,
+        MaskShape.Circle,
+    )
+}
+
+@Preview
+@Composable
+private fun ImageComponentView_Preview_MaskShape(
+    @PreviewParameter(MaskShapeProvider::class) maskShape: MaskShape,
+) {
+    val themeImageUrls = previewThemeImageUrls(widthPx = 400u, heightPx = 200u)
+    Box(modifier = Modifier.background(ComposeColor.Blue)) {
+        ImageComponentView(
+            style = previewImageComponentStyle(
+                themeImageUrls = themeImageUrls,
+                size = Size(width = Fixed(400u), height = Fixed(200u)),
+                fitMode = FitMode.FIT,
+                shape = maskShape,
+            ),
+            state = previewEmptyState(),
+            previewImageLoader = previewImageLoader(themeImageUrls),
+        )
+    }
+}
+
 @Suppress("LongParameterList")
 @Composable
 private fun previewImageComponentStyle(
     themeImageUrls: ThemeImageUrls,
     size: Size,
     fitMode: FitMode,
+    shape: MaskShape,
     overlay: ColorScheme? = null,
 ) = ImageComponentStyle(
     sources = nonEmptyMapOf(LocaleId("en_US") to themeImageUrls),
     size = size,
-    shape = RoundedCornerShape(20.dp, 20.dp, 20.dp, 20.dp),
+    shape = shape.toShape(),
     overlay = overlay,
     contentScale = fitMode.toContentScale(),
     rcPackage = null,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/Shape.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/Shape.kt
@@ -11,6 +11,12 @@ import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.paywalls.components.properties.MaskShape
 import com.revenuecat.purchases.paywalls.components.properties.Shape as RcShape
 
+/**
+ * The scale factor to use on the Y axis when drawing a Concave or Convex shape. This will be multiplied by Y to
+ * determine the start and end point of the curve from the bottom of the shape.
+ */
+private const val SCALE_Y_OFFSET_CONCAVE_CONVEX = 0.2f
+
 @JvmSynthetic
 internal fun RcShape.toShape(): Shape =
     when (this) {
@@ -39,20 +45,22 @@ internal fun MaskShape.toShape(): Shape =
 
         is MaskShape.Pill -> RoundedCornerShape(percent = 50)
         is MaskShape.Concave -> GenericShape { size, _ ->
-            // TODO Actually implement a Concave shape.
-            // This is just a rectangle.
+            val yOffset = SCALE_Y_OFFSET_CONCAVE_CONVEX * size.height * 2f
+
+            moveTo(x = 0f, y = 0f)
             lineTo(x = size.width, y = 0f)
             lineTo(x = size.width, y = size.height)
-            lineTo(x = 0f, y = size.height)
+            quadraticTo(x1 = size.width / 2, y1 = size.height - yOffset, x2 = 0f, y2 = size.height)
             lineTo(x = 0f, y = 0f)
         }
 
         is MaskShape.Convex -> GenericShape { size, _ ->
-            // TODO Actually implement a Convex shape.
-            // This is just a rectangle.
+            val yOffset = SCALE_Y_OFFSET_CONCAVE_CONVEX * size.height
+
+            moveTo(x = 0f, y = 0f)
             lineTo(x = size.width, y = 0f)
-            lineTo(x = size.width, y = size.height)
-            lineTo(x = 0f, y = size.height)
+            lineTo(x = size.width, y = size.height - yOffset)
+            quadraticTo(x1 = size.width / 2, y1 = size.height + yOffset, x2 = 0f, y2 = size.height - yOffset)
             lineTo(x = 0f, y = 0f)
         }
         is MaskShape.Circle -> CircleShape

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/Shape.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/Shape.kt
@@ -13,7 +13,7 @@ import com.revenuecat.purchases.paywalls.components.properties.Shape as RcShape
 
 /**
  * The scale factor to use on the Y axis when drawing a Concave or Convex shape. This will be multiplied by Y to
- * determine the start and end point of the curve from the bottom of the shape.
+ * determine the maximum distance of the curve to the bottom of the shape.
  */
 private const val SCALE_Y_OFFSET_CONCAVE_CONVEX = 0.2f
 


### PR DESCRIPTION
## Description
As the title says. Implementation is the same as [the dashboard](https://github.com/RevenueCat/revenuecat-app/blob/main/src/concepts/projects/paywall-builder/components/previewer/components/image.tsx#L88-L115), except it uses a relative offset (0.2 x height) instead of a fixed one (27 px).  

![image](https://github.com/user-attachments/assets/2cf1de6d-3314-48cc-9d13-bb486a8618c3)

