### PR TITLE
Explicitly sets the `defaults` flavor as the default.

### DIFF
--- a/api-tester/build.gradle
+++ b/api-tester/build.gradle
@@ -10,6 +10,7 @@ android {
     productFlavors {
         defaults {
             dimension "apis"
+            getIsDefault().set(true)
         }
         customEntitlementComputation {
             dimension "apis"

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallColorAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/revenuecatui/PaywallColorAPI.kt
@@ -1,9 +1,12 @@
 package com.revenuecat.apitester.kotlin.revenuecatui
 
 import android.graphics.Color
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.revenuecat.purchases.paywalls.PaywallColor
 
 @Suppress("unused", "UNUSED_VARIABLE")
+@RequiresApi(Build.VERSION_CODES.O)
 private class PaywallColorAPI {
     fun check(paywallColor: PaywallColor) {
         val stringRepresentation: String = paywallColor.stringRepresentation

--- a/feature/amazon/build.gradle
+++ b/feature/amazon/build.gradle
@@ -16,6 +16,7 @@ android {
     productFlavors {
         defaults {
             dimension "apis"
+            getIsDefault().set(true)
         }
     }
 

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -23,6 +23,7 @@ android {
     productFlavors {
         defaults {
             dimension "apis"
+            getIsDefault().set(true)
         }
         customEntitlementComputation {
             dimension "apis"

--- a/ui/debugview/build.gradle
+++ b/ui/debugview/build.gradle
@@ -17,6 +17,7 @@ android {
     productFlavors {
         defaults {
             dimension "apis"
+            getIsDefault().set(true)
         }
     }
 

--- a/ui/revenuecatui/build.gradle
+++ b/ui/revenuecatui/build.gradle
@@ -24,6 +24,7 @@ android {
     productFlavors {
         defaults {
             dimension "apis"
+            getIsDefault().set(true)
         }
     }
 


### PR DESCRIPTION
## Description
As the title says. This makes Android Studio recognize this as the default too, which should reduce errors caused by mismatched variants. (For instance, previews in `revenuecatui` break if its selected variant doesn't match `purchases`.)

![image](https://github.com/user-attachments/assets/2a02e7f2-547f-4786-bb85-7250eafcac05)
