### PR TITLE
[Paywalls V2] Disables the click handler for the selected package

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/pkg/PackageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/pkg/PackageComponentView.kt
@@ -21,6 +21,8 @@ internal fun PackageComponentView(
         state = state,
         // We act like a button, so we're handling the click already.
         clickHandler = { },
-        modifier = modifier.clickable { state.update(selectedPackage = style.rcPackage) },
+        modifier = modifier.clickable(
+            enabled = state.selectedPackageInfo?.rcPackage != style.rcPackage,
+        ) { state.update(selectedPackage = style.rcPackage) },
     )
 }


### PR DESCRIPTION
## Description
This has the desired effect of not being able to "select" a singular package on a paywall, without having to traverse the tree. It also avoids [the potentially confusing case of trying to reselect an already selected package](https://revenuecat.slack.com/archives/C07H5S8CFL3/p1739371997220059). 