### PR TITLE
Updates on no active purchases screen

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterUIConstants.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterUIConstants.kt
@@ -12,6 +12,7 @@ internal object CustomerCenterUIConstants {
 
     private val PaddingSmall = 8.dp
     private val PaddingMedium = 16.dp
+    private val PaddingLarge = 24.dp
     private val PaddingXL = 32.dp
 
     val ManagementViewTitleTopPadding = 64.dp
@@ -27,7 +28,7 @@ internal object CustomerCenterUIConstants {
 
     val ContentUnavailableViewPadding = PaddingMedium
     val ContentUnavailableViewPaddingTopTitle = PaddingSmall
-    val ContentUnavailableViewPaddingTopDescription = PaddingMedium
+    val ContentUnavailableViewPaddingTopDescription = PaddingLarge
     val ContentUnavailableIconSize = 56.dp
 
     val ManagementViewHorizontalPadding = PaddingMedium

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterConfigTestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterConfigTestData.kt
@@ -26,7 +26,7 @@ internal object CustomerCenterConfigTestData {
                     paths = listOf(
                         CustomerCenterConfigData.HelpPath(
                             id = "1",
-                            title = "Didn't receive purchase",
+                            title = "Check for previous purchases",
                             type = CustomerCenterConfigData.HelpPath.PathType.MISSING_PURCHASE,
                         ),
                         CustomerCenterConfigData.HelpPath(
@@ -80,12 +80,12 @@ internal object CustomerCenterConfigTestData {
                 ),
                 CustomerCenterConfigData.Screen.ScreenType.NO_ACTIVE to CustomerCenterConfigData.Screen(
                     type = CustomerCenterConfigData.Screen.ScreenType.NO_ACTIVE,
-                    title = "No Active Subscription",
-                    subtitle = "You currently have no active subscriptions",
+                    title = "No subscriptions found",
+                    subtitle = "We can try checking your account for any previous purchases",
                     paths = listOf(
                         CustomerCenterConfigData.HelpPath(
                             id = "9q9719171o",
-                            title = "Check purchases",
+                            title = "Check for previous purchases",
                             type = CustomerCenterConfigData.HelpPath.PathType.MISSING_PURCHASE,
                         ),
                     ),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/ManageSubscriptionsView.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
@@ -163,7 +162,7 @@ private fun ContentUnavailableView(
 
         Text(
             text = title,
-            style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+            style = MaterialTheme.typography.headlineSmall,
             modifier = Modifier.padding(top = ContentUnavailableViewPaddingTopTitle),
         )
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PromotionalOfferScreen.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PromotionalOfferScreen.kt
@@ -119,7 +119,7 @@ internal fun PromotionalOfferViewPreview() {
         ),
         originalPath = CustomerCenterConfigData.HelpPath(
             id = "1",
-            title = "Didn't receive purchase",
+            title = "Check for previous purchases",
             type = CustomerCenterConfigData.HelpPath.PathType.MISSING_PURCHASE,
         ),
         localizedPricingPhasesDescription = "1 month for $7.99, then $9.99/mth",


### PR DESCRIPTION
| Before | After | 
|--------|-----|
| <img width="617" alt="Screenshot 2025-02-12 at 14 43 37" src="https://github.com/user-attachments/assets/12a8407c-dcba-4cd7-a101-c7d32e9a1c5c" /> | ![image](https://github.com/user-attachments/assets/9a75f998-169a-4b48-973b-fa1a800b8556) |

This pull request includes several updates to the `CustomerCenterUIConstants`, `CustomerCenterConfigTestData`, and `ManageSubscriptionsView` files to improve UI consistency and update text for better clarity.

### UI Constants Updates:
* Added a new padding value `PaddingLarge` and updated the padding for `ContentUnavailableViewPaddingTopDescription` to use `PaddingLarge` instead of `PaddingMedium`. (`[[1]](diffhunk://#diff-be840fca768a3e52732a6f0037def19ef22eb16112e1d11ce52ec9cf8112fbb0R15)`, `[[2]](diffhunk://#diff-be840fca768a3e52732a6f0037def19ef22eb16112e1d11ce52ec9cf8112fbb0L30-R31)`)

### Text Updates:
* Updated some text in `CustomerCenterConfigTestData` which will also be updated in the backend, such as changing "Didn't receive purchase" to "Check for previous purchases" and "No Active Subscription" to "No subscriptions found". (`[[1]](diffhunk://#diff-ec03abb9be7c6ca9e2d9b3665216f85049d87f3a305bcfa04e062815a02426b5L29-R29)`, `[[2]](diffhunk://#diff-ec03abb9be7c6ca9e2d9b3665216f85049d87f3a305bcfa04e062815a02426b5L83-R88)`, `[[3]](diffhunk://#diff-7ea7a03bcb73ac8b43859b3db40d1a8a544623068cf9ea1cc66fc48f62bb1099L122-R122)`)