### PR TITLE
[Paywalls V2] Fixes locales without region and `X-Preferred-Locales`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -270,7 +270,7 @@ internal class HTTPClient(
             "X-Platform-Device" to Build.MODEL,
             "X-Platform-Brand" to Build.BRAND,
             "X-Version" to Config.frameworkVersion,
-            "X-Preferred-Locales" to localeProvider.currentLocalesLanguageTags,
+            "X-Preferred-Locales" to localeProvider.currentLocalesLanguageTags.replace(oldChar = '-', newChar = '_'),
             "X-Client-Locale" to appConfig.languageTag,
             "X-Client-Version" to appConfig.versionName,
             "X-Client-Bundle-ID" to appConfig.packageName,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/Localization.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/Localization.kt
@@ -23,7 +23,14 @@ import kotlinx.serialization.encoding.Encoder
 @InternalRevenueCatAPI
 @Serializable
 @JvmInline
-value class LocaleId(@get:JvmSynthetic val value: String)
+value class LocaleId(@get:JvmSynthetic val value: String) {
+
+    val language: String
+        get() = value.split('-', '_').getOrNull(0).orEmpty()
+
+    val region: String
+        get() = value.split('-', '_').getOrNull(1).orEmpty()
+}
 
 @InternalRevenueCatAPI
 @Serializable

--- a/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/BaseHTTPClientTest.kt
@@ -64,14 +64,16 @@ internal abstract class BaseHTTPClientTest {
         dateProvider: DateProvider = DefaultDateProvider(),
         eTagManager: ETagManager = mockETagManager,
         signingManager: SigningManager? = null,
-        storefrontProvider: StorefrontProvider = mockStorefrontProvider
+        storefrontProvider: StorefrontProvider = mockStorefrontProvider,
+        localeProvider: LocaleProvider = DefaultLocaleProvider()
     ) = HTTPClient(
         appConfig,
         eTagManager,
         diagnosticsTracker,
         signingManager ?: mockSigningManager,
         storefrontProvider,
-        dateProvider
+        dateProvider,
+        localeProvider = localeProvider
     )
 
     protected fun createAppConfig(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/FakeLocaleProvider.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/FakeLocaleProvider.kt
@@ -1,0 +1,11 @@
+package com.revenuecat.purchases.common
+
+internal class FakeLocaleProvider(
+    vararg languageTags: String,
+): LocaleProvider {
+
+    private val languageTags: List<String> = languageTags.toList()
+
+    override val currentLocalesLanguageTags: String
+        get() = languageTags.joinToString()
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -166,6 +166,10 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
 
     @Test
     fun addsDefaultHeadersToRequest() {
+        client = createClient(
+            localeProvider = FakeLocaleProvider("en-US", "ja-JP"),
+        )
+        val expectedPreferredLocales = "en_US, ja_JP"
         val expectedResult = HTTPResult.createResult()
         val endpoint = Endpoint.LogIn
         enqueue(
@@ -185,6 +189,7 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
         assertThat(request.getHeader("X-Platform-Flavor")).isEqualTo(expectedPlatformInfo.flavor)
         assertThat(request.getHeader("X-Platform-Flavor-Version")).isEqualTo(expectedPlatformInfo.version)
         assertThat(request.getHeader("X-Version")).isEqualTo(Config.frameworkVersion)
+        assertThat(request.getHeader("X-Preferred-Locales")).isEqualTo(expectedPreferredLocales)
         assertThat(request.getHeader("X-Client-Locale")).isEqualTo("en-US")
         assertThat(request.getHeader("X-Client-Version")).isEqualTo("")
         assertThat(request.getHeader("X-Client-Bundle-ID")).isEqualTo("mock-package-name")

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/LocaleIdTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/LocaleIdTests.kt
@@ -1,0 +1,66 @@
+package com.revenuecat.purchases.paywalls.components.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class LocaleIdTests(
+    val locale: String,
+    val args: Args,
+) {
+
+    data class Args(
+        val expectedLanguage: String,
+        val expectedRegion: String,
+    )
+
+    companion object {
+
+        @Suppress("LongMethod")
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun parameters(): Collection<*> = listOf(
+            arrayOf(
+                "en_US",
+                Args(
+                    expectedLanguage = "en",
+                    expectedRegion = "US",
+                ),
+            ),
+            arrayOf(
+                "en-US",
+                Args(
+                    expectedLanguage = "en",
+                    expectedRegion = "US",
+                ),
+            ),
+            arrayOf(
+                "en",
+                Args(
+                    expectedLanguage = "en",
+                    expectedRegion = "",
+                ),
+            ),
+            arrayOf(
+                "",
+                Args(
+                    expectedLanguage = "",
+                    expectedRegion = "",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `Should properly parse language and region`() {
+        // Arrange, Act
+        val actual = LocaleId(locale)
+
+        // Assert
+        assertThat(actual.language).isEqualTo(args.expectedLanguage)
+        assertThat(actual.region).isEqualTo(args.expectedRegion)
+    }
+
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -188,7 +188,10 @@ internal sealed interface PaywallState {
                 // Configured locales take precedence over the default one.
                 map { it.toLocaleId() }.plus(locales.head)
                     // Find the first locale we have a LocalizationDictionary for.
-                    .first { id -> locales.contains(id) }
+                    .firstNotNullOf { locale ->
+                        locale.takeIf { locales.contains(it) }
+                            ?: locale.languageOnly().takeIf { locales.contains(it) }
+                    }
 
             private fun List<AvailablePackages.Info>.mostExpensivePricePerMonthMicros(): Long? =
                 asSequence()
@@ -196,6 +199,9 @@ internal sealed interface PaywallState {
                     .mapNotNull { product -> product.pricePerMonth() }
                     .maxByOrNull { price -> price.amountMicros }
                     ?.amountMicros
+
+            private fun LocaleId.languageOnly(): LocaleId =
+                LocaleId(language)
         }
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsLocaleTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsLocaleTests.kt
@@ -1,0 +1,129 @@
+package com.revenuecat.purchases.ui.revenuecatui.data
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.intl.LocaleList
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.ui.revenuecatui.components.previewStackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
+import com.revenuecat.purchases.ui.revenuecatui.helpers.NonEmptyList
+import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyListOf
+import com.revenuecat.purchases.ui.revenuecatui.helpers.toNonEmptySetOrNull
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.util.Date
+
+@RunWith(Parameterized::class)
+internal class PaywallStateLoadedComponentsLocaleTests(
+    @Suppress("UNUSED_PARAMETER") name: String,
+    private val args: Args
+) {
+
+    class Args(
+        val paywallLocales: NonEmptyList<String>,
+        val deviceLocales: NonEmptyList<String>,
+        val expected: String,
+    )
+
+    companion object {
+
+        @Suppress("LongMethod")
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun parameters(): Collection<*> = listOf(
+            arrayOf(
+                "single language",
+                Args(
+                    paywallLocales = nonEmptyListOf("en_US"),
+                    deviceLocales = nonEmptyListOf("en-US"),
+                    expected = "en-US",
+                ),
+            ),
+            arrayOf(
+                "prefer device",
+                Args(
+                    paywallLocales = nonEmptyListOf("en_US", "ja_JP"),
+                    deviceLocales = nonEmptyListOf("ja-JP", "en-US"),
+                    expected = "ja-JP",
+                ),
+            ),
+            arrayOf(
+                "paywall locale without region",
+                Args(
+                    paywallLocales = nonEmptyListOf("ja"),
+                    deviceLocales = nonEmptyListOf("ja-JP"),
+                    expected = "ja",
+                ),
+            ),
+            arrayOf(
+                "paywall locale without region, prefer device",
+                Args(
+                    paywallLocales = nonEmptyListOf("en_US", "ja"),
+                    deviceLocales = nonEmptyListOf("ja-JP", "en-US"),
+                    // We pick Japanese because the device prefers that, but we don't add the region as our paywall
+                    // resources won't have a region either.
+                    expected = "ja",
+                ),
+            ),
+            arrayOf(
+                "paywall locale without region, no matching device locale",
+                Args(
+                    paywallLocales = nonEmptyListOf("ja"),
+                    deviceLocales = nonEmptyListOf("en-US"),
+                    expected = "ja",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `Should properly determine locale`() {
+        // Arrange
+        val state = paywallState(
+            paywallLocales = args.paywallLocales,
+            deviceLocales = args.deviceLocales,
+        )
+
+        // Act
+        val actual = state.locale.toLanguageTag()
+
+        // Assert
+        assertThat(actual).isEqualTo(args.expected)
+    }
+
+    private fun paywallState(
+        paywallLocales: NonEmptyList<String>,
+        deviceLocales: NonEmptyList<String>,
+    ) = PaywallState.Loaded.Components(
+        stack = previewStackComponentStyle(children = emptyList()),
+        stickyFooter = null,
+        background = BackgroundStyles.Color(color = ColorStyles(light = ColorStyle.Solid(Color.White))),
+        showPricesWithDecimals = true,
+        variableConfig = UiConfig.VariableConfig(),
+        offering = Offering(
+            identifier = "id",
+            serverDescription = "description",
+            metadata = emptyMap(),
+            availablePackages = emptyList(),
+            paywall = null,
+            paywallComponents = null,
+        ),
+        locales = paywallLocales.map { LocaleId(it) }.toNonEmptySetOrNull()!!,
+        activelySubscribedProductIds = emptySet(),
+        purchasedNonSubscriptionProductIds = emptySet(),
+        dateProvider = { Date() },
+        packages = PaywallState.Loaded.Components.AvailablePackages(
+            packagesOutsideTabs = emptyList(),
+            packagesByTab = emptyMap(),
+        ),
+        initialLocaleList = LocaleList(deviceLocales.map { Locale(it) }),
+        initialSelectedTabIndex = 0,
+    )
+
+}


### PR DESCRIPTION
## Bug
A paywall with a non-default locale containing only a language would fall back to the default locale, even if the device prefers the non-default one.

## Causes
This has 2 causes:
- The SDK didn't properly match against locales without a region, such as `ja`. The device would have `ja-JP` configured, and it would not pick `ja` from the paywall configuration. 
- The `X-Preferred-Locales` header was sent with locales containing dashes, but khepri expects underscores. This meant that the SDK never received any non-default locales. 

## Fix
Respectively:
- The SDK now checks the "language only" variant of the locale as well.
- The SDK sends the `X-Preferred-Locales` header with underscores.