### PR TITLE
Issue when loading promotional offers when products are missing base plans

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -665,12 +665,13 @@ internal class CustomerCenterViewModelImpl(
         promotionalOffer: CustomerCenterConfigData.HelpPath.PathDetail.PromotionalOffer,
         product: StoreProduct,
     ): SubscriptionOption? {
+        val googleProduct = product.googleProduct
         val crossProductPromotion: CrossProductPromotion? =
             promotionalOffer.crossProductPromotions[product.id]
                 // Check for cross-product promotions first (product.id includes base plan ex: "sub:p1m")
                 // But it's possible the product is not configured with base plan in RevenueCat
                 // so we also check for the Google product ID (which does not include base plan ex: "sub")
-                ?: promotionalOffer.crossProductPromotions[product.googleProduct?.productId ?: ""]
+                ?: googleProduct?.let { promotionalOffer.crossProductPromotions[it.productId] }
                 ?: promotionalOffer.productMapping[product.id]?.let {
                     CrossProductPromotion(
                         storeOfferIdentifier = it,
@@ -687,12 +688,12 @@ internal class CustomerCenterViewModelImpl(
 
         val targetProduct: StoreProduct? = when {
             crossProductPromotion.targetProductId == product.id -> product
-            product.googleProduct?.basePlanId != null ->
-                // Passing oringinal product's base plan ID to find the target product
+            googleProduct?.basePlanId != null ->
+                // Passing original product's base plan ID to find the target product
                 // in case the target product is missing the base plan ID in the dashboard
                 // which is common for old products. Purchases.getProducts would return all products
                 // with the same product ID but different base plan IDs. That way we can find the most relevant product.
-                findTargetProduct(crossProductPromotion.targetProductId, product.googleProduct!!.basePlanId!!)
+                findTargetProduct(crossProductPromotion.targetProductId, googleProduct.basePlanId!!)
             else -> null
         }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -666,6 +666,10 @@ internal class CustomerCenterViewModelImpl(
     ): SubscriptionOption? {
         val crossProductPromotion: CrossProductPromotion? =
             promotionalOffer.crossProductPromotions[product.id]
+                // Check for cross-product promotions first (product.id includes base plan ex: "sub:p1m")
+                // But it's possible the product is not configured with base plan in RevenueCat
+                // so we also check for the Google product ID (which does not include base plan ex: "sub")
+                ?: promotionalOffer.crossProductPromotions[product.googleProduct?.productId ?: ""]
                 ?: promotionalOffer.productMapping[product.id]?.let {
                     CrossProductPromotion(
                         storeOfferIdentifier = it,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -71,9 +71,13 @@ internal class PurchasesImpl(private val purchases: Purchases = Purchases.shared
 
     override suspend fun awaitGetProduct(productId: String, basePlan: String?): StoreProduct? {
         val products = purchases.awaitGetProducts(listOf(productId))
-        return products.firstOrNull {
-            it.googleProduct?.basePlanId == basePlan
-        } ?: products.firstOrNull()
+        // Get products returns one product per base plan ID if it is a subscription product.
+        // If the product is an in-app product, it will return a single product.
+        return if (basePlan == null) {
+            products.firstOrNull()
+        } else {
+            products.firstOrNull { it.googleProduct?.basePlanId == basePlan }
+        }
     }
 
     override fun track(event: FeatureEvent) {


### PR DESCRIPTION
There's an issue when loading promotional offers for target products that miss a base plan

For example this configuration is valid if the product is old and configured without base plans in the dashboard:

<img width="728" alt="Screenshot 2025-06-27 at 12 05 36" src="https://github.com/user-attachments/assets/4d121b68-4214-478c-ad2d-05621ebfc810" />

The SDK will fail to load the promotional becasue it looks for the `product.id`, which in that case would look like `annual_freetrial:p1y`. On the other hand `product.googleProduct?.productId` has only the product id `annual_freetrial` so we should be looking for that instead if we can't find a promotional matching the base plan.

There was also another issue when loading the target product, since we were picking the first one returned, which is not ideal. For example, if the product "subscription" had "monthly" and "annual" base plans. And the target product was just "subscription", `Purchases.getProducts` without an specific base plan returns two products, one for each base plan. Which could load an unexpected product. I changed the logic to load the base plan that's equivalent to the currently active subscription. 