### PR TITLE
Make purchases module to transitive dependency for the ui module

### DIFF
--- a/ui/revenuecatui/build.gradle.kts
+++ b/ui/revenuecatui/build.gradle.kts
@@ -75,7 +75,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":purchases"))
+    api(project(":purchases"))
 
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)


### PR DESCRIPTION
### Motivation

As we've discussed, making purchases module to transitive dependency for the `ui` module. I'm going to apply for the `amazon` module as well once #2327 is merged.