### PR TITLE
Update `PaywallTester` colors

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/theme/Color.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/theme/Color.kt
@@ -4,10 +4,18 @@ package com.revenuecat.paywallstester.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+// Light Theme Colors
+val warm_beige_background = Color(0xFFF2F1F0) // Warm beige background color
+val off_white_surface = Color(0xFFFAF9F9) // Almost white surface color
+val deep_purple_primary = Color(0xFF6750A4) // Deep purple for primary actions
+val muted_purple_secondary = Color(0xFF625B71) // Muted purple for secondary elements
+val dusty_rose_tertiary = Color(0xFF7D5260) // Dusty rose for tertiary elements
+val charcoal_text = Color(0xFF1C1B1F) // Dark charcoal for text
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+// Dark Theme Colors
+val rich_dark_background = Color(0xFF1C1B1F) // Rich dark background
+val elevated_dark_surface = Color(0xFF2C2C2C) // Slightly lighter surface for elevation
+val light_purple_primary = Color(0xFF6750A4) // Light purple for primary actions
+val muted_purple_dark = Color(0xFF625B71) // Muted purple for secondary elements
+val dusty_rose_dark = Color(0xFF7D5260) // Dusty rose for tertiary elements
+val pure_white_text = Color.White // Pure white for text on dark backgrounds

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/theme/Theme.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/theme/Theme.kt
@@ -15,27 +15,24 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
-private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80,
-    surface = PurpleGrey80,
+private val LightColorScheme = lightColorScheme(
+    primary = deep_purple_primary,
+    secondary = muted_purple_secondary,
+    tertiary = dusty_rose_tertiary,
+    background = warm_beige_background,
+    surface = off_white_surface,
+    onBackground = charcoal_text,
+    onSurface = charcoal_text,
 )
 
-private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40,
-    surface = PurpleGrey80,
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-     */
+private val DarkColorScheme = darkColorScheme(
+    primary = light_purple_primary,
+    secondary = muted_purple_dark,
+    tertiary = dusty_rose_dark,
+    background = rich_dark_background,
+    surface = elevated_dark_surface,
+    onBackground = pure_white_text,
+    onSurface = pure_white_text,
 )
 
 @Composable
@@ -50,7 +47,6 @@ fun PaywallTesterAndroidTheme(
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
-
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
     }
@@ -58,8 +54,15 @@ fun PaywallTesterAndroidTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+            // Set both status bar and navigation bar colors
+            window.statusBarColor = colorScheme.background.toArgb()
+            window.navigationBarColor = colorScheme.background.toArgb()
+
+            // Configure system bars' content color
+            WindowCompat.getInsetsController(window, view).apply {
+                isAppearanceLightStatusBars = !darkTheme
+                isAppearanceLightNavigationBars = !darkTheme
+            }
         }
     }
 

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/theme/Theme.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/theme/Theme.kt
@@ -10,10 +10,8 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 
 private val LightColorScheme = lightColorScheme(
     primary = deep_purple_primary,
@@ -54,15 +52,6 @@ fun PaywallTesterAndroidTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            // Set both status bar and navigation bar colors
-            window.statusBarColor = colorScheme.background.toArgb()
-            window.navigationBarColor = colorScheme.background.toArgb()
-
-            // Configure system bars' content color
-            WindowCompat.getInsetsController(window, view).apply {
-                isAppearanceLightStatusBars = !darkTheme
-                isAppearanceLightNavigationBars = !darkTheme
-            }
         }
     }
 


### PR DESCRIPTION
I've been working on some improvements on the Customer Center and I updated the colors in Paywalls Tester to make it look a bit better.

I extracted those changes into its own PR to make it easier to review.

| Before | After |
|--------|--------|
| <img width="388" alt="Screenshot 2025-06-09 at 20 41 06" src="https://github.com/user-attachments/assets/d2d616ac-f4c2-43c6-b964-d2ae50b51a65" /> | <img width="385" alt="Screenshot 2025-06-09 at 20 38 30" src="https://github.com/user-attachments/assets/99a8bf6d-1d64-4719-9069-78b42a0d29bf" /> |

Example of the updates I've been working on:

| Example |
|--------|
| ![Screenshot_20250609_203348](https://github.com/user-attachments/assets/5541aaff-e98d-4f28-862e-b124ad048333) | 

