### PR TITLE
Support spaces in template IDs when recording Paywall screenshots

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -649,7 +649,7 @@ DESC
         if file_path =~ /\>\>(.*?)\<\</
           offering_id = $1
           target_dir = "#{target_repository_path}/screenshots/templates/#{offering_id}"
-          sh("mkdir -p #{target_dir}")
+          sh("mkdir -p \"#{target_dir}\"")
           sh("mv \"#{file_path}\" \"#{target_dir}/android.png\"")
         else
           UI.user_error!("No offering ID found in file: #{File.basename(file_path)}")


### PR DESCRIPTION
## Description
Our latest Paywall template has a space in its Offering ID. This [broke](https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/15641/workflows/5f607155-90a3-4791-8fc7-f4de0bfe00c6/jobs/80605) recording of screenshots. This PR should fix that. 