### PR TITLE
[Paywalls V2] Makes linear gradients consistent with CSS

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -343,7 +343,7 @@ private fun ImageComponentView_Preview_LinearGradient() {
                 ),
                 overlay = ColorStyles(
                     light = ColorInfo.Gradient.Linear(
-                        degrees = -90f,
+                        degrees = 0f,
                         points = listOf(
                             ColorInfo.Gradient.Point(
                                 color = Color.parseColor("#88FF0000"),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Border.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Border.kt
@@ -119,7 +119,7 @@ private fun Border_Preview_LinearGradient(shape: Shape) {
                 border = BorderStyle(
                     width = 10.dp,
                     color = ColorInfo.Gradient.Linear(
-                        degrees = -45f,
+                        degrees = 135f,
                         points = listOf(
                             ColorInfo.Gradient.Point(
                                 color = Color.Cyan.toArgb(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Shadow.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Shadow.kt
@@ -214,7 +214,7 @@ private fun Shadow_Preview_Gradient_CustomShape() {
                 .shadow(
                     shadow = ShadowStyle(
                         color = ColorInfo.Gradient.Linear(
-                            degrees = 0f,
+                            degrees = 90f,
                             points = listOf(
                                 ColorInfo.Gradient.Point(
                                     color = Color.Red.toArgb(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/BackgroundStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/BackgroundStyle.kt
@@ -137,7 +137,7 @@ private fun Background_Preview_ColorGradientLinear() {
             .background(
                 BackgroundStyle.Color(
                     ColorInfo.Gradient.Linear(
-                        degrees = 0f,
+                        degrees = 90f,
                         points = listOf(
                             ColorInfo.Gradient.Point(
                                 color = Color.Red.toArgb(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
@@ -167,30 +167,35 @@ private fun relativeLinearGradient(
 private class RelativeLinearGradient(
     private val colors: List<Color>,
     private val stops: List<Float>? = null,
-    private val degrees: Float,
+    degrees: Float,
     private val tileMode: TileMode = TileMode.Clamp,
 ) : ShaderBrush() {
 
+    // We need to adjust the degrees to match CSS’s angle definition.
+    @Suppress("MagicNumber")
+    private val degrees = degrees - 90f
+
+    /**
+     * Creates a linear gradient shader following the
+     * [CSS definition](https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient#composition_of_a_linear_gradient).
+     */
+    @Suppress("MaxLineLength")
     override fun createShader(size: Size): Shader {
-        // 1. Compute the center of the drawing area.
         val center = Offset(size.width / 2f, size.height / 2f)
 
-        // 2. Convert degrees to radians and compute the direction vector.
-        // (Note: adjust the sign of degrees if needed to match CSS’s angle definition.)
-        val angleRad = -1 * Math.toRadians(degrees.toDouble())
-        val dx = cos(angleRad).toFloat()
-        val dy = sin(angleRad).toFloat()
+        val radians = Math.toRadians(degrees.toDouble())
+        val dx = cos(radians).toFloat()
+        val dy = sin(radians).toFloat()
 
-        // 3. Compute the half-dimensions.
         val halfWidth = size.width / 2f
         val halfHeight = size.height / 2f
 
-        // 4. Compute the half diagonal (distance from center to the furthest corner).
+        // Compute the distance from the center to the furthest corner.
         val halfDiagonal = sqrt((halfWidth * halfWidth) + (halfHeight * halfHeight))
 
-        // 5. Compute the absolute start and end points along the gradient line.
-        val startPx = center - Offset(dx * halfDiagonal, dy * halfDiagonal)
-        val endPx = center + Offset(dx * halfDiagonal, dy * halfDiagonal)
+        // Compute the absolute start and end points along the gradient line.
+        val startPx = center - Offset(x = dx * halfDiagonal, y = dy * halfDiagonal)
+        val endPx = center + Offset(x = dx * halfDiagonal, y = dy * halfDiagonal)
 
         return LinearGradientShader(
             colors = colors,
@@ -242,12 +247,15 @@ private fun LinearGradient_Preview_Rectangle() {
     )
 }
 
+/**
+ * [reference](https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient#gradient_at_a_45-degree_angle)
+ */
 @Preview
 @Composable
 private fun LinearGradient_Preview_Rectangle_RedBlue() {
     Box(
         modifier = Modifier
-            .requiredSize(800.dp, 70.dp)
+            .requiredSize(300.dp, 55.dp)
             .background(
                 relativeLinearGradient(
                     colorStops = arrayOf(
@@ -255,6 +263,49 @@ private fun LinearGradient_Preview_Rectangle_RedBlue() {
                         1f to Color.Blue,
                     ),
                     degrees = 45f,
+                ),
+            ),
+    )
+}
+
+/**
+ * [reference](https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient#gradient_that_starts_at_60_of_the_gradient_line)
+ */
+@Suppress("MagicNumber")
+@Preview
+@Composable
+private fun LinearGradient_Preview_Rectangle_OrangeCyan() {
+    Box(
+        modifier = Modifier
+            .requiredSize(300.dp, 55.dp)
+            .background(
+                relativeLinearGradient(
+                    colorStops = arrayOf(
+                        0.6f to Color(red = 0xFF, green = 0xA5, blue = 0x00),
+                        1f to Color.Cyan,
+                    ),
+                    degrees = 135f,
+                ),
+            ),
+    )
+}
+
+/**
+ * [reference](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_images/Using_CSS_gradients#using_angles)
+ */
+@Preview
+@Composable
+private fun LinearGradient_Preview_Square_BluePink() {
+    Box(
+        modifier = Modifier
+            .requiredSize(100.dp)
+            .background(
+                relativeLinearGradient(
+                    colorStops = arrayOf(
+                        0f to Color.Blue,
+                        1f to Color(red = 0xFF, green = 0xC0, blue = 0xCB),
+                    ),
+                    degrees = 70f,
                 ),
             ),
     )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
@@ -31,10 +31,9 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyListOf
 import com.revenuecat.purchases.ui.revenuecatui.helpers.orSuccessfullyNull
 import com.revenuecat.purchases.ui.revenuecatui.helpers.zipOrAccumulate
 import dev.drewhamilton.poko.Poko
-import kotlin.math.abs
 import kotlin.math.cos
-import kotlin.math.min
 import kotlin.math.sin
+import kotlin.math.sqrt
 
 /**
  * Used to normalize [ColorInfo.Gradient.Point.percent] values (which are in the range 0..100) to a range of 0..1.
@@ -177,27 +176,21 @@ private class RelativeLinearGradient(
         val center = Offset(size.width / 2f, size.height / 2f)
 
         // 2. Convert degrees to radians and compute the direction vector.
+        // (Note: adjust the sign of degrees if needed to match CSS’s angle definition.)
         val angleRad = -1 * Math.toRadians(degrees.toDouble())
         val dx = cos(angleRad).toFloat()
         val dy = sin(angleRad).toFloat()
 
-        // 3. Determine how far we can go from the center before hitting an edge.
-        // Calculate half-dimensions.
+        // 3. Compute the half-dimensions.
         val halfWidth = size.width / 2f
         val halfHeight = size.height / 2f
 
-        // Compute scaling factors to reach the vertical and horizontal boundaries.
-        // If dx or dy is 0, we avoid division by zero.
-        val scaleX = if (dx != 0f) halfWidth / abs(dx) else Float.MAX_VALUE
-        val scaleY = if (dy != 0f) halfHeight / abs(dy) else Float.MAX_VALUE
+        // 4. Compute the half diagonal (distance from center to the furthest corner).
+        val halfDiagonal = sqrt((halfWidth * halfWidth) + (halfHeight * halfHeight))
 
-        // The scaling factor that keeps the point inside the rectangle.
-        val scale = min(scaleX, scaleY)
-
-        // 4. Compute the absolute start and end points.
-        // The line goes through the center in both directions.
-        val startPx = center - Offset(dx * scale, dy * scale)
-        val endPx = center + Offset(dx * scale, dy * scale)
+        // 5. Compute the absolute start and end points along the gradient line.
+        val startPx = center - Offset(dx * halfDiagonal, dy * halfDiagonal)
+        val endPx = center + Offset(dx * halfDiagonal, dy * halfDiagonal)
 
         return LinearGradientShader(
             colors = colors,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
@@ -171,7 +171,7 @@ private class RelativeLinearGradient(
     private val tileMode: TileMode = TileMode.Clamp,
 ) : ShaderBrush() {
 
-    // We need to adjust the degrees to match CSS’s angle definition.
+    // We need to adjust the degrees to match CSS' angle definition.
     @Suppress("MagicNumber")
     private val degrees = degrees - 90f
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
@@ -308,7 +308,7 @@ private fun TextComponentView_Preview_LinearGradient() {
                 "Tell them to put some sunglasses on.",
             color = ColorStyles(
                 light = ColorInfo.Gradient.Linear(
-                    degrees = -45f,
+                    degrees = 135f,
                     points = listOf(
                         ColorInfo.Gradient.Point(
                             color = Color.Cyan.toArgb(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/timeline/TimelineComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/timeline/TimelineComponentView.kt
@@ -294,7 +294,7 @@ private fun previewItems(
             connector = previewConnectorStyle(
                 margin = connectorMargins,
                 color = ColorInfo.Gradient.Linear(
-                    degrees = 90f,
+                    degrees = 0f,
                     listOf(
                         ColorInfo.Gradient.Point(color = Color(color = 0x000FD483).toArgb(), percent = 0f),
                         ColorInfo.Gradient.Point(color = Color(color = 0xFF0FD483).toArgb(), percent = 100f),


### PR DESCRIPTION
## Description
This PR does 2 things:
- Ensures the angle is consistent, even if the area is not square.
- Ensures the interpretation of the angle is consistent with CSS' [`linear-gradient`](https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient). It's not a 100% 1 to 1, but it's close I think. 

| CSS | purchases-android |
|-----|--------------------|
| ![image](https://github.com/user-attachments/assets/cfb40af1-c64b-4c68-a790-24e49503cea2) | ![image](https://github.com/user-attachments/assets/1b497849-bb43-4069-a29c-41f567b4ae02) |
| ![image](https://github.com/user-attachments/assets/3e3e008a-d3cc-438f-8de1-5e89c9e9c119) | ![image](https://github.com/user-attachments/assets/d37c33f4-3093-4581-8657-84a1d2ab9f60) |
| ![image](https://github.com/user-attachments/assets/65a18385-2100-4ce1-a7fe-ef7530642ea5) | ![image](https://github.com/user-attachments/assets/f84b4b94-8d7f-40a1-9606-22dc37811423) |





