### PR TITLE
Use subscription's managementURL instead of CustomerInfo's in Customer Center

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformation.kt
@@ -42,7 +42,6 @@ internal data class PurchaseInformation(
         entitlementInfo: EntitlementInfo? = null,
         subscribedProduct: StoreProduct? = null,
         transaction: TransactionDetails,
-        managementURL: Uri?,
         dateFormatter: DateFormatter = DefaultDateFormatter(),
         locale: Locale,
     ) : this(
@@ -56,7 +55,7 @@ internal data class PurchaseInformation(
             subscribedProduct?.let { PriceDetails.Paid(it.price.formatted) } ?: PriceDetails.Unknown
         },
         isSubscription = transaction is TransactionDetails.Subscription && transaction.store != Store.PROMOTIONAL,
-        managementURL = managementURL,
+        managementURL = (transaction as? TransactionDetails.Subscription)?.managementURL,
         isExpired = entitlementInfo?.isActive?.let { !it }
             ?: when (transaction) {
                 is TransactionDetails.Subscription -> !transaction.isActive

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -111,6 +111,7 @@ internal sealed class TransactionDetails(
         val willRenew: Boolean,
         val expiresDate: Date?,
         val isTrial: Boolean,
+        val managementURL: Uri?,
     ) : TransactionDetails(productIdentifier, store)
 
     data class NonSubscription(
@@ -359,7 +360,6 @@ internal class CustomerCenterViewModelImpl(
                 return createPurchaseInformation(
                     activeTransactionDetails,
                     entitlement,
-                    customerInfo.managementURL,
                     dateFormatter,
                     locale,
                 )
@@ -396,6 +396,7 @@ internal class CustomerCenterViewModelImpl(
                     willRenew = it.willRenew,
                     expiresDate = it.expiresDate,
                     isTrial = it.periodType == PeriodType.TRIAL,
+                    managementURL = it.managementURL,
                 )
 
                 is Transaction -> TransactionDetails.NonSubscription(
@@ -411,7 +412,6 @@ internal class CustomerCenterViewModelImpl(
     private suspend fun createPurchaseInformation(
         transaction: TransactionDetails,
         entitlement: EntitlementInfo?,
-        managementURL: Uri?,
         dateFormatter: DateFormatter,
         locale: Locale,
     ): PurchaseInformation {
@@ -435,7 +435,6 @@ internal class CustomerCenterViewModelImpl(
             entitlementInfo = entitlement,
             subscribedProduct = product,
             transaction = transaction,
-            managementURL = managementURL,
             dateFormatter = dateFormatter,
             locale = locale,
         )

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterViewModelTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterViewModelTests.kt
@@ -1192,7 +1192,7 @@ class CustomerCenterViewModelTests {
     }
 
     @Test
-    fun `isSupportedPaths filters CANCEL when management URL is not present and not Google Play Store`() = runTest {
+    fun `isSupportedPaths filters CANCEL when management URL is not present`() = runTest {
         setupPurchasesMock()
         every { customerInfo.activeSubscriptions } returns setOf(TestData.Packages.monthly.product.id)
         every { customerInfo.subscriptionsByProductIdentifier } returns mapOf(
@@ -1215,7 +1215,7 @@ class CustomerCenterViewModelTests {
                 displayName = null,
                 price = null,
                 productPlanIdentifier = "monthly",
-                managementURL = Uri.parse("https://example.com/manage"),
+                managementURL = null,
             )
         )
 
@@ -1312,57 +1312,6 @@ class CustomerCenterViewModelTests {
                     val paths = state.supportedPathsForManagementScreen ?: emptyList()
                     assertThat(paths)
                         .withFailMessage("Expected CANCEL path to not be present for lifetime purchases. Paths: $paths")
-                        .noneMatch { it.type == HelpPath.PathType.CANCEL }
-                    cancel()
-                }
-            }
-        }
-
-        job.join()
-    }
-
-    @Test
-    fun `isSupportedPaths filters CANCEL for non-Play Store without management URL`() = runTest {
-        setupPurchasesMock()
-        every { customerInfo.activeSubscriptions } returns setOf(TestData.Packages.monthly.product.id)
-        every { customerInfo.managementURL } returns null
-        every { customerInfo.subscriptionsByProductIdentifier } returns mapOf(
-            "productIdentifier" to SubscriptionInfo(
-                productIdentifier = "productIdentifier",
-                purchaseDate = Date(),
-                originalPurchaseDate = null,
-                expiresDate = null,
-                store = Store.APP_STORE,
-                unsubscribeDetectedAt = null,
-                isSandbox = false,
-                billingIssuesDetectedAt = null,
-                gracePeriodExpiresDate = null,
-                ownershipType = OwnershipType.PURCHASED,
-                periodType = PeriodType.NORMAL,
-                refundedAt = null,
-                storeTransactionId = null,
-                requestDate = Date(),
-                autoResumeDate = null,
-                displayName = null,
-                price = null,
-                productPlanIdentifier = "monthly",
-                managementURL = Uri.parse("https://example.com/manage"),
-            )
-        )
-
-        val model = CustomerCenterViewModelImpl(
-            purchases = purchases,
-            locale = Locale.US,
-            colorScheme = TestData.Constants.currentColorScheme,
-            isDarkMode = false
-        )
-
-        val job = launch {
-            model.state.collect { state ->
-                if (state is CustomerCenterState.Success) {
-                    val paths = state.supportedPathsForManagementScreen ?: emptyList()
-                    assertThat(paths)
-                        .withFailMessage("Expected CANCEL path to not be present for non-PLAY_STORE without management URL. Paths: $paths")
                         .noneMatch { it.type == HelpPath.PathType.CANCEL }
                     cancel()
                 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformationTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformationTest.kt
@@ -69,7 +69,6 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = storeProduct,
             transaction = transaction,
-            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale,
         )
@@ -121,7 +120,6 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = storeProduct,
             transaction = transaction,
-            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -173,7 +171,6 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = storeProduct,
             transaction = transaction,
-            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -216,7 +213,6 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
-            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -259,7 +255,6 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
-            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -302,7 +297,6 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
-            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -339,14 +333,14 @@ class PurchaseInformationTest {
             willRenew = false,
             store = Store.PROMOTIONAL,
             productIdentifier = "rc_promo_pro_cat_yearly",
-            expiresDate = expiresDate
+            expiresDate = expiresDate,
+            managementURL = null,
         )
 
         val purchaseInformation = PurchaseInformation(
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
-            managementURL = null,
             dateFormatter = dateFormatter,
             locale = locale,
         )
@@ -362,6 +356,7 @@ class PurchaseInformationTest {
             isTrial = false,
             isCancelled = true,
             expirationOrRenewal = ExpirationOrRenewal.Expiration("3 Oct 2063"),
+            managementURL = null,
         )
     }
 
@@ -383,14 +378,14 @@ class PurchaseInformationTest {
             willRenew = false,
             store = Store.PROMOTIONAL,
             productIdentifier = "rc_promo_pro_cat_lifetime",
-            expiresDate = expiresDate
+            expiresDate = expiresDate,
+            managementURL = null,
         )
 
         val purchaseInformation = PurchaseInformation(
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
-            managementURL = null,
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -406,6 +401,7 @@ class PurchaseInformationTest {
             isTrial = false,
             isCancelled = true,
             expirationOrRenewal = ExpirationOrRenewal.Expiration("3 Oct 2222"),
+            managementURL = null,
         )
     }
 
@@ -433,7 +429,6 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
-            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -448,7 +443,8 @@ class PurchaseInformationTest {
             isExpired = false,
             isTrial = false,
             isCancelled = false,
-            expirationOrRenewal = ExpirationOrRenewal.Renewal("3 Oct 2063")
+            expirationOrRenewal = ExpirationOrRenewal.Renewal("3 Oct 2063"),
+            managementURL = Uri.parse(MANAGEMENT_URL),
         )
     }
 
@@ -476,7 +472,6 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
-            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -492,6 +487,7 @@ class PurchaseInformationTest {
             isTrial = false,
             isCancelled = true,
             expirationOrRenewal = ExpirationOrRenewal.Expiration("3 Oct 2063"),
+            managementURL = Uri.parse(MANAGEMENT_URL),
         )
     }
 
@@ -519,7 +515,6 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
-            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -535,6 +530,7 @@ class PurchaseInformationTest {
             isTrial = false,
             isCancelled = true,
             expirationOrRenewal = ExpirationOrRenewal.Expiration("3 Oct 2063"),
+            managementURL = Uri.parse(MANAGEMENT_URL),
         )
     }
 
@@ -562,7 +558,6 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
-            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -577,7 +572,8 @@ class PurchaseInformationTest {
             isExpired = false,
             isTrial = false,
             isCancelled = false,
-            expirationOrRenewal = ExpirationOrRenewal.Renewal("3 Oct 2063")
+            expirationOrRenewal = ExpirationOrRenewal.Renewal("3 Oct 2063"),
+            managementURL = Uri.parse(MANAGEMENT_URL),
         )
     }
 
@@ -605,7 +601,6 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
-            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -621,6 +616,7 @@ class PurchaseInformationTest {
             isTrial = false,
             isCancelled = true,
             expirationOrRenewal = ExpirationOrRenewal.Expiration("3 Oct 2063"),
+            managementURL = Uri.parse(MANAGEMENT_URL),
         )
     }
 
@@ -648,7 +644,6 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = null,
             transaction = transaction,
-            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -664,6 +659,7 @@ class PurchaseInformationTest {
             isTrial = false,
             isCancelled = true,
             expirationOrRenewal = ExpirationOrRenewal.Expiration("3 Oct 2063"),
+            managementURL = Uri.parse(MANAGEMENT_URL),
         )
     }
 
@@ -702,7 +698,6 @@ class PurchaseInformationTest {
             entitlementInfo = entitlementInfo,
             subscribedProduct = storeProduct,
             transaction = transaction,
-            managementURL = Uri.parse(MANAGEMENT_URL),
             dateFormatter = dateFormatter,
             locale = locale
         )
@@ -718,6 +713,7 @@ class PurchaseInformationTest {
             isTrial = true,
             isCancelled = false,
             expirationOrRenewal = ExpirationOrRenewal.Renewal("3 Oct 2063"),
+            managementURL = Uri.parse(MANAGEMENT_URL),
         )
     }
 
@@ -732,6 +728,7 @@ class PurchaseInformationTest {
         isTrial: Boolean = false,
         isCancelled: Boolean = false,
         expirationOrRenewal: ExpirationOrRenewal? = null,
+        managementURL: Uri? = Uri.parse(MANAGEMENT_URL)
     ) {
         assertThat(purchaseInformation.title).isEqualTo(title)
         assertThat(purchaseInformation.pricePaid).isEqualTo(price)
@@ -742,6 +739,7 @@ class PurchaseInformationTest {
         assertThat(purchaseInformation.isTrial).isEqualTo(isTrial)
         assertThat(purchaseInformation.isCancelled).isEqualTo(isCancelled)
         assertThat(purchaseInformation.expirationOrRenewal).isEqualTo(expirationOrRenewal)
+        assertThat(purchaseInformation.managementURL).isEqualTo(managementURL)
     }
 
     private fun createEntitlementInfo(
@@ -780,6 +778,7 @@ class PurchaseInformationTest {
         expiresDate: Date?,
         productPlanIdentifier: String? = null,
         isTrial: Boolean = false,
+        managementURL: Uri? = Uri.parse(MANAGEMENT_URL)
     ): TransactionDetails.Subscription {
         return TransactionDetails.Subscription(
             productIdentifier = productIdentifier,
@@ -789,6 +788,7 @@ class PurchaseInformationTest {
             expiresDate = expiresDate,
             productPlanIdentifier = productPlanIdentifier,
             isTrial = isTrial,
+            managementURL = managementURL
         )
     }
 


### PR DESCRIPTION
We should be using the managementURL of the displayed subcription not the CustomerInfo one. We needed #2468 for this