### PR TITLE
dont build integration tests on jitpack

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -10,18 +10,18 @@ def isJitpack = System.getenv('JITPACK') == 'true'
 
 if (!isJitpack) {
     include ':integration-tests'
+    include 'examples:purchase-tester'
+    include ':examples:paywall-tester'
+    include ':test-apps:testpurchasesandroidcompatibility'
+    include ':test-apps:testpurchasesuiandroidcompatibility'
+    include ':examples:web-purchase-redemption-sample'
 } else {
     println "Building on JitPack - excluding integration-tests module"
 }
 
 include ':feature:amazon'
 include ':purchases'
-include 'examples:purchase-tester'
 include ':api-tester'
 include 'ui:debugview'
 include ':ui:revenuecatui'
-include ':examples:paywall-tester'
-include ':test-apps:testpurchasesandroidcompatibility'
-include ':test-apps:testpurchasesuiandroidcompatibility'
-include ':examples:web-purchase-redemption-sample'
 include ':dokka-hide-internal'

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,8 +6,15 @@ pluginManagement {
     }
 }
 
+def isJitpack = System.getenv('JITPACK') == 'true'
+
+if (!isJitpack) {
+    include ':integration-tests'
+} else {
+    println "Building on JitPack - excluding integration-tests module"
+}
+
 include ':feature:amazon'
-include ':integration-tests'
 include ':purchases'
 include 'examples:purchase-tester'
 include ':api-tester'


### PR DESCRIPTION
### Motivation
We'd like to allow developers to test out virtual currency features on a beta branch. The easiest way to do this is with [Jitpack](https://jitpack.io), but several of our modules don't build on Jitpack since they're missing various sensitive files, like keystores. This PR modifies the build system to exclude integration tests & test apps when the SDK is being built by Jitpack.

### Description
Manually tested changes through Jitpack
