### PR TITLE
Add async storefront country code apis

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -21,6 +21,7 @@ import com.revenuecat.purchases.amazon.AmazonConfiguration;
 import com.revenuecat.purchases.customercenter.CustomerCenterListener;
 import com.revenuecat.purchases.customercenter.CustomerCenterManagementOption;
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback;
+import com.revenuecat.purchases.interfaces.GetStorefrontCallback;
 import com.revenuecat.purchases.interfaces.LogInCallback;
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback;
 import com.revenuecat.purchases.interfaces.RedeemWebPurchaseListener;
@@ -87,6 +88,16 @@ final class PurchasesAPI {
             }
         };
 
+        final GetStorefrontCallback getStorefrontCallback = new GetStorefrontCallback() {
+            @Override
+            public void onReceived(@NonNull String storefrontCountryCode) {
+            }
+
+            @Override
+            public void onError(@NonNull PurchasesError error) {
+            }
+        };
+
         purchases.syncAttributesAndOfferingsIfNeeded(syncAttributesAndOfferingsCallback);
         purchases.syncPurchases();
         purchases.syncPurchases(syncPurchasesCallback);
@@ -112,6 +123,7 @@ final class PurchasesAPI {
         final Store store = purchases.getStore();
 
         final String storefrontCountryCode = purchases.getStorefrontCountryCode();
+        purchases.getStorefrontCountryCode(getStorefrontCallback);
 
         final PurchasesConfiguration configuration = purchases.getCurrentConfiguration();
 

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.awaitCustomerInfo
 import com.revenuecat.purchases.awaitLogIn
 import com.revenuecat.purchases.awaitLogOut
 import com.revenuecat.purchases.awaitRestore
+import com.revenuecat.purchases.awaitStorefrontCountryCode
 import com.revenuecat.purchases.awaitSyncAttributesAndOfferingsIfNeeded
 import com.revenuecat.purchases.awaitSyncPurchases
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
@@ -31,7 +32,9 @@ import com.revenuecat.purchases.data.LogInResult
 import com.revenuecat.purchases.getAmazonLWAConsentStatus
 import com.revenuecat.purchases.getAmazonLWAConsentStatusWith
 import com.revenuecat.purchases.getCustomerInfoWith
+import com.revenuecat.purchases.getStorefrontCountryCodeWith
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback
+import com.revenuecat.purchases.interfaces.GetStorefrontCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.RedeemWebPurchaseListener
@@ -73,6 +76,10 @@ private class PurchasesAPI {
             override fun onSuccess(status: AmazonLWAConsentStatus) {}
             override fun onError(error: PurchasesError) {}
         }
+        val getStorefrontCallback = object : GetStorefrontCallback {
+            override fun onReceived(storefrontCountryCode: String) {}
+            override fun onError(error: PurchasesError) {}
+        }
 
         purchases.syncAttributesAndOfferingsIfNeeded(syncAttributesAndOfferingsCallback)
         purchases.getAmazonLWAConsentStatus(getAmazonLWAConsentStatusCallback)
@@ -100,6 +107,7 @@ private class PurchasesAPI {
         val store: Store = purchases.store
 
         val countryCode = purchases.storefrontCountryCode
+        purchases.getStorefrontCountryCode(getStorefrontCallback)
 
         val configuration: PurchasesConfiguration = purchases.currentConfiguration
 
@@ -112,6 +120,10 @@ private class PurchasesAPI {
     fun checkListenerConversions(
         purchases: Purchases,
     ) {
+        purchases.getStorefrontCountryCodeWith(
+            onError = { _: PurchasesError -> },
+            onSuccess = { _: String -> },
+        )
         purchases.logInWith(
             "",
             onError = { _: PurchasesError -> },
@@ -154,6 +166,7 @@ private class PurchasesAPI {
     suspend fun checkCoroutines(
         purchases: Purchases,
     ) {
+        val storefrontCountryCode: String = purchases.awaitStorefrontCountryCode()
         val customerInfo: CustomerInfo = purchases.awaitCustomerInfo()
         val customerInfoFetchPolicy: CustomerInfo =
             purchases.awaitCustomerInfo(fetchPolicy = CacheFetchPolicy.FETCH_CURRENT)

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -92,6 +92,11 @@ class Purchases internal constructor(
     val appUserID: String
         @Synchronized get() = purchasesOrchestrator.appUserID
 
+    /**
+     * The storefront country code in ISO-3166-1 alpha2.
+     * This may be null if the store hasn't connected yet or fetching the country code hasn't finished or failed.
+     * To get the country code asynchronously use [getStorefrontCountryCode] or [awaitStorefrontCountryCode].
+     */
     val storefrontCountryCode: String?
         @Synchronized get() = purchasesOrchestrator.storefrontCountryCode
 

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -18,6 +18,7 @@ import com.revenuecat.purchases.interfaces.Callback
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback
 import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
+import com.revenuecat.purchases.interfaces.GetStorefrontCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
@@ -148,6 +149,14 @@ class Purchases internal constructor(
     }
 
     // region Public Methods
+
+    /**
+     * This method will try to obtain the Store (Google/Amazon) country code in ISO-3166-1 alpha2.
+     * If there is any error, it will return null and log said error.
+     */
+    fun getStorefrontCountryCode(callback: GetStorefrontCallback) {
+        purchasesOrchestrator.getStorefrontCountryCode(callback)
+    }
 
     /**
      * This method will send all the purchases to the RevenueCat backend. Call this when using your own implementation

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
@@ -9,6 +9,23 @@ import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
 /**
+ * This method will try to obtain the Store (Google/Amazon) country code in ISO-3166-1 alpha2.
+ * If there is any error, it will return null and log said error.
+ * Coroutine friendly version of [Purchases.getStorefrontCountryCode].
+ *
+ * @throws [PurchasesException] with a [PurchasesError] if there's an error retrieving the country code.
+ * @return The Store country code in ISO-3166-1 alpha2.
+ */
+suspend fun Purchases.awaitStorefrontCountryCode(): String {
+    return suspendCoroutine { continuation ->
+        getStorefrontCountryCodeWith(
+            onSuccess = continuation::resume,
+            onError = { continuation.resumeWithException(PurchasesException(it)) },
+        )
+    }
+}
+
+/**
  * Get latest available customer info.
  * Coroutine friendly version of [Purchases.getCustomerInfo].
  *

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback
 import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback
+import com.revenuecat.purchases.interfaces.GetStorefrontCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.ProductChangeCallback
 import com.revenuecat.purchases.interfaces.SyncAttributesAndOfferingsCallback
@@ -89,6 +90,28 @@ internal fun getCustomerCenterConfigDataListener(
     override fun onError(error: PurchasesError) {
         onError(error)
     }
+}
+
+/**
+ * This method will try to obtain the Store (Google/Amazon) country code in ISO-3166-1 alpha2.
+ * If there is any error, it will return null and log said error.
+ * @param [onSuccess] Will be called after the call has completed.
+ * @param [onError] Will be called after the call has completed with an error.
+ */
+@Suppress("unused")
+fun Purchases.getStorefrontCountryCodeWith(
+    onError: (error: PurchasesError) -> Unit = ON_ERROR_STUB,
+    onSuccess: (storefrontCountryCode: String) -> Unit,
+) {
+    getStorefrontCountryCode(object : GetStorefrontCallback {
+        override fun onReceived(storefrontCountryCode: String) {
+            onSuccess(storefrontCountryCode)
+        }
+
+        override fun onError(error: PurchasesError) {
+            onError(error)
+        }
+    })
 }
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -51,6 +51,7 @@ import com.revenuecat.purchases.interfaces.Callback
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback
 import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
+import com.revenuecat.purchases.interfaces.GetStorefrontCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.ProductChangeCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
@@ -275,6 +276,23 @@ internal class PurchasesOrchestrator(
     }
 
     // region Public Methods
+
+    fun getStorefrontCountryCode(callback: GetStorefrontCallback) {
+        storefrontCountryCode?.let {
+            callback.onReceived(it)
+        } ?: run {
+            billing.getStorefront(
+                onSuccess = { countryCode ->
+                    storefrontCountryCode = countryCode
+                    callback.onReceived(countryCode)
+                },
+                onError = { error ->
+                    errorLog(error)
+                    callback.onError(error)
+                },
+            )
+        }
+    }
 
     fun syncAttributesAndOfferingsIfNeeded(
         callback: SyncAttributesAndOfferingsCallback,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetStorefrontCallback.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetStorefrontCallback.kt
@@ -1,0 +1,25 @@
+//  Purchases
+//
+//  Copyright © 2025 RevenueCat, Inc. All rights reserved.
+//
+package com.revenuecat.purchases.interfaces
+
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.PurchasesError
+
+/**
+ * Interface to be implemented when calling [Purchases.getStorefrontCountryCode]
+ */
+interface GetStorefrontCallback {
+    /**
+     * Will be called after the call has completed.
+     * @param customerInfo [CustomerInfo] class sent back when the call has completed
+     */
+    fun onReceived(storefrontCountryCode: String)
+
+    /**
+     * Will be called after the call has completed with an error.
+     * @param error A [PurchasesError] containing the reason for the failure of the call
+     */
+    fun onError(error: PurchasesError)
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetStorefrontCallback.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetStorefrontCallback.kt
@@ -13,7 +13,7 @@ import com.revenuecat.purchases.PurchasesError
 interface GetStorefrontCallback {
     /**
      * Will be called after the call has completed.
-     * @param customerInfo [CustomerInfo] class sent back when the call has completed
+     * @param storefrontCountryCode [String] containing the Store country code in ISO-3166-1 alpha2
      */
     fun onReceived(storefrontCountryCode: String)
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetStorefrontCallback.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetStorefrontCallback.kt
@@ -4,7 +4,6 @@
 //
 package com.revenuecat.purchases.interfaces
 
-import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.PurchasesError
 
 /**

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -130,6 +130,7 @@ internal class PurchasesTest : BasePurchasesTest() {
         var storefrontCountryCode: String? = null
         purchases.getStorefrontCountryCodeWith { storefrontCountryCode = it }
 
+        assertThat(storefrontCountryCode).isEqualTo("test-storefront")
         assertThat(purchases.storefrontCountryCode).isEqualTo("test-storefront")
         verify(exactly = 1) { mockBillingAbstract.getStorefront(any(), any()) }
     }
@@ -155,6 +156,21 @@ internal class PurchasesTest : BasePurchasesTest() {
 
         assertThat(purchases.storefrontCountryCode).isEqualTo("test-storefront")
         verify(exactly = 1) { mockBillingAbstract.getStorefront(any(), any()) }
+    }
+
+    @Test
+    fun `if getting storefront fails, it propagates failure`() {
+        every { mockBillingAbstract.getStorefront(any(), captureLambda()) }.answers {
+            lambda<(PurchasesError) -> Unit>().captured.invoke(PurchasesError(PurchasesErrorCode.StoreProblemError))
+        }
+
+        var error: PurchasesError? = null
+        purchases.getStorefrontCountryCodeWith(
+            onError = { error = it },
+            onSuccess = { fail("Should error") }
+        )
+
+        assertThat(error?.code).isEqualTo(PurchasesErrorCode.StoreProblemError)
     }
 
     // endregion storefrontCountryCode

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -117,6 +117,48 @@ internal class PurchasesTest : BasePurchasesTest() {
         assertThat(purchases.appUserID).isEqualTo(appUserId)
     }
 
+    // region storefrontCountryCode
+
+    @Test
+    fun `getting storefront country code calls billing store with correct parameters`() {
+        assertThat(purchases.storefrontCountryCode).isNull()
+
+        every { mockBillingAbstract.getStorefront(captureLambda(), any()) }.answers {
+            lambda<(String) -> Unit>().captured.invoke("test-storefront")
+        }
+
+        var storefrontCountryCode: String? = null
+        purchases.getStorefrontCountryCodeWith { storefrontCountryCode = it }
+
+        assertThat(purchases.storefrontCountryCode).isEqualTo("test-storefront")
+        verify(exactly = 1) { mockBillingAbstract.getStorefront(any(), any()) }
+    }
+
+    @Test
+    fun `if already there, getting storefront country code does not calls billing store`() {
+        assertThat(purchases.storefrontCountryCode).isNull()
+
+        every { mockBillingAbstract.getStorefront(captureLambda(), any()) }.answers {
+            lambda<(String) -> Unit>().captured.invoke("test-storefront")
+        }
+
+        purchases.getStorefrontCountryCodeWith {  }
+
+        assertThat(purchases.storefrontCountryCode).isEqualTo("test-storefront")
+        verify(exactly = 1) { mockBillingAbstract.getStorefront(any(), any()) }
+
+        every { mockBillingAbstract.getStorefront(captureLambda(), any()) }.answers {
+            lambda<(String) -> Unit>().captured.invoke("test-storefront-should-not-be-called")
+        }
+
+        purchases.getStorefrontCountryCodeWith {  }
+
+        assertThat(purchases.storefrontCountryCode).isEqualTo("test-storefront")
+        verify(exactly = 1) { mockBillingAbstract.getStorefront(any(), any()) }
+    }
+
+    // endregion storefrontCountryCode
+
     // region purchasing
 
     @Test


### PR DESCRIPTION
### Description
We already had a `Purchases.storefrontCountryCode` property. This basically was null until the storefront property was returned. 

This PR adds some new APIs to obtain the `storefrontCountryCode` asynchronously, which is the real nature of this data