### PR TITLE
Introduce the Compose compiler metrics option for the ui package

### DIFF
--- a/ui/revenuecatui/build.gradle.kts
+++ b/ui/revenuecatui/build.gradle.kts
@@ -89,6 +89,18 @@ metalava {
     )
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        if (project.findProperty("revenuecat.enableComposeCompilerReports") == "true") {
+            val composeMetricsDir = "${project.buildDir.absolutePath}/compose_metrics"
+            freeCompilerArgs += listOf(
+                "-P", "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$composeMetricsDir",
+                "-P", "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$composeMetricsDir",
+            )
+        }
+    }
+}
+
 dependencies {
     api(project(":purchases"))
 


### PR DESCRIPTION
Introduce the [Compose compiler metrics](https://developer.android.com/develop/ui/compose/performance/stability/diagnose#compose-compiler) option for the ui package. So now we can improve the stability and compose performance by utilizing these metrics.

### Composable function metrics
[revenuecatui_defaultsRelease-composables.txt](https://github.com/user-attachments/files/20993966/revenuecatui_defaultsRelease-composables.txt)

### Class stability metrics
[revenuecatui_defaultsRelease-classes.txt](https://github.com/user-attachments/files/20993965/revenuecatui_defaultsRelease-classes.txt)

### How to generate those metrics?

```
./gradlew assembleRelease -Prevenuecat.enableComposeCompilerReports=true
```
