### PR TITLE
Fixes a typo: matalava -> metalava.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,7 @@ jobs:
           command: ./gradlew detektAll
       - android/save-gradle-cache
 
-  matalava:
+  metalava:
     <<: *android-executor
     shell: /bin/bash --login -o pipefail
     steps:
@@ -775,7 +775,7 @@ workflows:
     jobs:
       - test
       - detekt
-      - matalava
+      - metalava
       - assemble-purchase-tester
       - assemble-paywall-tester-release
       - run-backend-integration-tests


### PR DESCRIPTION
## Description
Super quick follow-up to #2370. Otherwise this typo will live forever 😅 