### PR TITLE
Fix `CustomerCenterActivity` colors on dark mode

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenter.kt
@@ -1,6 +1,9 @@
 package com.revenuecat.purchases.ui.revenuecatui.customercenter
 
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 
 /**
@@ -23,9 +26,12 @@ fun CustomerCenter(
     options: CustomerCenterOptions = CustomerCenterOptions.Builder().build(),
     onDismiss: () -> Unit,
 ) {
-    InternalCustomerCenter(
-        modifier = modifier,
-        listener = options.listener,
-        onDismiss = onDismiss,
-    )
+    // Ensure proper content color is set for the entire CustomerCenter
+    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onBackground) {
+        InternalCustomerCenter(
+            modifier = modifier,
+            listener = options.listener,
+            onDismiss = onDismiss,
+        )
+    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterActivity.kt
@@ -5,7 +5,11 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.Modifier
 
 internal class CustomerCenterActivity : ComponentActivity() {
@@ -19,13 +23,20 @@ internal class CustomerCenterActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            CustomerCenter(
-                modifier = Modifier.fillMaxSize(),
-                onDismiss = {
-                    setResult(RESULT_OK)
-                    finish()
-                },
-            )
+            val isDarkTheme = isSystemInDarkTheme()
+            val colorScheme = if (isDarkTheme) darkColorScheme() else lightColorScheme()
+
+            MaterialTheme(
+                colorScheme = colorScheme,
+            ) {
+                CustomerCenter(
+                    modifier = Modifier.fillMaxSize(),
+                    onDismiss = {
+                        setResult(RESULT_OK)
+                        finish()
+                    },
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Dark mode colors were not correctly applied in React Native. We needed to set the correct theme and also set the correct `LocalContentColor` based on the theme to the whole `InternalCustomerCenter` otherwise composables would default to black.