### PR TITLE
Use coil-base instead of coil-compose for purchases package

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -143,6 +143,7 @@ compose-constraintlayout = { module = "androidx.constraintlayout:constraintlayou
 window = { module = "androidx.window:window", version.ref = "window" }
 window-core = { module = "androidx.window:window-core", version.ref = "window" }
 
+coil-base = { module = "io.coil-kt:coil-base", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coil" }
 coil-test = { module = "io.coil-kt:coil-test", version.ref = "coil" }

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -101,11 +101,11 @@ dependencies {
     implementation libs.playServices.ads.identifier
 
     compileOnly libs.amazon.appstore.sdk
-    compileOnly libs.coil.compose
+    compileOnly libs.coil.base
 
     dokkaPlugin(project(":dokka-hide-internal"))
 
-    testImplementation libs.coil.compose
+    testImplementation libs.coil.base
     testImplementation libs.bundles.test
     testImplementation libs.billing
     testImplementation libs.coroutines.test


### PR DESCRIPTION
### Motivation

Use `coil-base` dependency instead of `coil-compose` for the `purchases` package.

This isn't an issue on the client side at all. However, since it involves UI-related APIs (e.g, Jetpack Compose) at compile time, this work helps prevent potential mistakes on the SDK developer side

![image](https://github.com/user-attachments/assets/9495c627-d288-4de2-a0bc-3c79abdd0ee3)
