### PR TITLE
Update CustomEntitlementComputation sample app kotlin version

### DIFF
--- a/examples/CustomEntitlementComputationSample/app/build.gradle.kts
+++ b/examples/CustomEntitlementComputationSample/app/build.gradle.kts
@@ -58,7 +58,7 @@ android {
         buildConfig = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.3.2"
+        kotlinCompilerExtensionVersion = "1.4.8"
     }
     packaging {
         resources {

--- a/examples/CustomEntitlementComputationSample/gradle/libs.versions.toml
+++ b/examples/CustomEntitlementComputationSample/gradle/libs.versions.toml
@@ -1,9 +1,7 @@
 [versions]
 agp = "8.1.3"
-androidxNavigation = "2.5.3"
-kotlin = "1.7.20"
+kotlin = "1.8.22"
 purchases = "8.23.0-SNAPSHOT"
-lifecycle = "2.5.0"
 androidxCore = "1.10.1"
 
 [plugins]
@@ -12,14 +10,7 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 
 [libraries]
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
-androidx-lifecycle-livedata = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
-androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
-androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidxNavigation" }
-androidx-navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidxNavigation" }
 
-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
-
-material = "com.google.android.material:material:1.3.0"
 lifecycle-runtime-ktx = "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
 activity-compose = "androidx.activity:activity-compose:1.3.1"
 compose-bom = "androidx.compose:compose-bom:2023.05.01"


### PR DESCRIPTION
### Description
This updates the CustomEntitlementComputation sample app to kotlin 1.8.22. This is needed after dropping support for 1.7 in #2493 