### PR TITLE
[Paywalls V2] Badge: Handle main stack border width correctly in overlay and nested badge styles

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -205,7 +205,7 @@ private fun ImageComponentView_Preview(
                 size = parameters.viewSize,
                 fitMode = parameters.fitMode,
                 shape = MaskShape.Rectangle(
-                    corners = CornerRadiuses(
+                    corners = CornerRadiuses.Dp(
                         topLeading = 20.0,
                         topTrailing = 20.0,
                         bottomLeading = 20.0,
@@ -234,7 +234,7 @@ private fun ImageComponentView_Preview_SmallerContainer() {
                 size = Size(width = Fixed(400u), height = Fixed(400u)),
                 fitMode = FitMode.FIT,
                 shape = MaskShape.Rectangle(
-                    corners = CornerRadiuses(
+                    corners = CornerRadiuses.Dp(
                         topLeading = 20.0,
                         topTrailing = 20.0,
                         bottomLeading = 20.0,
@@ -265,7 +265,7 @@ private fun ImageComponentView_Preview_Margin_Padding() {
                 marginValues = PaddingValues(20.dp),
                 fitMode = FitMode.FIT,
                 shape = MaskShape.Rectangle(
-                    corners = CornerRadiuses(
+                    corners = CornerRadiuses.Dp(
                         topLeading = 20.0,
                         topTrailing = 20.0,
                         bottomLeading = 20.0,
@@ -292,7 +292,7 @@ private fun ImageComponentView_Preview_LinearGradient() {
                 size = Size(width = Fixed(400u), height = Fit),
                 fitMode = FitMode.FIT,
                 shape = MaskShape.Rectangle(
-                    corners = CornerRadiuses(
+                    corners = CornerRadiuses.Dp(
                         topLeading = 20.0,
                         topTrailing = 20.0,
                         bottomLeading = 20.0,
@@ -337,7 +337,7 @@ private fun ImageComponentView_Preview_RadialGradient() {
                 size = Size(width = Fixed(400u), height = Fit),
                 fitMode = FitMode.FIT,
                 shape = MaskShape.Rectangle(
-                    corners = CornerRadiuses(
+                    corners = CornerRadiuses.Dp(
                         topLeading = 20.0,
                         topTrailing = 20.0,
                         bottomLeading = 20.0,
@@ -372,7 +372,7 @@ private fun ImageComponentView_Preview_RadialGradient() {
 private class MaskShapeProvider : PreviewParameterProvider<MaskShape> {
     override val values: Sequence<MaskShape> = sequenceOf(
         MaskShape.Rectangle(
-            corners = CornerRadiuses(
+            corners = CornerRadiuses.Dp(
                 topLeading = 30.0,
                 topTrailing = 50.0,
                 bottomLeading = 20.0,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -169,7 +170,8 @@ private fun StackWithOverlaidBadge(
 ) {
     Box(modifier = modifier) {
         MainStackComponent(stackState, state, clickHandler)
-        OverlaidBadge(badgeStack, state, alignment)
+        val mainStackBorderWidth = with(LocalDensity.current) { stackState.border?.width?.dp?.toPx() }
+        OverlaidBadge(badgeStack, state, alignment, mainStackBorderWidth)
     }
 }
 
@@ -405,6 +407,7 @@ private fun BoxScope.OverlaidBadge(
     badgeStack: StackComponentStyle,
     state: PaywallState.Loaded.Components,
     alignment: TwoDimensionalAlignment,
+    mainStackBorderWidth: Float?,
     modifier: Modifier = Modifier,
 ) {
     StackComponentView(
@@ -418,7 +421,7 @@ private fun BoxScope.OverlaidBadge(
                 layout(placeable.width, placeable.height) {
                     placeable.placeRelative(
                         x = 0,
-                        y = getOverlaidBadgeOffsetY(placeable.height, alignment),
+                        y = getOverlaidBadgeOffsetY(placeable.height, alignment, mainStackBorderWidth ?: 0f),
                     )
                 }
             },
@@ -499,7 +502,10 @@ private fun MainStackComponent(
 
     val innerShapeModifier = remember(stackState, borderStyle) {
         Modifier
-            .applyIfNotNull(borderStyle) { border(it, composeShape) }
+            .applyIfNotNull(borderStyle) {
+                border(it, composeShape)
+                    .padding(it.width)
+            }
             .padding(stackState.padding)
             .padding(stackState.dimension, stackState.spacing)
     }
@@ -574,21 +580,24 @@ private fun Modifier.padding(dimension: Dimension, spacing: Dp): Modifier =
         is Dimension.ZLayer -> this
     }
 
-private fun getOverlaidBadgeOffsetY(height: Int, alignment: TwoDimensionalAlignment) =
-    when (alignment) {
-        TwoDimensionalAlignment.CENTER,
-        TwoDimensionalAlignment.LEADING,
-        TwoDimensionalAlignment.TRAILING,
-        -> 0
-        TwoDimensionalAlignment.TOP,
-        TwoDimensionalAlignment.TOP_LEADING,
-        TwoDimensionalAlignment.TOP_TRAILING,
-        -> (-(height.toFloat() / 2)).roundToInt()
-        TwoDimensionalAlignment.BOTTOM,
-        TwoDimensionalAlignment.BOTTOM_LEADING,
-        TwoDimensionalAlignment.BOTTOM_TRAILING,
-        -> (height.toFloat() / 2).roundToInt()
-    }
+private fun getOverlaidBadgeOffsetY(
+    height: Int,
+    alignment: TwoDimensionalAlignment,
+    mainStackBorderWidth: Float = 0f,
+) = when (alignment) {
+    TwoDimensionalAlignment.CENTER,
+    TwoDimensionalAlignment.LEADING,
+    TwoDimensionalAlignment.TRAILING,
+    -> 0
+    TwoDimensionalAlignment.TOP,
+    TwoDimensionalAlignment.TOP_LEADING,
+    TwoDimensionalAlignment.TOP_TRAILING,
+    -> (-((height.toFloat() - mainStackBorderWidth) / 2)).roundToInt()
+    TwoDimensionalAlignment.BOTTOM,
+    TwoDimensionalAlignment.BOTTOM_LEADING,
+    TwoDimensionalAlignment.BOTTOM_TRAILING,
+    -> ((height.toFloat() - mainStackBorderWidth) / 2).roundToInt()
+}
 
 /**
  * Make this CornerSize absolute, based on the provided [placeable]. This is useful for turning relative
@@ -692,7 +701,7 @@ private fun StackComponentView_Preview_Overlay_Badge(
                 padding = PaddingValues(all = 12.dp),
                 margin = PaddingValues(all = 0.dp),
                 shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
-                border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
+                border = Border(width = 10.0, color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))),
                 shadow = null,
                 badge = previewBadge(Badge.Style.Overlay, alignment, badgeShape),
                 rcPackage = null,
@@ -813,7 +822,7 @@ private fun StackComponentView_Preview_Nested_Badge(
                 padding = PaddingValues(all = 0.dp),
                 margin = PaddingValues(all = 0.dp),
                 shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
-                border = Border(width = 2.0, color = ColorScheme(light = ColorInfo.Hex(Color.Yellow.toArgb()))),
+                border = Border(width = 10.0, color = ColorScheme(light = ColorInfo.Hex(Color.Yellow.toArgb()))),
                 shadow = null,
                 badge = previewBadge(Badge.Style.Nested, alignment, badgeShape),
                 rcPackage = null,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -170,8 +170,10 @@ private fun StackWithOverlaidBadge(
 ) {
     Box(modifier = modifier) {
         MainStackComponent(stackState, state, clickHandler)
-        val mainStackBorderWidth = with(LocalDensity.current) { stackState.border?.width?.dp?.toPx() }
-        OverlaidBadge(badgeStack, state, alignment, mainStackBorderWidth)
+        val mainStackBorderWidthPx = with(LocalDensity.current) {
+            stackState.border?.width?.dp?.toPx()
+        }
+        OverlaidBadge(badgeStack, state, alignment, mainStackBorderWidthPx)
     }
 }
 
@@ -407,7 +409,7 @@ private fun BoxScope.OverlaidBadge(
     badgeStack: StackComponentStyle,
     state: PaywallState.Loaded.Components,
     alignment: TwoDimensionalAlignment,
-    mainStackBorderWidth: Float?,
+    mainStackBorderWidthPx: Float?,
     modifier: Modifier = Modifier,
 ) {
     StackComponentView(
@@ -421,7 +423,7 @@ private fun BoxScope.OverlaidBadge(
                 layout(placeable.width, placeable.height) {
                     placeable.placeRelative(
                         x = 0,
-                        y = getOverlaidBadgeOffsetY(placeable.height, alignment, mainStackBorderWidth ?: 0f),
+                        y = getOverlaidBadgeOffsetY(placeable.height, alignment, mainStackBorderWidthPx ?: 0f),
                     )
                 }
             },
@@ -583,7 +585,7 @@ private fun Modifier.padding(dimension: Dimension, spacing: Dp): Modifier =
 private fun getOverlaidBadgeOffsetY(
     height: Int,
     alignment: TwoDimensionalAlignment,
-    mainStackBorderWidth: Float = 0f,
+    mainStackBorderWidthPx: Float = 0f,
 ) = when (alignment) {
     TwoDimensionalAlignment.CENTER,
     TwoDimensionalAlignment.LEADING,
@@ -592,11 +594,11 @@ private fun getOverlaidBadgeOffsetY(
     TwoDimensionalAlignment.TOP,
     TwoDimensionalAlignment.TOP_LEADING,
     TwoDimensionalAlignment.TOP_TRAILING,
-    -> (-((height.toFloat() - mainStackBorderWidth) / 2)).roundToInt()
+    -> (-((height.toFloat() - mainStackBorderWidthPx) / 2)).roundToInt()
     TwoDimensionalAlignment.BOTTOM,
     TwoDimensionalAlignment.BOTTOM_LEADING,
     TwoDimensionalAlignment.BOTTOM_TRAILING,
-    -> ((height.toFloat() - mainStackBorderWidth) / 2).roundToInt()
+    -> ((height.toFloat() - mainStackBorderWidthPx) / 2).roundToInt()
 }
 
 /**
@@ -721,14 +723,7 @@ private fun StackComponentView_Preview_EdgeToEdge_Badge(
     Box(
         modifier = Modifier.padding(all = 32.dp),
     ) {
-        val badgeShape = Shape.Rectangle(
-            corners = CornerRadiuses.Dp(
-                topLeading = 20.0,
-                topTrailing = 20.0,
-                bottomLeading = 20.0,
-                bottomTrailing = 20.0,
-            ),
-        )
+        val badgeShape = Shape.Pill
         StackComponentView(
             style = StackComponentStyle(
                 children = previewChildren(),


### PR DESCRIPTION
### Description
- In Overlay style badges, the badge will now be placed in the middle of the border if any.
- In Nested style badges, we fix an issue where the border width wasn't added as padding, so the border was drawn on top of the stack content. This also means the badge is now placed inside the border.

<img width="407" alt="image" src="https://github.com/user-attachments/assets/bcb65c06-aae9-40a0-9608-04c6fe8dcda0" />

<img width="438" alt="image" src="https://github.com/user-attachments/assets/3f9780be-e759-4bb4-a0fd-6e5c7d8a4758" />
