### PR TITLE
[Paywalls V2] Fixes the update-paywall-templates job

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -589,14 +589,14 @@ DESC
     templates_file = File.join(templates_dir, "offerings_paywalls_v2_templates.json")
     api_key = ENV["PAYWALLS_V2_TEMPLATE_REPO_API_KEY"] || UI.user_error!("Missing PAYWALLS_V2_TEMPLATE_REPO_API_KEY environment variable")
 
-    # Recreate our output directory so we start fresh.
-    sh("rm -rf #{templates_dir}")
-    sh("mkdir -p #{templates_dir}")
-
     # Ensure we're starting from an up-to-date main.
     sh("git", "fetch", "origin")
 
     create_or_checkout_branch(branch_name: branch_name)
+
+    # Recreate our output directory so we start fresh.
+    sh("rm -rf #{templates_dir}")
+    sh("mkdir -p #{templates_dir}")
 
     # Get offerings and save to file.
     offerings_response = get_offerings(


### PR DESCRIPTION
## Description
I'm sure I tested this, but when running from `main` I got a "[No such file or directory](https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/14671/workflows/77041cdb-1dd9-467e-9cbb-d94e4bc2a3fa/jobs/72243)" error. This PR recreates the output dir after branch switching, and that seems to fix it.