### PR TITLE
Fix `Switch` component previews

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PreviewHelpers.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PreviewHelpers.kt
@@ -69,6 +69,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallResourceProvider
 import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallValidationResult
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Result
 import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
+import com.revenuecat.purchases.ui.revenuecatui.helpers.map
 import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toComponentsPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toNonEmptyMapOrNull
@@ -80,7 +81,7 @@ private const val MILLIS_2025_01_25 = 1737763200000
 
 @Composable
 @JvmSynthetic
-internal fun previewEmptyState(): PaywallState.Loaded.Components {
+internal fun previewEmptyState(initialSelectedTabIndex: Int? = null): PaywallState.Loaded.Components {
     val data = PaywallComponentsData(
         templateName = "template",
         assetBaseURL = URL("https://assets.pawwalls.com"),
@@ -111,7 +112,13 @@ internal fun previewEmptyState(): PaywallState.Loaded.Components {
             data = data,
         ),
     )
-    val validated = offering.validatePaywallComponentsDataOrNullForPreviews()?.getOrThrow()!!
+    val validated = offering.validatePaywallComponentsDataOrNullForPreviews()?.map {
+        if (initialSelectedTabIndex != null) {
+            it.copy(initialSelectedTabIndex = initialSelectedTabIndex)
+        } else {
+            it
+        }
+    }?.getOrThrow()!!
     return offering.toComponentsPaywallState(
         validationResult = validated,
         activelySubscribedProductIds = emptySet(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -823,7 +823,6 @@ internal class StyleFactory(
         ) { thumbColorOn, thumbColorOff, trackColorOn, trackColorOff ->
             defaultTabIndex = if (component.defaultValue) 1 else 0
             TabControlToggleComponentStyle(
-                defaultValue = component.defaultValue,
                 thumbColorOn = thumbColorOn,
                 thumbColorOff = thumbColorOff,
                 trackColorOn = trackColorOn,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/TabsComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/TabsComponentStyle.kt
@@ -29,8 +29,6 @@ internal data class TabControlButtonComponentStyle(
 @Immutable
 internal class TabControlToggleComponentStyle(
     @get:JvmSynthetic
-    val defaultValue: Boolean,
-    @get:JvmSynthetic
     val thumbColorOn: ColorStyles,
     @get:JvmSynthetic
     val thumbColorOff: ColorStyles,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabControlToggleView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabControlToggleView.kt
@@ -58,9 +58,9 @@ private class CheckedPreviewProvider : PreviewParameterProvider<Boolean> {
 private fun TabControlToggleView_Preview(
     @PreviewParameter(CheckedPreviewProvider::class) checked: Boolean,
 ) {
+    val initialTabIndex = if (checked) 1 else 0
     TabControlToggleView(
         style = TabControlToggleComponentStyle(
-            defaultValue = checked,
             thumbColorOn = ColorStyles(
                 light = ColorStyle.Solid(color = Color.Red),
                 dark = ColorStyle.Solid(color = Color.Blue),
@@ -78,7 +78,7 @@ private fun TabControlToggleView_Preview(
                 dark = ColorStyle.Solid(color = Color.Yellow),
             ),
         ),
-        state = previewEmptyState(),
+        state = previewEmptyState(initialSelectedTabIndex = initialTabIndex),
     )
 }
 
@@ -102,7 +102,6 @@ private fun TabControlToggleView_Gradient_Preview() {
 
     TabControlToggleView(
         style = TabControlToggleComponentStyle(
-            defaultValue = false,
             thumbColorOn = ColorStyles(
                 light = ColorInfo.Gradient.Radial(
                     points = pointsRgb,


### PR DESCRIPTION
### Description
This fixes the previews for the `Switch` component so we can preview the checked state. They weren't working since they tried to use an unused property `defaultValue`, which is removed in this PR. The component uses the selected tab index to know whether the switch should be checked or not.