### PR TITLE
[Paywalls V2] Tweaks the `MissingPackage` error message.

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
@@ -86,7 +86,7 @@ internal sealed class PaywallValidationError : Throwable() {
     ) : PaywallValidationError() {
         override val message: String =
             PaywallValidationErrorStrings.MISSING_PACKAGE
-                .format(offeringId, missingPackageId, allPackageIds.joinToString())
+                .format(missingPackageId, offeringId, allPackageIds.joinToString())
     }
     data class MissingColorAlias(
         val alias: ColorAlias,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/strings/PaywallValidationErrorStrings.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/strings/PaywallValidationErrorStrings.kt
@@ -21,7 +21,8 @@ internal object PaywallValidationErrorStrings {
     const val ALL_VARIABLE_LOCALIZATIONS_MISSING_FOR_LOCALE =
         "All variable localizations for locale '%s' are missing."
     const val MISSING_PACKAGE =
-        "Offering with id '%s' does not have a package with id '%s'. It has these packages instead: [%s]."
+        "The Paywall references a package with id '%s', but Offering '%s' does not contain such a package. " +
+            "It has these packages instead: [%s]."
     const val MISSING_COLOR_ALIAS = "Aliased color '%s' does not exist."
     const val ALIASED_COLOR_IS_ALIAS = "Aliased color '%s' has an aliased value '%s', which is not allowed."
     const val MISSING_FONT_ALIAS = "Aliased font '%s' does not exist."

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/strings/PaywallValidationErrorStrings.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/strings/PaywallValidationErrorStrings.kt
@@ -22,7 +22,8 @@ internal object PaywallValidationErrorStrings {
         "All variable localizations for locale '%s' are missing."
     const val MISSING_PACKAGE =
         "The Paywall references a package with id '%s', but Offering '%s' does not contain such a package. " +
-            "It has these packages instead: [%s]."
+            "It has these packages instead: [%s]. Either add the missing package to the Offering or remove it from " +
+            "the Paywall."
     const val MISSING_COLOR_ALIAS = "Aliased color '%s' does not exist."
     const val ALIASED_COLOR_IS_ALIAS = "Aliased color '%s' has an aliased value '%s', which is not allowed."
     const val MISSING_FONT_ALIAS = "Aliased font '%s' does not exist."


### PR DESCRIPTION
## Motivation
I figured this error message could better describe what the actual issue is, and how to resolve it. This hopefully reduces tickets of [people running into it](https://community.revenuecat.com/sdks-51/paywall-v2-not-being-shown-on-android-5972?postid=20850#post20850).