### PR TITLE
Logs from RevenueCatUI are now tagged with `[Purchases]` too.

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/Logger.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/Logger.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui.helpers
 import android.util.Log
 
 internal object Logger {
-    private const val TAG = "RevenueCatUI"
+    private const val TAG = "[Purchases]"
 
     // TODO-PAYWALLS, allow hooking up a custom log handler
     fun e(message: String) {


### PR DESCRIPTION
## Motivation
Our [docs](https://www.revenuecat.com/docs/test-and-launch/debugging#custom-log-handling) mention that all logs are prefixed with `[Purchases]`, but this was not actually the case. [This caused logs being missed](https://community.revenuecat.com/general-questions-7/basicc-paywall-showing-not-the-designed-v2-paywall-5979?postid=20528#post20528).
>All logs from the SDK are prepended with “[Purchases]“, you can use this string as a filter in your log output to clearly see the logs that are from Purchases.