### PR TITLE
[Paywalls V2] Support stroke color and width in Carousel indicator

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/CarouselComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/CarouselComponent.kt
@@ -77,7 +77,17 @@ class CarouselComponent(
         @get:JvmSynthetic
         @SerialName("ms_transition_time")
         val msTransitionTime: Int,
-    )
+        @get:JvmSynthetic
+        @SerialName("transition_type")
+        val transitionType: TransitionType?,
+    ) {
+        @Serializable(with = CarouselTransitionTypeDeserializer::class)
+        enum class TransitionType {
+            // SerialNames are handled by the CarouselTransitionTypeDeserializer.
+            FADE,
+            SLIDE,
+        }
+    }
 
     @Poko
     @Serializable
@@ -114,6 +124,12 @@ class CarouselComponent(
             val height: UInt,
             @get:JvmSynthetic
             val color: ColorScheme,
+            @get:JvmSynthetic
+            @SerialName("stroke_color")
+            val strokeColor: ColorScheme? = null,
+            @get:JvmSynthetic
+            @SerialName("stroke_width")
+            val strokeWidth: UInt? = null,
         )
 
         @Serializable(with = CarouselPageControlPositionDeserializer::class)
@@ -175,3 +191,9 @@ class PartialCarouselComponent(
 internal object CarouselPageControlPositionDeserializer : EnumDeserializerWithDefault<PageControl.Position>(
     defaultValue = PageControl.Position.BOTTOM,
 )
+
+@OptIn(InternalRevenueCatAPI::class)
+internal object CarouselTransitionTypeDeserializer :
+    EnumDeserializerWithDefault<CarouselComponent.AutoAdvancePages.TransitionType>(
+        defaultValue = CarouselComponent.AutoAdvancePages.TransitionType.SLIDE,
+    )

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/CarouselComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/CarouselComponentTests.kt
@@ -186,7 +186,8 @@ internal class CarouselComponentTests {
                           "loop": true,
                           "auto_advance": {
                             "ms_time_per_page": 1000,
-                            "ms_transition_time": 500
+                            "ms_transition_time": 500,
+                            "transition_type": "fade"
                           },
                           "pages": [
                             {
@@ -288,7 +289,8 @@ internal class CarouselComponentTests {
                             loop = true,
                             autoAdvance = CarouselComponent.AutoAdvancePages(
                                 msTimePerPage = 1000,
-                                msTransitionTime = 500
+                                msTransitionTime = 500,
+                                transitionType = CarouselComponent.AutoAdvancePages.TransitionType.FADE,
                             )
                         )
                     ),
@@ -583,7 +585,8 @@ internal class CarouselComponentTests {
                           "loop": true,
                           "auto_advance": {
                             "ms_time_per_page": 1000,
-                            "ms_transition_time": 500
+                            "ms_transition_time": 500,
+                            "transition_type": "fade"
                           }
                         }
                         """.trimIndent(),
@@ -673,7 +676,8 @@ internal class CarouselComponentTests {
                             loop = true,
                             autoAdvance = CarouselComponent.AutoAdvancePages(
                                 msTimePerPage = 1000,
-                                msTransitionTime = 500
+                                msTransitionTime = 500,
+                                transitionType = CarouselComponent.AutoAdvancePages.TransitionType.FADE,
                             )
                         )
                     )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -6,6 +6,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components.carousel
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -58,6 +59,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.CarouselCompone
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.extensions.applyIfNotNull
+import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import androidx.compose.ui.unit.lerp as lerpUnit
@@ -230,6 +232,16 @@ private fun Indicator(
         }
     }
 
+    val targetStrokeWidth by remember {
+        derivedStateOf {
+            lerpUnit(
+                pageControl.default.strokeWidth ?: 0.dp,
+                pageControl.active.strokeWidth ?: 0.dp,
+                progress,
+            )
+        }
+    }
+
     val width by animateDpAsState(
         targetValue = targetWidth,
     )
@@ -243,12 +255,28 @@ private fun Indicator(
         progress,
     )
 
+    val shouldApplyStroke = (pageControl.default.strokeColor != null || pageControl.active.strokeColor != null) &&
+        (pageControl.default.strokeWidth != null || pageControl.active.strokeWidth != null)
+
+    val strokeColor = lerp(
+        (pageControl.default.strokeColor?.forCurrentTheme as? ColorStyle.Solid)?.color ?: Color.Transparent,
+        (pageControl.active.strokeColor?.forCurrentTheme as? ColorStyle.Solid)?.color ?: Color.Transparent,
+        progress,
+    )
+
+    val strokeWidth by animateDpAsState(
+        targetValue = targetStrokeWidth,
+    )
+
     Box(
         modifier = Modifier
             .padding(horizontal = pageControl.spacing / 2)
             .clip(Shape.Pill.toShape())
             .background(color)
-            .size(width = width, height = height),
+            .size(width = width, height = height)
+            .conditional(shouldApplyStroke) {
+                border(width = strokeWidth, color = strokeColor, shape = Shape.Pill.toShape())
+            },
     )
 }
 
@@ -331,6 +359,7 @@ private fun CarouselComponentView_Loop_Preview() {
                 autoAdvance = CarouselComponent.AutoAdvancePages(
                     msTimePerPage = 1000,
                     msTransitionTime = 500,
+                    transitionType = CarouselComponent.AutoAdvancePages.TransitionType.FADE,
                 ),
             ),
             state = previewEmptyState(),
@@ -416,11 +445,15 @@ private fun previewPageControl(
             width = 14.dp,
             height = 10.dp,
             color = ColorStyles(light = ColorStyle.Solid(Color.Blue)),
+            strokeColor = ColorStyles(light = ColorStyle.Solid(Color.Red)),
+            strokeWidth = 2.dp,
         ),
         default = CarouselComponentStyle.IndicatorStyles(
             width = 8.dp,
             height = 8.dp,
             color = ColorStyles(light = ColorStyle.Solid(Color.Gray)),
+            strokeColor = null,
+            strokeWidth = null,
         ),
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/CarouselComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/CarouselComponentStyle.kt
@@ -97,5 +97,9 @@ internal data class CarouselComponentStyle(
         val height: Dp,
         @get:JvmSynthetic
         val color: ColorStyles,
+        @get:JvmSynthetic
+        val strokeColor: ColorStyles?,
+        @get:JvmSynthetic
+        val strokeWidth: Dp?,
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PageControlExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PageControlExtensions.kt
@@ -23,7 +23,9 @@ internal fun CarouselComponent.PageControl.toPageControlStyles(aliases: Map<Colo
         third = backgroundColor?.toColorStyles(aliases = aliases).orSuccessfullyNull(),
         fourth = border?.toBorderStyles(aliases = aliases).orSuccessfullyNull(),
         fifth = shadow?.toShadowStyles(aliases = aliases).orSuccessfullyNull(),
-    ) { activeColor, defaultColor, backgroundColor, borderStyle, shadowStyle ->
+        sixth = active.strokeColor?.toColorStyles(aliases = aliases).orSuccessfullyNull(),
+        seventh = default.strokeColor?.toColorStyles(aliases = aliases).orSuccessfullyNull(),
+    ) { activeColor, defaultColor, backgroundColor, borderStyle, shadowStyle, activeStrokeColor, defaultStrokeColor ->
         CarouselComponentStyle.PageControlStyles(
             position = position,
             spacing = spacing?.dp ?: 0.dp,
@@ -37,11 +39,15 @@ internal fun CarouselComponent.PageControl.toPageControlStyles(aliases: Map<Colo
                 width = active.width.toInt().dp,
                 height = active.height.toInt().dp,
                 color = activeColor,
+                strokeColor = activeStrokeColor,
+                strokeWidth = active.strokeWidth?.toInt()?.dp,
             ),
             default = CarouselComponentStyle.IndicatorStyles(
                 width = default.width.toInt().dp,
                 height = default.height.toInt().dp,
                 color = defaultColor,
+                strokeColor = defaultStrokeColor,
+                strokeWidth = default.strokeWidth?.toInt()?.dp,
             ),
         )
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/Result.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/Result.kt
@@ -232,6 +232,42 @@ internal inline fun <A, B, C, D, E, F, G, H> zipOrAccumulate(
 }
 
 /**
+ * Combines the values from the provided Results using [transform], or accumulates the errors if at least
+ * one is a [Result.Error].
+ */
+@Suppress("LongParameterList")
+@JvmSynthetic
+internal inline fun <A, B, C, D, E, F, G, H, I> zipOrAccumulate(
+    first: Result<A, NonEmptyList<I>>,
+    second: Result<B, NonEmptyList<I>>,
+    third: Result<C, NonEmptyList<I>>,
+    fourth: Result<D, NonEmptyList<I>>,
+    fifth: Result<E, NonEmptyList<I>>,
+    sixth: Result<F, NonEmptyList<I>>,
+    seventh: Result<G, NonEmptyList<I>>,
+    transform: (A, B, C, D, E, F, G) -> H,
+): Result<H, NonEmptyList<I>> {
+    // This one can be extended to support as many parameters as we need.
+    val results = listOf(first, second, third, fourth, fifth, sixth)
+    val errors = results.collectErrors()
+
+    return errors.toNonEmptyListOrNull()
+        ?.let { Result.Error(it) }
+        // We know they're all successful here.
+        ?: Result.Success(
+            transform(
+                (first as Result.Success<A>).value,
+                (second as Result.Success<B>).value,
+                (third as Result.Success<C>).value,
+                (fourth as Result.Success<D>).value,
+                (fifth as Result.Success<E>).value,
+                (sixth as Result.Success<F>).value,
+                (seventh as Result.Success<G>).value,
+            ),
+        )
+}
+
+/**
  * Maps the values from these Results using [transform], or accumulates the errors if at least one is a [Result.Error].
  */
 @JvmSynthetic


### PR DESCRIPTION
### Description
This adds support for stroke color and width for the Carousel indicators.

Equivalent of https://github.com/RevenueCat/purchases-ios/pull/5045