### PR TITLE
[Paywalls v2] Avoid image cropping when combining single-sided margin with Fixed size constraint

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -101,6 +101,8 @@ internal fun ImageComponentView(
         // in order to have the border applied on top of the overlay, which uses onDrawWithContent
         Box(
             modifier = modifier
+                .size(imageState.marginAdjustedSize)
+                .applyIfNotNull(imageState.marginAdjustedAspectRatio) { aspectRatio(it) }
                 .padding(imageState.margin)
                 .applyIfNotNull(shadowStyle) { shadow(it, composeShape) }
                 .clip(composeShape)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentView.kt
@@ -101,8 +101,6 @@ internal fun ImageComponentView(
         // in order to have the border applied on top of the overlay, which uses onDrawWithContent
         Box(
             modifier = modifier
-                .size(imageState.size)
-                .applyIfNotNull(imageState.aspectRatio) { aspectRatio(it) }
                 .padding(imageState.margin)
                 .applyIfNotNull(shadowStyle) { shadow(it, composeShape) }
                 .clip(composeShape)
@@ -468,6 +466,28 @@ private fun ImageComponentView_Preview_MaskShape(
                     size = Size(width = Fixed(400u), height = Fixed(200u)),
                     fitMode = FitMode.FIT,
                     shape = maskShape,
+                ),
+                state = previewEmptyState(),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ImageComponentView_Preview_FixedFixedFitMargin() {
+    val themeImageUrls = previewThemeImageUrls(widthPx = 96u, heightPx = 96u)
+    ProvidePreviewImageLoader(previewImageLoader(themeImageUrls)) {
+        Box(modifier = Modifier.background(ComposeColor.Red)) {
+            ImageComponentView(
+                style = previewImageComponentStyle(
+                    themeImageUrls = themeImageUrls,
+                    size = Size(width = Fixed(24u), height = Fixed(24u)),
+                    fitMode = FitMode.FIT,
+                    shape = MaskShape.Rectangle(),
+                    marginValues = PaddingValues(end = 8.dp),
+                    border = null,
+                    shadow = null,
                 ),
                 state = previewEmptyState(),
             )


### PR DESCRIPTION
## Bug
Adding a margin to a single side of an image component with Fixed size constraints would result in the image being cropped as it would treat it as padding.

## Fix
Adjusts the size and aspect ratio modifiers of the outer `Box`, to ensure it grows enough to account for the margin. 