### PR TITLE
Don't show product identifier for non-Google purchases in Customer Center

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -250,6 +250,12 @@ data class CustomerCenterConfigData(
 
             @SerialName("resubscribe")
             RESUBSCRIBE,
+
+            @SerialName("generic_subscription")
+            GENERIC_SUBSCRIPTION,
+
+            @SerialName("generic_one_time_purchase")
+            GENERIC_ONE_TIME_PURCHASE,
             ;
 
             val defaultValue: String
@@ -336,6 +342,8 @@ data class CustomerCenterConfigData(
                     UNKNOWN_STORE -> "Unknown"
                     CARD_STORE_PROMOTIONAL -> "Via Support"
                     RESUBSCRIBE -> "Resubscribe"
+                    GENERIC_SUBSCRIPTION -> "Subscription"
+                    GENERIC_ONE_TIME_PURCHASE -> "One time purchase"
                 }
         }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -251,11 +251,11 @@ data class CustomerCenterConfigData(
             @SerialName("resubscribe")
             RESUBSCRIBE,
 
-            @SerialName("generic_subscription")
-            GENERIC_SUBSCRIPTION,
+            @SerialName("type_subscription")
+            TYPE_SUBSCRIPTION,
 
-            @SerialName("generic_one_time_purchase")
-            GENERIC_ONE_TIME_PURCHASE,
+            @SerialName("type_one_time_purchase")
+            TYPE_ONE_TIME_PURCHASE,
             ;
 
             val defaultValue: String
@@ -342,8 +342,8 @@ data class CustomerCenterConfigData(
                     UNKNOWN_STORE -> "Unknown"
                     CARD_STORE_PROMOTIONAL -> "Via Support"
                     RESUBSCRIBE -> "Resubscribe"
-                    GENERIC_SUBSCRIPTION -> "Subscription"
-                    GENERIC_ONE_TIME_PURCHASE -> "One time purchase"
+                    TYPE_SUBSCRIPTION -> "Subscription"
+                    TYPE_ONE_TIME_PURCHASE -> "One time purchase"
                 }
         }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformation.kt
