### PR TITLE
[Paywalls v2] Uses a fixed date for template previews to avoid daily changes.

### DIFF
--- a/ui/revenuecatui/src/debug/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/TemplatePreviews.kt
+++ b/ui/revenuecatui/src/debug/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/TemplatePreviews.kt
@@ -28,6 +28,7 @@ import java.net.URI
 import java.util.Date
 
 private const val DIR_TEMPLATES = "paywall-templates"
+private const val MILLIS_2025_04_23 = 1745366400000
 
 /**
  * A PreviewParameterProvider that parses the offerings JSON and provides each offering that has a v2 Paywall.
@@ -163,7 +164,7 @@ internal fun PaywallComponentsTemplate_Preview(
         activelySubscribedProductIds = emptySet(),
         purchasedNonSubscriptionProductIds = emptySet(),
         storefrontCountryCode = "US",
-        dateProvider = { Date() },
+        dateProvider = { Date(MILLIS_2025_04_23) },
     )
 
     ProvidePreviewImageLoader(PaywallTemplateImageLoader(LocalContext.current)) {


### PR DESCRIPTION
## Motivation
Since we now have a few templates with date variables, we should use a fixed date to avoid seeing changed snapshots daily. 