### PR TITLE
[Paywalls V2] Removes `MaskShape.Pill` in favor of `MaskShape.Circle`.

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/MaskShape.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/MaskShape.kt
@@ -17,10 +17,6 @@ sealed interface MaskShape {
     ) : MaskShape
 
     @Serializable
-    @SerialName("pill")
-    object Pill : MaskShape
-
-    @Serializable
     @SerialName("concave")
     object Concave : MaskShape
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/MaskShapeTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/MaskShapeTests.kt
@@ -73,17 +73,6 @@ internal class MaskShapeTests(@Suppress("UNUSED_PARAMETER") name: String, privat
                 )
             ),
             arrayOf(
-                "pill",
-                Args(
-                    json = """
-                        {
-                          "type": "pill"
-                        }
-                        """.trimIndent(),
-                    expected = MaskShape.Pill
-                )
-            ),
-            arrayOf(
                 "concave",
                 Args(
                     json = """

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -379,7 +379,6 @@ private class MaskShapeProvider : PreviewParameterProvider<MaskShape> {
                 bottomTrailing = 40.0,
             ),
         ),
-        MaskShape.Pill,
         MaskShape.Concave,
         MaskShape.Convex,
         MaskShape.Circle,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/Shape.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/Shape.kt
@@ -43,7 +43,6 @@ internal fun MaskShape.toShape(): Shape =
             )
         } ?: RectangleShape
 
-        is MaskShape.Pill -> RoundedCornerShape(percent = 50)
         is MaskShape.Concave -> GenericShape { size, _ ->
             val yOffset = SCALE_Y_OFFSET_CONCAVE_CONVEX * size.height * 2f
 


### PR DESCRIPTION
## Description
`Circle` is the new `Pill`. See https://github.com/RevenueCat/purchases-ios/pull/4674#discussion_r1917238488 for context. 