### PR TITLE
[Paywalls V2] Improves fuzzy matching locale when the region doesn't match

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/Localization.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ktx/Localization.kt
@@ -84,6 +84,10 @@ internal fun LocaleId.toJavaLocale(): JavaLocale =
     JavaLocale.forLanguageTag(value.replace('_', '-'))
 
 @JvmSynthetic
+internal fun JavaLocale.toLocaleId(): LocaleId =
+    LocaleId(toLanguageTag().replace('-', '_'))
+
+@JvmSynthetic
 internal fun ComposeLocale.toLocaleId(): LocaleId =
     LocaleId(toLanguageTag().replace('-', '_'))
 
@@ -114,7 +118,7 @@ internal fun Set<LocaleId>.getBestMatch(localeId: LocaleId): LocaleId? {
         val languageId = LocaleId(language)
         val languageScriptId = script?.let { LocaleId("${language}_$script") }
         val languageScriptRegionId = script?.let { LocaleId("${language}_${script}_$region") }
-        val exactId = LocaleId(preferredLocale.toLanguageTag().replace('-', '_'))
+        val exactId = preferredLocale.toLocaleId()
 
         // First see if we can find an exact match of one of our permutations:
         buildList {
@@ -128,8 +132,8 @@ internal fun Set<LocaleId>.getBestMatch(localeId: LocaleId): LocaleId? {
         // If not, try a fuzzy match by dropping the region:
         val javaLocales = this.map { it.toJavaLocale() }
 
-        languageScriptId?.takeIf { javaLocales.any { it.language == language && it.script == script } }
-            ?: languageId.takeIf { javaLocales.any { it.language == language } }
+        javaLocales.firstOrNull { it.language == language && it.script == script }?.toLocaleId()
+            ?: javaLocales.firstOrNull { it.language == language }?.toLocaleId()
     }
 }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsLocaleTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsLocaleTests.kt
@@ -270,7 +270,7 @@ internal class PaywallStateLoadedComponentsLocaleTests(
                 ),
             ),
             arrayOf(
-                "simplified Chinese zh-Hant-TW -> zh-Hant-HK",
+                "traditional Chinese zh-Hant-TW -> zh-Hant-HK",
                 Args(
                     paywallLocales = nonEmptyListOf("zh_Hans_MY", "zh_Hant_HK"),
                     deviceLocales = nonEmptyListOf("zh-Hant-TW", "zh-Hans-MY"),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsLocaleTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsLocaleTests.kt
@@ -82,13 +82,21 @@ internal class PaywallStateLoadedComponentsLocaleTests(
                 ),
             ),
             arrayOf(
-                "device locale only matches language, not region",
+                "device locale only matches language, not region, en-IE -> en-US",
                 Args(
                     paywallLocales = nonEmptyListOf("en_US", "es_ES"),
                     deviceLocales = nonEmptyListOf("en-IE", "es-ES"),
                     // Even though there's an exact language and region match for Spanish, we pick English as that has
                     // higher priority.
-                    expected = "en",
+                    expected = "en-US",
+                ),
+            ),
+            arrayOf(
+                "device locale only matches language, not region, es-AR -> es-ES",
+                Args(
+                    paywallLocales = nonEmptyListOf("en_US", "es_ES"),
+                    deviceLocales = nonEmptyListOf("es-AR",),
+                    expected = "es-ES",
                 ),
             ),
             arrayOf(
@@ -172,13 +180,13 @@ internal class PaywallStateLoadedComponentsLocaleTests(
                 ),
             ),
             arrayOf(
-                "simplified Chinese zh-Hans-MY -> zh-Hans",
+                "simplified Chinese zh-Hans-MY -> zh-Hans-CN",
                 Args(
                     paywallLocales = nonEmptyListOf("zh_Hant_TW", "zh_Hans_CN"),
                     deviceLocales = nonEmptyListOf("zh-Hans-MY", "zh-Hant-TW"),
                     // Even though there's an exact language and region match for traditional Chinese, we pick
                     // simplified Chinese as that has higher device priority.
-                    expected = "zh-Hans",
+                    expected = "zh-Hans-CN",
                 ),
             ),
             arrayOf(
@@ -262,13 +270,13 @@ internal class PaywallStateLoadedComponentsLocaleTests(
                 ),
             ),
             arrayOf(
-                "simplified Chinese zh-Hant-TW -> zh-Hant",
+                "simplified Chinese zh-Hant-TW -> zh-Hant-HK",
                 Args(
                     paywallLocales = nonEmptyListOf("zh_Hans_MY", "zh_Hant_HK"),
                     deviceLocales = nonEmptyListOf("zh-Hant-TW", "zh-Hans-MY"),
                     // Even though there's an exact language and region match for simplified Chinese, we pick
                     // traditional Chinese as that has higher device priority.
-                    expected = "zh-Hant",
+                    expected = "zh-Hant-HK",
                 ),
             ),
             arrayOf(


### PR DESCRIPTION
## Bug
We were still not always properly localizing the paywall when the region doesn't match between the device and the paywall configuration.

## Cause
This is caused by the fact that in this scenario we use a LocaleId containing only the language and script, without the region. If we then try to find this LocaleId in the paywall's localizations map, we can't find any, because the localizations map contains a region.

## Fix
We use the matched locale ID as it exists in the paywall config, instead of a permutation.