### PR TITLE
Rename to Web Billing

### DIFF
--- a/examples/web-purchase-redemption-sample/src/main/java/com/revenuecat/webpurchaseredemptionsample/Constants.kt
+++ b/examples/web-purchase-redemption-sample/src/main/java/com/revenuecat/webpurchaseredemptionsample/Constants.kt
@@ -1,9 +1,9 @@
 package com.revenuecat.webpurchaseredemptionsample
 
 object Constants {
-    // Put API key for the android app associated to the same project as your RCBilling project
+    // Put API key for the android app associated to the same project as your Web Billing app
     const val API_KEY = "api_key"
 
-    // Put the same entitlement ID that the purchase unlocks in your RCBilling project
+    // Put the same entitlement ID that the purchase unlocks in your Web Billing project
     const val ENTITLEMENT_ID = "catServices"
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
@@ -220,7 +220,7 @@ enum class Store {
     AMAZON,
 
     /**
-     * For entitlements granted via RC Billing.
+     * For entitlements granted via RevenueCat's Web Billing.
      */
     @SerialName("rc_billing")
     RC_BILLING,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendRedeemWebPurchaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendRedeemWebPurchaseTest.kt
@@ -95,7 +95,7 @@ class BackendRedeemWebPurchaseTest {
         val responseBody = """
             {
                 "code": 7849,
-                "message": "Invalid RevenueCat Billing redemption token."
+                "message": "Invalid Web Billing redemption token."
             }
         """.trimIndent()
         mockHttpResult(responseCode = RCHTTPStatusCodes.BAD_REQUEST, responseBody = responseBody)


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
RevenueCat Billing product is being renamed to Web Billing
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
- Rename "RevenueCat Billing"/"RC Billing" to "Web Billing" in a couple of places. 
- Store enum remains unchanged