### PR TITLE
Add coroutines to core SDK

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -108,6 +108,7 @@ compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview"
 compose-ui-util = { module = "androidx.compose.ui:ui-util" }
 compose-window-size = { module = "androidx.compose.material3:material3-window-size-class" }
 
+coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
 detekt-compose = { module = "io.nlopez.compose.rules:detekt", version.ref = "detektRulesCompose" }

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -129,6 +129,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.tink)
     implementation(libs.playServices.ads.identifier)
+    implementation(libs.coroutines.core)
     api(libs.billing)
 
     compileOnly(libs.amazon.appstore.sdk)


### PR DESCRIPTION
### Description
Noticed integration tests were failing building because it wasn't finding the coroutines classes on release. This fixes that issue on release, at the cost of adding a new library.