### PR TITLE
Fix downgrade of constraint layout version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ activityCompose = "1.9.3"
 # We should not add that permission ourselves, so keeping it at 17.0.1 for now.
 adsIdentifier = "17.0.1"
 amazon = "3.0.5"
+androidxConstraintLayout = "2.1.3"
 androidxCore = "1.8.0"
 androidxNavigation = "2.5.3"
 annotation = "1.3.0"
@@ -56,7 +57,7 @@ activity-compose = { module = "androidx.activity:activity-compose", version.ref 
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
-androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidxConstraintLayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreference" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }


### PR DESCRIPTION
It looks like this change https://github.com/RevenueCat/purchases-android/pull/2318/files#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR59 downgraded the version of `androidx.constraintlayout` to `1.1.0`

I am suspicious it could be causing https://github.com/RevenueCat/react-native-purchases/issues/1266