### PR TITLE
[Paywalls V2] Handles intro offer eligibility overrides

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverrides.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverrides.kt
@@ -3,13 +3,15 @@ package com.revenuecat.purchases.paywalls.components.common
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.components.PartialComponent
 import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @InternalRevenueCatAPI
 @Poko
 @Serializable
 class ComponentOverrides<T : PartialComponent>(
-    @get:JvmSynthetic val introOffer: T? = null,
+    @get:JvmSynthetic @SerialName("intro_offer") val introOffer: T? = null,
+    @get:JvmSynthetic @SerialName("multiple_intro_offers") val multipleIntroOffers: T? = null,
     @get:JvmSynthetic val states: ComponentStates<T>? = null,
     @get:JvmSynthetic val conditions: ComponentConditions<T>? = null,
 )

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentOverridesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentOverridesTests.kt
@@ -38,8 +38,11 @@ internal class ComponentOverridesTests {
                     Args(
                         json = """
                         {
-                          "introOffer": {
+                          "intro_offer": {
                             "font_name": "intro font"
+                          },
+                          "multiple_intro_offers": {
+                            "font_name": "multiple intros font"
                           },
                           "states": {
                             "selected": {
@@ -61,6 +64,7 @@ internal class ComponentOverridesTests {
                         """.trimIndent(),
                         expected = ComponentOverrides(
                             introOffer = PartialTextComponent(fontName = "intro font"),
+                            multipleIntroOffers = PartialTextComponent(fontName = "multiple intros font"),
                             states = ComponentStates(
                                 selected = PartialTextComponent(fontName = "selected font")
                             ),
@@ -117,8 +121,11 @@ internal class ComponentOverridesTests {
                     Args(
                         json = """
                         {
-                          "introOffer": {
+                          "intro_offer": {
                             "override_source_lid": "intro"
+                          },
+                          "multiple_intro_offers": {
+                            "override_source_lid": "multiple_intros"
                           },
                           "states": {
                             "selected": {
@@ -140,6 +147,9 @@ internal class ComponentOverridesTests {
                         """.trimIndent(),
                         expected = ComponentOverrides(
                             introOffer = PartialImageComponent(overrideSourceLid = LocalizationKey("intro")),
+                            multipleIntroOffers = PartialImageComponent(
+                                overrideSourceLid = LocalizationKey("multiple_intros")
+                            ),
                             states = ComponentStates(
                                 selected = PartialImageComponent(overrideSourceLid = LocalizationKey("selected"))
                             ),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
@@ -35,9 +35,13 @@ private fun <T : PresentedPartial<T>> PresentedPartial<T>?.combineOrReplace(with
 @Poko
 internal class PresentedOverrides<T : PresentedPartial<T>>(
     /**
-     * Override for different selection states.
+     * Override when the user is eligible for a single offer.
      */
     @get:JvmSynthetic val introOffer: T?,
+    /**
+     * Override when the user is eligible for multiple offers.
+     */
+    @get:JvmSynthetic val multipleIntroOffers: T?,
     /**
      * Override for different selection states.
      */
@@ -89,6 +93,9 @@ internal fun <T : PartialComponent, P : PresentedPartial<P>> ComponentOverrides<
     val introOffer = introOffer?.let(transform)
         ?.getOrElse { return Result.Error(it.head) }
 
+    val multipleIntroOffers = multipleIntroOffers?.let(transform)
+        ?.getOrElse { return Result.Error(it.head) }
+
     val selectedState = states?.selected?.let(transform)
         ?.getOrElse { return Result.Error(it.head) }
 
@@ -105,6 +112,7 @@ internal fun <T : PartialComponent, P : PresentedPartial<P>> ComponentOverrides<
     return Result.Success(
         PresentedOverrides(
             introOffer = introOffer,
+            multipleIntroOffers = multipleIntroOffers,
             states = states,
             conditions = conditions,
         ),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
@@ -125,7 +125,7 @@ internal fun <T : PartialComponent, P : PresentedPartial<P>> ComponentOverrides<
  * is eligible for an intro offer.
  *
  * @param windowSize Current screen condition (compact / medium / expanded).
- * @param isEligibleForIntroOffer Whether the user is eligible for an intro offer.
+ * @param introOfferEligibility Whether the user is eligible for an intro offer.
  * @param state Current view state (selected / unselected).
  *
  * @return A presentable partial component, or null if [this] [PresentedOverrides] did not contain any

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components
 
 import com.revenuecat.purchases.paywalls.components.PartialComponent
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverrides
+import com.revenuecat.purchases.ui.revenuecatui.composables.IntroOfferEligibility
 import com.revenuecat.purchases.ui.revenuecatui.errors.PaywallValidationError
 import com.revenuecat.purchases.ui.revenuecatui.helpers.NonEmptyList
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Result
@@ -133,14 +134,23 @@ internal fun <T : PartialComponent, P : PresentedPartial<P>> ComponentOverrides<
 @JvmSynthetic
 internal fun <T : PresentedPartial<T>> PresentedOverrides<T>.buildPresentedPartial(
     windowSize: ScreenCondition,
-    isEligibleForIntroOffer: Boolean,
+    introOfferEligibility: IntroOfferEligibility,
     state: ComponentViewState,
 ): T? {
     var conditionPartial = buildScreenConditionPartial(windowSize)
 
-    if (isEligibleForIntroOffer) {
-        // If conditionPartial is null here, we want to continue with the introOffer partial.
-        conditionPartial = conditionPartial.combineOrReplace(introOffer)
+    when (introOfferEligibility) {
+        IntroOfferEligibility.INELIGIBLE -> {
+            // Nothing to do.
+        }
+        IntroOfferEligibility.SINGLE_OFFER_ELIGIBLE -> {
+            // If conditionPartial is null here, we want to continue with the introOffer partial.
+            conditionPartial = conditionPartial.combineOrReplace(introOffer)
+        }
+        IntroOfferEligibility.MULTIPLE_OFFERS_ELIGIBLE -> {
+            // If conditionPartial is null here, we want to continue with the multipleIntroOffers partial.
+            conditionPartial = conditionPartial.combineOrReplace(multipleIntroOffers)
+        }
     }
 
     when (state) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
@@ -20,7 +20,9 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toPaddingValues
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toShape
 import com.revenuecat.purchases.ui.revenuecatui.components.style.BadgeStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.composables.IntroOfferEligibility
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 
 @JvmSynthetic
 @Composable
@@ -30,7 +32,6 @@ internal fun rememberUpdatedStackComponentState(
 ): StackComponentState =
     rememberUpdatedStackComponentState(
         style = style,
-        isEligibleForIntroOffer = paywallState.isEligibleForIntroOffer,
         selectedPackageProvider = { paywallState.selectedPackage },
     )
 
@@ -38,7 +39,6 @@ internal fun rememberUpdatedStackComponentState(
 @Composable
 internal fun rememberUpdatedStackComponentState(
     style: StackComponentStyle,
-    isEligibleForIntroOffer: Boolean = false,
     selectedPackageProvider: () -> Package?,
 ): StackComponentState {
     val windowSize = currentWindowAdaptiveInfo().windowSizeClass.windowWidthSizeClass
@@ -46,14 +46,12 @@ internal fun rememberUpdatedStackComponentState(
     return remember(style) {
         StackComponentState(
             initialWindowSize = windowSize,
-            initialIsEligibleForIntroOffer = isEligibleForIntroOffer,
             style = style,
             selectedPackageProvider = selectedPackageProvider,
         )
     }.apply {
         update(
             windowSize = windowSize,
-            isEligibleForIntroOffer = isEligibleForIntroOffer,
         )
     }
 }
@@ -61,20 +59,26 @@ internal fun rememberUpdatedStackComponentState(
 @Stable
 internal class StackComponentState(
     initialWindowSize: WindowWidthSizeClass,
-    initialIsEligibleForIntroOffer: Boolean,
     private val style: StackComponentStyle,
     private val selectedPackageProvider: () -> Package?,
 ) {
     private var windowSize by mutableStateOf(initialWindowSize)
-    private var isEligibleForIntroOffer by mutableStateOf(initialIsEligibleForIntroOffer)
     private val selected by derivedStateOf {
         if (style.rcPackage != null) style.rcPackage.identifier == selectedPackageProvider()?.identifier else false
+    }
+
+    /**
+     * The package to consider for intro offer eligibility.
+     */
+    private val applicablePackage by derivedStateOf {
+        style.rcPackage ?: selectedPackageProvider()
     }
     private val presentedPartial by derivedStateOf {
         val windowCondition = ScreenCondition.from(windowSize)
         val componentState = if (selected) ComponentViewState.SELECTED else ComponentViewState.DEFAULT
+        val introOfferEligibility = applicablePackage?.introEligibility ?: IntroOfferEligibility.INELIGIBLE
 
-        style.overrides?.buildPresentedPartial(windowCondition, isEligibleForIntroOffer, componentState)
+        style.overrides?.buildPresentedPartial(windowCondition, introOfferEligibility, componentState)
     }
 
     @get:JvmSynthetic
@@ -124,9 +128,7 @@ internal class StackComponentState(
     @JvmSynthetic
     fun update(
         windowSize: WindowWidthSizeClass? = null,
-        isEligibleForIntroOffer: Boolean? = null,
     ) {
         if (windowSize != null) this.windowSize = windowSize
-        if (isEligibleForIntroOffer != null) this.isEligibleForIntroOffer = isEligibleForIntroOffer
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
@@ -50,11 +50,13 @@ import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.rememberColorStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.TextComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.composables.IntroOfferEligibility
 import com.revenuecat.purchases.ui.revenuecatui.composables.Markdown
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableProcessor
 import com.revenuecat.purchases.ui.revenuecatui.extensions.applyIfNotNull
+import com.revenuecat.purchases.ui.revenuecatui.extensions.introEligibility
 import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
 import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toComponentsPaywallState
@@ -136,6 +138,15 @@ private fun rememberProcessedText(
     val processedText by remember(state, textState, fixedPackage) {
         derivedStateOf {
             (fixedPackage ?: state.selectedPackage)?.let { packageToUse ->
+
+                val introEligibility = packageToUse.introEligibility
+
+                when (introEligibility) {
+                    IntroOfferEligibility.INELIGIBLE -> textState.text
+                    IntroOfferEligibility.SINGLE_OFFER_ELIGIBLE -> textState.text
+                    IntroOfferEligibility.MULTIPLE_OFFERS_ELIGIBLE -> textState.text
+                }
+
                 val discount = discountPercentage(
                     pricePerMonthMicros = packageToUse.product.pricePerMonth()?.amountMicros,
                     mostExpensiveMicros = state.mostExpensivePricePerMonthMicros,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.Offering
-import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentsConfig
@@ -83,7 +82,6 @@ internal fun TextComponentView(
         state = state,
         textState = textState,
         variables = variableDataProvider,
-        fixedPackage = style.rcPackage,
     )
 
     val colorStyle = rememberColorStyle(scheme = textState.color)
@@ -133,11 +131,10 @@ private fun rememberProcessedText(
     state: PaywallState.Loaded.Components,
     textState: TextComponentState,
     variables: VariableDataProvider,
-    fixedPackage: Package?,
 ): String {
-    val processedText by remember(state, textState, fixedPackage) {
+    val processedText by remember(state, textState) {
         derivedStateOf {
-            (fixedPackage ?: state.selectedPackage)?.let { packageToUse ->
+            textState.applicablePackage?.let { packageToUse ->
 
                 val introEligibility = packageToUse.introEligibility
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -77,23 +77,19 @@ internal sealed interface PaywallState {
              */
             private val locales: NonEmptySet<LocaleId>,
             initialLocaleList: LocaleList = LocaleList.current,
-            initialIsEligibleForIntroOffer: Boolean = false,
             initialSelectedPackage: Package? = null,
         ) : Loaded {
             private var localeId by mutableStateOf(initialLocaleList.toLocaleId())
 
             val locale by derivedStateOf { localeId.toComposeLocale() }
 
-            var isEligibleForIntroOffer by mutableStateOf(initialIsEligibleForIntroOffer)
-                private set
             var selectedPackage by mutableStateOf<Package?>(initialSelectedPackage)
                 private set
 
             val mostExpensivePricePerMonthMicros: Long? = offering.availablePackages.mostExpensivePricePerMonthMicros()
 
-            fun update(localeList: FrameworkLocaleList? = null, isEligibleForIntroOffer: Boolean? = null) {
+            fun update(localeList: FrameworkLocaleList? = null) {
                 if (localeList != null) localeId = LocaleList(localeList.toLanguageTags()).toLocaleId()
-                if (isEligibleForIntroOffer != null) this.isEligibleForIntroOffer = isEligibleForIntroOffer
             }
 
             fun update(selectedPackage: Package?) {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/assertions/assertPixelColorEquals.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/assertions/assertPixelColorEquals.kt
@@ -6,6 +6,10 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import com.revenuecat.purchases.ui.revenuecatui.helpers.captureToImageCompat
 import kotlin.math.abs
 
@@ -283,56 +287,66 @@ internal fun SemanticsNodeInteraction.assertApproximatePixelColorPercentage(
 
 /**
  * Asserts the border color of a rectangular element.
+ *
+ * @param size The size of the element. Will use the entire node's size if this is null.
+ * @param offset The offset of the element within this node.
  */
 internal fun SemanticsNodeInteraction.assertRectangularBorderColor(
     borderWidth: Dp,
     expectedBorderColor: Color,
     expectedBackgroundColor: Color,
+    size: DpSize? = null,
+    offset: DpOffset? = null,
 ): SemanticsNodeInteraction = run {
 
     val node = fetchSemanticsNode()
     // Compose seems to have a minimum border width of 2 px. See also Dp.Hairline.
     val borderWidthPx = with(node.layoutInfo.density) { borderWidth.roundToPx() }.coerceAtLeast(2)
-    val size = node.size
+    val sizePx = size?.let {
+            with(node.layoutInfo.density) { IntSize(width = it.width.roundToPx(), height = it.height.roundToPx()) }
+        } ?: node.size
+    val offsetPx = offset?.let {
+            with(node.layoutInfo.density) { IntOffset(x = it.x.roundToPx(), y = it.y.roundToPx()) }
+    } ?: IntOffset(x = 0, y = 0)
 
     // Top edge
     assertPixelColorEquals(
-        startX = 0,
-        startY = 0,
-        width = size.width,
+        startX = offsetPx.x,
+        startY = offsetPx.y,
+        width = sizePx.width,
         height = borderWidthPx,
         color = expectedBorderColor
     )
         // Left edge
         .assertPixelColorEquals(
-            startX = 0,
-            startY = 0,
+            startX = offsetPx.x,
+            startY = offsetPx.y,
             width = borderWidthPx,
-            height = size.height,
+            height = sizePx.height,
             color = expectedBorderColor
         )
         // Right edge
         .assertPixelColorEquals(
-            startX = size.width - borderWidthPx,
-            startY = 0,
+            startX = offsetPx.x + sizePx.width - borderWidthPx,
+            startY = offsetPx.y,
             width = borderWidthPx,
-            height = size.height,
+            height = sizePx.height,
             color = expectedBorderColor
         )
         // Bottom edge
         .assertPixelColorEquals(
-            startX = 0,
-            startY = size.height - borderWidthPx,
-            width = size.width,
+            startX = offsetPx.x,
+            startY = offsetPx.y + sizePx.height - borderWidthPx,
+            width = sizePx.width,
             height = borderWidthPx,
             color = expectedBorderColor
         )
         // Inner area
         .assertPixelColorEquals(
-            startX = borderWidthPx,
-            startY = borderWidthPx,
-            width = size.width - borderWidthPx - borderWidthPx,
-            height = size.height - borderWidthPx - borderWidthPx,
+            startX = offsetPx.x + borderWidthPx,
+            startY = offsetPx.y + borderWidthPx,
+            width = sizePx.width - borderWidthPx - borderWidthPx,
+            height = sizePx.height - borderWidthPx - borderWidthPx,
             color = expectedBackgroundColor
         )
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
@@ -17,6 +17,10 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState.SE
 import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition.COMPACT
 import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition.EXPANDED
 import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition.MEDIUM
+import com.revenuecat.purchases.ui.revenuecatui.composables.IntroOfferEligibility
+import com.revenuecat.purchases.ui.revenuecatui.composables.IntroOfferEligibility.INELIGIBLE
+import com.revenuecat.purchases.ui.revenuecatui.composables.IntroOfferEligibility.MULTIPLE_OFFERS_ELIGIBLE
+import com.revenuecat.purchases.ui.revenuecatui.composables.IntroOfferEligibility.SINGLE_OFFER_ELIGIBLE
 import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
 import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
 import org.junit.Test
@@ -31,11 +35,12 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
     class Args(
         val availableOverrides: PresentedOverrides<LocalizedTextPartial>,
         val windowSize: ScreenCondition,
-        val isEligibleForIntroOffer: Boolean,
+        val introOfferEligibility: IntroOfferEligibility,
         val state: ComponentViewState,
         val expected: LocalizedTextPartial?,
     )
 
+    @Suppress("LargeClass")
     companion object {
         private val localeId = LocaleId("en_US")
         private val dummyLocalizationDictionary = nonEmptyMapOf(
@@ -90,8 +95,6 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
             )
         ).getOrThrow()
 
-        // FIXME Add/adjust test cases here!!
-
         @Suppress("LongMethod")
         @JvmStatic
         @Parameterized.Parameters(name = "{0}")
@@ -112,13 +115,13 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         )
                     ),
                     windowSize = MEDIUM,
-                    isEligibleForIntroOffer = true,
+                    introOfferEligibility = MULTIPLE_OFFERS_ELIGIBLE,
                     state = SELECTED,
                     expected = selectedPartial,
                 ),
             ),
             arrayOf(
-                "should pick intro when all overrides available and state is not selected",
+                "should pick multiple intros when all overrides available and state is not selected",
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = introOfferPartial,
@@ -133,7 +136,28 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         )
                     ),
                     windowSize = MEDIUM,
-                    isEligibleForIntroOffer = true,
+                    introOfferEligibility = MULTIPLE_OFFERS_ELIGIBLE,
+                    state = DEFAULT,
+                    expected = multipleIntroOffersPartial,
+                ),
+            ),
+            arrayOf(
+                "should pick intro when all overrides available and state is not selected and eligibility is single",
+                Args(
+                    availableOverrides = PresentedOverrides(
+                        introOffer = introOfferPartial,
+                        multipleIntroOffers = multipleIntroOffersPartial,
+                        states = PresentedStates(
+                            selected = selectedPartial
+                        ),
+                        conditions = PresentedConditions(
+                            compact = compactPartial,
+                            medium = mediumPartial,
+                            expanded = expandedPartial,
+                        )
+                    ),
+                    windowSize = MEDIUM,
+                    introOfferEligibility = SINGLE_OFFER_ELIGIBLE,
                     state = DEFAULT,
                     expected = introOfferPartial,
                 ),
@@ -154,7 +178,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         )
                     ),
                     windowSize = COMPACT,
-                    isEligibleForIntroOffer = false,
+                    introOfferEligibility = INELIGIBLE,
                     state = DEFAULT,
                     expected = compactPartial,
                 ),
@@ -175,7 +199,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         )
                     ),
                     windowSize = MEDIUM,
-                    isEligibleForIntroOffer = false,
+                    introOfferEligibility = INELIGIBLE,
                     state = DEFAULT,
                     expected = mediumPartial,
                 ),
@@ -196,13 +220,13 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         )
                     ),
                     windowSize = EXPANDED,
-                    isEligibleForIntroOffer = false,
+                    introOfferEligibility = INELIGIBLE,
                     state = DEFAULT,
                     expected = expandedPartial,
                 ),
             ),
             arrayOf(
-                "should pick intro when all overrides applicable, but selected override unavailable",
+                "should pick multiple intros when all overrides applicable, but selected override unavailable",
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = introOfferPartial,
@@ -215,9 +239,48 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         )
                     ),
                     windowSize = MEDIUM,
-                    isEligibleForIntroOffer = true,
+                    introOfferEligibility = MULTIPLE_OFFERS_ELIGIBLE,
+                    state = SELECTED,
+                    expected = multipleIntroOffersPartial,
+                ),
+            ),
+            arrayOf(
+                "should pick intro when all overrides applicable, but selected and multiple intro override unavailable",
+                Args(
+                    availableOverrides = PresentedOverrides(
+                        introOffer = introOfferPartial,
+                        multipleIntroOffers = null,
+                        states = null,
+                        conditions = PresentedConditions(
+                            compact = compactPartial,
+                            medium = mediumPartial,
+                            expanded = expandedPartial,
+                        )
+                    ),
+                    windowSize = MEDIUM,
+                    introOfferEligibility = SINGLE_OFFER_ELIGIBLE,
                     state = SELECTED,
                     expected = introOfferPartial,
+                ),
+            ),
+            arrayOf(
+                "should pick medium when all overrides applicable, eligibility is multiple, but only single override " +
+                    "available",
+                Args(
+                    availableOverrides = PresentedOverrides(
+                        introOffer = introOfferPartial,
+                        multipleIntroOffers = null,
+                        states = null,
+                        conditions = PresentedConditions(
+                            compact = compactPartial,
+                            medium = mediumPartial,
+                            expanded = expandedPartial,
+                        )
+                    ),
+                    windowSize = MEDIUM,
+                    introOfferEligibility = MULTIPLE_OFFERS_ELIGIBLE,
+                    state = SELECTED,
+                    expected = mediumPartial,
                 ),
             ),
             arrayOf(
@@ -234,7 +297,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         )
                     ),
                     windowSize = MEDIUM,
-                    isEligibleForIntroOffer = true,
+                    introOfferEligibility = MULTIPLE_OFFERS_ELIGIBLE,
                     state = SELECTED,
                     expected = mediumPartial,
                 ),
@@ -254,7 +317,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         )
                     ),
                     windowSize = EXPANDED,
-                    isEligibleForIntroOffer = true,
+                    introOfferEligibility = MULTIPLE_OFFERS_ELIGIBLE,
                     state = SELECTED,
                     expected = mediumPartial,
                 ),
@@ -274,7 +337,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         )
                     ),
                     windowSize = MEDIUM,
-                    isEligibleForIntroOffer = true,
+                    introOfferEligibility = MULTIPLE_OFFERS_ELIGIBLE,
                     state = SELECTED,
                     expected = compactPartial,
                 ),
@@ -294,7 +357,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         )
                     ),
                     windowSize = COMPACT,
-                    isEligibleForIntroOffer = true,
+                    introOfferEligibility = MULTIPLE_OFFERS_ELIGIBLE,
                     state = SELECTED,
                     expected = null,
                 ),
@@ -309,7 +372,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         conditions = null,
                     ),
                     windowSize = COMPACT,
-                    isEligibleForIntroOffer = true,
+                    introOfferEligibility = SINGLE_OFFER_ELIGIBLE,
                     state = SELECTED,
                     expected = null,
                 ),
@@ -326,7 +389,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         conditions = null,
                     ),
                     windowSize = COMPACT,
