### PR TITLE
Fixes building sample apps with SNAPSHOT dependencies

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,7 +49,6 @@ Sometimes you might need to release a patch on a version that's not the latest. 
 Fixing timeouts when closing repository
 =========
 Sonatype might fail when performing the `closeAndRelease` step. Fortunately, we can close and release manually if the publish task succeeds.
-- Head to https://oss.sonatype.org/#stagingRepositories, login using the credentials in 1Password
-- That link should redirect you to the Staging Repositories section, if it doesn't go to that section on the left hand side of the website, under the Build Promotion section.
+- Head to https://central.sonatype.com/publishing/deployments, login using the credentials in 1Password
 - You should see one staging repository there. If there are more than one, drop all of them and rerun the failing job in CircleCI.
 - Select the only repository available, then do Close. When close finishes, do Release and automatically drop the repository.

--- a/examples/CustomEntitlementComputationSample/settings.gradle.kts
+++ b/examples/CustomEntitlementComputationSample/settings.gradle.kts
@@ -2,7 +2,6 @@ pluginManagement {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
         gradlePluginPortal()
     }
 }
@@ -11,7 +10,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
+        maven(url = "https://central.sonatype.com/repository/maven-snapshots/") {
+            content { includeGroup("com.revenuecat.purchases") }
+        }
     }
 }
 rootProject.name = "CustomEntitlementComputationSample"

--- a/examples/MagicWeather/build.gradle.kts
+++ b/examples/MagicWeather/build.gradle.kts
@@ -8,7 +8,9 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
+        maven(url = "https://central.sonatype.com/repository/maven-snapshots/") {
+            content { includeGroup("com.revenuecat.purchases") }
+        }
     }
 }
 

--- a/examples/MagicWeather/settings.gradle.kts
+++ b/examples/MagicWeather/settings.gradle.kts
@@ -3,7 +3,6 @@ pluginManagement {
         google()
         gradlePluginPortal()
         mavenCentral()
-        maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
     }
 }
 

--- a/examples/MagicWeatherCompose/settings.gradle.kts
+++ b/examples/MagicWeatherCompose/settings.gradle.kts
@@ -2,7 +2,6 @@ pluginManagement {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
         gradlePluginPortal()
     }
 }
@@ -11,7 +10,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
+        maven(url = "https://central.sonatype.com/repository/maven-snapshots/") {
+            content { includeGroup("com.revenuecat.purchases") }
+        }
     }
 }
 rootProject.name = "MagicWeatherCompose"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,9 +46,6 @@ dependencyResolutionManagement {
             }
         }
 
-        // fetch plugins from gradle plugin portal (https://plugins.gradle.org)
-        gradlePluginPortal()
-
         // fallback for the rest of the dependencies
         mavenCentral()
     }


### PR DESCRIPTION
## Description
The SNAPSHOT repo URL has changed, now that we migrated to Central Portal publishing. I also removed it from plugin repos, as we don't use SNAPSHOT plugins, and removed `gradlePluginPortal()` from depencency repos, as no dependencies are published there. 

This should fix the following failing CI jobs: 
- [assemble-magic-weather-compose-sample-app
](https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/15853/workflows/c8bccc8d-259f-4eed-8b60-9128a79683ea/jobs/82702)
- [assemble-custom-entitlement-computation-sample-app
](https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/15853/workflows/c8bccc8d-259f-4eed-8b60-9128a79683ea/jobs/82703)