### PR TITLE
[Paywalls V2] Adds support for fallback components

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
@@ -1,8 +1,53 @@
 package com.revenuecat.purchases.paywalls.components
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 @InternalRevenueCatAPI
-@Serializable
+@Serializable(with = PaywallComponentSerializer::class)
 sealed interface PaywallComponent
+
+@InternalRevenueCatAPI
+internal class PaywallComponentSerializer : KSerializer<PaywallComponent> {
+    // We're only describing the type field, while it will have many more. This works for now, but for a proper
+    // implementation we can look at SealedClassSerializer. Unfortunately that's currently annotated with
+    // @InternalSerializationApi.
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("PaywallComponent") {
+        element("type", String.serializer().descriptor)
+    }
+
+    override fun serialize(encoder: Encoder, value: PaywallComponent) {
+        // Serialization is not implemented as it is not needed.
+    }
+
+    override fun deserialize(decoder: Decoder): PaywallComponent {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw SerializationException("Can only deserialize PaywallComponent from JSON, got: ${decoder::class}")
+        val json = jsonDecoder.decodeJsonElement().jsonObject
+        return when (val type = json["type"]?.jsonPrimitive?.content) {
+            "button" -> jsonDecoder.json.decodeFromString<ButtonComponent>(json.toString())
+            "image" -> jsonDecoder.json.decodeFromString<ImageComponent>(json.toString())
+            "package" -> jsonDecoder.json.decodeFromString<PackageComponent>(json.toString())
+            "purchase_button" -> jsonDecoder.json.decodeFromString<PurchaseButtonComponent>(json.toString())
+            "stack" -> jsonDecoder.json.decodeFromString<StackComponent>(json.toString())
+            "sticky_footer" -> jsonDecoder.json.decodeFromString<StickyFooterComponent>(json.toString())
+            "text" -> jsonDecoder.json.decodeFromString<TextComponent>(json.toString())
+            else -> json["fallback"]
+                ?.let { it as? JsonObject }
+                ?.toString()
+                ?.let { jsonDecoder.json.decodeFromString<PaywallComponent>(it) }
+                ?: throw SerializationException("No fallback provided for unknown type: $type")
+        }
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/FallbackComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/FallbackComponentTests.kt
@@ -1,0 +1,178 @@
+package com.revenuecat.purchases.paywalls.components
+
+import com.revenuecat.purchases.common.OfferingParser
+import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import kotlinx.serialization.SerializationException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class FallbackComponentTests {
+
+    @Test
+    fun `Should deserialize the fallback if the type is unknown`() {
+        // Arrange
+        // language=json
+        val serialized = """
+        {
+          "type": "super_new_type",
+          "unknown_property": {
+            "type": "more_unknown"
+          },
+          "fallback": {
+            "components": [
+              {
+                "color": {
+                  "light": {
+                    "type": "alias",
+                    "value": "primary"
+                  }
+                },
+                "components": [],
+                "id": "xmpgCrN9Rb",
+                "name": "Text",
+                "text_lid": "7bkohQjzIE",
+                "type": "text"
+              }
+            ],
+            "id": "WLbwQoNUKF",
+            "name": "Stack",
+            "type": "stack"
+          }
+        }
+        """.trimIndent()
+        val expected = StackComponent(
+            components = listOf(
+                TextComponent(
+                    text = LocalizationKey("7bkohQjzIE"),
+                    color = ColorScheme(light = ColorInfo.Alias("primary"))
+                )
+            )
+        )
+
+        // Act
+        val actual = OfferingParser.json.decodeFromString<PaywallComponent>(serialized)
+
+        // Assert
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `Should fail to deserialize an unknown type without a fallback`() {
+        // Arrange
+        // language=json
+        val serialized = """
+        {
+          "type": "super_new_type",
+          "unknown_property": {
+            "type": "more_unknown"
+          }
+        }
+        """.trimIndent()
+
+        // Act
+        val actual = try{
+            OfferingParser.json.decodeFromString<PaywallComponent>(serialized)
+            error("Should have thrown an exception")
+        } catch (e: SerializationException) {
+            e
+        }
+
+        // Assert
+        assertThat(actual).isInstanceOf(SerializationException::class.java)
+        assertThat(actual.message).isEqualTo("No fallback provided for unknown type: super_new_type")
+    }
+
+    @Test
+    fun `Should fail to deserialize an unknown type with a null fallback`() {
+        // Arrange
+        // language=json
+        val serialized = """
+        {
+          "type": "super_new_type",
+          "unknown_property": {
+            "type": "more_unknown"
+          },
+          "fallback": null
+        }
+        """.trimIndent()
+
+        // Act
+        val actual = try{
+            OfferingParser.json.decodeFromString<PaywallComponent>(serialized)
+            error("Should have thrown an exception")
+        } catch (e: SerializationException) {
+            e
+        }
+
+        // Assert
+        assertThat(actual).isInstanceOf(SerializationException::class.java)
+        assertThat(actual.message).isEqualTo("No fallback provided for unknown type: super_new_type")
+    }
+
+    @Test
+    fun `Should fail to deserialize an unknown fallback`() {
+        // Arrange
+        // language=json
+        val serialized = """
+        {
+          "type": "super_new_type",
+          "unknown_property": {
+            "type": "more_unknown"
+          },
+          "fallback": {
+            "type": "less_new_but_still_new_type",
+            "unknown_property": {
+              "type": "more_unknown"
+            }
+          }
+        }
+        """.trimIndent()
+
+        // Act
+        val actual = try{
+            OfferingParser.json.decodeFromString<PaywallComponent>(serialized)
+            error("Should have thrown an exception")
+        } catch (e: SerializationException) {
+            e
+        }
+
+        // Assert
+        assertThat(actual).isInstanceOf(SerializationException::class.java)
+        assertThat(actual.message).isEqualTo("No fallback provided for unknown type: less_new_but_still_new_type")
+    }
+
+    @Test
+    fun `Should fail to deserialize an invalid fallback`() {
+        // Arrange
+        // language=json
+        val serialized = """
+        {
+          "type": "super_new_type",
+          "unknown_property": {
+            "type": "more_unknown"
+          },
+          "fallback": {
+            "type": "text",
+            "wrong": "property"
+          }
+        }
+        """.trimIndent()
+
+        // Act
+        val actual = try{
+            OfferingParser.json.decodeFromString<PaywallComponent>(serialized)
+            error("Should have thrown an exception")
+        } catch (e: SerializationException) {
+            e
+        }
+
+        // Assert
+        assertThat(actual).isInstanceOf(SerializationException::class.java)
+        assertThat(actual.message).isEqualTo(
+            "Fields [text_lid, color] are required for type with serial name 'text', but they were missing at path: $"
+        )
+    }
+
+}


### PR DESCRIPTION
## Description
As the title says. Adds a custom serializer that looks for a `fallback` key if the `type` is unknown. 

This is the Android equivalent of https://github.com/RevenueCat/purchases-ios/pull/4621.