### PR TITLE
Removes Intent.FLAG_ACTIVITY_NEW_TASK when starting CustomerCenterActivity

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/ShowCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/ShowCustomerCenter.kt
@@ -22,9 +22,7 @@ import androidx.activity.result.contract.ActivityResultContract
  */
 class ShowCustomerCenter : ActivityResultContract<Unit, Unit>() {
     override fun createIntent(context: Context, input: Unit): Intent {
-        return CustomerCenterActivity.createIntent(context).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
+        return CustomerCenterActivity.createIntent(context)
     }
 
     override fun parseResult(resultCode: Int, intent: Intent?) {


### PR DESCRIPTION
This was preventing from getting the activity result since it always sends `0` to the caller `onActivityResult` right before the `onCreate` of `CustomerCenterActivity`