### PR TITLE
Do not fail the build if `local.properties` does not exist.

### DIFF
--- a/examples/CustomEntitlementComputationSample/app/build.gradle.kts
+++ b/examples/CustomEntitlementComputationSample/app/build.gradle.kts
@@ -7,7 +7,8 @@ plugins {
 }
 
 val localProperties = Properties()
-localProperties.load(FileInputStream(rootProject.file("local.properties")))
+val localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) localProperties.load(FileInputStream(localPropertiesFile))
 
 android {
     namespace = "com.revenuecat.sample"


### PR DESCRIPTION
## Description
As the title says. We've had some CI failures like [this one](https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/15162/workflows/16d4d9c3-8998-497e-a2a8-996d5cda50e0/jobs/76187). This fixes it locally for me.