### PR TITLE
Fixes "View field header collides with a variable" data binding error in PurchaseTester

### DIFF
--- a/examples/purchase-tester/src/main/res/layout/row_view.xml
+++ b/examples/purchase-tester/src/main/res/layout/row_view.xml
@@ -18,7 +18,7 @@
             android:layout_height="wrap_content">
 
         <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/header"
+                android:id="@+id/headerView"
                 android:textStyle="bold"
                 android:text="@{header}"
                 android:layout_width="wrap_content"
@@ -33,7 +33,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/header"
+                app:layout_constraintTop_toBottomOf="@+id/headerView"
                 app:layout_constraintBottom_toBottomOf="parent"
                 tools:text="value"/>
 


### PR DESCRIPTION
## Description
As the title says. It can be seen in CI on `main` [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/13468/workflows/24e8614e-be03-41fa-9bc7-58d670905a91/jobs/62094). 

>warning: ERROR: View field header collides with a variable or import file://examples/purchase-tester/src/main/res/layout/row_view.xml Line:19