### PR TITLE
`PaywallTesterApp` is no longer wrapped in a `Surface`

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
@@ -5,9 +5,10 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import com.revenuecat.paywallstester.ui.theme.PaywallTesterAndroidTheme
 import com.revenuecat.purchases.Offering
@@ -23,7 +24,7 @@ class MainActivity : ComponentActivity(), PaywallResultHandler {
         paywallActivityLauncher = PaywallActivityLauncher(this, this)
         setContent {
             PaywallTesterAndroidTheme {
-                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
                     PaywallTesterApp()
                 }
             }


### PR DESCRIPTION
## Motivation
While debugging some theming issues in PaywallsTester, I noticed that the entire app composable is wrapped in a `Surface`.  This turned out not to be the cause of the issue, but it made my spidey sense tingle, as `Surface` overrides the `LocalContentColor` of its children. To avoid potential issues, and confusion / red-herring-chasing in the future, I figured we can change this to a `Box` with a `.background()`.