### PR TITLE
Fixes `X` in promo offer not dismissing the promo

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -71,11 +71,7 @@ internal fun InternalCustomerCenter(
     }
 
     BackHandler {
-        val buttonType = state.navigationButtonType
-        viewModel.onNavigationButtonPressed(context)
-        if (buttonType == CustomerCenterState.NavigationButtonType.CLOSE) {
-            onDismiss()
-        }
+        viewModel.onNavigationButtonPressed(context, onDismiss)
     }
 
     viewModel.actionError.value?.let {
@@ -106,11 +102,7 @@ internal fun InternalCustomerCenter(
                 is CustomerCenterAction.ContactSupport -> viewModel.contactSupport(context, action.email)
                 is CustomerCenterAction.OpenURL -> viewModel.openURL(context, action.url)
                 is CustomerCenterAction.NavigationButtonPressed -> {
-                    val buttonType = state.navigationButtonType
-                    viewModel.onNavigationButtonPressed(context)
-                    if (buttonType == CustomerCenterState.NavigationButtonType.CLOSE) {
-                        onDismiss()
-                    }
+                    viewModel.onNavigationButtonPressed(context, onDismiss)
                 }
 
                 is CustomerCenterAction.DismissPromotionalOffer ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -106,7 +106,7 @@ internal fun InternalCustomerCenter(
                 }
 
                 is CustomerCenterAction.DismissPromotionalOffer ->
-                    viewModel.dismissPromotionalOffer(action.originalPath, context)
+                    viewModel.dismissPromotionalOffer(context, action.originalPath)
                 is CustomerCenterAction.PurchasePromotionalOffer -> {
                     val activity = context.getActivity()
                     coroutineScope.launch {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -72,7 +72,7 @@ internal fun InternalCustomerCenter(
 
     BackHandler {
         val buttonType = state.navigationButtonType
-        viewModel.onNavigationButtonPressed()
+        viewModel.onNavigationButtonPressed(context)
         if (buttonType == CustomerCenterState.NavigationButtonType.CLOSE) {
             onDismiss()
         }
@@ -107,7 +107,7 @@ internal fun InternalCustomerCenter(
                 is CustomerCenterAction.OpenURL -> viewModel.openURL(context, action.url)
                 is CustomerCenterAction.NavigationButtonPressed -> {
                     val buttonType = state.navigationButtonType
-                    viewModel.onNavigationButtonPressed()
+                    viewModel.onNavigationButtonPressed(context)
                     if (buttonType == CustomerCenterState.NavigationButtonType.CLOSE) {
                         onDismiss()
                     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterState.kt
@@ -32,7 +32,6 @@ internal sealed class CustomerCenterState(
         @get:JvmSynthetic val promotionalOfferData: PromotionalOfferData? = null,
         @get:JvmSynthetic val title: String? = null,
         @get:JvmSynthetic override val navigationButtonType: NavigationButtonType = NavigationButtonType.CLOSE,
-        @get:JvmSynthetic val onNavigationOverride: (() -> Unit)? = null,
     ) : CustomerCenterState(navigationButtonType)
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterState.kt
@@ -32,6 +32,7 @@ internal sealed class CustomerCenterState(
         @get:JvmSynthetic val promotionalOfferData: PromotionalOfferData? = null,
         @get:JvmSynthetic val title: String? = null,
         @get:JvmSynthetic override val navigationButtonType: NavigationButtonType = NavigationButtonType.CLOSE,
+        @get:JvmSynthetic val onNavigationOverride: (() -> Unit)? = null,
     ) : CustomerCenterState(navigationButtonType)
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -475,7 +475,7 @@ internal class CustomerCenterViewModelImpl(
                     currentState.navigationButtonType == CustomerCenterState.NavigationButtonType.BACK -> {
                     currentState.resetToMainScreen()
                 }
-                else -> currentState
+                else -> CustomerCenterState.NotLoaded
             }
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -526,6 +526,7 @@ internal class CustomerCenterViewModelImpl(
             showRestoreDialog = false,
             title = null,
             navigationButtonType = CustomerCenterState.NavigationButtonType.CLOSE,
+            onNavigationOverride = null,
         )
 
     private fun showManageSubscriptions(context: Context, productId: String) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -135,12 +135,15 @@ internal class CustomerCenterViewModelImpl(
                 goBackToMain()
                 option?.let {
                     if (product != null && it.promotionalOffer != null) {
-                        loadAndDisplayPromotionalOffer(
+                        val loaded = loadAndDisplayPromotionalOffer(
                             product,
                             it.promotionalOffer!!,
                             path,
                             context,
                         )
+                        if (!loaded) {
+                            mainPathAction(path, context)
+                        }
                     } else {
                         mainPathAction(path, context)
                     }
@@ -150,12 +153,15 @@ internal class CustomerCenterViewModelImpl(
         }
 
         if (product != null && path.promotionalOffer != null) {
-            loadAndDisplayPromotionalOffer(
+            val loaded = loadAndDisplayPromotionalOffer(
                 product,
                 path.promotionalOffer!!,
                 path,
                 context,
             )
+            if (!loaded) {
+                mainPathAction(path, context)
+            }
         } else {
             mainPathAction(path, context)
         }
@@ -417,7 +423,9 @@ internal class CustomerCenterViewModelImpl(
                     currentState
                 }
             }
+            return true
         }
+        return false
     }
 
     override suspend fun onAcceptedPromotionalOffer(subscriptionOption: SubscriptionOption, activity: Activity?) {
@@ -459,12 +467,12 @@ internal class CustomerCenterViewModelImpl(
         _state.update { currentState ->
             when {
                 currentState is CustomerCenterState.Success &&
-                currentState.onNavigationOverride != null -> {
+                    currentState.onNavigationOverride != null -> {
                     currentState.onNavigationOverride.invoke()
                     currentState.copy(onNavigationOverride = null)
                 }
                 currentState is CustomerCenterState.Success &&
-                currentState.navigationButtonType == CustomerCenterState.NavigationButtonType.BACK -> {
+                    currentState.navigationButtonType == CustomerCenterState.NavigationButtonType.BACK -> {
                     currentState.copy(
                         feedbackSurveyData = null,
                         showRestoreDialog = false,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -71,7 +71,7 @@ internal interface CustomerCenterViewModel {
 
     suspend fun onAcceptedPromotionalOffer(subscriptionOption: SubscriptionOption, activity: Activity?)
     fun dismissPromotionalOffer(originalPath: CustomerCenterConfigData.HelpPath, context: Context)
-    fun onNavigationButtonPressed(context: Context)
+    fun onNavigationButtonPressed(context: Context, onDismiss: () -> Unit)
     suspend fun loadCustomerCenter()
     fun openURL(
         context: Context,
@@ -462,7 +462,7 @@ internal class CustomerCenterViewModelImpl(
         }
     }
 
-    override fun onNavigationButtonPressed(context: Context) {
+    override fun onNavigationButtonPressed(context: Context, onDismiss: () -> Unit) {
         val currentState = _state.value
         if (currentState is CustomerCenterState.Success && currentState.promotionalOfferData != null) {
             dismissPromotionalOffer(currentState.promotionalOfferData.originalPath, context)
@@ -476,6 +476,10 @@ internal class CustomerCenterViewModelImpl(
                     }
                     else -> CustomerCenterState.NotLoaded
                 }
+            }
+            val buttonType = state.value.navigationButtonType
+            if (buttonType == CustomerCenterState.NavigationButtonType.CLOSE) {
+                onDismiss()
             }
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -63,14 +63,14 @@ internal interface CustomerCenterViewModel {
     suspend fun restorePurchases()
     fun contactSupport(context: Context, supportEmail: String)
     fun loadAndDisplayPromotionalOffer(
+        context: Context,
         product: StoreProduct,
         promotionalOffer: CustomerCenterConfigData.HelpPath.PathDetail.PromotionalOffer,
         originalPath: CustomerCenterConfigData.HelpPath,
-        context: Context,
     ): Boolean
 
     suspend fun onAcceptedPromotionalOffer(subscriptionOption: SubscriptionOption, activity: Activity?)
-    fun dismissPromotionalOffer(originalPath: CustomerCenterConfigData.HelpPath, context: Context)
+    fun dismissPromotionalOffer(context: Context, originalPath: CustomerCenterConfigData.HelpPath)
     fun onNavigationButtonPressed(context: Context, onDismiss: () -> Unit)
     suspend fun loadCustomerCenter()
     fun openURL(
@@ -136,10 +136,10 @@ internal class CustomerCenterViewModelImpl(
                 option?.let {
                     if (product != null && it.promotionalOffer != null) {
                         val loaded = loadAndDisplayPromotionalOffer(
+                            context,
                             product,
                             it.promotionalOffer!!,
                             path,
-                            context,
                         )
                         if (!loaded) {
                             mainPathAction(path, context)
@@ -154,10 +154,10 @@ internal class CustomerCenterViewModelImpl(
 
         if (product != null && path.promotionalOffer != null) {
             val loaded = loadAndDisplayPromotionalOffer(
+                context,
                 product,
                 path.promotionalOffer!!,
                 path,
-                context,
             )
             if (!loaded) {
                 mainPathAction(path, context)
@@ -390,10 +390,10 @@ internal class CustomerCenterViewModelImpl(
     }
 
     override fun loadAndDisplayPromotionalOffer(
+        context: Context,
         product: StoreProduct,
         promotionalOffer: CustomerCenterConfigData.HelpPath.PathDetail.PromotionalOffer,
         originalPath: CustomerCenterConfigData.HelpPath,
-        context: Context,
     ): Boolean {
         val offerIdentifier = promotionalOffer.productMapping[product.id]
         val subscriptionOption = product.subscriptionOptions?.firstOrNull { option ->
@@ -448,7 +448,10 @@ internal class CustomerCenterViewModelImpl(
         }
     }
 
-    override fun dismissPromotionalOffer(originalPath: CustomerCenterConfigData.HelpPath, context: Context) {
+    override fun dismissPromotionalOffer(
+        context: Context,
+        originalPath: CustomerCenterConfigData.HelpPath,
+    ) {
         // Continue with the original action and remove the promotional offer data
         mainPathAction(originalPath, context)
 
@@ -465,7 +468,7 @@ internal class CustomerCenterViewModelImpl(
     override fun onNavigationButtonPressed(context: Context, onDismiss: () -> Unit) {
         val currentState = _state.value
         if (currentState is CustomerCenterState.Success && currentState.promotionalOfferData != null) {
-            dismissPromotionalOffer(currentState.promotionalOfferData.originalPath, context)
+            dismissPromotionalOffer(context, currentState.promotionalOfferData.originalPath)
         } else {
             // Perform the default navigation action
             _state.update { state ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -418,11 +418,11 @@ internal class CustomerCenterViewModelImpl(
                             pricingPhasesDescription,
                         ),
                     )
+                    return true
                 } else {
                     currentState
                 }
             }
-            return true
         }
         return false
     }


### PR DESCRIPTION
Touching the `X` navigation button in the promotional offer closes the whole Customer Center, this PR modifies that behavior and adds a way to override what the X does. In the case of the promotional offer, it should call `dismissPromotionalOffer` which effectively calls the main action that the user triggered (like Cancel Purchase)

Also fixes another bug related to promotional offers, when the promo offer can't be loaded, it wasn't triggering the main path either, it was not doing anything.