### PR TITLE
Fix background painting outside composable

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Background.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/modifier/Background.kt
@@ -33,10 +33,10 @@ internal fun Modifier.background(
     when (background) {
         is BackgroundStyle.Color -> this.background(color = background.color, shape = shape)
         is BackgroundStyle.Image ->
-            this.paint(
-                painter = background.painter,
-                contentScale = background.contentScale,
-            )
+            this.clip(shape)
+                .paint(
+                    painter = background.painter,
+                    contentScale = background.contentScale,
+                )
                 .applyIfNotNull(background.colorOverlay) { underlay(it, shape) }
-                .clip(shape)
     }


### PR DESCRIPTION
### Description
There was an issue where the background painter could actually paint outside the composable itself. This fixes that by making clipping happen before painting.
| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/3fd0bc09-94d6-4c3d-bae8-1e526f439882) | ![image](https://github.com/user-attachments/assets/60a9e2aa-8346-4b08-9896-822e84ee0cf2) |