### PR TITLE
Convert WebBilling products into TestStoreProducts

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/TestStoreProductAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/TestStoreProductAPI.java
@@ -2,12 +2,14 @@ package com.revenuecat.apitester.java;
 
 import com.revenuecat.purchases.models.Period;
 import com.revenuecat.purchases.models.Price;
+import com.revenuecat.purchases.models.PricingPhase;
 import com.revenuecat.purchases.models.StoreProduct;
 import com.revenuecat.purchases.models.TestStoreProduct;
 
 @SuppressWarnings({"unused", "deprecation"})
 final class TestStoreProductAPI {
     static void checkConstructors(final Price price, final Period period) {
+        PricingPhase pricingPhase = null;
         new TestStoreProduct(
                 "id", "title", "description", price, period, null, null
         );
@@ -15,7 +17,7 @@ final class TestStoreProductAPI {
                 "id",  "title", "description", price, period, period, price
         );
         new TestStoreProduct(
-             "id", "name", "title", "description", price, period, null, null
+             "id", "name", "title", "description", price, period, pricingPhase, pricingPhase
         );
         new TestStoreProduct(
             "id", "name", "title", "description", price, period, period, price

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/TestStoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/TestStoreProduct.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.models
 
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.teststore.TestStorePurchasingData
 import dev.drewhamilton.poko.Poko
 
 /**
@@ -16,9 +17,68 @@ class TestStoreProduct(
     override val description: String,
     override val price: Price,
     override val period: Period?,
-    private val freeTrialPeriod: Period? = null,
-    private val introPrice: Price? = null,
+    private val freeTrialPricingPhase: PricingPhase? = null,
+    private val introPricePricingPhase: PricingPhase? = null,
 ) : StoreProduct {
+    constructor(
+        id: String,
+        name: String,
+        title: String,
+        description: String,
+        price: Price,
+        period: Period? = null,
+    ) : this(
+        id,
+        name,
+        title,
+        description,
+        price,
+        period,
+        freeTrialPricingPhase = null,
+        introPricePricingPhase = null,
+    )
+
+    @Deprecated(
+        "Replaced with constructor that takes pricing phases for free trial and intro price",
+        ReplaceWith(
+            "TestStoreProduct(id, name, title, description, price, period, " +
+                "freeTrialPricingPhase, introPricePricingPhase)",
+        ),
+    )
+    constructor(
+        id: String,
+        name: String,
+        title: String,
+        description: String,
+        price: Price,
+        period: Period? = null,
+        freeTrialPeriod: Period? = null,
+        introPrice: Price? = null,
+    ) : this(
+        id,
+        name,
+        title,
+        description,
+        price,
+        period,
+        freeTrialPeriod?.let {
+            PricingPhase(
+                billingPeriod = it,
+                recurrenceMode = RecurrenceMode.FINITE_RECURRING,
+                billingCycleCount = 1,
+                price = Price(amountMicros = 0, currencyCode = price.currencyCode, formatted = "Free"),
+            )
+        },
+        introPrice?.let {
+            PricingPhase(
+                billingPeriod = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
+                recurrenceMode = RecurrenceMode.FINITE_RECURRING,
+                billingCycleCount = 1,
+                price = it,
+            )
+        },
+    )
+
     @Deprecated(
         "Replaced with constructor that takes a name",
         ReplaceWith(
@@ -50,13 +110,11 @@ class TestStoreProduct(
         get() = buildSubscriptionOptions()
     override val defaultOption: SubscriptionOption?
         get() = subscriptionOptions?.defaultOffer
-    override val purchasingData: PurchasingData
-        get() = object : PurchasingData {
-            override val productId: String
-                get() = id
-            override val productType: ProductType
-                get() = type
-        }
+    override val purchasingData: PurchasingData = TestStorePurchasingData(
+        productId = id,
+        productType = type,
+        storeProduct = this,
+    )
 
     @Deprecated(
         "Use presentedOfferingContext",
@@ -83,22 +141,6 @@ class TestStoreProduct(
 
     private fun buildSubscriptionOptions(): SubscriptionOptions? {
         if (period == null) return null
-        val freePhase = freeTrialPeriod?.let { freeTrialPeriod ->
-            PricingPhase(
-                billingPeriod = freeTrialPeriod,
-                recurrenceMode = RecurrenceMode.FINITE_RECURRING,
-                billingCycleCount = 1,
-                price = Price(amountMicros = 0, currencyCode = price.currencyCode, formatted = "Free"),
-            )
-        }
-        val introPhase = introPrice?.let { introPrice ->
-            PricingPhase(
-                billingPeriod = Period(value = 1, unit = Period.Unit.MONTH, iso8601 = "P1M"),
-                recurrenceMode = RecurrenceMode.FINITE_RECURRING,
-                billingCycleCount = 1,
-                price = introPrice,
-            )
-        }
         val basePricePhase = PricingPhase(
             billingPeriod = period,
             recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
@@ -107,12 +149,12 @@ class TestStoreProduct(
         )
         val subscriptionOptionsList = listOfNotNull(
             TestSubscriptionOption(
-                id,
-                listOfNotNull(freePhase, introPhase, basePricePhase),
-            ).takeIf { freeTrialPeriod != null || introPhase != null },
+                listOfNotNull(freeTrialPricingPhase, introPricePricingPhase, basePricePhase),
+                purchasingData = purchasingData,
+            ).takeIf { freeTrialPricingPhase != null || introPricePricingPhase != null },
             TestSubscriptionOption(
-                id,
                 listOf(basePricePhase),
+                purchasingData = purchasingData,
             ),
         )
         return SubscriptionOptions(subscriptionOptionsList)
@@ -120,7 +162,6 @@ class TestStoreProduct(
 }
 
 private class TestSubscriptionOption(
-    val productIdentifier: String,
     override val pricingPhases: List<PricingPhase>,
     val basePlanId: String = "testBasePlanId",
     override val tags: List<String> = emptyList(),
@@ -128,18 +169,11 @@ private class TestSubscriptionOption(
         offeringIdentifier = "offering",
     ),
     override val installmentsInfo: InstallmentsInfo? = null,
+    override val purchasingData: PurchasingData,
 ) : SubscriptionOption {
     override val id: String
         get() = if (pricingPhases.size == 1) basePlanId else "$basePlanId:testOfferId"
 
     override val presentedOfferingIdentifier: String?
         get() = presentedOfferingContext.offeringIdentifier
-
-    override val purchasingData: PurchasingData
-        get() = object : PurchasingData {
-            override val productId: String
-                get() = productIdentifier
-            override val productType: ProductType
-                get() = ProductType.SUBS
-        }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/teststore/TestStoreProductConverter.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/teststore/TestStoreProductConverter.kt
@@ -19,7 +19,10 @@ internal object TestStoreProductConverter {
     @JvmSynthetic
     @Suppress("LongMethod")
     @Throws(PurchasesException::class)
-    fun convertToStoreProduct(productResponse: WebBillingProductResponse, locale: Locale = Locale.getDefault()): TestStoreProduct {
+    fun convertToStoreProduct(
+        productResponse: WebBillingProductResponse,
+        locale: Locale = Locale.getDefault(),
+    ): TestStoreProduct {
         val defaultPurchaseOptionId = productResponse.defaultPurchaseOptionId
         val purchaseOptions = productResponse.purchaseOptions
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/teststore/TestStoreProductConverter.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/teststore/TestStoreProductConverter.kt
@@ -11,13 +11,15 @@ import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.RecurrenceMode
 import com.revenuecat.purchases.models.TestStoreProduct
+import com.revenuecat.purchases.utils.PriceFactory
+import java.util.Locale
 
 internal object TestStoreProductConverter {
 
     @JvmSynthetic
     @Suppress("LongMethod")
     @Throws(PurchasesException::class)
-    fun convertToStoreProduct(productResponse: WebBillingProductResponse): TestStoreProduct {
+    fun convertToStoreProduct(productResponse: WebBillingProductResponse, locale: Locale = Locale.getDefault()): TestStoreProduct {
         val defaultPurchaseOptionId = productResponse.defaultPurchaseOptionId
         val purchaseOptions = productResponse.purchaseOptions
 
@@ -38,20 +40,12 @@ internal object TestStoreProductConverter {
 
         if (purchaseOption.basePrice != null) {
             val basePriceObj = purchaseOption.basePrice
-            basePrice = Price(
-                formatted = formatPrice(basePriceObj.amountMicros, basePriceObj.currency),
-                amountMicros = basePriceObj.amountMicros,
-                currencyCode = basePriceObj.currency,
-            )
+            basePrice = PriceFactory.createPrice(basePriceObj.amountMicros, basePriceObj.currency, locale)
         } else {
             val basePhase = purchaseOption.base
             if (basePhase?.price != null) {
                 val priceObj = basePhase.price
-                basePrice = Price(
-                    formatted = formatPrice(priceObj.amountMicros, priceObj.currency),
-                    amountMicros = priceObj.amountMicros,
-                    currencyCode = priceObj.currency,
-                )
+                basePrice = PriceFactory.createPrice(priceObj.amountMicros, priceObj.currency, locale)
                 if (basePhase.periodDuration != null) {
                     period = Period.create(basePhase.periodDuration)
                 }
@@ -65,16 +59,12 @@ internal object TestStoreProductConverter {
             }
 
             val trialPhase = purchaseOption.trial
-            if (trialPhase?.periodDuration != null && trialPhase.cycleCount != null) {
+            if (trialPhase?.periodDuration != null && trialPhase.cycleCount != null && basePhase.price != null) {
                 freeTrialPricingPhase = PricingPhase(
                     billingPeriod = Period.create(trialPhase.periodDuration),
                     recurrenceMode = RecurrenceMode.FINITE_RECURRING,
                     billingCycleCount = trialPhase.cycleCount,
-                    price = Price(
-                        formatted = "Free",
-                        amountMicros = 0L,
-                        currencyCode = basePrice.currencyCode,
-                    ),
+                    price = PriceFactory.createPrice(0, basePhase.price.currency, locale),
                 )
             }
 
@@ -85,11 +75,7 @@ internal object TestStoreProductConverter {
                     billingPeriod = Period.create(introPhase.periodDuration),
                     recurrenceMode = RecurrenceMode.FINITE_RECURRING,
                     billingCycleCount = introPhase.cycleCount,
-                    price = Price(
-                        formatted = formatPrice(priceObj.amountMicros, priceObj.currency),
-                        amountMicros = priceObj.amountMicros,
-                        currencyCode = priceObj.currency,
-                    ),
+                    price = PriceFactory.createPrice(priceObj.amountMicros, priceObj.currency, locale),
                 )
             }
         }
@@ -104,10 +90,5 @@ internal object TestStoreProductConverter {
             freeTrialPricingPhase = freeTrialPricingPhase,
             introPricePricingPhase = introPricePricingPhase,
         )
-    }
-
-    @Suppress("MagicNumber")
-    private fun formatPrice(amountMicros: Long, currencyCode: String): String {
-        return "$currencyCode ${"%.2f".format(amountMicros / 1_000_000.0)}"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/teststore/TestStoreProductConverter.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/teststore/TestStoreProductConverter.kt
@@ -1,0 +1,113 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.teststore
+
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.common.networking.WebBillingProductResponse
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.PricingPhase
+import com.revenuecat.purchases.models.RecurrenceMode
+import com.revenuecat.purchases.models.TestStoreProduct
+
+internal object TestStoreProductConverter {
+
+    @JvmSynthetic
+    @Suppress("LongMethod")
+    @Throws(PurchasesException::class)
+    fun convertToStoreProduct(productResponse: WebBillingProductResponse): TestStoreProduct {
+        val defaultPurchaseOptionId = productResponse.defaultPurchaseOptionId
+        val purchaseOptions = productResponse.purchaseOptions
+
+        val purchaseOptionKey = defaultPurchaseOptionId ?: purchaseOptions.keys.first()
+        val purchaseOption = purchaseOptions[purchaseOptionKey] ?: run {
+            throw PurchasesException(
+                PurchasesError(
+                    PurchasesErrorCode.ProductNotAvailableForPurchaseError,
+                    "No purchase option found for product ${productResponse.identifier}",
+                ),
+            )
+        }
+
+        val basePrice: Price?
+        var period: Period? = null
+        var freeTrialPricingPhase: PricingPhase? = null
+        var introPricePricingPhase: PricingPhase? = null
+
+        if (purchaseOption.basePrice != null) {
+            val basePriceObj = purchaseOption.basePrice
+            basePrice = Price(
+                formatted = formatPrice(basePriceObj.amountMicros, basePriceObj.currency),
+                amountMicros = basePriceObj.amountMicros,
+                currencyCode = basePriceObj.currency,
+            )
+        } else {
+            val basePhase = purchaseOption.base
+            if (basePhase?.price != null) {
+                val priceObj = basePhase.price
+                basePrice = Price(
+                    formatted = formatPrice(priceObj.amountMicros, priceObj.currency),
+                    amountMicros = priceObj.amountMicros,
+                    currencyCode = priceObj.currency,
+                )
+                if (basePhase.periodDuration != null) {
+                    period = Period.create(basePhase.periodDuration)
+                }
+            } else {
+                throw PurchasesException(
+                    PurchasesError(
+                        PurchasesErrorCode.ProductNotAvailableForPurchaseError,
+                        "Base price is required for test subscription products",
+                    ),
+                )
+            }
+
+            val trialPhase = purchaseOption.trial
+            if (trialPhase?.periodDuration != null && trialPhase.cycleCount != null) {
+                freeTrialPricingPhase = PricingPhase(
+                    billingPeriod = Period.create(trialPhase.periodDuration),
+                    recurrenceMode = RecurrenceMode.FINITE_RECURRING,
+                    billingCycleCount = trialPhase.cycleCount,
+                    price = Price(
+                        formatted = "Free",
+                        amountMicros = 0L,
+                        currencyCode = basePrice.currencyCode,
+                    ),
+                )
+            }
+
+            val introPhase = purchaseOption.introPrice
+            if (introPhase?.price != null && introPhase.periodDuration != null && introPhase.cycleCount != null) {
+                val priceObj = introPhase.price
+                introPricePricingPhase = PricingPhase(
+                    billingPeriod = Period.create(introPhase.periodDuration),
+                    recurrenceMode = RecurrenceMode.FINITE_RECURRING,
+                    billingCycleCount = introPhase.cycleCount,
+                    price = Price(
+                        formatted = formatPrice(priceObj.amountMicros, priceObj.currency),
+                        amountMicros = priceObj.amountMicros,
+                        currencyCode = priceObj.currency,
+                    ),
+                )
+            }
+        }
+
+        return TestStoreProduct(
+            id = productResponse.identifier,
+            name = productResponse.title,
+            title = productResponse.title,
+            description = productResponse.description ?: "",
+            price = basePrice,
+            period = period,
+            freeTrialPricingPhase = freeTrialPricingPhase,
+            introPricePricingPhase = introPricePricingPhase,
+        )
+    }
+
+    @Suppress("MagicNumber")
+    private fun formatPrice(amountMicros: Long, currencyCode: String): String {
+        return "$currencyCode ${"%.2f".format(amountMicros / 1_000_000.0)}"
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/teststore/TestStorePurchasingData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/teststore/TestStorePurchasingData.kt
@@ -1,0 +1,11 @@
+package com.revenuecat.purchases.teststore
+
+import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.models.PurchasingData
+import com.revenuecat.purchases.models.StoreProduct
+
+internal data class TestStorePurchasingData(
+    override val productId: String,
+    override val productType: ProductType,
+    val storeProduct: StoreProduct,
+) : PurchasingData

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PriceExtensions.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PriceExtensions.kt
@@ -1,11 +1,8 @@
 package com.revenuecat.purchases.utils
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.common.SharedConstants.MICRO_MULTIPLIER
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
-import java.text.NumberFormat
-import java.util.Currency
 import java.util.Locale
 
 @JvmSynthetic
@@ -28,19 +25,7 @@ internal fun Price.pricePerYear(billingPeriod: Period, locale: Locale): Price {
     return pricePerPeriod(billingPeriod.valueInYears, locale)
 }
 
-@OptIn(InternalRevenueCatAPI::class)
 private fun Price.pricePerPeriod(units: Double, locale: Locale): Price {
-    val currency = Currency.getInstance(currencyCode)
-    val numberFormat = NumberFormat.getCurrencyInstance(locale).apply {
-        this.currency = currency
-        // Making sure we do not add spurious digits:
-        val digits = currency.defaultFractionDigits.coerceAtLeast(0)
-        maximumFractionDigits = digits
-        minimumFractionDigits = digits
-    }
-
     val value = amountMicros / units
-    val formatted = numberFormat.format(value / MICRO_MULTIPLIER)
-
-    return Price(formatted, (value).toLong(), currencyCode)
+    return PriceFactory.createPrice(value.toLong(), currencyCode, locale)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PriceFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PriceFactory.kt
@@ -31,5 +31,4 @@ internal object PriceFactory {
 
         return Price(formatted, amountMicros, currencyCode)
     }
-
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PriceFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PriceFactory.kt
@@ -1,0 +1,35 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.utils
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.SharedConstants.MICRO_MULTIPLIER
+import com.revenuecat.purchases.models.Price
+import java.text.NumberFormat
+import java.util.Currency
+import java.util.Locale
+
+internal object PriceFactory {
+
+    @JvmSynthetic
+    @OptIn(InternalRevenueCatAPI::class)
+    internal fun createPrice(
+        amountMicros: Long,
+        currencyCode: String,
+        locale: Locale,
+    ): Price {
+        val currency = Currency.getInstance(currencyCode)
+        val numberFormat = NumberFormat.getCurrencyInstance(locale).apply {
+            this.currency = currency
+            // Making sure we do not add spurious digits:
+            val digits = currency.defaultFractionDigits.coerceAtLeast(0)
+            maximumFractionDigits = digits
+            minimumFractionDigits = digits
+        }
+
+        val formatted = numberFormat.format(amountMicros / MICRO_MULTIPLIER)
+
+        return Price(formatted, amountMicros, currencyCode)
+    }
+
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/teststore/TestStoreProductConverterTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/teststore/TestStoreProductConverterTest.kt
@@ -17,9 +17,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 class TestStoreProductConverterTest {
+
+    private val testLocale = Locale.US
 
     @Test
     fun `converts one time product correctly`() {
@@ -39,14 +42,14 @@ class TestStoreProductConverterTest {
             )
         )
 
-        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+        val result = convertToStoreProduct(productResponse)
 
         assertThat(result).isInstanceOf(TestStoreProduct::class.java)
         assertThat(result.id).isEqualTo("test_product")
         assertThat(result.title).isEqualTo("Test Product")
         assertThat(result.name).isEqualTo("Test Product")
         assertThat(result.description).isEqualTo("Test Description")
-        assertThat(result.price.formatted).isEqualTo("USD 9.99")
+        assertThat(result.price.formatted).isEqualTo("$9.99")
         assertThat(result.price.amountMicros).isEqualTo(9990000L)
         assertThat(result.price.currencyCode).isEqualTo("USD")
     }
@@ -72,10 +75,10 @@ class TestStoreProductConverterTest {
             )
         )
 
-        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+        val result = convertToStoreProduct(productResponse)
 
         val expectedPrice = Price(
-            formatted = "EUR 4.99",
+            formatted = "€4.99",
             amountMicros = 4990000L,
             currencyCode = "EUR"
         )
@@ -119,7 +122,7 @@ class TestStoreProductConverterTest {
             )
         )
 
-        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+        val result = convertToStoreProduct(productResponse)
 
         assertThat(result.defaultOption?.freePhase).isEqualTo(
             PricingPhase(
@@ -127,7 +130,7 @@ class TestStoreProductConverterTest {
                 recurrenceMode = RecurrenceMode.FINITE_RECURRING,
                 billingCycleCount = 2,
                 price = Price(
-                    formatted = "Free",
+                    formatted = "$0.00",
                     amountMicros = 0L,
                     currencyCode = "USD"
                 )
@@ -140,7 +143,7 @@ class TestStoreProductConverterTest {
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = null,
                 price = Price(
-                    formatted = "USD 9.99",
+                    formatted = "$9.99",
                     amountMicros = 9990000L,
                     currencyCode = "USD"
                 )
@@ -177,7 +180,7 @@ class TestStoreProductConverterTest {
             )
         )
 
-        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+        val result = convertToStoreProduct(productResponse)
 
         assertThat(result.defaultOption?.freePhase).isNull()
         assertThat(result.defaultOption?.introPhase).isEqualTo(
@@ -186,7 +189,7 @@ class TestStoreProductConverterTest {
                 recurrenceMode = RecurrenceMode.FINITE_RECURRING,
                 billingCycleCount = 3,
                 price = Price(
-                    formatted = "USD 1.99",
+                    formatted = "$1.99",
                     amountMicros = 1990000L,
                     currencyCode = "USD"
                 )
@@ -198,7 +201,7 @@ class TestStoreProductConverterTest {
                 recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
                 billingCycleCount = null,
                 price = Price(
-                    formatted = "USD 9.99",
+                    formatted = "$9.99",
                     amountMicros = 9990000L,
                     currencyCode = "USD"
                 )
@@ -225,7 +228,7 @@ class TestStoreProductConverterTest {
         )
 
         try {
-            TestStoreProductConverter.convertToStoreProduct(productResponse)
+            convertToStoreProduct(productResponse)
             fail("Expected PurchasesException to be thrown")
         } catch (e: PurchasesException) {
             assertThat(e.error.code).isEqualTo(PurchasesErrorCode.ProductNotAvailableForPurchaseError)
@@ -252,7 +255,7 @@ class TestStoreProductConverterTest {
         )
 
         try {
-            val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+            val result = convertToStoreProduct(productResponse)
             fail("Expected PurchasesException to be thrown, but got result: $result")
         } catch (e: PurchasesException) {
             assertThat(e.error.code).isEqualTo(PurchasesErrorCode.ProductNotAvailableForPurchaseError)
@@ -284,7 +287,7 @@ class TestStoreProductConverterTest {
             )
         )
 
-        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+        val result = convertToStoreProduct(productResponse)
 
         assertThat(result.subscriptionOptions?.freeTrial).isNull()
     }
@@ -315,7 +318,7 @@ class TestStoreProductConverterTest {
             )
         )
 
-        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+        val result = convertToStoreProduct(productResponse)
 
         assertThat(result.subscriptionOptions?.introOffer).isNull()
     }
@@ -338,9 +341,9 @@ class TestStoreProductConverterTest {
             )
         )
 
-        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+        val result = convertToStoreProduct(productResponse)
 
-        assertThat(result.price.formatted).isEqualTo("JPY 12.35")
+        assertThat(result.price.formatted).isEqualTo("¥12")
     }
 
     @Test
@@ -361,9 +364,16 @@ class TestStoreProductConverterTest {
             )
         )
 
-        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+        val result = convertToStoreProduct(productResponse)
 
-        assertThat(result.price.formatted).isEqualTo("USD 0.00")
+        assertThat(result.price.formatted).isEqualTo("$0.00")
         assertThat(result.price.amountMicros).isEqualTo(0L)
+    }
+
+    private fun convertToStoreProduct(
+        productResponse: WebBillingProductResponse,
+        locale: Locale = testLocale
+    ): TestStoreProduct {
+        return TestStoreProductConverter.convertToStoreProduct(productResponse, locale)
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/teststore/TestStoreProductConverterTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/teststore/TestStoreProductConverterTest.kt
@@ -1,0 +1,369 @@
+package com.revenuecat.purchases.teststore
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.common.networking.WebBillingPhase
+import com.revenuecat.purchases.common.networking.WebBillingPrice
+import com.revenuecat.purchases.common.networking.WebBillingProductResponse
+import com.revenuecat.purchases.common.networking.WebBillingPurchaseOption
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.PricingPhase
+import com.revenuecat.purchases.models.RecurrenceMode
+import com.revenuecat.purchases.models.TestStoreProduct
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TestStoreProductConverterTest {
+
+    @Test
+    fun `converts one time product correctly`() {
+        val productResponse = WebBillingProductResponse(
+            identifier = "test_product",
+            productType = "subscription",
+            title = "Test Product",
+            description = "Test Description",
+            defaultPurchaseOptionId = "option1",
+            purchaseOptions = mapOf(
+                "option1" to WebBillingPurchaseOption(
+                    basePrice = WebBillingPrice(
+                        amountMicros = 9990000L,
+                        currency = "USD"
+                    )
+                )
+            )
+        )
+
+        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+
+        assertThat(result).isInstanceOf(TestStoreProduct::class.java)
+        assertThat(result.id).isEqualTo("test_product")
+        assertThat(result.title).isEqualTo("Test Product")
+        assertThat(result.name).isEqualTo("Test Product")
+        assertThat(result.description).isEqualTo("Test Description")
+        assertThat(result.price.formatted).isEqualTo("USD 9.99")
+        assertThat(result.price.amountMicros).isEqualTo(9990000L)
+        assertThat(result.price.currencyCode).isEqualTo("USD")
+    }
+
+    @Test
+    fun `converts subscription product correctly`() {
+        val productResponse = WebBillingProductResponse(
+            identifier = "sub_product",
+            productType = "subscription",
+            title = "Sub Product",
+            description = null,
+            defaultPurchaseOptionId = null,
+            purchaseOptions = mapOf(
+                "option1" to WebBillingPurchaseOption(
+                    base = WebBillingPhase(
+                        price = WebBillingPrice(
+                            amountMicros = 4990000L,
+                            currency = "EUR"
+                        ),
+                        periodDuration = "P1M",
+                    )
+                )
+            )
+        )
+
+        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+
+        val expectedPrice = Price(
+            formatted = "EUR 4.99",
+            amountMicros = 4990000L,
+            currencyCode = "EUR"
+        )
+        assertThat(result.id).isEqualTo("sub_product")
+        assertThat(result.description).isEqualTo("")
+        assertThat(result.price).isEqualTo(expectedPrice)
+        assertThat(result.period).isEqualTo(Period.create("P1M"))
+        assertThat(result.defaultOption?.pricingPhases?.size).isEqualTo(1)
+        assertThat(result.defaultOption?.pricingPhases?.get(0)).isEqualTo(
+            PricingPhase(
+                billingPeriod = Period.create("P1M"),
+                recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                billingCycleCount = null,
+                price = expectedPrice,
+            )
+        )
+    }
+
+    @Test
+    fun `converts product with free trial correctly`() {
+        val productResponse = WebBillingProductResponse(
+            identifier = "trial_product",
+            productType = "subscription",
+            title = "Trial Product",
+            description = "With trial",
+            defaultPurchaseOptionId = "option1",
+            purchaseOptions = mapOf(
+                "option1" to WebBillingPurchaseOption(
+                    base = WebBillingPhase(
+                        price = WebBillingPrice(
+                            amountMicros = 9990000L,
+                            currency = "USD"
+                        ),
+                        periodDuration = "P1M"
+                    ),
+                    trial = WebBillingPhase(
+                        periodDuration = "P7D",
+                        cycleCount = 2
+                    )
+                )
+            )
+        )
+
+        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+
+        assertThat(result.defaultOption?.freePhase).isEqualTo(
+            PricingPhase(
+                billingPeriod = Period.create("P7D"),
+                recurrenceMode = RecurrenceMode.FINITE_RECURRING,
+                billingCycleCount = 2,
+                price = Price(
+                    formatted = "Free",
+                    amountMicros = 0L,
+                    currencyCode = "USD"
+                )
+            )
+        )
+        assertThat(result.defaultOption?.introPhase).isNull()
+        assertThat(result.defaultOption?.fullPricePhase).isEqualTo(
+            PricingPhase(
+                billingPeriod = Period.create("P1M"),
+                recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                billingCycleCount = null,
+                price = Price(
+                    formatted = "USD 9.99",
+                    amountMicros = 9990000L,
+                    currencyCode = "USD"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `converts product with intro price correctly`() {
+        val productResponse = WebBillingProductResponse(
+            identifier = "intro_product",
+            productType = "subscription",
+            title = "Intro Product",
+            description = "With intro",
+            defaultPurchaseOptionId = "option1",
+            purchaseOptions = mapOf(
+                "option1" to WebBillingPurchaseOption(
+                    base = WebBillingPhase(
+                        price = WebBillingPrice(
+                            amountMicros = 9990000L,
+                            currency = "USD"
+                        ),
+                        periodDuration = "P1M"
+                    ),
+                    introPrice = WebBillingPhase(
+                        price = WebBillingPrice(
+                            amountMicros = 1990000L,
+                            currency = "USD"
+                        ),
+                        periodDuration = "P1M",
+                        cycleCount = 3
+                    )
+                )
+            )
+        )
+
+        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+
+        assertThat(result.defaultOption?.freePhase).isNull()
+        assertThat(result.defaultOption?.introPhase).isEqualTo(
+            PricingPhase(
+                billingPeriod = Period.create("P1M"),
+                recurrenceMode = RecurrenceMode.FINITE_RECURRING,
+                billingCycleCount = 3,
+                price = Price(
+                    formatted = "USD 1.99",
+                    amountMicros = 1990000L,
+                    currencyCode = "USD"
+                )
+            )
+        )
+        assertThat(result.defaultOption?.fullPricePhase).isEqualTo(
+            PricingPhase(
+                billingPeriod = Period.create("P1M"),
+                recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                billingCycleCount = null,
+                price = Price(
+                    formatted = "USD 9.99",
+                    amountMicros = 9990000L,
+                    currencyCode = "USD"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `throws exception when defaultPurchaseOptionId is invalid`() {
+        val productResponse = WebBillingProductResponse(
+            identifier = "test_product",
+            productType = "subscription",
+            title = "Test Product",
+            description = "Test",
+            defaultPurchaseOptionId = "missing_option",
+            purchaseOptions = mapOf(
+                "option1" to WebBillingPurchaseOption(
+                    basePrice = WebBillingPrice(
+                        amountMicros = 9990000L,
+                        currency = "USD"
+                    )
+                )
+            )
+        )
+
+        try {
+            TestStoreProductConverter.convertToStoreProduct(productResponse)
+            fail("Expected PurchasesException to be thrown")
+        } catch (e: PurchasesException) {
+            assertThat(e.error.code).isEqualTo(PurchasesErrorCode.ProductNotAvailableForPurchaseError)
+            assertThat(e.error.underlyingErrorMessage).isEqualTo("No purchase option found for product test_product")
+        }
+    }
+
+    @Test
+    fun `handles missing base price gracefully`() {
+        val productResponse = WebBillingProductResponse(
+            identifier = "no_price",
+            productType = "subscription",
+            title = "No Price",
+            description = "Test",
+            defaultPurchaseOptionId = "option1",
+            purchaseOptions = mapOf(
+                "option1" to WebBillingPurchaseOption(
+                    base = WebBillingPhase(
+                        price = null,
+                        periodDuration = "P1M"
+                    )
+                )
+            )
+        )
+
+        try {
+            val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+            fail("Expected PurchasesException to be thrown, but got result: $result")
+        } catch (e: PurchasesException) {
+            assertThat(e.error.code).isEqualTo(PurchasesErrorCode.ProductNotAvailableForPurchaseError)
+            assertThat(e.error.underlyingErrorMessage).isEqualTo("Base price is required for test subscription products")
+        }
+    }
+
+    @Test
+    fun `handles missing trial phase data gracefully`() {
+        val productResponse = WebBillingProductResponse(
+            identifier = "incomplete_trial",
+            productType = "subscription",
+            title = "Incomplete Trial",
+            description = "Test",
+            defaultPurchaseOptionId = "option1",
+            purchaseOptions = mapOf(
+                "option1" to WebBillingPurchaseOption(
+                    base = WebBillingPhase(
+                        price = WebBillingPrice(
+                            amountMicros = 9990000L,
+                            currency = "USD"
+                        ),
+                        periodDuration = "P1M",
+                    ),
+                    trial = WebBillingPhase(
+                        cycleCount = 1, // No period provided
+                    )
+                )
+            )
+        )
+
+        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+
+        assertThat(result.subscriptionOptions?.freeTrial).isNull()
+    }
+
+    @Test
+    fun `handles missing intro price data gracefully`() {
+        val productResponse = WebBillingProductResponse(
+            identifier = "incomplete_intro",
+            productType = "subscription",
+            title = "Incomplete Intro",
+            description = "Test",
+            defaultPurchaseOptionId = "option1",
+            purchaseOptions = mapOf(
+                "option1" to WebBillingPurchaseOption(
+                    base = WebBillingPhase(
+                        price = WebBillingPrice(
+                            amountMicros = 9990000L,
+                            currency = "USD"
+                        ),
+                        periodDuration = "P1M"
+                    ),
+                    introPrice = WebBillingPhase(
+                        price = null, // No price provided
+                        periodDuration = "P1M",
+                        cycleCount = 3
+                    )
+                )
+            )
+        )
+
+        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+
+        assertThat(result.subscriptionOptions?.introOffer).isNull()
+    }
+
+    @Test
+    fun `formatPrice formats correctly`() {
+        val productResponse = WebBillingProductResponse(
+            identifier = "format_test",
+            productType = "subscription",
+            title = "Format Test",
+            description = "Test",
+            defaultPurchaseOptionId = "option1",
+            purchaseOptions = mapOf(
+                "option1" to WebBillingPurchaseOption(
+                    basePrice = WebBillingPrice(
+                        amountMicros = 12345678L,
+                        currency = "JPY"
+                    )
+                )
+            )
+        )
+
+        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+
+        assertThat(result.price.formatted).isEqualTo("JPY 12.35")
+    }
+
+    @Test
+    fun `handles zero price correctly`() {
+        val productResponse = WebBillingProductResponse(
+            identifier = "free_product",
+            productType = "subscription",
+            title = "Free Product",
+            description = "Test",
+            defaultPurchaseOptionId = "option1",
+            purchaseOptions = mapOf(
+                "option1" to WebBillingPurchaseOption(
+                    basePrice = WebBillingPrice(
+                        amountMicros = 0L,
+                        currency = "USD"
+                    )
+                )
+            )
+        )
+
+        val result = TestStoreProductConverter.convertToStoreProduct(productResponse)
+
+        assertThat(result.price.formatted).isEqualTo("USD 0.00")
+        assertThat(result.price.amountMicros).isEqualTo(0L)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/PriceFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/PriceFactoryTest.kt
@@ -1,0 +1,127 @@
+package com.revenuecat.purchases.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.models.Price
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+
+@RunWith(AndroidJUnit4::class)
+class PriceFactoryTest {
+
+    @Test
+    fun `creates price with US locale correctly`() {
+        val price = PriceFactory.createPrice(9990000L, "USD", Locale.US)
+
+        assertThat(price.formatted).isEqualTo("$9.99")
+        assertThat(price.amountMicros).isEqualTo(9990000L)
+        assertThat(price.currencyCode).isEqualTo("USD")
+    }
+
+    @Test
+    fun `creates price with EUR currency correctly`() {
+        val price = PriceFactory.createPrice(4990000L, "EUR", Locale.GERMANY)
+
+        assertThat(price.formatted).isEqualTo("4,99 €")
+        assertThat(price.amountMicros).isEqualTo(4990000L)
+        assertThat(price.currencyCode).isEqualTo("EUR")
+    }
+
+    @Test
+    fun `creates price with JPY currency correctly`() {
+        val price = PriceFactory.createPrice(12345678L, "JPY", Locale.JAPAN)
+
+        assertThat(price.formatted).isEqualTo("￥12")
+        assertThat(price.amountMicros).isEqualTo(12345678L)
+        assertThat(price.currencyCode).isEqualTo("JPY")
+    }
+
+    @Test
+    fun `creates zero price correctly`() {
+        val price = PriceFactory.createPrice(0L, "USD", Locale.US)
+
+        assertThat(price.formatted).isEqualTo("$0.00")
+        assertThat(price.amountMicros).isEqualTo(0L)
+        assertThat(price.currencyCode).isEqualTo("USD")
+    }
+
+    @Test
+    fun `creates price with large amount correctly`() {
+        val price = PriceFactory.createPrice(99999990000L, "USD", Locale.US)
+
+        assertThat(price.formatted).isEqualTo("$99,999.99")
+        assertThat(price.amountMicros).isEqualTo(99999990000L)
+        assertThat(price.currencyCode).isEqualTo("USD")
+    }
+
+    @Test
+    fun `creates price with different locale formats USD correctly`() {
+        val priceUS = PriceFactory.createPrice(9990000L, "USD", Locale.US)
+        val priceUK = PriceFactory.createPrice(9990000L, "USD", Locale.UK)
+
+        assertThat(priceUS.formatted).isEqualTo("$9.99")
+        assertThat(priceUK.formatted).isEqualTo("US$9.99")
+        assertThat(priceUS.amountMicros).isEqualTo(priceUK.amountMicros)
+        assertThat(priceUS.currencyCode).isEqualTo(priceUK.currencyCode)
+    }
+
+    @Test
+    fun `creates price with GBP currency correctly`() {
+        val price = PriceFactory.createPrice(7990000L, "GBP", Locale.UK)
+
+        assertThat(price.formatted).isEqualTo("£7.99")
+        assertThat(price.amountMicros).isEqualTo(7990000L)
+        assertThat(price.currencyCode).isEqualTo("GBP")
+    }
+
+    @Test
+    fun `creates price with CAD currency correctly`() {
+        val price = PriceFactory.createPrice(12990000L, "CAD", Locale.CANADA)
+
+        assertThat(price.formatted).isEqualTo("$12.99")
+        assertThat(price.amountMicros).isEqualTo(12990000L)
+        assertThat(price.currencyCode).isEqualTo("CAD")
+    }
+
+    @Test
+    fun `creates price with BRL currency correctly`() {
+        val price = PriceFactory.createPrice(24990000L, "BRL", Locale("pt", "BR"))
+
+        // BRL formatting varies by locale - just check structure
+        assertThat(price.formatted).contains("24,99")
+        assertThat(price.formatted).contains("R$")
+        assertThat(price.amountMicros).isEqualTo(24990000L)
+        assertThat(price.currencyCode).isEqualTo("BRL")
+    }
+
+    @Test
+    fun `creates price with KRW currency correctly`() {
+        val price = PriceFactory.createPrice(15000000000L, "KRW", Locale.KOREA)
+
+        assertThat(price.formatted).isEqualTo("₩15,000")
+        assertThat(price.amountMicros).isEqualTo(15000000000L)
+        assertThat(price.currencyCode).isEqualTo("KRW")
+    }
+
+    @Test
+    fun `creates price with very small amount correctly`() {
+        val price = PriceFactory.createPrice(10000L, "USD", Locale.US)
+
+        assertThat(price.formatted).isEqualTo("$0.01")
+        assertThat(price.amountMicros).isEqualTo(10000L)
+        assertThat(price.currencyCode).isEqualTo("USD")
+    }
+
+    @Test
+    fun `creates price with fraction digits for different currencies`() {
+        val usdPrice = PriceFactory.createPrice(9990000L, "USD", Locale.US)
+        val jpyPrice = PriceFactory.createPrice(999000000L, "JPY", Locale.JAPAN)
+
+        // USD has 2 fraction digits
+        assertThat(usdPrice.formatted).isEqualTo("$9.99")
+        
+        // JPY has 0 fraction digits
+        assertThat(jpyPrice.formatted).isEqualTo("￥999")
+    }
+}


### PR DESCRIPTION
### Description
This is another step in preparation to support the new TestStore. This adds the logic to transform WebBilling products into `TestStoreProduct`. These will be used for purchasing when using a test api key.

The logic here is currently unused, but will be used in follow-up PRs