### PR TITLE
Add `hasPaywall` property to `Offering`

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingAPI.java
@@ -30,6 +30,7 @@ final class OfferingAPI {
         final String metadataString = offering.getMetadataString("key", "default");
 
         final @Nullable PaywallData paywallData = offering.getPaywall();
+        final Boolean hasPaywall = offering.getHasPaywall();
 
         new Offering(
                 identifier,

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingAPI.java
@@ -30,7 +30,7 @@ final class OfferingAPI {
         final String metadataString = offering.getMetadataString("key", "default");
 
         final @Nullable PaywallData paywallData = offering.getPaywall();
-        final Boolean hasPaywall = offering.getHasPaywall();
+        final Boolean hasPaywall = offering.hasPaywall()
 
         new Offering(
                 identifier,

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/OfferingAPI.java
@@ -30,7 +30,7 @@ final class OfferingAPI {
         final String metadataString = offering.getMetadataString("key", "default");
 
         final @Nullable PaywallData paywallData = offering.getPaywall();
-        final Boolean hasPaywall = offering.hasPaywall()
+        final Boolean hasPaywall = offering.hasPaywall();
 
         new Offering(
                 identifier,

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/OfferingAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/OfferingAPI.kt
@@ -23,6 +23,7 @@ private class OfferingAPI {
             val metadata: Map<String, Any> = metadata
             val metadataString: String = getMetadataString("key", "default")
             val paywall: PaywallData? = paywall
+            var hasPaywall: Boolean = hasPaywall
 
             Offering(
                 identifier = identifier,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
@@ -38,6 +38,13 @@ constructor(
     )
 
     /**
+     * Whether the offering contains a paywall.
+     */
+    @OptIn(InternalRevenueCatAPI::class)
+    val hasPaywall: Boolean
+        get() = paywall != null || paywallComponents != null
+
+    /**
      * Lifetime package type configured in the RevenueCat dashboard, if available.
      */
     val lifetime by lazy { findPackage(PackageType.LIFETIME) }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
@@ -41,6 +41,7 @@ constructor(
      * Whether the offering contains a paywall.
      */
     @OptIn(InternalRevenueCatAPI::class)
+    @get:JvmName("hasPaywall")
     val hasPaywall: Boolean
         get() = paywall != null || paywallComponents != null
 


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Checking whether an `Offering` has a paywall is not possible now that there's also v2 paywalls. Added the same property in iOS (see RevenueCat/purchases-ios/pull/4847)

### Description
This PR adds the `hasPaywall` property to `Offering` to allow knowing whether an `Offering` has a paywall or not.