### PR TITLE
Correctly translates variables when a fuzzy match is required.

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentState.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState
 import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition
 import com.revenuecat.purchases.ui.revenuecatui.components.buildPresentedPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.getBestMatch
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toAlignment
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toFontWeight
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toLocaleId
@@ -118,7 +119,9 @@ internal class TextComponentState(
 
     @get:JvmSynthetic
     val localizedVariableKeys by derivedStateOf {
-        style.variableLocalizations.run { getOrDefault(localeId, entry.value) }
+        // We use getBestMatch here, because the localeId in `texts` might be different from the one in
+        // `variableLocalizations`. For instance, `texts` might have `de_DE` while `variableLocalizations` has `de`.
+        style.variableLocalizations.run { getBestMatch(localeId) ?: entry.value }
     }
 
     @get:JvmSynthetic

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/NonEmptyMap.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/NonEmptyMap.kt
@@ -37,6 +37,13 @@ internal class NonEmptyMap<K, out V> private constructor(
         all.mapValues(transform)
             // Make sure the entry still has the same key.
             .let { nonEmptyMapOf(entry = entry.key to it.getValue(entry.key), map = it) }
+
+    @JvmSynthetic
+    inline fun <R> mapKeys(transform: (Map.Entry<K, V>) -> R): NonEmptyMap<R, V> {
+        val mappedEntryKey = transform(entry)
+        val mappedAll = all.mapKeys { if (it.key == entry.key) mappedEntryKey else transform(it) }
+        return nonEmptyMapOf(entry = mappedEntryKey to mappedAll.getValue(mappedEntryKey), map = mappedAll)
+    }
 }
 
 @JvmSynthetic


### PR DESCRIPTION
## Bug
In the offerings response, variables could be keyed by just the language (`de`) while the rest of the strings are keyed by language and region (`de_DE`). 

## Fix
The fix is to apply fuzzy locale matching when looking for the right variables to use. 

I also had to make some other changes to properly set up this scenario in a test.

Fixes https://github.com/RevenueCat/purchases-kmp/issues/386