### PR TITLE
Add `onManagementOptionSelected` to `CustomerCenterListener`

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -2,6 +2,7 @@ package com.revenuecat.apitester.java;
 
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 
 import androidx.annotation.NonNull;
 
@@ -18,6 +19,7 @@ import com.revenuecat.purchases.Store;
 import com.revenuecat.purchases.WebPurchaseRedemption;
 import com.revenuecat.purchases.amazon.AmazonConfiguration;
 import com.revenuecat.purchases.customercenter.CustomerCenterListener;
+import com.revenuecat.purchases.customercenter.CustomerCenterManagementOption;
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback;
 import com.revenuecat.purchases.interfaces.LogInCallback;
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback;
@@ -192,6 +194,17 @@ final class PurchasesAPI {
 
             @Override
             public void onRestoreStarted() {
+            }
+            @Override
+            public void onManagementOptionSelected(@NonNull CustomerCenterManagementOption action) {
+                //noinspection StatementWithEmptyBody
+                if (action instanceof CustomerCenterManagementOption.MissingPurchase) {
+                } else //noinspection StatementWithEmptyBody
+                    if (action instanceof CustomerCenterManagementOption.Cancel) {
+                } else if (action instanceof CustomerCenterManagementOption.CustomUrl) {
+                    CustomerCenterManagementOption.CustomUrl customUrl = (CustomerCenterManagementOption.CustomUrl) action;
+                    Uri uri = customUrl.getUri();
+                }
             }
         };
         Purchases.getSharedInstance().setCustomerCenterListener(new CustomerCenterListener() {});

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -2,6 +2,7 @@ package com.revenuecat.apitester.kotlin
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import com.revenuecat.purchases.AmazonLWAConsentStatus
 import com.revenuecat.purchases.CacheFetchPolicy
 import com.revenuecat.purchases.CustomerInfo

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -266,7 +266,7 @@ private class PurchasesAPI {
                     CustomerCenterManagementOption.Cancel -> {
                     }
                     is CustomerCenterManagementOption.CustomUrl -> {
-                        action.uri
+                        val uri: Uri = action.uri
                     }
                 }
             }

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -25,6 +25,7 @@ import com.revenuecat.purchases.awaitSyncAttributesAndOfferingsIfNeeded
 import com.revenuecat.purchases.awaitSyncPurchases
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
+import com.revenuecat.purchases.customercenter.CustomerCenterManagementOption
 import com.revenuecat.purchases.data.LogInResult
 import com.revenuecat.purchases.getAmazonLWAConsentStatus
 import com.revenuecat.purchases.getAmazonLWAConsentStatusWith
