### PR TITLE
[Paywalls v2] Improves `PaywallComponentsTemplatePreviewRecorder` stability

### DIFF
--- a/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
+++ b/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import org.junit.After
-import org.junit.Before
+import org.junit.AfterClass
+import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -50,16 +50,18 @@ class PaywallComponentsTemplatePreviewRecorder(
                 .map { offering -> arrayOf(offering.identifier, offering) }
                 .toList()
         }
-    }
 
-    @Before
-    fun setup() {
-        Dispatchers.setMain(newSingleThreadContext("PaywallComponentsTemplatePreviewRecorder-main-dispatcher"))
-    }
+        @JvmStatic
+        @BeforeClass
+        fun setup() {
+            Dispatchers.setMain(newSingleThreadContext("PaywallComponentsTemplatePreviewRecorder-main-dispatcher"))
+        }
 
-    @After
-    fun teardown() {
-        Dispatchers.resetMain()
+        @JvmStatic
+        @AfterClass
+        fun teardown() {
+            Dispatchers.resetMain()
+        }
     }
 
     @Suppress("TestFunctionName", "FunctionNaming")


### PR DESCRIPTION
## Motivation
`PaywallComponentsTemplatePreviewRecorder` uses a dedicated main Dispatcher, which in turn is used by Coil to call our preview ImageLoader. Without this dedicated main Dispatcher, recording the screenshots hangs after the first template. 
   
We've been getting [some failures](https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/14987/workflows/2f1f1294-8839-4918-8dd6-c2085ed2a74b/jobs/74784/tests) related to concurrently setting and resetting the main Dispatcher in CI though:
>Dispatchers.Main is used concurrently with setting it 
  
This isn't happening locally for me, but maybe CI runs the individual test cases (templates) of the parameterized test (slightly) in parallel?

In this PR we only set and reset the main Dispatcher once for all of `PaywallComponentsTemplatePreviewRecorder`.