### PR TITLE
Remove redundant kotlin stdlib dependencies

### DIFF
--- a/examples/MagicWeather/app/build.gradle.kts
+++ b/examples/MagicWeather/app/build.gradle.kts
@@ -53,7 +53,6 @@ android {
 dependencies {
     implementation(libs.revenuecat)
     implementation(libs.revenuecat.amazon)
-    implementation(libs.kotlin.stdlib)
     implementation(libs.androidx.core)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/examples/purchase-tester/build.gradle
+++ b/examples/purchase-tester/build.gradle
@@ -62,7 +62,6 @@ dependencies {
     implementation project(path: ':purchases')
     implementation project(path: ':feature:amazon')
 
-    implementation libs.kotlin.stdlib
     implementation libs.androidx.appcompat
     implementation libs.androidx.constraintlayout
     implementation libs.androidx.recyclerview

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,7 +104,6 @@ detekt-compose = { module = "io.nlopez.compose.rules:detekt", version.ref = "det
 emerge-snapshots = { module = "com.emergetools.snapshots:snapshots", version.ref = "emergeSnapshots" }
 emerge-snapshots-annotations = { module = "com.emergetools.snapshots:snapshots-annotations", version.ref = "emergeSnapshots" }
 
-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJSON"}
 
 material = { module = "com.google.android.material:material", version.ref = "material" }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -45,7 +45,6 @@ android {
 dependencies {
     implementation project(path: ':purchases')
 
-    implementation libs.kotlin.stdlib
     implementation libs.androidx.core
     implementation libs.androidx.appcompat
     implementation libs.material

--- a/purchases/build.gradle
+++ b/purchases/build.gradle
@@ -89,7 +89,6 @@ def obtainTestBuildType() {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
-    implementation libs.kotlin.stdlib
     implementation libs.androidx.core
     implementation libs.androidx.annotation
     implementation libs.androidx.lifecycle.runtime


### PR DESCRIPTION
### Motivation

Starting from [Kotlin 1.4](https://kotlinlang.org/docs/reference/whatsnew14.html#dependency-on-the-standard-library-added-by-default), the dependency on the standard library added by default via `kotlin-android (org.jetbrains.kotlin.android) plugin`, so we can remove them:

> You no longer need to declare a dependency on the stdlib library in any Kotlin Gradle project, including a multiplatform one. The dependency is added by default. 
>
> The automatically added standard library will be the same version of the Kotlin Gradle plugin, since they have the same versioning.
>
> For platform-specific source sets, the corresponding platform-specific variant of the library is used, while a common standard library is added to the rest. The Kotlin Gradle plugin will select the appropriate JVM standard library depending on the kotlinOptions.jvmTarget compiler option of your Gradle build script.