### PR TITLE
Make `CustomerCenter` public

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenter.kt
@@ -1,20 +1,23 @@
-@file:JvmSynthetic
-
 package com.revenuecat.purchases.ui.revenuecatui.customercenter
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 
 /**
- * Composable offering a full screen Customer Center UI configured from the RevenueCat dashboard.
- */
-@JvmSynthetic
+* Use the Customer Center in your app to help your customers manage common support tasks.
+*
+* Customer Center is a self-service UI that can be added to your app to help
+* your customers manage their subscriptions on their own. With it, you can prevent
+* churn with pre-emptive promotional offers, capture actionable customer data with
+* exit feedback prompts, and lower support volumes for common inquiries — all
+* without any help from your support team.
+*
+* The `CustomerCenter` composable is a full screen UI that can be used to integrate
+* the Customer Center directly in your app with Compose.
+*
+* For more information, see the [Customer Center docs](https://www.revenuecat.com/docs/tools/customer-center).
+*/
 @Composable
-@ExperimentalPreviewRevenueCatUIPurchasesAPI
-@SuppressWarnings("PreviewPublic")
-@InternalRevenueCatAPI
 fun CustomerCenter(
     modifier: Modifier = Modifier,
     onDismiss: () -> Unit,


### PR DESCRIPTION
Removed the `@JvmSynthetic`, `@ExperimentalPreviewRevenueCatUIPurchasesAPI`, `@SuppressWarnings("PreviewPublic")`, and `@InternalRevenueCatAPI` annotations to make the CustomerCenter public