### PR TITLE
chore: Delete key from customer center survey event

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
@@ -53,8 +53,6 @@ internal sealed class BackendEvent : Event {
         val url: String?,
         @SerialName("survey_option_id")
         val surveyOptionID: String?,
-        @SerialName("survey_option_title_key")
-        val surveyOptionTitleKey: String?,
     ) : BackendEvent()
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -103,7 +103,6 @@ internal fun CustomerCenterImpressionEvent.toBackendStoredEvent(
             path = null,
             url = null,
             surveyOptionID = null,
-            surveyOptionTitleKey = null,
         ),
     )
 }
@@ -135,7 +134,6 @@ internal fun CustomerCenterSurveyOptionChosenEvent.toBackendStoredEvent(
             path = data.path,
             url = data.url,
             surveyOptionID = data.surveyOptionID,
-            surveyOptionTitleKey = data.surveyOptionTitleKey,
         ),
     )
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/events/CustomerCenterSurveyOptionChosenEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/events/CustomerCenterSurveyOptionChosenEvent.kt
@@ -44,7 +44,6 @@ class CustomerCenterSurveyOptionChosenEvent(
         val path: CustomerCenterConfigData.HelpPath.PathType,
         val url: String?, // URL if CUSTOM_URL
         val surveyOptionID: String,
-        val surveyOptionTitleKey: String,
         val additionalContext: String? = null, // null for now until we support
 
         // isSandbox not available in Android

--- a/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendEventsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/backend_integration_tests/ProductionBackendEventsTest.kt
@@ -52,8 +52,7 @@ internal class ProductionBackendEventsTest: BaseBackendIntegrationTest() {
                             locale = "en_US",
                             path = null,
                             url = null,
-                            surveyOptionID = null,
-                            surveyOptionTitleKey = null,
+                            surveyOptionID = null
                         ),
                         BackendEvent.CustomerCenter(
                             id = UUID.randomUUID().toString(),
@@ -67,7 +66,6 @@ internal class ProductionBackendEventsTest: BaseBackendIntegrationTest() {
                             path = CustomerCenterConfigData.HelpPath.PathType.CANCEL,
                             url = null,
                             surveyOptionID = "surveyOptionID",
-                            surveyOptionTitleKey = "surveyOptionTitleKey",
                             locale = "en_US",
                         )
                     )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -154,7 +154,6 @@ internal class CustomerCenterViewModelImpl(
                         path = path.type,
                         url = path.url,
                         surveyOptionID = it.id,
-                        surveyOptionTitleKey = it.title,
                     )
 
                     if (product != null && it.promotionalOffer != null) {
@@ -580,7 +579,6 @@ internal class CustomerCenterViewModelImpl(
         path: CustomerCenterConfigData.HelpPath.PathType,
         url: String?,
         surveyOptionID: String,
-        surveyOptionTitleKey: String,
     ) {
         val locale = _lastLocaleList.value.get(0) ?: Locale.getDefault()
         val event = CustomerCenterSurveyOptionChosenEvent(
@@ -591,7 +589,6 @@ internal class CustomerCenterViewModelImpl(
                 path = path,
                 url = url,
                 surveyOptionID = surveyOptionID,
-                surveyOptionTitleKey = surveyOptionTitleKey,
             ),
         )
         purchases.track(event)


### PR DESCRIPTION
### Motivation
This is the counterpart of https://github.com/RevenueCat/purchases-ios/pull/4837

### Description
`survey_option_title_key` is ignored in the backend, so there's no need to have it here. 
This PR removes it and adds a test that verifies backwards compatibility with stored events. However, I think we should move to an implementation similar to iOS, where the StoredEvents contains an already encoded version of the event. That would remove any need to test backwards compatibility.



