### PR TITLE
[Paywalls V2] Ignores template previews for now.

### DIFF
--- a/ui/revenuecatui/src/debug/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/TemplatePreviews.kt
+++ b/ui/revenuecatui/src/debug/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/TemplatePreviews.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.emergetools.snapshots.annotations.IgnoreEmergeSnapshot
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.models.StoreProduct
@@ -78,6 +79,7 @@ private class OfferingProvider : PreviewParameterProvider<Offering> {
         drop(index).firstOrNull()
 }
 
+@IgnoreEmergeSnapshot
 @Preview
 @Composable
 private fun PaywallComponentsTemplate_Preview(


### PR DESCRIPTION
## Motivation
`PaywallComponentsTemplate_Preview` has been identified as a problematic preview that crashes the Emerge emulator. Apparently we're running into this emulator crash: https://issuetracker.google.com/issues/398784711. 

I'm ignoring it to keep our shipping velocity up. I will explore rendering them outside of Emerge and then uploading them as an alternative next. 