### PR TITLE
`getOfferings()` returns fresh Offerings and Products when the locale has changed

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
@@ -50,8 +50,9 @@ internal class OfferingsCache(
             cachedLanguageTags != localeProvider.currentLocalesLanguageTags
 
     @Synchronized
-    fun clearOfferingsCacheTimestamp() {
+    fun forceCacheStale() {
         offeringsCachedObject.clearCacheTimestamp()
+        cachedLanguageTags = null
     }
 
     // endregion Offerings cache

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -174,7 +174,7 @@ internal class OfferingsManager(
             OfferingStrings.FETCHING_OFFERINGS_ERROR.format(error),
         )
 
-        offeringsCache.clearOfferingsCacheTimestamp()
+        offeringsCache.forceCacheStale()
         dispatch {
             onError?.invoke(error)
         }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/FakeLocaleProvider.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/FakeLocaleProvider.kt
@@ -4,7 +4,7 @@ internal class FakeLocaleProvider(
     vararg languageTags: String,
 ): LocaleProvider {
 
-    private val languageTags: List<String> = languageTags.toList()
+    var languageTags: List<String> = languageTags.toList()
 
     override val currentLocalesLanguageTags: String
         get() = languageTags.joinToString()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.common.offerings
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.FakeLocaleProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.utils.add
 import io.mockk.Runs
@@ -52,6 +53,8 @@ class OfferingsCacheTest {
         assertThat(offeringsCache.cachedOfferings).isNotNull
         offeringsCache.clearCache()
         assertThat(offeringsCache.cachedOfferings).isNull()
+        assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = false)).isTrue
+        assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = true)).isTrue
         verify(exactly = 1) { deviceCache.clearOfferingsResponseCache() }
     }
 
@@ -103,6 +106,91 @@ class OfferingsCacheTest {
     }
 
     // endregion offerings cache
+
+    // region locale cache tests
+
+    @Test
+    fun `cache is not stale when locales remain the same`() {
+        // Arrange
+        val localeProvider = FakeLocaleProvider("en-US", "es-ES")
+        val offeringsCache = OfferingsCache(deviceCache, dateProvider = dateProvider, localeProvider = localeProvider)
+        mockDeviceCacheOfferingResponse()
+
+        // Act
+        offeringsCache.cacheOfferings(mockk(), mockk())
+
+        // Assert
+        assertThat(offeringsCache.isOfferingsCacheStale(false)).isFalse
+    }
+
+    @Test
+    fun `cache is stale when locales change after caching`() {
+        // Arrange
+        val localeProvider = FakeLocaleProvider("en-US", "es-ES")
+        val offeringsCache = OfferingsCache(deviceCache, dateProvider = dateProvider, localeProvider = localeProvider)
+        mockDeviceCacheOfferingResponse()
+
+        // Act
+        offeringsCache.cacheOfferings(mockk(), mockk())
+        localeProvider.languageTags = listOf("fr-FR", "de-DE")
+
+        // Assert
+        assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = false)).isTrue
+        assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = true)).isTrue
+    }
+
+    @Test
+    fun `cache is stale when a single locale changes`() {
+        // Arrange
+        val localeProvider = FakeLocaleProvider("en-US")
+        val offeringsCache = OfferingsCache(deviceCache, dateProvider = dateProvider, localeProvider = localeProvider)
+        mockDeviceCacheOfferingResponse()
+
+        // Act
+        offeringsCache.cacheOfferings(mockk(), mockk())
+        localeProvider.languageTags = listOf("fr-FR")
+
+        // Assert
+        assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = false)).isTrue
+        assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = true)).isTrue
+    }
+
+    @Test
+    fun `cache is stale when locale order changes`() {
+        // Arrange
+        val localeProvider = FakeLocaleProvider("en-US", "es-ES")
+        val offeringsCache = OfferingsCache(deviceCache, dateProvider = dateProvider, localeProvider = localeProvider)
+        mockDeviceCacheOfferingResponse()
+
+        // Act
+        offeringsCache.cacheOfferings(mockk(), mockk())
+        localeProvider.languageTags = listOf("es-ES", "en-US")
+
+        // Assert
+        assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = false)).isTrue
+        assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = true)).isTrue
+    }
+
+    @Test
+    fun `clear cache also clears cached locales`() {
+        // Arrange
+        val localeProvider = FakeLocaleProvider("en-US")
+        val offeringsCache = OfferingsCache(deviceCache, dateProvider = dateProvider, localeProvider = localeProvider)
+        mockDeviceCacheOfferingResponse()
+        every { deviceCache.clearOfferingsResponseCache() } just Runs
+
+        // Act
+        offeringsCache.cacheOfferings(mockk(), mockk())
+        assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = false)).isFalse
+        assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = true)).isFalse
+        offeringsCache.clearCache()
+        
+        // Assert
+        assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = false)).isTrue
+        assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = true)).isTrue
+    }
+
+    // endregion locale cache tests
 
     // region offerings response cache
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
@@ -98,10 +98,10 @@ class OfferingsCacheTest {
     }
 
     @Test
-    fun `cache is stale if cached value removes update time`() {
+    fun `cache is stale if forced to be stale`() {
         mockDeviceCacheOfferingResponse()
         offeringsCache.cacheOfferings(mockk(), mockk())
-        offeringsCache.clearOfferingsCacheTimestamp()
+        offeringsCache.forceCacheStale()
         assertThat(offeringsCache.isOfferingsCacheStale(false)).isTrue
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -333,7 +333,7 @@ class OfferingsManagerTest {
 
         assertThat(purchasesError).isNotNull
         verify(exactly = 1) {
-            cache.clearOfferingsCacheTimestamp()
+            cache.forceCacheStale()
         }
     }
 
@@ -395,7 +395,7 @@ class OfferingsManagerTest {
         )
 
         assertThat(receivedError).isEqualTo(expectedError)
-        verify(exactly = 1) { cache.clearOfferingsCacheTimestamp() }
+        verify(exactly = 1) { cache.forceCacheStale() }
     }
 
     // This situation shouldn't happen normally since we only cache when we have loaded the offerings at least once,
@@ -426,7 +426,7 @@ class OfferingsManagerTest {
 
         assertThat(receivedError).isEqualTo(expectedError)
 
-        verify(exactly = 1) { cache.clearOfferingsCacheTimestamp() }
+        verify(exactly = 1) { cache.forceCacheStale() }
     }
 
     // endregion getOfferings
@@ -781,7 +781,7 @@ class OfferingsManagerTest {
         if (wasSuccessful) {
             every { cache.cacheOfferings(any(), any()) } just Runs
         } else {
-            every { cache.clearOfferingsCacheTimestamp() } just Runs
+            every { cache.forceCacheStale() } just Runs
         }
     }
 


### PR DESCRIPTION
## Motivation
The `OfferingsCache` would return cached Offerings (including products with localized descriptions) even if the locale has changes since caching. This prevents developers from showing the correct description in this scenario. 

## Changes introduced
`OfferingsCache` now remembers the locales at time of caching, and verifies they are unchanged when checking for staleness. Developers will receive up-to-date Offerings (including products with correctly-localized descriptions) when they call `getOfferings()` after the locale has changed.
