### PR TITLE
[Diagnostics] Sync diagnostics if file reaches lower limit

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -247,6 +247,7 @@ internal class PurchasesFactory(
                     backend,
                     eventsDispatcher,
                 )
+                diagnosticsTracker.listener = diagnosticsSynchronizer
             }
 
             val syncPurchasesHelper = SyncPurchasesHelper(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
@@ -15,10 +15,20 @@ internal class DiagnosticsFileHelper(
     companion object {
         const val DIAGNOSTICS_FILE_PATH = "RevenueCat/diagnostics/diagnostic_entries.jsonl"
         const val DIAGNOSTICS_FILE_LIMIT_IN_KB = 500
+        const val DIAGNOSTICS_FILE_SYNC_LIMIT_IN_KB = 200
     }
 
     @Synchronized
     fun isDiagnosticsFileTooBig(): Boolean {
-        return fileHelper.fileSizeInKB(DIAGNOSTICS_FILE_PATH) > DIAGNOSTICS_FILE_LIMIT_IN_KB
+        return diagnosticsFileSize() > DIAGNOSTICS_FILE_LIMIT_IN_KB
+    }
+
+    @Synchronized
+    fun isDiagnosticsFileBigEnoughToSync(): Boolean {
+        return diagnosticsFileSize() > DIAGNOSTICS_FILE_SYNC_LIMIT_IN_KB
+    }
+
+    private fun diagnosticsFileSize(): Double {
+        return fileHelper.fileSizeInKB(DIAGNOSTICS_FILE_PATH)
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsTracker.kt
@@ -23,6 +23,10 @@ import java.io.IOException
 import java.util.UUID
 import kotlin.time.Duration
 
+internal fun interface DiagnosticsEventTrackerListener {
+    fun onEventTracked()
+}
+
 /**
  * This class is the entry point for all diagnostics tracking. It contains all information for all events
  * sent and their properties. Use this class if you want to send a a diagnostics entry.
@@ -74,6 +78,8 @@ internal class DiagnosticsTracker(
     } else {
         emptyMap()
     }
+
+    var listener: DiagnosticsEventTrackerListener? = null
 
     @Suppress("LongParameterList")
     fun trackHttpRequestPerformed(
@@ -581,6 +587,7 @@ internal class DiagnosticsTracker(
             verboseLog("Tracking diagnostics entry: $diagnosticsEntry")
             try {
                 diagnosticsFileHelper.appendEvent(diagnosticsEntry)
+                listener?.onEventTracked()
             } catch (e: IOException) {
                 verboseLog("Error tracking diagnostics entry: $e")
             }


### PR DESCRIPTION
### Description
With all the new events we've been adding, we can potentially reach the file size limit much more easily, specially considering we only sync once per app open. This changes the logic, so we also sync if, after tracking an event, the file reaches a lower file size than the maximum. This should help us receiving events more frequently and avoid losing those events.