-                    isEligibleForIntroOffer = true,
+                    introOfferEligibility = MULTIPLE_OFFERS_ELIGIBLE,
                     state = SELECTED,
                     expected = null,
                 ),
@@ -343,7 +406,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         conditions = null,
                     ),
                     windowSize = MEDIUM,
-                    isEligibleForIntroOffer = true,
+                    introOfferEligibility = MULTIPLE_OFFERS_ELIGIBLE,
                     state = SELECTED,
                     expected = selectedPartial,
                 ),
@@ -360,9 +423,27 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         conditions = null,
                     ),
                     windowSize = MEDIUM,
-                    isEligibleForIntroOffer = true,
+                    introOfferEligibility = MULTIPLE_OFFERS_ELIGIBLE,
                     state = SELECTED,
                     expected = selectedPartial,
+                ),
+            ),
+            arrayOf(
+                "should pick multiple intros when all overrides applicable, but window and selected overrides " +
+                    "unavailable",
+                Args(
+                    availableOverrides = PresentedOverrides(
+                        introOffer = introOfferPartial,
+                        multipleIntroOffers = multipleIntroOffersPartial,
+                        states = PresentedStates(
+                            selected = null
+                        ),
+                        conditions = null,
+                    ),
+                    windowSize = MEDIUM,
+                    introOfferEligibility = MULTIPLE_OFFERS_ELIGIBLE,
+                    state = SELECTED,
+                    expected = introOfferPartial,
                 ),
             ),
             arrayOf(
@@ -377,7 +458,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         conditions = null,
                     ),
                     windowSize = MEDIUM,
