### PR TITLE
Allows configuring `showInAppMessagesAutomatically` and `pendingTransactionsForPrepaidPlansEnabled` in customEntitlementComputation mode

### DIFF
--- a/api-tester/src/customEntitlementComputation/kotlin/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/customEntitlementComputation/kotlin/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -12,6 +12,8 @@ final class PurchasesAPI {
     static void checkConfiguration(final Context context,
                                    final ExecutorService executorService) {
         Purchases.configureInCustomEntitlementsComputationMode(context, "", "");
+        Purchases.configureInCustomEntitlementsComputationMode(context, "", "", false);
+        Purchases.configureInCustomEntitlementsComputationMode(context, "", "", false, false);
     }
 
     static void check(final Purchases purchases) {

--- a/api-tester/src/customEntitlementComputation/kotlin/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/customEntitlementComputation/kotlin/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -3,6 +3,7 @@ package com.revenuecat.apitester.java;
 import android.content.Context;
 
 import com.revenuecat.purchases.Purchases;
+import com.revenuecat.purchases.PurchasesConfigurationForCustomEntitlementsComputationMode;
 
 import java.util.concurrent.ExecutorService;
 
@@ -12,8 +13,15 @@ final class PurchasesAPI {
     static void checkConfiguration(final Context context,
                                    final ExecutorService executorService) {
         Purchases.configureInCustomEntitlementsComputationMode(context, "", "");
-        Purchases.configureInCustomEntitlementsComputationMode(context, "", "", false);
-        Purchases.configureInCustomEntitlementsComputationMode(context, "", "", false, false);
+        Purchases.configureInCustomEntitlementsComputationMode(
+                new PurchasesConfigurationForCustomEntitlementsComputationMode.Builder(
+                        context,
+                        "",
+                        ""
+                ).showInAppMessagesAutomatically(false)
+                        .pendingTransactionsForPrepaidPlansEnabled(false)
+                        .build()
+        );
     }
 
     static void check(final Purchases purchases) {

--- a/api-tester/src/customEntitlementComputation/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/customEntitlementComputation/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -11,6 +11,25 @@ private class PurchasesAPI {
         val configured: Boolean = Purchases.isConfigured
 
         Purchases.configureInCustomEntitlementsComputationMode(context, apiKey = "", appUserID = "")
+        Purchases.configureInCustomEntitlementsComputationMode(
+            context,
+            apiKey = "",
+            appUserID = "",
+            showInAppMessagesAutomatically = false,
+        )
+        Purchases.configureInCustomEntitlementsComputationMode(
+            context,
+            apiKey = "",
+            appUserID = "",
+            pendingTransactionsForPrepaidPlansEnabled = false,
+        )
+        Purchases.configureInCustomEntitlementsComputationMode(
+            context,
+            apiKey = "",
+            appUserID = "",
+            showInAppMessagesAutomatically = false,
+            pendingTransactionsForPrepaidPlansEnabled = false,
+        )
     }
 
     fun check(purchases: Purchases) {

--- a/api-tester/src/customEntitlementComputation/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/customEntitlementComputation/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -2,6 +2,7 @@ package com.revenuecat.apitester.kotlin
 
 import android.content.Context
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesConfigurationForCustomEntitlementsComputationMode
 
 @Suppress("unused", "UNUSED_VARIABLE", "EmptyFunctionBlock")
 private class PurchasesAPI {
@@ -12,23 +13,15 @@ private class PurchasesAPI {
 
         Purchases.configureInCustomEntitlementsComputationMode(context, apiKey = "", appUserID = "")
         Purchases.configureInCustomEntitlementsComputationMode(
-            context,
-            apiKey = "",
-            appUserID = "",
-            showInAppMessagesAutomatically = false,
-        )
-        Purchases.configureInCustomEntitlementsComputationMode(
-            context,
-            apiKey = "",
-            appUserID = "",
-            pendingTransactionsForPrepaidPlansEnabled = false,
-        )
-        Purchases.configureInCustomEntitlementsComputationMode(
-            context,
-            apiKey = "",
-            appUserID = "",
-            showInAppMessagesAutomatically = false,
-            pendingTransactionsForPrepaidPlansEnabled = false,
+            PurchasesConfigurationForCustomEntitlementsComputationMode
+                .Builder(
+                    context = context,
+                    apiKey = "",
+                    appUserID = "",
+                )
+                .showInAppMessagesAutomatically(false)
+                .pendingTransactionsForPrepaidPlansEnabled(false)
+                .build(),
         )
     }
 

--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -278,37 +278,53 @@ class Purchases internal constructor(
          * @param context: the Application context object of your Application.
          * @param apiKey: the API Key for your app. Obtained from the RevenueCat dashboard.
          * @param appUserID: a unique id for identifying the user.
-         * @param showInAppMessagesAutomatically Enable this setting to show in-app messages from Google Play
-         * automatically. Default is enabled. For more info: [rev.cat](https://rev.cat/googleplayinappmessaging). If
-         * this setting is disabled, you can show the snackbar by calling [Purchases.showInAppMessagesIfNeeded].
-         * @param pendingTransactionsForPrepaidPlansEnabled Enable this setting if you want to allow pending purchases
-         * for prepaid subscriptions (only supported in Google Play). Note that entitlements are not granted until
-         * payment is done. Default is enabled.
-         *
          * @return An instantiated `[Purchases] object that has been set as a singleton.
          */
-        @JvmOverloads
         @JvmStatic
         fun configureInCustomEntitlementsComputationMode(
             context: Context,
             apiKey: String,
             appUserID: String,
-            showInAppMessagesAutomatically: Boolean = true,
-            pendingTransactionsForPrepaidPlansEnabled: Boolean = true,
+        ): Purchases =
+            configureInCustomEntitlementsComputationMode(
+                configuration = PurchasesConfigurationForCustomEntitlementsComputationMode
+                    .Builder(
+                        context = context,
+                        apiKey = apiKey,
+                        appUserID = appUserID,
+                    )
+                    .showInAppMessagesAutomatically(true)
+                    .pendingTransactionsForPrepaidPlansEnabled(true)
+                    .build(),
+            )
+
+        /**
+         * Configures an instance of the Purchases SDK with a specified API key. The instance will
+         * be set as a singleton. You should access the singleton instance using [Purchases.sharedInstance]
+         * @param configuration The [PurchasesConfigurationForCustomEntitlementsComputationMode] object you wish to use
+         * to configure [Purchases].
+         *
+         * @return An instantiated `[Purchases] object that has been set as a singleton.
+         */
+        @JvmStatic
+        fun configureInCustomEntitlementsComputationMode(
+            configuration: PurchasesConfigurationForCustomEntitlementsComputationMode,
         ): Purchases {
             if (isConfigured) {
                 infoLog(ConfigureStrings.INSTANCE_ALREADY_EXISTS)
             }
-            val configuration = PurchasesConfiguration.Builder(context, apiKey)
-                .appUserID(appUserID)
-                .dangerousSettings(DangerousSettings(customEntitlementComputation = true))
-                .showInAppMessagesAutomatically(showInAppMessagesAutomatically)
-                .pendingTransactionsForPrepaidPlansEnabled(pendingTransactionsForPrepaidPlansEnabled)
-                .build()
+            val purchasesConfiguration = with(configuration) {
+                PurchasesConfiguration.Builder(context, apiKey)
+                    .appUserID(appUserID)
+                    .dangerousSettings(DangerousSettings(customEntitlementComputation = true))
+                    .showInAppMessagesAutomatically(showInAppMessagesAutomatically)
+                    .pendingTransactionsForPrepaidPlansEnabled(pendingTransactionsForPrepaidPlansEnabled)
+                    .build()
+            }
             return PurchasesFactory(
-                isDebugBuild = DefaultIsDebugBuildProvider(context),
+                isDebugBuild = DefaultIsDebugBuildProvider(configuration.context),
             ).createPurchases(
-                configuration,
+                purchasesConfiguration,
                 platformInfo,
                 proxyURL,
             ).also {

--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -278,13 +278,23 @@ class Purchases internal constructor(
          * @param context: the Application context object of your Application.
          * @param apiKey: the API Key for your app. Obtained from the RevenueCat dashboard.
          * @param appUserID: a unique id for identifying the user.
+         * @param showInAppMessagesAutomatically Enable this setting to show in-app messages from Google Play
+         * automatically. Default is enabled. For more info: [rev.cat](https://rev.cat/googleplayinappmessaging). If
+         * this setting is disabled, you can show the snackbar by calling [Purchases.showInAppMessagesIfNeeded].
+         * @param pendingTransactionsForPrepaidPlansEnabled Enable this setting if you want to allow pending purchases
+         * for prepaid subscriptions (only supported in Google Play). Note that entitlements are not granted until
+         * payment is done. Default is enabled.
+         *
          * @return An instantiated `[Purchases] object that has been set as a singleton.
          */
+        @JvmOverloads
         @JvmStatic
         fun configureInCustomEntitlementsComputationMode(
             context: Context,
             apiKey: String,
             appUserID: String,
+            showInAppMessagesAutomatically: Boolean = true,
+            pendingTransactionsForPrepaidPlansEnabled: Boolean = true,
         ): Purchases {
             if (isConfigured) {
                 infoLog(ConfigureStrings.INSTANCE_ALREADY_EXISTS)
@@ -292,7 +302,8 @@ class Purchases internal constructor(
             val configuration = PurchasesConfiguration.Builder(context, apiKey)
                 .appUserID(appUserID)
                 .dangerousSettings(DangerousSettings(customEntitlementComputation = true))
-                .pendingTransactionsForPrepaidPlansEnabled(true)
+                .showInAppMessagesAutomatically(showInAppMessagesAutomatically)
+                .pendingTransactionsForPrepaidPlansEnabled(pendingTransactionsForPrepaidPlansEnabled)
                 .build()
             return PurchasesFactory(
                 isDebugBuild = DefaultIsDebugBuildProvider(context),

--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/PurchasesConfigurationForCustomEntitlementsComputationMode.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/PurchasesConfigurationForCustomEntitlementsComputationMode.kt
@@ -1,0 +1,62 @@
+package com.revenuecat.purchases
+
+import android.content.Context
+import com.revenuecat.purchases.PurchasesConfigurationForCustomEntitlementsComputationMode.Builder
+
+/**
+ * Holds parameters to initialize the SDK in Custom Entitlements Computation mode. Create an instance of this class
+ * using the [Builder] and pass it to [Purchases.configureInCustomEntitlementsComputationMode].
+ */
+class PurchasesConfigurationForCustomEntitlementsComputationMode internal constructor(
+    internal val context: Context,
+    internal val apiKey: String,
+    internal val appUserID: String,
+    internal val showInAppMessagesAutomatically: Boolean,
+    internal val pendingTransactionsForPrepaidPlansEnabled: Boolean,
+) {
+    /**
+     * @param context: the Application context object of your Application.
+     * @param apiKey: the API Key for your app. Obtained from the RevenueCat dashboard.
+     * @param appUserID: a unique id for identifying the user.
+     */
+    class Builder(
+        private val context: Context,
+        private val apiKey: String,
+        private val appUserID: String,
+    ) {
+        private var showInAppMessagesAutomatically: Boolean = true
+        private var pendingTransactionsForPrepaidPlansEnabled: Boolean = true
+
+        /**
+         * Enable this setting to show in-app messages from Google Play automatically. Default is enabled.
+         * For more info: [rev.cat](https://rev.cat/googleplayinappmessaging).
+         *
+         * If this setting is disabled, you can show the snackbar by calling [Purchases.showInAppMessagesIfNeeded].
+         */
+        fun showInAppMessagesAutomatically(enabled: Boolean): Builder {
+            showInAppMessagesAutomatically = enabled
+            return this
+        }
+
+        /**
+         * Enable this setting if you want to allow pending purchases for prepaid subscriptions (only supported in
+         * Google Play). Note that entitlements are not granted until payment is done. Default is enabled.
+         */
+        fun pendingTransactionsForPrepaidPlansEnabled(enabled: Boolean): Builder {
+            pendingTransactionsForPrepaidPlansEnabled = enabled
+            return this
+        }
+
+        /**
+         * Creates a [PurchasesConfigurationForCustomEntitlementsComputationMode] instance with the specified
+         * properties.
+         */
+        fun build() = PurchasesConfigurationForCustomEntitlementsComputationMode(
+            context = context,
+            apiKey = apiKey,
+            appUserID = appUserID,
+            showInAppMessagesAutomatically = showInAppMessagesAutomatically,
+            pendingTransactionsForPrepaidPlansEnabled = pendingTransactionsForPrepaidPlansEnabled,
+        )
+    }
+}


### PR DESCRIPTION
## Description
Allows for more configuration in customEntitlementComputation mode. Supersedes https://github.com/RevenueCat/purchases-android/pull/2243. 