### PR TITLE
[Paywalls V2] Fix issue with sizing of stacks with nested badges

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -918,7 +918,7 @@ private fun StackComponentView_Preview_Nested_Badge(
                         light = ColorStyle.Solid(Color.Red),
                     ),
                 ),
-                padding = PaddingValues(all = 0.dp),
+                padding = PaddingValues(all = 20.dp),
                 margin = PaddingValues(all = 0.dp),
                 shape = Shape.Rectangle(CornerRadiuses.Dp(all = 20.0)),
                 border = BorderStyles(width = 10.dp, colors = ColorStyles(light = ColorStyle.Solid(Color.Yellow))),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -547,12 +547,16 @@ private fun MainStackComponent(
             .applyIfNotNull(backgroundStyle) { background(it, composeShape) }
     }
 
-    val innerShapeModifier = remember(stackState, borderStyle) {
+    val borderModifier = remember(stackState, borderStyle) {
         Modifier
             .applyIfNotNull(borderStyle) {
                 border(it, composeShape)
                     .padding(it.width)
             }
+    }
+
+    val innerShapeModifier = remember(stackState, borderStyle) {
+        Modifier
             .padding(stackState.padding)
             .padding(stackState.dimension, stackState.spacing)
     }
@@ -560,6 +564,7 @@ private fun MainStackComponent(
     if (nestedBadge == null && overlay == null) {
         stack(
             outerShapeModifier
+                .then(borderModifier)
                 .then(innerShapeModifier)
                 .padding(bottomSystemBarsPadding)
                 .consumeWindowInsets(bottomSystemBarsPadding)
@@ -569,7 +574,8 @@ private fun MainStackComponent(
         Box(
             modifier = modifier
                 .then(outerShapeModifier)
-                .clip(composeShape),
+                .clip(composeShape)
+                .then(borderModifier),
         ) {
             stack(Modifier.then(innerShapeModifier))
             StackComponentView(
@@ -586,7 +592,7 @@ private fun MainStackComponent(
                 .then(outerShapeModifier)
                 .clip(composeShape),
         ) {
-            stack(innerShapeModifier)
+            stack(borderModifier.then(innerShapeModifier))
             overlay()
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -566,8 +566,12 @@ private fun MainStackComponent(
                 .consumeWindowInsets(topSystemBarsPadding),
         )
     } else if (nestedBadge != null) {
-        Box(modifier = modifier.then(outerShapeModifier).clip(composeShape).then(innerShapeModifier)) {
-            stack(Modifier)
+        Box(
+            modifier = modifier
+                .then(outerShapeModifier)
+                .clip(composeShape),
+        ) {
+            stack(Modifier.then(innerShapeModifier))
             StackComponentView(
                 nestedBadge.stackStyle,
                 state,


### PR DESCRIPTION
### Description
Fixes an issue with sizing of stacks that have nested badges. The padding wasn't applied in the correct place

| Before | After |
| ----- | ----- |
| <img width="353" alt="image" src="https://github.com/user-attachments/assets/5d6f42fa-5ddb-4701-9e4b-c9a6bb8500fe" /> | <img width="354" alt="image" src="https://github.com/user-attachments/assets/3f2b85b7-3f31-4286-98f3-6a6bfc57fe14" /> |