### PR TITLE
Gives 4096M to the Gradle and Kotlin daemons.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -51,4 +51,4 @@ ANDROID_VARIANT_TO_PUBLISH=defaultsRelease
 SONATYPE_HOST=DEFAULT
 SONATYPE_AUTOMATIC_RELEASE=true
 
-org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.jvmargs=-Xmx4096M -Dkotlin.daemon.jvm.options\="-Xmx4096M"


### PR DESCRIPTION
## Motivation
This is an attempt to fix the following error that's plaguing `main`:
>Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)

This is usually a lack of resources, in my experience. 

We're using the Docker Large executor on CircleCI, which [should have 8 GB of memory](https://circleci.com/docs/configuration-reference/#resourceclass).