### PR TITLE
fix: Hide contact support if there's no email

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -266,8 +266,8 @@ private fun CustomerCenterLoaded(
             state = state.restorePurchasesState,
             onDismiss = { onAction(CustomerCenterAction.DismissRestoreDialog) },
             onRestore = { onAction(CustomerCenterAction.PerformRestore) },
-            onContactSupport = {
-                state.customerCenterConfigData.support.email?.let { email ->
+            onContactSupport = state.customerCenterConfigData.support.email?.let { email ->
+                {
                     onAction(CustomerCenterAction.ContactSupport(email))
                 }
             },

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/dialogs/RestorePurchasesDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/dialogs/RestorePurchasesDialog.kt
@@ -23,7 +23,7 @@ internal fun RestorePurchasesDialog(
     state: RestorePurchasesState,
     onDismiss: () -> Unit,
     onRestore: () -> Unit,
-    onContactSupport: () -> Unit,
+    onContactSupport: (() -> Unit)?,
 ) {
     when (state) {
         RestorePurchasesState.INITIAL -> InitialStateDialog(
@@ -121,7 +121,7 @@ private fun PurchasesRecoveredDialog(onDismiss: () -> Unit) {
 @Composable
 private fun PurchasesNotFoundDialog(
     onDismiss: () -> Unit,
-    onContactSupport: () -> Unit,
+    onContactSupport: (() -> Unit)? = null,
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -138,8 +138,10 @@ private fun PurchasesNotFoundDialog(
             )
         },
         confirmButton = {
-            Button(onClick = onContactSupport) {
-                Text("Contact Support")
+            if (onContactSupport != null) {
+                Button(onClick = onContactSupport) {
+                    Text("Contact Support")
+                }
             }
         },
         dismissButton = {


### PR DESCRIPTION
### Description
Hide the contact support button if the email is not set in CustomerCenter

![Screenshot 2025-02-11 at 12 37 14](https://github.com/user-attachments/assets/adb7df3f-6dea-4a35-9529-ba5ae7554cc9)
