### PR TITLE
Product name truncation issue in Customer Center on Android

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
@@ -130,7 +130,7 @@ internal fun SubscriptionDetailsRow(
             Text(
                 text = title,
                 style = titleTextStyle,
-                maxLines = 1,
+                maxLines = 2,
                 modifier = Modifier.alpha(
                     if (prominentSubtitle) SettingsRowSupportingTextAlpha else SettingsRowMainTextAlpha,
                 ),
@@ -257,6 +257,29 @@ private class SubscriptionInformationProvider : PreviewParameterProvider<Purchas
         ),
         PurchaseInformation(
             title = "Basic",
+            durationTitle = "Weekly",
+            price = PriceDetails.Paid("$1.99"),
+            explanation = Explanation.EXPIRED,
+            expirationOrRenewal =
+            ExpirationOrRenewal(
+                ExpirationOrRenewal.Label.EXPIRED,
+                ExpirationOrRenewal.Date.DateString("June 1st, 2024"),
+            ),
+            store = Store.PLAY_STORE,
+            managementURL = Uri.parse(MANAGEMENT_URL),
+            product = TestStoreProduct(
+                "basic_weekly",
+                "name",
+                "title",
+                "description",
+                Price("$0.99", 990_000, "US"),
+                Period(1, Period.Unit.WEEK, "P1W"),
+            ),
+            isLifetime = false,
+        ),
+
+        PurchaseInformation(
+            title = "This is a very long title that will be two lines",
             durationTitle = "Weekly",
             price = PriceDetails.Paid("$1.99"),
             explanation = Explanation.EXPIRED,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/SubscriptionDetailsView.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -131,6 +132,7 @@ internal fun SubscriptionDetailsRow(
                 text = title,
                 style = titleTextStyle,
                 maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.alpha(
                     if (prominentSubtitle) SettingsRowSupportingTextAlpha else SettingsRowMainTextAlpha,
                 ),
@@ -138,7 +140,6 @@ internal fun SubscriptionDetailsRow(
             Text(
                 text = subtitle,
                 style = subtitleTextStyle,
-                maxLines = 2,
                 modifier = Modifier.alpha(
                     if (prominentSubtitle) SettingsRowMainTextAlpha else SettingsRowSupportingTextAlpha,
                 ),
@@ -279,7 +280,7 @@ private class SubscriptionInformationProvider : PreviewParameterProvider<Purchas
         ),
 
         PurchaseInformation(
-            title = "This is a very long title that will be two lines",
+            title = "Monthly long subscription name that overflows",
             durationTitle = "Weekly",
             price = PriceDetails.Paid("$1.99"),
             explanation = Explanation.EXPIRED,


### PR DESCRIPTION
The subscription name is truncated by the Customer Center. 

For example "Monthly long subscription name" looks like:

<img width="202" alt="Screenshot 2025-04-16 at 11 57 27" src="https://github.com/user-attachments/assets/d88d9b15-4e64-4dfa-acfb-f27dd33bd9e0" />

Made it max 2 lines and added elipsis

<img width="204" alt="Screenshot 2025-04-16 at 12 00 18" src="https://github.com/user-attachments/assets/b05665a3-da6c-4dc8-93f4-b8dd9729f480" />
