### PR TITLE
Use collectAsStateWithLifecycle instead of collectAsState in Compose

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/offerings/OfferingsScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,6 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.paywallstester.MainActivity
 import com.revenuecat.purchases.InternalRevenueCatAPI
@@ -57,7 +57,7 @@ fun OfferingsScreen(
     tappedOnOfferingByPlacement: (String) -> Unit,
     viewModel: OfferingsViewModel = viewModel<OfferingsViewModelImpl>(),
 ) {
-    when (val state = viewModel.offeringsState.collectAsState().value) {
+    when (val state = viewModel.offeringsState.collectAsStateWithLifecycle().value) {
         is OfferingsState.Error -> ErrorOfferingsScreen(errorState = state)
         is OfferingsState.Loaded -> OfferingsListScreen(
             offeringsState = state,

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreen.kt
@@ -7,9 +7,9 @@ import androidx.compose.material.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
@@ -24,7 +24,7 @@ fun PaywallScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        when (val state = viewModel.state.collectAsState().value) {
+        when (val state = viewModel.state.collectAsStateWithLifecycle().value) {
             is PaywallScreenState.Loading -> {
                 Text(text = "Loading...")
             }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywallfooter/PaywallFooterScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywallfooter/PaywallFooterScreen.kt
@@ -12,9 +12,9 @@ import androidx.compose.material.AlertDialog
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.paywallstester.ui.screens.paywall.PaywallScreenState
 import com.revenuecat.paywallstester.ui.screens.paywall.PaywallScreenViewModel
@@ -32,7 +32,7 @@ fun PaywallFooterScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        when (val state = viewModel.state.collectAsState().value) {
+        when (val state = viewModel.state.collectAsStateWithLifecycle().value) {
             is PaywallScreenState.Loading -> {
                 Text(text = "Loading...")
             }

--- a/ui/debugview/src/debug/kotlin/com/revenuecat/purchases/ui/debugview/InternalDebugRevenueCatScreen.kt
+++ b/ui/debugview/src/debug/kotlin/com/revenuecat/purchases/ui/debugview/InternalDebugRevenueCatScreen.kt
@@ -11,11 +11,11 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PurchasesTransactionException
@@ -49,7 +49,7 @@ internal fun InternalDebugRevenueCatScreen(
             .padding(bottom = 16.dp),
     ) {
         val currentActivity = activity ?: LocalContext.current.findActivity()
-        val state = viewModel.state.collectAsState().value
+        val state = viewModel.state.collectAsStateWithLifecycle().value
         DisplayToastMessageIfNeeded(viewModel, state = state)
         Text(
             text = "RevenueCat Debug Menu",

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -17,12 +17,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
@@ -71,7 +71,7 @@ internal fun InternalPaywall(
         viewModel.refreshStateIfColorsChanged(colorScheme = colorScheme, isDark = isDark)
     }
 
-    val state = viewModel.state.collectAsState().value
+    val state = viewModel.state.collectAsStateWithLifecycle().value
 
     PaywallTheme(fontProvider = options.fontProvider) {
         AnimatedVisibility(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -38,6 +37,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -79,7 +79,7 @@ internal fun InternalCustomerCenter(
 ) {
     viewModel.refreshStateIfColorsChanged(MaterialTheme.colorScheme, isSystemInDarkTheme())
 
-    val state by viewModel.state.collectAsState()
+    val state by viewModel.state.collectAsStateWithLifecycle()
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
 


### PR DESCRIPTION
Use `collectAsStateWithLifecycle` instead of `collectAsState` in Compose.

### Description

`collectAsState` is not lifecycle-aware and operates independently of Android's lifecycle system. This means it continues to collect data from the `Flow` even when the UI is no longer visible, potentially leading to unnecessary background work and performance issues.

On the other hand, `collectAsStateWithLifecycle` is a safer and more lifecycle-conscious alternative. It automatically suspends collection when the composable leaves the active lifecycle state (e.g., when the UI is not in the foreground), helping you avoid wasted resources and keeping your UI logic tightly aligned with the Android lifecycle.

Key advantages of `collectAsStateWithLifecycle`:
- It respects the `Lifecycle` of the host activity or fragment.
- Collection is automatically paused when the UI is in the background (e.g., during screen rotations or navigation).
- It prevents memory leaks by ensuring the Flow does not keep running when it is no longer needed.