### PR TITLE
Some Material 3 updates to the `ManageSubscriptionsView`

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -19,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -231,9 +234,19 @@ private fun ManageSubscriptionButton(
             buttonContent(Modifier)
         }
     } else {
+        val layoutDirection = LocalLayoutDirection.current
+        val totalHorizontalButtonPadding = 16.dp
+
+        val startPadding = totalHorizontalButtonPadding -
+            ButtonDefaults.TextButtonContentPadding.calculateStartPadding(layoutDirection)
+        val endPadding = totalHorizontalButtonPadding -
+            ButtonDefaults.TextButtonContentPadding.calculateEndPadding(layoutDirection)
+
         TextButton(
             onClick = { onDetermineFlow(path) },
-            modifier = buttonModifier.heightIn(60.dp),
+            modifier = buttonModifier
+                .heightIn(60.dp)
+                .padding(start = startPadding, end = endPadding),
             // It's a rectangle so it gets clipped by the parent Surface.
             shape = RectangleShape,
             colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onSurface),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
@@ -74,7 +74,6 @@ private fun ActiveUserManagementView(
         Text(
             text = screen.title,
             style = MaterialTheme.typography.titleLarge,
-            // fontWeight = FontWeight.Bold,
             modifier = Modifier.padding(end = 16.dp, top = 32.dp),
         )
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
@@ -216,7 +216,6 @@ private fun ManageSubscriptionButton(
     val buttonContent: @Composable (Modifier) -> Unit = { modifier ->
         Text(
             text = path.title,
-            color = MaterialTheme.colorScheme.primary,
             modifier = modifier,
             textAlign = TextAlign.Start,
             style = MaterialTheme.typography.bodyLarge,
@@ -227,6 +226,7 @@ private fun ManageSubscriptionButton(
         OutlinedButton(
             onClick = { onDetermineFlow(path) },
             modifier = buttonModifier,
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.primary),
         ) {
             buttonContent(Modifier)
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
@@ -3,23 +3,25 @@ package com.revenuecat.purchases.ui.revenuecatui.customercenter.views
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
@@ -71,36 +73,28 @@ private fun ActiveUserManagementView(
     Column {
         Text(
             text = screen.title,
-            style = MaterialTheme.typography.headlineMedium,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(16.dp),
+            style = MaterialTheme.typography.titleLarge,
+            // fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(end = 16.dp, top = 32.dp),
         )
 
         screen.subtitle?.let { subtitle ->
+            Spacer(modifier = Modifier.size(4.dp))
             Text(
                 text = subtitle,
                 style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.padding(bottom = 24.dp),
             )
         }
+        Spacer(modifier = Modifier.size(32.dp))
 
-        LazyColumn {
-            item {
-                Card(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 16.dp),
-                    elevation = CardDefaults.cardElevation(
-                        defaultElevation = 4.dp,
-                    ),
-                ) {
-                    SubscriptionDetailsView(details = purchaseInformation)
-                }
-            }
+        SubscriptionDetailsView(details = purchaseInformation)
 
-            item {
-                ManageSubscriptionsButtonsView(screen = screen, onDetermineFlow = onDetermineFlow)
-            }
+        Spacer(modifier = Modifier.size(32.dp))
+
+        Surface(
+            shape = MaterialTheme.shapes.medium,
+        ) {
+            ManageSubscriptionsButtonsView(screen = screen, onDetermineFlow = onDetermineFlow)
         }
     }
 }
@@ -220,10 +214,13 @@ private fun ManageSubscriptionButton(
         .fillMaxWidth()
         .padding(vertical = 4.dp)
 
-    val buttonContent: @Composable () -> Unit = {
+    val buttonContent: @Composable (Modifier) -> Unit = { modifier ->
         Text(
             text = path.title,
-            color = if (useOutlinedButton) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onPrimary,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = modifier,
+            textAlign = TextAlign.Start,
+            style = MaterialTheme.typography.bodyLarge,
         )
     }
 
@@ -232,15 +229,17 @@ private fun ManageSubscriptionButton(
             onClick = { onDetermineFlow(path) },
             modifier = buttonModifier,
         ) {
-            buttonContent()
+            buttonContent(Modifier)
         }
     } else {
-        Button(
+        TextButton(
             onClick = { onDetermineFlow(path) },
-            modifier = buttonModifier,
-            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
+            modifier = buttonModifier.heightIn(60.dp),
+            // It's a rectangle so it gets clipped by the parent Surface.
+            shape = RectangleShape,
+            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onSurface),
         ) {
-            buttonContent()
+            buttonContent(Modifier.fillMaxWidth())
         }
     }
 }


### PR DESCRIPTION
## Description
As the title says. These are just some suggestions. Feel free to ignore.

- Uses `TextButton`s instead of primary `Button`s, and places them on a `Surface`. (The latter is more of an artistic choice haha.)
- Uses the `titleLarge` style for the screen title, following the [guidelines](https://m3.material.io/styles/typography/applying-type#e9e0cea3-10cb-405d-98a9-cf6a90758967). 
- Updates spacing. 
- Removes the shadow from the top card, as elevation is not often shown with shadows in Material 3. 

| Before | After |
|-------|------|
|  ![image](https://github.com/user-attachments/assets/a58d6f6e-0503-432f-b454-55a725f4f547)  | ![image](https://github.com/user-attachments/assets/77f9c8b0-fb61-4f33-9480-8a38555a1255) |