-                    isEligibleForIntroOffer = true,
+                    introOfferEligibility = SINGLE_OFFER_ELIGIBLE,
                     state = SELECTED,
                     expected = introOfferPartial,
                 ),
@@ -451,7 +532,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         ),
                     ),
                     windowSize = EXPANDED,
-                    isEligibleForIntroOffer = false,
+                    introOfferEligibility = INELIGIBLE,
                     state = DEFAULT,
                     // We expect all of the non-null properties from the expanded override, the non-null properties
                     // from the medium override that are null in expanded, and the non-null properties from the compact
@@ -490,7 +571,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                                 backgroundColor = null,
                                 fontName = null,
                                 fontWeight = null,
-                                fontSize = null,
+                                fontSize = FontSize.BODY_XL,
                                 horizontalAlignment = HorizontalAlignment.CENTER,
                                 size = Size(width = Fixed(50.toUInt()), height = Fixed(50.toUInt())),
                                 padding = Padding(top = 50.0, bottom = 50.0, leading = 50.0, trailing = 50.0),
@@ -506,8 +587,8 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                                 backgroundColor = null,
                                 fontName = null,
                                 fontWeight = null,
-                                fontSize = FontSize.BODY_XL,
-                                horizontalAlignment = null,
+                                fontSize = FontSize.HEADING_XL,
+                                horizontalAlignment = HorizontalAlignment.CENTER,
                                 size = Size(width = Fixed(50.toUInt()), height = Fixed(50.toUInt())),
                                 padding = Padding(top = 50.0, bottom = 50.0, leading = 50.0, trailing = 50.0),
                                 margin = Padding(top = 60.0, bottom = 60.0, leading = 60.0, trailing = 60.0),
