### PR TITLE
Clean up libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,48 +1,142 @@
 [versions]
 agp = "8.8.0"
-kotlin = "1.8.22"
-# Can't update until we use more recent kotlin. 1.6.0 uses Kotlin 1.9.0
-kotlinxSerializationJSON = "1.5.1"
-billing = "7.1.1"
-lifecycle = "2.5.0"
-testLibraries = "1.4.0"
-testJUnit = "1.1.3"
-testJUnitParams = "1.1.1"
-roboelectric = "4.11.1"
-mockk = "1.13.11"
-assertJ = "3.22.0"
-annotation = "1.3.0"
-mockwebserver = "4.2.0"
-tink = "1.8.0"
-detekt = "1.23.6"
-detektRulesCompose =  "0.4.10"
-coroutines = "1.6.4"
-androidxNavigation = "2.5.3"
-appcompat = "1.4.1"
-dokka = "1.8.10"
-androidxCore = "1.8.0"
-dependencyGraph = "0.9"
-kover = "0.7.0"
-mavenPublish = "0.28.0"
-multidex = "2.0.1"
-recyclerview = "1.2.1"
-amazon = "3.0.5"
-espresso = "3.4.0"
-material = "1.6.0"
+activityCompose = "1.9.3"
 # Note that version 18.0.1 adds the AD_ID permission to the SDK.
 # We should not add that permission ourselves, so keeping it at 17.0.1 for now.
 adsIdentifier = "17.0.1"
-viewmodelCompose = "2.4.0"
-paparrazzi = "1.3.1"
+amazon = "3.0.5"
+androidxCore = "1.8.0"
+androidxNavigation = "2.5.3"
+annotation = "1.3.0"
+appcompat = "1.4.1"
+assertJ = "3.22.0"
+browser = "1.8.0"
+billing = "7.1.1"
+composeBom = "2024.09.00"
 coil = "2.4.0"
-window = "1.1.0"
+coreTesting = "2.0.0"
 commonmark = "0.21.0"
-activity-compose = "1.9.3"
-fragment = "1.6.1"
-hamcrest = "1.3"
+constraintlayout = "1.1.0"
+coroutines = "1.6.4"
+datastorePreference = "1.0.0"
+dependencyGraph = "0.9"
+detekt = "1.23.6"
+detektRulesCompose = "0.4.10"
+dokka = "1.8.10"
 emergeGradlePlugin = "4.2.0"
 emergeSnapshots = "1.3.0"
