### PR TITLE
Use script instead of gradle for metalava apiDump and apiCheck

### DIFF
--- a/.run/apiCheck.run.xml
+++ b/.run/apiCheck.run.xml
@@ -1,25 +1,17 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="apiCheck" type="GradleRunConfiguration" factoryName="Gradle">
-    <ExternalSystemSettings>
-      <option name="executionName" />
-      <option name="externalProjectPath" value="$PROJECT_DIR$" />
-      <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="" />
-      <option name="taskDescriptions">
-        <list />
-      </option>
-      <option name="taskNames">
-        <list>
-          <option value="metalavaCheckCompatibilityDefaultsRelease" />
-          <option value="metalavaCheckCompatibilityCustomEntitlementComputationRelease" />
-        </list>
-      </option>
-      <option name="vmOptions" />
-    </ExternalSystemSettings>
-    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
-    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-    <DebugAllEnabled>false</DebugAllEnabled>
-    <RunAsTest>false</RunAsTest>
+  <configuration default="false" name="apiCheck" type="ShConfigurationType" focusToolWindowBeforeRun="true">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/scripts/api-check.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs />
     <method v="2" />
   </configuration>
 </component>

--- a/.run/apiDump.run.xml
+++ b/.run/apiDump.run.xml
@@ -1,25 +1,17 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="apiDump" type="GradleRunConfiguration" factoryName="Gradle">
-    <ExternalSystemSettings>
-      <option name="executionName" />
-      <option name="externalProjectPath" value="$PROJECT_DIR$" />
-      <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="" />
-      <option name="taskDescriptions">
-        <list />
-      </option>
-      <option name="taskNames">
-        <list>
-          <option value="metalavaGenerateSignatureDefaultsRelease" />
-          <option value="metalavaGenerateSignatureCustomEntitlementComputationRelease" />
-        </list>
-      </option>
-      <option name="vmOptions" />
-    </ExternalSystemSettings>
-    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
-    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-    <DebugAllEnabled>false</DebugAllEnabled>
-    <RunAsTest>false</RunAsTest>
+  <configuration default="false" name="apiDump" type="ShConfigurationType" focusToolWindowBeforeRun="true">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/scripts/api-dump.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs />
     <method v="2" />
   </configuration>
 </component>

--- a/scripts/api-check.sh
+++ b/scripts/api-check.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+exit_code=0
+
+./gradlew metalavaCheckCompatibilityDefaultsRelease || exit_code=$?
+./gradlew metalavaCheckCompatibilityCustomEntitlementComputationRelease || exit_code=$?
+
+exit $exit_code

--- a/scripts/api-dump.sh
+++ b/scripts/api-dump.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+exit_code=0
+
+./gradlew metalavaGenerateSignatureDefaultsRelease || exit_code=$?
+./gradlew metalavaGenerateSignatureCustomEntitlementComputationRelease || exit_code=$?
+
+exit $exit_code


### PR DESCRIPTION
We noticed the config run wasn't really working and it was failing at executing both gradle tasks. It looks like executing the gradle task like this `./gradlew metalavaGenerateSignatureDefaultsRelease metalavaGenerateSignatureCustomEntitlementComputationRelease` doesn't work very well as it wasn't modifying the `api-entitlement.txt` file, whereas executing the single task like `./gradlew metalavaGenerateSignatureCustomEntitlementComputationRelease` was working fine

We changed it to use a shell script instead and this is working as expected