@@ -588,7 +669,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         ),
                     ),
                     windowSize = EXPANDED,
-                    isEligibleForIntroOffer = true,
+                    introOfferEligibility = MULTIPLE_OFFERS_ELIGIBLE,
                     state = SELECTED,
                     expected = LocalizedTextPartial(
                         from = PartialTextComponent(
@@ -598,7 +679,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                             backgroundColor = ColorScheme(light = ColorInfo.Alias("mediumBgColor")),
                             fontName = "expandedFont",
                             fontWeight = FontWeight.BOLD,
-                            fontSize = FontSize.BODY_XL,
+                            fontSize = FontSize.HEADING_XL,
                             horizontalAlignment = HorizontalAlignment.CENTER,
                             size = Size(width = Fixed(60.toUInt()), height = Fixed(60.toUInt())),
                             padding = Padding(top = 60.0, bottom = 60.0, leading = 60.0, trailing = 60.0),
@@ -620,7 +701,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
         // Arrange, Act
         val actual: LocalizedTextPartial? = args.availableOverrides.buildPresentedPartial(
             windowSize = args.windowSize,
-            isEligibleForIntroOffer = args.isEligibleForIntroOffer,
+            introOfferEligibility = args.introOfferEligibility,
             state = args.state,
         )
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
@@ -57,6 +57,14 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 )
             )
         ).getOrThrow()
