### PR TITLE
[Paywalls V2] Reorganizes stack arrangement logic

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
@@ -1,3 +1,5 @@
+@file:JvmSynthetic
+
 package com.revenuecat.purchases.ui.revenuecatui.components.stack
 
 import androidx.compose.foundation.layout.Row

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
@@ -20,6 +20,9 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toAlignment
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toHorizontalArrangement
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
 
+/**
+ * A horizontal stack of components which properly handles the arrangement of items.
+ */
 @Composable
 internal fun HorizontalStack(
     size: Size,
@@ -60,15 +63,15 @@ internal fun HorizontalStack(
         }
 
         edgeSpacerIfNeeded()
-        scope.content.invoke(this)
+        scope.rowContent(this)
         edgeSpacerIfNeeded()
     }
 }
 
 internal interface HorizontalStackScope {
     fun items(
-        children: List<ComponentStyle>,
-        itemContent: @Composable RowScope.(index: Int, child: ComponentStyle) -> Unit,
+        items: List<ComponentStyle>,
+        itemContent: @Composable RowScope.(item: ComponentStyle) -> Unit,
     )
 }
 
@@ -78,20 +81,20 @@ private class HorizontalStackScopeImpl(
     private val fillSpaceSpacer: @Composable (Float) -> Unit,
     private val width: SizeConstraint,
 ) : HorizontalStackScope {
-    var content: @Composable RowScope.() -> Unit = {}
-    private var hasAnyChildrenWithFillWidth = false
+    private var hasAnyItemsWithFillWidth = false
+    var rowContent: @Composable RowScope.() -> Unit = {}
     val shouldApplyFillSpacers: Boolean
-        get() = width != Fit && !hasAnyChildrenWithFillWidth
+        get() = width != Fit && !hasAnyItemsWithFillWidth
 
     override fun items(
-        children: List<ComponentStyle>,
-        itemContent: @Composable RowScope.(index: Int, child: ComponentStyle) -> Unit,
+        items: List<ComponentStyle>,
+        itemContent: @Composable RowScope.(item: ComponentStyle) -> Unit,
     ) {
-        hasAnyChildrenWithFillWidth = children.any { it.size.width == Fill }
-        content = {
-            children.forEachIndexed { index, child ->
-                val isLast = index == children.size - 1
-                itemContent(index, child)
+        hasAnyItemsWithFillWidth = items.any { it.size.width == Fill }
+        rowContent = {
+            items.forEachIndexed { index, item ->
+                val isLast = index == items.size - 1
+                itemContent(item)
 
                 if (distribution.usesAllAvailableSpace && !isLast) {
                     Spacer(modifier = Modifier.widthIn(min = spacing))

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
@@ -28,8 +28,8 @@ internal fun HorizontalStack(
     size: Size,
     dimension: Dimension.Horizontal,
     spacing: Dp,
-    content: HorizontalStackScope.() -> Unit,
     modifier: Modifier = Modifier,
+    content: HorizontalStackScope.() -> Unit,
 ) {
     Row(
         modifier = modifier,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
@@ -1,38 +1,29 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.stack
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.paywalls.components.properties.Dimension
 import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
 import com.revenuecat.purchases.paywalls.components.properties.Size
-import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
-import com.revenuecat.purchases.ui.revenuecatui.components.ComponentView
-import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toAlignment
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toHorizontalArrangement
-import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
-import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
-import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 
 @Composable
 internal fun HorizontalStack(
     size: Size,
     dimension: Dimension.Horizontal,
     spacing: Dp,
-    topSystemBarsPadding: PaddingValues,
-    children: List<ComponentStyle>,
-    state: PaywallState.Loaded.Components,
-    clickHandler: suspend (PaywallAction) -> Unit,
-    contentAlpha: Float,
+    hasAnyChildrenWithFillWidth: Boolean,
+    content: HorizontalStackScope.() -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -42,8 +33,7 @@ internal fun HorizontalStack(
             spacing = spacing,
         ),
     ) {
-        val hasChildrenWithFillWidth = children.any { it.size.width == Fill }
-        val shouldApplyFillSpacers = size.width != Fit && !hasChildrenWithFillWidth
+        val shouldApplyFillSpacers = size.width != Fit && !hasAnyChildrenWithFillWidth
         val fillSpaceSpacer: @Composable (Float) -> Unit = @Composable { weight ->
             Spacer(modifier = Modifier.weight(weight))
         }
@@ -58,34 +48,49 @@ internal fun HorizontalStack(
             }
         }
 
-        edgeSpacerIfNeeded()
-
-        children.forEachIndexed { index, child ->
-            val isLast = index == children.size - 1
-            val childPadding = if (child.ignoreTopWindowInsets) {
-                PaddingValues(all = 0.dp)
-            } else {
-                topSystemBarsPadding
-            }
-
-            ComponentView(
-                style = child,
-                state = state,
-                onClick = clickHandler,
-                modifier = Modifier
-                    .conditional(child.size.width == Fill) { Modifier.weight(1f) }
-                    .padding(childPadding)
-                    .alpha(contentAlpha),
+        val latestContent by rememberUpdatedState(content)
+        val scope = remember(dimension.distribution, spacing) {
+            HorizontalStackScopeImpl(
+                distribution = dimension.distribution,
+                spacing = spacing,
+                fillSpaceSpacer = if (shouldApplyFillSpacers) fillSpaceSpacer else null,
             )
-
-            if (dimension.distribution.usesAllAvailableSpace && !isLast) {
-                Spacer(modifier = Modifier.widthIn(min = spacing))
-                if (shouldApplyFillSpacers) {
-                    fillSpaceSpacer(if (dimension.distribution == FlexDistribution.SPACE_AROUND) 2f else 1f)
-                }
-            }
         }
 
         edgeSpacerIfNeeded()
+
+        scope.latestContent()
+        scope.content.invoke(this)
+
+        edgeSpacerIfNeeded()
+    }
+}
+
+internal interface HorizontalStackScope {
+    fun items(
+        count: Int,
+        itemContent: @Composable RowScope.(index: Int) -> Unit,
+    )
+}
+
+private class HorizontalStackScopeImpl(
+    private val distribution: FlexDistribution,
+    private val spacing: Dp,
+    private val fillSpaceSpacer: (@Composable (Float) -> Unit)?,
+) : HorizontalStackScope {
+    var content: @Composable RowScope.() -> Unit = {}
+
+    override fun items(count: Int, itemContent: @Composable RowScope.(index: Int) -> Unit) {
+        content = {
+            repeat(count) { index ->
+                val isLast = index == count - 1
+                itemContent(index)
+
+                if (distribution.usesAllAvailableSpace && !isLast) {
+                    Spacer(modifier = Modifier.widthIn(min = spacing))
+                    fillSpaceSpacer?.invoke(if (distribution == FlexDistribution.SPACE_AROUND) 2f else 1f)
+                }
+            }
+        }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/HorizontalStack.kt
@@ -1,0 +1,91 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.stack
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.paywalls.components.properties.Dimension
+import com.revenuecat.purchases.paywalls.components.properties.FlexDistribution
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
+import com.revenuecat.purchases.ui.revenuecatui.components.ComponentView
+import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toAlignment
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toHorizontalArrangement
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
+
+@Composable
+internal fun HorizontalStack(
+    size: Size,
+    dimension: Dimension.Horizontal,
+    spacing: Dp,
+    topSystemBarsPadding: PaddingValues,
+    children: List<ComponentStyle>,
+    state: PaywallState.Loaded.Components,
+    clickHandler: suspend (PaywallAction) -> Unit,
+    contentAlpha: Float,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = dimension.alignment.toAlignment(),
+        horizontalArrangement = dimension.distribution.toHorizontalArrangement(
+            spacing = spacing,
+        ),
+    ) {
+        val hasChildrenWithFillWidth = children.any { it.size.width == Fill }
+        val shouldApplyFillSpacers = size.width != Fit && !hasChildrenWithFillWidth
+        val fillSpaceSpacer: @Composable (Float) -> Unit = @Composable { weight ->
+            Spacer(modifier = Modifier.weight(weight))
+        }
+        val edgeSpacerIfNeeded = @Composable {
+            if (shouldApplyFillSpacers &&
+                (
+                    dimension.distribution == FlexDistribution.SPACE_AROUND ||
+                        dimension.distribution == FlexDistribution.SPACE_EVENLY
+                    )
+            ) {
+                fillSpaceSpacer(1f)
+            }
+        }
+
+        edgeSpacerIfNeeded()
+
+        children.forEachIndexed { index, child ->
+            val isLast = index == children.size - 1
+            val childPadding = if (child.ignoreTopWindowInsets) {
+                PaddingValues(all = 0.dp)
+            } else {
+                topSystemBarsPadding
+            }
+
+            ComponentView(
+                style = child,
+                state = state,
+                onClick = clickHandler,
+                modifier = Modifier
+                    .conditional(child.size.width == Fill) { Modifier.weight(1f) }
+                    .padding(childPadding)
+                    .alpha(contentAlpha),
+            )
+
+            if (dimension.distribution.usesAllAvailableSpace && !isLast) {
+                Spacer(modifier = Modifier.widthIn(min = spacing))
+                if (shouldApplyFillSpacers) {
+                    fillSpaceSpacer(if (dimension.distribution == FlexDistribution.SPACE_AROUND) 2f else 1f)
+                }
+            }
+        }
+
+        edgeSpacerIfNeeded()
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -536,21 +536,15 @@ private fun MainStackComponent(
                     spacing = stackState.spacing,
                     content = {
                         items(stackState.children) { index, child ->
-                            // In a Vertical container, we only want to apply topSystemBarsPadding to the first child,
-                            // except when that child has `ignoreTopWindowInsets` set to true.
-                            val childPadding = if (index != 0 || child.ignoreTopWindowInsets) {
-                                PaddingValues(all = 0.dp)
-                            } else {
-                                topSystemBarsPadding
-                            }
-
                             ComponentView(
                                 style = child,
                                 state = state,
                                 onClick = clickHandler,
                                 modifier = Modifier
                                     .conditional(child.size.height == Fill) { Modifier.weight(1f) }
-                                    .padding(childPadding)
+                                    .padding(
+                                        child.verticalStackChildPadding(isFirst = index == 0, topSystemBarsPadding),
+                                    )
                                     .alpha(contentAlpha),
                             )
                         }
@@ -738,6 +732,18 @@ private val ComponentStyle.ignoreTopWindowInsets: Boolean
 
 private fun ComponentStyle.horizontalStackChildPadding(topSystemBarsPadding: PaddingValues): PaddingValues =
     if (ignoreTopWindowInsets) {
+        PaddingValues(all = 0.dp)
+    } else {
+        topSystemBarsPadding
+    }
+
+private fun ComponentStyle.verticalStackChildPadding(
+    isFirst: Boolean,
+    topSystemBarsPadding: PaddingValues,
+): PaddingValues =
+    // In a Vertical container, we only want to apply topSystemBarsPadding to the first child,
+    // except when that child has `ignoreTopWindowInsets` set to true.
+    if (!isFirst || ignoreTopWindowInsets) {
         PaddingValues(all = 0.dp)
     } else {
         topSystemBarsPadding

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -512,10 +512,8 @@ private fun MainStackComponent(
                     size = stackState.size,
                     dimension = dimension,
                     spacing = stackState.spacing,
-                    hasAnyChildrenWithFillWidth = stackState.children.any { it.size.width == Fill },
                     content = {
-                        items(stackState.children.size) { index ->
-                            val child = stackState.children[index]
+                        items(stackState.children) { index, child ->
                             val childPadding = if (child.ignoreTopWindowInsets) {
                                 PaddingValues(all = 0.dp)
                             } else {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -523,7 +523,7 @@ private fun MainStackComponent(
                             onClick = clickHandler,
                             modifier = Modifier
                                 .conditional(child.size.width == Fill) { Modifier.weight(1f) }
-                                .padding(child.horizontalStackChildPadding(topSystemBarsPadding))
+                                .padding(child.stackChildPadding(topSystemBarsPadding))
                                 .alpha(contentAlpha),
                         )
                     }
@@ -569,18 +569,12 @@ private fun MainStackComponent(
                     contentAlignment = dimension.alignment.toAlignment(),
                 ) {
                     stackState.children.forEach { child ->
-                        val childPadding = if (child.ignoreTopWindowInsets) {
-                            PaddingValues(all = 0.dp)
-                        } else {
-                            topSystemBarsPadding
-                        }
-
                         ComponentView(
                             style = child,
                             state = state,
                             onClick = clickHandler,
                             modifier = Modifier
-                                .padding(childPadding)
+                                .padding(child.stackChildPadding(topSystemBarsPadding))
                                 .alpha(contentAlpha),
                         )
                     }
@@ -728,13 +722,21 @@ internal val FlexDistribution.usesAllAvailableSpace: Boolean
 private val ComponentStyle.ignoreTopWindowInsets: Boolean
     get() = this is ImageComponentStyle && ignoreTopWindowInsets
 
-private fun ComponentStyle.horizontalStackChildPadding(topSystemBarsPadding: PaddingValues): PaddingValues =
+/**
+ * Provides the padding to be used for this child of a stack. This should only be used for horizontal and z-layer
+ * stacks. Vertical stacks should use [verticalStackChildPadding].
+ */
+private fun ComponentStyle.stackChildPadding(topSystemBarsPadding: PaddingValues): PaddingValues =
     if (ignoreTopWindowInsets) {
         PaddingValues(all = 0.dp)
     } else {
         topSystemBarsPadding
     }
 
+/**
+ * Provides the padding to be used for this child of a stack. This should only be used for vertical stacks. Horizontal
+ * and z-layer stacks should use [stackChildPadding].
+ */
 private fun ComponentStyle.verticalStackChildPadding(
     isFirst: Boolean,
     topSystemBarsPadding: PaddingValues,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -514,19 +514,13 @@ private fun MainStackComponent(
                     spacing = stackState.spacing,
                     content = {
                         items(stackState.children) { child ->
-                            val childPadding = if (child.ignoreTopWindowInsets) {
-                                PaddingValues(all = 0.dp)
-                            } else {
-                                topSystemBarsPadding
-                            }
-
                             ComponentView(
                                 style = child,
                                 state = state,
                                 onClick = clickHandler,
                                 modifier = Modifier
                                     .conditional(child.size.width == Fill) { Modifier.weight(1f) }
-                                    .padding(childPadding)
+                                    .padding(child.horizontalStackChildPadding(topSystemBarsPadding))
                                     .alpha(contentAlpha),
                             )
                         }
@@ -770,8 +764,15 @@ internal val FlexDistribution.usesAllAvailableSpace: Boolean
         -> false
     }
 
-internal val ComponentStyle.ignoreTopWindowInsets: Boolean
+private val ComponentStyle.ignoreTopWindowInsets: Boolean
     get() = this is ImageComponentStyle && ignoreTopWindowInsets
+
+private fun ComponentStyle.horizontalStackChildPadding(topSystemBarsPadding: PaddingValues): PaddingValues =
+    if (ignoreTopWindowInsets) {
+        PaddingValues(all = 0.dp)
+    } else {
+        topSystemBarsPadding
+    }
 
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO or Configuration.UI_MODE_TYPE_NORMAL)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -513,7 +513,7 @@ private fun MainStackComponent(
                     dimension = dimension,
                     spacing = stackState.spacing,
                     content = {
-                        items(stackState.children) { index, child ->
+                        items(stackState.children) { child ->
                             val childPadding = if (child.ignoreTopWindowInsets) {
                                 PaddingValues(all = 0.dp)
                             } else {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -512,11 +512,27 @@ private fun MainStackComponent(
                     size = stackState.size,
                     dimension = dimension,
                     spacing = stackState.spacing,
-                    topSystemBarsPadding = topSystemBarsPadding,
-                    children = stackState.children,
-                    state = state,
-                    clickHandler = clickHandler,
-                    contentAlpha = contentAlpha,
+                    hasAnyChildrenWithFillWidth = stackState.children.any { it.size.width == Fill },
+                    content = {
+                        items(stackState.children.size) { index ->
+                            val child = stackState.children[index]
+                            val childPadding = if (child.ignoreTopWindowInsets) {
+                                PaddingValues(all = 0.dp)
+                            } else {
+                                topSystemBarsPadding
+                            }
+
+                            ComponentView(
+                                style = child,
+                                state = state,
+                                onClick = clickHandler,
+                                modifier = Modifier
+                                    .conditional(child.size.width == Fill) { Modifier.weight(1f) }
+                                    .padding(childPadding)
+                                    .alpha(contentAlpha),
+                            )
+                        }
+                    },
                     modifier = modifier
                         .size(stackState.size, verticalAlignment = dimension.alignment.toAlignment())
                         .applyIfNotNull(scrollState, stackState.scrollOrientation) { state, orientation ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -509,53 +509,51 @@ private fun MainStackComponent(
                     size = stackState.size,
                     dimension = dimension,
                     spacing = stackState.spacing,
-                    content = {
-                        items(stackState.children) { _, child ->
-                            ComponentView(
-                                style = child,
-                                state = state,
-                                onClick = clickHandler,
-                                modifier = Modifier
-                                    .conditional(child.size.width == Fill) { Modifier.weight(1f) }
-                                    .padding(child.horizontalStackChildPadding(topSystemBarsPadding))
-                                    .alpha(contentAlpha),
-                            )
-                        }
-                    },
                     modifier = modifier
                         .size(stackState.size, verticalAlignment = dimension.alignment.toAlignment())
                         .applyIfNotNull(scrollState, stackState.scrollOrientation) { state, orientation ->
                             scrollable(state, orientation)
                         }
                         .then(rootModifier),
-                )
+                ) {
+                    items(stackState.children) { _, child ->
+                        ComponentView(
+                            style = child,
+                            state = state,
+                            onClick = clickHandler,
+                            modifier = Modifier
+                                .conditional(child.size.width == Fill) { Modifier.weight(1f) }
+                                .padding(child.horizontalStackChildPadding(topSystemBarsPadding))
+                                .alpha(contentAlpha),
+                        )
+                    }
+                }
 
                 is Dimension.Vertical -> VerticalStack(
                     size = stackState.size,
                     dimension = dimension,
                     spacing = stackState.spacing,
-                    content = {
-                        items(stackState.children) { index, child ->
-                            ComponentView(
-                                style = child,
-                                state = state,
-                                onClick = clickHandler,
-                                modifier = Modifier
-                                    .conditional(child.size.height == Fill) { Modifier.weight(1f) }
-                                    .padding(
-                                        child.verticalStackChildPadding(isFirst = index == 0, topSystemBarsPadding),
-                                    )
-                                    .alpha(contentAlpha),
-                            )
-                        }
-                    },
                     modifier = modifier
                         .size(stackState.size, horizontalAlignment = dimension.alignment.toAlignment())
                         .applyIfNotNull(scrollState, stackState.scrollOrientation) { state, orientation ->
                             scrollable(state, orientation)
                         }
                         .then(rootModifier),
-                )
+                ) {
+                    items(stackState.children) { index, child ->
+                        ComponentView(
+                            style = child,
+                            state = state,
+                            onClick = clickHandler,
+                            modifier = Modifier
+                                .conditional(child.size.height == Fill) { Modifier.weight(1f) }
+                                .padding(
+                                    child.verticalStackChildPadding(isFirst = index == 0, topSystemBarsPadding),
+                                )
+                                .alpha(contentAlpha),
+                        )
+                    }
+                }
 
                 is Dimension.ZLayer -> Box(
                     modifier = modifier

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/VerticalStack.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/VerticalStack.kt
@@ -28,8 +28,8 @@ internal fun VerticalStack(
     size: Size,
     dimension: Dimension.Vertical,
     spacing: Dp,
-    content: VerticalStackScope.() -> Unit,
     modifier: Modifier = Modifier,
+    content: VerticalStackScope.() -> Unit,
 ) {
     Column(
         modifier = modifier,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/VerticalStack.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/VerticalStack.kt
@@ -1,9 +1,9 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.stack
 
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -17,37 +17,37 @@ import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toAlignment
-import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toHorizontalArrangement
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toVerticalArrangement
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
 
 /**
- * A horizontal stack of components which properly handles the arrangement of items.
+ * A vertical stack of components which properly handles the arrangement of items.
  */
 @Composable
-internal fun HorizontalStack(
+internal fun VerticalStack(
     size: Size,
-    dimension: Dimension.Horizontal,
+    dimension: Dimension.Vertical,
     spacing: Dp,
-    content: HorizontalStackScope.() -> Unit,
+    content: VerticalStackScope.() -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
+    Column(
         modifier = modifier,
-        verticalAlignment = dimension.alignment.toAlignment(),
-        horizontalArrangement = dimension.distribution.toHorizontalArrangement(
+        verticalArrangement = dimension.distribution.toVerticalArrangement(
             spacing = spacing,
         ),
+        horizontalAlignment = dimension.alignment.toAlignment(),
     ) {
         val fillSpaceSpacer: @Composable (Float) -> Unit = @Composable { weight ->
             Spacer(modifier = Modifier.weight(weight))
         }
         val latestContent by rememberUpdatedState(content)
         val scope = remember(dimension.distribution, spacing, latestContent) {
-            HorizontalStackScopeImpl(
+            VerticalStackScopeImpl(
                 distribution = dimension.distribution,
                 spacing = spacing,
                 fillSpaceSpacer = fillSpaceSpacer,
-                width = size.width,
+                height = size.height,
             ).apply(latestContent)
         }
 
@@ -63,41 +63,41 @@ internal fun HorizontalStack(
         }
 
         edgeSpacerIfNeeded()
-        scope.rowContent(this)
+        scope.columnContent(this)
         edgeSpacerIfNeeded()
     }
 }
 
-internal interface HorizontalStackScope {
+internal interface VerticalStackScope {
     fun items(
         items: List<ComponentStyle>,
-        itemContent: @Composable RowScope.(index: Int, item: ComponentStyle) -> Unit,
+        itemContent: @Composable ColumnScope.(index: Int, item: ComponentStyle) -> Unit,
     )
 }
 
-private class HorizontalStackScopeImpl(
+private class VerticalStackScopeImpl(
     private val distribution: FlexDistribution,
     private val spacing: Dp,
     private val fillSpaceSpacer: @Composable (Float) -> Unit,
-    private val width: SizeConstraint,
-) : HorizontalStackScope {
-    private var hasAnyItemsWithFillWidth = false
+    private val height: SizeConstraint,
+) : VerticalStackScope {
+    private var hasAnyItemsWithFillHeight = false
     val shouldApplyFillSpacers: Boolean
-        get() = width != Fit && !hasAnyItemsWithFillWidth
-    var rowContent: @Composable RowScope.() -> Unit = {}
+        get() = height != Fit && !hasAnyItemsWithFillHeight
+    var columnContent: @Composable ColumnScope.() -> Unit = {}
 
     override fun items(
         items: List<ComponentStyle>,
-        itemContent: @Composable RowScope.(index: Int, item: ComponentStyle) -> Unit,
+        itemContent: @Composable ColumnScope.(index: Int, item: ComponentStyle) -> Unit,
     ) {
-        hasAnyItemsWithFillWidth = items.any { it.size.width == Fill }
-        rowContent = {
+        hasAnyItemsWithFillHeight = items.any { it.size.height == Fill }
+        columnContent = {
             items.forEachIndexed { index, item ->
                 val isLast = index == items.size - 1
                 itemContent(index, item)
 
                 if (distribution.usesAllAvailableSpace && !isLast) {
-                    Spacer(modifier = Modifier.widthIn(min = spacing))
+                    Spacer(modifier = Modifier.heightIn(min = spacing))
                     if (shouldApplyFillSpacers) {
                         fillSpaceSpacer(if (distribution == FlexDistribution.SPACE_AROUND) 2f else 1f)
                     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/VerticalStack.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/VerticalStack.kt
@@ -1,3 +1,5 @@
+@file:JvmSynthetic
+
 package com.revenuecat.purchases.ui.revenuecatui.components.stack
 
 import androidx.compose.foundation.layout.Column


### PR DESCRIPTION
## Description
This PR adds `HorizontalStack` and `VerticalStack`, which are used by `StackComponentView`. They handle the item arrangement logic, adding spacers where needed. There should be no change in functionality. Just moving stuff around.

## Motivation
`StackComponentView.kt` is a huge file. Moving self-contained pieces of logic out of there improves maintainability. 