### PR TITLE
Fix upgrades/downgrades after BC8 update

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -466,8 +466,10 @@ internal class BillingWrapper(
                     appInBackground,
                     googleProductType,
                 ),
-                { purchasesByProductId ->
-                    val purchasesRecordWrapper = purchasesByProductId[productId]
+                { purchasesByHashedToken ->
+                    val purchasesRecordWrapper = purchasesByHashedToken.values.firstOrNull {
+                        it.productIds.firstOrNull() == productId
+                    }
                     if (purchasesRecordWrapper != null) {
                         onCompletion(purchasesRecordWrapper)
                     } else {


### PR DESCRIPTION
### Description
Upgrades/downgrades were not working after the changes in #2506. This fixes the issue and adds some tests to the relevant code to avoid it from happening again.

This should deal with #2531 