+        private val multipleIntroOffersPartial = LocalizedTextPartial(
+            from = PartialTextComponent(),
+            using = nonEmptyMapOf(
+                localeId to nonEmptyMapOf(
+                    LocalizationKey("key") to LocalizationData.Text("Hello multiple intros"),
+                )
+            )
+        ).getOrThrow()
         private val compactPartial = LocalizedTextPartial(
             from = PartialTextComponent(),
             using = nonEmptyMapOf(
@@ -82,6 +90,8 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
             )
         ).getOrThrow()
 
+        // FIXME Add/adjust test cases here!!
+
         @Suppress("LongMethod")
         @JvmStatic
         @Parameterized.Parameters(name = "{0}")
@@ -91,6 +101,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = introOfferPartial,
+                        multipleIntroOffers = multipleIntroOffersPartial,
                         states = PresentedStates(
                             selected = selectedPartial
                         ),
@@ -111,6 +122,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = introOfferPartial,
+                        multipleIntroOffers = multipleIntroOffersPartial,
                         states = PresentedStates(
                             selected = selectedPartial
                         ),
@@ -131,6 +143,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = introOfferPartial,
+                        multipleIntroOffers = multipleIntroOffersPartial,
                         states = PresentedStates(
                             selected = selectedPartial
                         ),
