### PR TITLE
Add launchPaywallWindow helper

### DIFF
--- a/ui/revenuecatui/api.txt
+++ b/ui/revenuecatui/api.txt
@@ -48,6 +48,10 @@ package com.revenuecat.purchases.ui.revenuecatui {
     method @androidx.compose.runtime.Composable public static void Paywall(com.revenuecat.purchases.ui.revenuecatui.PaywallOptions options);
   }
 
+  public final class PaywallWindowKt {
+    method public static void launchPaywallWindow(android.app.Activity activity, optional com.revenuecat.purchases.Offering? offering, optional com.revenuecat.purchases.ui.revenuecatui.PaywallListener? listener);
+  }
+
   public interface PaywallListener {
     method public default void onPurchaseCancelled();
     method public default void onPurchaseCompleted(com.revenuecat.purchases.CustomerInfo customerInfo, com.revenuecat.purchases.models.StoreTransaction storeTransaction);

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWindow.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallWindow.kt
@@ -1,0 +1,50 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import android.app.Activity
+import android.graphics.PixelFormat
+import android.view.ViewGroup
+import android.view.WindowManager
+import android.widget.FrameLayout
+import androidx.window.layout.WindowMetricsCalculator
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.views.PaywallView
+
+/**
+ * Launches the RevenueCat Paywall inside a new [android.view.Window].
+ * The window will match the size of the current one and will be removed
+ * when the paywall is dismissed.
+ *
+ * @param activity host activity used to create the window.
+ * @param offering optional [Offering] to display.
+ * @param listener optional [PaywallListener] to receive callbacks.
+ */
+@JvmOverloads
+fun launchPaywallWindow(
+    activity: Activity,
+    offering: Offering? = null,
+    listener: PaywallListener? = null,
+) {
+    val windowManager = activity.windowManager
+    val metrics = WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(activity)
+    val params = WindowManager.LayoutParams(
+        metrics.bounds.width(),
+        metrics.bounds.height(),
+        WindowManager.LayoutParams.TYPE_APPLICATION_PANEL,
+        WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN,
+        PixelFormat.TRANSLUCENT,
+    ).apply {
+        token = activity.window.decorView.applicationWindowToken
+    }
+
+    val container = FrameLayout(activity)
+    val paywallView = PaywallView(activity, offering, listener) {
+        windowManager.removeView(container)
+    }
+    container.addView(
+        paywallView,
+        ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT),
+    )
+
+    windowManager.addView(container, params)
+}
+


### PR DESCRIPTION
## Summary
- add a new helper `launchPaywallWindow` to show `PaywallView` in its own `Window`
- expose the API in `ui/revenuecatui/api.txt`

## Testing
- `scripts/api-dump.sh` *(fails: Unable to tunnel through proxy)*
- `scripts/pre-commit.sh` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6870d0014288833087b952bed3e7f014