### PR TITLE
Expose Virtual Currency Constructors with @InternalRevenueCatAPI

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/VirtualCurrenciesAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/VirtualCurrenciesAPI.java
@@ -1,13 +1,22 @@
 package com.revenuecat.apitester.java;
 
+import androidx.annotation.OptIn;
+
+import com.revenuecat.purchases.InternalRevenueCatAPI;
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies;
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrency;
 
+import java.util.HashMap;
 import java.util.Map;
 
 final class VirtualCurrenciesAPI {
     static void check(final VirtualCurrencies virtualCurrencies){
         final Map<String, VirtualCurrency> all = virtualCurrencies.getAll();
         final VirtualCurrency testGetVC = virtualCurrencies.get("COIN");
+    }
+
+    @OptIn(markerClass = InternalRevenueCatAPI.class)
+    static void checkInternalRevenueCatAPIs() {
+        final VirtualCurrencies vcs = new VirtualCurrencies(new HashMap<String, VirtualCurrency>());
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/VirtualCurrencyAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/VirtualCurrencyAPI.java
@@ -1,5 +1,8 @@
 package com.revenuecat.apitester.java;
 
+import androidx.annotation.OptIn;
+
+import com.revenuecat.purchases.InternalRevenueCatAPI;
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrency;
 
 final class VirtualCurrencyAPI {
@@ -9,5 +12,22 @@ final class VirtualCurrencyAPI {
         final String name = virtualCurrency.getName();
         final String code = virtualCurrency.getCode();
         final String serverDescription = virtualCurrency.getServerDescription();
+    }
+
+    @OptIn(markerClass = InternalRevenueCatAPI.class)
+    static void checkInternalRevenueCatAPIs() {
+        VirtualCurrency virtualCurrencyWithServerDescription = new VirtualCurrency(
+                100,
+                "Gold",
+                "GLD",
+                "This is a test currency."
+        );
+
+        VirtualCurrency virtualCurrencyWithoutServerDescription = new VirtualCurrency(
+                100,
+                "Gold",
+                "GLD",
+                null
+        );
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VirtualCurrenciesAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VirtualCurrenciesAPI.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.apitester.kotlin
 
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrency
 
@@ -9,5 +10,12 @@ private class VirtualCurrenciesAPI {
         val all: Map<String, VirtualCurrency> = virtualCurrencies.all
         val subscriptTest: VirtualCurrency? = virtualCurrencies["COIN"]
         val getTest: VirtualCurrency? = virtualCurrencies.get(code = "COIN")
+    }
+
+    @OptIn(InternalRevenueCatAPI::class)
+    fun checkInternalRevenueCatAPIs() {
+        val virtualCurrencies = VirtualCurrencies(
+            all = emptyMap(),
+        )
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VirtualCurrencyAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/VirtualCurrencyAPI.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.apitester.kotlin
 
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrency
 
 @Suppress("unused", "UNUSED_VARIABLE")
@@ -9,5 +10,22 @@ private class VirtualCurrencyAPI {
         val name: String = virtualCurrency.name
         val code: String = virtualCurrency.code
         val serverDescription: String? = virtualCurrency.serverDescription
+    }
+
+    @OptIn(InternalRevenueCatAPI::class)
+    fun checkInternalRevenueCatAPIs() {
+        val virtualCurrencyWithServerDescription = VirtualCurrency(
+            balance = 100,
+            name = "Gold",
+            code = "GLD",
+            serverDescription = "hello",
+        )
+
+        val virtualCurrencyWithoutServerDescription = VirtualCurrency(
+            balance = 100,
+            name = "Gold",
+            code = "GLD",
+            serverDescription = null,
+        )
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/InternalRevenueCatAPI.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/InternalRevenueCatAPI.kt
@@ -11,5 +11,6 @@ package com.revenuecat.purchases
     AnnotationTarget.FUNCTION,
     AnnotationTarget.PROPERTY,
     AnnotationTarget.TYPEALIAS,
+    AnnotationTarget.CONSTRUCTOR,
 )
 annotation class InternalRevenueCatAPI

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/virtualcurrencies/VirtualCurrencies.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/virtualcurrencies/VirtualCurrencies.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.virtualcurrencies
 
 import android.os.Parcelable
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
@@ -14,7 +15,7 @@ import kotlinx.serialization.Serializable
 @Poko
 @Parcelize
 @Serializable
-class VirtualCurrencies internal constructor(
+class VirtualCurrencies @InternalRevenueCatAPI constructor(
     @SerialName("virtual_currencies")
     val all: Map<String, VirtualCurrency>,
 ) : Parcelable {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/virtualcurrencies/VirtualCurrency.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/virtualcurrencies/VirtualCurrency.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.virtualcurrencies
 
 import android.os.Parcelable
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
@@ -17,7 +18,7 @@ import kotlinx.serialization.Serializable
 @Poko
 @Serializable
 @Parcelize
-class VirtualCurrency internal constructor(
+class VirtualCurrency @InternalRevenueCatAPI constructor(
     val balance: Int,
     val name: String,
     val code: String,


### PR DESCRIPTION
### Description
This PR exposes the `VirtualCurrency` and `VirtualCurrencies` constructors publicly behind the `@InternalRevenueCatAPI` annotation. This will help us in a few scenarios when we need to instantiate VC objects outside of `purchases-android`, including in the mapper tests in PHC.

#### Other Approaches Considered
We considered a few other approaches before deciding to use `@InternalRevenueCatAPI`:
- Making the constructor public without an annotation. This works, but isn't ideal for a few reasons:
   - Adding new properties would be a breaking change unless we used the `@JvmOverloads` annotation. Even then, we would need to provide a default value, and that won't always be easy (e.g. when we add VC icons, these will likely not be optionals)
   - Parsing the VC objects from JSON in the PHC mapper tests. This would work but feels a little dirty, and wouldn't help us if we ever need to do this in other circumstances.

Using `@InternalRevenueCatAPI` allows us to access the constructor outside of `purchases-android` while still giving us the freedom to make breaking changes to the constructor in the future.