### PR TITLE
Improve paywall error logs

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FontSpec.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/properties/FontSpec.kt
@@ -96,7 +96,7 @@ internal fun Result<FontSpec, PaywallValidationError>.recoverFromFontAliasError(
             // Treating this as a dashboard error and just ignoring it. No need to log.
             Result.Success(null)
         } else if (error is PaywallValidationError.MissingFontAlias) {
-            Logger.e(
+            Logger.w(
                 "Font named '${error.alias}' was not found in the font config. Try re-adding it in the Paywall editor.",
             )
             Result.Success(null)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -405,9 +405,9 @@ internal class PaywallViewModelImpl(
 
         validationResult.errors?.let { validationErrors ->
             validationErrors.forEach { error ->
-                Logger.w(error.associatedErrorString(offering))
+                Logger.e(error.associatedErrorString(offering))
             }
-            Logger.w(PaywallValidationErrorStrings.DISPLAYING_DEFAULT)
+            Logger.e(PaywallValidationErrorStrings.DISPLAYING_DEFAULT)
         }
 
         val activelySubscribedProductIds = customerInfo.activeSubscriptions


### PR DESCRIPTION
### Description
Errors that caused us to fallback to the fallback paywall were only warnings, and some other issues that were recoverable were errors. This improves some of those logs so they are clearer for developers to know what's causing the issue with their paywalls.