### PR TITLE
Downgrades Emerge Snapshots sdk to 1.3.0.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ activity-compose = "1.9.3"
 fragment = "1.6.1"
 hamcrest = "1.3"
 emergeGradlePlugin = "4.2.0"
-emergeSnapshots = "1.3.3"
+emergeSnapshots = "1.3.0"
 constraintlayout = "1.1.0"
 
 [plugins]


### PR DESCRIPTION
Drafty.