### PR TITLE
feat: Add support for tracking customer center events

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -316,7 +316,7 @@ internal class PurchasesFactory(
                 identityManager,
                 eventsDispatcher,
                 postEvents = { request, onSuccess, onError ->
-                    backend.postPaywallEvents(
+                    backend.postEvents(
                         paywallEventRequest = request,
                         onSuccessHandler = onSuccess,
                         onErrorHandler = onError,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -492,7 +492,7 @@ internal class Backend(
         }
     }
 
-    fun postPaywallEvents(
+    fun postEvents(
         paywallEventRequest: EventsRequest,
         onSuccessHandler: () -> Unit,
         onErrorHandler: (error: PurchasesError, shouldMarkAsSynced: Boolean) -> Unit,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common.events
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
+import com.revenuecat.purchases.customercenter.events.CustomerCenterEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.utils.Event
 import kotlinx.serialization.SerialName
@@ -70,6 +71,31 @@ internal fun PaywallEvent.toBackendStoredEvent(appUserID: String): BackendStored
             displayMode = data.displayMode,
             darkMode = data.darkMode,
             localeIdentifier = data.localeIdentifier,
+        ),
+    )
+}
+
+/**
+ * Converts a `PaywallEvent` into a `BackendStoredEvent.Paywalls` instance.
+ *
+ * @receiver The `PaywallEvent` to be converted.
+ * @param appUserID The user ID associated with the event.
+ * @return A `BackendStoredEvent.Paywalls` containing a `BackendEvent.Paywalls`.
+ */
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+internal fun CustomerCenterEvent.toBackendStoredEvent(appUserID: String): BackendStoredEvent {
+    return BackendStoredEvent.CustomerCenter(
+        BackendEvent.CustomerCenter(
+            id = creationData.id.toString(),
+            revisionID = data.revisionID,
+            type = data.type.value,
+            appUserID = appUserID,
+            appSessionID = data.sessionIdentifier.toString(),
+            timestamp = data.timestamp.time,
+            darkMode = data.darkMode,
+            locale = data.locale,
+            isSandbox = data.isSandbox,
+            displayMode = data.displayMode.value,
         ),
     )
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/EventsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/EventsManager.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.common.FileHelper
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.verboseLog
+import com.revenuecat.purchases.customercenter.events.CustomerCenterEvent
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallStoredEvent
@@ -103,6 +104,7 @@ internal class EventsManager(
 
             val backendEvent = when (event) {
                 is PaywallEvent -> event.toBackendStoredEvent(identityManager.currentAppUserID)
+                is CustomerCenterEvent -> event.toBackendStoredEvent(identityManager.currentAppUserID)
                 else -> null
             }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/events/CustomerCenterDisplayMode.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/events/CustomerCenterDisplayMode.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.customercenter.events
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
@@ -9,8 +8,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 @ExperimentalPreviewRevenueCatPurchasesAPI
-enum class CustomerCenterDisplayMode {
+enum class CustomerCenterDisplayMode(val value: String) {
 
-    @SerialName("full_screen")
-    FULL_SCREEN,
+    FULL_SCREEN(value = "full_screen"),
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/events/CustomerCenterEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/events/CustomerCenterEvent.kt
@@ -15,11 +15,10 @@ import java.util.UUID
  * Type representing a customer center event and associated data. Meant for RevenueCatUI use.
  */
 @ExperimentalPreviewRevenueCatPurchasesAPI
-@Poko
 @Serializable
-class CustomerCenterEvent(
+data class CustomerCenterEvent constructor(
     val creationData: CreationData,
-    val eventData: Data,
+    val data: Data,
 ) : FeatureEvent {
 
     companion object {
@@ -38,18 +37,19 @@ class CustomerCenterEvent(
     )
 
     @ExperimentalPreviewRevenueCatPurchasesAPI
-    @Poko
     @Serializable
     @SuppressWarnings("LongParameterList")
-    class Data(
+    data class Data(
         val type: CustomerCenterEventType,
         @Serializable(with = DateSerializer::class)
         val timestamp: Date,
+        @Serializable(with = UUIDSerializer::class)
+        val sessionIdentifier: UUID,
         val darkMode: Boolean,
         val locale: String,
         val isSandbox: Boolean,
         val version: Int = 1,
-        val revisionId: Int = 1,
+        val revisionID: Int = 1,
         val displayMode: CustomerCenterDisplayMode = CustomerCenterDisplayMode.FULL_SCREEN,
     )
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/events/CustomerCenterEventType.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/events/CustomerCenterEventType.kt
@@ -9,16 +9,16 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 @ExperimentalPreviewRevenueCatPurchasesAPI
-enum class CustomerCenterEventType {
+enum class CustomerCenterEventType(val value: String) {
     /**
      * The customer center was shown to the user.
      */
     @SerialName("customer_center_impression")
-    IMPRESSION,
+    IMPRESSION(value = "customer_center_impression"),
 
     /**
      * The customer center was closed by the user.
      */
     @SerialName("customer_center_survey_option_chosen")
-    SURVEY_OPTION_CHOSEN,
+    SURVEY_OPTION_CHOSEN(value = "customer_center_survey_option_chosen"),
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendIntegrationTest.kt
@@ -187,7 +187,7 @@ internal class ProductionBackendIntegrationTest: BaseBackendIntegrationTest() {
         ).mapNotNull { it.toBackendEvent() })
 
         ensureBlockFinishes { latch ->
-            backend.postPaywallEvents(
+            backend.postEvents(
                 request,
                 onSuccessHandler = {
                     latch.countDown()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
@@ -96,7 +96,7 @@ class BackendPaywallEventTest {
     @Test
     fun `postPaywallEvents posts events correctly`() {
         mockHttpResult()
-        backend.postPaywallEvents(
+        backend.postEvents(
             paywallEventRequest,
             onSuccessHandler = {},
             onErrorHandler = { _, _ -> },
@@ -127,7 +127,7 @@ class BackendPaywallEventTest {
     fun `postPaywallEvents calls success handler`() {
         mockHttpResult()
         var successCalled = false
-        backend.postPaywallEvents(
+        backend.postEvents(
             paywallEventRequest,
             onSuccessHandler = { successCalled = true },
             onErrorHandler = { _, _ -> fail("Expected success") },
@@ -139,7 +139,7 @@ class BackendPaywallEventTest {
     fun `postPaywallEvents calls error handler if error response code`() {
         mockHttpResult(responseCode = RCHTTPStatusCodes.ERROR)
         var errorCalled = false
-        backend.postPaywallEvents(
+        backend.postEvents(
             paywallEventRequest,
             onSuccessHandler = { fail("Expected error") },
             onErrorHandler = { _, _ -> errorCalled = true },
@@ -151,7 +151,7 @@ class BackendPaywallEventTest {
     fun `postPaywallEvents calls error handler with shouldMarkAsSynced false if server error`() {
         mockHttpResult(responseCode = RCHTTPStatusCodes.ERROR)
         var errorCalled = false
-        backend.postPaywallEvents(
+        backend.postEvents(
             paywallEventRequest,
             onSuccessHandler = { fail("Expected error") },
             onErrorHandler = { _, shouldMarkAsSynced ->
@@ -166,7 +166,7 @@ class BackendPaywallEventTest {
     fun `postPaywallEvents calls error handler with shouldMarkAsSynced false if 404`() {
         mockHttpResult(responseCode = RCHTTPStatusCodes.NOT_FOUND)
         var errorCalled = false
-        backend.postPaywallEvents(
+        backend.postEvents(
             paywallEventRequest,
             onSuccessHandler = { fail("Expected error") },
             onErrorHandler = { _, shouldMarkAsSynced ->
@@ -181,7 +181,7 @@ class BackendPaywallEventTest {
     fun `postPaywallEvents calls error handler with shouldMarkAsSynced true if 400`() {
         mockHttpResult(responseCode = RCHTTPStatusCodes.BAD_REQUEST)
         var errorCalled = false
-        backend.postPaywallEvents(
+        backend.postEvents(
             paywallEventRequest,
             onSuccessHandler = { fail("Expected error") },
             onErrorHandler = { _, shouldMarkAsSynced ->
@@ -205,7 +205,7 @@ class BackendPaywallEventTest {
             JsonPrimitive(123)
         }
         var errorCalled = false
-        backend.postPaywallEvents(
+        backend.postEvents(
             paywallEventRequest,
             onSuccessHandler = { fail("Expected error") },
             onErrorHandler = { _, shouldMarkAsSynced ->
@@ -221,7 +221,7 @@ class BackendPaywallEventTest {
     fun `postPaywallEvents calls error handler with shouldMarkAsSynced false if a network error is raised`() {
         mockHttpClientException()
         var errorCalled = false
-        backend.postPaywallEvents(
+        backend.postEvents(
             paywallEventRequest,
             onSuccessHandler = { fail("Expected error") },
             onErrorHandler = { _, shouldMarkAsSynced ->
@@ -236,12 +236,12 @@ class BackendPaywallEventTest {
     fun `postPaywallEvents multiple times with same request, only one is triggered`() {
         mockHttpResult(delayMs = 10)
         val lock = CountDownLatch(2)
-        asyncBackend.postPaywallEvents(
+        asyncBackend.postEvents(
             paywallEventRequest,
             onSuccessHandler = { lock.countDown() },
             onErrorHandler = { _, _ -> },
         )
-        asyncBackend.postPaywallEvents(
+        asyncBackend.postEvents(
             paywallEventRequest,
             onSuccessHandler = { lock.countDown() },
             onErrorHandler = { _, _ -> },

--- a/purchases/src/test/java/com/revenuecat/purchases/common/events/EventsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/events/EventsManagerTest.kt
@@ -9,17 +9,23 @@ import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.FileHelper
 import com.revenuecat.purchases.common.SyncDispatcher
+import com.revenuecat.purchases.customercenter.events.CustomerCenterDisplayMode
+import com.revenuecat.purchases.customercenter.events.CustomerCenterEvent
+import com.revenuecat.purchases.customercenter.events.CustomerCenterEventType
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventType
 import com.revenuecat.purchases.paywalls.events.PaywallStoredEvent
 import com.revenuecat.purchases.utils.EventsFileHelper
+import com.revenuecat.purchases.utils.serializers.DateSerializer
+import com.revenuecat.purchases.utils.serializers.UUIDSerializer
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.serialization.Serializable
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -34,7 +40,7 @@ import java.util.UUID
 class EventsManagerTest {
 
     private val userID = "testAppUserId"
-    private val event = PaywallEvent(
+    private val paywallEvent = PaywallEvent(
         creationData = PaywallEvent.CreationData(
             id = UUID.fromString("298207f4-87af-4b57-a581-eb27bcc6e009"),
             date = Date(1699270688884)
@@ -49,7 +55,21 @@ class EventsManagerTest {
         ),
         type = PaywallEventType.IMPRESSION,
     )
-    private val storedEvent = PaywallStoredEvent(event, userID)
+    private val customerCenterEvent = CustomerCenterEvent(
+        creationData = CustomerCenterEvent.CreationData(
+            id = UUID.fromString("298207f4-87af-4b57-a581-eb27bcc6e009"),
+            date = Date(1699270688884)
+        ),
+        data = CustomerCenterEvent.Data(
+            type = CustomerCenterEventType.IMPRESSION,
+            timestamp = Date(1699270688884),
+            sessionIdentifier = UUID.fromString("315107f4-98bf-4b68-a582-eb27bcb6e111"),
+            darkMode = true,
+            locale = "es_ES",
+            isSandbox = true,
+        )
+    )
+    private val storedEvent = PaywallStoredEvent(paywallEvent, userID)
 
     private val testFolder = "temp_test_folder"
 
@@ -87,7 +107,7 @@ class EventsManagerTest {
             identityManager,
             paywallEventsDispatcher,
             postEvents = { request, onSuccess, onError ->
-                backend.postPaywallEvents(
+                backend.postEvents(
                     paywallEventRequest = request,
                     onSuccessHandler = onSuccess,
                     onErrorHandler = onError,
@@ -103,14 +123,14 @@ class EventsManagerTest {
     }
 
     @Test
-    fun `tracking events adds them to file`() {
-        eventsManager.track(event)
+    fun `tracking paywall adds them to file`() {
+        eventsManager.track(paywallEvent)
 
         checkFileContents(
             """{"type":"paywalls","event":{"id":"298207f4-87af-4b57-a581-eb27bcc6e009","version":1,"type":"paywall_impression","app_user_id":"testAppUserId","session_id":"315107f4-98bf-4b68-a582-eb27bcb6e111","offering_id":"offeringID","paywall_revision":5,"timestamp":1699270688884,"display_mode":"footer","dark_mode":true,"locale":"es_ES"}}""".trimIndent() + "\n"
         )
 
-        eventsManager.track(event.copy(type = PaywallEventType.CANCEL))
+        eventsManager.track(paywallEvent.copy(type = PaywallEventType.CANCEL))
         checkFileContents(
             """{"type":"paywalls","event":{"id":"298207f4-87af-4b57-a581-eb27bcc6e009","version":1,"type":"paywall_impression","app_user_id":"testAppUserId","session_id":"315107f4-98bf-4b68-a582-eb27bcb6e111","offering_id":"offeringID","paywall_revision":5,"timestamp":1699270688884,"display_mode":"footer","dark_mode":true,"locale":"es_ES"}}""".trimIndent()
                 + "\n"
@@ -120,10 +140,43 @@ class EventsManagerTest {
     }
 
     @Test
+    fun `tracking mixed events adds them to file`() {
+        eventsManager.track(customerCenterEvent)
+        eventsManager.track(paywallEvent)
+        checkFileContents(
+            """{"type":"customer_center","event":{"id":"298207f4-87af-4b57-a581-eb27bcc6e009","revision_id":1,"type":"customer_center_impression","app_user_id":"testAppUserId","app_session_id":"315107f4-98bf-4b68-a582-eb27bcb6e111","timestamp":1699270688884,"dark_mode":true,"locale":"es_ES","is_sandbox":true,"display_mode":"full_screen"}}""".trimIndent()
+                + "\n"
+                + """{"type":"paywalls","event":{"id":"298207f4-87af-4b57-a581-eb27bcc6e009","version":1,"type":"paywall_impression","app_user_id":"testAppUserId","session_id":"315107f4-98bf-4b68-a582-eb27bcb6e111","offering_id":"offeringID","paywall_revision":5,"timestamp":1699270688884,"display_mode":"footer","dark_mode":true,"locale":"es_ES"}}""".trimIndent()
+                + "\n"
+        )
+    }
+
+    @Test
+    fun `tracking customer center adds them to file`() {
+        eventsManager.track(customerCenterEvent)
+
+        checkFileContents(
+            """{"type":"customer_center","event":{"id":"298207f4-87af-4b57-a581-eb27bcc6e009","revision_id":1,"type":"customer_center_impression","app_user_id":"testAppUserId","app_session_id":"315107f4-98bf-4b68-a582-eb27bcb6e111","timestamp":1699270688884,"dark_mode":true,"locale":"es_ES","is_sandbox":true,"display_mode":"full_screen"}}""".trimIndent() + "\n"
+        )
+
+        var surveyEvent = CustomerCenterEvent(
+            creationData = customerCenterEvent.creationData,
+            data = customerCenterEvent.data.copy(type = CustomerCenterEventType.SURVEY_OPTION_CHOSEN)
+        )
+        eventsManager.track(surveyEvent)
+        checkFileContents(
+            """{"type":"customer_center","event":{"id":"298207f4-87af-4b57-a581-eb27bcc6e009","revision_id":1,"type":"customer_center_impression","app_user_id":"testAppUserId","app_session_id":"315107f4-98bf-4b68-a582-eb27bcb6e111","timestamp":1699270688884,"dark_mode":true,"locale":"es_ES","is_sandbox":true,"display_mode":"full_screen"}}""".trimIndent()
+                + "\n"
+                + """{"type":"customer_center","event":{"id":"298207f4-87af-4b57-a581-eb27bcc6e009","revision_id":1,"type":"customer_center_survey_option_chosen","app_user_id":"testAppUserId","app_session_id":"315107f4-98bf-4b68-a582-eb27bcb6e111","timestamp":1699270688884,"dark_mode":true,"locale":"es_ES","is_sandbox":true,"display_mode":"full_screen"}}""".trimIndent()
+                + "\n"
+        )
+    }
+
+    @Test
     fun `flushEvents sends available events to backend`() {
         mockBackendResponse(success = true)
-        eventsManager.track(event)
-        eventsManager.track(event)
+        eventsManager.track(paywallEvent)
+        eventsManager.track(paywallEvent)
         eventsManager.flushEvents()
         checkFileContents("")
         val expectedRequest = EventsRequest(
@@ -137,7 +190,7 @@ class EventsManagerTest {
             ).mapNotNull { it.toBackendEvent() }
         )
         verify(exactly = 1) {
-            backend.postPaywallEvents(
+            backend.postEvents(
                 expectedRequest,
                 any(),
                 any(),
@@ -149,7 +202,7 @@ class EventsManagerTest {
     fun `flushEvents without events, does not call backend`() {
         eventsManager.flushEvents()
         verify(exactly = 0) {
-            backend.postPaywallEvents(any(), any(), any())
+            backend.postEvents(any(), any(), any())
         }
     }
 
@@ -157,7 +210,7 @@ class EventsManagerTest {
     fun `if more than maximum events flushEvents only posts maximum events`() {
         mockBackendResponse(success = true)
         for (i in 0..99) {
-            eventsManager.track(event)
+            eventsManager.track(paywallEvent)
         }
         checkFileNumberOfEvents(100)
         eventsManager.flushEvents()
@@ -168,7 +221,7 @@ class EventsManagerTest {
     fun `if backend errors without marking events as synced, events are not deleted`() {
         mockBackendResponse(success = false, shouldMarkAsSyncedOnError = false)
         for (i in 0..99) {
-            eventsManager.track(event)
+            eventsManager.track(paywallEvent)
         }
         checkFileNumberOfEvents(100)
         eventsManager.flushEvents()
@@ -179,7 +232,7 @@ class EventsManagerTest {
     fun `if backend errors but marking events as synced, events are deleted`() {
         mockBackendResponse(success = false, shouldMarkAsSyncedOnError = true)
         for (i in 0..99) {
-            eventsManager.track(event)
+            eventsManager.track(paywallEvent)
         }
         checkFileNumberOfEvents(100)
         eventsManager.flushEvents()
@@ -189,15 +242,15 @@ class EventsManagerTest {
     @Test
     fun `flushEvents multiple times only executes once`() {
         every {
-            backend.postPaywallEvents(any(), any(), any())
+            backend.postEvents(any(), any(), any())
         } just Runs
-        eventsManager.track(event)
-        eventsManager.track(event)
+        eventsManager.track(paywallEvent)
+        eventsManager.track(paywallEvent)
         eventsManager.flushEvents()
         eventsManager.flushEvents()
         eventsManager.flushEvents()
         verify(exactly = 1) {
-            backend.postPaywallEvents(any(), any(), any())
+            backend.postEvents(any(), any(), any())
         }
     }
 
@@ -205,25 +258,25 @@ class EventsManagerTest {
     fun `flushEvents multiple times, then finishing, adding events and flushing again works`() {
         val successSlot = slot<() -> Unit>()
         every {
-            backend.postPaywallEvents(any(), capture(successSlot), any())
+            backend.postEvents(any(), capture(successSlot), any())
         } just Runs
-        eventsManager.track(event)
-        eventsManager.track(event)
+        eventsManager.track(paywallEvent)
+        eventsManager.track(paywallEvent)
         eventsManager.flushEvents()
         eventsManager.flushEvents()
         eventsManager.flushEvents()
         verify(exactly = 1) {
-            backend.postPaywallEvents(any(), any(), any())
+            backend.postEvents(any(), any(), any())
         }
         successSlot.captured()
         checkFileContents("")
-        eventsManager.track(event)
-        eventsManager.track(event)
-        eventsManager.track(event)
+        eventsManager.track(paywallEvent)
+        eventsManager.track(paywallEvent)
+        eventsManager.track(paywallEvent)
         eventsManager.flushEvents()
         eventsManager.flushEvents()
         verify(exactly = 2) {
-            backend.postPaywallEvents(any(), any(), any())
+            backend.postEvents(any(), any(), any())
         }
         successSlot.captured()
         checkFileContents("")
@@ -232,9 +285,9 @@ class EventsManagerTest {
     @Test
     fun `flushEvents with invalid events, flushes valid events`() {
         mockBackendResponse(success = true)
-        eventsManager.track(event)
+        eventsManager.track(paywallEvent)
         appendToFile("invalid event\n")
-        eventsManager.track(event)
+        eventsManager.track(paywallEvent)
         appendToFile("invalid event 2\n")
         checkFileNumberOfEvents(4)
         eventsManager.flushEvents()
@@ -246,12 +299,12 @@ class EventsManagerTest {
     fun `flushEvents with invalid events, flushes valid events when reaching max count per request`() {
         mockBackendResponse(success = true)
         for (i in 0..24) {
-            eventsManager.track(event)
+            eventsManager.track(paywallEvent)
         }
         appendToFile("invalid event\n")
         appendToFile("invalid event 2\n")
         for (i in 0..49) {
-            eventsManager.track(event)
+            eventsManager.track(paywallEvent)
         }
         appendToFile("invalid event 3\n")
         checkFileNumberOfEvents(78)
@@ -275,7 +328,7 @@ class EventsManagerTest {
         val successSlot = slot<() -> Unit>()
         val errorSlot = slot<(PurchasesError, Boolean) -> Unit>()
         every {
-            backend.postPaywallEvents(any(), capture(successSlot), capture(errorSlot))
+            backend.postEvents(any(), capture(successSlot), capture(errorSlot))
         } answers {
             if (success) {
                 successSlot.captured.invoke()
@@ -290,7 +343,7 @@ class EventsManagerTest {
             List(eventsSynced) { BackendStoredEvent.Paywalls(storedEvent.toBackendEvent()) }.mapNotNull { it.toBackendEvent() }
         )
         verify(exactly = 1) {
-            backend.postPaywallEvents(
+            backend.postEvents(
                 expectedRequest,
                 any(),
                 any(),

--- a/purchases/src/test/java/com/revenuecat/purchases/customercenter/events/CustomerCenterEventSerializationTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/customercenter/events/CustomerCenterEventSerializationTests.kt
@@ -21,21 +21,20 @@ public class CustomerCenterEventSerializationTests {
             id = UUID.fromString("298207f4-87af-4b57-a581-eb27bcc6e009"),
             date = Date(1699270688884)
         ),
-        eventData = CustomerCenterEvent.Data(
+        data = CustomerCenterEvent.Data(
             type = CustomerCenterEventType.IMPRESSION,
             timestamp = Date(1699270688884),
             darkMode = true,
             locale = "en_US",
             isSandbox = true,
-            version = 1,
-            revisionId = 1,
+            sessionIdentifier = UUID.fromString("298207f4-87af-4b57-a581-eb27bcc6e009"),
         )
     )
 
     @Test
     fun `can encode customer center event correctly`() {
         val eventString: String = CustomerCenterEvent.json.encodeToString(event)
-        val expectedJson = "{\"creationData\":{\"id\":\"298207f4-87af-4b57-a581-eb27bcc6e009\",\"date\":1699270688884},\"eventData\":{\"type\":\"customer_center_impression\",\"timestamp\":1699270688884,\"darkMode\":true,\"locale\":\"en_US\",\"isSandbox\":true}}"
+        val expectedJson = "{\"creationData\":{\"id\":\"298207f4-87af-4b57-a581-eb27bcc6e009\",\"date\":1699270688884},\"data\":{\"type\":\"customer_center_impression\",\"timestamp\":1699270688884,\"sessionIdentifier\":\"298207f4-87af-4b57-a581-eb27bcc6e009\",\"darkMode\":true,\"locale\":\"en_US\",\"isSandbox\":true}}"
 
         assertThat(eventString).isEqualTo(expectedJson)
     }


### PR DESCRIPTION
### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
This is a follow-up of https://github.com/RevenueCat/purchases-android/pull/2096
- Rename `backend.postPaywallEvents` to `backend.postEvents`
- Add missing pieces for `CustomerCenterEvent`
- Add a coupe of tests to validate mixed tracking

### Next
- Track customer center events
