### PR TITLE
[Paywalls V2] Refactor to use a single ImageLoader singleton in RevenueCatUI

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/CoilImageLoader.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/CoilImageLoader.kt
@@ -6,34 +6,42 @@ import android.content.Context
 import coil.ImageLoader
 import coil.disk.DiskCache
 import coil.memory.MemoryCache
-import coil.request.CachePolicy
 
 // Note: these values have to match those in CoilImageDownloader
 private const val MAX_CACHE_SIZE_BYTES = 25 * 1024 * 1024L // 25 MB
 private const val PAYWALL_IMAGE_CACHE_FOLDER = "revenuecatui_cache"
 
 /**
+ * We hold a singleton reference to the ImageLoader to avoid creating multiple instances.
+ * The ImageLoader only holds a reference to the application context, so we shouldn't leak anything.
+ */
+private var cachedImageLoader: ImageLoader? = null
+
+/**
  * This downloads paywall images in a specific cache for RevenueCat.
  * If you update this, make sure the version in the [CoilImageDownloader] class is also updated.
- *
- * @param readCache: set to false to ignore cache for reading, but allow overwriting with updated image.
  */
 @JvmSynthetic
-internal fun Context.getRevenueCatUIImageLoader(readCache: Boolean): ImageLoader {
-    val cachePolicy = if (readCache) CachePolicy.ENABLED else CachePolicy.WRITE_ONLY
-
-    return ImageLoader.Builder(this)
-        .diskCache {
-            DiskCache.Builder()
-                .directory(cacheDir.resolve(PAYWALL_IMAGE_CACHE_FOLDER))
-                .maxSizeBytes(MAX_CACHE_SIZE_BYTES)
+internal fun Context.getRevenueCatUIImageLoader(): ImageLoader {
+    return synchronized(Unit) {
+        val currentImageLoader = cachedImageLoader
+        if (currentImageLoader == null) {
+            val newImageLoader = ImageLoader.Builder(this)
+                .diskCache {
+                    DiskCache.Builder()
+                        .directory(cacheDir.resolve(PAYWALL_IMAGE_CACHE_FOLDER))
+                        .maxSizeBytes(MAX_CACHE_SIZE_BYTES)
+                        .build()
+                }
+                .memoryCache(
+                    MemoryCache.Builder(this)
+                        .build(),
+                )
                 .build()
+            cachedImageLoader = newImageLoader
+            newImageLoader
+        } else {
+            currentImageLoader
         }
-        .memoryCache(
-            MemoryCache.Builder(this)
-                .build(),
-        )
-        .diskCachePolicy(cachePolicy)
-        .memoryCachePolicy(cachePolicy)
-        .build()
+    }
 }


### PR DESCRIPTION
### Description
This is an attempt to fix an issue where some icon images where failing to load. Our theory is that the ImageLoader was getting deallocated, since it seemed the connection was getting closed. I haven't been able to reproduce though, so not sure if this will fix it. A couple things to consider:
- We are only using a single ImageLoader when fetching the images, we are still using multiple image loaders to predownload the images. Plan to address this later
- I noticed for images when cache is disabled, we're not setting the loader which in effect, would fallback to the "default" image loader. We might want to fix that at some point as well.