-constraintlayout = "1.1.0"
+espresso = "3.4.0"
+fragment = "1.6.1"
+hamcrest = "1.3"
+recyclerview = "1.2.1"
+roboelectric = "4.11.1"
+kotlin = "1.8.22"
+kotlinBom = "1.8.0"
+# Can't update until we use more recent kotlin. 1.6.0 uses Kotlin 1.9.0
+kotlinxSerializationJSON = "1.5.1"
+kover = "0.7.0"
+legacyCoreUi = "1.0.0"
+lifecycle = "2.5.0"
+material = "1.6.0"
+mavenPublish = "0.28.0"
+mockk = "1.13.11"
+mockwebserver = "4.2.0"
+multidex = "2.0.1"
+paparrazzi = "1.3.1"
+poko = "0.13.1"
+testJUnit = "1.1.3"
+testJUnitParams = "1.1.1"
+testLibraries = "1.4.0"
+tink = "1.8.0"
+viewmodelCompose = "2.4.0"
+window = "1.1.0"
+
+[libraries]
+activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
+androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
+androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreference" }
+androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
+androidx-legacy-core-ui = { module = "androidx.legacy:legacy-support-core-ui", version.ref = "legacyCoreUi" }
+androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "lifecycle" }
+androidx-lifecycle-livedata = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle" }
+androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "lifecycle" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "viewmodelCompose" }
+androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "multidex" }
+androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidxNavigation" }
+androidx-navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidxNavigation" }
+androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerview" }
+
+androidx-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "coreTesting" }
+androidx-test-compose = { module = "androidx.compose.ui:ui-test-junit4" }
+androidx-test-compose-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+androidx-test-core = { module = "androidx.test:core-ktx", version.ref = "testLibraries" }
+androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+androidx-test-junit = { module = "androidx.test.ext:junit-ktx", version.ref = "testJUnit" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "testLibraries" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "testLibraries" }
+
+assertJ = { module = "org.assertj:assertj-core", version.ref = "assertJ" }
+amazon-appstore-sdk = { module = "com.amazon.device:amazon-appstore-sdk", version.ref = "amazon" }
+billing = { module = "com.android.billingclient:billing", version.ref = "billing" }
+
+coil-base = { module = "io.coil-kt:coil-base", version.ref = "coil" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coil" }
+coil-test = { module = "io.coil-kt:coil-test", version.ref = "coil" }
+
+commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
+commonmark-strikethrough = { module = "org.commonmark:commonmark-ext-gfm-strikethrough", version.ref = "commonmark" }
+
+compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
+compose-constraintlayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraintlayout" }
+compose-material = { module = "androidx.compose.material:material" }
+compose-material3 = { module = "androidx.compose.material3:material3" }
+compose-material3Adaptive = { module = "androidx.compose.material3.adaptive:adaptive" }
+compose-ui = { module = "androidx.compose.ui:ui" }
+compose-ui-google-fonts = { module = "androidx.compose.ui:ui-text-google-fonts" }
+compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+compose-ui-util = { module = "androidx.compose.ui:ui-util" }
+compose-window-size = { module = "androidx.compose.material3:material3-window-size-class" }
+
+coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+
+detekt-compose = { module = "io.nlopez.compose.rules:detekt", version.ref = "detektRulesCompose" }
+detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+
+dokka-base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
+dokka-baseTestUtils = { module = "org.jetbrains.dokka:dokka-base-test-utils", version.ref = "dokka" }
+dokka-core = { module = "org.jetbrains.dokka:dokka-core", version.ref = "dokka" }
+dokka-testApi = { module = "org.jetbrains.dokka:dokka-test-api", version.ref = "dokka" }
+
+emerge-snapshots = { module = "com.emergetools.snapshots:snapshots", version.ref = "emergeSnapshots" }
+emerge-snapshots-annotations = { module = "com.emergetools.snapshots:snapshots-annotations", version.ref = "emergeSnapshots" }
+hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest" }
+
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlinBom" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJSON" }
+
+material = { module = "com.google.android.material:material", version.ref = "material" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+mockk-agent = { module = "io.mockk:mockk-agent", version.ref = "mockk" }
+mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
+navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
+playServices-ads-identifier = { module = "com.google.android.gms:play-services-ads-identifier", version.ref = "adsIdentifier" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "roboelectric" }
+testJUnitParams = { module = "pl.pragmatists:JUnitParams", version.ref = "testJUnitParams" }
+tink = { module = "com.google.crypto.tink:tink-android", version.ref = "tink" }
+window = { module = "androidx.window:window", version.ref = "window" }
+window-core = { module = "androidx.window:window-core", version.ref = "window" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -59,104 +153,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover"}
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 paparazzi = { id = "app.cash.paparazzi", version.ref = "paparrazzi" }
-poko = { id = "dev.drewhamilton.poko", version = "0.13.1" }
-
-[libraries]
-androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
-androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
-androidx-browser = { module = "androidx.browser:browser", version = "1.8.0" }
-androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.3"
-androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
-androidx-datastore-preferences = "androidx.datastore:datastore-preferences:1.0.0"
-androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "lifecycle" }
-androidx-lifecycle-livedata = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
-androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle" }
-androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "lifecycle" }
-androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
-androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
-androidx-lifecycle-viewmodel-compose = { module = 'androidx.lifecycle:lifecycle-viewmodel-compose', version.ref= "viewmodelCompose" }
-androidx-legacy-core-ui = { module = 'androidx.legacy:legacy-support-core-ui', version = "1.0.0" }
-
-androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "multidex" }
-androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidxNavigation" }
-androidx-navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidxNavigation" }
-androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerview" }
-androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
-
-amazon-appstore-sdk = { module = "com.amazon.device:amazon-appstore-sdk", version.ref = "amazon" }
-
-androidx-test-core = { module = "androidx.test:core-ktx", version.ref = "testLibraries" }
-androidx-core-testing = { module = "androidx.arch.core:core-testing", version = "2.0.0" }
-androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
-androidx-test-junit = { module = "androidx.test.ext:junit-ktx", version.ref = "testJUnit" }
-androidx-test-runner = { module = "androidx.test:runner", version.ref = "testLibraries" }
-androidx-test-rules = { module = "androidx.test:rules", version.ref = "testLibraries" }
-androidx-test-compose = { module = "androidx.compose.ui:ui-test-junit4" }
-androidx-test-compose-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
-
-assertJ = { module = "org.assertj:assertj-core", version.ref = "assertJ"}
-
-billing = { module = "com.android.billingclient:billing" , version.ref = "billing" }
-
-detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
-detekt-compose = { module = "io.nlopez.compose.rules:detekt", version.ref = "detektRulesCompose" }
-
-emerge-snapshots = { module = "com.emergetools.snapshots:snapshots", version.ref = "emergeSnapshots" }
-emerge-snapshots-annotations = { module = "com.emergetools.snapshots:snapshots-annotations", version.ref = "emergeSnapshots" }
-
-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJSON"}
-
-material = { module = "com.google.android.material:material", version.ref = "material" }
-
-mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
-mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
-mockk-agent = { module = "io.mockk:mockk-agent", version.ref = "mockk" }
-testJUnitParams = { module = "pl.pragmatists:JUnitParams", version.ref = "testJUnitParams" }
-
-okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
-
-playServices-ads-identifier = { module = "com.google.android.gms:play-services-ads-identifier", version.ref = "adsIdentifier" }
-
-robolectric = { module = "org.robolectric:robolectric", version.ref = "roboelectric" }
-hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest" }
-
-tink = { module = "com.google.crypto.tink:tink-android", version.ref = "tink" }
-
-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
-
-kotlin-bom = "org.jetbrains.kotlin:kotlin-bom:1.8.0"
-kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
-compose-bom = "androidx.compose:compose-bom:2024.09.00"
-compose-ui = { module = "androidx.compose.ui:ui" }
-compose-ui-util = { module = "androidx.compose.ui:ui-util" }
-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
-compose-ui-google-fonts = { module = "androidx.compose.ui:ui-text-google-fonts" }
-compose-material = { module = "androidx.compose.material:material" }
-compose-material3 = { module = "androidx.compose.material3:material3" }
-compose-window-size = { module = "androidx.compose.material3:material3-window-size-class" }
-compose-material3Adaptive = { module = "androidx.compose.material3.adaptive:adaptive" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
-compose-constraintlayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraintlayout" }
-
-window = { module = "androidx.window:window", version.ref = "window" }
-window-core = { module = "androidx.window:window-core", version.ref = "window" }
-
-coil-base = { module = "io.coil-kt:coil-base", version.ref = "coil" }
-coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
-coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coil" }
-coil-test = { module = "io.coil-kt:coil-test", version.ref = "coil" }
-
-commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
-commonmark-strikethrough = { module = "org.commonmark:commonmark-ext-gfm-strikethrough", version.ref = "commonmark" }
-
-navigation-compose = "androidx.navigation:navigation-compose:2.5.3"
-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
-
-dokka-base = { module ="org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
-dokka-core = { module ="org.jetbrains.dokka:dokka-core", version.ref = "dokka" }
-dokka-testApi = { module = "org.jetbrains.dokka:dokka-test-api", version.ref = "dokka"}
-dokka-baseTestUtils = { module = "org.jetbrains.dokka:dokka-base-test-utils", version.ref = "dokka" }
+poko = { id = "dev.drewhamilton.poko", version.ref = "poko" }
 
 [bundles]
 test = ["androidx-test-core", "androidx-core-testing", "androidx-test-runner", "androidx-test-rules", "androidx-test-junit", "robolectric", "mockk", "assertJ"]


### PR DESCRIPTION
### Description

Clean up the `libs.versions.toml` file for consistency and improve readability.

- Versions have nothing changed.
- re-ordered versions & dependencies alphabetically.
- Hard-coded versions are moved to be referenced.

The result:

```toml
[versions]
agp = "8.8.0"
activityCompose = "1.9.3"
# Note that version 18.0.1 adds the AD_ID permission to the SDK.
# We should not add that permission ourselves, so keeping it at 17.0.1 for now.
adsIdentifier = "17.0.1"
amazon = "3.0.5"
androidxCore = "1.8.0"
androidxNavigation = "2.5.3"
annotation = "1.3.0"
appcompat = "1.4.1"
assertJ = "3.22.0"
browser = "1.8.0"
billing = "7.1.1"
composeBom = "2024.09.00"
coil = "2.4.0"
coreTesting = "2.0.0"
commonmark = "0.21.0"
constraintlayout = "1.1.0"
coroutines = "1.6.4"
datastorePreference = "1.0.0"
dependencyGraph = "0.9"
detekt = "1.23.6"
detektRulesCompose = "0.4.10"
dokka = "1.8.10"
emergeGradlePlugin = "4.2.0"
emergeSnapshots = "1.3.0"
espresso = "3.4.0"
fragment = "1.6.1"
hamcrest = "1.3"
recyclerview = "1.2.1"
roboelectric = "4.11.1"
kotlin = "1.8.22"
kotlinBom = "1.8.0"
# Can't update until we use more recent kotlin. 1.6.0 uses Kotlin 1.9.0
kotlinxSerializationJSON = "1.5.1"
kover = "0.7.0"
legacyCoreUi = "1.0.0"
lifecycle = "2.5.0"
material = "1.6.0"
mavenPublish = "0.28.0"
mockk = "1.13.11"
mockwebserver = "4.2.0"
multidex = "2.0.1"
paparrazzi = "1.3.1"
poko = "0.13.1"
testJUnit = "1.1.3"
testJUnitParams = "1.1.1"
testLibraries = "1.4.0"
tink = "1.8.0"
viewmodelCompose = "2.4.0"
window = "1.1.0"

[libraries]
activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreference" }
androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
androidx-legacy-core-ui = { module = "androidx.legacy:legacy-support-core-ui", version.ref = "legacyCoreUi" }
androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "lifecycle" }
androidx-lifecycle-livedata = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle" }
androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "lifecycle" }
androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "viewmodelCompose" }
androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "multidex" }
androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidxNavigation" }
androidx-navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidxNavigation" }
androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerview" }

androidx-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "coreTesting" }
androidx-test-compose = { module = "androidx.compose.ui:ui-test-junit4" }
androidx-test-compose-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
androidx-test-core = { module = "androidx.test:core-ktx", version.ref = "testLibraries" }
androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
androidx-test-junit = { module = "androidx.test.ext:junit-ktx", version.ref = "testJUnit" }
androidx-test-rules = { module = "androidx.test:rules", version.ref = "testLibraries" }
androidx-test-runner = { module = "androidx.test:runner", version.ref = "testLibraries" }

assertJ = { module = "org.assertj:assertj-core", version.ref = "assertJ" }
amazon-appstore-sdk = { module = "com.amazon.device:amazon-appstore-sdk", version.ref = "amazon" }
billing = { module = "com.android.billingclient:billing", version.ref = "billing" }

coil-base = { module = "io.coil-kt:coil-base", version.ref = "coil" }
coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coil" }
coil-test = { module = "io.coil-kt:coil-test", version.ref = "coil" }

commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
commonmark-strikethrough = { module = "org.commonmark:commonmark-ext-gfm-strikethrough", version.ref = "commonmark" }

compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
compose-constraintlayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraintlayout" }
compose-material = { module = "androidx.compose.material:material" }
compose-material3 = { module = "androidx.compose.material3:material3" }
compose-material3Adaptive = { module = "androidx.compose.material3.adaptive:adaptive" }
compose-ui = { module = "androidx.compose.ui:ui" }
compose-ui-google-fonts = { module = "androidx.compose.ui:ui-text-google-fonts" }
compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
compose-ui-util = { module = "androidx.compose.ui:ui-util" }
compose-window-size = { module = "androidx.compose.material3:material3-window-size-class" }

coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }

detekt-compose = { module = "io.nlopez.compose.rules:detekt", version.ref = "detektRulesCompose" }
detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }

dokka-base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
dokka-baseTestUtils = { module = "org.jetbrains.dokka:dokka-base-test-utils", version.ref = "dokka" }
dokka-core = { module = "org.jetbrains.dokka:dokka-core", version.ref = "dokka" }
dokka-testApi = { module = "org.jetbrains.dokka:dokka-test-api", version.ref = "dokka" }

emerge-snapshots = { module = "com.emergetools.snapshots:snapshots", version.ref = "emergeSnapshots" }
emerge-snapshots-annotations = { module = "com.emergetools.snapshots:snapshots-annotations", version.ref = "emergeSnapshots" }
hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest" }

kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlinBom" }
kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJSON" }

material = { module = "com.google.android.material:material", version.ref = "material" }
mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
mockk-agent = { module = "io.mockk:mockk-agent", version.ref = "mockk" }
mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
playServices-ads-identifier = { module = "com.google.android.gms:play-services-ads-identifier", version.ref = "adsIdentifier" }
robolectric = { module = "org.robolectric:robolectric", version.ref = "roboelectric" }
testJUnitParams = { module = "pl.pragmatists:JUnitParams", version.ref = "testJUnitParams" }
tink = { module = "com.google.crypto.tink:tink-android", version.ref = "tink" }
window = { module = "androidx.window:window", version.ref = "window" }
window-core = { module = "androidx.window:window-core", version.ref = "window" }

[plugins]
android-application = { id = "com.android.application", version.ref = "agp" }
android-library = { id = "com.android.library", version.ref = "agp" }
androidx-navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidxNavigation" }
dependencyGraph = { id = "com.savvasdalkitsis.module-dependency-graph", version.ref = "dependencyGraph" }
detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
dokka = { id ="org.jetbrains.dokka", version.ref = "dokka"}
emerge = { id = "com.emergetools.android", version.ref = "emergeGradlePlugin" }
kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover"}
mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
paparazzi = { id = "app.cash.paparazzi", version.ref = "paparrazzi" }
poko = { id = "dev.drewhamilton.poko", version.ref = "poko" }

[bundles]
test = ["androidx-test-core", "androidx-core-testing", "androidx-test-runner", "androidx-test-rules", "androidx-test-junit", "robolectric", "mockk", "assertJ"]
```
