### PR TITLE
Fix landscape mode in Paywalls v1 Template 3

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/templates/Template3.kt
@@ -114,6 +114,8 @@ private fun ColumnScope.LandscapeContent(state: PaywallState.Loaded.Legacy, view
             .padding(horizontal = UIConstant.defaultHorizontalPadding),
     ) {
         Column(
+            modifier = Modifier
+                .weight(UIConstant.halfWeight),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(UIConstant.defaultVerticalSpacing, Alignment.CenterVertically),
         ) {
@@ -125,7 +127,10 @@ private fun ColumnScope.LandscapeContent(state: PaywallState.Loaded.Legacy, view
             Spacer(modifier = Modifier.weight(UIConstant.halfWeight))
         }
 
-        Column {
+        Column(
+            modifier = Modifier
+                .weight(UIConstant.halfWeight),
+        ) {
             Features(state, spacing = Template3UIConstants.featureSpacingLandscape)
 
             OfferDetails(state = state, color = state.templateConfiguration.getCurrentColors().text2)


### PR DESCRIPTION
### Motivation

Landscape in Paywalls v1 Template 3 looked squished or overflowing off the edge

### Description

Force 0.5 weight on each of the columns in landscape mode

| Before | After |
|--------|--------|
| ![Screenshot 2025-03-18 at 6 36 06 AM](https://github.com/user-attachments/assets/bb59deb4-f7e1-4f78-887f-0a31d0559ce0) | ![Screenshot 2025-03-18 at 6 41 39 AM](https://github.com/user-attachments/assets/f1d76fe8-ecc8-4985-844d-4b4d2015efcd) | 



