### PR TITLE
Attempts to have Emerge Snapshots handle merge queue branches.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,7 +653,7 @@ jobs:
             if [ -z "$PR_NUM" ]; then
               branch=$(git rev-parse --abbrev-ref HEAD)
               # The branch name must follow this format:
-              #   gh-readonly-queue/<base-branch>/pr-<number>-<commit-hash>
+              #   gh-readonly-queue/<base-branch>/pr-<number>-<base-commit>
               PR_NUM=$(echo "$branch" | sed -En 's/^gh-readonly-queue\/[^/]+\/pr-([0-9]+)-[0-9a-f]+$/\1/p')
             fi
             # Set base-sha to empty string if no PR number is found.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -649,6 +649,13 @@ jobs:
             if [ -n "$CIRCLE_PULL_REQUEST" ] && [[ "$CIRCLE_PULL_REQUEST" == */* ]]; then
               PR_NUM=$(echo "$CIRCLE_PULL_REQUEST" | rev | cut -d'/' -f1 | rev)
             fi
+            # If PR_NUM is still empty, try to parse it from the branch name.
+            if [ -z "$PR_NUM" ]; then
+              branch=$(git rev-parse --abbrev-ref HEAD)
+              # The branch name must follow this format:
+              #   gh-readonly-queue/<base-branch>/pr-<number>-<commit-hash>
+              PR_NUM=$(echo "$branch" | sed -En 's/^gh-readonly-queue\/[^/]+\/pr-([0-9]+)-[0-9a-f]+$/\1/p')
+            fi
             # Set base-sha to empty string if no PR number is found.
             PR_ARG=""
             if [ -n "$PR_NUM" ]; then

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -53,12 +53,23 @@ emerge {
     apiToken.set(System.getenv("EMERGE_API_TOKEN"))
 
     vcs {
-        sha.set(System.getenv("CIRCLE_SHA1"))
+        sha.set(Runtime.getRuntime().exec(arrayOf("git", "rev-parse", "HEAD")).inputReader().readText().trim())
+        branchName.set(
+            Runtime.getRuntime()
+                .exec(arrayOf("git", "rev-parse", "--abbrev-ref", "HEAD"))
+                .inputReader().readText().trim(),
+        )
         val prNum = System.getenv("CIRCLE_PULL_REQUEST")
             .takeUnless { prUrl -> prUrl.isNullOrEmpty() }
             ?.takeIf { prUrl -> prUrl.contains('/') }
             ?.split('/')
             ?.lastOrNull()
+            // Extract the PR number from the merge queue branch name.
+            ?: "^gh-readonly-queue\\/([^/]+)\\/pr-(\\d+)-([0-9a-f]+)\$".toRegex(RegexOption.MULTILINE)
+                .matchEntire(branchName.get())
+                ?.groupValues
+                ?.get(2)
+
         if (prNum != null) {
             prNumber.set(prNum)
         } else {


### PR DESCRIPTION
## Description
GitHub's merge queue feature runs CI on intermediate branches with names looking like this: 
> gh-readonly-queue/main/pr-2305-de127b96b159da7def5cef15f51af329369eac92

Such a CI run is not a "PR" run, which means that the `CIRCLE_PULL_REQUEST` environment variable is not set. Fortunately we can extract the PR number from the branch name, which is implemented in this PR.