### PR TITLE
[Paywalls V2] Avoids the theme from influencing the text color

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -182,16 +183,19 @@ private fun TextComponentView_Preview_Default() {
 @Composable
 private fun TextComponentView_Preview_HeadingXlExtraBold() {
     // Since we use LocalTextStyle, a MaterialTheme can influence the rendering.
+    // We expect the TextComponentStyle to override the MaterialTheme and LocalTextStyle.
     MaterialTheme {
-        TextComponentView(
-            style = previewTextComponentStyle(
-                text = "Experience Pro today!",
-                color = ColorStyles(light = ColorStyle.Solid(Color.Black)),
-                fontSize = 34,
-                fontWeight = FontWeight.EXTRA_BOLD,
-            ),
-            state = previewEmptyState(),
-        )
+        ProvideTextStyle(LocalTextStyle.current.copy(color = Color.Blue)) {
+            TextComponentView(
+                style = previewTextComponentStyle(
+                    text = "Experience Pro today!",
+                    color = ColorStyles(light = ColorStyle.Solid(Color.Black)),
+                    fontSize = 34,
+                    fontWeight = FontWeight.EXTRA_BOLD,
+                ),
+                state = previewEmptyState(),
+            )
+        }
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Markdown.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/Markdown.kt
@@ -219,6 +219,7 @@ private fun MDParagraph(
             pushStyle(
                 style
                     .copy(
+                        color = color,
                         fontWeight = fontWeight,
                         fontSize = if (applyFontSizeToParagraph) fontSize else style.fontSize,
                         fontFamily = fontFamily,


### PR DESCRIPTION
Reported in the [Community](https://community.revenuecat.com/sdks-51/paywall-for-compose-multiplatform-different-text-colors-in-emulator-than-paywall-editor-text-field-to-enter-discount-code-6008). 

## Bug
The text color on the paywall was influenced by the text color in the Material 3 theme.

## Cause & fix
Our annotated text in the markdown component did not properly set the color.