### PR TITLE
Dont run VC tests on load shedder integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -786,7 +786,7 @@ workflows:
       - emerge_purchases_ui_snapshot_tests
       - integration-tests-build
       - purchases-integration-tests-build
-      - run-firebase-tests-purchases-custom-entitlement-computation-integration-test
+      - run-firebase-tests-purchases-custom-entitlement-computation-integration-test:
       - run-firebase-tests-purchases-integration-test:
           requires:
             - purchases-integration-tests-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -784,13 +784,15 @@ workflows:
       - record-and-upload-paparazzi-revenuecatui-snapshots
       - run-revenuecatui-ui-tests
       - emerge_purchases_ui_snapshot_tests
-      - integration-tests-build
-      - purchases-integration-tests-build
+      - integration-tests-build: *release-branches
+      - purchases-integration-tests-build: *release-branches
       - run-firebase-tests-purchases-custom-entitlement-computation-integration-test:
+          <<: *release-branches
       - run-firebase-tests-purchases-integration-test:
           requires:
             - purchases-integration-tests-build
       - run-firebase-tests-purchases-load-shedder-integration-test:
+          <<: *release-branches
           context:
             - slack-secrets
       - run-firebase-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -784,11 +784,15 @@ workflows:
       - record-and-upload-paparazzi-revenuecatui-snapshots
       - run-revenuecatui-ui-tests
       - emerge_purchases_ui_snapshot_tests
-      - integration-tests-build:
-      - purchases-integration-tests-build:
+      - integration-tests-build: *release-branches
+      - purchases-integration-tests-build: *release-branches
       - run-firebase-tests-purchases-custom-entitlement-computation-integration-test:
+          <<: *release-branches
       - run-firebase-tests-purchases-integration-test:
+          requires:
+            - purchases-integration-tests-build
       - run-firebase-tests-purchases-load-shedder-integration-test:
+          <<: *release-branches
           context:
             - slack-secrets
       - run-firebase-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -784,15 +784,11 @@ workflows:
       - record-and-upload-paparazzi-revenuecatui-snapshots
       - run-revenuecatui-ui-tests
       - emerge_purchases_ui_snapshot_tests
-      - integration-tests-build: *release-branches
-      - purchases-integration-tests-build: *release-branches
+      - integration-tests-build:
+      - purchases-integration-tests-build:
       - run-firebase-tests-purchases-custom-entitlement-computation-integration-test:
-          <<: *release-branches
       - run-firebase-tests-purchases-integration-test:
-          requires:
-            - purchases-integration-tests-build
       - run-firebase-tests-purchases-load-shedder-integration-test:
-          <<: *release-branches
           context:
             - slack-secrets
       - run-firebase-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -786,7 +786,7 @@ workflows:
       - emerge_purchases_ui_snapshot_tests
       - integration-tests-build
       - purchases-integration-tests-build
-      - run-firebase-tests-purchases-custom-entitlement-computation-integration-test:
+      - run-firebase-tests-purchases-custom-entitlement-computation-integration-test
       - run-firebase-tests-purchases-integration-test:
           requires:
             - purchases-integration-tests-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -784,15 +784,13 @@ workflows:
       - record-and-upload-paparazzi-revenuecatui-snapshots
       - run-revenuecatui-ui-tests
       - emerge_purchases_ui_snapshot_tests
-      - integration-tests-build: *release-branches
-      - purchases-integration-tests-build: *release-branches
+      - integration-tests-build
+      - purchases-integration-tests-build
       - run-firebase-tests-purchases-custom-entitlement-computation-integration-test:
-          <<: *release-branches
       - run-firebase-tests-purchases-integration-test:
           requires:
             - purchases-integration-tests-build
       - run-firebase-tests-purchases-load-shedder-integration-test:
-          <<: *release-branches
           context:
             - slack-secrets
       - run-firebase-tests:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -274,7 +274,8 @@ platform :android do
         google_purchase_token: ENV['LOAD_SHEDDER_GOOGLE_PURCHASE_TOKEN'],
         product_id_to_purchase: ENV['LOAD_SHEDDER_PRODUCT_ID_TO_PURCHASE'],
         base_plan_id_to_purchase: ENV['LOAD_SHEDDER_BASE_PLAN_ID_TO_PURCHASE'],
-        active_entitlements_to_verify: ENV['LOAD_SHEDDER_ACTIVE_ENTITLEMENTS_TO_VERIFY'] || ''
+        active_entitlements_to_verify: ENV['LOAD_SHEDDER_ACTIVE_ENTITLEMENTS_TO_VERIFY'] || '',
+        is_load_shedder_integration_tests: true
       )
 
       run_firebase_integration_tests(app_name)
@@ -324,7 +325,8 @@ platform :android do
 
   def build_purchases_integration_tests(app_name:, api_key:, google_purchase_token:, product_id_to_purchase:,
                                         base_plan_id_to_purchase:, active_entitlements_to_verify: '',
-                                        proxy_url: nil, build_type: 'release', flavor: 'defaults')
+                                        proxy_url: nil, build_type: 'release', flavor: 'defaults', 
+                                        is_load_shedder_integration_tests: false)
     constants_path = './purchases/src/androidTest/kotlin/com/revenuecat/purchases/Constants.kt'
     replace_text_in_files(
       previous_text: "REVENUECAT_API_KEY",
@@ -352,6 +354,13 @@ platform :android do
       allow_empty: true,
       paths_of_files_to_update: [constants_path]
     )