@@ -256,6 +257,18 @@ private class PurchasesAPI {
             }
 
             override fun onRestoreStarted() {
+            }
+
+            override fun onManagementOptionSelected(action: CustomerCenterManagementOption) {
+                when (action) {
+                    CustomerCenterManagementOption.MissingPurchase -> {
+                    }
+                    CustomerCenterManagementOption.Cancel -> {
+                    }
+                    is CustomerCenterManagementOption.CustomUrl -> {
+                        action.uri
+                    }
+                }
             }
         }
         sharedInstance.customerCenterListener = object : CustomerCenterListener {}

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
@@ -33,6 +33,7 @@ import com.revenuecat.paywallstester.ui.screens.main.appinfo.AppInfoScreenViewMo
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
+import com.revenuecat.purchases.customercenter.CustomerCenterManagementOption
 import com.revenuecat.purchases.ui.debugview.DebugRevenueCatBottomSheet
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenter
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenterOptions
@@ -231,6 +232,10 @@ private fun ApiKeyDialog_Preview() {
 
 private fun createCustomerCenterListener(): CustomerCenterListener {
     return object : CustomerCenterListener {
+        override fun onManagementOptionSelected(action: CustomerCenterManagementOption) {
+            Log.d(TAG, "Local listener: onManagementOptionSelected called with action: $action")
+        }
+
         override fun onRestoreStarted() {
             Log.d(TAG, "Local listener: onRestoreStarted called")
         }

--- a/purchases/src/main/java/com/revenuecat/purchases/customercenter/CustomerCenterManagementOption.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/customercenter/CustomerCenterManagementOption.kt
@@ -3,9 +3,9 @@ package com.revenuecat.purchases.customercenter
 import android.net.Uri
 
 /**
- * Sealed interface representing different customer center management options.
+ * Interface representing different customer center management options.
  */
-sealed interface CustomerCenterManagementOption {
+interface CustomerCenterManagementOption {
     /**
      * Action to cancel the current operation
      */

--- a/purchases/src/main/java/com/revenuecat/purchases/customercenter/CustomerCenterManagementOption.kt
+++ b/purchases/src/main/java/com/revenuecat/purchases/customercenter/CustomerCenterManagementOption.kt
@@ -1,0 +1,24 @@
+package com.revenuecat.purchases.customercenter
+
+import android.net.Uri
+
+/**
+ * Sealed interface representing different customer center management options.
+ */
+sealed interface CustomerCenterManagementOption {
+    /**
+     * Action to cancel the current operation
+     */
+    object Cancel : CustomerCenterManagementOption
+
+    /**
+     * Action to open a custom URL
+     * @property uri The URI to open
+     */
+    data class CustomUrl(val uri: Uri) : CustomerCenterManagementOption
+
+    /**
+     * Action to handle a missing purchase
+     */
+    object MissingPurchase : CustomerCenterManagementOption
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterListener.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterListener.kt
@@ -50,4 +50,13 @@ interface CustomerCenterListener {
     fun onFeedbackSurveyCompleted(feedbackSurveyOptionId: String) {
         // Default empty implementation
     }
+
+    /**
+     * Called when a customer center management option is selected.
+     *
+     * @param action The selected management action
+     */
+    fun onManagementOptionSelected(action: CustomerCenterManagementOption) {
+        // Default empty implementation
+    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -25,6 +25,7 @@ import com.revenuecat.purchases.SubscriptionInfo
 import com.revenuecat.purchases.common.SharedConstants
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
+import com.revenuecat.purchases.customercenter.CustomerCenterManagementOption
 import com.revenuecat.purchases.customercenter.events.CustomerCenterImpressionEvent
 import com.revenuecat.purchases.customercenter.events.CustomerCenterSurveyOptionChosenEvent
 import com.revenuecat.purchases.models.GoogleSubscriptionOption
@@ -148,6 +149,7 @@ internal class CustomerCenterViewModelImpl(
         path: CustomerCenterConfigData.HelpPath,
         product: StoreProduct?,
     ) {
+        notifyListenersForManagementOptionSelected(path)
         path.feedbackSurvey?.let { feedbackSurvey ->
             displayFeedbackSurvey(feedbackSurvey, onAnswerSubmitted = { option ->
                 goBackToMain()
@@ -682,5 +684,26 @@ internal class CustomerCenterViewModelImpl(
     private fun notifyListenersForFeedbackSurveyCompleted(feedbackSurveyOptionId: String) {
         listener?.onFeedbackSurveyCompleted(feedbackSurveyOptionId)
         purchases.customerCenterListener?.onFeedbackSurveyCompleted(feedbackSurveyOptionId)
+    }
+
+    private fun notifyListenersForManagementOptionSelected(path: CustomerCenterConfigData.HelpPath) {
+        val action = when (path.type) {
+            CustomerCenterConfigData.HelpPath.PathType.MISSING_PURCHASE ->
+                CustomerCenterManagementOption.MissingPurchase
+
+            CustomerCenterConfigData.HelpPath.PathType.CANCEL ->
+                CustomerCenterManagementOption.Cancel
+
+            CustomerCenterConfigData.HelpPath.PathType.CUSTOM_URL ->
+                path.url?.let {
+                    CustomerCenterManagementOption.CustomUrl(Uri.parse(it))
+                }
+
+            else -> null
+        }
+        action?.let {
+            listener?.onManagementOptionSelected(it)
+            purchases.customerCenterListener?.onManagementOptionSelected(it)
+        }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -701,9 +701,9 @@ internal class CustomerCenterViewModelImpl(
 
             else -> null
         }
-        action?.let {
-            listener?.onManagementOptionSelected(it)
-            purchases.customerCenterListener?.onManagementOptionSelected(it)
+        if (action != null) {
+            listener?.onManagementOptionSelected(action)
+            purchases.customerCenterListener?.onManagementOptionSelected(action)
         }
     }
 }


### PR DESCRIPTION
Equivalent of https://github.com/RevenueCat/purchases-ios/pull/4872/files adding a listener that gets triggered as soon as an option is selected