### PR TITLE
Fixes pre-commit script

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -2,18 +2,18 @@
 
 echo "Running detekt check..."
 OUTPUT="/tmp/detekt-$(date +%s)"
-./gradlew detektAll > $OUTPUT
+./gradlew detektAll > "$OUTPUT"
 EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then
-  cat $OUTPUT
-  rm $OUTPUT
+  cat "$OUTPUT"
+  rm "$OUTPUT"
   echo "***********************************************"
   echo "                 Detekt failed                 "
   echo " Please fix the above issues before committing "
   echo "***********************************************"
   exit $EXIT_CODE
 fi
-rm $OUTPUT
+rm "$OUTPUT"
 
 echo "Running metalava (defaults) check..."
 ./gradlew metalavaCheckCompatibilityDefaultsRelease -q
@@ -23,7 +23,7 @@ if [ $EXIT_CODE -ne 0 ]; then
 
   ./gradlew metalavaGenerateSignatureDefaultsRelease -q
 
-  echo "API dump done. Please check the updated API dump and add it to your commit.
+  echo "API dump done. Please check the updated API dump and add it to your commit."
   exit $EXIT_CODE
 fi
 
@@ -35,6 +35,6 @@ if [ $EXIT_CODE -ne 0 ]; then
 
   ./gradlew metalavaGenerateSignatureCustomEntitlementComputationRelease -q
 
-  echo "API dump done. Please check the updated API dump and add it to your commit.
+  echo "API dump done. Please check the updated API dump and add it to your commit."
   exit $EXIT_CODE
 fi


### PR DESCRIPTION
- Adds closing quotes to the `echo` message parameter (this was breaking)
- Adds quotes around the OUTPUT variable (not breaking but a shellcheck warning)
