### PR TITLE
fix: Use TextButton instead of outline for Promotionals

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -254,6 +254,7 @@ private fun CustomerCenterLoaded(
         PromotionalOfferScreen(
             promotionalOfferData = promotionalOfferData,
             appearance = state.customerCenterConfigData.appearance,
+            localization = state.customerCenterConfigData.localization,
             onAccept = { subscriptionOption ->
                 onAction(CustomerCenterAction.PurchasePromotionalOffer(subscriptionOption))
             },

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PromotionalOfferScreen.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PromotionalOfferScreen.kt
@@ -90,6 +90,9 @@ internal fun PromotionalOfferScreen(
 
         TextButton(
             onClick = { onDismiss() },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp),
         ) {
             Text(
                 text = localization.commonLocalizedString(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PromotionalOfferScreen.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PromotionalOfferScreen.kt
@@ -13,12 +13,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
@@ -32,9 +32,11 @@ import com.revenuecat.purchases.ui.revenuecatui.utils.previewSubscriptionOption
 
 @JvmSynthetic
 @Composable
+@Suppress("LongParameterList")
 internal fun PromotionalOfferScreen(
     promotionalOfferData: PromotionalOfferData,
     appearance: CustomerCenterConfigData.Appearance,
+    localization: CustomerCenterConfigData.Localization,
     onAccept: (SubscriptionOption) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
@@ -85,17 +87,16 @@ internal fun PromotionalOfferScreen(
         ) {
             Text(promotionalOfferData.localizedPricingPhasesDescription)
         }
-        OutlinedButton(
+
+        TextButton(
             onClick = { onDismiss() },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 16.dp),
-            colors = ButtonDefaults.outlinedButtonColors(
-                containerColor = Color.Transparent,
-                contentColor = buttonTextColor ?: MaterialTheme.colorScheme.primary,
-            ),
         ) {
-            Text("No Thanks")
+            Text(
+                text = localization.commonLocalizedString(
+                    key = CustomerCenterConfigData.Localization.CommonLocalizedString.NO_THANKS,
+                ),
+                textAlign = TextAlign.Center,
+            )
         }
     }
 }
@@ -123,6 +124,7 @@ internal fun PromotionalOfferViewPreview() {
     PromotionalOfferScreen(
         data,
         appearance = CustomerCenterConfigTestData.customerCenterData().appearance,
+        localization = CustomerCenterConfigTestData.customerCenterData().localization,
         onAccept = {},
         onDismiss = {},
     )


### PR DESCRIPTION
### Description
The OutlineButton does not offer a way of customizing it.
This PR replaces OutlineButton with TextButton, and uses localization instead of a hardcoded string.

