### PR TITLE
[Paywalls v2] Fixes `update-paywall-preview-resources-submodule` CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -680,6 +680,8 @@ jobs:
       - image: cimg/ruby:3.2.0
     steps:
       - checkout
+      - checkout-submodule:
+          path: upstream/paywall-preview-resources
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - revenuecat/setup-git-credentials

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -596,6 +596,7 @@ DESC
       sh("git", "fetch")
       sh("git", "checkout", "main")
       sh("git", "pull")
+      sh("git", "status", "--porcelain")
     end
 
     has_changes = !sh("git", "status", "--porcelain").empty?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -596,7 +596,6 @@ DESC
       sh("git", "fetch")
       sh("git", "checkout", "main")
       sh("git", "pull")
-      sh("git", "status", "--porcelain")
     end
 
     has_changes = !sh("git", "status", "--porcelain").empty?


### PR DESCRIPTION
## Description
The `update-paywall-preview-resources-submodule` job did not actually initialize and checkout the submodule, which means changes were never detected. This PR fixes that. 