### PR TITLE
[Paywalls V2] Remove cursive as a generic font

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FontSpec.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FontSpec.kt
@@ -44,7 +44,6 @@ internal sealed interface FontSpec {
         object SansSerif : Generic
         object Serif : Generic
         object Monospace : Generic
-        object Cursive : Generic
     }
 
     data class System(@get:JvmSynthetic val name: String) : FontSpec
@@ -85,7 +84,6 @@ internal fun FontSpec.resolve(
         FontSpec.Generic.SansSerif -> FontFamily.SansSerif
         FontSpec.Generic.Serif -> FontFamily.Serif
         FontSpec.Generic.Monospace -> FontFamily.Monospace
-        FontSpec.Generic.Cursive -> FontFamily.Cursive
     }
 
     is FontSpec.System -> FontFamily(
@@ -100,7 +98,6 @@ private fun ResourceProvider.determineFontSpec(info: FontInfo): FontSpec =
             FontFamily.SansSerif.name -> FontSpec.Generic.SansSerif
             FontFamily.Serif.name -> FontSpec.Generic.Serif
             FontFamily.Monospace.name -> FontSpec.Generic.Monospace
-            FontFamily.Cursive.name -> FontSpec.Generic.Cursive
             else -> {
                 @SuppressLint("DiscouragedApi")
                 val fontId = getResourceIdentifier(name = info.value, type = "font")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
@@ -237,20 +237,6 @@ private fun TextComponentView_Preview_MonospaceFont() {
     )
 }
 
-@Preview(name = "CursiveFont")
-@Composable
-private fun TextComponentView_Preview_CursiveFont() {
-    TextComponentView(
-        style = previewTextComponentStyle(
-            text = "Hello, world",
-            color = ColorStyles(light = ColorStyle.Solid(Color.Black)),
-            fontSpec = FontSpec.Generic.Cursive,
-            size = Size(width = Fit, height = Fit),
-        ),
-        state = previewEmptyState(),
-    )
-}
-
 @Preview
 @Composable
 private fun TextComponentView_Preview_FontSize() {


### PR DESCRIPTION
### Motivation

Remove `cursive` as a generic font to match with what is possible with other platforms (iOS)

### Description

(Above)
