### PR TITLE
Some Metalava updates

### DIFF
--- a/.run/apiCheck.run.xml
+++ b/.run/apiCheck.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="apiCheck" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="metalavaCheckCompatibilityDefaultsRelease" />
+          <option value="metalavaCheckCompatibilityCustomEntitlementComputationRelease" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/apiDump.run.xml
+++ b/.run/apiDump.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="apiDump" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="metalavaGenerateSignatureDefaultsRelease" />
+          <option value="metalavaGenerateSignatureCustomEntitlementComputationRelease" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -14,27 +14,3 @@ if [ $EXIT_CODE -ne 0 ]; then
   exit $EXIT_CODE
 fi
 rm "$OUTPUT"
-
-echo "Running metalava check on defaultsRelease..."
-./gradlew metalavaCheckCompatibilityDefaultsRelease -q
-EXIT_CODE=$?
-if [ $EXIT_CODE -ne 0 ]; then
-  echo "❌ metalava for defaults flavor failed, running it for you..."
-
-  ./gradlew metalavaGenerateSignatureDefaultsRelease -q
-
-  echo "API dump done. Please check the updated API dump and add it to your commit."
-  exit $EXIT_CODE
-fi
-
-echo "Running metalava check on customEntitlementComputationRelease..."
-./gradlew metalavaCheckCompatibilityCustomEntitlementComputationRelease -q
-EXIT_CODE=$?
-if [ $EXIT_CODE -ne 0 ]; then
-  echo "❌ metalava for custom entitlement flavor failed, running it for you..."
-
-  ./gradlew metalavaGenerateSignatureCustomEntitlementComputationRelease -q
-
-  echo "API dump done. Please check the updated API dump and add it to your commit."
-  exit $EXIT_CODE
-fi


### PR DESCRIPTION
## Description
I've just made Metalava a required CI check. This PR makes 2 updates for added Metalava convenience: 
- It is no longer ran as a pre-commit hook. This was a bit slow, and we don't update the public API surface that often, while every commit had to wait for this check.
- 2 Android Studio Run Configurations are added:
    - `apiDump` generates new public API definition files.
    - `apiCheck` checks whether the current public API still corresponds to the current definition files. This is also what the CI check does.

  
![image](https://github.com/user-attachments/assets/9c724556-59bc-4b3b-a94d-ef00eb7598bc)
