### PR TITLE
Include commit hash in commit message for paywall-rendering-validation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -617,6 +617,9 @@ DESC
   desc "Records Paywall template screenshots and pushes them to the repository at target_repository_path"
   lane :record_and_push_paywall_template_screenshots do |options|
     UI.user_error!("Please provide the target_repository_path, and make sure it is cloned.") unless options[:target_repository_path]
+
+    this_commit_hash = sh("git", "rev-parse", "HEAD").strip
+
     target_repository_path = Dir.chdir("..") do
       File.expand_path(options[:target_repository_path])
     end
@@ -661,7 +664,7 @@ DESC
       commit_push_and_create_pr_if_necessary(
         repo: target_repository_name,
         branch_name: target_repository_branch,
-        commit_message: "[Automated] Updates Android template screenshots.",
+        commit_message: "[Automated] Updates Android template screenshots (commit #{this_commit_hash})",
         title: "[AUTOMATIC] Updates Android template screenshots",
         body: "This is an automatic update of the Android template screenshots.",
         team_reviewers: ["coresdk", "monetization", "bab-s"]


### PR DESCRIPTION
The same as https://github.com/RevenueCat/purchases-ios/pull/5265

### Motivation
When CI does a commit into the `paywall-rendering-validation` repo, there's no easy way to identify the origin of that commit.

### Description
This PR adds the hash of the commit of this repo that generates the commit in `paywall-rendering-validation`, so that the commit messages look like this:

> [Automated] Updates Android template screenshots (commit: `61889e5d522fdd116f4dec9bebdc81854eb7ee2b`)