### PR TITLE
Customer Center use remote appearance config

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallColorTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/PaywallColorTest.kt
@@ -6,7 +6,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import java.util.*
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -5,6 +5,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.customercenter
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -37,6 +38,7 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
 import com.revenuecat.purchases.ui.revenuecatui.composables.ErrorDialog
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.actions.CustomerCenterAction
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCenterConfigTestData
@@ -143,8 +145,20 @@ private fun InternalCustomerCenter(
         } else {
             appearance.light?.accentColor?.colorInt
         }?.let { Color(it) }
+
+        // Only change background if there is a promotional offer
+        var backgroundColor: Color? = null
+        if (state.promotionalOfferData != null) {
+            backgroundColor = if (isDark) {
+                appearance.dark?.backgroundColor?.colorInt
+            } else {
+                appearance.light?.backgroundColor?.colorInt
+            }?.let { Color(it) }
+        }
+
         colorScheme = MaterialTheme.colorScheme.copy(
             primary = accentColor ?: MaterialTheme.colorScheme.primary,
+            background = backgroundColor ?: MaterialTheme.colorScheme.background,
         )
     } else {
         colorScheme = MaterialTheme.colorScheme
@@ -154,7 +168,8 @@ private fun InternalCustomerCenter(
         colorScheme = colorScheme,
     ) {
         CustomerCenterScaffold(
-            modifier = modifier,
+            modifier = modifier
+                .background(MaterialTheme.colorScheme.background),
             title = title,
             onAction = onAction,
             navigationButtonType =
@@ -246,6 +261,7 @@ private fun CustomerCenterLoaded(
         val promotionalOfferData = state.promotionalOfferData
         PromotionalOfferView(
             promotionalOfferData = promotionalOfferData,
+            appearance = state.customerCenterConfigData.appearance,
             onAccept = { subscriptionOption ->
                 onAction(CustomerCenterAction.PurchasePromotionalOffer(subscriptionOption))
             },

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -5,6 +5,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.customercenter
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -16,6 +17,7 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -26,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -130,25 +133,46 @@ private fun InternalCustomerCenter(
     onAction: (CustomerCenterAction) -> Unit,
 ) {
     val title = getTitleForState(state)
-    CustomerCenterScaffold(
-        modifier = modifier,
-        title = title,
-        onAction = onAction,
-        navigationButtonType =
-        if (state is CustomerCenterState.Success) {
-            state.navigationButtonType
+
+    val colorScheme: ColorScheme
+    if (state is CustomerCenterState.Success) {
+        val isDark = isSystemInDarkTheme()
+        val appearance: CustomerCenterConfigData.Appearance = state.customerCenterConfigData.appearance
+        val accentColor: Color? = if (isDark) {
+            appearance.dark?.accentColor?.colorInt
         } else {
-            CustomerCenterState.NavigationButtonType.CLOSE
-        },
+            appearance.light?.accentColor?.colorInt
+        }?.let { Color(it) }
+        colorScheme = MaterialTheme.colorScheme.copy(
+            primary = accentColor ?: MaterialTheme.colorScheme.primary,
+        )
+    } else {
+        colorScheme = MaterialTheme.colorScheme
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
     ) {
-        when (state) {
-            is CustomerCenterState.NotLoaded -> {}
-            is CustomerCenterState.Loading -> CustomerCenterLoading()
-            is CustomerCenterState.Error -> CustomerCenterError(state)
-            is CustomerCenterState.Success -> CustomerCenterLoaded(
-                state,
-                onAction,
-            )
+        CustomerCenterScaffold(
+            modifier = modifier,
+            title = title,
+            onAction = onAction,
+            navigationButtonType =
+            if (state is CustomerCenterState.Success) {
+                state.navigationButtonType
+            } else {
+                CustomerCenterState.NavigationButtonType.CLOSE
+            },
+        ) {
+            when (state) {
+                is CustomerCenterState.NotLoaded -> {}
+                is CustomerCenterState.Loading -> CustomerCenterLoading()
+                is CustomerCenterState.Error -> CustomerCenterError(state)
+                is CustomerCenterState.Success -> CustomerCenterLoaded(
+                    state,
+                    onAction,
+                )
+            }
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -38,11 +37,11 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
-import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
 import com.revenuecat.purchases.ui.revenuecatui.composables.ErrorDialog
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.actions.CustomerCenterAction
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCenterConfigTestData
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCenterState
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.getColorForTheme
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.dialogs.RestorePurchasesDialog
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.viewmodel.CustomerCenterViewModel
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.viewmodel.CustomerCenterViewModelFactory
@@ -140,20 +139,13 @@ private fun InternalCustomerCenter(
     if (state is CustomerCenterState.Success) {
         val isDark = isSystemInDarkTheme()
         val appearance: CustomerCenterConfigData.Appearance = state.customerCenterConfigData.appearance
-        val accentColor: Color? = if (isDark) {
-            appearance.dark?.accentColor?.colorInt
-        } else {
-            appearance.light?.accentColor?.colorInt
-        }?.let { Color(it) }
+        val accentColor = appearance.getColorForTheme(isDark) { it.accentColor }
 
-        // Only change background if there is a promotional offer
-        var backgroundColor: Color? = null
-        if (state.promotionalOfferData != null) {
-            backgroundColor = if (isDark) {
-                appearance.dark?.backgroundColor?.colorInt
-            } else {
-                appearance.light?.backgroundColor?.colorInt
-            }?.let { Color(it) }
+        // Only change background when presenting a promotional offer
+        val backgroundColor = if (state.promotionalOfferData != null) {
+            appearance.getColorForTheme(isDark) { it.backgroundColor }
+        } else {
+            null
         }
 
         colorScheme = MaterialTheme.colorScheme.copy(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -135,8 +134,7 @@ private fun InternalCustomerCenter(
 ) {
     val title = getTitleForState(state)
 
-    val colorScheme: ColorScheme
-    if (state is CustomerCenterState.Success) {
+    val colorScheme = if (state is CustomerCenterState.Success) {
         val isDark = isSystemInDarkTheme()
         val appearance: CustomerCenterConfigData.Appearance = state.customerCenterConfigData.appearance
         val accentColor = appearance.getColorForTheme(isDark) { it.accentColor }
@@ -148,12 +146,12 @@ private fun InternalCustomerCenter(
             null
         }
 
-        colorScheme = MaterialTheme.colorScheme.copy(
+        MaterialTheme.colorScheme.copy(
             primary = accentColor ?: MaterialTheme.colorScheme.primary,
             background = backgroundColor ?: MaterialTheme.colorScheme.background,
         )
     } else {
-        colorScheme = MaterialTheme.colorScheme
+        MaterialTheme.colorScheme
     }
 
     MaterialTheme(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterConfigDataExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterConfigDataExtensions.kt
@@ -1,0 +1,19 @@
+@file:JvmSynthetic
+@file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.customercenter.data
+
+import androidx.compose.ui.graphics.Color
+import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
+import com.revenuecat.purchases.customercenter.RCColor
+
+@JvmSynthetic internal fun CustomerCenterConfigData.Appearance.getColorForTheme(
+    isDark: Boolean,
+    selector: (CustomerCenterConfigData.Appearance.ColorInformation) -> RCColor?,
+): Color? {
+    return (if (isDark) dark else light)
+        ?.let(selector)
+        ?.colorInt
+        ?.let { Color(it) }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
@@ -161,6 +162,7 @@ fun CompatibilityContentUnavailableView(
         Image(
             painter = painterResource(id = drawableResId),
             contentDescription = null,
+            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
             modifier = Modifier
                 .size(48.dp)
                 .padding(bottom = 8.dp),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
@@ -331,7 +331,7 @@ private fun CustomerCenterButton(
                 .padding(start = startPadding, end = endPadding),
             // It's a rectangle so it gets clipped by the parent Surface.
             shape = RectangleShape,
-            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onSurface),
+            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.primary),
         ) {
             buttonContent(Modifier.fillMaxWidth())
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PromotionalOfferView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PromotionalOfferView.kt
@@ -3,6 +3,7 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.customercenter.views
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,12 +11,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.android.billingclient.api.ProductDetails
@@ -38,10 +41,28 @@ import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.PromotionalO
 @Composable
 internal fun PromotionalOfferView(
     promotionalOfferData: PromotionalOfferData,
+    appearance: CustomerCenterConfigData.Appearance,
     onAccept: (SubscriptionOption) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val isDark = isSystemInDarkTheme()
+    val textColor: Color? = if (isDark) {
+        appearance.dark?.textColor?.colorInt
+    } else {
+        appearance.light?.textColor?.colorInt
+    }?.let { Color(it) }
+    val buttonBackgroundColor: Color? = if (isDark) {
+        appearance.dark?.buttonBackgroundColor?.colorInt
+    } else {
+        appearance.light?.buttonBackgroundColor?.colorInt
+    }?.let { Color(it) }
+    val buttonTextColor: Color? = if (isDark) {
+        appearance.dark?.buttonTextColor?.colorInt
+    } else {
+        appearance.light?.buttonTextColor?.colorInt
+    }?.let { Color(it) }
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
@@ -57,11 +78,13 @@ internal fun PromotionalOfferView(
         Text(
             text = promotionalOfferData.configuredPromotionalOffer.title,
             style = MaterialTheme.typography.headlineLarge,
+            color = textColor ?: MaterialTheme.colorScheme.onBackground,
             modifier = Modifier.padding(top = 16.dp),
         )
         Text(
             text = promotionalOfferData.configuredPromotionalOffer.subtitle,
             style = MaterialTheme.typography.bodyLarge,
+            color = textColor ?: MaterialTheme.colorScheme.onBackground,
             modifier = Modifier.padding(top = 16.dp),
         )
 
@@ -74,6 +97,10 @@ internal fun PromotionalOfferView(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 16.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = buttonBackgroundColor ?: MaterialTheme.colorScheme.primary,
+                contentColor = buttonTextColor ?: MaterialTheme.colorScheme.onPrimary,
+            ),
         ) {
             @Suppress("ForbiddenComment")
             // TODO: modify this to display price of the offer
@@ -84,6 +111,10 @@ internal fun PromotionalOfferView(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 16.dp),
+            colors = ButtonDefaults.outlinedButtonColors(
+                containerColor = Color.Transparent,
+                contentColor = buttonTextColor ?: MaterialTheme.colorScheme.primary,
+            ),
         ) {
             Text("No Thanks")
         }
@@ -111,6 +142,7 @@ internal fun PromotionalOfferViewPreview() {
     )
     PromotionalOfferView(
         data,
+        appearance = CustomerCenterConfigTestData.customerCenterData().appearance,
         onAccept = {},
         onDismiss = {},
     )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PromotionalOfferView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PromotionalOfferView.kt
@@ -36,6 +36,7 @@ import com.revenuecat.purchases.models.toRecurrenceMode
 import com.revenuecat.purchases.ui.revenuecatui.composables.AppIcon
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCenterConfigTestData
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.PromotionalOfferData
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.getColorForTheme
 
 @JvmSynthetic
 @Composable
@@ -47,21 +48,9 @@ internal fun PromotionalOfferView(
     modifier: Modifier = Modifier,
 ) {
     val isDark = isSystemInDarkTheme()
-    val textColor: Color? = if (isDark) {
-        appearance.dark?.textColor?.colorInt
-    } else {
-        appearance.light?.textColor?.colorInt
-    }?.let { Color(it) }
-    val buttonBackgroundColor: Color? = if (isDark) {
-        appearance.dark?.buttonBackgroundColor?.colorInt
-    } else {
-        appearance.light?.buttonBackgroundColor?.colorInt
-    }?.let { Color(it) }
-    val buttonTextColor: Color? = if (isDark) {
-        appearance.dark?.buttonTextColor?.colorInt
-    } else {
-        appearance.light?.buttonTextColor?.colorInt
-    }?.let { Color(it) }
+    val textColor = appearance.getColorForTheme(isDark) { it.textColor }
+    val buttonBackgroundColor = appearance.getColorForTheme(isDark) { it.buttonBackgroundColor }
+    val buttonTextColor = appearance.getColorForTheme(isDark) { it.buttonTextColor }
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,


### PR DESCRIPTION
For this configuration:

<img width="881" alt="Screenshot 2025-01-30 at 19 40 25" src="https://github.com/user-attachments/assets/bea30893-eba3-4700-8e3f-8d7f22a45e5d" />

This is how it's built:

| Light | Dark |
|--------|--------|
| <img width="428" alt="Screenshot 2025-01-30 at 19 47 34" src="https://github.com/user-attachments/assets/71f2f780-0c7c-44e4-9b5b-bbc2d86774d9" /> | <img width="427" alt="Screenshot 2025-01-30 at 19 41 27" src="https://github.com/user-attachments/assets/2181e950-dd55-476f-aafe-35d20fe102bc" /> |
| <img width="427" alt="Screenshot 2025-01-30 at 19 47 02" src="https://github.com/user-attachments/assets/8a65403c-ed81-40b1-8d48-7e9ec77ee790" /> | <img width="431" alt="Screenshot 2025-01-30 at 19 46 19" src="https://github.com/user-attachments/assets/752e0651-c2b0-431e-b1d5-7bc393b56db9" /> |
| <img width="423" alt="Screenshot 2025-01-30 at 19 48 01" src="https://github.com/user-attachments/assets/b8c98695-b120-47ab-ac41-2a3bb2aba50d" /> | <img width="430" alt="Screenshot 2025-01-30 at 19 48 24" src="https://github.com/user-attachments/assets/49932ed5-6d94-4204-a964-eddfe99e98fc" /> |
| <img width="432" alt="Screenshot 2025-01-30 at 19 49 02" src="https://github.com/user-attachments/assets/7eaeee80-5935-45c3-be1b-239559b5263f" /> | <img width="427" alt="Screenshot 2025-01-30 at 19 48 44" src="https://github.com/user-attachments/assets/abf5a08e-e7a3-439e-91da-8501e72bf87b" /> |
