### PR TITLE
[Paywalls V2] Fix stack clipping issues

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -4,6 +4,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.stack
 
 import android.content.res.Configuration
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -911,6 +912,59 @@ private fun StackComponentView_Preview_Horizontal() {
                     x = 0.dp,
                     y = 5.dp,
                 ),
+                badge = null,
+                scrollOrientation = null,
+                rcPackage = null,
+                tabIndex = null,
+                overrides = emptyList(),
+            ),
+            state = previewEmptyState(),
+            clickHandler = { },
+        )
+    }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL)
+@Composable
+private fun StackComponentView_Preview_Children_Extend_Over_Parent() {
+    Box(
+        modifier = Modifier.padding(all = 32.dp).background(Color.Gray),
+    ) {
+        StackComponentView(
+            style = StackComponentStyle(
+                children = listOf(
+                    previewStackComponentStyle(
+                        children = previewChildren(),
+                        shadow = ShadowStyles(
+                            colors = ColorStyles(ColorStyle.Solid(Color.Black)),
+                            radius = 10.dp,
+                            x = 0.dp,
+                            y = 3.dp,
+                        ),
+                        badge = previewBadge(
+                            Badge.Style.Overlay,
+                            TwoDimensionalAlignment.TOP_TRAILING,
+                            Shape.Rectangle(),
+                        ),
+                    ),
+                ),
+                dimension = Dimension.Horizontal(
+                    alignment = VerticalAlignment.CENTER,
+                    distribution = FlexDistribution.START,
+                ),
+                size = Size(width = Fit, height = Fit),
+                spacing = 16.dp,
+                background = BackgroundStyles.Color(
+                    ColorStyles(
+                        light = ColorStyle.Solid(Color.Red),
+                        dark = ColorStyle.Solid(Color.Yellow),
+                    ),
+                ),
+                padding = PaddingValues(all = 0.dp),
+                margin = PaddingValues(all = 16.dp),
+                shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
+                border = null,
+                shadow = null,
                 badge = null,
                 scrollOrientation = null,
                 rcPackage = null,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -521,7 +521,6 @@ private fun MainStackComponent(
             .padding(stackState.margin)
             .applyIfNotNull(shadowStyle) { shadow(it, composeShape) }
             .applyIfNotNull(backgroundStyle) { background(it, composeShape) }
-            .clip(composeShape)
     }
 
     val innerShapeModifier = remember(stackState, borderStyle) {
@@ -534,12 +533,10 @@ private fun MainStackComponent(
             .padding(stackState.dimension, stackState.spacing)
     }
 
-    val commonModifier = outerShapeModifier.then(innerShapeModifier)
-
     if (nestedBadge == null && overlay == null) {
         stack(outerShapeModifier.then(innerShapeModifier))
     } else if (nestedBadge != null) {
-        Box(modifier = modifier.then(commonModifier)) {
+        Box(modifier = modifier.then(outerShapeModifier).clip(composeShape).then(innerShapeModifier)) {
             stack(Modifier)
             StackComponentView(
                 nestedBadge.stackStyle,
@@ -550,7 +547,10 @@ private fun MainStackComponent(
             )
         }
     } else if (overlay != null) {
-        Box(modifier = modifier.then(outerShapeModifier)) {
+        Box(modifier = modifier
+            .then(outerShapeModifier)
+            .clip(composeShape)
+        ) {
             stack(innerShapeModifier)
             overlay()
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -547,9 +547,10 @@ private fun MainStackComponent(
             )
         }
     } else if (overlay != null) {
-        Box(modifier = modifier
-            .then(outerShapeModifier)
-            .clip(composeShape)
+        Box(
+            modifier = modifier
+                .then(outerShapeModifier)
+                .clip(composeShape),
         ) {
             stack(innerShapeModifier)
             overlay()


### PR DESCRIPTION
### Description
A number of components clip their contents so they don't go out of bounds of the component itself. This is a problem for the `StackComponent` since sometimes we want shadows of children or other elements to extend beyond the bounds of the stack itself. An example of this, is with overlaid badges.

This PR removes the clipping of the stack component itself except when there is a Leading/Trailing EdgeToEdge badge or Nested badge, in which we actually need to clip.

| Before | After |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/dbc1aa52-4c18-47de-bb67-6366531d4aae) | ![image](https://github.com/user-attachments/assets/c128a9a3-4480-4846-8033-f083fcd352ca) |
| <img width="303" alt="image" src="https://github.com/user-attachments/assets/87d952fc-4857-4d4a-857a-b78bdda5640f" /> | <img width="311" alt="image" src="https://github.com/user-attachments/assets/3934a977-a628-4e93-b9d3-859365480cd5" /> |