### PR TITLE
fix: Track customer center events

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -37,16 +37,13 @@ internal sealed class BackendStoredEvent : Event {
  * Converts a `BackendStoredEvent` into a `BackendEvent`.
  *
  * @receiver The stored backend event to be converted.
- * @return A `BackendEvent` instance or `null` if conversion is not possible.
+ * @return A `BackendEvent` instance.
  */
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
-internal fun BackendStoredEvent.toBackendEvent(): BackendEvent? {
+internal fun BackendStoredEvent.toBackendEvent(): BackendEvent {
     return when (this) {
         is BackendStoredEvent.Paywalls -> { this.event }
-        is BackendStoredEvent.CustomerCenter -> {
-            // For now, returning null:
-            null
-        }
+        is BackendStoredEvent.CustomerCenter -> { this.event }
     }
 }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/EventsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/EventsManager.kt
@@ -160,7 +160,7 @@ internal class EventsManager(
 
             verboseLog("New event flush: posting ${storedEvents.size} events.")
             postEvents(
-                EventsRequest(storedEvents.mapNotNull { it.toBackendEvent() }),
+                EventsRequest(storedEvents.map { it.toBackendEvent() }),
                 {
                     verboseLog("New event flush: success.")
                     enqueue {
@@ -197,7 +197,7 @@ internal class EventsManager(
 
             verboseLog("Legacy event flush: posting ${storedBackendEvents.size} events.")
             postEvents(
-                EventsRequest(storedBackendEvents.mapNotNull { it.toBackendEvent() }),
+                EventsRequest(storedBackendEvents.map { it.toBackendEvent() }),
                 {
                     verboseLog("Legacy event flush: success.")
                     enqueue { legacyEventsFileHelper.clear(storedLegacyEventsWithNullValues.size) }


### PR DESCRIPTION
### Motivation
This PR enables customer center tracking. We missed it because the tests were only checking for paywalls, but now the modified test checks for both.

