### PR TITLE
Adds a `LocalPreviewImageLoader` `CompositionLocal`.

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -19,3 +19,6 @@ style:
   UnusedPrivateMember:
     active: true
     ignoreAnnotated: [ 'Preview' ]
+Compose:
+  CompositionLocalAllowlist:
+    allowedCompositionLocals: LocalPreviewImageLoader

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/iconcomponent/IconComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/iconcomponent/IconComponentView.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.tooling.preview.Preview
-import coil.ImageLoader
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
@@ -33,6 +32,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.IconComponentSt
 import com.revenuecat.purchases.ui.revenuecatui.composables.RemoteImage
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.extensions.applyIfNotNull
+import com.revenuecat.purchases.ui.revenuecatui.helpers.ProvidePreviewImageLoader
 
 @JvmSynthetic
 @Composable
@@ -40,7 +40,6 @@ internal fun IconComponentView(
     style: IconComponentStyle,
     state: PaywallState.Loaded.Components,
     modifier: Modifier = Modifier,
-    previewImageLoader: ImageLoader? = null,
 ) {
     val iconState = rememberUpdatedIconComponentState(
         style = style,
@@ -74,23 +73,23 @@ internal fun IconComponentView(
             .applyIfNotNull(borderStyle) { border(it, composeShape) }
             .padding(iconState.padding),
         colorFilter = colorFilter,
-        previewImageLoader = previewImageLoader,
     )
 }
 
 @Preview
 @Composable
 private fun IconComponentView_Preview() {
-    Box(modifier = Modifier.background(Color.LightGray)) {
-        IconComponentView(
-            style = previewIconComponentStyle(
-                size = Size(
-                    width = SizeConstraint.Fixed(200u),
-                    height = SizeConstraint.Fixed(200u),
+    ProvidePreviewImageLoader(previewImageLoader()) {
+        Box(modifier = Modifier.background(Color.LightGray)) {
+            IconComponentView(
+                style = previewIconComponentStyle(
+                    size = Size(
+                        width = SizeConstraint.Fixed(200u),
+                        height = SizeConstraint.Fixed(200u),
+                    ),
                 ),
-            ),
-            state = previewEmptyState(),
-            previewImageLoader = previewImageLoader(),
-        )
+                state = previewEmptyState(),
+            )
+        }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -72,6 +72,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.ImageComponentS
 import com.revenuecat.purchases.ui.revenuecatui.composables.RemoteImage
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.extensions.applyIfNotNull
+import com.revenuecat.purchases.ui.revenuecatui.helpers.ProvidePreviewImageLoader
 import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
 import java.net.URL
 import androidx.compose.ui.graphics.Color as ComposeColor
@@ -82,7 +83,6 @@ internal fun ImageComponentView(
     style: ImageComponentStyle,
     state: PaywallState.Loaded.Components,
     modifier: Modifier = Modifier,
-    previewImageLoader: ImageLoader? = null,
 ) {
     // Get an ImageComponentState that calculates the overridden properties we should use.
     val imageState = rememberUpdatedImageComponentState(
@@ -116,7 +116,6 @@ internal fun ImageComponentView(
                     .padding(imageState.padding),
                 placeholderUrlString = imageState.imageUrls.webpLowRes.toString(),
                 contentScale = imageState.contentScale,
-                previewImageLoader = previewImageLoader,
             )
         }
     }
@@ -200,24 +199,25 @@ private fun ImageComponentView_Preview(
     @PreviewParameter(PreviewParametersProvider::class) parameters: PreviewParameters,
 ) {
     val themeImageUrls = previewThemeImageUrls(widthPx = parameters.imageWidth, heightPx = parameters.imageHeight)
-    Box(modifier = Modifier.background(ComposeColor.Red)) {
-        ImageComponentView(
-            style = previewImageComponentStyle(
-                themeImageUrls = themeImageUrls,
-                size = parameters.viewSize,
-                fitMode = parameters.fitMode,
-                shape = MaskShape.Rectangle(
-                    corners = CornerRadiuses.Dp(
-                        topLeading = 20.0,
-                        topTrailing = 20.0,
-                        bottomLeading = 20.0,
-                        bottomTrailing = 20.0,
+    ProvidePreviewImageLoader(previewImageLoader(themeImageUrls)) {
+        Box(modifier = Modifier.background(ComposeColor.Red)) {
+            ImageComponentView(
+                style = previewImageComponentStyle(
+                    themeImageUrls = themeImageUrls,
+                    size = parameters.viewSize,
+                    fitMode = parameters.fitMode,
+                    shape = MaskShape.Rectangle(
+                        corners = CornerRadiuses.Dp(
+                            topLeading = 20.0,
+                            topTrailing = 20.0,
+                            bottomLeading = 20.0,
+                            bottomTrailing = 20.0,
+                        ),
                     ),
                 ),
-            ),
-            state = previewEmptyState(),
-            previewImageLoader = previewImageLoader(themeImageUrls),
-        )
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
@@ -225,23 +225,24 @@ private fun ImageComponentView_Preview(
 @Composable
 private fun ImageComponentView_Bigger_Container_Fill_Fit_FitModeFill_Preview() {
     val themeImageUrls = previewThemeImageUrls(widthPx = 100u, heightPx = 100u)
-    Box(
-        modifier = Modifier
-            .background(ComposeColor.Red)
-            .fillMaxHeight()
-            .width(200.dp)
-            .padding(20.dp),
-    ) {
-        ImageComponentView(
-            style = previewImageComponentStyle(
-                themeImageUrls = themeImageUrls,
-                size = Size(width = Fill, height = Fit),
-                fitMode = FitMode.FILL,
-                shape = MaskShape.Rectangle(),
-            ),
-            state = previewEmptyState(),
-            previewImageLoader = previewImageLoader(themeImageUrls),
-        )
+    ProvidePreviewImageLoader(previewImageLoader(themeImageUrls)) {
+        Box(
+            modifier = Modifier
+                .background(ComposeColor.Red)
+                .fillMaxHeight()
+                .width(200.dp)
+                .padding(20.dp),
+        ) {
+            ImageComponentView(
+                style = previewImageComponentStyle(
+                    themeImageUrls = themeImageUrls,
+                    size = Size(width = Fill, height = Fit),
+                    fitMode = FitMode.FILL,
+                    shape = MaskShape.Rectangle(),
+                ),
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
@@ -249,23 +250,24 @@ private fun ImageComponentView_Bigger_Container_Fill_Fit_FitModeFill_Preview() {
 @Composable
 private fun ImageComponentView_Bigger_Container_Fit_Fill_FitModeFill_Preview() {
     val themeImageUrls = previewThemeImageUrls(widthPx = 100u, heightPx = 100u)
-    Box(
-        modifier = Modifier
-            .background(ComposeColor.Red)
-            .fillMaxWidth()
-            .height(200.dp)
-            .padding(20.dp),
-    ) {
-        ImageComponentView(
-            style = previewImageComponentStyle(
-                themeImageUrls = themeImageUrls,
-                size = Size(width = Fit, height = Fill),
-                fitMode = FitMode.FILL,
-                shape = MaskShape.Rectangle(),
-            ),
-            state = previewEmptyState(),
-            previewImageLoader = previewImageLoader(themeImageUrls),
-        )
+    ProvidePreviewImageLoader(previewImageLoader(themeImageUrls)) {
+        Box(
+            modifier = Modifier
+                .background(ComposeColor.Red)
+                .fillMaxWidth()
+                .height(200.dp)
+                .padding(20.dp),
+        ) {
+            ImageComponentView(
+                style = previewImageComponentStyle(
+                    themeImageUrls = themeImageUrls,
+                    size = Size(width = Fit, height = Fill),
+                    fitMode = FitMode.FILL,
+                    shape = MaskShape.Rectangle(),
+                ),
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
@@ -273,28 +275,29 @@ private fun ImageComponentView_Bigger_Container_Fit_Fill_FitModeFill_Preview() {
 @Composable
 private fun ImageComponentView_Preview_SmallerContainer() {
     val themeImageUrls = previewThemeImageUrls(widthPx = 400u, heightPx = 400u)
-    Box(
-        modifier = Modifier
-            .height(200.dp)
-            .background(ComposeColor.Blue),
-    ) {
-        ImageComponentView(
-            style = previewImageComponentStyle(
-                themeImageUrls = themeImageUrls,
-                size = Size(width = Fixed(400u), height = Fixed(400u)),
-                fitMode = FitMode.FIT,
-                shape = MaskShape.Rectangle(
-                    corners = CornerRadiuses.Dp(
-                        topLeading = 20.0,
-                        topTrailing = 20.0,
-                        bottomLeading = 20.0,
-                        bottomTrailing = 20.0,
+    ProvidePreviewImageLoader(previewImageLoader(themeImageUrls)) {
+        Box(
+            modifier = Modifier
+                .height(200.dp)
+                .background(ComposeColor.Blue),
+        ) {
+            ImageComponentView(
+                style = previewImageComponentStyle(
+                    themeImageUrls = themeImageUrls,
+                    size = Size(width = Fixed(400u), height = Fixed(400u)),
+                    fitMode = FitMode.FIT,
+                    shape = MaskShape.Rectangle(
+                        corners = CornerRadiuses.Dp(
+                            topLeading = 20.0,
+                            topTrailing = 20.0,
+                            bottomLeading = 20.0,
+                            bottomTrailing = 20.0,
+                        ),
                     ),
                 ),
-            ),
-            state = previewEmptyState(),
-            previewImageLoader = previewImageLoader(themeImageUrls),
-        )
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
@@ -302,31 +305,32 @@ private fun ImageComponentView_Preview_SmallerContainer() {
 @Composable
 private fun ImageComponentView_Preview_Margin_Padding() {
     val themeImageUrls = previewThemeImageUrls(widthPx = 400u, heightPx = 400u)
-    Box(
-        modifier = Modifier
-            .height(200.dp)
-            .background(ComposeColor.Gray),
-    ) {
-        ImageComponentView(
-            style = previewImageComponentStyle(
-                themeImageUrls = themeImageUrls,
-                size = Size(width = Fixed(400u), height = Fixed(400u)),
-                paddingValues = PaddingValues(20.dp),
-                marginValues = PaddingValues(20.dp),
-                fitMode = FitMode.FIT,
-                shape = MaskShape.Rectangle(
-                    corners = CornerRadiuses.Dp(
-                        topLeading = 20.0,
-                        topTrailing = 20.0,
-                        bottomLeading = 20.0,
-                        bottomTrailing = 20.0,
+    ProvidePreviewImageLoader(previewImageLoader(themeImageUrls)) {
+        Box(
+            modifier = Modifier
+                .height(200.dp)
+                .background(ComposeColor.Gray),
+        ) {
+            ImageComponentView(
+                style = previewImageComponentStyle(
+                    themeImageUrls = themeImageUrls,
+                    size = Size(width = Fixed(400u), height = Fixed(400u)),
+                    paddingValues = PaddingValues(20.dp),
+                    marginValues = PaddingValues(20.dp),
+                    fitMode = FitMode.FIT,
+                    shape = MaskShape.Rectangle(
+                        corners = CornerRadiuses.Dp(
+                            topLeading = 20.0,
+                            topTrailing = 20.0,
+                            bottomLeading = 20.0,
+                            bottomTrailing = 20.0,
+                        ),
                     ),
+                    shadow = null,
                 ),
-                shadow = null,
-            ),
-            state = previewEmptyState(),
-            previewImageLoader = previewImageLoader(themeImageUrls),
-        )
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
@@ -335,49 +339,50 @@ private fun ImageComponentView_Preview_Margin_Padding() {
 @Composable
 private fun ImageComponentView_Preview_LinearGradient() {
     val themeImageUrls = previewThemeImageUrls(widthPx = 400u, heightPx = 400u)
-    Box(modifier = Modifier.background(ComposeColor.Red)) {
-        ImageComponentView(
-            style = previewImageComponentStyle(
-                themeImageUrls = themeImageUrls,
-                size = Size(width = Fixed(400u), height = Fit),
-                fitMode = FitMode.FIT,
-                shape = MaskShape.Rectangle(
-                    corners = CornerRadiuses.Dp(
-                        topLeading = 20.0,
-                        topTrailing = 20.0,
-                        bottomLeading = 20.0,
-                        bottomTrailing = 20.0,
-                    ),
-                ),
-                border = BorderStyles(
-                    width = 10.dp,
-                    colors = ColorStyles(
-                        light = ColorStyle.Solid(ComposeColor.Blue),
-                    ),
-                ),
-                overlay = ColorStyles(
-                    light = ColorInfo.Gradient.Linear(
-                        degrees = 0f,
-                        points = listOf(
-                            ColorInfo.Gradient.Point(
-                                color = Color.parseColor("#88FF0000"),
-                                percent = 0f,
-                            ),
-                            ColorInfo.Gradient.Point(
-                                color = Color.parseColor("#8800FF00"),
-                                percent = 50f,
-                            ),
-                            ColorInfo.Gradient.Point(
-                                color = Color.parseColor("#880000FF"),
-                                percent = 100f,
-                            ),
+    ProvidePreviewImageLoader(previewImageLoader(themeImageUrls)) {
+        Box(modifier = Modifier.background(ComposeColor.Red)) {
+            ImageComponentView(
+                style = previewImageComponentStyle(
+                    themeImageUrls = themeImageUrls,
+                    size = Size(width = Fixed(400u), height = Fit),
+                    fitMode = FitMode.FIT,
+                    shape = MaskShape.Rectangle(
+                        corners = CornerRadiuses.Dp(
+                            topLeading = 20.0,
+                            topTrailing = 20.0,
+                            bottomLeading = 20.0,
+                            bottomTrailing = 20.0,
                         ),
-                    ).toColorStyle(),
+                    ),
+                    border = BorderStyles(
+                        width = 10.dp,
+                        colors = ColorStyles(
+                            light = ColorStyle.Solid(ComposeColor.Blue),
+                        ),
+                    ),
+                    overlay = ColorStyles(
+                        light = ColorInfo.Gradient.Linear(
+                            degrees = 0f,
+                            points = listOf(
+                                ColorInfo.Gradient.Point(
+                                    color = Color.parseColor("#88FF0000"),
+                                    percent = 0f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color.parseColor("#8800FF00"),
+                                    percent = 50f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color.parseColor("#880000FF"),
+                                    percent = 100f,
+                                ),
+                            ),
+                        ).toColorStyle(),
+                    ),
                 ),
-            ),
-            state = previewEmptyState(),
-            previewImageLoader = previewImageLoader(themeImageUrls),
-        )
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
@@ -386,42 +391,43 @@ private fun ImageComponentView_Preview_LinearGradient() {
 @Composable
 private fun ImageComponentView_Preview_RadialGradient() {
     val themeImageUrls = previewThemeImageUrls(widthPx = 400u, heightPx = 400u)
-    Box(modifier = Modifier.background(ComposeColor.Red)) {
-        ImageComponentView(
-            style = previewImageComponentStyle(
-                themeImageUrls = themeImageUrls,
-                size = Size(width = Fixed(400u), height = Fit),
-                fitMode = FitMode.FIT,
-                shape = MaskShape.Rectangle(
-                    corners = CornerRadiuses.Dp(
-                        topLeading = 20.0,
-                        topTrailing = 20.0,
-                        bottomLeading = 20.0,
-                        bottomTrailing = 20.0,
+    ProvidePreviewImageLoader(previewImageLoader(themeImageUrls)) {
+        Box(modifier = Modifier.background(ComposeColor.Red)) {
+            ImageComponentView(
+                style = previewImageComponentStyle(
+                    themeImageUrls = themeImageUrls,
+                    size = Size(width = Fixed(400u), height = Fit),
+                    fitMode = FitMode.FIT,
+                    shape = MaskShape.Rectangle(
+                        corners = CornerRadiuses.Dp(
+                            topLeading = 20.0,
+                            topTrailing = 20.0,
+                            bottomLeading = 20.0,
+                            bottomTrailing = 20.0,
+                        ),
+                    ),
+                    overlay = ColorStyles(
+                        light = ColorInfo.Gradient.Radial(
+                            listOf(
+                                ColorInfo.Gradient.Point(
+                                    color = Color.parseColor("#88FF0000"),
+                                    percent = 0f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color.parseColor("#8800FF00"),
+                                    percent = 50f,
+                                ),
+                                ColorInfo.Gradient.Point(
+                                    color = Color.parseColor("#880000FF"),
+                                    percent = 100f,
+                                ),
+                            ),
+                        ).toColorStyle(),
                     ),
                 ),
-                overlay = ColorStyles(
-                    light = ColorInfo.Gradient.Radial(
-                        listOf(
-                            ColorInfo.Gradient.Point(
-                                color = Color.parseColor("#88FF0000"),
-                                percent = 0f,
-                            ),
-                            ColorInfo.Gradient.Point(
-                                color = Color.parseColor("#8800FF00"),
-                                percent = 50f,
-                            ),
-                            ColorInfo.Gradient.Point(
-                                color = Color.parseColor("#880000FF"),
-                                percent = 100f,
-                            ),
-                        ),
-                    ).toColorStyle(),
-                ),
-            ),
-            state = previewEmptyState(),
-            previewImageLoader = previewImageLoader(themeImageUrls),
-        )
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
@@ -447,17 +453,18 @@ private fun ImageComponentView_Preview_MaskShape(
     @PreviewParameter(MaskShapeProvider::class) maskShape: MaskShape,
 ) {
     val themeImageUrls = previewThemeImageUrls(widthPx = 400u, heightPx = 200u)
-    Box(modifier = Modifier.background(ComposeColor.Blue)) {
-        ImageComponentView(
-            style = previewImageComponentStyle(
-                themeImageUrls = themeImageUrls,
-                size = Size(width = Fixed(400u), height = Fixed(200u)),
-                fitMode = FitMode.FIT,
-                shape = maskShape,
-            ),
-            state = previewEmptyState(),
-            previewImageLoader = previewImageLoader(themeImageUrls),
-        )
+    ProvidePreviewImageLoader(previewImageLoader(themeImageUrls)) {
+        Box(modifier = Modifier.background(ComposeColor.Blue)) {
+            ImageComponentView(
+                style = previewImageComponentStyle(
+                    themeImageUrls = themeImageUrls,
+                    size = Size(width = Fixed(400u), height = Fixed(200u)),
+                    fitMode = FitMode.FIT,
+                    shape = maskShape,
+                ),
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/timeline/TimelineComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/timeline/TimelineComponentView.kt
@@ -20,7 +20,6 @@ import androidx.constraintlayout.compose.ConstrainedLayoutReference
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.ConstraintLayoutBaseScope.HorizontalAnchor
 import androidx.constraintlayout.compose.Dimension
-import coil.ImageLoader
 import com.revenuecat.purchases.paywalls.components.TimelineComponent
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.FontWeight
@@ -42,6 +41,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.IconComponentSt
 import com.revenuecat.purchases.ui.revenuecatui.components.style.TimelineComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.text.TextComponentView
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.ProvidePreviewImageLoader
 
 @Suppress("LongMethod", "CyclomaticComplexMethod", "DestructuringDeclarationWithTooManyEntries")
 @Composable
@@ -49,7 +49,6 @@ internal fun TimelineComponentView(
     style: TimelineComponentStyle,
     state: PaywallState.Loaded.Components,
     modifier: Modifier = Modifier,
-    previewImageLoader: ImageLoader? = null,
 ) {
     val timelineState = rememberUpdatedTimelineComponentState(
         style = style,
@@ -108,7 +107,6 @@ internal fun TimelineComponentView(
                         }
                     }
                 },
-                previewImageLoader = previewImageLoader,
             )
 
             TextComponentView(
@@ -177,39 +175,42 @@ internal fun TimelineComponentView(
 @Preview
 @Composable
 private fun TimelineComponentView_Align_Title_Preview() {
-    Box {
-        TimelineComponentView(
-            style = previewStyle(iconAlignment = TimelineComponent.IconAlignment.Title),
-            state = previewEmptyState(),
-            previewImageLoader = previewImageLoader(),
-        )
+    ProvidePreviewImageLoader(previewImageLoader()) {
+        Box {
+            TimelineComponentView(
+                style = previewStyle(iconAlignment = TimelineComponent.IconAlignment.Title),
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
 @Preview
 @Composable
 private fun TimelineComponentView_Align_TitleAndDescription_Preview() {
-    Box {
-        TimelineComponentView(
-            style = previewStyle(iconAlignment = TimelineComponent.IconAlignment.TitleAndDescription),
-            state = previewEmptyState(),
-            previewImageLoader = previewImageLoader(),
-        )
+    ProvidePreviewImageLoader(previewImageLoader()) {
+        Box {
+            TimelineComponentView(
+                style = previewStyle(iconAlignment = TimelineComponent.IconAlignment.TitleAndDescription),
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 
 @Preview
 @Composable
 private fun TimelineComponentView_Connector_Margin_Preview() {
-    Box {
-        TimelineComponentView(
-            style = previewStyle(
-                iconAlignment = TimelineComponent.IconAlignment.TitleAndDescription,
-                items = previewItems(connectorMargins = PaddingValues(0.dp, 12.dp, 0.dp, 12.dp)),
-            ),
-            state = previewEmptyState(),
-            previewImageLoader = previewImageLoader(),
-        )
+    ProvidePreviewImageLoader(previewImageLoader()) {
+        Box {
+            TimelineComponentView(
+                style = previewStyle(
+                    iconAlignment = TimelineComponent.IconAlignment.TitleAndDescription,
+                    items = previewItems(connectorMargins = PaddingValues(0.dp, 12.dp, 0.dp, 12.dp)),
+                ),
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/RemoteImage.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.withSave
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import coil.ImageLoader
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
@@ -32,8 +31,8 @@ import coil.request.SuccessResult
 import coil.transform.Transformation
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
-import com.revenuecat.purchases.ui.revenuecatui.R
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
+import com.revenuecat.purchases.ui.revenuecatui.helpers.LocalPreviewImageLoader
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
 import kotlinx.coroutines.runBlocking
@@ -59,7 +58,6 @@ internal fun LocalImage(
         transformation = transformation,
         alpha = alpha,
         colorFilter = colorFilter,
-        previewImageLoader = null,
     )
 }
 
@@ -78,7 +76,6 @@ internal fun RemoteImage(
     transformation: Transformation? = null,
     alpha: Float = 1f,
     colorFilter: ColorFilter? = null,
-    previewImageLoader: ImageLoader? = null,
 ) {
     Image(
         source = ImageSource.Remote(urlString),
@@ -89,7 +86,6 @@ internal fun RemoteImage(
         transformation = transformation,
         alpha = alpha,
         colorFilter = colorFilter,
-        previewImageLoader = previewImageLoader,
     )
 }
 
@@ -115,9 +111,9 @@ private fun Image(
     transformation: Transformation?,
     alpha: Float,
     colorFilter: ColorFilter?,
-    previewImageLoader: ImageLoader?,
 ) {
     // Previews don't support images
+    val previewImageLoader = LocalPreviewImageLoader.current
     val isInPreviewMode = isInPreviewMode()
     if (isInPreviewMode && previewImageLoader == null) {
         return ImageForPreviews(modifier)
@@ -195,7 +191,7 @@ private fun AsyncImage(
                     Logger.e("Error loading placeholder image", errorState.result.throwable)
                 },
             )
-        } ?: if (isInPreviewMode()) painterResource(R.drawable.android) else null,
+        } ?: if (isInPreviewMode()) imageLoader.getPreviewPlaceholder(imageRequest) else null,
         imageLoader = imageLoader,
         modifier = modifier,
         contentScale = contentScale,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/HelperFunctions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/HelperFunctions.kt
@@ -2,11 +2,14 @@ package com.revenuecat.purchases.ui.revenuecatui.helpers
 
 import android.app.Activity
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalInspectionMode
+import coil.ImageLoader
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesException
@@ -19,6 +22,15 @@ import kotlin.coroutines.suspendCoroutine
  * Needs to be provided, it's null by default.
  */
 internal val LocalActivity: ProvidableCompositionLocal<Activity?> = compositionLocalOf { null }
+
+internal val LocalPreviewImageLoader: ProvidableCompositionLocal<ImageLoader?> = staticCompositionLocalOf { null }
+
+@Composable
+internal fun ProvidePreviewImageLoader(imageLoader: ImageLoader, content: @Composable () -> Unit): Unit =
+    CompositionLocalProvider(
+        LocalPreviewImageLoader provides imageLoader,
+        content,
+    )
 
 @Composable
 @ReadOnlyComposable


### PR DESCRIPTION
## Description
This replaces the `previewImageLoader` parameter in `RemoteImage` with a `LocalPreviewImageLoader` `CompositionLocal`. This is similar to [how previews are handled in Coil 3](https://coil-kt.github.io/coil/compose/#previews).

## Motivation
This will be very helpful in rendering images in our template previews. Without this change, we would have to propagate the `previewImageLoader` parameter through the entire component tree, adding it to every `ComponentView`. This change avoids that, because we can just wrap our previewed composable in `ProvidePreviewImageLoader()`.