### PR TITLE
fix: Address typo and wrong doc for CustomerCenter events

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -2,7 +2,7 @@ package com.revenuecat.purchases.common.events
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.customercenter.events.CustomerCenterImpressionEvent
-import com.revenuecat.purchases.customercenter.events.CustomerCenterSurverOptionChosenEvent
+import com.revenuecat.purchases.customercenter.events.CustomerCenterSurveyOptionChosenEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.utils.Event
 import kotlinx.serialization.SerialName
@@ -80,11 +80,11 @@ internal fun PaywallEvent.toBackendStoredEvent(
 }
 
 /**
- * Converts a `PaywallEvent` into a `BackendStoredEvent.Paywalls` instance.
+ * Converts a `CustomerCenterImpressionEvent` into a `BackendStoredEvent.CustomerCenter` instance.
  *
- * @receiver The `PaywallEvent` to be converted.
+ * @receiver The `CustomerCenterImpressionEvent` to be converted.
  * @param appUserID The user ID associated with the event.
- * @return A `BackendStoredEvent.Paywalls` containing a `BackendEvent.Paywalls`.
+ * @return A `BackendStoredEvent.CustomerCenter` containing a `BackendEvent.CustomerCenter`.
  */
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @JvmSynthetic
@@ -112,15 +112,15 @@ internal fun CustomerCenterImpressionEvent.toBackendStoredEvent(
 }
 
 /**
- * Converts a `PaywallEvent` into a `BackendStoredEvent.Paywalls` instance.
+ * Converts a `CustomerCenterSurveyOptionChosenEvent` into a `BackendStoredEvent.CustomerCenter` instance.
  *
- * @receiver The `PaywallEvent` to be converted.
+ * @receiver The `CustomerCenterSurveyOptionChosenEvent` to be converted.
  * @param appUserID The user ID associated with the event.
- * @return A `BackendStoredEvent.Paywalls` containing a `BackendEvent.Paywalls`.
+ * @return A `BackendStoredEvent.CustomerCenter` containing a `BackendEvent.CustomerCenter`.
  */
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 @JvmSynthetic
-internal fun CustomerCenterSurverOptionChosenEvent.toBackendStoredEvent(
+internal fun CustomerCenterSurveyOptionChosenEvent.toBackendStoredEvent(
     appUserID: String,
     appSessionID: String,
 ): BackendStoredEvent {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/EventsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/EventsManager.kt
@@ -9,7 +9,7 @@ import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.customercenter.events.CustomerCenterImpressionEvent
-import com.revenuecat.purchases.customercenter.events.CustomerCenterSurverOptionChosenEvent
+import com.revenuecat.purchases.customercenter.events.CustomerCenterSurveyOptionChosenEvent
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallStoredEvent
@@ -117,7 +117,7 @@ internal class EventsManager(
                     identityManager.currentAppUserID,
                     appSessionID.toString(),
                 )
-                is CustomerCenterSurverOptionChosenEvent -> event.toBackendStoredEvent(
+                is CustomerCenterSurveyOptionChosenEvent -> event.toBackendStoredEvent(
                     identityManager.currentAppUserID,
                     appSessionID.toString(),
                 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/events/CustomerCenterSurveyOptionChosenEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/events/CustomerCenterSurveyOptionChosenEvent.kt
@@ -14,7 +14,7 @@ import java.util.UUID
  */
 @ExperimentalPreviewRevenueCatPurchasesAPI
 @Poko
-class CustomerCenterSurverOptionChosenEvent(
+class CustomerCenterSurveyOptionChosenEvent(
     val creationData: CreationData = CreationData(),
     val data: Data,
 ) : FeatureEvent {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/events/EventsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/events/EventsManagerTest.kt
@@ -11,8 +11,7 @@ import com.revenuecat.purchases.common.FileHelper
 import com.revenuecat.purchases.common.SyncDispatcher
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.events.CustomerCenterImpressionEvent
-import com.revenuecat.purchases.customercenter.events.CustomerCenterEventType
-import com.revenuecat.purchases.customercenter.events.CustomerCenterSurverOptionChosenEvent
+import com.revenuecat.purchases.customercenter.events.CustomerCenterSurveyOptionChosenEvent
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventType
@@ -156,12 +155,12 @@ class EventsManagerTest {
             """{"type":"customer_center","event":{"id":"298207f4-87af-4b57-a581-eb27bcc6e009","revision_id":1,"type":"customer_center_impression","app_user_id":"testAppUserId","app_session_id":"${appSessionID}","timestamp":1699270688884,"dark_mode":true,"locale":"es_ES","display_mode":"full_screen"}}""".trimIndent() + "\n"
         )
 
-        var surveyEvent = CustomerCenterSurverOptionChosenEvent(
-            creationData = CustomerCenterSurverOptionChosenEvent.CreationData(
+        var surveyEvent = CustomerCenterSurveyOptionChosenEvent(
+            creationData = CustomerCenterSurveyOptionChosenEvent.CreationData(
                 id = UUID.fromString("298207f4-87af-4b57-a581-eb27bcc6e009"),
                 date = Date(1699270688884)
             ),
-            data = CustomerCenterSurverOptionChosenEvent.Data(
+            data = CustomerCenterSurveyOptionChosenEvent.Data(
                 timestamp = Date(1699270688884),
                 darkMode = true,
                 locale = "es_ES",

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -25,7 +25,7 @@ import com.revenuecat.purchases.SubscriptionInfo
 import com.revenuecat.purchases.common.SharedConstants
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.events.CustomerCenterImpressionEvent
-import com.revenuecat.purchases.customercenter.events.CustomerCenterSurverOptionChosenEvent
+import com.revenuecat.purchases.customercenter.events.CustomerCenterSurveyOptionChosenEvent
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.SubscriptionOption
@@ -563,8 +563,8 @@ internal class CustomerCenterViewModelImpl(
         surveyOptionTitleKey: String,
     ) {
         val locale = _lastLocaleList.value.get(0) ?: Locale.getDefault()
-        val event = CustomerCenterSurverOptionChosenEvent(
-            data = CustomerCenterSurverOptionChosenEvent.Data(
+        val event = CustomerCenterSurveyOptionChosenEvent(
+            data = CustomerCenterSurveyOptionChosenEvent.Data(
                 timestamp = Date(),
                 darkMode = isDarkMode,
                 locale = locale.toString(),


### PR DESCRIPTION
### Motivation
This is a follow-up of https://github.com/RevenueCat/purchases-android/pull/2124

### Description
- Address typo
- Address wrong documentation