### PR TITLE
[Paywalls V2] Handles potential locale id inconsistency between strings and variables

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/Localization.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/Localization.kt
@@ -33,6 +33,10 @@ value class LocaleId(@get:JvmSynthetic val value: String) {
 }
 
 @InternalRevenueCatAPI
+fun LocaleId.languageOnly(): LocaleId =
+    LocaleId(language)
+
+@InternalRevenueCatAPI
 @Serializable
 @JvmInline
 value class LocalizationKey(@get:JvmSynthetic val value: String)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -15,6 +15,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.UiConfig.VariableConfig
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.paywalls.components.common.languageOnly
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toComposeLocale
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toLocaleId
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
@@ -208,9 +209,6 @@ internal sealed interface PaywallState {
                     .mapNotNull { product -> product.pricePerMonth() }
                     .maxByOrNull { price -> price.amountMicros }
                     ?.amountMicros
-
-            private fun LocaleId.languageOnly(): LocaleId =
-                LocaleId(language)
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.paywalls.components.common.LocalizationData
 import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.common.VariableLocalizationKey
+import com.revenuecat.purchases.paywalls.components.common.languageOnly
 import com.revenuecat.purchases.paywalls.components.properties.Dimension
 import com.revenuecat.purchases.paywalls.components.properties.Size
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
@@ -407,9 +408,11 @@ private fun PaywallData.validateTemplate(): PaywallTemplate? {
 
 private val PaywallComponentsData.defaultLocalization: Map<LocalizationKey, LocalizationData>?
     get() = componentsLocalizations[defaultLocaleIdentifier]
+        ?: componentsLocalizations[defaultLocaleIdentifier.languageOnly()]
 
 private val Offering.PaywallComponents.defaultVariableLocalization: Map<VariableLocalizationKey, String>?
     get() = uiConfig.localizations[data.defaultLocaleIdentifier]
+        ?: uiConfig.localizations[data.defaultLocaleIdentifier.languageOnly()]
 
 private val TabsComponentStyle.defaultTabIndex: Int
     get() = when (control) {


### PR DESCRIPTION
This was reported here: https://github.com/RevenueCat/react-native-purchases/issues/1178#issuecomment-2710805526.

## Bug
Some paywalls would fail to render due to missing variable localizations: 
>All variable localizations for locale 'de_DE' are missing.

## Cause
This was caused by the fact that the network response would sometimes contain inconsistent locale ids in `components_localizations` (`de_DE`) and `ui_config.localizations` (`de`). The Android SDK would pick `de_DE` and would be unable to find the variable localizations in `ui_config.localizations`. 

## Fix
This is fixed by having the SDK also check the "language only" locale id if the "full" locale id is not found. 