### PR TITLE
Remove logic to avoid repurchasing already subscribed products

### DIFF
--- a/ui/revenuecatui/src/debug/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/TemplatePreviews.kt
+++ b/ui/revenuecatui/src/debug/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/TemplatePreviews.kt
@@ -5,7 +5,7 @@ package com.revenuecat.purchases.ui.revenuecatui.components
 import android.content.Context
 import android.graphics.BitmapFactory
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
@@ -177,8 +177,6 @@ internal fun PaywallComponentsTemplate_Preview(
             val validationResult = result.value
             val state = offering.toComponentsPaywallState(
                 validationResult = validationResult,
-                activelySubscribedProductIds = emptySet(),
-                purchasedNonSubscriptionProductIds = emptySet(),
                 storefrontCountryCode = "US",
                 dateProvider = { Date(MILLIS_2025_04_23) },
             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -67,8 +67,6 @@ internal fun LoadingPaywall(
             resourceProvider,
             isInPreviewMode(),
         ),
-        activelySubscribedProductIdentifiers = setOf(),
-        nonSubscriptionProductIdentifiers = setOf(),
         mode = mode,
         validatedPaywallData = paywallData,
         template = LoadingPaywallConstants.template,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -364,8 +364,6 @@ private fun LoadedPaywallComponents_Preview_Bless() {
     val validated = offering.validatePaywallComponentsDataOrNullForPreviews()?.getOrThrow()!!
     val state = offering.toComponentsPaywallState(
         validationResult = validated,
-        activelySubscribedProductIds = emptySet(),
-        purchasedNonSubscriptionProductIds = emptySet(),
         storefrontCountryCode = null,
         dateProvider = { Date(MILLIS_2025_01_25) },
     )
@@ -452,8 +450,6 @@ private fun previewHelloWorldPaywallState(): PaywallState.Loaded.Components {
     val validated = offering.validatePaywallComponentsDataOrNullForPreviews()?.getOrThrow()!!
     return offering.toComponentsPaywallState(
         validationResult = validated,
-        activelySubscribedProductIds = emptySet(),
-        purchasedNonSubscriptionProductIds = emptySet(),
         storefrontCountryCode = null,
         dateProvider = { Date(MILLIS_2025_01_25) },
     )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PreviewHelpers.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PreviewHelpers.kt
@@ -114,8 +114,6 @@ internal fun previewEmptyState(): PaywallState.Loaded.Components {
     val validated = offering.validatePaywallComponentsDataOrNullForPreviews()?.getOrThrow()!!
     return offering.toComponentsPaywallState(
         validationResult = validated,
-        activelySubscribedProductIds = emptySet(),
-        purchasedNonSubscriptionProductIds = emptySet(),
         storefrontCountryCode = null,
         dateProvider = { Date(MILLIS_2025_01_25) },
     )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -25,7 +25,6 @@ import com.revenuecat.purchases.ui.revenuecatui.composables.SimpleSheetState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.ProcessedLocalizedConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
-import com.revenuecat.purchases.ui.revenuecatui.data.processed.currentlySubscribed
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.helpers.NonEmptySet
 import com.revenuecat.purchases.ui.revenuecatui.isFullScreen
@@ -92,8 +91,6 @@ internal sealed interface PaywallState {
              * All locales that this paywall supports, with `locales.head` being the default one.
              */
             private val locales: NonEmptySet<LocaleId>,
-            val activelySubscribedProductIds: Set<String>,
-            val purchasedNonSubscriptionProductIds: Set<String>,
             private val dateProvider: () -> Date,
             private val packages: AvailablePackages,
             initialLocaleList: LocaleList = LocaleList.current,
@@ -127,7 +124,6 @@ internal sealed interface PaywallState {
 
             data class SelectedPackageInfo(
                 val rcPackage: Package,
-                val currentlySubscribed: Boolean,
             )
 
             private val initialSelectedPackageOutsideTabs = packages.packagesOutsideTabs
@@ -167,13 +163,7 @@ internal sealed interface PaywallState {
 
             val selectedPackageInfo by derivedStateOf {
                 selectedPackage?.let { rcPackage ->
-                    SelectedPackageInfo(
-                        rcPackage = rcPackage,
-                        currentlySubscribed = rcPackage.currentlySubscribed(
-                            activelySubscribedProductIdentifiers = activelySubscribedProductIds,
-                            nonSubscriptionProductIdentifiers = purchasedNonSubscriptionProductIds,
-                        ),
-                    )
+                    SelectedPackageInfo(rcPackage = rcPackage)
                 }
             }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
@@ -3,7 +3,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.data.processed
 
 import com.revenuecat.purchases.Package
-import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.ui.revenuecatui.errors.PackageConfigurationError
@@ -15,8 +14,6 @@ internal object PackageConfigurationFactory {
     fun createPackageConfiguration(
         variableDataProvider: VariableDataProvider,
         availablePackages: List<Package>,
-        activelySubscribedProductIdentifiers: Set<String>,
-        nonSubscriptionProductIdentifiers: Set<String>,
         packageIdsInConfig: List<String>,
         default: String?,
         configurationType: PackageConfigurationType,
@@ -44,8 +41,6 @@ internal object PackageConfigurationFactory {
                 makeSinglePackageConfiguration(
                     filteredRCPackages,
                     variableDataProvider,
-                    activelySubscribedProductIdentifiers,
-                    nonSubscriptionProductIdentifiers,
                     paywallData,
                     storefrontCountryCode,
                 )
@@ -54,8 +49,6 @@ internal object PackageConfigurationFactory {
                 makeMultiplePackageConfiguration(
                     filteredRCPackages,
                     variableDataProvider,
-                    activelySubscribedProductIdentifiers,
-                    nonSubscriptionProductIdentifiers,
                     paywallData,
                     default,
                     storefrontCountryCode,
@@ -67,8 +60,6 @@ internal object PackageConfigurationFactory {
                     packageIdsInConfig,
                     availablePackages,
                     variableDataProvider,
-                    activelySubscribedProductIdentifiers,
-                    nonSubscriptionProductIdentifiers,
                     storefrontCountryCode,
                 )
             }
@@ -81,8 +72,6 @@ internal object PackageConfigurationFactory {
         packageIdsInConfig: List<String>,
         availablePackages: List<Package>,
         variableDataProvider: VariableDataProvider,
-        activelySubscribedProductIdentifiers: Set<String>,
-        nonSubscriptionProductIdentifiers: Set<String>,
         storefrontCountryCode: String?,
     ): Result<Pair<Locale, TemplateConfiguration.PackageConfiguration.MultiTier>> {
         val tiers = paywallData.config.tiers ?: return Result.failure(
@@ -102,8 +91,6 @@ internal object PackageConfigurationFactory {
                 filter = tier.packageIds,
                 localization = localizationForTier,
                 variableDataProvider = variableDataProvider,
-                activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers,
-                nonSubscriptionProductIdentifiers = nonSubscriptionProductIdentifiers,
                 locale = locale,
                 storefrontCountryCode = storefrontCountryCode,
                 zeroDecimalPlaceCountries = paywallData.zeroDecimalPlaceCountries,
@@ -163,8 +150,6 @@ internal object PackageConfigurationFactory {
     private fun makeMultiplePackageConfiguration(
         filteredRCPackages: List<Package>,
         variableDataProvider: VariableDataProvider,
-        activelySubscribedProductIdentifiers: Set<String>,
-        nonSubscriptionProductIdentifiers: Set<String>,
         paywallData: PaywallData,
         default: String?,
         storefrontCountryCode: String?,
@@ -172,8 +157,6 @@ internal object PackageConfigurationFactory {
         val (locale, packageInfos) = makePackageInfo(
             packages = filteredRCPackages,
             variableDataProvider = variableDataProvider,
-            activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers,
-            nonSubscriptionProductIdentifiers = nonSubscriptionProductIdentifiers,
             paywallData = paywallData,
             storefrontCountryCode = storefrontCountryCode,
         )
@@ -196,16 +179,12 @@ internal object PackageConfigurationFactory {
     private fun makeSinglePackageConfiguration(
         filteredRCPackages: List<Package>,
         variableDataProvider: VariableDataProvider,
-        activelySubscribedProductIdentifiers: Set<String>,
-        nonSubscriptionProductIdentifiers: Set<String>,
         paywallData: PaywallData,
         storefrontCountryCode: String?,
     ): Result<Pair<Locale, TemplateConfiguration.PackageConfiguration.Single>> {
         val (locale, packageInfos) = makePackageInfo(
             packages = filteredRCPackages,
             variableDataProvider = variableDataProvider,
-            activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers,
-            nonSubscriptionProductIdentifiers = nonSubscriptionProductIdentifiers,
             paywallData = paywallData,
             storefrontCountryCode = storefrontCountryCode,
         )
@@ -223,8 +202,6 @@ internal object PackageConfigurationFactory {
     private fun makePackageInfo(
         packages: List<Package>,
         variableDataProvider: VariableDataProvider,
-        activelySubscribedProductIdentifiers: Set<String>,
-        nonSubscriptionProductIdentifiers: Set<String>,
         paywallData: PaywallData,
         storefrontCountryCode: String?,
     ): Pair<Locale, List<TemplateConfiguration.PackageInfo>> {
@@ -232,11 +209,6 @@ internal object PackageConfigurationFactory {
 
         val (locale, localization) = paywallData.localizedConfiguration
         val packageInfos = packages.map {
-            val currentlySubscribed = it.currentlySubscribed(
-                activelySubscribedProductIdentifiers,
-                nonSubscriptionProductIdentifiers,
-            )
-
             val discountRelativeToMostExpensivePerMonth = productDiscount(
                 it.product.pricePerMonth(),
                 mostExpensivePricePerMonth,
@@ -259,7 +231,6 @@ internal object PackageConfigurationFactory {
                     rcPackage = it,
                     locale = locale,
                 ),
-                currentlySubscribed = currentlySubscribed,
                 discountRelativeToMostExpensivePerMonth = discountRelativeToMostExpensivePerMonth,
             )
         }
@@ -273,8 +244,6 @@ internal object PackageConfigurationFactory {
         filter: List<String>,
         localization: PaywallData.LocalizedConfiguration,
         variableDataProvider: VariableDataProvider,
-        activelySubscribedProductIdentifiers: Set<String>,
-        nonSubscriptionProductIdentifiers: Set<String>,
         locale: Locale,
         storefrontCountryCode: String?,
         zeroDecimalPlaceCountries: List<String>,
@@ -287,11 +256,6 @@ internal object PackageConfigurationFactory {
                 val discount = productDiscount(
                     pricePerMonth = it.product.pricePerMonth(),
                     mostExpensive = mostExpensivePricePerMonth,
-                )
-
-                val currentlySubscribed = it.currentlySubscribed(
-                    activelySubscribedProductIdentifiers,
-                    nonSubscriptionProductIdentifiers,
                 )
 
                 val shouldRound = if (storefrontCountryCode != null) {
@@ -311,7 +275,6 @@ internal object PackageConfigurationFactory {
                         rcPackage = it,
                         locale = locale,
                     ),
-                    currentlySubscribed = currentlySubscribed,
                     discountRelativeToMostExpensivePerMonth = discount,
                 )
             }
@@ -334,25 +297,4 @@ internal object PackageConfigurationFactory {
             }
         }
     }
-}
-
-@JvmSynthetic
-internal fun Package.currentlySubscribed(
-    activelySubscribedProductIdentifiers: Set<String>,
-    nonSubscriptionProductIdentifiers: Set<String>,
-): Boolean = when (packageType) {
-    PackageType.ANNUAL,
-    PackageType.SIX_MONTH,
-    PackageType.THREE_MONTH,
-    PackageType.TWO_MONTH,
-    PackageType.MONTHLY,
-    PackageType.WEEKLY,
-    -> activelySubscribedProductIdentifiers.contains(product.id)
-
-    PackageType.LIFETIME,
-    -> nonSubscriptionProductIdentifiers.contains(product.id)
-
-    PackageType.CUSTOM,
-    PackageType.UNKNOWN,
-    -> false
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfiguration.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfiguration.kt
@@ -42,7 +42,6 @@ internal data class TemplateConfiguration(
     data class PackageInfo(
         val rcPackage: Package,
         val localization: ProcessedLocalizedConfiguration,
-        val currentlySubscribed: Boolean,
         val discountRelativeToMostExpensivePerMonth: Double?,
     )
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactory.kt
@@ -12,8 +12,6 @@ internal object TemplateConfigurationFactory {
         mode: PaywallMode,
         paywallData: PaywallData,
         availablePackages: List<Package>,
-        activelySubscribedProductIdentifiers: Set<String>,
-        nonSubscriptionProductIdentifiers: Set<String>,
         template: PaywallTemplate,
         storefrontCountryCode: String?,
     ): Result<TemplateConfiguration> {
@@ -37,8 +35,6 @@ internal object TemplateConfigurationFactory {
             PackageConfigurationFactory.createPackageConfiguration(
                 variableDataProvider = variableDataProvider,
                 availablePackages = availablePackages,
-                activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers,
-                nonSubscriptionProductIdentifiers = nonSubscriptionProductIdentifiers,
                 packageIdsInConfig = paywallData.config.packageIds,
                 default = paywallData.config.defaultPackage,
                 configurationType = template.configurationType,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -488,8 +488,6 @@ internal class MockViewModel(
         when (val validated = offering.validatedPaywall(TestData.Constants.currentColorScheme, resourceProvider)) {
             is PaywallValidationResult.Legacy -> offering.toLegacyPaywallState(
                 variableDataProvider = VariableDataProvider(resourceProvider),
-                activelySubscribedProductIdentifiers = setOf(),
-                nonSubscriptionProductIdentifiers = setOf(),
                 mode = mode,
                 validatedPaywallData = validated.displayablePaywall,
                 template = validated.template,
@@ -498,8 +496,6 @@ internal class MockViewModel(
             )
             is PaywallValidationResult.Components -> offering.toComponentsPaywallState(
                 validationResult = validated,
-                activelySubscribedProductIds = emptySet(),
-                purchasedNonSubscriptionProductIds = emptySet(),
                 storefrontCountryCode = null,
                 dateProvider = { Date(MILLIS_2025_01_25) },
             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -285,8 +285,6 @@ private fun PaywallData.LocalizedConfiguration.validate(): PaywallValidationErro
 @Suppress("ReturnCount", "TooGenericExceptionCaught", "LongParameterList")
 internal fun Offering.toLegacyPaywallState(
     variableDataProvider: VariableDataProvider,
-    activelySubscribedProductIdentifiers: Set<String>,
-    nonSubscriptionProductIdentifiers: Set<String>,
     mode: PaywallMode,
     validatedPaywallData: PaywallData,
     template: PaywallTemplate,
@@ -298,8 +296,6 @@ internal fun Offering.toLegacyPaywallState(
         mode = mode,
         paywallData = validatedPaywallData,
         availablePackages = availablePackages,
-        activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers,
-        nonSubscriptionProductIdentifiers = nonSubscriptionProductIdentifiers,
         template,
         storefrontCountryCode = storefrontCountryCode,
     )
@@ -318,8 +314,6 @@ internal fun Offering.toLegacyPaywallState(
 @Suppress("LongParameterList")
 internal fun Offering.toComponentsPaywallState(
     validationResult: PaywallValidationResult.Components,
-    activelySubscribedProductIds: Set<String>,
-    purchasedNonSubscriptionProductIds: Set<String>,
     storefrontCountryCode: String?,
     dateProvider: () -> Date,
 ): PaywallState.Loaded.Components {
@@ -336,8 +330,6 @@ internal fun Offering.toComponentsPaywallState(
         variableDataProvider = validationResult.variableDataProvider,
         offering = this,
         locales = validationResult.locales,
-        activelySubscribedProductIds = activelySubscribedProductIds,
-        purchasedNonSubscriptionProductIds = purchasedNonSubscriptionProductIds,
         dateProvider = dateProvider,
         packages = validationResult.packages,
         initialSelectedTabIndex = validationResult.initialSelectedTabIndex,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsLocaleTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallStateLoadedComponentsLocaleTests.kt
@@ -95,7 +95,7 @@ internal class PaywallStateLoadedComponentsLocaleTests(
                 "device locale only matches language, not region, es-AR -> es-ES",
                 Args(
                     paywallLocales = nonEmptyListOf("en_US", "es_ES"),
-                    deviceLocales = nonEmptyListOf("es-AR",),
+                    deviceLocales = nonEmptyListOf("es-AR"),
                     expected = "es-ES",
                 ),
             ),
@@ -365,8 +365,6 @@ internal class PaywallStateLoadedComponentsLocaleTests(
             paywallComponents = null,
         ),
         locales = paywallLocales.map { LocaleId(it) }.toNonEmptySetOrNull()!!,
-        activelySubscribedProductIds = emptySet(),
-        purchasedNonSubscriptionProductIds = emptySet(),
         dateProvider = { Date() },
         packages = PaywallState.Loaded.Components.AvailablePackages(
             packagesOutsideTabs = emptyList(),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/MultiTierTemplateConfigurationFactoryTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/MultiTierTemplateConfigurationFactoryTest.kt
@@ -40,12 +40,6 @@ internal class MultiTierTemplateConfigurationFactoryTest {
                 TestData.Packages.annual,
                 TestData.Packages.lifetime,
             ),
-            activelySubscribedProductIdentifiers = setOf(
-                TestData.Packages.monthly.product.id,
-            ),
-            nonSubscriptionProductIdentifiers = setOf(
-                TestData.Packages.lifetime.product.id
-            ),
             template = PaywallTemplate.TEMPLATE_7,
             storefrontCountryCode = "US",
         )
@@ -118,37 +112,31 @@ internal class MultiTierTemplateConfigurationFactoryTest {
         )
 
         val monthlyPackage = TestData.Packages.monthly.getPackageInfoForTest(
-            currentlySubscribed = true,
             paywallData = TestData.template7,
             features = basicFeatures,
             tierId = "basic"
         )
         val bimonthlyPackage = TestData.Packages.bimonthly.getPackageInfoForTest(
-            currentlySubscribed = false,
             paywallData = TestData.template7,
             features = standardFeatures,
             tierId = "standard"
         )
         val quarterlyPackage = TestData.Packages.quarterly.getPackageInfoForTest(
-            currentlySubscribed = false,
             paywallData = TestData.template7,
             features = premiumFeatures,
             tierId = "premium"
         )
         val semesterPackage = TestData.Packages.semester.getPackageInfoForTest(
-            currentlySubscribed = false,
             paywallData = TestData.template7,
             features = standardFeatures,
             tierId = "standard"
         )
         val annualPackage = TestData.Packages.annual.getPackageInfoForTest(
-            currentlySubscribed = false,
             paywallData = TestData.template7,
             features = basicFeatures,
             tierId = "basic"
         )
         val lifetime = TestData.Packages.lifetime.getPackageInfoForTest(
-            currentlySubscribed = true,
             paywallData = TestData.template7,
             features = premiumFeatures,
             tierId = "premium"
@@ -248,8 +236,6 @@ internal class MultiTierTemplateConfigurationFactoryTest {
                 TestData.Packages.weekly,
                 TestData.Packages.lifetime,
             ),
-            activelySubscribedProductIdentifiers = emptySet(),
-            nonSubscriptionProductIdentifiers = emptySet(),
             template = PaywallTemplate.TEMPLATE_7,
             storefrontCountryCode = "US",
         )

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/TemplateConfigurationFactoryTest.kt
@@ -34,12 +34,6 @@ internal class TemplateConfigurationFactoryTest {
                 TestData.Packages.annual,
                 TestData.Packages.lifetime,
             ),
-            activelySubscribedProductIdentifiers = setOf(
-                TestData.Packages.monthly.product.id,
-            ),
-            nonSubscriptionProductIdentifiers = setOf(
-                TestData.Packages.lifetime.product.id
-            ),
             template = PaywallTemplate.TEMPLATE_2,
             storefrontCountryCode = "US",
         )
@@ -68,9 +62,9 @@ internal class TemplateConfigurationFactoryTest {
         )
         val packageConfiguration = template2Configuration.packages as TemplateConfiguration.PackageConfiguration.Multiple
 
-        val annualPackage = TestData.Packages.annual.getPackageInfoForTest(currentlySubscribed = false)
-        val monthlyPackage = TestData.Packages.monthly.getPackageInfoForTest(currentlySubscribed = true)
-        val lifetime = TestData.Packages.lifetime.getPackageInfoForTest(currentlySubscribed = true)
+        val annualPackage = TestData.Packages.annual.getPackageInfoForTest()
+        val monthlyPackage = TestData.Packages.monthly.getPackageInfoForTest()
+        val lifetime = TestData.Packages.lifetime.getPackageInfoForTest()
 
         val expectedConfiguration = TemplateConfiguration.PackageConfiguration.Multiple(
             TemplateConfiguration.PackageConfiguration.MultiPackage(

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallState.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/extensions/PaywallState.kt
@@ -17,15 +17,11 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.validatePaywallComponent
  */
 internal fun Offering.toComponentsPaywallState(
     validationResult: PaywallValidationResult.Components,
-    activelySubscribedProductIds: Set<String> = emptySet(),
-    purchasedNonSubscriptionProductIds: Set<String> = emptySet(),
     storefrontCountryCode: String? = null,
     dateProvider: () -> Date = { Date() }
 ): PaywallState.Loaded.Components =
     actualToComponentsPaywallState(
         validationResult = validationResult,
-        activelySubscribedProductIds = activelySubscribedProductIds,
-        purchasedNonSubscriptionProductIds = purchasedNonSubscriptionProductIds,
         storefrontCountryCode = storefrontCountryCode,
         dateProvider = dateProvider,
     )

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PackageInfoForTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PackageInfoForTest.kt
@@ -10,7 +10,6 @@ import com.revenuecat.purchases.ui.revenuecatui.data.testdata.templates.template
 import java.util.Locale
 
 internal fun Package.getPackageInfoForTest(
-    currentlySubscribed: Boolean = false,
     paywallData: PaywallData = TestData.template2,
     features: List<PaywallData.LocalizedConfiguration.Feature> = emptyList(),
     tierId: String? = null,
@@ -106,7 +105,6 @@ internal fun Package.getPackageInfoForTest(
     return TemplateConfiguration.PackageInfo(
         rcPackage = this,
         localization = processedLocalization,
-        currentlySubscribed = currentlySubscribed,
         discountRelativeToMostExpensivePerMonth = discountRelativeToMostExpensivePerMonth,
     )
 }


### PR DESCRIPTION
### Description
As the title says. Now, we will rely on Google instead to handle resubscribing. The default behavior by Google is:
- If trying to purchase the same base plan that the user is already subscribed, display a message indicating so, with a link to manage subscriptions
- If trying to purchase a different base plan for a product the user is already subscribed to, perform an upgrade/downgrade.
- If trying to purchase a product the user has an active but cancelled subscription for, resubscribe.