### PR TITLE
[Paywalls V2] Adds progress indicator to buttons

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -3,13 +3,17 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.button
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
@@ -51,6 +55,21 @@ internal fun ButtonComponentView(
 
     val coroutineScope = rememberCoroutineScope()
     var isClickable by remember { mutableStateOf(true) }
+
+    val progressIndicator: (@Composable BoxScope.(Modifier) -> Unit)? by remember {
+        derivedStateOf {
+            if (isClickable) {
+                null
+            } else {
+                @Composable { modifier ->
+                    CircularProgressIndicator(
+                        modifier = modifier.align(Alignment.Center),
+                    )
+                }
+            }
+        }
+    }
+
     StackComponentView(
         style = style.stackComponentStyle,
         state = state,
@@ -63,6 +82,7 @@ internal fun ButtonComponentView(
                 isClickable = true
             }
         },
+        progressIndicator = progressIndicator,
     )
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -75,6 +75,10 @@ internal fun ButtonComponentView(
     val animatedContentAlpha by animateFloatAsState(targetValue = contentAlpha)
     val animatedProgressAlpha by animateFloatAsState(targetValue = progressAlpha)
 
+    // We are using a custom Layout instead of a Box to properly handle the case where the StackComponentView is
+    // smaller than the CircularProgressIndicator, in either dimension. In this case, we want the
+    // CircularProgressIndicator to shrink so it doesn't exceed the StackComponentView's bounds. Using IntrinsicSize
+    // and matchParentSize() was considered, but in the end a custom Layout seemed to be the only reliable option.
     Layout(
         content = {
             StackComponentView(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -36,7 +36,6 @@ import com.revenuecat.purchases.ui.revenuecatui.components.properties.Background
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.BorderStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
-import com.revenuecat.purchases.ui.revenuecatui.components.properties.GradientBrush
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ShadowStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.forCurrentTheme
 import com.revenuecat.purchases.ui.revenuecatui.components.stack.StackComponentView
@@ -145,8 +144,7 @@ private fun progressColorFor(colorStyle: ColorStyle): Color =
     when (colorStyle) {
         is ColorStyle.Solid -> if (colorStyle.color.brightness > BRIGHTNESS_CUTOFF) Color.Black else Color.White
         is ColorStyle.Gradient -> {
-            val brush = colorStyle.brush as GradientBrush
-            val averageBrightness = brush.colors.map { it.brightness }.average()
+            val averageBrightness = colorStyle.brush.colors.map { it.brightness }.average()
             if (averageBrightness > BRIGHTNESS_CUTOFF) Color.Black else Color.White
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -74,20 +74,6 @@ internal fun ButtonComponentView(
     val progressAlpha by remember { derivedStateOf { if (isClickable) 0f else 1f } }
     val animatedContentAlpha by animateFloatAsState(targetValue = contentAlpha)
     val animatedProgressAlpha by animateFloatAsState(targetValue = progressAlpha)
-    val progressIndicator: (@Composable () -> Unit)? by remember {
-        derivedStateOf {
-            if (isClickable) {
-                null
-            } else {
-                @Composable {
-                    CircularProgressIndicator(
-                        modifier = Modifier.alpha(animatedProgressAlpha),
-                        color = progressColorFor(style.stackComponentStyle.background),
-                    )
-                }
-            }
-        }
-    }
 
     Layout(
         content = {
@@ -98,7 +84,10 @@ internal fun ButtonComponentView(
                 clickHandler = { },
                 contentAlpha = animatedContentAlpha,
             )
-            progressIndicator?.invoke()
+            CircularProgressIndicator(
+                modifier = Modifier.alpha(animatedProgressAlpha),
+                color = progressColorFor(style.stackComponentStyle.background),
+            )
         },
         modifier = modifier.clickable(enabled = isClickable) {
             isClickable = false
@@ -110,7 +99,7 @@ internal fun ButtonComponentView(
         measurePolicy = { measurables, constraints ->
             val stack = measurables[0].measure(constraints)
             // Ensure that the progress indicator is not bigger than the stack.
-            val progress = measurables.getOrNull(1)?.measure(
+            val progress = measurables[1].measure(
                 constraints.copy(maxHeight = stack.height, maxWidth = stack.width),
             )
             val totalWidth = stack.width
@@ -121,7 +110,7 @@ internal fun ButtonComponentView(
             ) {
                 stack.placeRelative(x = 0, y = 0)
                 // Center the progress indicator.
-                progress?.placeRelative(
+                progress.placeRelative(
                     x = ((totalWidth / 2f) - (progress.width / 2f)).roundToInt(),
                     y = ((totalHeight / 2f) - (progress.height / 2f)).roundToInt(),
                 )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/ColorStyle.kt
@@ -155,6 +155,15 @@ private fun List<ColorInfo.Gradient.Point>.toColorStops(): Array<Pair<Float, Col
     map { point -> point.percent / PERCENT_SCALE to Color(point.color) }
         .toTypedArray()
 
+/**
+ * An intermediate type for linear and radial gradients that allows for reading the [colors] after the brush has been
+ * constructed.
+ */
+internal abstract class GradientBrush : ShaderBrush() {
+    @get:JvmSynthetic
+    internal abstract val colors: List<Color>
+}
+
 @Stable
 private fun relativeLinearGradient(
     vararg colorStops: Pair<Float, Color>,
@@ -180,11 +189,11 @@ private fun relativeLinearGradient(
 @Poko
 @Immutable
 private class RelativeLinearGradient(
-    private val colors: List<Color>,
+    override val colors: List<Color>,
     private val stops: List<Float>? = null,
     degrees: Float,
     private val tileMode: TileMode = TileMode.Clamp,
-) : ShaderBrush() {
+) : GradientBrush() {
 
     // Handling extreme degrees.
     private val degrees: Float = ((90 - degrees) % 360 + 360) % 360


### PR DESCRIPTION
This is the Android equivalent of https://github.com/RevenueCat/purchases-ios/pull/4787. 

## Description
This adds a progress indicator to the `ButtonComponentView`. It calculates the indicator color in the same way as we do on iOS. I created a new `GradientBrush` intermediate type that allows for reading the gradient colors after the brush has been constructed. This is used to determine the progress indicator color when the `StackComponentView` has a gradient background.

I didn't want to add the logic to  `StackComponentView`, as that one is big enough already, and my first attempt at doing so resulted in multiple layout issues. Also, ideally it is unaware of the progress indicator. Perhaps in the future, we can add a slot API to `StackComponentView`, but we're not there yet. 