### PR TITLE
[Paywalls V2] Use original paywall fallback when trying to use Footer modes in a Components paywall

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorSt
 
 internal sealed class PaywallValidationError : Throwable() {
 
+    @Suppress("CyclomaticComplexMethod")
     fun associatedErrorString(offering: Offering): String {
         return when (this) {
             is InvalidIcons -> {
@@ -35,6 +36,7 @@ internal sealed class PaywallValidationError : Throwable() {
             is MissingColorAlias -> message
             is AliasedColorIsAlias -> message
             is MissingFontAlias -> message
+            is InvalidModeForComponentsPaywall -> PaywallValidationErrorStrings.INVALID_MODE_FOR_COMPONENTS_PAYWALL
         }
     }
 
@@ -90,4 +92,5 @@ internal sealed class PaywallValidationError : Throwable() {
     ) : PaywallValidationError() {
         override val message: String = PaywallValidationErrorStrings.MISSING_FONT_ALIAS.format(alias.value)
     }
+    object InvalidModeForComponentsPaywall : PaywallValidationError()
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -63,7 +63,8 @@ internal fun PaywallData.validate(
     )
 }
 
-private fun Offering.fallbackPaywall(
+@JvmSynthetic
+internal fun Offering.fallbackPaywall(
     currentColorScheme: ColorScheme,
     resourceProvider: ResourceProvider,
     error: PaywallValidationError,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/strings/PaywallValidationErrorStrings.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/strings/PaywallValidationErrorStrings.kt
@@ -22,4 +22,6 @@ internal object PaywallValidationErrorStrings {
     const val MISSING_COLOR_ALIAS = "Aliased color '%s' does not exist."
     const val ALIASED_COLOR_IS_ALIAS = "Aliased color '%s' has an aliased value '%s', which is not allowed."
     const val MISSING_FONT_ALIAS = "Aliased font '%s' does not exist."
+    const val INVALID_MODE_FOR_COMPONENTS_PAYWALL =
+        "Components paywall does not support footer modes. Falling back to legacy fallback paywall."
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -573,6 +573,66 @@ class PaywallViewModelTest {
     }
 
     @Test
+    fun `Should load paywall components if using components paywall in full screen mode`(): Unit = runBlocking {
+        // Arrange
+        val offering = Offering(
+            identifier = "offering-id",
+            serverDescription = "description",
+            metadata = emptyMap(),
+            availablePackages = listOf(TestData.Packages.monthly, TestData.Packages.annual),
+            paywallComponents = Offering.PaywallComponents(UiConfig(), emptyPaywallComponentsData),
+        )
+
+        // Act
+        val model = create(offering = offering, mode = PaywallMode.FULL_SCREEN)
+
+        // Assert
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+    }
+
+    @Test
+    fun `Should load fallback paywall if using components paywall in footer mode`(): Unit = runBlocking {
+        // Arrange
+        val offering = Offering(
+            identifier = "offering-id",
+            serverDescription = "description",
+            metadata = emptyMap(),
+            availablePackages = listOf(TestData.Packages.monthly, TestData.Packages.annual),
+            paywallComponents = Offering.PaywallComponents(UiConfig(), emptyPaywallComponentsData),
+        )
+
+        // Act
+        val model = create(offering = offering, mode = PaywallMode.FOOTER)
+
+        // Assert
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Legacy::class.java)
+        assertThat(
+            (model.state.value as PaywallState.Loaded.Legacy).templateConfiguration.packages.all.size
+        ).isEqualTo(2)
+    }
+
+    @Test
+    fun `Should load fallback paywall if using components paywall in footer condensed mode`(): Unit = runBlocking {
+        // Arrange
+        val offering = Offering(
+            identifier = "offering-id",
+            serverDescription = "description",
+            metadata = emptyMap(),
+            availablePackages = listOf(TestData.Packages.monthly, TestData.Packages.annual),
+            paywallComponents = Offering.PaywallComponents(UiConfig(), emptyPaywallComponentsData),
+        )
+
+        // Act
+        val model = create(offering = offering, mode = PaywallMode.FOOTER_CONDENSED)
+
+        // Assert
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Legacy::class.java)
+        assertThat(
+            (model.state.value as PaywallState.Loaded.Legacy).templateConfiguration.packages.all.size
+        ).isEqualTo(2)
+    }
+
+    @Test
     fun `selectPackage`() {
         val model = create()
 
@@ -1129,7 +1189,8 @@ class PaywallViewModelTest {
         activeSubscriptions: Set<String> = setOf(),
         nonSubscriptionTransactionProductIdentifiers: Set<String> = setOf(),
         customPurchaseLogic: PurchaseLogic? = null,
-        shouldDisplayBlock: ((CustomerInfo) -> Boolean)? = null
+        mode: PaywallMode = PaywallMode.default,
+        shouldDisplayBlock: ((CustomerInfo) -> Boolean)? = null,
     ): PaywallViewModelImpl {
         mockActiveSubscriptions(activeSubscriptions)
         mockNonSubscriptionTransactions(nonSubscriptionTransactionProductIdentifiers)
@@ -1141,6 +1202,7 @@ class PaywallViewModelTest {
                 .setListener(listener)
                 .setOffering(offering)
                 .setPurchaseLogic(customPurchaseLogic)
+                .setMode(mode)
                 .build(),
             TestData.Constants.currentColorScheme,
             isDarkMode = false,


### PR DESCRIPTION
### Description
Until now, if trying to present a components paywall as a footer, it would display the paywall mostly full screen with some indeterminate behavior.

After this, if the developer tries to present a paywall v2 as a footer/condensed footer, we will fallback to the original paywall fallback paywall, which uses template 2 right now.