### PR TITLE
Set metaspace size to avoid "Daemon disappeared" failures

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -51,4 +51,4 @@ ANDROID_VARIANT_TO_PUBLISH=defaultsRelease
 SONATYPE_HOST=DEFAULT
 SONATYPE_AUTOMATIC_RELEASE=true
 
-org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.jvmargs=-Xmx2048M -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8


### PR DESCRIPTION
Likely the result of this Gradle bug: https://github.com/gradle/gradle/issues/19750

Please thumbs up that linked bug and share with everyone!

I saw this PR https://github.com/RevenueCat/purchases-android/pull/2121 and thought I could help :)