+    if is_load_shedder_integration_tests
+      replace_text_in_files(
+        previous_text: "IS_RUNNING_LOAD_SHEDDER_INTEGRATION_TESTS",
+        new_text: "true",
+        paths_of_files_to_update: [constants_path]
+      )
+    end
     unless proxy_url.nil?
       replace_text_in_files(
         previous_text: "NO_PROXY_URL",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -360,6 +360,12 @@ platform :android do
         new_text: "true",
         paths_of_files_to_update: [constants_path]
       )
+    else
+      replace_text_in_files(
+        previous_text: "IS_RUNNING_LOAD_SHEDDER_INTEGRATION_TESTS",
+        new_text: "false",
+        paths_of_files_to_update: [constants_path]
+      )
     end
     unless proxy_url.nil?
       replace_text_in_files(

--- a/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
+++ b/purchases/src/androidTest/kotlin/com/revenuecat/purchases/BasePurchasesIntegrationTest.kt
@@ -170,6 +170,10 @@ open class BasePurchasesIntegrationTest {
         }
     }
 
+    protected fun isRunningLoadShedderIntegrationTests(): Boolean {
+        return Constants.isRunningLoadShedderIntegrationTests.toBoolean()
+    }
+
     private fun clearAllSharedPreferences(context: Context) {
         PreferenceManager.getDefaultSharedPreferences(context).edit().clear().commit()
         context.getSharedPreferences(

--- a/purchases/src/androidTest/kotlin/com/revenuecat/purchases/Constants.kt
+++ b/purchases/src/androidTest/kotlin/com/revenuecat/purchases/Constants.kt
@@ -9,4 +9,6 @@ object Constants {
 
     // comma separated list of active entitlements to verify
     const val activeEntitlementIdsToVerify = "ACTIVE_ENTITLEMENT_IDS_TO_VERIFY"
+
+    const val isRunningLoadShedderIntegrationTests = "IS_RUNNING_LOAD_SHEDDER_INTEGRATION_TESTS"
 }

--- a/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
+++ b/purchases/src/androidTestDefaults/kotlin/com/revenuecat/purchases/PurchasesIntegrationTest.kt
@@ -211,6 +211,12 @@ class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
 
     @Test
     fun testGetVirtualCurrenciesWithBalancesOfZero() {
+        // Virtual Currencies aren't supported by the load shedder yet, so we don't want to run
+        // VC tests in the load shedder integration tests
+        if (isRunningLoadShedderIntegrationTests()) {
+            return
+        }
+
         val appUserIDWith0BalanceCurrencies = "integrationTestUserWithAllBalancesEqualTo0"
         val lock = CountDownLatch(1)
 
@@ -238,6 +244,12 @@ class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
 
     @Test
     fun testGetVirtualCurrenciesWithBalancesWithSomeNonZeroValues() {
+        // Virtual Currencies aren't supported by the load shedder yet, so we don't want to run
+        // VC tests in the load shedder integration tests
+        if (isRunningLoadShedderIntegrationTests()) {
+            return
+        }
+
         val appUserIDWith0BalanceCurrencies = "integrationTestUserWithAllBalancesNonZero"
         val lock = CountDownLatch(1)
 
@@ -265,6 +277,12 @@ class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
 
     @Test
     fun testGettingVirtualCurrenciesForNewUserReturnsVCsWith0Balance() {
+        // Virtual Currencies aren't supported by the load shedder yet, so we don't want to run
+        // VC tests in the load shedder integration tests
+        if (isRunningLoadShedderIntegrationTests()) {
+            return
+        }
+
         val newAppUserID = "integrationTestUser_${UUID.randomUUID()}"
         val lock = CountDownLatch(1)
 
@@ -292,6 +310,12 @@ class PurchasesIntegrationTest : BasePurchasesIntegrationTest() {
 
     @Test
     fun testCachedVirtualCurrencies() {
+        // Virtual Currencies aren't supported by the load shedder yet, so we don't want to run
+        // VC tests in the load shedder integration tests
+        if (isRunningLoadShedderIntegrationTests()) {
+            return
+        }
+
         val appUserID = "integrationTestUserWithAllBalancesNonZero"
         val lock = CountDownLatch(1)
 


### PR DESCRIPTION
### Description
We were running virtual currency integration tests both with and without the load shedder. However, the load shedder doesn't currently support virtual currencies, so these tests were failing when run for the load shedder integration test app. This PR updates the integration tests so that the virtual currency integration tests don't run for the load shedder integration tests app.

### Implementation Details
We are able to accomplish this by:
- When we're running integration tests through the integration tests app, fastlane sets the `IS_RUNNING_LOAD_SHEDDER_INTEGRATION_TESTS` string to `true` in `Constants.kt`.
- There's a new function `BasePurchasesIntegrationTest.isRunningLoadShedderIntegrationTests`, that tests can use to determine if they're running in the load shedder integration test app.

### Testing
I manually forced the integration tests to run on this PR, and both the regular and load shedder integration tests passed in Firebase