### PR TITLE
Add support to manage non-Google purchases in Customer Center

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
@@ -5,9 +5,10 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import com.revenuecat.paywallstester.ui.theme.PaywallTesterAndroidTheme
 import com.revenuecat.purchases.Offering
@@ -22,8 +23,8 @@ class MainActivity : ComponentActivity(), PaywallResultHandler {
         super.onCreate(savedInstanceState)
         paywallActivityLauncher = PaywallActivityLauncher(this, this)
         setContent {
-            PaywallTesterAndroidTheme {
-                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+            PaywallTesterAndroidTheme(dynamicColor = false) {
+                Box(modifier = Modifier.fillMaxSize().background(color = MaterialTheme.colorScheme.background)) {
                     PaywallTesterApp()
                 }
             }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -11,11 +11,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/theme/Theme.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/theme/Theme.kt
@@ -19,6 +19,7 @@ private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
     secondary = PurpleGrey80,
     tertiary = Pink80,
+    surface = PurpleGrey80,
 )
 
 private val LightColorScheme = lightColorScheme(

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/theme/Theme.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/theme/Theme.kt
@@ -25,10 +25,10 @@ private val LightColorScheme = lightColorScheme(
     primary = Purple40,
     secondary = PurpleGrey40,
     tertiary = Pink40,
+    surface = PurpleGrey80,
 
     /* Other default colors to override
     background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
     onPrimary = Color.White,
     onSecondary = Color.White,
     onTertiary = Color.White,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -137,6 +137,9 @@ data class CustomerCenterConfigData(
             @SerialName("purchases_not_recovered")
             PURCHASES_NOT_RECOVERED,
 
+            @SerialName("manage_subscription")
+            MANAGE_SUBSCRIPTION,
+
             @SerialName("you_have_promo")
             YOU_HAVE_PROMO,
 
@@ -199,6 +202,7 @@ data class CustomerCenterConfigData(
                     PURCHASES_NOT_RECOVERED ->
                         "We couldn't find any additional purchases under this account. " +
                             "Contact support for assistance if you think this is an error."
+                    MANAGE_SUBSCRIPTION -> "Manage your subscription"
                     YOU_HAVE_PROMO -> "You've been granted a subscription that doesn’t renew"
                     YOU_HAVE_LIFETIME -> "Your active lifetime subscription"
                     WEB_SUBSCRIPTION_MANAGE ->

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetCustomerCenterConfigTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetCustomerCenterConfigTest.kt
@@ -186,6 +186,7 @@ class BackendGetCustomerCenterConfigTest {
                     "You can manage your subscription by visiting your account.",
                 "free" to "Free",
                 "never" to "Never",
+                "manage_subscription" to "Manage your subscription",
             )
         ),
         support = CustomerCenterConfigData.Support(

--- a/purchases/src/test/resources/get_customer_center_config_success.json
+++ b/purchases/src/test/resources/get_customer_center_config_success.json
@@ -58,7 +58,8 @@
         "you_have_lifetime": "Your active lifetime subscription",
         "web_subscription_manage": "You have an active subscription that was created on the web. You can manage your subscription by visiting your account.",
         "free": "Free",
-        "never": "Never"
+        "never": "Never",
+        "manage_subscription": "Manage your subscription"
       }
     },
     "screens":{

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -91,6 +91,7 @@ internal fun InternalCustomerCenter(
 
                 is CustomerCenterAction.DismissRestoreDialog -> viewModel.dismissRestoreDialog()
                 is CustomerCenterAction.ContactSupport -> viewModel.contactSupport(context, action.email)
+                is CustomerCenterAction.OpenURL -> viewModel.openURL(context, action.url)
                 is CustomerCenterAction.NavigationButtonPressed -> {
                     val buttonType = state.navigationButtonType
                     viewModel.onNavigationButtonPressed()
@@ -227,9 +228,8 @@ private fun MainScreen(
                 screen = managementScreen,
                 localization = configuration.localization,
                 purchaseInformation = state.purchaseInformation,
-                onPathButtonPress = { path ->
-                    onAction(CustomerCenterAction.PathButtonPressed(path))
-                },
+                support = configuration.support,
+                onAction = onAction,
             )
         } ?: run {
             // Handle missing management screen
@@ -240,9 +240,8 @@ private fun MainScreen(
             ManageSubscriptionsView(
                 screen = noActiveScreen,
                 localization = configuration.localization,
-                onPathButtonPress = { path ->
-                    onAction(CustomerCenterAction.PathButtonPressed(path))
-                },
+                support = configuration.support,
+                onAction = onAction,
             )
         } ?: run {
             // Fallback with a restore button

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.customercenter
 
+import android.net.Uri
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -219,6 +220,7 @@ private class SubscriptionInformationProvider : PreviewParameterProvider<Purchas
                 ExpirationOrRenewal.Date.DateString("June 1st, 2024"),
             ),
             store = Store.PLAY_STORE,
+            managementURL = Uri.parse("https://play.google.com/store/account/subscriptions"),
         ),
         PurchaseInformation(
             title = "Basic",
@@ -232,6 +234,7 @@ private class SubscriptionInformationProvider : PreviewParameterProvider<Purchas
                 ExpirationOrRenewal.Date.DateString("June 1st, 2024"),
             ),
             store = Store.PLAY_STORE,
+            managementURL = Uri.parse("https://play.google.com/store/account/subscriptions"),
         ),
         PurchaseInformation(
             title = "Basic",
@@ -245,6 +248,7 @@ private class SubscriptionInformationProvider : PreviewParameterProvider<Purchas
                 ExpirationOrRenewal.Date.DateString("June 1st, 2024"),
             ),
             store = Store.PLAY_STORE,
+            managementURL = Uri.parse("https://play.google.com/store/account/subscriptions"),
         ),
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
@@ -206,6 +206,8 @@ private val PaddingHorizontal = 8.dp
 private val PaddingVertical = 8.dp
 private const val SizeIconDp = 22
 
+private const val MANAGEMENT_URL = "https://play.google.com/store/account/subscriptions"
+
 private class SubscriptionInformationProvider : PreviewParameterProvider<PurchaseInformation> {
     override val values: Sequence<PurchaseInformation> = sequenceOf(
         PurchaseInformation(
@@ -220,7 +222,7 @@ private class SubscriptionInformationProvider : PreviewParameterProvider<Purchas
                 ExpirationOrRenewal.Date.DateString("June 1st, 2024"),
             ),
             store = Store.PLAY_STORE,
-            managementURL = Uri.parse("https://play.google.com/store/account/subscriptions"),
+            managementURL = Uri.parse(MANAGEMENT_URL),
         ),
         PurchaseInformation(
             title = "Basic",
@@ -234,7 +236,7 @@ private class SubscriptionInformationProvider : PreviewParameterProvider<Purchas
                 ExpirationOrRenewal.Date.DateString("June 1st, 2024"),
             ),
             store = Store.PLAY_STORE,
-            managementURL = Uri.parse("https://play.google.com/store/account/subscriptions"),
+            managementURL = Uri.parse(MANAGEMENT_URL),
         ),
         PurchaseInformation(
             title = "Basic",
@@ -248,7 +250,7 @@ private class SubscriptionInformationProvider : PreviewParameterProvider<Purchas
                 ExpirationOrRenewal.Date.DateString("June 1st, 2024"),
             ),
             store = Store.PLAY_STORE,
-            managementURL = Uri.parse("https://play.google.com/store/account/subscriptions"),
+            managementURL = Uri.parse(MANAGEMENT_URL),
         ),
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/actions/CustomerCenterAction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/actions/CustomerCenterAction.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.customercenter.actions
 
+import android.net.Uri
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 
@@ -9,5 +10,6 @@ internal sealed class CustomerCenterAction {
     object PerformRestore : CustomerCenterAction()
     object DismissRestoreDialog : CustomerCenterAction()
     data class ContactSupport(val email: String) : CustomerCenterAction()
+    data class OpenURL(val url: Uri) : CustomerCenterAction()
     object NavigationButtonPressed : CustomerCenterAction()
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterConfigTestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterConfigTestData.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.customercenter.data
 
+import android.net.Uri
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
@@ -122,6 +123,7 @@ internal object CustomerCenterConfigTestData {
         ),
         productIdentifier = "monthly_product_id",
         store = Store.PLAY_STORE,
+        managementURL = Uri.parse("https://play.google.com/store/account/subscriptions"),
     )
 
     val purchaseInformationYearlyExpiring = PurchaseInformation(
@@ -136,5 +138,6 @@ internal object CustomerCenterConfigTestData {
         ),
         productIdentifier = "yearly_product_id",
         store = Store.PLAY_STORE,
+        managementURL = Uri.parse("https://play.google.com/store/account/subscriptions"),
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformation.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.customercenter.data
 
+import android.net.Uri
 import com.revenuecat.purchases.EntitlementInfo
 import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.models.StoreProduct
@@ -18,12 +19,14 @@ internal class PurchaseInformation(
     val expirationOrRenewal: ExpirationOrRenewal?,
     val productIdentifier: String,
     val store: Store,
+    val managementURL: Uri?,
 ) {
 
     constructor(
         entitlementInfo: EntitlementInfo? = null,
         subscribedProduct: StoreProduct? = null,
         transaction: TransactionDetails,
+        managementURL: Uri?,
         dateFormatter: DateFormatter = DefaultDateFormatter(),
         locale: Locale,
     ) : this(
@@ -73,6 +76,7 @@ internal class PurchaseInformation(
         } else {
             subscribedProduct?.let { PriceDetails.Paid(it.price.formatted) } ?: PriceDetails.Unknown
         },
+        managementURL = managementURL,
     )
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -4,6 +4,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.revenuecat.purchases.CacheFetchPolicy
@@ -15,11 +16,13 @@ import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.SubscriptionInfo
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.models.Transaction
+import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCenterState
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.FeedbackSurveyData
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.PurchaseInformation
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.dialogs.RestorePurchasesState
 import com.revenuecat.purchases.ui.revenuecatui.data.PurchasesType
+import com.revenuecat.purchases.ui.revenuecatui.extensions.openUriOrElse
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.utils.DateFormatter
 import com.revenuecat.purchases.ui.revenuecatui.utils.DefaultDateFormatter
@@ -293,11 +296,14 @@ internal class CustomerCenterViewModelImpl(
 
     @SuppressWarnings("ForbiddenComment")
     override fun openURL(context: Context, url: Uri) {
-        // TODO: Handle In-App Browser
-        try {
-            context.startActivity(Intent(Intent.ACTION_VIEW, url))
-        } catch (e: ActivityNotFoundException) {
-            Logger.e("Error opening URL", e)
+        context.openUriOrElse(url.toString()) { exception ->
+            val msg = if (exception is ActivityNotFoundException) {
+                context.getString(R.string.no_browser_cannot_open_link)
+            } else {
+                context.getString(R.string.cannot_open_link)
+            }
+            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+            Logger.w(msg)
         }
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -42,6 +42,7 @@ internal interface CustomerCenterViewModel {
     fun contactSupport(context: Context, supportEmail: String)
     fun onNavigationButtonPressed()
     suspend fun loadCustomerCenter()
+    fun openURL(context: Context, url: Uri)
 }
 
 internal sealed class TransactionDetails(
@@ -203,7 +204,13 @@ internal class CustomerCenterViewModelImpl(
                 val entitlement = customerInfo.entitlements.all.values
                     .firstOrNull { it.productIdentifier == activeTransactionDetails.productIdentifier }
 
-                return createPurchaseInformation(activeTransactionDetails, entitlement, dateFormatter, locale)
+                return createPurchaseInformation(
+                    activeTransactionDetails,
+                    entitlement,
+                    customerInfo.managementURL,
+                    dateFormatter,
+                    locale,
+                )
             } else {
                 Logger.w("Could not find subscription information")
             }
@@ -248,6 +255,7 @@ internal class CustomerCenterViewModelImpl(
     private suspend fun createPurchaseInformation(
         transaction: TransactionDetails,
         entitlement: EntitlementInfo?,
+        managementURL: Uri?,
         dateFormatter: DateFormatter,
         locale: Locale,
     ): PurchaseInformation {
@@ -268,6 +276,7 @@ internal class CustomerCenterViewModelImpl(
             entitlementInfo = entitlement,
             subscribedProduct = product,
             transaction = transaction,
+            managementURL = managementURL,
             dateFormatter = dateFormatter,
             locale = locale,
         )
@@ -280,6 +289,16 @@ internal class CustomerCenterViewModelImpl(
             putExtra(Intent.EXTRA_TEXT, "Support request details...")
         }
         context.startActivity(Intent.createChooser(intent, "Contact Support"))
+    }
+
+    @SuppressWarnings("ForbiddenComment")
+    override fun openURL(context: Context, url: Uri) {
+        // TODO: Handle In-App Browser
+        try {
+            context.startActivity(Intent(Intent.ACTION_VIEW, url))
+        } catch (e: ActivityNotFoundException) {
+            Logger.e("Error opening URL", e)
+        }
     }
 
     override fun onNavigationButtonPressed() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -240,48 +239,37 @@ private fun OtherPlatformSubscriptionButtonsView(
     support: CustomerCenterConfigData.Support,
     managementURL: Uri?,
     onAction: (CustomerCenterAction) -> Unit,
-    useOutlinedButton: Boolean = false,
 ) {
-    val buttonModifier = Modifier
-        .fillMaxWidth()
-        .padding(vertical = 4.dp)
-
     Column {
         managementURL?.let {
-            Button(
+            CustomerCenterButton(
                 onClick = { onAction(CustomerCenterAction.OpenURL(it)) },
-                modifier = buttonModifier,
-                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
-            ) {
-                Text(
-                    text = localization.commonLocalizedString(
-                        CustomerCenterConfigData.Localization.CommonLocalizedString.MANAGE_SUBSCRIPTION,
-                    ),
-                    color = if (useOutlinedButton) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.onPrimary
-                    },
-                )
-            }
+                buttonContent = { modifier ->
+                    Text(
+                        text = localization.commonLocalizedString(
+                            CustomerCenterConfigData.Localization.CommonLocalizedString.MANAGE_SUBSCRIPTION,
+                        ),
+                        modifier = modifier,
+                        textAlign = TextAlign.Start,
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                },
+            )
         }
         support.email?.let {
-            Button(
+            CustomerCenterButton(
                 onClick = { onAction(CustomerCenterAction.ContactSupport(it)) },
-                modifier = buttonModifier,
-                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
-            ) {
-                Text(
-                    text = localization.commonLocalizedString(
-                        CustomerCenterConfigData.Localization.CommonLocalizedString.CONTACT_SUPPORT,
-                    ),
-                    color = if (useOutlinedButton) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.onPrimary
-                    },
-                )
-            }
+                buttonContent = { modifier ->
+                    Text(
+                        text = localization.commonLocalizedString(
+                            CustomerCenterConfigData.Localization.CommonLocalizedString.CONTACT_SUPPORT,
+                        ),
+                        modifier = modifier,
+                        textAlign = TextAlign.Start,
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                },
+            )
         }
     }
 }
@@ -293,22 +281,35 @@ private fun ManageSubscriptionButton(
     onButtonPress: (CustomerCenterConfigData.HelpPath) -> Unit,
     useOutlinedButton: Boolean,
 ) {
-    val buttonModifier = Modifier
+    CustomerCenterButton(
+        onClick = { onButtonPress(path) },
+        useOutlinedButton = useOutlinedButton,
+        buttonContent = { modifier ->
+            Text(
+                text = path.title,
+                modifier = modifier,
+                textAlign = TextAlign.Start,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        },
+    )
+}
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@Composable
+private fun CustomerCenterButton(
+    onClick: () -> Unit,
+    useOutlinedButton: Boolean = false,
+    modifier: Modifier = Modifier,
+    buttonContent: @Composable (Modifier) -> Unit,
+) {
+    val buttonModifier = modifier
         .fillMaxWidth()
         .padding(vertical = 4.dp)
 
-    val buttonContent: @Composable (Modifier) -> Unit = { modifier ->
-        Text(
-            text = path.title,
-            modifier = modifier,
-            textAlign = TextAlign.Start,
-            style = MaterialTheme.typography.bodyLarge,
-        )
-    }
-
     if (useOutlinedButton) {
         OutlinedButton(
-            onClick = { onButtonPress(path) },
+            onClick = onClick,
             modifier = buttonModifier,
             colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.primary),
         ) {
@@ -324,7 +325,7 @@ private fun ManageSubscriptionButton(
             ButtonDefaults.TextButtonContentPadding.calculateEndPadding(layoutDirection)
 
         TextButton(
-            onClick = { onButtonPress(path) },
+            onClick = onClick,
             modifier = buttonModifier
                 .heightIn(60.dp)
                 .padding(start = startPadding, end = endPadding),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
@@ -299,8 +299,8 @@ private fun ManageSubscriptionButton(
 @Composable
 private fun CustomerCenterButton(
     onClick: () -> Unit,
-    useOutlinedButton: Boolean = false,
     modifier: Modifier = Modifier,
+    useOutlinedButton: Boolean = false,
     buttonContent: @Composable (Modifier) -> Unit,
 ) {
     val buttonModifier = modifier

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
@@ -104,6 +104,8 @@ private fun ActiveUserManagementView(
 
         SubscriptionDetailsView(details = purchaseInformation, localization = localization)
 
+        Spacer(modifier = Modifier.size(32.dp))
+
         Surface(
             shape = MaterialTheme.shapes.medium,
         ) {
@@ -224,7 +226,7 @@ private fun ManageSubscriptionsButtonsView(
         screen.supportedPaths.forEach { path ->
             ManageSubscriptionButton(
                 path = path,
-                onDetermineFlow = onButtonPress,
+                onButtonPress = onButtonPress,
                 useOutlinedButton = useOutlinedButton,
             )
         }
@@ -288,7 +290,7 @@ private fun OtherPlatformSubscriptionButtonsView(
 @Composable
 private fun ManageSubscriptionButton(
     path: CustomerCenterConfigData.HelpPath,
-    onDetermineFlow: (CustomerCenterConfigData.HelpPath) -> Unit,
+    onButtonPress: (CustomerCenterConfigData.HelpPath) -> Unit,
     useOutlinedButton: Boolean,
 ) {
     val buttonModifier = Modifier
@@ -306,7 +308,7 @@ private fun ManageSubscriptionButton(
 
     if (useOutlinedButton) {
         OutlinedButton(
-            onClick = { onDetermineFlow(path) },
+            onClick = { onButtonPress(path) },
             modifier = buttonModifier,
             colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.primary),
         ) {
@@ -322,7 +324,7 @@ private fun ManageSubscriptionButton(
             ButtonDefaults.TextButtonContentPadding.calculateEndPadding(layoutDirection)
 
         TextButton(
-            onClick = { onDetermineFlow(path) },
+            onClick = { onButtonPress(path) },
             modifier = buttonModifier
                 .heightIn(60.dp)
                 .padding(start = startPadding, end = endPadding),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.customercenter.views
 
+import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -28,20 +30,24 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.SubscriptionDetailsView
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.actions.CustomerCenterAction
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCenterConfigTestData
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.PurchaseInformation
 
+@SuppressWarnings("LongParameterList")
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @Composable
 internal fun ManageSubscriptionsView(
     screen: CustomerCenterConfigData.Screen,
     localization: CustomerCenterConfigData.Localization,
+    support: CustomerCenterConfigData.Support,
     modifier: Modifier = Modifier,
     purchaseInformation: PurchaseInformation? = null,
-    onPathButtonPress: (CustomerCenterConfigData.HelpPath) -> Unit,
+    onAction: (CustomerCenterAction) -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -58,11 +64,14 @@ internal fun ManageSubscriptionsView(
                     screen = screen,
                     localization = localization,
                     purchaseInformation = purchaseInformation,
-                    onDetermineFlow = onPathButtonPress,
+                    support = support,
+                    onAction = onAction,
                 )
             } ?: NoActiveUserManagementView(
                 screen = screen,
-                onDetermineFlow = onPathButtonPress,
+                onPathButtonPress = {
+                    onAction(CustomerCenterAction.PathButtonPressed(it))
+                },
             )
         }
     }
@@ -74,7 +83,8 @@ private fun ActiveUserManagementView(
     screen: CustomerCenterConfigData.Screen,
     localization: CustomerCenterConfigData.Localization,
     purchaseInformation: PurchaseInformation,
-    onDetermineFlow: (CustomerCenterConfigData.HelpPath) -> Unit,
+    support: CustomerCenterConfigData.Support,
+    onAction: (CustomerCenterAction) -> Unit,
 ) {
     Column {
         Text(
@@ -94,12 +104,21 @@ private fun ActiveUserManagementView(
 
         SubscriptionDetailsView(details = purchaseInformation, localization = localization)
 
-        Spacer(modifier = Modifier.size(32.dp))
-
         Surface(
             shape = MaterialTheme.shapes.medium,
         ) {
-            ManageSubscriptionsButtonsView(screen = screen, onDetermineFlow = onDetermineFlow)
+            if (purchaseInformation.store == Store.PLAY_STORE) {
+                ManageSubscriptionsButtonsView(screen = screen, onButtonPress = {
+                    onAction(CustomerCenterAction.PathButtonPressed(it))
+                })
+            } else {
+                OtherPlatformSubscriptionButtonsView(
+                    localization = localization,
+                    support = support,
+                    managementURL = purchaseInformation.managementURL,
+                    onAction = onAction,
+                )
+            }
         }
     }
 }
@@ -108,7 +127,7 @@ private fun ActiveUserManagementView(
 @Composable
 private fun NoActiveUserManagementView(
     screen: CustomerCenterConfigData.Screen,
-    onDetermineFlow: (CustomerCenterConfigData.HelpPath) -> Unit,
+    onPathButtonPress: (CustomerCenterConfigData.HelpPath) -> Unit,
 ) {
     Column {
         CompatibilityContentUnavailableView(
@@ -119,7 +138,7 @@ private fun NoActiveUserManagementView(
 
         ManageSubscriptionsButtonsView(
             screen = screen,
-            onDetermineFlow = onDetermineFlow,
+            onButtonPress = onPathButtonPress,
             useOutlinedButton = true,
         )
     }
@@ -172,8 +191,9 @@ private fun ManageSubscriptionsViewPreview() {
     ManageSubscriptionsView(
         screen = managementScreen,
         localization = testData.localization,
+        support = testData.support,
         purchaseInformation = CustomerCenterConfigTestData.purchaseInformationMonthlyRenewing,
-        onPathButtonPress = {},
+        onAction = {},
     )
 }
 
@@ -187,8 +207,9 @@ private fun NoActiveSubscriptionsViewPreview() {
     ManageSubscriptionsView(
         screen = noActiveScreen,
         localization = testData.localization,
+        support = testData.support,
         purchaseInformation = null,
-        onPathButtonPress = {},
+        onAction = {},
     )
 }
 
@@ -196,16 +217,69 @@ private fun NoActiveSubscriptionsViewPreview() {
 @Composable
 private fun ManageSubscriptionsButtonsView(
     screen: CustomerCenterConfigData.Screen,
-    onDetermineFlow: (CustomerCenterConfigData.HelpPath) -> Unit,
+    onButtonPress: (CustomerCenterConfigData.HelpPath) -> Unit,
     useOutlinedButton: Boolean = false,
 ) {
     Column {
         screen.supportedPaths.forEach { path ->
             ManageSubscriptionButton(
                 path = path,
-                onDetermineFlow = onDetermineFlow,
+                onDetermineFlow = onButtonPress,
                 useOutlinedButton = useOutlinedButton,
             )
+        }
+    }
+}
+
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@Composable
+private fun OtherPlatformSubscriptionButtonsView(
+    localization: CustomerCenterConfigData.Localization,
+    support: CustomerCenterConfigData.Support,
+    managementURL: Uri?,
+    onAction: (CustomerCenterAction) -> Unit,
+    useOutlinedButton: Boolean = false,
+) {
+    val buttonModifier = Modifier
+        .fillMaxWidth()
+        .padding(vertical = 4.dp)
+
+    Column {
+        managementURL?.let {
+            Button(
+                onClick = { onAction(CustomerCenterAction.OpenURL(it)) },
+                modifier = buttonModifier,
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+            ) {
+                Text(
+                    text = localization.commonLocalizedString(
+                        CustomerCenterConfigData.Localization.CommonLocalizedString.MANAGE_SUBSCRIPTION,
+                    ),
+                    color = if (useOutlinedButton) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onPrimary
+                    },
+                )
+            }
+        }
+        support.email?.let {
+            Button(
+                onClick = { onAction(CustomerCenterAction.ContactSupport(it)) },
+                modifier = buttonModifier,
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+            ) {
+                Text(
+                    text = localization.commonLocalizedString(
+                        CustomerCenterConfigData.Localization.CommonLocalizedString.CONTACT_SUPPORT,
+                    ),
+                    color = if (useOutlinedButton) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onPrimary
+                    },
+                )
+            }
         }
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformationTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformationTest.kt
@@ -23,6 +23,8 @@ import java.util.Date
 import java.util.Locale
 import kotlin.time.Duration.Companion.days
 
+private const val MANAGEMENT_URL = "https://play.google.com/store/account/subscriptions"
+
 @RunWith(AndroidJUnit4::class)
 class PurchaseInformationTest {
 
@@ -32,8 +34,6 @@ class PurchaseInformationTest {
 
     private val dateFormatter = mockk<DateFormatter>()
     private val locale = Locale.US
-
-    private const val MANAGEMENT_URL = "https://play.google.com/store/account/subscriptions"
 
     @Test
     fun `test PurchaseInformation with active Google subscription and entitlement`() {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformationTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformationTest.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.customercenter.data
 
+import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.EntitlementInfo
 import com.revenuecat.purchases.OwnershipType
@@ -31,6 +32,8 @@ class PurchaseInformationTest {
 
     private val dateFormatter = mockk<DateFormatter>()
     private val locale = Locale.US
+
+    private const val MANAGEMENT_URL = "https://play.google.com/store/account/subscriptions"
 
     @Test
     fun `test PurchaseInformation with active Google subscription and entitlement`() {
@@ -65,8 +68,9 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = storeProduct,
             transaction = transaction,
+            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
-            locale = locale
+            locale = locale,
         )
 
         assertPurchaseInformation(
@@ -115,6 +119,7 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = storeProduct,
             transaction = transaction,
+            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -165,6 +170,7 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = storeProduct,
             transaction = transaction,
+            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -206,6 +212,7 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
+            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -247,6 +254,7 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
+            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -288,6 +296,7 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
+            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -329,6 +338,7 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
+            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -370,6 +380,7 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
+            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -412,6 +423,7 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
+            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -453,6 +465,7 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
+            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -494,6 +507,7 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
+            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )


### PR DESCRIPTION
If the active purchase is not from Google, we just display a button for Managing subscriptions and another one for contacting support. Although this should probably be configurable from the dashboard, this is the same we do in iOS atm.