@@ -151,6 +164,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = introOfferPartial,
+                        multipleIntroOffers = multipleIntroOffersPartial,
                         states = PresentedStates(
                             selected = selectedPartial
                         ),
@@ -171,6 +185,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = introOfferPartial,
+                        multipleIntroOffers = multipleIntroOffersPartial,
                         states = PresentedStates(
                             selected = selectedPartial
                         ),
@@ -191,6 +206,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = introOfferPartial,
+                        multipleIntroOffers = multipleIntroOffersPartial,
                         states = null,
                         conditions = PresentedConditions(
                             compact = compactPartial,
@@ -209,6 +225,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = null,
+                        multipleIntroOffers = null,
                         states = null,
                         conditions = PresentedConditions(
                             compact = compactPartial,
@@ -228,6 +245,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = null,
+                        multipleIntroOffers = null,
                         states = null,
                         conditions = PresentedConditions(
                             compact = compactPartial,
@@ -247,6 +265,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = null,
+                        multipleIntroOffers = null,
                         states = null,
                         conditions = PresentedConditions(
                             compact = compactPartial,
@@ -266,6 +285,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = null,
+                        multipleIntroOffers = null,
                         states = null,
                         conditions = PresentedConditions(
                             compact = null,
@@ -284,6 +304,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = null,
+                        multipleIntroOffers = null,
                         states = null,
                         conditions = null,
                     ),
@@ -298,6 +319,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = null,
+                        multipleIntroOffers = null,
                         states = PresentedStates(
                             selected = null
                         ),
@@ -314,6 +336,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = introOfferPartial,
+                        multipleIntroOffers = multipleIntroOffersPartial,
                         states = PresentedStates(
                             selected = selectedPartial
                         ),
@@ -330,6 +353,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = null,
+                        multipleIntroOffers = null,
                         states = PresentedStates(
                             selected = selectedPartial
                         ),
@@ -342,10 +366,11 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 ),
             ),
             arrayOf(
-                "should pick intro when all overrides applicable, but window and intro overrides unavailable",
+                "should pick intro when all overrides applicable, but window and selected overrides unavailable",
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = introOfferPartial,
+                        multipleIntroOffers = multipleIntroOffersPartial,
                         states = PresentedStates(
                             selected = null
                         ),
@@ -362,6 +387,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                 Args(
                     availableOverrides = PresentedOverrides(
                         introOffer = null,
+                        multipleIntroOffers = null,
                         states = PresentedStates(
                             selected = null
                         ),
@@ -464,8 +490,24 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                                 backgroundColor = null,
                                 fontName = null,
                                 fontWeight = null,
-                                fontSize = FontSize.BODY_XL,
+                                fontSize = null,
                                 horizontalAlignment = HorizontalAlignment.CENTER,
+                                size = Size(width = Fixed(50.toUInt()), height = Fixed(50.toUInt())),
+                                padding = Padding(top = 50.0, bottom = 50.0, leading = 50.0, trailing = 50.0),
+                                margin = Padding(top = 60.0, bottom = 60.0, leading = 60.0, trailing = 60.0),
+                            ),
+                            using = nonEmptyMapOf(localeId to dummyLocalizationDictionary),
+                        ).getOrThrow(),
+                        multipleIntroOffers =  LocalizedTextPartial(
+                            from = PartialTextComponent(
+                                visible = true,
+                                text = null,
+                                color = null,
+                                backgroundColor = null,
+                                fontName = null,
+                                fontWeight = null,
+                                fontSize = FontSize.BODY_XL,
+                                horizontalAlignment = null,
                                 size = Size(width = Fixed(50.toUInt()), height = Fixed(50.toUInt())),
                                 padding = Padding(top = 50.0, bottom = 50.0, leading = 50.0, trailing = 50.0),
                                 margin = Padding(top = 60.0, bottom = 60.0, leading = 60.0, trailing = 60.0),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ToPresentedOverridesTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ToPresentedOverridesTests.kt
@@ -53,6 +53,7 @@ internal class ToPresentedOverridesTests(@Suppress("UNUSED_PARAMETER") name: Str
                 Args(
                     availableOverrides = ComponentOverrides(
                         introOffer = PartialTextComponent(fontName = "introOffer"),
+                        multipleIntroOffers = PartialTextComponent(fontName = "multipleIntroOffers"),
                         states = ComponentStates(
                             selected = PartialTextComponent(fontName = "selected"),
                         ),
@@ -74,10 +75,37 @@ internal class ToPresentedOverridesTests(@Suppress("UNUSED_PARAMETER") name: Str
                 )
             ),
             arrayOf(
+                "Should fail if transforming multipleIntroOffers fails",
+                Args(
+                    availableOverrides = ComponentOverrides(
+                        introOffer = PartialTextComponent(fontName = "introOffer"),
+                        multipleIntroOffers = PartialTextComponent(fontName = "multipleIntroOffers"),
+                        states = ComponentStates(
+                            selected = PartialTextComponent(fontName = "selected"),
+                        ),
+                        conditions = ComponentConditions(
+                            compact = PartialTextComponent(fontName = "compact"),
+                            medium = PartialTextComponent(fontName = "medium"),
+                            expanded = PartialTextComponent(fontName = "expanded"),
+                        ),
+                    ),
+                    transform = { partial ->
+                        if (partial.fontName == "multipleIntroOffers")
+                            Result.Error(nonEmptyListOf(InvalidTemplate(partial.fontName!!)))
+                        else LocalizedTextPartial(
+                            from = partial,
+                            using = nonEmptyMapOf(localeId to dummyLocalizationDictionary)
+                        )
+                    },
+                    expected = Result.Error(InvalidTemplate("multipleIntroOffers"))
+                )
+            ),
+            arrayOf(
                 "Should fail if transforming selected fails",
                 Args(
                     availableOverrides = ComponentOverrides(
                         introOffer = PartialTextComponent(fontName = "introOffer"),
+                        multipleIntroOffers = PartialTextComponent(fontName = "multipleIntroOffers"),
                         states = ComponentStates(
                             selected = PartialTextComponent(fontName = "selected"),
                         ),
@@ -103,6 +131,7 @@ internal class ToPresentedOverridesTests(@Suppress("UNUSED_PARAMETER") name: Str
                 Args(
                     availableOverrides = ComponentOverrides(
                         introOffer = PartialTextComponent(fontName = "introOffer"),
+                        multipleIntroOffers = PartialTextComponent(fontName = "multipleIntroOffers"),
                         states = ComponentStates(
                             selected = PartialTextComponent(fontName = "selected"),
                         ),
@@ -128,6 +157,7 @@ internal class ToPresentedOverridesTests(@Suppress("UNUSED_PARAMETER") name: Str
                 Args(
                     availableOverrides = ComponentOverrides(
                         introOffer = PartialTextComponent(fontName = "introOffer"),
+                        multipleIntroOffers = PartialTextComponent(fontName = "multipleIntroOffers"),
                         states = ComponentStates(
                             selected = PartialTextComponent(fontName = "selected"),
                         ),
@@ -153,6 +183,7 @@ internal class ToPresentedOverridesTests(@Suppress("UNUSED_PARAMETER") name: Str
                 Args(
                     availableOverrides = ComponentOverrides(
                         introOffer = PartialTextComponent(fontName = "introOffer"),
+                        multipleIntroOffers = PartialTextComponent(fontName = "multipleIntroOffers"),
                         states = ComponentStates(
                             selected = PartialTextComponent(fontName = "selected"),
                         ),
@@ -178,6 +209,7 @@ internal class ToPresentedOverridesTests(@Suppress("UNUSED_PARAMETER") name: Str
                 Args(
                     availableOverrides = ComponentOverrides(
                         introOffer = PartialTextComponent(fontName = "introOffer"),
+                        multipleIntroOffers = PartialTextComponent(fontName = "multipleIntroOffers"),
                         states = ComponentStates(
                             selected = PartialTextComponent(fontName = "selected"),
                         ),
@@ -195,6 +227,10 @@ internal class ToPresentedOverridesTests(@Suppress("UNUSED_PARAMETER") name: Str
                         PresentedOverrides(
                             introOffer = LocalizedTextPartial(
                                 from = PartialTextComponent(fontName = "introOffer"),
+                                using = nonEmptyMapOf(localeId to dummyLocalizationDictionary)
+                            ).getOrThrow(),
+                            multipleIntroOffers = LocalizedTextPartial(
+                                from = PartialTextComponent(fontName = "multipleIntroOffers"),
                                 using = nonEmptyMapOf(localeId to dummyLocalizationDictionary)
                             ).getOrThrow(),
                             states = PresentedStates(


### PR DESCRIPTION
## Description
Intro offer eligibility was not properly hooked up yet to the override system, and it was using the iOS concept of at most being eligible for a single offer. This PR ensures the offer eligibility follows the Android model of potentially being eligible for multiple offers, and hooks it up to the override system. 

A bunch of the added lines are tests. 