### PR TITLE
Bump Emerge Gradle Plugin Version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ commonmark = "0.21.0"
 activity-compose = "1.9.3"
 fragment = "1.6.1"
 hamcrest = "1.3"
-emergeGradlePlugin = "4.2.0"
+emergeGradlePlugin = "4.3.0"
 emergeSnapshots = "1.3.3"
 constraintlayout = "1.1.0"
 


### PR DESCRIPTION
This bumps the Emerge Gradle Plugin version to 4.3.0.
Release notes are here: https://github.com/EmergeTools/emerge-android/releases/tag/gradle-plugin-v4.3.0