### PR TITLE
Remove TestStoreProduct purchase check

### DIFF
--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -355,13 +355,7 @@ class Purchases internal constructor(
         storeProduct: StoreProduct,
         callback: PurchaseCallback,
     ) {
-        purchasesOrchestrator.startPurchase(
-            activity,
-            storeProduct.purchasingData,
-            null,
-            null,
-            callback,
-        )
+        purchase(PurchaseParams.Builder(activity, storeProduct).build(), callback)
     }
 
     /**
@@ -385,13 +379,7 @@ class Purchases internal constructor(
         packageToPurchase: Package,
         listener: PurchaseCallback,
     ) {
-        purchasesOrchestrator.startPurchase(
-            activity,
-            packageToPurchase.product.purchasingData,
-            packageToPurchase.presentedOfferingContext,
-            null,
-            listener,
-        )
+        purchase(PurchaseParams.Builder(activity, packageToPurchase).build(), listener)
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
@@ -5,7 +5,6 @@ import com.revenuecat.purchases.models.GoogleReplacementMode
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.SubscriptionOption
-import com.revenuecat.purchases.models.TestStoreProduct
 import dev.drewhamilton.poko.Poko
 
 @Poko
@@ -59,17 +58,6 @@ class PurchaseParams(val builder: Builder) {
 
         constructor(activity: Activity, storeProduct: StoreProduct) :
             this(activity, storeProduct.purchasingData, storeProduct.presentedOfferingContext, storeProduct)
-
-        private fun ensureNoTestProduct(storeProduct: StoreProduct) {
-            if (storeProduct is TestStoreProduct) {
-                throw PurchasesException(
-                    PurchasesError(
-                        PurchasesErrorCode.ProductNotAvailableForPurchaseError,
-                        "Cannot purchase $storeProduct",
-                    ),
-                )
-            }
-        }
 
         constructor(activity: Activity, subscriptionOption: SubscriptionOption) :
             this(
@@ -135,10 +123,6 @@ class PurchaseParams(val builder: Builder) {
         }
 
         open fun build(): PurchaseParams {
-            product?.let {
-                ensureNoTestProduct(it)
-            }
-
             return PurchaseParams(this)
         }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -1141,7 +1141,7 @@ internal class PurchasesOrchestrator(
         }
     }
 
-    fun startPurchase(
+    private fun startPurchase(
         activity: Activity,
         purchasingData: PurchasingData,
         presentedOfferingContext: PresentedOfferingContext?,
@@ -1193,7 +1193,7 @@ internal class PurchasesOrchestrator(
         )
     }
 
-    fun startProductChange(
+    private fun startProductChange(
         activity: Activity,
         purchasingData: PurchasingData,
         presentedOfferingContext: PresentedOfferingContext?,
@@ -1261,62 +1261,6 @@ internal class PurchasesOrchestrator(
                 errorLog(it)
             }
             getAndClearAllPurchaseCallbacks().forEach { it.dispatch(operationInProgressError) }
-        }
-    }
-
-    fun startDeprecatedProductChange(
-        activity: Activity,
-        purchasingData: PurchasingData,
-        presentedOfferingContext: PresentedOfferingContext?,
-        oldProductId: String,
-        googleReplacementMode: GoogleReplacementMode?,
-        listener: ProductChangeCallback,
-    ) {
-        if (purchasingData.productType != ProductType.SUBS) {
-            getAndClearProductChangeCallback()
-            listener.dispatch(
-                PurchasesError(
-                    PurchasesErrorCode.PurchaseNotAllowedError,
-                    PurchaseStrings.UPGRADING_INVALID_TYPE,
-                ).also { errorLog(it) },
-            )
-            return
-        }
-
-        log(LogIntent.PURCHASE) {
-            PurchaseStrings.PRODUCT_CHANGE_STARTED.format(
-                " $purchasingData ${
-                    presentedOfferingContext?.offeringIdentifier?.let {
-                        PurchaseStrings.OFFERING + "$it"
-                    }
-                } oldProductId: $oldProductId googleReplacementMode $googleReplacementMode",
-
-            )
-        }
-        var userPurchasing: String? = null // Avoids race condition for userid being modified before purchase is made
-        synchronized(this@PurchasesOrchestrator) {
-            if (!appConfig.finishTransactions) {
-                log(LogIntent.WARNING) { PurchaseStrings.PURCHASE_FINISH_TRANSACTION_FALSE }
-            }
-            if (state.deprecatedProductChangeCallback == null) {
-                state = state.copy(deprecatedProductChangeCallback = listener)
-                userPurchasing = identityManager.currentAppUserID
-            }
-        }
-        userPurchasing?.let { appUserID ->
-            replaceOldPurchaseWithNewProduct(
-                purchasingData,
-                oldProductId,
-                googleReplacementMode,
-                activity,
-                appUserID,
-                presentedOfferingContext,
-                null,
-                listener,
-            )
-        } ?: run {
-            getAndClearProductChangeCallback()
-            listener.dispatch(PurchasesError(PurchasesErrorCode.OperationAlreadyInProgressError).also { errorLog(it) })
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchaseParamsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchaseParamsTest.kt
@@ -50,24 +50,6 @@ class PurchaseParamsTest {
     }
 
     @Test
-    fun `Initializing with TestStoreProduct throws error`() {
-        val storeProduct = TestStoreProduct(
-            "id",
-            "name",
-            "title",
-            "description",
-            Price("$1.99", 1_990_000, "US"),
-            Period(1, Period.Unit.MONTH, "P1M")
-        )
-        try {
-            PurchaseParams.Builder(mockk(), storeProduct).build()
-            fail("Expected error")
-        } catch (e: PurchasesException) {
-            assertThat(e.code).isEqualTo(PurchasesErrorCode.ProductNotAvailableForPurchaseError)
-        }
-    }
-
-    @Test
     fun `Initializing with SubscriptionOption sets proper presentedOfferingIdentifier`() {
         val storeProduct = stubStoreProduct(
             productId = "abc",
@@ -95,25 +77,6 @@ class PurchaseParamsTest {
 
         val expectedPurchasingData = packageToPurchase.product.purchasingData
         assertThat(purchasePackageParams.purchasingData).isEqualTo(expectedPurchasingData)
-    }
-
-    @Test
-    fun `Initializing with Package containing TestStoreProduct throws error`() {
-        val storeProduct = TestStoreProduct(
-            "id",
-            "name",
-            "title",
-            "description",
-            Price("$1.99", 1_990_000, "US"),
-            Period(1, Period.Unit.MONTH, "P1M")
-        )
-        val (_, offerings) = stubOfferings(storeProduct)
-        try {
-            PurchaseParams.Builder(mockk(), offerings[STUB_OFFERING_IDENTIFIER]!!.monthly!!).build()
-            fail("Expected error")
-        } catch (e: PurchasesException) {
-            assertThat(e.code).isEqualTo(PurchasesErrorCode.ProductNotAvailableForPurchaseError)
-        }
     }
 
     @Test


### PR DESCRIPTION
### Description
Until now we had a check that threw an exception when trying to purchase using a TestStoreProduct. However, as part of supporting the Test store we want to remove this check. The purchase method would still fail later, when checking the purchase type in the Google/Amazon stores.
