### PR TITLE
Allow custom entitlement mode to have custom configuration

### DIFF
--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
+import android.content.res.Configuration
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
@@ -285,15 +286,17 @@ class Purchases internal constructor(
             context: Context,
             apiKey: String,
             appUserID: String,
+            configurationBuilder: PurchasesConfiguration.Builder = PurchasesConfiguration.Builder(context, apiKey)
+                .appUserID(appUserID)
+                .pendingTransactionsForPrepaidPlansEnabled(true),
         ): Purchases {
             if (isConfigured) {
                 infoLog(ConfigureStrings.INSTANCE_ALREADY_EXISTS)
             }
-            val configuration = PurchasesConfiguration.Builder(context, apiKey)
-                .appUserID(appUserID)
+            val configuration = configurationBuilder
                 .dangerousSettings(DangerousSettings(customEntitlementComputation = true))
-                .pendingTransactionsForPrepaidPlansEnabled(true)
                 .build()
+
             return PurchasesFactory(
                 isDebugBuild = DefaultIsDebugBuildProvider(context),
             ).createPurchases(


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests 
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

Existing Unit tests should cover

### Motivation
<!-- Why is this change required? What problem does it solve? -->
Currently, purchase configurations for custom entitlement mode are set. That means developers cannot control pending transactions, showInAppMessagesAutomatically or any other configurations.


<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
Create a param for configuration builder in `configureInCustomEntitlementsComputationMode` method

<!-- Please describe in detail how you tested your changes -->
Existing unit tests