### PR TITLE
chore: Unify Json encoding with JsonHelper

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -497,7 +497,7 @@ internal class Backend(
         onSuccessHandler: () -> Unit,
         onErrorHandler: (error: PurchasesError, shouldMarkAsSynced: Boolean) -> Unit,
     ) {
-        val body = EventsRequest.json.encodeToJsonElement(paywallEventRequest).asMap()
+        val body = JsonHelper.json.encodeToJsonElement(paywallEventRequest).asMap()
         if (body == null) {
             onErrorHandler(
                 PurchasesError(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -497,7 +497,7 @@ internal class Backend(
         onSuccessHandler: () -> Unit,
         onErrorHandler: (error: PurchasesError, shouldMarkAsSynced: Boolean) -> Unit,
     ) {
-        val body = JsonHelper.json.encodeToJsonElement(paywallEventRequest).asMap()
+        val body = JsonProvider.defaultJson.encodeToJsonElement(paywallEventRequest).asMap()
         if (body == null) {
             onErrorHandler(
                 PurchasesError(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/CustomerInfoFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/CustomerInfoFactory.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.common
 
 import android.net.Uri
-import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.EntitlementInfos
 import com.revenuecat.purchases.SubscriptionInfo
@@ -15,7 +14,6 @@ import com.revenuecat.purchases.utils.Iso8601Utils
 import com.revenuecat.purchases.utils.SerializationException
 import com.revenuecat.purchases.utils.optDate
 import com.revenuecat.purchases.utils.optNullableString
-import kotlinx.serialization.json.Json
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.Collections.emptyMap
@@ -26,12 +24,6 @@ import java.util.Date
  * @throws [JSONException] If the json is invalid.
  */
 internal object CustomerInfoFactory {
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal val json = Json {
-        ignoreUnknownKeys = true
-    }
-
     @Throws(JSONException::class)
     fun buildCustomerInfo(httpResult: HTTPResult): CustomerInfo {
         return buildCustomerInfo(httpResult.body, httpResult.requestDate, httpResult.verificationResult)
@@ -106,7 +98,7 @@ internal object CustomerInfoFactory {
         try {
             subscriptions.keys().forEach { productId ->
                 val subscriptionJSONObject = subscriptions.getJSONObject(productId)
-                val subscriptionInfoResponse = json.decodeFromString<SubscriptionInfoResponse>(
+                val subscriptionInfoResponse = JsonHelper.json.decodeFromString<SubscriptionInfoResponse>(
                     subscriptionJSONObject.toString(),
                 )
                 subscriptionMap[productId] = SubscriptionInfo(productId, requestDate, subscriptionInfoResponse)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/CustomerInfoFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/CustomerInfoFactory.kt
@@ -98,7 +98,7 @@ internal object CustomerInfoFactory {
         try {
             subscriptions.keys().forEach { productId ->
                 val subscriptionJSONObject = subscriptions.getJSONObject(productId)
-                val subscriptionInfoResponse = JsonHelper.json.decodeFromString<SubscriptionInfoResponse>(
+                val subscriptionInfoResponse = JsonProvider.defaultJson.decodeFromString<SubscriptionInfoResponse>(
                     subscriptionJSONObject.toString(),
                 )
                 subscriptionMap[productId] = SubscriptionInfo(productId, requestDate, subscriptionInfoResponse)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/JsonHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/JsonHelper.kt
@@ -1,0 +1,22 @@
+package com.revenuecat.purchases.common
+
+import com.revenuecat.purchases.common.events.BackendEvent
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+
+internal object JsonHelper {
+    companion object {
+        val json = Json {
+            serializersModule = SerializersModule {
+                polymorphic(BackendEvent::class) {
+                    subclass(BackendEvent.CustomerCenter::class, BackendEvent.CustomerCenter.serializer())
+                    subclass(BackendEvent.Paywalls::class, BackendEvent.Paywalls.serializer())
+                }
+            }
+            classDiscriminator = "discriminator"
+            encodeDefaults = false
+            ignoreUnknownKeys = true
+        }
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/JsonProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/JsonProvider.kt
@@ -5,9 +5,9 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 
-internal object JsonHelper {
+internal sealed class JsonProvider {
     companion object {
-        val json = Json {
+        val defaultJson = Json {
             serializersModule = SerializersModule {
                 polymorphic(BackendEvent::class) {
                     subclass(BackendEvent.CustomerCenter::class, BackendEvent.CustomerCenter.serializer())

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/EventsRequest.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/EventsRequest.kt
@@ -1,9 +1,6 @@
 package com.revenuecat.purchases.common.events
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.polymorphic
 
 /**
  * A request object for handling events.
@@ -14,31 +11,6 @@ import kotlinx.serialization.modules.polymorphic
 data class EventsRequest internal constructor(
     internal val events: List<BackendEvent>,
 ) {
-
-    /**
-     * Companion object to provide serialization configuration for [EventsRequest].
-     */
-    companion object {
-        /**
-         * JSON configuration with custom serialization rules for handling polymorphic [BackendEvent] types.
-         *
-         * - Uses a `discriminator` field to distinguish subclasses.
-         * - Enables encoding of default values.
-         * - Ignores unknown keys to ensure forward compatibility.
-         */
-        val json = Json {
-            serializersModule = SerializersModule {
-                polymorphic(BackendEvent::class) {
-                    subclass(BackendEvent.CustomerCenter::class, BackendEvent.CustomerCenter.serializer())
-                    subclass(BackendEvent.Paywalls::class, BackendEvent.Paywalls.serializer())
-                }
-            }
-            classDiscriminator = "discriminator"
-            encodeDefaults = false
-            ignoreUnknownKeys = true
-        }
-    }
-
     /**
      * Generates a cache key based on the hash codes of the contained events.
      *

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
@@ -16,7 +16,7 @@ import com.revenuecat.purchases.common.events.toBackendEvent
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
-import com.revenuecat.purchases.common.JsonHelper
+import com.revenuecat.purchases.common.JsonProvider
 import com.revenuecat.purchases.paywalls.events.PaywallEventType
 import com.revenuecat.purchases.utils.asMap
 import io.mockk.every
@@ -70,7 +70,7 @@ class BackendPaywallEventTest {
     fun setUp() {
         appConfig = mockk()
         httpClient = mockk()
-        unmockkObject(JsonHelper)
+        unmockkObject(JsonProvider)
         val backendHelper = BackendHelper("TEST_API_KEY", SyncDispatcher(), appConfig, httpClient)
 
         val asyncDispatcher1 = createAsyncDispatcher()
@@ -196,10 +196,10 @@ class BackendPaywallEventTest {
 
     @Test
     fun `postPaywallEvents calls error handler with shouldMarkAsSynced true if json error`() {
-        mockkObject(JsonHelper)
+        mockkObject(JsonProvider)
         val mockJson = mockk<Json>()
         every {
-            JsonHelper.json
+            JsonProvider.defaultJson
         } returns mockJson
 
         every {
@@ -264,8 +264,8 @@ class BackendPaywallEventTest {
     }
 
     private fun verifyCallWithBody(body: String) {
-        val expectedRequest: EventsRequest = JsonHelper.json.decodeFromString(body)
-        val expectedBody = JsonHelper.json.encodeToJsonElement(expectedRequest).asMap()
+        val expectedRequest: EventsRequest = JsonProvider.defaultJson.decodeFromString(body)
+        val expectedBody = JsonProvider.defaultJson.encodeToJsonElement(expectedRequest).asMap()
         verify(exactly = 1) {
             httpClient.performRequest(
                 AppConfig.paywallEventsURL,

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventsRequestSerializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventsRequestSerializationTest.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.common.events.BackendEvent
 import com.revenuecat.purchases.common.events.BackendStoredEvent
 import com.revenuecat.purchases.common.events.EventsRequest
 import com.revenuecat.purchases.common.events.toBackendEvent
+import com.revenuecat.purchases.common.JsonHelper
 import kotlinx.serialization.encodeToString
 import org.assertj.core.api.Assertions
 import org.junit.Test
@@ -35,7 +36,7 @@ class PaywallEventsRequestSerializationTest {
 
     @Test
     fun `can encode paywall event request correctly`() {
-        val requestString = EventsRequest.json.encodeToString(request)
+        val requestString = JsonHelper.json.encodeToString(request)
         Assertions.assertThat(requestString).isEqualTo(
             "{" +
                 "\"events\":[" +
@@ -60,8 +61,8 @@ class PaywallEventsRequestSerializationTest {
 
     @Test
     fun `can encode and decode event correctly`() {
-        val requestString = EventsRequest.json.encodeToString(request)
-        val decodedRequest = EventsRequest.json.decodeFromString<EventsRequest>(requestString)
+        val requestString = JsonHelper.json.encodeToString(request)
+        val decodedRequest = JsonHelper.json.decodeFromString<EventsRequest>(requestString)
         Assertions.assertThat(decodedRequest).isEqualTo(request)
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventsRequestSerializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventsRequestSerializationTest.kt
@@ -6,7 +6,7 @@ import com.revenuecat.purchases.common.events.BackendEvent
 import com.revenuecat.purchases.common.events.BackendStoredEvent
 import com.revenuecat.purchases.common.events.EventsRequest
 import com.revenuecat.purchases.common.events.toBackendEvent
-import com.revenuecat.purchases.common.JsonHelper
+import com.revenuecat.purchases.common.JsonProvider
 import kotlinx.serialization.encodeToString
 import org.assertj.core.api.Assertions
 import org.junit.Test
@@ -36,7 +36,7 @@ class PaywallEventsRequestSerializationTest {
 
     @Test
     fun `can encode paywall event request correctly`() {
-        val requestString = JsonHelper.json.encodeToString(request)
+        val requestString = JsonProvider.defaultJson.encodeToString(request)
         Assertions.assertThat(requestString).isEqualTo(
             "{" +
                 "\"events\":[" +
@@ -61,8 +61,8 @@ class PaywallEventsRequestSerializationTest {
 
     @Test
     fun `can encode and decode event correctly`() {
-        val requestString = JsonHelper.json.encodeToString(request)
-        val decodedRequest = JsonHelper.json.decodeFromString<EventsRequest>(requestString)
+        val requestString = JsonProvider.defaultJson.encodeToString(request)
+        val decodedRequest = JsonProvider.defaultJson.decodeFromString<EventsRequest>(requestString)
         Assertions.assertThat(decodedRequest).isEqualTo(request)
     }
 }


### PR DESCRIPTION
### Motivation
As promised to @tonidero and @JayShortway, here's a `JsonHelper` that unifies Json use.
This PR introduces `JsonProvider`, and a `defaultJson`. 

> Sadly, `classDiscriminator` cannot be dynamic so we need one per discriminator (paywalls will need one)
