### PR TITLE
[Diagnostics] Add `id` and `app_session_id` to events

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntry.kt
@@ -6,17 +6,22 @@ import com.revenuecat.purchases.utils.Event
 import com.revenuecat.purchases.utils.Iso8601Utils
 import org.json.JSONObject
 import java.util.Date
+import java.util.UUID
 
 internal data class DiagnosticsEntry(
+    val id: UUID = UUID.randomUUID(),
     val name: DiagnosticsEntryName,
     val properties: Map<String, Any>,
+    val appSessionID: UUID,
     val dateProvider: DateProvider = DefaultDateProvider(),
     val dateTime: Date = dateProvider.now,
 ) : Event {
     private companion object {
+        const val ID_KEY = "id"
         const val VERSION_KEY = "version"
         const val NAME_KEY = "name"
         const val PROPERTIES_KEY = "properties"
+        const val APP_SESSION_ID_KEY = "app_session_id"
         const val TIMESTAMP_KEY = "timestamp"
 
         const val VERSION = 1
@@ -27,9 +32,11 @@ internal data class DiagnosticsEntry(
     }
 
     private fun toJSONObject() = JSONObject().apply {
+        put(ID_KEY, id)
         put(VERSION_KEY, VERSION)
         put(NAME_KEY, name.name.lowercase())
         put(PROPERTIES_KEY, JSONObject(properties))
+        put(APP_SESSION_ID_KEY, appSessionID)
         put(TIMESTAMP_KEY, Iso8601Utils.format(dateTime))
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.events.EventsManager
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.verboseLog
@@ -15,6 +16,7 @@ import com.revenuecat.purchases.strings.OfflineEntitlementsStrings
 import com.revenuecat.purchases.utils.filterNotNullValues
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import java.io.IOException
+import java.util.UUID
 import kotlin.time.Duration
 
 /**
@@ -27,6 +29,7 @@ internal class DiagnosticsTracker(
     private val diagnosticsFileHelper: DiagnosticsFileHelper,
     private val diagnosticsHelper: DiagnosticsHelper,
     private val diagnosticsDispatcher: Dispatcher,
+    private val appSessionID: UUID = EventsManager.appSessionID,
 ) {
     private companion object {
         const val ENDPOINT_NAME_KEY = "endpoint_name"
@@ -53,18 +56,16 @@ internal class DiagnosticsTracker(
     ) {
         val eTagHit = resultOrigin == HTTPResult.Origin.CACHE
         trackEvent(
-            DiagnosticsEntry(
-                name = DiagnosticsEntryName.HTTP_REQUEST_PERFORMED,
-                properties = mapOf(
-                    ENDPOINT_NAME_KEY to endpoint.name,
-                    RESPONSE_TIME_MILLIS_KEY to responseTime.inWholeMilliseconds,
-                    SUCCESSFUL_KEY to wasSuccessful,
-                    RESPONSE_CODE_KEY to responseCode,
-                    BACKEND_ERROR_CODE_KEY to backendErrorCode,
-                    ETAG_HIT_KEY to eTagHit,
-                    VERIFICATION_RESULT_KEY to verificationResult.name,
-                ).filterNotNullValues(),
-            ),
+            eventName = DiagnosticsEntryName.HTTP_REQUEST_PERFORMED,
+            properties = mapOf(
+                ENDPOINT_NAME_KEY to endpoint.name,
+                RESPONSE_TIME_MILLIS_KEY to responseTime.inWholeMilliseconds,
+                SUCCESSFUL_KEY to wasSuccessful,
+                RESPONSE_CODE_KEY to responseCode,
+                BACKEND_ERROR_CODE_KEY to backendErrorCode,
+                ETAG_HIT_KEY to eTagHit,
+                VERIFICATION_RESULT_KEY to verificationResult.name,
+            ).filterNotNullValues(),
         )
     }
 
@@ -77,14 +78,12 @@ internal class DiagnosticsTracker(
         responseTime: Duration,
     ) {
         trackEvent(
-            DiagnosticsEntry(
-                name = DiagnosticsEntryName.GOOGLE_QUERY_PRODUCT_DETAILS_REQUEST,
-                properties = mapOf(
-                    PRODUCT_TYPE_QUERIED_KEY to productType,
-                    BILLING_RESPONSE_CODE to billingResponseCode,
-                    BILLING_DEBUG_MESSAGE to billingDebugMessage,
-                    RESPONSE_TIME_MILLIS_KEY to responseTime.inWholeMilliseconds,
-                ),
+            eventName = DiagnosticsEntryName.GOOGLE_QUERY_PRODUCT_DETAILS_REQUEST,
+            properties = mapOf(
+                PRODUCT_TYPE_QUERIED_KEY to productType,
+                BILLING_RESPONSE_CODE to billingResponseCode,
+                BILLING_DEBUG_MESSAGE to billingDebugMessage,
+                RESPONSE_TIME_MILLIS_KEY to responseTime.inWholeMilliseconds,
             ),
         )
     }
@@ -96,14 +95,12 @@ internal class DiagnosticsTracker(
         responseTime: Duration,
     ) {
         trackEvent(
-            DiagnosticsEntry(
-                name = DiagnosticsEntryName.GOOGLE_QUERY_PURCHASES_REQUEST,
-                properties = mapOf(
-                    PRODUCT_TYPE_QUERIED_KEY to productType,
-                    BILLING_RESPONSE_CODE to billingResponseCode,
-                    BILLING_DEBUG_MESSAGE to billingDebugMessage,
-                    RESPONSE_TIME_MILLIS_KEY to responseTime.inWholeMilliseconds,
-                ),
+            eventName = DiagnosticsEntryName.GOOGLE_QUERY_PURCHASES_REQUEST,
+            properties = mapOf(
+                PRODUCT_TYPE_QUERIED_KEY to productType,
+                BILLING_RESPONSE_CODE to billingResponseCode,
+                BILLING_DEBUG_MESSAGE to billingDebugMessage,
+                RESPONSE_TIME_MILLIS_KEY to responseTime.inWholeMilliseconds,
             ),
         )
     }
@@ -115,14 +112,12 @@ internal class DiagnosticsTracker(
         responseTime: Duration,
     ) {
         trackEvent(
-            DiagnosticsEntry(
-                name = DiagnosticsEntryName.GOOGLE_QUERY_PURCHASE_HISTORY_REQUEST,
-                properties = mapOf(
-                    PRODUCT_TYPE_QUERIED_KEY to productType,
-                    BILLING_RESPONSE_CODE to billingResponseCode,
-                    BILLING_DEBUG_MESSAGE to billingDebugMessage,
-                    RESPONSE_TIME_MILLIS_KEY to responseTime.inWholeMilliseconds,
-                ),
+            eventName = DiagnosticsEntryName.GOOGLE_QUERY_PURCHASE_HISTORY_REQUEST,
+            properties = mapOf(
+                PRODUCT_TYPE_QUERIED_KEY to productType,
+                BILLING_RESPONSE_CODE to billingResponseCode,
+                BILLING_DEBUG_MESSAGE to billingDebugMessage,
+                RESPONSE_TIME_MILLIS_KEY to responseTime.inWholeMilliseconds,
             ),
         )
     }
@@ -136,12 +131,10 @@ internal class DiagnosticsTracker(
         wasSuccessful: Boolean,
     ) {
         trackEvent(
-            DiagnosticsEntry(
-                name = DiagnosticsEntryName.AMAZON_QUERY_PRODUCT_DETAILS_REQUEST,
-                properties = mapOf(
-                    SUCCESSFUL_KEY to wasSuccessful,
-                    RESPONSE_TIME_MILLIS_KEY to responseTime.inWholeMilliseconds,
-                ),
+            eventName = DiagnosticsEntryName.AMAZON_QUERY_PRODUCT_DETAILS_REQUEST,
+            properties = mapOf(
+                SUCCESSFUL_KEY to wasSuccessful,
+                RESPONSE_TIME_MILLIS_KEY to responseTime.inWholeMilliseconds,
             ),
         )
     }
@@ -151,12 +144,10 @@ internal class DiagnosticsTracker(
         wasSuccessful: Boolean,
     ) {
         trackEvent(
-            DiagnosticsEntry(
-                name = DiagnosticsEntryName.AMAZON_QUERY_PURCHASES_REQUEST,
-                properties = mapOf(
-                    SUCCESSFUL_KEY to wasSuccessful,
-                    RESPONSE_TIME_MILLIS_KEY to responseTime.inWholeMilliseconds,
-                ),
+            eventName = DiagnosticsEntryName.AMAZON_QUERY_PURCHASES_REQUEST,
+            properties = mapOf(
+                SUCCESSFUL_KEY to wasSuccessful,
+                RESPONSE_TIME_MILLIS_KEY to responseTime.inWholeMilliseconds,
             ),
         )
     }
@@ -167,6 +158,7 @@ internal class DiagnosticsTracker(
         val event = DiagnosticsEntry(
             name = DiagnosticsEntryName.MAX_EVENTS_STORED_LIMIT_REACHED,
             properties = mapOf(),
+            appSessionID = appSessionID,
         )
         if (useCurrentThread) {
             trackEventInCurrentThread(event)
@@ -177,19 +169,15 @@ internal class DiagnosticsTracker(
 
     fun trackMaxDiagnosticsSyncRetriesReached() {
         trackEvent(
-            DiagnosticsEntry(
-                name = DiagnosticsEntryName.MAX_DIAGNOSTICS_SYNC_RETRIES_REACHED,
-                properties = mapOf(),
-            ),
+            eventName = DiagnosticsEntryName.MAX_DIAGNOSTICS_SYNC_RETRIES_REACHED,
+            properties = emptyMap(),
         )
     }
 
     fun trackClearingDiagnosticsAfterFailedSync() {
         trackEvent(
-            DiagnosticsEntry(
-                name = DiagnosticsEntryName.CLEARING_DIAGNOSTICS_AFTER_FAILED_SYNC,
-                properties = mapOf(),
-            ),
+            eventName = DiagnosticsEntryName.CLEARING_DIAGNOSTICS_AFTER_FAILED_SYNC,
+            properties = emptyMap(),
         )
     }
 
@@ -197,8 +185,8 @@ internal class DiagnosticsTracker(
         billingResponseCode: Int,
         billingDebugMessage: String,
     ) {
-        val event = DiagnosticsEntry(
-            name = DiagnosticsEntryName.PRODUCT_DETAILS_NOT_SUPPORTED,
+        trackEvent(
+            eventName = DiagnosticsEntryName.PRODUCT_DETAILS_NOT_SUPPORTED,
             properties = mapOf(
                 "play_store_version" to (appConfig.playStoreVersionName ?: ""),
                 "play_services_version" to (appConfig.playServicesVersionName ?: ""),
@@ -206,7 +194,6 @@ internal class DiagnosticsTracker(
                 BILLING_DEBUG_MESSAGE to billingDebugMessage,
             ),
         )
-        trackEvent(event)
     }
 
     fun trackCustomerInfoVerificationResultIfNeeded(
@@ -216,23 +203,21 @@ internal class DiagnosticsTracker(
         if (verificationResult == VerificationResult.NOT_REQUESTED) {
             return
         }
-        val event = DiagnosticsEntry(
-            name = DiagnosticsEntryName.CUSTOMER_INFO_VERIFICATION_RESULT,
+        trackEvent(
+            eventName = DiagnosticsEntryName.CUSTOMER_INFO_VERIFICATION_RESULT,
             properties = mapOf(
                 VERIFICATION_RESULT_KEY to verificationResult.name,
             ),
         )
-        trackEvent(event)
     }
 
     // region Offline Entitlements
 
     fun trackEnteredOfflineEntitlementsMode() {
-        val event = DiagnosticsEntry(
-            name = DiagnosticsEntryName.ENTERED_OFFLINE_ENTITLEMENTS_MODE,
+        trackEvent(
+            eventName = DiagnosticsEntryName.ENTERED_OFFLINE_ENTITLEMENTS_MODE,
             properties = mapOf(),
         )
-        trackEvent(event)
     }
 
     fun trackErrorEnteringOfflineEntitlementsMode(error: PurchasesError) {
@@ -243,17 +228,26 @@ internal class DiagnosticsTracker(
         } else {
             "unknown"
         }
-        val event = DiagnosticsEntry(
-            name = DiagnosticsEntryName.ERROR_ENTERING_OFFLINE_ENTITLEMENTS_MODE,
+        trackEvent(
+            eventName = DiagnosticsEntryName.ERROR_ENTERING_OFFLINE_ENTITLEMENTS_MODE,
             properties = mapOf(
                 "offline_entitlement_error_reason" to reason,
                 "error_message" to "${error.message} Underlying error: ${error.underlyingErrorMessage}",
             ),
         )
-        trackEvent(event)
     }
 
     // endregion
+
+    private fun trackEvent(eventName: DiagnosticsEntryName, properties: Map<String, Any>) {
+        trackEvent(
+            DiagnosticsEntry(
+                name = eventName,
+                properties = properties,
+                appSessionID = appSessionID,
+            ),
+        )
+    }
 
     fun trackEvent(diagnosticsEntry: DiagnosticsEntry) {
         checkAndClearDiagnosticsFileIfTooBig {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsEntryTest.kt
@@ -8,6 +8,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.util.Date
+import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -27,16 +28,22 @@ class DiagnosticsEntryTest {
 
     @Test
     fun `toString transforms event to correct JSON`() {
+        val eventID = UUID.randomUUID()
+        val appSessionID = UUID.randomUUID()
         val event = DiagnosticsEntry(
+            id = eventID,
             name = DiagnosticsEntryName.HTTP_REQUEST_PERFORMED,
             properties = mapOf("test-key-1" to "test-value-1", "test-key-2" to 123, "test-key-3" to true),
-            dateProvider = testDateProvider
+            dateProvider = testDateProvider,
+            appSessionID = appSessionID,
         )
         val eventAsString = event.toString()
         val expectedString = "{" +
+            "\"id\":\"$eventID\"," +
             "\"version\":1," +
             "\"name\":\"http_request_performed\"," +
             "\"properties\":{\"test-key-1\":\"test-value-1\",\"test-key-2\":123,\"test-key-3\":true}," +
+            "\"app_session_id\":\"$appSessionID\"," +
             "\"timestamp\":\"2023-02-09T14:49:05.000Z\"" +
             "}"
         assertThat(eventAsString).isEqualTo(expectedString)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelperTest.kt
@@ -14,6 +14,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -21,7 +22,8 @@ class DiagnosticsFileHelperTest {
 
     private val testDiagnosticsEntry = DiagnosticsEntry(
         name = DiagnosticsEntryName.HTTP_REQUEST_PERFORMED,
-        properties = emptyMap()
+        properties = emptyMap(),
+        appSessionID = UUID.randomUUID(),
     )
     private val diagnosticsFilePath = DiagnosticsFileHelper.DIAGNOSTICS_FILE_PATH
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerFunctionalTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerFunctionalTest.kt
@@ -13,6 +13,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
+import java.util.UUID
 import kotlin.random.Random
 
 @RunWith(AndroidJUnit4::class)
@@ -72,14 +73,15 @@ class DiagnosticsTrackerFunctionalTest {
 
     private fun createDiagnosticsEntry(): DiagnosticsEntry {
         return DiagnosticsEntry(
-            DiagnosticsEntryName.GOOGLE_QUERY_PURCHASES_REQUEST,
-            mapOf(
+            name = DiagnosticsEntryName.GOOGLE_QUERY_PURCHASES_REQUEST,
+            properties = mapOf(
                 "test_key_1" to "test_value_1",
                 "test_key_2" to Random.nextBoolean(),
                 "test_key_3" to Random.nextInt(),
                 "test_key_4" to "test_value_${Random.nextInt()}",
                 "test_key_5" to "test_value_5",
-            )
+            ),
+            appSessionID = UUID.randomUUID(),
         )
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/diagnostics/DiagnosticsTrackerTest.kt
@@ -33,6 +33,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.IOException
+import java.util.UUID
 import kotlin.time.Duration.Companion.milliseconds
 
 @RunWith(AndroidJUnit4::class)
@@ -41,7 +42,8 @@ class DiagnosticsTrackerTest {
 
     private val testDiagnosticsEntry = DiagnosticsEntry(
         name = DiagnosticsEntryName.HTTP_REQUEST_PERFORMED,
-        properties = mapOf("test-key-1" to "test-value-1")
+        properties = mapOf("test-key-1" to "test-value-1"),
+        appSessionID = UUID.randomUUID(),
     )
 
     private lateinit var diagnosticsFileHelper: DiagnosticsFileHelper


### PR DESCRIPTION
### Description
This adds some new properties to diagnostics so we're able to better track events and what happens within the same session.

It also adds a small refactor to `DiagnosticsTracker` track events to avoid repetition to pass the app session id.