@@ -117,11 +117,11 @@ private fun determineTitle(
         ?: when (transaction) {
             is TransactionDetails.Subscription ->
                 localization.commonLocalizedString(
-                    CustomerCenterConfigData.Localization.CommonLocalizedString.GENERIC_SUBSCRIPTION,
+                    CustomerCenterConfigData.Localization.CommonLocalizedString.TYPE_SUBSCRIPTION,
                 )
             is TransactionDetails.NonSubscription ->
                 localization.commonLocalizedString(
-                    CustomerCenterConfigData.Localization.CommonLocalizedString.GENERIC_ONE_TIME_PURCHASE,
+                    CustomerCenterConfigData.Localization.CommonLocalizedString.TYPE_ONE_TIME_PURCHASE,
                 )
         }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -475,6 +475,7 @@ internal class CustomerCenterViewModelImpl(
     private suspend fun loadPurchases(
         dateFormatter: DateFormatter,
         locale: Locale,
+        localization: CustomerCenterConfigData.Localization,
     ): List<PurchaseInformation> {
         val customerInfo = purchases.awaitCustomerInfo(fetchPolicy = CacheFetchPolicy.FETCH_CURRENT)
 
@@ -494,6 +495,7 @@ internal class CustomerCenterViewModelImpl(
                         entitlement,
                         dateFormatter,
                         locale,
+                        localization,
                     )
                 }
             } else {
@@ -513,6 +515,7 @@ internal class CustomerCenterViewModelImpl(
                     entitlement,
                     dateFormatter,
                     locale,
+                    localization,
                 ),
             )
         } else {
@@ -558,6 +561,7 @@ internal class CustomerCenterViewModelImpl(
         entitlement: EntitlementInfo?,
         dateFormatter: DateFormatter,
         locale: Locale,
+        localization: CustomerCenterConfigData.Localization,
     ): PurchaseInformation {
         val product = if (transaction.store == Store.PLAY_STORE) {
             purchases.awaitGetProduct(
@@ -581,6 +585,7 @@ internal class CustomerCenterViewModelImpl(
             transaction = transaction,
             dateFormatter = dateFormatter,
             locale = locale,
+            localization = localization,
         )
     }
 
@@ -763,7 +768,7 @@ internal class CustomerCenterViewModelImpl(
         }
         try {
             val customerCenterConfigData = purchases.awaitCustomerCenterConfigData()
-            val purchases = loadPurchases(dateFormatter, locale)
+            val purchases = loadPurchases(dateFormatter, locale, customerCenterConfigData.localization)
             val successState = CustomerCenterState.Success(
                 customerCenterConfigData,
                 purchases,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformationTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/PurchaseInformationTest.kt
@@ -219,7 +219,7 @@ class PurchaseInformationTest {
 
         assertPurchaseInformation(
             purchaseInformation,
-            title = "test_product",
+            title = "test_entitlement",
             price = PriceDetails.Unknown,
             store = Store.APP_STORE,
             product = null,
@@ -261,7 +261,7 @@ class PurchaseInformationTest {
 
         assertPurchaseInformation(
             purchaseInformation,
-            title = "test_product",
+            title = "test_entitlement",
             price = PriceDetails.Unknown,
             store = Store.APP_STORE,
             product = null,
@@ -303,7 +303,7 @@ class PurchaseInformationTest {
 
         assertPurchaseInformation(
             purchaseInformation,
-            title = "test_product",
+            title = "test_entitlement",
             price = PriceDetails.Unknown,
             store = Store.APP_STORE,
             product = null,
@@ -435,7 +435,7 @@ class PurchaseInformationTest {
 
         assertPurchaseInformation(
             purchaseInformation,
-            title = "com.revenuecat.product",
+            title = "test_entitlement",
             price = PriceDetails.Unknown,
             store = Store.STRIPE,
             product = null,
@@ -478,7 +478,7 @@ class PurchaseInformationTest {
 
         assertPurchaseInformation(
             purchaseInformation,
-            title = "com.revenuecat.product",
+            title = "test_entitlement",
             price = PriceDetails.Unknown,
             store = Store.STRIPE,
             product = null,
@@ -521,7 +521,7 @@ class PurchaseInformationTest {
 
         assertPurchaseInformation(
             purchaseInformation,
-            title = "com.revenuecat.product",
+            title = "test_entitlement",
             price = PriceDetails.Unknown,
             store = Store.STRIPE,
             product = null,
@@ -564,7 +564,7 @@ class PurchaseInformationTest {
 
         assertPurchaseInformation(
             purchaseInformation,
-            title = "com.revenuecat.product",
+            title = "test_entitlement",
             price = PriceDetails.Unknown,
             store = Store.PADDLE,
             product = null,
@@ -607,7 +607,7 @@ class PurchaseInformationTest {
 
         assertPurchaseInformation(
             purchaseInformation,
-            title = "com.revenuecat.product",
+            title = "test_entitlement",
             price = PriceDetails.Unknown,
             store = Store.PADDLE,
             product = null,
@@ -650,7 +650,7 @@ class PurchaseInformationTest {
 
         assertPurchaseInformation(
             purchaseInformation,
-            title = "com.revenuecat.product",
+            title = "test_entitlement",
             price = PriceDetails.Unknown,
             store = Store.PADDLE,
             product = null,
@@ -715,6 +715,40 @@ class PurchaseInformationTest {
             expirationOrRenewal = ExpirationOrRenewal.Renewal("3 Oct 2063"),
             managementURL = Uri.parse(MANAGEMENT_URL),
         )
+    }
+
+    @Test
+    fun `test PurchaseInformation with no entitlement and no subscribed product shows user-friendly fallback`() {
+        val subscriptionTransaction = createTransactionDetails(
+            isActive = true,
+            willRenew = true,
+            store = Store.STRIPE,
+            productIdentifier = "com.revenuecat.technical.id",
+            expiresDate = null
+        )
+        val subscriptionPurchaseInfo = PurchaseInformation(
+            entitlementInfo = null,
+            subscribedProduct = null,
+            transaction = subscriptionTransaction,
+            dateFormatter = dateFormatter,
+            locale = locale
+        )
+
+        assertThat(subscriptionPurchaseInfo.title).isEqualTo("Subscription")
+
+        val nonSubscriptionTransaction = createNonSubscriptionTransactionDetails(
+            store = Store.STRIPE,
+            productIdentifier = "com.revenuecat.technical.id"
+        )
+        val nonSubscriptionPurchaseInfo = PurchaseInformation(
+            entitlementInfo = null,
+            subscribedProduct = null,
+            transaction = nonSubscriptionTransaction,
+            dateFormatter = dateFormatter,
+            locale = locale
+        )
+
+        assertThat(nonSubscriptionPurchaseInfo.title).isEqualTo("One time purchase")
     }
 
     private fun assertPurchaseInformation(
@@ -789,6 +823,16 @@ class PurchaseInformationTest {
             productPlanIdentifier = productPlanIdentifier,
             isTrial = isTrial,
             managementURL = managementURL
+        )
+    }
+
+    private fun createNonSubscriptionTransactionDetails(
+        store: Store,
+        productIdentifier: String,
+    ): TransactionDetails.NonSubscription {
+        return TransactionDetails.NonSubscription(
+            productIdentifier = productIdentifier,
+            store = store,
         )
     }
 


### PR DESCRIPTION
We were displaying the product id for purchases that we don't have the details for. This happens for example for Apple purchases, or for Stripe. 

<img width="239" height="161" alt="Screenshot 2025-07-31 at 14 12 32" src="https://github.com/user-attachments/assets/21529c71-7f42-485f-98fa-40a194c121a7" />

With this change we will start displaying the entitlement, or if there's no entitlement, "Subscription" or "One time purchase"