### PR TITLE
[Paywalls V2] Fixes empty stacks not showing up.

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
@@ -2,6 +2,9 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.components.stack
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
@@ -10,9 +13,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowWidthSizeClass
 import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState
 import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition
 import com.revenuecat.purchases.ui.revenuecatui.components.buildPresentedPartial
@@ -44,10 +51,12 @@ internal fun rememberUpdatedStackComponentState(
     selectedTabIndexProvider: () -> Int,
 ): StackComponentState {
     val windowSize = currentWindowAdaptiveInfo().windowSizeClass.windowWidthSizeClass
+    val layoutDirection = LocalLayoutDirection.current
 
     return remember(style) {
         StackComponentState(
             initialWindowSize = windowSize,
+            initialLayoutDirection = layoutDirection,
             style = style,
             selectedPackageProvider = selectedPackageProvider,
             selectedTabIndexProvider = selectedTabIndexProvider,
@@ -62,11 +71,13 @@ internal fun rememberUpdatedStackComponentState(
 @Stable
 internal class StackComponentState(
     initialWindowSize: WindowWidthSizeClass,
+    initialLayoutDirection: LayoutDirection,
     private val style: StackComponentStyle,
     private val selectedPackageProvider: () -> Package?,
     private val selectedTabIndexProvider: () -> Int,
 ) {
     private var windowSize by mutableStateOf(initialWindowSize)
+    private var layoutDirection by mutableStateOf(initialLayoutDirection)
     private val selected by derivedStateOf {
         if (style.rcPackage != null) {
             style.rcPackage.identifier == selectedPackageProvider()?.identifier
@@ -107,9 +118,6 @@ internal class StackComponentState(
     val dimension by derivedStateOf { presentedPartial?.partial?.dimension ?: style.dimension }
 
     @get:JvmSynthetic
-    val size by derivedStateOf { presentedPartial?.partial?.size ?: style.size }
-
-    @get:JvmSynthetic
     val spacing by derivedStateOf { presentedPartial?.partial?.spacing?.dp ?: style.spacing }
 
     @get:JvmSynthetic
@@ -120,6 +128,11 @@ internal class StackComponentState(
 
     @get:JvmSynthetic
     val margin by derivedStateOf { presentedPartial?.partial?.margin?.toPaddingValues() ?: style.margin }
+
+    @get:JvmSynthetic
+    val size by derivedStateOf {
+        (presentedPartial?.partial?.size ?: style.size).adjustForMargin(margin, layoutDirection)
+    }
 
     @get:JvmSynthetic
     val shape by derivedStateOf { presentedPartial?.partial?.shape ?: style.shape }
@@ -149,7 +162,39 @@ internal class StackComponentState(
     @JvmSynthetic
     fun update(
         windowSize: WindowWidthSizeClass? = null,
+        layoutDirection: LayoutDirection? = null,
     ) {
         if (windowSize != null) this.windowSize = windowSize
+        if (layoutDirection != null) this.layoutDirection = layoutDirection
+    }
+
+    /**
+     * Since margin is not a thing in Compose, and we apply it as extra padding outside the border and background, we
+     * need to make sure the Composable's size is large enough to contain the margin.
+     */
+    private fun Size.adjustForMargin(margin: PaddingValues, layoutDirection: LayoutDirection): Size {
+        val adjustedWidth = when (val baseWidth = width) {
+            is SizeConstraint.Fixed -> SizeConstraint.Fixed(
+                baseWidth.value +
+                    margin.calculateStartPadding(layoutDirection).value.toUInt() +
+                    margin.calculateEndPadding(layoutDirection).value.toUInt(),
+            )
+            is SizeConstraint.Fill,
+            is SizeConstraint.Fit,
+            -> baseWidth
+        }
+
+        val adjustedHeight = when (val baseHeight = height) {
+            is SizeConstraint.Fixed -> SizeConstraint.Fixed(
+                baseHeight.value +
+                    margin.calculateTopPadding().value.toUInt() +
+                    margin.calculateBottomPadding().value.toUInt(),
+            )
+            is SizeConstraint.Fill,
+            is SizeConstraint.Fit,
+            -> baseHeight
+        }
+
+        return Size(width = adjustedWidth, height = adjustedHeight)
     }
 }


### PR DESCRIPTION
## Description
This was a though one. The cause of this is twofold:
1. `Column` and `Row` don't draw anything without children. Fixed by checking for this case and using a `Box` instead.
2. A `margin` would eat away the available space, making the divider invisible even with problem 1 fixed. This is fixed by adjusting the `size` for the `margin`. 


Fixes [MON-917](https://linear.app/revenuecat/issue/MON-917). 