### PR TITLE
fix: All optional properties

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/responses/SubscriptionInfoResponse.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/responses/SubscriptionInfoResponse.kt
@@ -19,35 +19,35 @@ internal data class SubscriptionInfoResponse(
     @SerialName("purchase_date") @Serializable(with = ISO8601DateSerializer::class)
     val purchaseDate: Date,
     @SerialName("original_purchase_date") @Serializable(with = ISO8601DateSerializer::class)
-    val originalPurchaseDate: Date?,
+    val originalPurchaseDate: Date? = null,
     @SerialName("expires_date") @Serializable(with = ISO8601DateSerializer::class)
-    val expiresDate: Date?,
+    val expiresDate: Date? = null,
     @SerialName("store")
     val store: Store,
     @SerialName("is_sandbox")
     val isSandbox: Boolean,
     @SerialName("unsubscribe_detected_at") @Serializable(with = ISO8601DateSerializer::class)
-    val unsubscribeDetectedAt: Date?,
+    val unsubscribeDetectedAt: Date? = null,
     @SerialName("billing_issues_detected_at") @Serializable(with = ISO8601DateSerializer::class)
-    val billingIssuesDetectedAt: Date?,
+    val billingIssuesDetectedAt: Date? = null,
     @SerialName("grace_period_expires_date") @Serializable(with = ISO8601DateSerializer::class)
-    val gracePeriodExpiresDate: Date?,
+    val gracePeriodExpiresDate: Date? = null,
     @SerialName("ownership_type")
     val ownershipType: OwnershipType = OwnershipType.UNKNOWN,
     @SerialName("period_type")
     val periodType: PeriodType,
     @SerialName("refunded_at") @Serializable(with = ISO8601DateSerializer::class)
-    val refundedAt: Date?,
+    val refundedAt: Date? = null,
     @SerialName("store_transaction_id")
-    val storeTransactionId: String?,
+    val storeTransactionId: String? = null,
     @SerialName("auto_resume_date") @Serializable(with = ISO8601DateSerializer::class)
-    val autoResumeDate: Date?,
+    val autoResumeDate: Date? = null,
     @SerialName("display_name")
-    val displayName: String?,
+    val displayName: String? = null,
     @SerialName("price")
-    val price: PriceResponse?,
+    val price: PriceResponse? = null,
     @SerialName("product_plan_identifier")
-    val productPlanIdentifier: String?,
+    val productPlanIdentifier: String? = null,
 ) {
 
     @Serializable


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

This resolves a JSON parsing issue for the subscriptions where properties that are marked optional e.g. `String?` did not have an initial value and thus if they were not present in the decoded JSON string it would instead produce a deserialisation error like so:

```
04-24 14:39:41.911 12055 12055 E [Purchases] - ERROR: Error deserializing subscription information. The input is not a SubscriptionInfo
04-24 14:39:41.911 12055 12055 E [Purchases] - ERROR: kotlinx.serialization.MissingFieldException: Field 'product_plan_identifier' is required for type with serial name 'com.revenuecat.purchases.common.responses.SubscriptionInfoResponse', but it was missing at path: $
04-24 14:39:41.911 12055 12055 E [Purchases] - ERROR: 	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:93)
04-24 14:39:41.911 12055 12055 E [Purchases] - ERROR: 	at kotlinx.serialization.json.Json.decodeFromString(Json.kt:107)
04-24 14:39:41.911 12055 12055 E [Purchases] - ERROR: 	at com.revenuecat.purchases.common.CustomerInfoFactory.parseSubscriptionInfos(CustomerInfoFactory.kt:161)
04-24 14:39:41.911 12055 12055 E [Purchases] - ERROR: 	at com.revenuecat.purchases.CustomerInfo$subscriptionsByProductIdentifier$2.invoke(CustomerInfo.kt:121)
04-24 14:39:41.911 12055 12055 E [Purchases] - ERROR: 	at com.revenuecat.purchases.CustomerInfo$subscriptionsByProductIdentifier$2.invoke(CustomerInfo.kt:120)
```

This also resolves the following issue that was posted (and experienced firsthand) in the React Native SDK here - https://github.com/RevenueCat/react-native-purchases/issues/1248

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

The changes in this PR simply follow the Kotlin Serialization guide here which states that for an optional property a initial value should be specified here - https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/basic-serialization.md#optional-properties
