### PR TITLE
[Paywalls V2] Implements color aliases for `StackComponent`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/ColorInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/properties/ColorInfo.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.paywalls.components.properties
 
 import androidx.annotation.ColorInt
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.parseRGBAColor
 import dev.drewhamilton.poko.Poko
@@ -29,7 +30,7 @@ sealed interface ColorInfo {
     @Poko
     @Serializable
     @SerialName("alias")
-    class Alias(@get:JvmSynthetic val value: String) : ColorInfo
+    class Alias(@get:JvmSynthetic val value: ColorAlias) : ColorInfo
 
     sealed interface Gradient : ColorInfo {
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
@@ -64,7 +65,7 @@ internal class ButtonComponentTests {
                                 components = listOf(
                                     TextComponent(
                                         text = LocalizationKey("7bkohQjzIE"),
-                                        color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                        color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                     )
                                 ),
                             )
@@ -106,7 +107,7 @@ internal class ButtonComponentTests {
                                 components = listOf(
                                     TextComponent(
                                         text = LocalizationKey("7bkohQjzIE"),
-                                        color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                        color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                     )
                                 ),
                             )
@@ -151,7 +152,7 @@ internal class ButtonComponentTests {
                                 components = listOf(
                                     TextComponent(
                                         text = LocalizationKey("7bkohQjzIE"),
-                                        color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                        color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                     )
                                 ),
                             )
@@ -203,7 +204,7 @@ internal class ButtonComponentTests {
                                 components = listOf(
                                     TextComponent(
                                         text = LocalizationKey("7bkohQjzIE"),
-                                        color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                        color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                     )
                                 ),
                             )
@@ -255,7 +256,7 @@ internal class ButtonComponentTests {
                                 components = listOf(
                                     TextComponent(
                                         text = LocalizationKey("7bkohQjzIE"),
-                                        color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                        color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                     )
                                 ),
                             )
@@ -307,7 +308,7 @@ internal class ButtonComponentTests {
                                 components = listOf(
                                     TextComponent(
                                         text = LocalizationKey("7bkohQjzIE"),
-                                        color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                        color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                     )
                                 ),
                             )

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/FallbackComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/FallbackComponentTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
@@ -46,7 +47,7 @@ internal class FallbackComponentTests {
             components = listOf(
                 TextComponent(
                     text = LocalizationKey("7bkohQjzIE"),
-                    color = ColorScheme(light = ColorInfo.Alias("primary"))
+                    color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                 )
             )
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/IconComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/IconComponentTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.paywalls.components.properties.Border
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
@@ -123,7 +124,7 @@ internal class IconComponentTests {
                                 width = SizeConstraint.Fixed(200u),
                             ),
                             color = ColorScheme(
-                                light = ColorInfo.Alias("primary")
+                                light = ColorInfo.Alias(ColorAlias("primary"))
                             ),
                             padding = Padding(
                                 bottom = 16.0,
@@ -139,7 +140,7 @@ internal class IconComponentTests {
                             ),
                             iconBackground = IconComponent.IconBackground(
                                 color = ColorScheme(
-                                    light = ColorInfo.Alias("secondary")
+                                    light = ColorInfo.Alias(ColorAlias("secondary"))
                                 ),
                                 shape = MaskShape.Rectangle(
                                     corners = CornerRadiuses.Dp(
@@ -151,7 +152,7 @@ internal class IconComponentTests {
                                 ),
                                 shadow = Shadow(
                                     color = ColorScheme(
-                                        light = ColorInfo.Alias("tertiary")
+                                        light = ColorInfo.Alias(ColorAlias("tertiary"))
                                     ),
                                     radius = 20.1,
                                     x = 23.6,
@@ -159,7 +160,7 @@ internal class IconComponentTests {
                                 ),
                                 border = Border(
                                     color = ColorScheme(
-                                        light = ColorInfo.Alias("secondary")
+                                        light = ColorInfo.Alias(ColorAlias("secondary"))
                                     ),
                                     width = 123.0,
                                 ),
@@ -320,7 +321,7 @@ internal class IconComponentTests {
                                 width = SizeConstraint.Fixed(200u),
                             ),
                             color = ColorScheme(
-                                light = ColorInfo.Alias("primary")
+                                light = ColorInfo.Alias(ColorAlias("primary"))
                             ),
                             padding = Padding(
                                 bottom = 16.0,
@@ -336,7 +337,7 @@ internal class IconComponentTests {
                             ),
                             iconBackground = IconComponent.IconBackground(
                                 color = ColorScheme(
-                                    light = ColorInfo.Alias("secondary")
+                                    light = ColorInfo.Alias(ColorAlias("secondary"))
                                 ),
                                 shape = MaskShape.Rectangle(
                                     corners = CornerRadiuses.Dp(
@@ -348,7 +349,7 @@ internal class IconComponentTests {
                                 ),
                                 shadow = Shadow(
                                     color = ColorScheme(
-                                        light = ColorInfo.Alias("tertiary")
+                                        light = ColorInfo.Alias(ColorAlias("tertiary"))
                                     ),
                                     radius = 20.1,
                                     x = 23.6,
@@ -356,7 +357,7 @@ internal class IconComponentTests {
                                 ),
                                 border = Border(
                                     color = ColorScheme(
-                                        light = ColorInfo.Alias("secondary")
+                                        light = ColorInfo.Alias(ColorAlias("secondary"))
                                     ),
                                     width = 123.0,
                                 ),

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ImageComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ImageComponentTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
@@ -111,7 +112,7 @@ internal class ImageComponentTests {
                                 )
                             ),
                             colorOverlay = ColorScheme(
-                                light = ColorInfo.Alias("primary")
+                                light = ColorInfo.Alias(ColorAlias("primary"))
                             ),
                             fitMode = FitMode.FILL,
                         )
@@ -259,7 +260,7 @@ internal class ImageComponentTests {
                                     bottomTrailing = 2.0,
                                 )
                             ),
-                            colorOverlay = ColorScheme(light = ColorInfo.Alias("primary"))
+                            colorOverlay = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                         )
                     )
                 ),

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/PackageComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/PackageComponentTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
@@ -59,7 +60,7 @@ internal class PackageComponentTests(@Suppress("UNUSED_PARAMETER") name: String,
                             components = listOf(
                                 TextComponent(
                                     text = LocalizationKey("7bkohQjzIE"),
-                                    color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                    color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                 )
                             ),
                         )

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/PurchaseButtonComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/PurchaseButtonComponentTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
@@ -58,7 +59,7 @@ internal class PurchaseButtonComponentTests(
                             components = listOf(
                                 TextComponent(
                                     text = LocalizationKey("7bkohQjzIE"),
-                                    color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                    color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                 )
                             ),
                         )

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/StackComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/StackComponentTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.paywalls.components.properties.Border
@@ -129,7 +130,7 @@ internal class StackComponentTests {
                             components = listOf(
                                 TextComponent(
                                     text = LocalizationKey("7bkohQjzIE"),
-                                    color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                    color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                 )
                             ),
                             dimension = Dimension.Vertical(
@@ -138,13 +139,13 @@ internal class StackComponentTests {
                             ),
                             size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit),
                             spacing = 8f,
-                            backgroundColor = ColorScheme(light = ColorInfo.Alias("secondary")),
+                            backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("secondary"))),
                             padding = Padding(top = 12.0, leading = 14.0, bottom = 16.0, trailing = 10.0),
                             margin = Padding(top = 14.0, leading = 12.0, bottom = 10.0, trailing = 16.0),
                             shape = Shape.Pill,
-                            border = Border(color = ColorScheme(light = ColorInfo.Alias("primary")), width = 123.0),
+                            border = Border(color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary"))), width = 123.0),
                             shadow = Shadow(
-                                color = ColorScheme(light = ColorInfo.Alias("tertiary")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("tertiary"))),
                                 radius = 20.1,
                                 x = 23.6,
                                 y = 45.2
@@ -181,7 +182,7 @@ internal class StackComponentTests {
                             components = listOf(
                                 TextComponent(
                                     text = LocalizationKey("7bkohQjzIE"),
-                                    color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                    color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                 )
                             ),
                         )
@@ -217,7 +218,7 @@ internal class StackComponentTests {
                             components = listOf(
                                 TextComponent(
                                     text = LocalizationKey("7bkohQjzIE"),
-                                    color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                    color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                 )
                             ),
                             margin = Padding.zero,
@@ -338,16 +339,16 @@ internal class StackComponentTests {
                             ),
                             size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit),
                             spacing = 8f,
-                            backgroundColor = ColorScheme(light = ColorInfo.Alias("primary")),
+                            backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary"))),
                             padding = Padding(top = 1.0, bottom = 2.0, leading = 3.0, trailing = 4.0),
                             margin = Padding(top = 4.0, bottom = 3.0, leading = 2.0, trailing = 1.0),
                             shape = Shape.Pill,
                             border = Border(
-                                color = ColorScheme(light = ColorInfo.Alias("secondary")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("secondary"))),
                                 width = 23.0
                             ),
                             shadow = Shadow(
-                                color = ColorScheme(light = ColorInfo.Alias("tertiary")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("tertiary"))),
                                 radius = 20.1,
                                 x = 23.6,
                                 y = 45.2

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/StickyFooterComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/StickyFooterComponentTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
@@ -58,7 +59,7 @@ internal class StickyFooterComponentTests(
                             components = listOf(
                                 TextComponent(
                                     text = LocalizationKey("7bkohQjzIE"),
-                                    color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                    color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                 )
                             ),
                         )

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/BackgroundTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/BackgroundTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components.common
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
@@ -44,7 +45,7 @@ internal class BackgroundTests(@Suppress("UNUSED_PARAMETER") name: String, priva
                         """.trimIndent(),
                     expected = Background.Color(
                         value = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         )
                     ),
                 ),

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentsConfigTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentsConfigTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components.common
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.StickyFooterComponent
@@ -60,13 +61,13 @@ internal class ComponentsConfigTests {
                         components = listOf(
                             TextComponent(
                                 text = LocalizationKey("7bkohQjzIE"),
-                                color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                             )
                         ),
                     ),
                     background = Background.Color(
                         value = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         )
                     )
                 )
@@ -158,13 +159,13 @@ internal class ComponentsConfigTests {
                                 components = listOf(
                                     TextComponent(
                                         text = LocalizationKey("7bkohQjzIE"),
-                                        color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                        color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                     )
                                 ),
                             ),
                             background = Background.Color(
                                 value = ColorScheme(
-                                    light = ColorInfo.Alias("primary")
+                                    light = ColorInfo.Alias(ColorAlias("primary"))
                                 )
                             ),
                             stickyFooter = StickyFooterComponent(
@@ -172,7 +173,7 @@ internal class ComponentsConfigTests {
                                     components = listOf(
                                         TextComponent(
                                             text = LocalizationKey("7bkohQjzIE"),
-                                            color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                            color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                         )
                                     ),
                                 )
@@ -219,13 +220,13 @@ internal class ComponentsConfigTests {
                                 components = listOf(
                                     TextComponent(
                                         text = LocalizationKey("7bkohQjzIE"),
-                                        color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                        color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                     )
                                 ),
                             ),
                             background = Background.Color(
                                 value = ColorScheme(
-                                    light = ColorInfo.Alias("primary")
+                                    light = ColorInfo.Alias(ColorAlias("primary"))
                                 )
                             )
                         )
@@ -271,13 +272,13 @@ internal class ComponentsConfigTests {
                                 components = listOf(
                                     TextComponent(
                                         text = LocalizationKey("7bkohQjzIE"),
-                                        color = ColorScheme(light = ColorInfo.Alias("primary"))
+                                        color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary")))
                                     )
                                 ),
                             ),
                             background = Background.Color(
                                 value = ColorScheme(
-                                    light = ColorInfo.Alias("primary")
+                                    light = ColorInfo.Alias(ColorAlias("primary"))
                                 )
                             )
                         )

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/PaywallComponentsDataTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/PaywallComponentsDataTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components.common
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.properties.Badge
@@ -89,7 +90,7 @@ internal class PaywallComponentsDataTests(
                                 ),
                                 background = Background.Color(
                                     value = ColorScheme(
-                                        light = ColorInfo.Alias("primary")
+                                        light = ColorInfo.Alias(ColorAlias("primary"))
                                     )
                                 )
                             )
@@ -147,7 +148,7 @@ internal class PaywallComponentsDataTests(
                                 ),
                                 background = Background.Color(
                                     value = ColorScheme(
-                                        light = ColorInfo.Alias("primary")
+                                        light = ColorInfo.Alias(ColorAlias("primary"))
                                     )
                                 )
                             )
@@ -219,7 +220,7 @@ internal class PaywallComponentsDataTests(
                                 ),
                                 background = Background.Color(
                                     value = ColorScheme(
-                                        light = ColorInfo.Alias("primary")
+                                        light = ColorInfo.Alias(ColorAlias("primary"))
                                     )
                                 )
                             )

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/BorderTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/BorderTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components.properties
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import org.intellij.lang.annotations.Language
 import org.junit.Test
@@ -36,7 +37,7 @@ internal class BorderTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         }
                         """.trimIndent(),
                     expected = Border(
-                        color = ColorScheme(light = ColorInfo.Alias("primary")),
+                        color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary"))),
                         width = 123.0
                     )
                 )
@@ -56,7 +57,7 @@ internal class BorderTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         }
                         """.trimIndent(),
                     expected = Border(
-                        color = ColorScheme(light = ColorInfo.Alias("primary")),
+                        color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary"))),
                         width = 456.34
                     )
                 )

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/ColorInfoTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/ColorInfoTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components.properties
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.paywalls.colorInt
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo.Gradient.Point
@@ -65,7 +66,9 @@ internal class ColorInfoTests {
                             }
                         """.trimIndent(),
                         expected = ColorInfo.Alias(
-                            value = "primary"
+                            ColorAlias(
+                                value = "primary"
+                            )
                         )
                     )
                 ),
@@ -196,9 +199,9 @@ internal class ColorInfoTests {
                         """.trimIndent(),
                         expected = ColorScheme(
                             light = ColorInfo.Hex(
-                                value = colorInt(alpha = 0xde, red = 0xf4, green = 0x03, blue = 0xa1))
-                            ,
-                            dark = ColorInfo.Alias(value = "primary"),
+                                value = colorInt(alpha = 0xde, red = 0xf4, green = 0x03, blue = 0xa1)
+                            ),
+                            dark = ColorInfo.Alias(ColorAlias(value = "primary")),
                         )
                     )
                 ),
@@ -214,7 +217,7 @@ internal class ColorInfoTests {
                             }
                         """.trimIndent(),
                         expected = ColorScheme(
-                            light = ColorInfo.Alias(value = "primary"),
+                            light = ColorInfo.Alias(ColorAlias(value = "primary")),
                         )
                     )
                 ),

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/ShadowTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/properties/ShadowTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.components.properties
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.common.OfferingParser
 import org.intellij.lang.annotations.Language
 import org.junit.Test
@@ -39,7 +40,7 @@ internal class ShadowTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         """.trimIndent(),
                     expected = Shadow(
                         color = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         ),
                         radius = 0.0,
                         x = 0.0,
@@ -65,7 +66,7 @@ internal class ShadowTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         """.trimIndent(),
                     expected = Shadow(
                         color = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         ),
                         radius = 10.0,
                         x = 20.0,
@@ -91,7 +92,7 @@ internal class ShadowTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         """.trimIndent(),
                     expected = Shadow(
                         color = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         ),
                         radius = 10.0,
                         x = -21.0,
@@ -117,7 +118,7 @@ internal class ShadowTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         """.trimIndent(),
                     expected = Shadow(
                         color = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         ),
                         radius = 0.0,
                         x = 0.0,
@@ -143,7 +144,7 @@ internal class ShadowTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         """.trimIndent(),
                     expected = Shadow(
                         color = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         ),
                         radius = 10.4,
                         x = 20.3,
@@ -169,7 +170,7 @@ internal class ShadowTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         """.trimIndent(),
                     expected = Shadow(
                         color = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         ),
                         radius = 10.1,
                         x = -21.2,
@@ -195,7 +196,7 @@ internal class ShadowTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         """.trimIndent(),
                     expected = Shadow(
                         color = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         ),
                         radius = 0.0,
                         x = 0.0,
@@ -221,7 +222,7 @@ internal class ShadowTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         """.trimIndent(),
                     expected = Shadow(
                         color = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         ),
                         radius = 10.0,
                         x = 20.0,
@@ -247,7 +248,7 @@ internal class ShadowTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         """.trimIndent(),
                     expected = Shadow(
                         color = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         ),
                         radius = 10.0,
                         x = -21.0,
@@ -273,7 +274,7 @@ internal class ShadowTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         """.trimIndent(),
                     expected = Shadow(
                         color = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         ),
                         radius = 0.0,
                         x = 0.0,
@@ -299,7 +300,7 @@ internal class ShadowTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         """.trimIndent(),
                     expected = Shadow(
                         color = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         ),
                         radius = 10.4,
                         x = 20.3,
@@ -325,7 +326,7 @@ internal class ShadowTests(@Suppress("UNUSED_PARAMETER") name: String, private v
                         """.trimIndent(),
                     expected = Shadow(
                         color = ColorScheme(
-                            light = ColorInfo.Alias("primary")
+                            light = ColorInfo.Alias(ColorAlias("primary"))
                         ),
                         radius = 10.1,
                         x = -21.2,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedStackPartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedStackPartial.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases.ui.revenuecatui.components
 
 import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.paywalls.components.PartialStackComponent
-import com.revenuecat.purchases.paywalls.components.PartialTextComponent
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.toColorStyles
@@ -21,9 +20,9 @@ internal class PresentedStackPartial(
 
     companion object {
         /**
-         * Creates a [LocalizedTextPartial] from the provided [PartialTextComponent] and [LocalizationDictionary]. If
-         * [PartialTextComponent.text] is non null, it should exist in the [LocalizationDictionary]. If it doesn't,
-         * this function will return a failure result.
+         * Creates a [PresentedStackPartial] from the provided [PartialStackComponent] and [using] map. If
+         * [PartialStackComponent.backgroundColor] is non null and contains a color alias, it should exist in the
+         * [using] map. If it doesn't, this function will return a failure result.
          */
         @JvmSynthetic
         operator fun invoke(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedStackPartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedStackPartial.kt
@@ -1,16 +1,51 @@
 package com.revenuecat.purchases.ui.revenuecatui.components
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.paywalls.components.PartialStackComponent
+import com.revenuecat.purchases.paywalls.components.PartialTextComponent
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.toColorStyles
+import com.revenuecat.purchases.ui.revenuecatui.errors.PaywallValidationError
+import com.revenuecat.purchases.ui.revenuecatui.helpers.NonEmptyList
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Result
+import com.revenuecat.purchases.ui.revenuecatui.helpers.map
+import com.revenuecat.purchases.ui.revenuecatui.helpers.orSuccessfullyNull
 import dev.drewhamilton.poko.Poko
 
 @Poko
 internal class PresentedStackPartial(
+    @get:JvmSynthetic val backgroundColorStyles: ColorStyles?,
     @get:JvmSynthetic val partial: PartialStackComponent,
 ) : PresentedPartial<PresentedStackPartial> {
+
+    companion object {
+        /**
+         * Creates a [LocalizedTextPartial] from the provided [PartialTextComponent] and [LocalizationDictionary]. If
+         * [PartialTextComponent.text] is non null, it should exist in the [LocalizationDictionary]. If it doesn't,
+         * this function will return a failure result.
+         */
+        @JvmSynthetic
+        operator fun invoke(
+            from: PartialStackComponent,
+            using: Map<ColorAlias, ColorScheme>,
+        ): Result<PresentedStackPartial, NonEmptyList<PaywallValidationError>> =
+            from.backgroundColor
+                ?.toColorStyles(aliases = using)
+                .orSuccessfullyNull()
+                .map { backgroundColorStyles ->
+                    PresentedStackPartial(
+                        backgroundColorStyles = backgroundColorStyles,
+                        partial = from,
+                    )
+                }
+    }
+
     override fun combine(with: PresentedStackPartial?): PresentedStackPartial {
         val otherPartial = with?.partial
 
         return PresentedStackPartial(
+            backgroundColorStyles = with?.backgroundColorStyles ?: backgroundColorStyles,
             partial = PartialStackComponent(
                 visible = otherPartial?.visible ?: partial.visible,
                 dimension = otherPartial?.dimension ?: partial.dimension,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedStackPartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedStackPartial.kt
@@ -20,17 +20,17 @@ internal class PresentedStackPartial(
 
     companion object {
         /**
-         * Creates a [PresentedStackPartial] from the provided [PartialStackComponent] and [using] map. If
+         * Creates a [PresentedStackPartial] from the provided [PartialStackComponent] and [aliases] map. If
          * [PartialStackComponent.backgroundColor] is non null and contains a color alias, it should exist in the
-         * [using] map. If it doesn't, this function will return a failure result.
+         * [aliases] map. If it doesn't, this function will return a failure result.
          */
         @JvmSynthetic
         operator fun invoke(
             from: PartialStackComponent,
-            using: Map<ColorAlias, ColorScheme>,
+            aliases: Map<ColorAlias, ColorScheme>,
         ): Result<PresentedStackPartial, NonEmptyList<PaywallValidationError>> =
             from.backgroundColor
-                ?.toColorStyles(aliases = using)
+                ?.toColorStyles(aliases = aliases)
                 .orSuccessfullyNull()
                 .map { backgroundColorStyles ->
                     PresentedStackPartial(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -43,6 +43,8 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toAlignment
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toFontWeight
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toPaddingValues
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toTextAlign
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.stack.StackComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
@@ -118,7 +120,7 @@ private fun previewButtonComponentStyle(
         dimension = Dimension.Vertical(alignment = HorizontalAlignment.CENTER, distribution = START),
         size = Size(width = Fit, height = Fit),
         spacing = 16.dp,
-        backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+        backgroundColor = ColorStyles(light = ColorStyle.Solid(Color.Red)),
         padding = PaddingValues(all = 16.dp),
         margin = PaddingValues(all = 16.dp),
         shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/iconcomponent/IconComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/iconcomponent/IconComponentView.kt
@@ -24,6 +24,7 @@ import coil.ImageLoader
 import coil.decode.DataSource
 import coil.request.SuccessResult
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.paywalls.components.IconComponent
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
@@ -194,7 +195,7 @@ private fun previewEmptyState(): PaywallState.Loaded.Components {
         serverDescription = "serverDescription",
         metadata = emptyMap(),
         availablePackages = emptyList(),
-        paywallComponents = data,
+        paywallComponents = Offering.PaywallComponents(UiConfig(), data),
     )
     val validated = offering.validatePaywallComponentsDataOrNull()?.getOrThrow()!!
     return offering.toComponentsPaywallState(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
@@ -133,7 +133,7 @@ internal fun ColorInfo.toColorStyle(
             when (aliasedInfo) {
                 is ColorInfo.Gradient,
                 is ColorInfo.Hex,
-                -> toColorStyle(aliases, useLightAlias)
+                -> aliasedInfo.toColorStyle(aliases, useLightAlias)
                 is ColorInfo.Alias -> Result.Error(PaywallValidationError.AliasedColorIsAlias(value, aliasedInfo.value))
                 null -> Result.Error(PaywallValidationError.MissingColorAlias(value))
             }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
@@ -1,6 +1,9 @@
+@file:Suppress("TooManyFunctions")
+
 package com.revenuecat.purchases.ui.revenuecatui.components.properties
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.runtime.Composable
@@ -18,9 +21,17 @@ import androidx.compose.ui.graphics.ShaderBrush
 import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.colorsForCurrentTheme
+import com.revenuecat.purchases.ui.revenuecatui.errors.PaywallValidationError
+import com.revenuecat.purchases.ui.revenuecatui.helpers.NonEmptyList
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Result
+import com.revenuecat.purchases.ui.revenuecatui.helpers.mapError
+import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyListOf
+import com.revenuecat.purchases.ui.revenuecatui.helpers.orSuccessfullyNull
+import com.revenuecat.purchases.ui.revenuecatui.helpers.zipOrAccumulate
 import dev.drewhamilton.poko.Poko
 import kotlin.math.abs
 import kotlin.math.cos
@@ -44,12 +55,24 @@ internal sealed interface ColorStyle {
     value class Gradient(@JvmSynthetic val brush: Brush) : ColorStyle
 }
 
+/**
+ * [ColorStyle]s for light and dark mode.
+ */
+internal data class ColorStyles(
+    @get:JvmSynthetic val light: ColorStyle,
+    @get:JvmSynthetic val dark: ColorStyle? = null,
+)
+
 @JvmSynthetic
 @Composable
 internal fun rememberColorStyle(scheme: ColorScheme): ColorStyle {
     val colorInfo = scheme.colorsForCurrentTheme
     return remember(colorInfo) { colorInfo.toColorStyle() }
 }
+
+internal val ColorStyles.forCurrentTheme: ColorStyle
+    @JvmSynthetic @Composable
+    get() = if (isSystemInDarkTheme()) dark ?: light else light
 
 @JvmSynthetic
 @Composable
@@ -71,6 +94,64 @@ internal fun ColorInfo.toColorStyle(): ColorStyle {
                     colorStops = points.toColorStops(),
                 )
             },
+        )
+    }
+}
+
+@JvmSynthetic
+internal fun ColorScheme.toColorStyles(
+    aliases: Map<ColorAlias, ColorScheme>,
+): Result<ColorStyles, NonEmptyList<PaywallValidationError>> =
+    zipOrAccumulate(
+        first = light.toColorStyle(aliases, useLightAlias = true)
+            .mapError { nonEmptyListOf(it) },
+        second = dark?.toColorStyle(aliases, useLightAlias = false)
+            .orSuccessfullyNull()
+            .mapError { nonEmptyListOf(it) },
+    ) { light, dark ->
+        ColorStyles(light = light, dark = dark)
+    }
+
+/**
+ * Converts a [ColorInfo] to a [ColorStyle], using [aliases] for lookup if this is a [ColorInfo.Alias].
+ *
+ * @param useLightAlias Since [aliases] maps to entire [ColorScheme]s, we need to know which [ColorInfo] to get from
+ * that scheme. If this is true, we'll use the light one. If this is false, we'll use the dark one if available, and
+ * light otherwise.
+ */
+@JvmSynthetic
+internal fun ColorInfo.toColorStyle(
+    aliases: Map<ColorAlias, ColorScheme>,
+    useLightAlias: Boolean,
+): Result<ColorStyle, PaywallValidationError> {
+    return when (this) {
+        is ColorInfo.Alias -> {
+            val aliasedScheme = aliases[value]
+            val aliasedInfo = aliasedScheme?.let {
+                if (useLightAlias) aliasedScheme.light else aliasedScheme.dark ?: aliasedScheme.light
+            }
+            when (aliasedInfo) {
+                is ColorInfo.Gradient,
+                is ColorInfo.Hex,
+                -> toColorStyle(aliases, useLightAlias)
+                is ColorInfo.Alias -> Result.Error(PaywallValidationError.AliasedColorIsAlias(value, aliasedInfo.value))
+                null -> Result.Error(PaywallValidationError.MissingColorAlias(value))
+            }
+        }
+        is ColorInfo.Hex -> Result.Success(ColorStyle.Solid(Color(color = value)))
+        is ColorInfo.Gradient -> Result.Success(
+            ColorStyle.Gradient(
+                when (this) {
+                    is ColorInfo.Gradient.Linear -> relativeLinearGradient(
+                        colorStops = points.toColorStops(),
+                        degrees = degrees,
+                    )
+
+                    is ColorInfo.Gradient.Radial -> Brush.radialGradient(
+                        colorStops = points.toColorStops(),
+                    )
+                },
+            ),
         )
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
@@ -96,7 +96,7 @@ internal class StackComponentState(
     val spacing by derivedStateOf { presentedPartial?.partial?.spacing?.dp ?: style.spacing }
 
     @get:JvmSynthetic
-    val backgroundColor by derivedStateOf { presentedPartial?.partial?.backgroundColor ?: style.backgroundColor }
+    val backgroundColor by derivedStateOf { presentedPartial?.backgroundColorStyles ?: style.backgroundColor }
 
     @get:JvmSynthetic
     val padding by derivedStateOf { presentedPartial?.partial?.padding?.toPaddingValues() ?: style.padding }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -78,9 +78,12 @@ import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.border
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.shadow
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.forCurrentTheme
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.rememberBorderStyle
-import com.revenuecat.purchases.ui.revenuecatui.components.properties.rememberColorStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.rememberShadowStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.toColorStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.style.BadgeStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
@@ -241,7 +244,7 @@ private fun StackWithLongEdgeToEdgeBadge(
 
         // Subcompose the background
         val backgroundMeasurable = subcompose("background") {
-            val backgroundColorStyle = badgeStack.backgroundColor?.let { rememberColorStyle(scheme = it) }
+            val backgroundColorStyle = badgeStack.backgroundColor?.forCurrentTheme
             val borderStyle = badgeStack.border?.let { rememberBorderStyle(border = it) }
             val shadowStyle = badgeStack.shadow?.let { rememberShadowStyle(shadow = it) }
             val backgroundShape = when (val badgeCornerRadiuses = badgeStack.shape.cornerRadiuses) {
@@ -490,7 +493,7 @@ private fun MainStackComponent(
         }
     }
 
-    val backgroundColorStyle = stackState.backgroundColor?.let { rememberColorStyle(scheme = it) }
+    val backgroundColorStyle = stackState.backgroundColor?.forCurrentTheme
     val borderStyle = stackState.border?.let { rememberBorderStyle(border = it) }
     val shadowStyle = stackState.shadow?.let { rememberShadowStyle(shadow = it) }
     val composeShape by remember(stackState.shape) { derivedStateOf { stackState.shape.toShape() } }
@@ -638,9 +641,9 @@ private fun StackComponentView_Preview_Vertical() {
                 ),
                 size = Size(width = Fit, height = Fit),
                 spacing = 16.dp,
-                backgroundColor = ColorScheme(
-                    light = ColorInfo.Hex(Color.Red.toArgb()),
-                    dark = ColorInfo.Hex(Color.Yellow.toArgb()),
+                backgroundColor = ColorStyles(
+                    light = ColorStyle.Solid(Color.Red),
+                    dark = ColorStyle.Solid(Color.Yellow),
                 ),
                 padding = PaddingValues(all = 16.dp),
                 margin = PaddingValues(all = 16.dp),
@@ -698,8 +701,8 @@ private fun StackComponentView_Preview_Overlay_Badge(
                 ),
                 size = Size(width = Fixed(200u), height = Fit),
                 spacing = 16.dp,
-                backgroundColor = ColorScheme(
-                    light = ColorInfo.Hex(Color.Red.toArgb()),
+                backgroundColor = ColorStyles(
+                    light = ColorStyle.Solid(Color.Red),
                 ),
                 padding = PaddingValues(all = 12.dp),
                 margin = PaddingValues(all = 0.dp),
@@ -734,8 +737,8 @@ private fun StackComponentView_Preview_EdgeToEdge_Badge(
                 ),
                 size = Size(width = Fixed(200u), height = Fit),
                 spacing = 16.dp,
-                backgroundColor = ColorScheme(
-                    light = ColorInfo.Hex(Color.Red.toArgb()),
+                backgroundColor = ColorStyles(
+                    light = ColorStyle.Solid(Color.Red),
                 ),
                 padding = PaddingValues(all = 0.dp),
                 margin = PaddingValues(all = 0.dp),
@@ -769,8 +772,8 @@ private fun StackComponentView_Preview_Pill_EdgeToEdge_Badge(
                 ),
                 size = Size(width = Fixed(200u), height = Fit),
                 spacing = 16.dp,
-                backgroundColor = ColorScheme(
-                    light = ColorInfo.Hex(Color.Red.toArgb()),
+                backgroundColor = ColorStyles(
+                    light = ColorStyle.Solid(Color.Red),
                 ),
                 padding = PaddingValues(all = 0.dp),
                 margin = PaddingValues(all = 0.dp),
@@ -812,8 +815,8 @@ private fun StackComponentView_Preview_Nested_Badge(
                 ),
                 size = Size(width = Fixed(200u), height = Fit),
                 spacing = 16.dp,
-                backgroundColor = ColorScheme(
-                    light = ColorInfo.Hex(Color.Red.toArgb()),
+                backgroundColor = ColorStyles(
+                    light = ColorStyle.Solid(Color.Red),
                 ),
                 padding = PaddingValues(all = 0.dp),
                 margin = PaddingValues(all = 0.dp),
@@ -846,9 +849,9 @@ private fun StackComponentView_Preview_Horizontal() {
                 ),
                 size = Size(width = Fit, height = Fit),
                 spacing = 16.dp,
-                backgroundColor = ColorScheme(
-                    light = ColorInfo.Hex(Color.Red.toArgb()),
-                    dark = ColorInfo.Hex(Color.Yellow.toArgb()),
+                backgroundColor = ColorStyles(
+                    light = ColorStyle.Solid(Color.Red),
+                    dark = ColorStyle.Solid(Color.Yellow),
                 ),
                 padding = PaddingValues(all = 16.dp),
                 margin = PaddingValues(all = 16.dp),
@@ -924,9 +927,9 @@ private fun StackComponentView_Preview_ZLayer() {
                 dimension = Dimension.ZLayer(alignment = TwoDimensionalAlignment.BOTTOM_TRAILING),
                 size = Size(width = Fit, height = Fit),
                 spacing = 16.dp,
-                backgroundColor = ColorScheme(
-                    light = ColorInfo.Hex(Color.Red.toArgb()),
-                    dark = ColorInfo.Hex(Color.Yellow.toArgb()),
+                backgroundColor = ColorStyles(
+                    light = ColorStyle.Solid(Color.Red),
+                    dark = ColorStyle.Solid(Color.Yellow),
                 ),
                 padding = PaddingValues(all = 16.dp),
                 margin = PaddingValues(all = 16.dp),
@@ -971,7 +974,7 @@ private fun StackComponentView_Preview_HorizontalChildrenFillWidth() {
             ),
             size = Size(width = Fixed(200u), height = Fit),
             spacing = 16.dp,
-            backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+            backgroundColor = ColorStyles(light = ColorStyle.Solid(Color.Red)),
             padding = PaddingValues(all = 16.dp),
             margin = PaddingValues(all = 16.dp),
             shape = Shape.Rectangle(corners = null),
@@ -1009,7 +1012,7 @@ private fun StackComponentView_Preview_VerticalChildrenFillHeight() {
             ),
             size = Size(width = Fit, height = Fixed(200u)),
             spacing = 16.dp,
-            backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+            backgroundColor = ColorStyles(light = ColorStyle.Solid(Color.Red)),
             padding = PaddingValues(all = 16.dp),
             margin = PaddingValues(all = 16.dp),
             shape = Shape.Rectangle(),
@@ -1069,7 +1072,7 @@ private fun StackComponentView_Preview_Distribution(
             // It's all set to Fit, because we want to see the `spacing` being interpreted as a minimum.
             size = Size(width = Fit, height = Fit),
             spacing = 16.dp,
-            backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+            backgroundColor = ColorStyles(light = ColorStyle.Solid(Color.Red)),
             padding = PaddingValues(all = 0.dp),
             margin = PaddingValues(all = 16.dp),
             shape = Shape.Rectangle(),
@@ -1240,7 +1243,7 @@ private fun previewBadge(style: Badge.Style, alignment: TwoDimensionalAlignment,
                         ColorInfo.Gradient.Point(Color.Yellow.toArgb(), percent = 80f),
                     ),
                 ),
-            ),
+            ).toColorStyles(aliases = emptyMap()).getOrThrow(),
             padding = PaddingValues(all = 0.dp),
             margin = PaddingValues(all = 0.dp),
             shape = shape,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StackComponentStyle.kt
@@ -5,13 +5,13 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.Dp
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.components.properties.Border
-import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.paywalls.components.properties.Dimension
 import com.revenuecat.purchases.paywalls.components.properties.Shadow
 import com.revenuecat.purchases.paywalls.components.properties.Shape
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedOverrides
 import com.revenuecat.purchases.ui.revenuecatui.components.PresentedStackPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
 
 @Suppress("LongParameterList")
 @Immutable
@@ -25,7 +25,7 @@ internal data class StackComponentStyle(
     @get:JvmSynthetic
     val spacing: Dp,
     @get:JvmSynthetic
-    val backgroundColor: ColorScheme?,
+    val backgroundColor: ColorStyles?,
     @get:JvmSynthetic
     val padding: PaddingValues,
     @get:JvmSynthetic

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -168,7 +168,7 @@ internal class StyleFactory(
     ): Result<StackComponentStyle, NonEmptyList<PaywallValidationError>> = zipOrAccumulate(
         // Build the PresentedOverrides.
         first = component.overrides
-            ?.toPresentedOverrides { partial -> PresentedStackPartial(from = partial, using = uiConfig.app.colors) }
+            ?.toPresentedOverrides { partial -> PresentedStackPartial(from = partial, aliases = uiConfig.app.colors) }
             .orSuccessfullyNull()
             .mapError { nonEmptyListOf(it) },
         // Build all children styles.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components.style
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.components.IconComponent
 import com.revenuecat.purchases.paywalls.components.ImageComponent
@@ -30,6 +31,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toFontWeight
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toPaddingValues
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toShape
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toTextAlign
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.toColorStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.toPresentedOverrides
 import com.revenuecat.purchases.ui.revenuecatui.errors.PaywallValidationError
 import com.revenuecat.purchases.ui.revenuecatui.helpers.NonEmptyList
@@ -48,6 +50,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.zipOrAccumulate
 @Suppress("TooManyFunctions")
 internal class StyleFactory(
     private val localizations: NonEmptyMap<LocaleId, LocalizationDictionary>,
+    private val uiConfig: UiConfig,
     private val offering: Offering,
 ) {
 
@@ -165,7 +168,7 @@ internal class StyleFactory(
     ): Result<StackComponentStyle, NonEmptyList<PaywallValidationError>> = zipOrAccumulate(
         // Build the PresentedOverrides.
         first = component.overrides
-            ?.toPresentedOverrides { partial -> Result.Success(PresentedStackPartial(partial)) }
+            ?.toPresentedOverrides { partial -> PresentedStackPartial(from = partial, using = uiConfig.app.colors) }
             .orSuccessfullyNull()
             .mapError { nonEmptyListOf(it) },
         // Build all children styles.
@@ -182,13 +185,14 @@ internal class StyleFactory(
                     )
                 }
         }.orSuccessfullyNull(),
-    ) { presentedOverrides, children, badge ->
+        fourth = component.backgroundColor?.toColorStyles(uiConfig.app.colors).orSuccessfullyNull(),
+    ) { presentedOverrides, children, badge, backgroundColorStyles ->
         StackComponentStyle(
             children = children,
             dimension = component.dimension,
             size = component.size,
             spacing = (component.spacing ?: DEFAULT_SPACING).dp,
-            backgroundColor = component.backgroundColor,
+            backgroundColor = backgroundColorStyles,
             padding = component.padding.toPaddingValues(),
             margin = component.margin.toPaddingValues(),
             shape = component.shape ?: Shape.Rectangle(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.errors
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
@@ -30,6 +31,8 @@ internal sealed class PaywallValidationError : Throwable() {
             is MissingImageLocalization -> message
             is AllLocalizationsMissing -> message
             is MissingPackage -> message
+            is MissingColorAlias -> message
+            is AliasedColorIsAlias -> message
         }
     }
 
@@ -67,5 +70,17 @@ internal sealed class PaywallValidationError : Throwable() {
     ) : PaywallValidationError() {
         override val message: String =
             PaywallValidationErrorStrings.ALL_LOCALIZATIONS_MISSING_FOR_LOCALE.format(offeringId, packageId)
+    }
+    data class MissingColorAlias(
+        val alias: ColorAlias,
+    ) : PaywallValidationError() {
+        override val message: String = PaywallValidationErrorStrings.MISSING_COLOR_ALIAS.format(alias.value)
+    }
+    data class AliasedColorIsAlias(
+        val alias: ColorAlias,
+        val aliasedValue: ColorAlias,
+    ) : PaywallValidationError() {
+        override val message: String = PaywallValidationErrorStrings.ALIASED_COLOR_IS_ALIAS
+            .format(alias.value, aliasedValue.value)
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -109,7 +109,11 @@ internal fun Offering.validatePaywallComponentsDataOrNull(): RcResult<PaywallVal
         .getOrElse { error -> return RcResult.Error(error) }
 
     // Create the StyleFactory to recursively create and validate all ComponentStyles.
-    val styleFactory = StyleFactory(localizations = localizations, offering = this)
+    val styleFactory = StyleFactory(
+        localizations = localizations,
+        uiConfig = paywallComponents.uiConfig,
+        offering = this,
+    )
     val config = paywallComponents.data.componentsConfig.base
 
     // Combine the main stack with the stickyFooter, or accumulate the encountered errors.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/strings/PaywallValidationErrorStrings.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/strings/PaywallValidationErrorStrings.kt
@@ -19,4 +19,6 @@ internal object PaywallValidationErrorStrings {
         "All localizations for locale '%s' are missing."
     const val MISSING_PACKAGE =
         "Offering with id '%s' does not have a package with id '%s'."
+    const val MISSING_COLOR_ALIAS = "Aliased color '%s' does not exist."
+    const val ALIASED_COLOR_IS_ALIAS = "Aliased color '%s' has an aliased value '%s', which is not allowed."
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.components
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.paywalls.components.PartialTextComponent
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.paywalls.components.common.LocalizationData
@@ -476,8 +477,8 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                                 from = PartialTextComponent(
                                     visible = true,
                                     text = LocalizationKey("compactKey"),
-                                    color = ColorScheme(light = ColorInfo.Alias("compactColor")),
-                                    backgroundColor = ColorScheme(light = ColorInfo.Alias("compactBgColor")),
+                                    color = ColorScheme(light = ColorInfo.Alias(ColorAlias("compactColor"))),
+                                    backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("compactBgColor"))),
                                     fontName = "compactFont",
                                     fontWeight = FontWeight.LIGHT,
                                     fontSize = 13,
@@ -540,8 +541,8 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         from = PartialTextComponent(
                             visible = true,
                             text = LocalizationKey("compactKey"),
-                            color = ColorScheme(light = ColorInfo.Alias("compactColor")),
-                            backgroundColor = ColorScheme(light = ColorInfo.Alias("compactBgColor")),
+                            color = ColorScheme(light = ColorInfo.Alias(ColorAlias("compactColor"))),
+                            backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("compactBgColor"))),
                             fontName = "mediumFont",
                             fontWeight = FontWeight.MEDIUM,
                             fontSize = 15,
@@ -617,8 +618,8 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                                 from = PartialTextComponent(
                                     visible = true,
                                     text = LocalizationKey("compactKey"),
-                                    color = ColorScheme(light = ColorInfo.Alias("compactColor")),
-                                    backgroundColor = ColorScheme(light = ColorInfo.Alias("compactBgColor")),
+                                    color = ColorScheme(light = ColorInfo.Alias(ColorAlias("compactColor"))),
+                                    backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("compactBgColor"))),
                                     fontName = "compactFont",
                                     fontWeight = FontWeight.LIGHT,
                                     fontSize = 13,
@@ -637,8 +638,8 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                                 from = PartialTextComponent(
                                     visible = true,
                                     text = null,
-                                    color = ColorScheme(light = ColorInfo.Alias("mediumColor")),
-                                    backgroundColor = ColorScheme(light = ColorInfo.Alias("mediumBgColor")),
+                                    color = ColorScheme(light = ColorInfo.Alias(ColorAlias("mediumColor"))),
+                                    backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("mediumBgColor"))),
                                     fontName = "mediumFont",
                                     fontWeight = FontWeight.MEDIUM,
                                     fontSize = 15,
@@ -674,8 +675,8 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
                         from = PartialTextComponent(
                             visible = true,
                             text = LocalizationKey("compactKey"),
-                            color = ColorScheme(light = ColorInfo.Alias("mediumColor")),
-                            backgroundColor = ColorScheme(light = ColorInfo.Alias("mediumBgColor")),
+                            color = ColorScheme(light = ColorInfo.Alias(ColorAlias("mediumColor"))),
+                            backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("mediumBgColor"))),
                             fontName = "expandedFont",
                             fontWeight = FontWeight.BOLD,
                             fontSize = 34,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LocalizedTextPartialTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LocalizedTextPartialTests.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.components
 
+import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.paywalls.components.PartialTextComponent
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.paywalls.components.common.LocalizationData
@@ -50,8 +51,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = true,
                                 text = LocalizationKey("baseKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("baseColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("baseBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseBgColor"))),
                                 fontName = "baseFont",
                                 fontWeight = FontWeight.LIGHT,
                                 fontSize = 13,
@@ -70,8 +71,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = false,
                                 text = LocalizationKey("overrideKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("overrideColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("overrideBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("overrideColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("overrideBgColor"))),
                                 fontName = "overrideFont",
                                 fontWeight = FontWeight.MEDIUM,
                                 fontSize = 15,
@@ -90,8 +91,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = false,
                                 text = LocalizationKey("overrideKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("overrideColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("overrideBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("overrideColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("overrideBgColor"))),
                                 fontName = "overrideFont",
                                 fontWeight = FontWeight.MEDIUM,
                                 fontSize = 15,
@@ -168,8 +169,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = true,
                                 text = LocalizationKey("baseKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("baseColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("baseBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseBgColor"))),
                                 fontName = "baseFont",
                                 fontWeight = FontWeight.LIGHT,
                                 fontSize = 13,
@@ -189,8 +190,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = true,
                                 text = LocalizationKey("baseKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("baseColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("baseBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseBgColor"))),
                                 fontName = "baseFont",
                                 fontWeight = FontWeight.LIGHT,
                                 fontSize = 13,
@@ -214,8 +215,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = true,
                                 text = LocalizationKey("baseKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("baseColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("baseBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseBgColor"))),
                                 fontName = "baseFont",
                                 fontWeight = FontWeight.LIGHT,
                                 fontSize = 13,
@@ -234,8 +235,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = false,
                                 text = LocalizationKey("overrideKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("overrideColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("overrideBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("overrideColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("overrideBgColor"))),
                                 fontName = "overrideFont",
                                 fontWeight = null,
                                 fontSize = null,
@@ -254,8 +255,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = false,
                                 text = LocalizationKey("overrideKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("overrideColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("overrideBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("overrideColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("overrideBgColor"))),
                                 fontName = "overrideFont",
                                 fontWeight = FontWeight.LIGHT,
                                 fontSize = 13,
@@ -294,8 +295,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = false,
                                 text = LocalizationKey("overrideKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("overrideColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("overrideBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("overrideColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("overrideBgColor"))),
                                 fontName = "overrideFont",
                                 fontWeight = null,
                                 fontSize = null,
@@ -314,8 +315,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = false,
                                 text = LocalizationKey("overrideKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("overrideColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("overrideBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("overrideColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("overrideBgColor"))),
                                 fontName = "overrideFont",
                                 fontWeight = FontWeight.LIGHT,
                                 fontSize = 13,
@@ -339,8 +340,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = true,
                                 text = LocalizationKey("baseKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("baseColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("baseBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseBgColor"))),
                                 fontName = "baseFont",
                                 fontWeight = FontWeight.LIGHT,
                                 fontSize = 13,
@@ -375,8 +376,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = true,
                                 text = LocalizationKey("baseKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("baseColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("baseBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseBgColor"))),
                                 fontName = "baseFont",
                                 fontWeight = FontWeight.MEDIUM,
                                 fontSize = 15,
@@ -400,8 +401,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = true,
                                 text = LocalizationKey("baseKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("baseColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("baseBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseBgColor"))),
                                 fontName = "baseFont",
                                 fontWeight = null,
                                 fontSize = null,
@@ -436,8 +437,8 @@ internal class LocalizedTextPartialTests {
                             from = PartialTextComponent(
                                 visible = true,
                                 text = LocalizationKey("baseKey"),
-                                color = ColorScheme(light = ColorInfo.Alias("baseColor")),
-                                backgroundColor = ColorScheme(light = ColorInfo.Alias("baseBgColor")),
+                                color = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseColor"))),
+                                backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("baseBgColor"))),
                                 fontName = "baseFont",
                                 fontWeight = FontWeight.MEDIUM,
                                 fontSize = 15,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedStackPartialTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedStackPartialTests.kt
@@ -1,0 +1,806 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import com.revenuecat.purchases.ColorAlias
+import com.revenuecat.purchases.paywalls.components.PartialStackComponent
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.properties.Badge
+import com.revenuecat.purchases.paywalls.components.properties.Border
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.CornerRadiuses
+import com.revenuecat.purchases.paywalls.components.properties.Dimension
+import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
+import com.revenuecat.purchases.paywalls.components.properties.HorizontalAlignment
+import com.revenuecat.purchases.paywalls.components.properties.Padding
+import com.revenuecat.purchases.paywalls.components.properties.Shadow
+import com.revenuecat.purchases.paywalls.components.properties.Shape
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fixed
+import com.revenuecat.purchases.paywalls.components.properties.TwoDimensionalAlignment
+import com.revenuecat.purchases.paywalls.components.properties.VerticalAlignment
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
+import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
+import com.revenuecat.purchases.ui.revenuecatui.helpers.isError
+import com.revenuecat.purchases.ui.revenuecatui.helpers.isSuccess
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Enclosed::class)
+internal class PresentedStackPartialTests {
+
+    @RunWith(Parameterized::class)
+    class CombinePresentedStackPartialTests(@Suppress("UNUSED_PARAMETER") name: String, private val args: Args) {
+
+        class Args(
+            val base: PresentedStackPartial,
+            val override: PresentedStackPartial?,
+            val expected: PresentedStackPartial,
+        )
+
+        companion object {
+
+            @Suppress("LongMethod")
+            @JvmStatic
+            @Parameterized.Parameters(name = "{0}")
+            fun parameters(): Collection<*> = listOf(
+                arrayOf(
+                    "Should properly override all properties if they are non-null in both",
+                    Args(
+                        base = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(10u), height = Fixed(10u)),
+                                spacing = 10f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                padding = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                margin = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 10.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                    width = 1.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Yellow.toArgb())),
+                                    radius = 10.0,
+                                    x = 10.0,
+                                    y = 10.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Overlay,
+                                    alignment = TwoDimensionalAlignment.TOP,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                        override = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(20u), height = Fixed(20u)),
+                                spacing = 20f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                padding = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                margin = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                    width = 2.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Cyan.toArgb())),
+                                    radius = 0.0,
+                                    x = 20.0,
+                                    y = 20.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Nested,
+                                    alignment = TwoDimensionalAlignment.BOTTOM,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                        expected = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(20u), height = Fixed(20u)),
+                                spacing = 20f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                padding = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                margin = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                    width = 2.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Cyan.toArgb())),
+                                    radius = 0.0,
+                                    x = 20.0,
+                                    y = 20.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Nested,
+                                    alignment = TwoDimensionalAlignment.BOTTOM,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow()
+                    )
+                ),
+                arrayOf(
+                    "Should not override anything if all properties are null in both",
+                    Args(
+                        base = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = null,
+                                dimension = null,
+                                size = null,
+                                spacing = null,
+                                backgroundColor = null,
+                                padding = null,
+                                margin = null,
+                                shape = null,
+                                border = null,
+                                shadow = null,
+                                badge = null
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                        override = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = null,
+                                dimension = null,
+                                size = null,
+                                spacing = null,
+                                backgroundColor = null,
+                                padding = null,
+                                margin = null,
+                                shape = null,
+                                border = null,
+                                shadow = null,
+                                badge = null
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                        expected = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = null,
+                                dimension = null,
+                                size = null,
+                                spacing = null,
+                                backgroundColor = null,
+                                padding = null,
+                                margin = null,
+                                shape = null,
+                                border = null,
+                                shadow = null,
+                                badge = null
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                    )
+                ),
+                arrayOf(
+                    "Should not override anything if override is null",
+                    Args(
+                        base = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(10u), height = Fixed(10u)),
+                                spacing = 10f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                padding = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                margin = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 10.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                    width = 1.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Yellow.toArgb())),
+                                    radius = 10.0,
+                                    x = 10.0,
+                                    y = 10.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Overlay,
+                                    alignment = TwoDimensionalAlignment.TOP,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                        override = null,
+                        expected = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(10u), height = Fixed(10u)),
+                                spacing = 10f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                padding = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                margin = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 10.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                    width = 1.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Yellow.toArgb())),
+                                    radius = 10.0,
+                                    x = 10.0,
+                                    y = 10.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Overlay,
+                                    alignment = TwoDimensionalAlignment.TOP,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                    )
+                ),
+                arrayOf(
+                    "Should properly override the first 6 individual properties if they are non-null in both",
+                    Args(
+                        base = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(10u), height = Fixed(10u)),
+                                spacing = 10f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                padding = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                margin = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 10.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                    width = 1.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Yellow.toArgb())),
+                                    radius = 10.0,
+                                    x = 10.0,
+                                    y = 10.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Overlay,
+                                    alignment = TwoDimensionalAlignment.TOP,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                        override = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(20u), height = Fixed(20u)),
+                                spacing = 20f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                padding = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                margin = null,
+                                shape = null,
+                                border = null,
+                                shadow = null,
+                                badge = null,
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                        expected = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(20u), height = Fixed(20u)),
+                                spacing = 20f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                padding = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                margin = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 10.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                    width = 1.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Yellow.toArgb())),
+                                    radius = 10.0,
+                                    x = 10.0,
+                                    y = 10.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Overlay,
+                                    alignment = TwoDimensionalAlignment.TOP,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                    )
+                ),
+                arrayOf(
+                    "Should properly override the first 6 individual properties if they are null in the base",
+                    Args(
+                        base = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = null,
+                                dimension = null,
+                                size = null,
+                                spacing = null,
+                                backgroundColor = null,
+                                padding = null,
+                                margin = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 10.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                    width = 1.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Yellow.toArgb())),
+                                    radius = 10.0,
+                                    x = 10.0,
+                                    y = 10.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Overlay,
+                                    alignment = TwoDimensionalAlignment.TOP,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                        override = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(20u), height = Fixed(20u)),
+                                spacing = 20f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                padding = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                margin = null,
+                                shape = null,
+                                border = null,
+                                shadow = null,
+                                badge = null,
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                        expected = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Horizontal(VerticalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(20u), height = Fixed(20u)),
+                                spacing = 20f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                padding = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                margin = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 10.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                    width = 1.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Yellow.toArgb())),
+                                    radius = 10.0,
+                                    x = 10.0,
+                                    y = 10.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Overlay,
+                                    alignment = TwoDimensionalAlignment.TOP,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                    )
+                ),
+                arrayOf(
+                    "Should properly override the second 5 individual properties if they are non-null in both",
+                    Args(
+                        base = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(10u), height = Fixed(10u)),
+                                spacing = 10f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                padding = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                margin = Padding(top = 20.0, bottom = 20.0, leading = 20.0, trailing = 20.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 10.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                                    width = 1.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Yellow.toArgb())),
+                                    radius = 10.0,
+                                    x = 10.0,
+                                    y = 10.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Overlay,
+                                    alignment = TwoDimensionalAlignment.TOP,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                        override = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = null,
+                                dimension = null,
+                                size = null,
+                                spacing = null,
+                                backgroundColor = null,
+                                padding = null,
+                                margin = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                    width = 2.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Cyan.toArgb())),
+                                    radius = 0.0,
+                                    x = 20.0,
+                                    y = 20.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Nested,
+                                    alignment = TwoDimensionalAlignment.BOTTOM,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                        expected = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(10u), height = Fixed(10u)),
+                                spacing = 10f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                padding = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                margin = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                    width = 2.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Cyan.toArgb())),
+                                    radius = 0.0,
+                                    x = 20.0,
+                                    y = 20.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Nested,
+                                    alignment = TwoDimensionalAlignment.BOTTOM,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                    )
+                ),
+                arrayOf(
+                    "Should properly override the second 5 individual properties if they are null in the base",
+                    Args(
+                        base = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(10u), height = Fixed(10u)),
+                                spacing = 10f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                padding = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                margin = null,
+                                shape = null,
+                                border = null,
+                                shadow = null,
+                                badge = null
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                        override = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = null,
+                                dimension = null,
+                                size = null,
+                                spacing = null,
+                                backgroundColor = null,
+                                padding = null,
+                                margin = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                    width = 2.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Cyan.toArgb())),
+                                    radius = 0.0,
+                                    x = 20.0,
+                                    y = 20.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Nested,
+                                    alignment = TwoDimensionalAlignment.BOTTOM,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                        expected = PresentedStackPartial(
+                            from = PartialStackComponent(
+                                visible = true,
+                                dimension = Dimension.Vertical(HorizontalAlignment.CENTER, FlexDistribution.START),
+                                size = Size(width = Fixed(10u), height = Fixed(10u)),
+                                spacing = 10f,
+                                backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                padding = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                margin = Padding(top = 10.0, bottom = 10.0, leading = 10.0, trailing = 10.0),
+                                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
+                                border = Border(
+                                    color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                                    width = 2.0
+                                ),
+                                shadow = Shadow(
+                                    ColorScheme(light = ColorInfo.Hex(Color.Cyan.toArgb())),
+                                    radius = 0.0,
+                                    x = 20.0,
+                                    y = 20.0
+                                ),
+                                badge = Badge(
+                                    stack = StackComponent(components = emptyList()),
+                                    style = Badge.Style.Nested,
+                                    alignment = TwoDimensionalAlignment.BOTTOM,
+                                ),
+                            ),
+                            using = emptyMap(),
+                        ).getOrThrow(),
+                    )
+                ),
+            )
+        }
+
+        @Test
+        fun `Should properly combine PresentedStackPartials`() {
+            // Arrange, Act
+            val actual = args.base.combine(args.override)
+
+            // Assert
+            assertEquals(args.expected, actual)
+        }
+    }
+
+    class CreatePresentedStackPartial {
+
+        @Test
+        fun `Should fail to create if the ColorAlias is not found`() {
+            // Arrange, Act
+            val actualResult = PresentedStackPartial(
+                from = PartialStackComponent(
+                    backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("missing-key")))
+                ),
+                using = mapOf(
+                    ColorAlias("existing-key") to ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb()))
+                )
+            )
+
+            // Assert
+            assert(actualResult.isError)
+        }
+
+        @Test
+        fun `Should create successfully if the ColorAlias is found`() {
+            // Arrange, Act
+            val actualResult = PresentedStackPartial(
+                from = PartialStackComponent(
+                    backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("existing-key"))),
+                ),
+                using = mapOf(
+                    ColorAlias("existing-key") to ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb()))
+                )
+            )
+
+            // Assert
+            assert(actualResult.isSuccess)
+        }
+
+        @Test
+        fun `Should create successfully if the PartialStackComponent has no ColorAlias`() {
+            // Arrange, Act
+            val actualResult = PresentedStackPartial(
+                from = PartialStackComponent(
+                    backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                ),
+                using = mapOf(
+                    ColorAlias("existing-key") to ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))
+                )
+            )
+
+            // Assert
+            assert(actualResult.isSuccess)
+        }
+
+        @Suppress("MaxLineLength")
+        @Test
+        fun `Should create successfully if the PartialStackComponent has no ColorAlias, alias map is empty`() {
+            // Arrange, Act
+            val actualResult = PresentedStackPartial(
+                from = PartialStackComponent(
+                    backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                ),
+                using = emptyMap()
+            )
+
+            // Assert
+            assert(actualResult.isSuccess)
+        }
+
+        @Test
+        fun `Should properly combine light and dark ColorAliases using different aliases`() {
+            // Arrange
+            val expectedLightColor = Color.Red
+            val expectedDarkColor = Color.Cyan
+            val partial = PartialStackComponent(
+                backgroundColor = ColorScheme(
+                    light = ColorInfo.Alias(ColorAlias("existing-light-key")),
+                    dark = ColorInfo.Alias(ColorAlias("existing-dark-key"))
+                ),
+            )
+            val colorAliases = mapOf(
+                ColorAlias("existing-light-key") to ColorScheme(
+                    light = ColorInfo.Hex(expectedLightColor.toArgb()),
+                    dark = ColorInfo.Hex(Color.Blue.toArgb())
+                ),
+                ColorAlias("existing-dark-key") to ColorScheme(
+                    light = ColorInfo.Hex(Color.Yellow.toArgb()),
+                    dark = ColorInfo.Hex(expectedDarkColor.toArgb())
+                ),
+            )
+            val expected = PresentedStackPartial(
+                backgroundColorStyles = ColorStyles(
+                    light = ColorStyle.Solid(expectedLightColor),
+                    dark = ColorStyle.Solid(expectedDarkColor),
+                ),
+                partial = partial,
+            )
+
+            // Act
+            val actualResult = PresentedStackPartial(
+                from = partial,
+                using = colorAliases,
+            )
+
+            // Assert
+            assert(actualResult.isSuccess)
+            val actual = actualResult.getOrThrow()
+            assert(actual == expected)
+        }
+
+        @Test
+        fun `Should properly combine light and dark ColorAliases using different aliases - aliased scheme only has light`() {
+            // Arrange
+            val expectedLightColor = Color.Red
+            val expectedDarkColor = Color.Cyan
+            val partial = PartialStackComponent(
+                backgroundColor = ColorScheme(
+                    light = ColorInfo.Alias(ColorAlias("existing-light-key")),
+                    dark = ColorInfo.Alias(ColorAlias("existing-dark-key"))
+                ),
+            )
+            val colorAliases = mapOf(
+                ColorAlias("existing-light-key") to ColorScheme(
+                    light = ColorInfo.Hex(expectedLightColor.toArgb()),
+                ),
+                ColorAlias("existing-dark-key") to ColorScheme(
+                    light = ColorInfo.Hex(expectedDarkColor.toArgb()),
+                ),
+            )
+            val expected = PresentedStackPartial(
+                backgroundColorStyles = ColorStyles(
+                    light = ColorStyle.Solid(expectedLightColor),
+                    dark = ColorStyle.Solid(expectedDarkColor),
+                ),
+                partial = partial,
+            )
+
+            // Act
+            val actualResult = PresentedStackPartial(
+                from = partial,
+                using = colorAliases,
+            )
+
+            // Assert
+            assert(actualResult.isSuccess)
+            val actual = actualResult.getOrThrow()
+            assert(actual == expected)
+        }
+
+        @Test
+        fun `Should properly combine light and dark ColorAliases using the same alias`() {
+            // Arrange
+            val expectedLightColor = Color.Red
+            val expectedDarkColor = Color.Cyan
+            val partial = PartialStackComponent(
+                backgroundColor = ColorScheme(
+                    light = ColorInfo.Alias(ColorAlias("existing-key")),
+                    dark = ColorInfo.Alias(ColorAlias("existing-key"))
+                ),
+            )
+            val colorAliases = mapOf(
+                ColorAlias("existing-key") to ColorScheme(
+                    light = ColorInfo.Hex(expectedLightColor.toArgb()),
+                    dark = ColorInfo.Hex(expectedDarkColor.toArgb())
+                ),
+            )
+            val expected = PresentedStackPartial(
+                backgroundColorStyles = ColorStyles(
+                    light = ColorStyle.Solid(expectedLightColor),
+                    dark = ColorStyle.Solid(expectedDarkColor),
+                ),
+                partial = partial,
+            )
+
+            // Act
+            val actualResult = PresentedStackPartial(
+                from = partial,
+                using = colorAliases,
+            )
+
+            // Assert
+            assert(actualResult.isSuccess)
+            val actual = actualResult.getOrThrow()
+            assert(actual == expected)
+        }
+
+        @Test
+        fun `Should properly combine light and dark ColorAliases using the same alias - aliased scheme only has light`() {
+            // Arrange
+            val expectedColor = Color.Red
+            val partial = PartialStackComponent(
+                backgroundColor = ColorScheme(
+                    light = ColorInfo.Alias(ColorAlias("existing-key")),
+                    dark = ColorInfo.Alias(ColorAlias("existing-key"))
+                ),
+            )
+            val colorAliases = mapOf(
+                ColorAlias("existing-key") to ColorScheme(
+                    light = ColorInfo.Hex(expectedColor.toArgb()),
+                ),
+            )
+            val expected = PresentedStackPartial(
+                backgroundColorStyles = ColorStyles(
+                    light = ColorStyle.Solid(expectedColor),
+                    dark = ColorStyle.Solid(expectedColor),
+                ),
+                partial = partial,
+            )
+
+            // Act
+            val actualResult = PresentedStackPartial(
+                from = partial,
+                using = colorAliases,
+            )
+
+            // Assert
+            assert(actualResult.isSuccess)
+            val actual = actualResult.getOrThrow()
+            assert(actual == expected)
+        }
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedStackPartialTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedStackPartialTests.kt
@@ -78,7 +78,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.TOP,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                         override = PresentedStackPartial(
                             from = PartialStackComponent(
@@ -106,7 +106,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.BOTTOM,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                         expected = PresentedStackPartial(
                             from = PartialStackComponent(
@@ -134,7 +134,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.BOTTOM,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow()
                     )
                 ),
@@ -155,7 +155,7 @@ internal class PresentedStackPartialTests {
                                 shadow = null,
                                 badge = null
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                         override = PresentedStackPartial(
                             from = PartialStackComponent(
@@ -171,7 +171,7 @@ internal class PresentedStackPartialTests {
                                 shadow = null,
                                 badge = null
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                         expected = PresentedStackPartial(
                             from = PartialStackComponent(
@@ -187,7 +187,7 @@ internal class PresentedStackPartialTests {
                                 shadow = null,
                                 badge = null
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                     )
                 ),
@@ -220,7 +220,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.TOP,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                         override = null,
                         expected = PresentedStackPartial(
@@ -249,7 +249,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.TOP,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                     )
                 ),
@@ -282,7 +282,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.TOP,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                         override = PresentedStackPartial(
                             from = PartialStackComponent(
@@ -298,7 +298,7 @@ internal class PresentedStackPartialTests {
                                 shadow = null,
                                 badge = null,
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                         expected = PresentedStackPartial(
                             from = PartialStackComponent(
@@ -326,7 +326,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.TOP,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                     )
                 ),
@@ -359,7 +359,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.TOP,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                         override = PresentedStackPartial(
                             from = PartialStackComponent(
@@ -375,7 +375,7 @@ internal class PresentedStackPartialTests {
                                 shadow = null,
                                 badge = null,
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                         expected = PresentedStackPartial(
                             from = PartialStackComponent(
@@ -403,7 +403,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.TOP,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                     )
                 ),
@@ -436,7 +436,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.TOP,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                         override = PresentedStackPartial(
                             from = PartialStackComponent(
@@ -464,7 +464,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.BOTTOM,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                         expected = PresentedStackPartial(
                             from = PartialStackComponent(
@@ -492,7 +492,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.BOTTOM,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                     )
                 ),
@@ -513,7 +513,7 @@ internal class PresentedStackPartialTests {
                                 shadow = null,
                                 badge = null
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                         override = PresentedStackPartial(
                             from = PartialStackComponent(
@@ -541,7 +541,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.BOTTOM,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                         expected = PresentedStackPartial(
                             from = PartialStackComponent(
@@ -569,7 +569,7 @@ internal class PresentedStackPartialTests {
                                     alignment = TwoDimensionalAlignment.BOTTOM,
                                 ),
                             ),
-                            using = emptyMap(),
+                            aliases = emptyMap(),
                         ).getOrThrow(),
                     )
                 ),
@@ -595,7 +595,7 @@ internal class PresentedStackPartialTests {
                 from = PartialStackComponent(
                     backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("missing-key")))
                 ),
-                using = mapOf(
+                aliases = mapOf(
                     ColorAlias("existing-key") to ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb()))
                 )
             )
@@ -611,7 +611,7 @@ internal class PresentedStackPartialTests {
                 from = PartialStackComponent(
                     backgroundColor = ColorScheme(light = ColorInfo.Alias(ColorAlias("existing-key"))),
                 ),
-                using = mapOf(
+                aliases = mapOf(
                     ColorAlias("existing-key") to ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb()))
                 )
             )
@@ -627,7 +627,7 @@ internal class PresentedStackPartialTests {
                 from = PartialStackComponent(
                     backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
                 ),
-                using = mapOf(
+                aliases = mapOf(
                     ColorAlias("existing-key") to ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))
                 )
             )
@@ -644,7 +644,7 @@ internal class PresentedStackPartialTests {
                 from = PartialStackComponent(
                     backgroundColor = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
                 ),
-                using = emptyMap()
+                aliases = emptyMap()
             )
 
             // Assert
@@ -683,7 +683,7 @@ internal class PresentedStackPartialTests {
             // Act
             val actualResult = PresentedStackPartial(
                 from = partial,
-                using = colorAliases,
+                aliases = colorAliases,
             )
 
             // Assert
@@ -722,7 +722,7 @@ internal class PresentedStackPartialTests {
             // Act
             val actualResult = PresentedStackPartial(
                 from = partial,
-                using = colorAliases,
+                aliases = colorAliases,
             )
 
             // Assert
@@ -759,7 +759,7 @@ internal class PresentedStackPartialTests {
             // Act
             val actualResult = PresentedStackPartial(
                 from = partial,
-                using = colorAliases,
+                aliases = colorAliases,
             )
 
             // Assert
@@ -794,7 +794,7 @@ internal class PresentedStackPartialTests {
             // Act
             val actualResult = PresentedStackPartial(
                 from = partial,
-                using = colorAliases,
+                aliases = colorAliases,
             )
 
             // Assert

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
@@ -37,6 +38,8 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toFontWeight
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toJavaLocale
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toPaddingValues
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toTextAlign
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StyleFactory
@@ -89,7 +92,7 @@ class ButtonComponentViewTests {
                     dimension = Dimension.Vertical(alignment = CENTER, distribution = START),
                     size = Size(width = Fill, height = Fill),
                     spacing = 16.dp,
-                    backgroundColor = ColorScheme(ColorInfo.Hex(Color.Red.toArgb())),
+                    backgroundColor = ColorStyles(ColorStyle.Solid(Color.Red)),
                     padding = PaddingValues(all = 16.dp),
                     margin = PaddingValues(all = 16.dp),
                     shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
@@ -170,7 +173,7 @@ class ButtonComponentViewTests {
             metadata = emptyMap(),
             availablePackages = emptyList(),
         )
-        val styleFactory = StyleFactory(localizations, offering)
+        val styleFactory = StyleFactory(localizations, UiConfig(), offering)
         val style = styleFactory.create(component).getOrThrow() as ButtonComponentStyle
         val state = FakePaywallState(
             localizations = localizations,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/pkg/PackageComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/pkg/PackageComponentViewTests.kt
@@ -181,6 +181,7 @@ class PackageComponentViewTests {
 
         val styleFactory = StyleFactory(
             localizations = localizations,
+            uiConfig = UiConfig(),
             offering = offering,
         )
         val styleYearly = styleFactory.create(componentYearly).getOrThrow() as PackageComponentStyle
@@ -301,6 +302,7 @@ class PackageComponentViewTests {
 
         val styleFactory = StyleFactory(
             localizations = localizations,
+            uiConfig = UiConfig(),
             offering = offering,
         )
         val styleYearly = styleFactory.create(componentYearly).getOrThrow() as PackageComponentStyle

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyleTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyleTests.kt
@@ -1,0 +1,173 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.properties
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import com.revenuecat.purchases.ColorAlias
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.ui.revenuecatui.errors.PaywallValidationError
+import com.revenuecat.purchases.ui.revenuecatui.helpers.errorOrNull
+import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
+import com.revenuecat.purchases.ui.revenuecatui.helpers.isError
+import com.revenuecat.purchases.ui.revenuecatui.helpers.isSuccess
+import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyListOf
+import org.junit.Test
+
+class ColorStyleTests {
+
+    @Test
+    fun `Should properly combine light and dark ColorAliases using different aliases`() {
+        // Arrange
+        val expectedLightColor = Color.Red
+        val expectedDarkColor = Color.Cyan
+        val colorScheme = ColorScheme(
+            light = ColorInfo.Alias(ColorAlias("existing-light-key")),
+            dark = ColorInfo.Alias(ColorAlias("existing-dark-key"))
+        )
+        val colorAliases = mapOf(
+            ColorAlias("existing-light-key") to ColorScheme(
+                light = ColorInfo.Hex(expectedLightColor.toArgb()),
+                dark = ColorInfo.Hex(Color.Blue.toArgb())
+            ),
+            ColorAlias("existing-dark-key") to ColorScheme(
+                light = ColorInfo.Hex(Color.Yellow.toArgb()),
+                dark = ColorInfo.Hex(expectedDarkColor.toArgb())
+            ),
+        )
+        val expected = ColorStyles(
+            light = ColorStyle.Solid(expectedLightColor),
+            dark = ColorStyle.Solid(expectedDarkColor),
+        )
+
+        // Act
+        val actualResult = colorScheme.toColorStyles(aliases = colorAliases)
+
+        // Assert
+        assert(actualResult.isSuccess)
+        val actual = actualResult.getOrThrow()
+        assert(actual == expected)
+    }
+
+    @Test
+    fun `Should properly combine light and dark ColorAliases using different aliases - aliased scheme only has light`() {
+        // Arrange
+        val expectedLightColor = Color.Red
+        val expectedDarkColor = Color.Cyan
+        val colorScheme = ColorScheme(
+            light = ColorInfo.Alias(ColorAlias("existing-light-key")),
+            dark = ColorInfo.Alias(ColorAlias("existing-dark-key"))
+        )
+        val colorAliases = mapOf(
+            ColorAlias("existing-light-key") to ColorScheme(
+                light = ColorInfo.Hex(expectedLightColor.toArgb()),
+            ),
+            ColorAlias("existing-dark-key") to ColorScheme(
+                light = ColorInfo.Hex(expectedDarkColor.toArgb()),
+            ),
+        )
+        val expected = ColorStyles(
+            light = ColorStyle.Solid(expectedLightColor),
+            dark = ColorStyle.Solid(expectedDarkColor),
+        )
+
+        // Act
+        val actualResult = colorScheme.toColorStyles(aliases = colorAliases)
+
+        // Assert
+        assert(actualResult.isSuccess)
+        val actual = actualResult.getOrThrow()
+        assert(actual == expected)
+    }
+
+    @Test
+    fun `Should properly combine light and dark ColorAliases using the same alias`() {
+        // Arrange
+        val expectedLightColor = Color.Red
+        val expectedDarkColor = Color.Cyan
+        val colorScheme = ColorScheme(
+            light = ColorInfo.Alias(ColorAlias("existing-key")),
+            dark = ColorInfo.Alias(ColorAlias("existing-key"))
+        )
+        val colorAliases = mapOf(
+            ColorAlias("existing-key") to ColorScheme(
+                light = ColorInfo.Hex(expectedLightColor.toArgb()),
+                dark = ColorInfo.Hex(expectedDarkColor.toArgb())
+            ),
+        )
+        val expected = ColorStyles(
+            light = ColorStyle.Solid(expectedLightColor),
+            dark = ColorStyle.Solid(expectedDarkColor),
+        )
+
+        // Act
+        val actualResult = colorScheme.toColorStyles(aliases = colorAliases)
+
+        // Assert
+        assert(actualResult.isSuccess)
+        val actual = actualResult.getOrThrow()
+        assert(actual == expected)
+    }
+
+    @Test
+    fun `Should properly combine light and dark ColorAliases using the same alias - aliased scheme only has light`() {
+        // Arrange
+        val expectedColor = Color.Red
+        val colorScheme = ColorScheme(
+            light = ColorInfo.Alias(ColorAlias("existing-key")),
+            dark = ColorInfo.Alias(ColorAlias("existing-key"))
+        )
+        val colorAliases = mapOf(
+            ColorAlias("existing-key") to ColorScheme(
+                light = ColorInfo.Hex(expectedColor.toArgb()),
+            ),
+        )
+        val expected = ColorStyles(
+            light = ColorStyle.Solid(expectedColor),
+            dark = ColorStyle.Solid(expectedColor),
+        )
+
+        // Act
+        val actualResult = colorScheme.toColorStyles(aliases = colorAliases)
+
+        // Assert
+        assert(actualResult.isSuccess)
+        val actual = actualResult.getOrThrow()
+        assert(actual == expected)
+    }
+
+    @Test
+    fun `Should fail to combine if the ColorAlias is missing`() {
+        // Arrange
+        val missingKey = ColorAlias("missing-key")
+        val colorScheme = ColorScheme(light = ColorInfo.Alias(missingKey),)
+        val colorAliases = emptyMap<ColorAlias, ColorScheme>()
+        val expected = nonEmptyListOf(PaywallValidationError.MissingColorAlias(missingKey))
+
+        // Act
+        val actualResult = colorScheme.toColorStyles(aliases = colorAliases)
+
+        // Assert
+        assert(actualResult.isError)
+        val actual = actualResult.errorOrNull()!!
+        assert(actual == expected)
+    }
+
+    @Test
+    fun `Should fail to combine if the ColorAlias points to another alias`() {
+        // Arrange
+        val incorrectKey = ColorAlias("incorrect-key")
+        val otherKey = ColorAlias("other-key")
+        val colorScheme = ColorScheme(light = ColorInfo.Alias(incorrectKey))
+        // Map of ColorAliases, which points to a ColorScheme containing a ColorInfo.Alias, which is wrong.
+        val colorAliases = mapOf(incorrectKey to ColorScheme(light = ColorInfo.Alias(otherKey)))
+        val expected = nonEmptyListOf(PaywallValidationError.AliasedColorIsAlias(incorrectKey, otherKey))
+
+        // Act
+        val actualResult = colorScheme.toColorStyles(aliases = colorAliases)
+
+        // Assert
+        assert(actualResult.isError)
+        val actual = actualResult.errorOrNull()!!
+        assert(actual == expected)
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentViewTests.kt
@@ -77,6 +77,7 @@ class StackComponentViewTests {
     )
     private val styleFactory = StyleFactory(
         localizations = localizations,
+        uiConfig = UiConfig(),
         offering = Offering(
             identifier = "identifier",
             serverDescription = "description",
@@ -334,6 +335,7 @@ class StackComponentViewTests {
         val state = offering.toComponentsPaywallState(validated)
         val styleFactory = StyleFactory(
             localizations = localizations,
+            uiConfig = UiConfig(),
             offering = offering,
         )
         val style = styleFactory.create(component).getOrThrow() as PackageComponentStyle
@@ -653,6 +655,7 @@ class StackComponentViewTests {
         val state = offering.toComponentsPaywallState(validated)
         val styleFactory = StyleFactory(
             localizations = localizations,
+            uiConfig = UiConfig(),
             offering = offering,
         )
         val noIntroOfferPackageComponentStyle =

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentViewWindowTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentViewWindowTests.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.paywalls.components.PartialStackComponent
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.common.ComponentConditions
@@ -136,6 +137,7 @@ internal class StackComponentViewWindowTests {
                     LocalizationKey("dummyKey") to LocalizationData.Text("dummyText")
                 )
             ),
+            uiConfig = UiConfig(),
             offering = Offering(
                 identifier = "identifier",
                 serverDescription = "description",

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.components.ImageComponent
 import com.revenuecat.purchases.paywalls.components.PartialImageComponent
@@ -50,6 +51,7 @@ class StyleFactoryTests {
             LOCALIZATION_KEY_TEXT_2 to LocalizationData.Text("this is text 2"),
         )
     )
+    private val uiConfig = UiConfig()
     private val offering = Offering(
         identifier = "identifier",
         serverDescription = "description",
@@ -59,7 +61,7 @@ class StyleFactoryTests {
 
     @Before
     fun setup() {
-        styleFactory = StyleFactory(localizations, offering)
+        styleFactory = StyleFactory(localizations, uiConfig, offering)
     }
 
     @Test
@@ -137,6 +139,7 @@ class StyleFactoryTests {
                     otherLocalizationKey to LocalizationData.Text(unexpectedText)
                 ),
             ),
+            uiConfig = uiConfig,
             offering = offering,
         )
 
@@ -176,6 +179,7 @@ class StyleFactoryTests {
                     // otherLocale is missing the overrideLocalizationKey.
                 ),
             ),
+            uiConfig = uiConfig,
             offering = offering,
         )
 
@@ -217,6 +221,7 @@ class StyleFactoryTests {
                     otherLocalizationKey to LocalizationData.Text(unexpectedText)
                 ),
             ),
+            uiConfig = uiConfig,
             offering = offering,
         )
 
@@ -272,6 +277,7 @@ class StyleFactoryTests {
                     LocalizationKey("key-text") to LocalizationData.Text("value-text"),
                 ),
             ),
+            uiConfig = uiConfig,
             offering = offering,
         )
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewTests.kt
@@ -157,6 +157,7 @@ class TextComponentViewTests {
     )
     private val styleFactory = StyleFactory(
         localizations = localizations,
+        uiConfig = UiConfig(),
         offering = Offering(
             identifier = "identifier",
             serverDescription = "description",
@@ -363,6 +364,7 @@ class TextComponentViewTests {
         val state = offering.toComponentsPaywallState(validated)
         val styleFactory = StyleFactory(
             localizations = localizations,
+            uiConfig = UiConfig(),
             offering = offering,
         )
         val style = styleFactory.create(component).getOrThrow() as PackageComponentStyle
@@ -524,6 +526,7 @@ class TextComponentViewTests {
         val state = offering.toComponentsPaywallState(validated)
         val styleFactory = StyleFactory(
             localizations = localizations,
+            uiConfig = UiConfig(),
             offering = offering,
         )
         val noIntroOfferPackageComponentStyle =
@@ -607,7 +610,7 @@ class TextComponentViewTests {
             metadata = emptyMap(),
             availablePackages = emptyList(),
         )
-        val styleFactory = StyleFactory(localizations, offering)
+        val styleFactory = StyleFactory(localizations, UiConfig(), offering)
         val style = styleFactory.create(component).getOrThrow() as TextComponentStyle
         val state = FakePaywallState(
             localizations = localizations,
@@ -656,7 +659,7 @@ class TextComponentViewTests {
             metadata = emptyMap(),
             availablePackages = emptyList(),
         )
-        val styleFactory = StyleFactory(localizations, offering)
+        val styleFactory = StyleFactory(localizations, UiConfig(), offering)
         val style = styleFactory.create(component).getOrThrow() as TextComponentStyle
         val state = FakePaywallState(
             localizations = localizations,
@@ -721,6 +724,7 @@ class TextComponentViewTests {
 
         val styleFactory = StyleFactory(
             localizations = localizations,
+            uiConfig = UiConfig(),
             offering = offering,
         )
         val styleSelected = styleFactory.create(selectedComponent).getOrThrow() as TextComponentStyle
@@ -812,6 +816,7 @@ class TextComponentViewTests {
 
         val styleFactory = StyleFactory(
             localizations = localizations,
+            uiConfig = UiConfig(),
             offering = offering,
         )
         val styleSelected = styleFactory.create(component).getOrThrow() as TextComponentStyle

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewWindowTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewWindowTests.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.paywalls.components.PartialTextComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.common.ComponentConditions
@@ -107,6 +108,7 @@ internal class TextComponentViewWindowTests {
         )
         val styleFactory = StyleFactory(
             localizations = localizations,
+            uiConfig = UiConfig(),
             offering = Offering(
             identifier = "identifier",
             serverDescription = "description",


### PR DESCRIPTION
## Description
This is similar to this iOS PR: https://github.com/RevenueCat/purchases-ios/pull/4650. This is not as bad as it looks. Hear me out. 😇 

Some small changes with lots of ripple effects:
- `ColorInfo.Alias`'s value is a `ColorAlias` now, allowing us to get color aliases from the `UiConfig` map with type safety. 
- Adds `ColorStyles`, which is basically to `ColorStyle` what `ColorScheme` is to `ColorInfo`. We need an object containing actual colors for both light and dark, without aliases. 
- Uses `ColorStyles` instead of `ColorScheme` in `StackComponentStyle` and `PresentedStackPartial`. 

A lot of the changed lines are tests:
- `PresentedStackPartialTests`
- `ColorStyleTests`

Follow-up PRs will change all usages of `ColorScheme`s in the other `*ComponentStyle`s to `ColorStyles`. 