### PR TITLE
Adds support for switching between 2 API keys to PaywallsTester

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,8 @@ commands:
           name: Replace API_KEY
           working_directory: examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/
           command: |
-            sed -i s/\"API_KEY\"/\"$PAYWALLS_V2_ALPHA_API_KEY\"/ Constants.kt
+            sed -i s/\"API_KEY_A\"/\"$PAYWALLS_V2_ALPHA_API_KEY\"/ Constants.kt
+            sed -i s/\"API_KEY_B\"/\"$PAYWALLS_V2_TEMPLATE_REPO_API_KEY\"/ Constants.kt
       - run:
           name: Create app bundle
           command: |

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ConfigurePurchasesUseCase.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ConfigurePurchasesUseCase.kt
@@ -1,0 +1,21 @@
+package com.revenuecat.paywallstester
+
+import android.content.Context
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesAreCompletedBy
+import com.revenuecat.purchases.PurchasesConfiguration
+
+internal class ConfigurePurchasesUseCase(
+    private val context: Context,
+) {
+
+    operator fun invoke(apiKey: String) {
+        Purchases.configure(
+            PurchasesConfiguration.Builder(context.applicationContext, apiKey)
+                .purchasesAreCompletedBy(PurchasesAreCompletedBy.REVENUECAT)
+                .appUserID(null)
+                .diagnosticsEnabled(true)
+                .build(),
+        )
+    }
+}

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.paywallstester
 
 object Constants {
-    const val GOOGLE_API_KEY = "API_KEY"
+    const val GOOGLE_API_KEY_A = "API_KEY_A"
+    const val GOOGLE_API_KEY_B = "API_KEY_B"
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.paywallstester
 
 object Constants {
+    // PaywallsTester supports switching between 2 API keys on the App Info screen. It uses "A" by default.
     const val GOOGLE_API_KEY_A = "API_KEY_A"
     const val GOOGLE_API_KEY_B = "API_KEY_B"
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainApplication.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainApplication.kt
@@ -3,8 +3,6 @@ package com.revenuecat.paywallstester
 import android.app.Application
 import com.revenuecat.purchases.LogLevel
 import com.revenuecat.purchases.Purchases
-import com.revenuecat.purchases.PurchasesAreCompletedBy
-import com.revenuecat.purchases.PurchasesConfiguration
 
 class MainApplication : Application() {
 
@@ -13,12 +11,7 @@ class MainApplication : Application() {
 
         Purchases.logLevel = LogLevel.VERBOSE
 
-        Purchases.configure(
-            PurchasesConfiguration.Builder(this, Constants.GOOGLE_API_KEY)
-                .purchasesAreCompletedBy(PurchasesAreCompletedBy.REVENUECAT)
-                .appUserID(null)
-                .diagnosticsEnabled(true)
-                .build(),
-        )
+        val configurePurchases = ConfigurePurchasesUseCase(this)
+        configurePurchases(Constants.GOOGLE_API_KEY_A)
     }
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.revenuecat.paywallstester.Constants
 import com.revenuecat.paywallstester.ui.screens.main.appinfo.AppInfoScreenViewModel.UiState
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ui.debugview.DebugRevenueCatBottomSheet
@@ -46,6 +47,7 @@ fun AppInfoScreen(
     var isDebugBottomSheetVisible by remember { mutableStateOf(false) }
     var isCustomerCenterVisible by remember { mutableStateOf(false) }
     var showLogInDialog by remember { mutableStateOf(false) }
+    var showApiKeyDialog by remember { mutableStateOf(false) }
 
     if (isCustomerCenterVisible) {
         CustomerCenter(modifier = Modifier.fillMaxSize()) {
@@ -70,6 +72,9 @@ fun AppInfoScreen(
         Button(onClick = { viewModel.logOut() }) {
             Text(text = "Log out")
         }
+        Button(onClick = { showApiKeyDialog = true }) {
+            Text(text = "Switch API key")
+        }
         Button(onClick = { isDebugBottomSheetVisible = true }) {
             Text(text = "Show debug view")
         }
@@ -82,6 +87,14 @@ fun AppInfoScreen(
 
     if (showLogInDialog) {
         LoginDialog(viewModel) { showLogInDialog = false }
+    }
+    if (showApiKeyDialog) {
+        ApiKeyDialog(
+            onApiKeyClick = {
+                viewModel.switchApiKey(it)
+                showApiKeyDialog = false
+            },
+        ) { showApiKeyDialog = false }
     }
 
     DebugRevenueCatBottomSheet(
@@ -133,6 +146,52 @@ private fun LoginDialog(viewModel: AppInfoScreenViewModel, onDismissed: () -> Un
     }
 }
 
+@Composable
+private fun ApiKeyDialog(onApiKeyClick: (String) -> Unit, onDismissed: () -> Unit) {
+    Dialog(onDismissRequest = { onDismissed() }) {
+        Surface(shape = MaterialTheme.shapes.medium) {
+            Column(Modifier.padding(all = 16.dp)) {
+                ApiKeyButton(
+                    label = "API Key A",
+                    apiKey = Constants.GOOGLE_API_KEY_A,
+                    onClick = onApiKeyClick,
+                )
+
+                ApiKeyButton(
+                    label = "API Key B",
+                    apiKey = Constants.GOOGLE_API_KEY_B,
+                    onClick = onApiKeyClick,
+                )
+
+                Spacer(Modifier.size(4.dp))
+                Row(
+                    Modifier
+                        .padding(8.dp)
+                        .fillMaxWidth(),
+                    Arrangement.spacedBy(8.dp, Alignment.End),
+                ) {
+                    TextButton(onClick = { onDismissed() }) {
+                        Text("CANCEL")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ApiKeyButton(label: String, apiKey: String, onClick: (String) -> Unit) {
+    TextButton(onClick = { onClick(apiKey) }) {
+        Column {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+            )
+            Text(text = apiKey)
+        }
+    }
+}
+
 @Suppress("EmptyFunctionBlock")
 @Preview(showBackground = true)
 @Composable
@@ -144,6 +203,16 @@ fun AppInfoScreenPreview() {
 
             override fun logIn(newAppUserId: String) { }
             override fun logOut() { }
+            override fun switchApiKey(newApiKey: String) { }
         },
+    )
+}
+
+@Preview
+@Composable
+private fun ApiKeyDialog_Preview() {
+    ApiKeyDialog(
+        onApiKeyClick = {},
+        onDismissed = {},
     )
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
@@ -61,7 +61,9 @@ fun AppInfoScreen(
     ) {
         val state by viewModel.state.collectAsState()
         val currentUserID by remember { derivedStateOf { state.appUserID } }
+        val currentApiKeyDescription by remember { derivedStateOf { state.apiKeyDescription } }
         Text(text = "Current user ID: $currentUserID")
+        Text(text = "Current API key: $currentApiKeyDescription")
         Button(onClick = { showLogInDialog = true }) {
             Text(text = "Log in")
         }
@@ -138,7 +140,7 @@ fun AppInfoScreenPreview() {
     AppInfoScreen(
         viewModel = object : AppInfoScreenViewModel {
             override val state: StateFlow<UiState>
-                get() = MutableStateFlow(UiState.Empty.copy(appUserID = "test-user-id"))
+                get() = MutableStateFlow(UiState(appUserID = "test-user-id", apiKeyDescription = "test-api-key"))
 
             override fun logIn(newAppUserId: String) { }
             override fun logOut() { }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -27,6 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.revenuecat.paywallstester.ui.screens.main.appinfo.AppInfoScreenViewModel.UiState
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ui.debugview.DebugRevenueCatBottomSheet
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
@@ -36,7 +38,11 @@ import kotlinx.coroutines.flow.StateFlow
 
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class, InternalRevenueCatAPI::class)
 @Composable
-fun AppInfoScreen(viewModel: AppInfoScreenViewModel = viewModel<AppInfoScreenViewModelImpl>()) {
+fun AppInfoScreen(
+    viewModel: AppInfoScreenViewModel = viewModel<AppInfoScreenViewModelImpl>(
+        factory = AppInfoScreenViewModelImpl.Factory,
+    ),
+) {
     var isDebugBottomSheetVisible by remember { mutableStateOf(false) }
     var isCustomerCenterVisible by remember { mutableStateOf(false) }
     var showLogInDialog by remember { mutableStateOf(false) }
@@ -53,7 +59,8 @@ fun AppInfoScreen(viewModel: AppInfoScreenViewModel = viewModel<AppInfoScreenVie
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        val currentUserID = viewModel.state.collectAsState().value ?: "No user logged in"
+        val state by viewModel.state.collectAsState()
+        val currentUserID by remember { derivedStateOf { state.appUserID } }
         Text(text = "Current user ID: $currentUserID")
         Button(onClick = { showLogInDialog = true }) {
             Text(text = "Log in")
@@ -130,8 +137,8 @@ private fun LoginDialog(viewModel: AppInfoScreenViewModel, onDismissed: () -> Un
 fun AppInfoScreenPreview() {
     AppInfoScreen(
         viewModel = object : AppInfoScreenViewModel {
-            override val state: StateFlow<String?>
-                get() = MutableStateFlow("test-user-id")
+            override val state: StateFlow<UiState>
+                get() = MutableStateFlow(UiState.Empty.copy(appUserID = "test-user-id"))
 
             override fun logIn(newAppUserId: String) { }
             override fun logOut() { }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreenViewModel.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreenViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.revenuecat.paywallstester.ConfigurePurchasesUseCase
+import com.revenuecat.paywallstester.Constants
 import com.revenuecat.paywallstester.ui.screens.main.appinfo.AppInfoScreenViewModel.UiState
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesException
@@ -59,6 +60,7 @@ internal class AppInfoScreenViewModelImpl(
 
     init {
         updateAppUserID()
+        updateApiKeyDescription()
     }
 
     override fun logIn(newAppUserId: String) {
@@ -85,5 +87,17 @@ internal class AppInfoScreenViewModelImpl(
 
     private fun updateAppUserID() {
         _state.update { it.copy(appUserID = Purchases.sharedInstance.appUserID) }
+    }
+
+    private fun updateApiKeyDescription() {
+        _state.update {
+            it.copy(
+                apiKeyDescription = when (val apiKey = Purchases.sharedInstance.currentConfiguration.apiKey) {
+                    Constants.GOOGLE_API_KEY_A -> "A - $apiKey"
+                    Constants.GOOGLE_API_KEY_B -> "B - $apiKey"
+                    else -> apiKey
+                },
+            )
+        }
     }
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreenViewModel.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreenViewModel.kt
@@ -35,6 +35,7 @@ interface AppInfoScreenViewModel {
 
     fun logIn(newAppUserId: String)
     fun logOut()
+    fun switchApiKey(newApiKey: String)
 }
 
 internal class AppInfoScreenViewModelImpl(
@@ -83,6 +84,11 @@ internal class AppInfoScreenViewModelImpl(
                 _state.update { it.copy(appUserID = "Error logging out: ${e.message}") }
             }
         }
+    }
+
+    override fun switchApiKey(newApiKey: String) {
+        configurePurchases(newApiKey)
+        updateApiKeyDescription()
     }
 
     private fun updateAppUserID() {

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreenViewModel.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreenViewModel.kt
@@ -1,7 +1,12 @@
 package com.revenuecat.paywallstester.ui.screens.main.appinfo
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.revenuecat.paywallstester.ConfigurePurchasesUseCase
+import com.revenuecat.paywallstester.ui.screens.main.appinfo.AppInfoScreenViewModel.UiState
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.awaitLogIn
@@ -9,21 +14,48 @@ import com.revenuecat.purchases.awaitLogOut
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 interface AppInfoScreenViewModel {
-    val state: StateFlow<String?>
+    data class UiState(
+        val appUserID: String,
+        val apiKeyDescription: String,
+    ) {
+        companion object {
+            val Empty = UiState(
+                appUserID = "",
+                apiKeyDescription = "",
+            )
+        }
+    }
+
+    val state: StateFlow<UiState>
 
     fun logIn(newAppUserId: String)
     fun logOut()
 }
 
-class AppInfoScreenViewModelImpl : ViewModel(), AppInfoScreenViewModel {
+internal class AppInfoScreenViewModelImpl(
+    private val configurePurchases: ConfigurePurchasesUseCase,
+) : ViewModel(), AppInfoScreenViewModel {
 
-    override val state: StateFlow<String?>
+    companion object {
+        val Factory = viewModelFactory {
+            initializer {
+                AppInfoScreenViewModelImpl(
+                    configurePurchases = ConfigurePurchasesUseCase(
+                        context = this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY]!!,
+                    ),
+                )
+            }
+        }
+    }
+
+    override val state: StateFlow<UiState>
         get() = _state.asStateFlow()
 
-    private val _state = MutableStateFlow<String?>(null)
+    private val _state = MutableStateFlow(UiState.Empty)
 
     init {
         updateAppUserID()
@@ -35,7 +67,7 @@ class AppInfoScreenViewModelImpl : ViewModel(), AppInfoScreenViewModel {
                 Purchases.sharedInstance.awaitLogIn(newAppUserId)
                 updateAppUserID()
             } catch (e: PurchasesException) {
-                _state.value = "Error logging in: ${e.message}"
+                _state.update { it.copy(appUserID = "Error logging in: ${e.message}") }
             }
         }
     }
@@ -46,12 +78,12 @@ class AppInfoScreenViewModelImpl : ViewModel(), AppInfoScreenViewModel {
                 Purchases.sharedInstance.awaitLogOut()
                 updateAppUserID()
             } catch (e: PurchasesException) {
-                _state.value = "Error logging out: ${e.message}"
+                _state.update { it.copy(appUserID = "Error logging out: ${e.message}") }
             }
         }
     }
 
     private fun updateAppUserID() {
-        _state.value = Purchases.sharedInstance.appUserID
+        _state.update { it.copy(appUserID = Purchases.sharedInstance.appUserID) }
     }
 }


### PR DESCRIPTION
This adds the ability to switch between 2 projects (API keys) to PaywallsTester. 

## Motivation
To be able to effectively test new paywall templates on Android. See [MON-970](https://linear.app/revenuecat/issue/MON-970) for more context and details.

## Description
I wanted to do this in the most pragmatic way possible without it being hacky, since we might be building other ways of previewing paywalls in the near future. Since the goal is to switch between 2 specific projects, I chose to support exactly that. Other options would have been to allow logging in with your account like RC Mobile, or adding your own API key in a text field, but that would have meant adding persistence. Let me know if you disagree or have other ideas! 🙏 

- `Constants.kt` now has `GOOGLE_API_KEY_A` and `GOOGLE_API_KEY_B`. The app uses `A` by default. During development you can leave `B` empty, as it is not used unless you attempt to switch API keys in the UI. 
- There's a new "Switch API key" button on the App Info screen.
- The published version of PaywallsTester will include the "Paywalls V2 Alpha" (as before) and "Official Paywalls V2 Template Repo" keys. 
- The `$PAYWALLS_V2_TEMPLATE_REPO_API_KEY` environment variable already exists on Circle CI for our `update-template-previews` update job. 

Closes [MON-970](https://linear.app/revenuecat/issue/MON-970).