### PR TITLE
Fixes `OutOfMemoryError` caused by printing large `Offerings` objects.

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsFactory.kt
@@ -63,7 +63,7 @@ internal class OfferingsFactory(
                                     ),
                                 )
                             } else {
-                                verboseLog(OfferingStrings.CREATED_OFFERINGS.format(offerings))
+                                verboseLog(OfferingStrings.CREATED_OFFERINGS.format(offerings.all.size))
                                 onSuccess(
                                     OfferingsResultData(offerings, allRequestedProductIdentifiers, notFoundProductIds),
                                 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/OfferingStrings.kt
@@ -8,7 +8,7 @@ internal object OfferingStrings {
     const val FETCHING_PRODUCTS = "Requesting products from the store with identifiers: %s"
     const val FETCHING_PRODUCTS_FINISHED = "Products request finished for %s"
     const val BUILDING_OFFERINGS = "Building offerings response with %d products"
-    const val CREATED_OFFERINGS = "Offerings object created: %s"
+    const val CREATED_OFFERINGS = "Offerings object created with %d offerings"
     const val JSON_EXCEPTION_ERROR = "JSONException when building Offerings object. Message: %s"
     const val LIST_PRODUCTS = "%s - %s"
     const val EXTRA_QUERY_PRODUCT_DETAILS_RESPONSE = "BillingClient queryProductDetails has returned more than once, " +


### PR DESCRIPTION
## Bug
While clicking around in the Play SDK Console I found [this `OutOfMemoryError`](https://play.google.com/sdk-console/accounts/3894912036640479868/sdks/8672516042485634097/crashes/39b13ee9/details?timeRange=LAST_28_DAYS&affectedApps=AFFECTED_APPS_FIVE_OR_MORE&errorTypes=CRASH&crashStatuses=SDK_CRASH_STATUS_UNSPECIFIED) that is caused by logging the entire `Offerings` object. This implicit `toString()` call runs out of memory if the `Offerings` object is too large.

## Fix
I fixed it by just logging the number of individual `Offering`s, instead of the entire object.