### PR TITLE
Fix pre commit hook

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -15,7 +15,7 @@ if [ $EXIT_CODE -ne 0 ]; then
 fi
 rm $OUTPUT
 
-echo "Running metalava (defaults) check..."
+echo "Running metalava check on defaultsRelease..."
 ./gradlew metalavaCheckCompatibilityDefaultsRelease -q
 EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then
@@ -27,7 +27,7 @@ if [ $EXIT_CODE -ne 0 ]; then
   exit $EXIT_CODE
 fi
 
-echo "Running metalava (custom entitlement) check..."
+echo "Running metalava check on customEntitlementComputationRelease..."
 ./gradlew metalavaCheckCompatibilityCustomEntitlementComputationRelease -q
 EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then


### PR DESCRIPTION
The parenthesis were causing issues on the pre-commit:

```
.git/hooks/pre-commit: line 30: syntax error near unexpected token `('
.git/hooks/pre-commit: line 30: `echo "Running metalava (custom entitlement) check..."'
```