### PR TITLE
[Paywalls V2] Ignores missing font alias if it's blank.

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LocalizedTextPartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LocalizedTextPartial.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ktx.stringForAllLocal
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.FontSpec
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.getFontSpec
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.recoverFromBlankFontAlias
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.toColorStyles
 import com.revenuecat.purchases.ui.revenuecatui.errors.PaywallValidationError
 import com.revenuecat.purchases.ui.revenuecatui.helpers.NonEmptyList
@@ -51,6 +52,7 @@ internal class LocalizedTextPartial private constructor(
                 third = from.backgroundColor?.toColorStyles(aliases).orSuccessfullyNull(),
                 fourth = from.fontName
                     ?.let { fontAliases.getFontSpec(it) }
+                    ?.recoverFromBlankFontAlias()
                     .orSuccessfullyNull()
                     .mapError { nonEmptyListOf(it) },
             ) { texts, color, backgroundColor, fontSpec ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -47,6 +47,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toTextAlign
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.FontSpec
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.getFontSpec
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.recoverFromBlankFontAlias
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.toBackgroundStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.toBorderStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.toColorStyles
@@ -381,6 +382,7 @@ internal class StyleFactory(
         fourth = component.backgroundColor?.toColorStyles(colorAliases).orSuccessfullyNull(),
         fifth = component.fontName
             ?.let { fontAlias -> fontAliases.getFontSpec(fontAlias) }
+            ?.recoverFromBlankFontAlias()
             .orSuccessfullyNull()
             .mapError { nonEmptyListOf(it) },
     ) { texts, presentedOverrides, color, backgroundColor, fontSpec ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/Result.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/Result.kt
@@ -77,6 +77,13 @@ internal inline fun <A, B, R> Result<A, B>.mapError(transform: (value: B) -> R):
     }
 
 @JvmSynthetic
+internal inline fun <A, B, R> Result<A, B>.flatMapError(transform: (value: B) -> Result<A, R>): Result<A, R> =
+    when (this) {
+        is Result.Success -> this
+        is Result.Error -> transform(value)
+    }
+
+@JvmSynthetic
 internal inline fun <A : R, B, R> Result<A, B>.getOrElse(onFailure: (error: B) -> R): R =
     when (this) {
         is Result.Success -> value


### PR DESCRIPTION
## Bug
A customer reported their paywall failed to render with the following validation error in the logs: 
> Aliased font ‘’ does not exist.

## Cause
The real cause seems to be on the dashboard, as their paywall was able to be published without any Font family selected: 
![image](https://github.com/user-attachments/assets/30fcd352-196d-462f-8dc8-f0811204914f)

## Fix
While this is ideally fixed on the dashboard, this PR introduces a behavior change in the SDK that will treat this situation as "no font selected". The SDK now ignores blank font aliases. This is a bit more defensive and less strict, but still valid behavior imo. 