### PR TITLE
[Paywalls] Ensures bottom window insets are applied to the sheet.

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -514,7 +514,8 @@ internal class StyleFactory(
             )
             is ButtonComponent.Destination.Sheet ->
                 zipOrAccumulate(
-                    first = createStackComponentStyle(destination.stack),
+                    first = createStackComponentStyle(destination.stack)
+                        .map { it.applyBottomWindowInsetsIfNecessary(shouldApply = true) },
                     second = destination.background
                         ?.toBackgroundStyles(colorAliases)
                         .orSuccessfullyNull(),


### PR DESCRIPTION
## Description
The bottom sheet should have window insets applied, to avoid clashing with system bars. This will only apply to its content. The background will still draw behind the system bar. 