### PR TITLE
Avoids triggering "unscheduled" workflows when triggering workflows via the CircleCI API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -645,8 +645,10 @@ workflows:
   version: 2
   danger:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "default", << pipeline.parameters.action >> ]
     jobs:
       - revenuecat/danger
 
@@ -658,23 +660,26 @@ workflows:
 
   snapshot-deploy-sample-app-tests:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "main", << pipeline.git.branch >> ]
+        - equal: [ "default", << pipeline.parameters.action >> ]
     jobs:
-      - deploy-snapshot: *only-main-branch
+      - deploy-snapshot
       - assemble-magic-weather-compose-sample-app:
-          <<: *only-main-branch
           requires:
             - deploy-snapshot
       - assemble-custom-entitlement-computation-sample-app:
-          <<: *only-main-branch
           requires:
             - deploy-snapshot
 
   build-test-deploy:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "default", << pipeline.parameters.action >> ]
     jobs:
       - test
       - detekt
@@ -732,10 +737,13 @@ workflows:
 
   snapshot-bump:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "main", << pipeline.git.branch >> ]
+        - equal: [ "default", << pipeline.parameters.action >> ]
     jobs:
-      - prepare-next-version: *only-main-branch
+      - prepare-next-version
 
   publish-paywall-tester-to-internal-track:
     when:
@@ -743,6 +751,7 @@ workflows:
         - not:
             equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "main", << pipeline.git.branch >> ]
+        - equal: [ "default", << pipeline.parameters.action >> ]
     jobs:
       - publish-paywall-tester-release:
           track: "internal"


### PR DESCRIPTION
## Description 
We have a bunch of workflows that check if the `pipeline.trigger_source` is **not** `scheduled_pipeline`. These will all be triggered when triggering workflows from the API, however, which is not what we want. This PR adds an additional check to make sure that the `action` is `default`. 

## Motivation
We've added a CI workflow that updates the Paywalls v2 template previews in [#2192](https://github.com/RevenueCat/purchases-android/pull/2192), which will be triggered from khepri. We don't want to trigger all the other workflows together with that.