### PR TITLE
[Diagnostics] Removes Android 7 requirement

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsFileHelper.kt
@@ -1,14 +1,11 @@
 package com.revenuecat.purchases.common.diagnostics
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.revenuecat.purchases.common.FileHelper
 import com.revenuecat.purchases.utils.EventsFileHelper
 
 /**
  * All methods in this file should be executed within the diagnostics thread to ensure there are no threading issues.
  */
-@RequiresApi(Build.VERSION_CODES.N)
 internal class DiagnosticsFileHelper(
     private val fileHelper: FileHelper,
 ) : EventsFileHelper<DiagnosticsEntry>(fileHelper, DIAGNOSTICS_FILE_PATH, null) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
@@ -2,11 +2,9 @@ package com.revenuecat.purchases.common.diagnostics
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.os.Build
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.Dispatcher
-import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.verboseLog
 import org.json.JSONObject
 import java.io.IOException
@@ -108,14 +106,9 @@ internal class DiagnosticsSynchronizer(
 
     private fun syncDiagnosticsFileIfBigEnough() {
         enqueue {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                if (diagnosticsFileHelper.isDiagnosticsFileBigEnoughToSync()) {
-                    verboseLog("Diagnostics file is big enough to sync. Syncing it.")
-                    syncDiagnosticsFileIfNeeded()
-                }
-            } else {
-                // This should never happen since we create this class only if diagnostics is supported
-                errorLog("Diagnostics only supported in Android 24+")
+            if (diagnosticsFileHelper.isDiagnosticsFileBigEnoughToSync()) {
+                verboseLog("Diagnostics file is big enough to sync. Syncing it.")
+                syncDiagnosticsFileIfNeeded()
             }
         }
     }


### PR DESCRIPTION
## Description
We still had a few leftover checks for Android 7, which are obsolete since #1944. This PR removes them, so Diagnostics can be used from Android 5 and up. 