### PR TITLE
Expose getStorefront APIs in CustomEntitlementComputation flavor

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -21,7 +21,6 @@ import com.revenuecat.purchases.amazon.AmazonConfiguration;
 import com.revenuecat.purchases.customercenter.CustomerCenterListener;
 import com.revenuecat.purchases.customercenter.CustomerCenterManagementOption;
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback;
-import com.revenuecat.purchases.interfaces.GetStorefrontCallback;
 import com.revenuecat.purchases.interfaces.GetVirtualCurrenciesCallback;
 import com.revenuecat.purchases.interfaces.LogInCallback;
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback;
@@ -90,16 +89,6 @@ final class PurchasesAPI {
             }
         };
 
-        final GetStorefrontCallback getStorefrontCallback = new GetStorefrontCallback() {
-            @Override
-            public void onReceived(@NonNull String storefrontCountryCode) {
-            }
-
-            @Override
-            public void onError(@NonNull PurchasesError error) {
-            }
-        };
-
         purchases.syncAttributesAndOfferingsIfNeeded(syncAttributesAndOfferingsCallback);
         purchases.syncPurchases();
         purchases.syncPurchases(syncPurchasesCallback);
@@ -123,9 +112,6 @@ final class PurchasesAPI {
         purchases.onAppForegrounded();
 
         final Store store = purchases.getStore();
-
-        final String storefrontCountryCode = purchases.getStorefrontCountryCode();
-        purchases.getStorefrontCountryCode(getStorefrontCallback);
 
         final PurchasesConfiguration configuration = purchases.getCurrentConfiguration();
 

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -25,7 +25,6 @@ import com.revenuecat.purchases.awaitLogIn
 import com.revenuecat.purchases.awaitLogOut
 import com.revenuecat.purchases.awaitRestore
 import com.revenuecat.purchases.awaitRestoreResult
-import com.revenuecat.purchases.awaitStorefrontCountryCode
 import com.revenuecat.purchases.awaitSyncAttributesAndOfferingsIfNeeded
 import com.revenuecat.purchases.awaitSyncPurchases
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
@@ -35,10 +34,8 @@ import com.revenuecat.purchases.data.LogInResult
 import com.revenuecat.purchases.getAmazonLWAConsentStatus
 import com.revenuecat.purchases.getAmazonLWAConsentStatusWith
 import com.revenuecat.purchases.getCustomerInfoWith
-import com.revenuecat.purchases.getStorefrontCountryCodeWith
 import com.revenuecat.purchases.getVirtualCurrenciesWith
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback
-import com.revenuecat.purchases.interfaces.GetStorefrontCallback
 import com.revenuecat.purchases.interfaces.GetVirtualCurrenciesCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
@@ -82,10 +79,6 @@ private class PurchasesAPI {
             override fun onSuccess(status: AmazonLWAConsentStatus) {}
             override fun onError(error: PurchasesError) {}
         }
-        val getStorefrontCallback = object : GetStorefrontCallback {
-            override fun onReceived(storefrontCountryCode: String) {}
-            override fun onError(error: PurchasesError) {}
-        }
 
         val getVirtualCurrenciesCallback = object : GetVirtualCurrenciesCallback {
             override fun onReceived(virtualCurrencies: VirtualCurrencies) {}
@@ -117,9 +110,6 @@ private class PurchasesAPI {
 
         val store: Store = purchases.store
 
-        val countryCode = purchases.storefrontCountryCode
-        purchases.getStorefrontCountryCode(getStorefrontCallback)
-
         val configuration: PurchasesConfiguration = purchases.currentConfiguration
 
         purchases.redeemWebPurchase(webPurchaseRedemption, redeemWebPurchaseListener)
@@ -135,10 +125,6 @@ private class PurchasesAPI {
     fun checkListenerConversions(
         purchases: Purchases,
     ) {
-        purchases.getStorefrontCountryCodeWith(
-            onError = { _: PurchasesError -> },
-            onSuccess = { _: String -> },
-        )
         purchases.logInWith(
             "",
             onError = { _: PurchasesError -> },
@@ -185,7 +171,6 @@ private class PurchasesAPI {
     suspend fun checkCoroutines(
         purchases: Purchases,
     ) {
-        val storefrontCountryCode: String = purchases.awaitStorefrontCountryCode()
         val customerInfo: CustomerInfo = purchases.awaitCustomerInfo()
         val customerInfoFetchPolicy: CustomerInfo =
             purchases.awaitCustomerInfo(fetchPolicy = CacheFetchPolicy.FETCH_CURRENT)

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/PurchasesCommonAPI.java
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.PurchasesConfiguration;
 import com.revenuecat.purchases.PurchasesError;
 import com.revenuecat.purchases.Store;
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback;
+import com.revenuecat.purchases.interfaces.GetStorefrontCallback;
 import com.revenuecat.purchases.interfaces.PurchaseCallback;
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback;
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener;
@@ -59,6 +60,15 @@ final class PurchasesCommonAPI {
             public void onError(@NonNull PurchasesError error) {
             }
         };
+        final GetStorefrontCallback getStorefrontCallback = new GetStorefrontCallback() {
+            @Override
+            public void onReceived(@NonNull String storefrontCountryCode) {
+            }
+
+            @Override
+            public void onError(@NonNull PurchasesError error) {
+            }
+        };
 
         purchases.getOfferings(receiveOfferingsListener);
         purchases.getProducts(productIds, productResponseListener);
@@ -71,6 +81,9 @@ final class PurchasesCommonAPI {
         final UpdatedCustomerInfoListener updatedCustomerInfoListener = purchases.getUpdatedCustomerInfoListener();
         purchases.setUpdatedCustomerInfoListener((CustomerInfo customerInfo) -> {
         });
+
+        final String storefrontCountryCode = purchases.getStorefrontCountryCode();
+        purchases.getStorefrontCountryCode(getStorefrontCallback);
 
         final List<InAppMessageType> inAppMessageTypeList = new ArrayList<>();
         purchases.showInAppMessagesIfNeeded(activity);

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesCommonAPI.kt
@@ -23,9 +23,12 @@ import com.revenuecat.purchases.awaitOfferings
 import com.revenuecat.purchases.awaitOfferingsResult
 import com.revenuecat.purchases.awaitPurchase
 import com.revenuecat.purchases.awaitPurchaseResult
+import com.revenuecat.purchases.awaitStorefrontCountryCode
 import com.revenuecat.purchases.getOfferingsWith
 import com.revenuecat.purchases.getProductsWith
+import com.revenuecat.purchases.getStorefrontCountryCodeWith
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
+import com.revenuecat.purchases.interfaces.GetStorefrontCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
@@ -61,6 +64,10 @@ private class PurchasesCommonAPI {
             override fun onReceived(storeProducts: List<StoreProduct>) {}
             override fun onError(error: PurchasesError) {}
         }
+        val getStorefrontCallback = object : GetStorefrontCallback {
+            override fun onReceived(storefrontCountryCode: String) {}
+            override fun onError(error: PurchasesError) {}
+        }
 
         purchases.getOfferings(receiveOfferingsCallback)
 
@@ -70,6 +77,9 @@ private class PurchasesCommonAPI {
         purchases.restorePurchases(receiveCustomerInfoCallback)
 
         val appUserID: String = purchases.appUserID
+
+        val countryCode = purchases.storefrontCountryCode
+        purchases.getStorefrontCountryCode(getStorefrontCallback)
 
         purchases.removeUpdatedCustomerInfoListener()
         purchases.close()
@@ -129,6 +139,10 @@ private class PurchasesCommonAPI {
         purchases: Purchases,
         purchaseParams: PurchaseParams,
     ) {
+        purchases.getStorefrontCountryCodeWith(
+            onError = { _: PurchasesError -> },
+            onSuccess = { _: String -> },
+        )
         purchases.getOfferingsWith(
             onError = { _: PurchasesError -> },
             onSuccess = { _: Offerings -> },
@@ -163,6 +177,7 @@ private class PurchasesCommonAPI {
         activity: Activity,
         packageToPurchase: Package,
     ) {
+        val storefrontCountryCode: String = purchases.awaitStorefrontCountryCode()
         val offerings: Offerings = purchases.awaitOfferings()
 
         val purchasePackageBuilder: PurchaseParams.Builder = PurchaseParams.Builder(activity, packageToPurchase)

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -27,13 +27,14 @@ package com.revenuecat.purchases {
     method @kotlin.jvm.JvmSynthetic public static suspend Object? awaitPurchaseResult(com.revenuecat.purchases.Purchases, com.revenuecat.purchases.PurchaseParams purchaseParams, kotlin.coroutines.Continuation<? super kotlin.Result<? extends com.revenuecat.purchases.PurchaseResult>>);
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesTransactionException::class) public static suspend Object? awaitRestore(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.CustomerInfo>);
     method @kotlin.jvm.JvmSynthetic public static suspend Object? awaitRestoreResult(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super kotlin.Result<? extends com.revenuecat.purchases.CustomerInfo>>);
+    method public static suspend Object? awaitStorefrontCountryCode(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super java.lang.String>);
   }
 
   public final class CoroutinesExtensionsKt {
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? awaitCustomerInfo(com.revenuecat.purchases.Purchases, optional com.revenuecat.purchases.CacheFetchPolicy fetchPolicy, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.CustomerInfo>);
+    method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? awaitGetVirtualCurrencies(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies>);
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesTransactionException::class) public static suspend Object? awaitLogIn(com.revenuecat.purchases.Purchases, String appUserID, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.data.LogInResult>);
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesTransactionException::class) public static suspend Object? awaitLogOut(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.CustomerInfo>);
-    method public static suspend Object? awaitStorefrontCountryCode(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super java.lang.String>);
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? awaitSyncAttributesAndOfferingsIfNeeded(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.Offerings>);
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? awaitSyncPurchases(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.CustomerInfo>);
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesException::class) public static suspend Object? getAmazonLWAConsentStatus(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.AmazonLWAConsentStatus>);
@@ -156,13 +157,14 @@ package com.revenuecat.purchases {
     method @kotlin.jvm.JvmSynthetic public static com.revenuecat.purchases.WebPurchaseRedemption? asWebPurchaseRedemption(android.content.Intent);
   }
 
-  @kotlin.RequiresOptIn(level=kotlin.RequiresOptIn.Level.ERROR, message="This is an internal RevenueCat API that may change frequently and without warning. " + "No compatibility guarantees are provided. It is strongly discouraged to use this API.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) @kotlin.annotation.Target(allowedTargets={kotlin.annotation.AnnotationTarget.CLASS, kotlin.annotation.AnnotationTarget.FUNCTION, kotlin.annotation.AnnotationTarget.PROPERTY, kotlin.annotation.AnnotationTarget.TYPEALIAS}) public @interface InternalRevenueCatAPI {
+  @kotlin.RequiresOptIn(level=kotlin.RequiresOptIn.Level.ERROR, message="This is an internal RevenueCat API that may change frequently and without warning. " + "No compatibility guarantees are provided. It is strongly discouraged to use this API.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) @kotlin.annotation.Target(allowedTargets={kotlin.annotation.AnnotationTarget.CLASS, kotlin.annotation.AnnotationTarget.FUNCTION, kotlin.annotation.AnnotationTarget.PROPERTY, kotlin.annotation.AnnotationTarget.TYPEALIAS, kotlin.annotation.AnnotationTarget.CONSTRUCTOR}) public @interface InternalRevenueCatAPI {
   }
 
   public final class ListenerConversionsCommonKt {
     method public static void getOfferingsWith(com.revenuecat.purchases.Purchases, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.Offerings,kotlin.Unit> onSuccess);
     method public static void getProductsWith(com.revenuecat.purchases.Purchases, java.util.List<java.lang.String> productIds, com.revenuecat.purchases.ProductType? type, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super java.util.List<? extends com.revenuecat.purchases.models.StoreProduct>,kotlin.Unit> onGetStoreProducts);
     method public static void getProductsWith(com.revenuecat.purchases.Purchases, java.util.List<java.lang.String> productIds, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super java.util.List<? extends com.revenuecat.purchases.models.StoreProduct>,kotlin.Unit> onGetStoreProducts);
+    method public static void getStorefrontCountryCodeWith(com.revenuecat.purchases.Purchases, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super java.lang.String,kotlin.Unit> onSuccess);
     method public static void purchaseWith(com.revenuecat.purchases.Purchases, com.revenuecat.purchases.PurchaseParams purchaseParams, optional kotlin.jvm.functions.Function2<? super com.revenuecat.purchases.PurchasesError,? super java.lang.Boolean,kotlin.Unit> onError, kotlin.jvm.functions.Function2<? super com.revenuecat.purchases.models.StoreTransaction?,? super com.revenuecat.purchases.CustomerInfo,kotlin.Unit> onSuccess);
     method public static void restorePurchasesWith(com.revenuecat.purchases.Purchases, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.CustomerInfo,kotlin.Unit> onSuccess);
   }
@@ -172,8 +174,8 @@ package com.revenuecat.purchases {
     method public static void getCustomerInfoWith(com.revenuecat.purchases.Purchases, com.revenuecat.purchases.CacheFetchPolicy fetchPolicy, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.CustomerInfo,kotlin.Unit> onSuccess);
     method public static void getCustomerInfoWith(com.revenuecat.purchases.Purchases, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.CustomerInfo,kotlin.Unit> onSuccess);
     method @Deprecated public static void getNonSubscriptionSkusWith(com.revenuecat.purchases.Purchases, java.util.List<java.lang.String> skus, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super java.util.List<? extends com.revenuecat.purchases.models.StoreProduct>,kotlin.Unit> onReceiveSkus);
-    method public static void getStorefrontCountryCodeWith(com.revenuecat.purchases.Purchases, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super java.lang.String,kotlin.Unit> onSuccess);
     method @Deprecated public static void getSubscriptionSkusWith(com.revenuecat.purchases.Purchases, java.util.List<java.lang.String> skus, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super java.util.List<? extends com.revenuecat.purchases.models.StoreProduct>,kotlin.Unit> onReceiveSkus);
+    method public static void getVirtualCurrenciesWith(com.revenuecat.purchases.Purchases, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies,kotlin.Unit> onSuccess);
     method public static void logInWith(com.revenuecat.purchases.Purchases, String appUserID, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function2<? super com.revenuecat.purchases.CustomerInfo,? super java.lang.Boolean,kotlin.Unit> onSuccess);
     method public static void logOutWith(com.revenuecat.purchases.Purchases, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.CustomerInfo,kotlin.Unit> onSuccess);
     method @Deprecated public static void purchasePackageWith(com.revenuecat.purchases.Purchases, android.app.Activity activity, com.revenuecat.purchases.Package packageToPurchase, optional kotlin.jvm.functions.Function2<? super com.revenuecat.purchases.PurchasesError,? super java.lang.Boolean,kotlin.Unit> onError, kotlin.jvm.functions.Function2<? super com.revenuecat.purchases.models.StoreTransaction,? super com.revenuecat.purchases.CustomerInfo,kotlin.Unit> onSuccess);
@@ -356,6 +358,7 @@ package com.revenuecat.purchases {
     method @Deprecated @kotlin.jvm.Synchronized public boolean getAllowSharingPlayStoreAccount();
     method public void getAmazonLWAConsentStatus(com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback callback);
     method @kotlin.jvm.Synchronized public String getAppUserID();
+    method public com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies? getCachedVirtualCurrencies();
     method public com.revenuecat.purchases.PurchasesConfiguration getCurrentConfiguration();
     method public com.revenuecat.purchases.customercenter.CustomerCenterListener? getCustomerCenterListener();
     method public void getCustomerInfo(com.revenuecat.purchases.CacheFetchPolicy fetchPolicy, com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback callback);
@@ -378,7 +381,9 @@ package com.revenuecat.purchases {
     method public void getStorefrontCountryCode(com.revenuecat.purchases.interfaces.GetStorefrontCallback callback);
     method @Deprecated public void getSubscriptionSkus(java.util.List<java.lang.String> productIds, com.revenuecat.purchases.interfaces.GetStoreProductsCallback callback);
     method @kotlin.jvm.Synchronized public com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener? getUpdatedCustomerInfoListener();
+    method public void getVirtualCurrencies(com.revenuecat.purchases.interfaces.GetVirtualCurrenciesCallback callback);
     method public void invalidateCustomerInfoCache();
+    method public void invalidateVirtualCurrenciesCache();
     method public boolean isAnonymous();
     method public static boolean isConfigured();
     method public void logIn(String newAppUserID);
@@ -438,6 +443,7 @@ package com.revenuecat.purchases {
     method public void syncPurchases(optional com.revenuecat.purchases.interfaces.SyncPurchasesCallback? listener);
     property @Deprecated @kotlin.jvm.Synchronized public final boolean allowSharingPlayStoreAccount;
     property @kotlin.jvm.Synchronized public final String appUserID;
+    property public final com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies? cachedVirtualCurrencies;
     property public final com.revenuecat.purchases.PurchasesConfiguration currentConfiguration;
     property public final com.revenuecat.purchases.customercenter.CustomerCenterListener? customerCenterListener;
     property @Deprecated public static final boolean debugLogsEnabled;
@@ -754,7 +760,16 @@ package com.revenuecat.purchases.common {
 
 package com.revenuecat.purchases.customercenter {
 
+  @dev.drewhamilton.poko.Poko public final class CustomActionData {
+    ctor public CustomActionData(String actionIdentifier, String? purchaseIdentifier);
+    method public String getActionIdentifier();
+    method public String? getPurchaseIdentifier();
+    property public final String actionIdentifier;
+    property public final String? purchaseIdentifier;
+  }
+
   public interface CustomerCenterListener {
+    method public default void onCustomActionSelected(String actionIdentifier, String? purchaseIdentifier);
     method public default void onFeedbackSurveyCompleted(String feedbackSurveyOptionId);
     method public default void onManagementOptionSelected(com.revenuecat.purchases.customercenter.CustomerCenterManagementOption action);
     method public default void onRestoreCompleted(com.revenuecat.purchases.CustomerInfo customerInfo);
@@ -768,6 +783,14 @@ package com.revenuecat.purchases.customercenter {
 
   public static final class CustomerCenterManagementOption.Cancel implements com.revenuecat.purchases.customercenter.CustomerCenterManagementOption {
     field public static final com.revenuecat.purchases.customercenter.CustomerCenterManagementOption.Cancel INSTANCE;
+  }
+
+  @dev.drewhamilton.poko.Poko public static final class CustomerCenterManagementOption.CustomAction implements com.revenuecat.purchases.customercenter.CustomerCenterManagementOption {
+    ctor public CustomerCenterManagementOption.CustomAction(String actionIdentifier, String? purchaseIdentifier);
+    method public String getActionIdentifier();
+    method public String? getPurchaseIdentifier();
+    property public final String actionIdentifier;
+    property public final String? purchaseIdentifier;
   }
 
   @dev.drewhamilton.poko.Poko public static final class CustomerCenterManagementOption.CustomUrl implements com.revenuecat.purchases.customercenter.CustomerCenterManagementOption {
@@ -813,6 +836,11 @@ package com.revenuecat.purchases.interfaces {
   public interface GetStorefrontCallback {
     method public void onError(com.revenuecat.purchases.PurchasesError error);
     method public void onReceived(String storefrontCountryCode);
+  }
+
+  public interface GetVirtualCurrenciesCallback {
+    method public void onError(com.revenuecat.purchases.PurchasesError error);
+    method public void onReceived(com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies virtualCurrencies);
   }
 
   public interface LogInCallback {
@@ -1271,7 +1299,9 @@ package com.revenuecat.purchases.models {
 
   @dev.drewhamilton.poko.Poko public final class TestStoreProduct implements com.revenuecat.purchases.models.StoreProduct {
     ctor @Deprecated public TestStoreProduct(String id, String title, String description, com.revenuecat.purchases.models.Price price, com.revenuecat.purchases.models.Period? period, optional com.revenuecat.purchases.models.Period? freeTrialPeriod, optional com.revenuecat.purchases.models.Price? introPrice);
-    ctor public TestStoreProduct(String id, String name, String title, String description, com.revenuecat.purchases.models.Price price, com.revenuecat.purchases.models.Period? period, optional com.revenuecat.purchases.models.Period? freeTrialPeriod, optional com.revenuecat.purchases.models.Price? introPrice);
+    ctor public TestStoreProduct(String id, String name, String title, String description, com.revenuecat.purchases.models.Price price, optional com.revenuecat.purchases.models.Period? period);
+    ctor @Deprecated public TestStoreProduct(String id, String name, String title, String description, com.revenuecat.purchases.models.Price price, optional com.revenuecat.purchases.models.Period? period, optional com.revenuecat.purchases.models.Period? freeTrialPeriod, optional com.revenuecat.purchases.models.Price? introPrice);
+    ctor public TestStoreProduct(String id, String name, String title, String description, com.revenuecat.purchases.models.Price price, com.revenuecat.purchases.models.Period? period, optional com.revenuecat.purchases.models.PricingPhase? freeTrialPricingPhase, optional com.revenuecat.purchases.models.PricingPhase? introPricePricingPhase);
     method @Deprecated public com.revenuecat.purchases.models.StoreProduct copyWithOfferingId(String offeringId);
     method public com.revenuecat.purchases.models.StoreProduct copyWithPresentedOfferingContext(com.revenuecat.purchases.PresentedOfferingContext? presentedOfferingContext);
     method public com.revenuecat.purchases.models.SubscriptionOption? getDefaultOption();
@@ -1341,6 +1371,27 @@ package com.revenuecat.purchases.utils {
 
   public final class LocaleExtensionsKt {
     method public static java.util.List<java.util.Locale> getDefaultLocales();
+  }
+
+}
+
+package com.revenuecat.purchases.virtualcurrencies {
+
+  @dev.drewhamilton.poko.Poko @kotlinx.parcelize.Parcelize @kotlinx.serialization.Serializable public final class VirtualCurrencies implements android.os.Parcelable {
+    method public operator com.revenuecat.purchases.virtualcurrencies.VirtualCurrency? get(String code);
+    method public java.util.Map<java.lang.String,com.revenuecat.purchases.virtualcurrencies.VirtualCurrency> getAll();
+    property public final java.util.Map<java.lang.String,com.revenuecat.purchases.virtualcurrencies.VirtualCurrency> all;
+  }
+
+  @dev.drewhamilton.poko.Poko @kotlinx.parcelize.Parcelize @kotlinx.serialization.Serializable public final class VirtualCurrency implements android.os.Parcelable {
+    method public int getBalance();
+    method public String getCode();
+    method public String getName();
+    method public String? getServerDescription();
+    property public final int balance;
+    property public final String code;
+    property public final String name;
+    property public final String? serverDescription;
   }
 
 }

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -27,6 +27,7 @@ package com.revenuecat.purchases {
     method @kotlin.jvm.JvmSynthetic public static suspend Object? awaitPurchaseResult(com.revenuecat.purchases.Purchases, com.revenuecat.purchases.PurchaseParams purchaseParams, kotlin.coroutines.Continuation<? super kotlin.Result<? extends com.revenuecat.purchases.PurchaseResult>>);
     method @kotlin.jvm.JvmSynthetic @kotlin.jvm.Throws(exceptionClasses=PurchasesTransactionException::class) public static suspend Object? awaitRestore(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super com.revenuecat.purchases.CustomerInfo>);
     method @kotlin.jvm.JvmSynthetic public static suspend Object? awaitRestoreResult(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super kotlin.Result<? extends com.revenuecat.purchases.CustomerInfo>>);
+    method public static suspend Object? awaitStorefrontCountryCode(com.revenuecat.purchases.Purchases, kotlin.coroutines.Continuation<? super java.lang.String>);
   }
 
   @dev.drewhamilton.poko.Poko @kotlinx.parcelize.Parcelize @kotlinx.parcelize.TypeParceler public final class CustomerInfo implements android.os.Parcelable com.revenuecat.purchases.models.RawDataContainer<org.json.JSONObject> {
@@ -142,13 +143,14 @@ package com.revenuecat.purchases {
   @kotlin.RequiresOptIn(level=kotlin.RequiresOptIn.Level.ERROR) @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) @kotlin.annotation.Target(allowedTargets={kotlin.annotation.AnnotationTarget.CLASS, kotlin.annotation.AnnotationTarget.FUNCTION, kotlin.annotation.AnnotationTarget.PROPERTY}) public @interface ExperimentalPreviewRevenueCatPurchasesAPI {
   }
 
-  @kotlin.RequiresOptIn(level=kotlin.RequiresOptIn.Level.ERROR, message="This is an internal RevenueCat API that may change frequently and without warning. " + "No compatibility guarantees are provided. It is strongly discouraged to use this API.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) @kotlin.annotation.Target(allowedTargets={kotlin.annotation.AnnotationTarget.CLASS, kotlin.annotation.AnnotationTarget.FUNCTION, kotlin.annotation.AnnotationTarget.PROPERTY, kotlin.annotation.AnnotationTarget.TYPEALIAS}) public @interface InternalRevenueCatAPI {
+  @kotlin.RequiresOptIn(level=kotlin.RequiresOptIn.Level.ERROR, message="This is an internal RevenueCat API that may change frequently and without warning. " + "No compatibility guarantees are provided. It is strongly discouraged to use this API.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) @kotlin.annotation.Target(allowedTargets={kotlin.annotation.AnnotationTarget.CLASS, kotlin.annotation.AnnotationTarget.FUNCTION, kotlin.annotation.AnnotationTarget.PROPERTY, kotlin.annotation.AnnotationTarget.TYPEALIAS, kotlin.annotation.AnnotationTarget.CONSTRUCTOR}) public @interface InternalRevenueCatAPI {
   }
 
   public final class ListenerConversionsCommonKt {
     method public static void getOfferingsWith(com.revenuecat.purchases.Purchases, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.Offerings,kotlin.Unit> onSuccess);
     method public static void getProductsWith(com.revenuecat.purchases.Purchases, java.util.List<java.lang.String> productIds, com.revenuecat.purchases.ProductType? type, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super java.util.List<? extends com.revenuecat.purchases.models.StoreProduct>,kotlin.Unit> onGetStoreProducts);
     method public static void getProductsWith(com.revenuecat.purchases.Purchases, java.util.List<java.lang.String> productIds, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super java.util.List<? extends com.revenuecat.purchases.models.StoreProduct>,kotlin.Unit> onGetStoreProducts);
+    method public static void getStorefrontCountryCodeWith(com.revenuecat.purchases.Purchases, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super java.lang.String,kotlin.Unit> onSuccess);
     method public static void purchaseWith(com.revenuecat.purchases.Purchases, com.revenuecat.purchases.PurchaseParams purchaseParams, optional kotlin.jvm.functions.Function2<? super com.revenuecat.purchases.PurchasesError,? super java.lang.Boolean,kotlin.Unit> onError, kotlin.jvm.functions.Function2<? super com.revenuecat.purchases.models.StoreTransaction?,? super com.revenuecat.purchases.CustomerInfo,kotlin.Unit> onSuccess);
     method public static void restorePurchasesWith(com.revenuecat.purchases.Purchases, optional kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.PurchasesError,kotlin.Unit> onError, kotlin.jvm.functions.Function1<? super com.revenuecat.purchases.CustomerInfo,kotlin.Unit> onSuccess);
   }
@@ -335,6 +337,7 @@ package com.revenuecat.purchases {
     method public static java.net.URL? getProxyURL();
     method public static com.revenuecat.purchases.Purchases getSharedInstance();
     method @kotlin.jvm.Synchronized public String? getStorefrontCountryCode();
+    method public void getStorefrontCountryCode(com.revenuecat.purchases.interfaces.GetStorefrontCallback callback);
     method @kotlin.jvm.Synchronized public com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener? getUpdatedCustomerInfoListener();
     method public static boolean isConfigured();
     method public void purchase(com.revenuecat.purchases.PurchaseParams purchaseParams, com.revenuecat.purchases.interfaces.PurchaseCallback callback);
@@ -670,7 +673,16 @@ package com.revenuecat.purchases.common {
 
 package com.revenuecat.purchases.customercenter {
 
+  @dev.drewhamilton.poko.Poko public final class CustomActionData {
+    ctor public CustomActionData(String actionIdentifier, String? purchaseIdentifier);
+    method public String getActionIdentifier();
+    method public String? getPurchaseIdentifier();
+    property public final String actionIdentifier;
+    property public final String? purchaseIdentifier;
+  }
+
   public interface CustomerCenterListener {
+    method public default void onCustomActionSelected(String actionIdentifier, String? purchaseIdentifier);
     method public default void onFeedbackSurveyCompleted(String feedbackSurveyOptionId);
     method public default void onManagementOptionSelected(com.revenuecat.purchases.customercenter.CustomerCenterManagementOption action);
     method public default void onRestoreCompleted(com.revenuecat.purchases.CustomerInfo customerInfo);
@@ -684,6 +696,14 @@ package com.revenuecat.purchases.customercenter {
 
   public static final class CustomerCenterManagementOption.Cancel implements com.revenuecat.purchases.customercenter.CustomerCenterManagementOption {
     field public static final com.revenuecat.purchases.customercenter.CustomerCenterManagementOption.Cancel INSTANCE;
+  }
+
+  @dev.drewhamilton.poko.Poko public static final class CustomerCenterManagementOption.CustomAction implements com.revenuecat.purchases.customercenter.CustomerCenterManagementOption {
+    ctor public CustomerCenterManagementOption.CustomAction(String actionIdentifier, String? purchaseIdentifier);
+    method public String getActionIdentifier();
+    method public String? getPurchaseIdentifier();
+    property public final String actionIdentifier;
+    property public final String? purchaseIdentifier;
   }
 
   @dev.drewhamilton.poko.Poko public static final class CustomerCenterManagementOption.CustomUrl implements com.revenuecat.purchases.customercenter.CustomerCenterManagementOption {
@@ -717,6 +737,11 @@ package com.revenuecat.purchases.interfaces {
   public interface GetStorefrontCallback {
     method public void onError(com.revenuecat.purchases.PurchasesError error);
     method public void onReceived(String storefrontCountryCode);
+  }
+
+  public interface GetVirtualCurrenciesCallback {
+    method public void onError(com.revenuecat.purchases.PurchasesError error);
+    method public void onReceived(com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies virtualCurrencies);
   }
 
   public interface LogInCallback {
@@ -1175,7 +1200,9 @@ package com.revenuecat.purchases.models {
 
   @dev.drewhamilton.poko.Poko public final class TestStoreProduct implements com.revenuecat.purchases.models.StoreProduct {
     ctor @Deprecated public TestStoreProduct(String id, String title, String description, com.revenuecat.purchases.models.Price price, com.revenuecat.purchases.models.Period? period, optional com.revenuecat.purchases.models.Period? freeTrialPeriod, optional com.revenuecat.purchases.models.Price? introPrice);
-    ctor public TestStoreProduct(String id, String name, String title, String description, com.revenuecat.purchases.models.Price price, com.revenuecat.purchases.models.Period? period, optional com.revenuecat.purchases.models.Period? freeTrialPeriod, optional com.revenuecat.purchases.models.Price? introPrice);
+    ctor public TestStoreProduct(String id, String name, String title, String description, com.revenuecat.purchases.models.Price price, optional com.revenuecat.purchases.models.Period? period);
+    ctor @Deprecated public TestStoreProduct(String id, String name, String title, String description, com.revenuecat.purchases.models.Price price, optional com.revenuecat.purchases.models.Period? period, optional com.revenuecat.purchases.models.Period? freeTrialPeriod, optional com.revenuecat.purchases.models.Price? introPrice);
+    ctor public TestStoreProduct(String id, String name, String title, String description, com.revenuecat.purchases.models.Price price, com.revenuecat.purchases.models.Period? period, optional com.revenuecat.purchases.models.PricingPhase? freeTrialPricingPhase, optional com.revenuecat.purchases.models.PricingPhase? introPricePricingPhase);
     method @Deprecated public com.revenuecat.purchases.models.StoreProduct copyWithOfferingId(String offeringId);
     method public com.revenuecat.purchases.models.StoreProduct copyWithPresentedOfferingContext(com.revenuecat.purchases.PresentedOfferingContext? presentedOfferingContext);
     method public com.revenuecat.purchases.models.SubscriptionOption? getDefaultOption();
@@ -1245,6 +1272,27 @@ package com.revenuecat.purchases.utils {
 
   public final class LocaleExtensionsKt {
     method public static java.util.List<java.util.Locale> getDefaultLocales();
+  }
+
+}
+
+package com.revenuecat.purchases.virtualcurrencies {
+
+  @dev.drewhamilton.poko.Poko @kotlinx.parcelize.Parcelize @kotlinx.serialization.Serializable public final class VirtualCurrencies implements android.os.Parcelable {
+    method public operator com.revenuecat.purchases.virtualcurrencies.VirtualCurrency? get(String code);
+    method public java.util.Map<java.lang.String,com.revenuecat.purchases.virtualcurrencies.VirtualCurrency> getAll();
+    property public final java.util.Map<java.lang.String,com.revenuecat.purchases.virtualcurrencies.VirtualCurrency> all;
+  }
+
+  @dev.drewhamilton.poko.Poko @kotlinx.parcelize.Parcelize @kotlinx.serialization.Serializable public final class VirtualCurrency implements android.os.Parcelable {
+    method public int getBalance();
+    method public String getCode();
+    method public String getName();
+    method public String? getServerDescription();
+    property public final int balance;
+    property public final String code;
+    property public final String name;
+    property public final String? serverDescription;
   }
 
 }

--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.common.infoLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.interfaces.Callback
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
+import com.revenuecat.purchases.interfaces.GetStorefrontCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
@@ -180,6 +181,14 @@ class Purchases internal constructor(
      */
     fun switchUser(newAppUserID: String) {
         purchasesOrchestrator.switchUser(newAppUserID)
+    }
+
+    /**
+     * This method will try to obtain the Store (Google/Amazon) country code in ISO-3166-1 alpha2.
+     * If there is any error, it will return null and log said error.
+     */
+    fun getStorefrontCountryCode(callback: GetStorefrontCallback) {
+        purchasesOrchestrator.getStorefrontCountryCode(callback)
     }
     //endregion
 

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
@@ -10,23 +10,6 @@ import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
 /**
- * This method will try to obtain the Store (Google/Amazon) country code in ISO-3166-1 alpha2.
- * If there is any error, it will return null and log said error.
- * Coroutine friendly version of [Purchases.getStorefrontCountryCode].
- *
- * @throws [PurchasesException] with a [PurchasesError] if there's an error retrieving the country code.
- * @return The Store country code in ISO-3166-1 alpha2.
- */
-suspend fun Purchases.awaitStorefrontCountryCode(): String {
-    return suspendCoroutine { continuation ->
-        getStorefrontCountryCodeWith(
-            onSuccess = continuation::resume,
-            onError = { continuation.resumeWithException(PurchasesException(it)) },
-        )
-    }
-}
-
-/**
  * Get latest available customer info.
  * Coroutine friendly version of [Purchases.getCustomerInfo].
  *

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/listenerConversions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/listenerConversions.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.interfaces.GetAmazonLWAConsentStatusCallback
 import com.revenuecat.purchases.interfaces.GetCustomerCenterConfigCallback
-import com.revenuecat.purchases.interfaces.GetStorefrontCallback
 import com.revenuecat.purchases.interfaces.GetVirtualCurrenciesCallback
 import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.ProductChangeCallback
@@ -105,28 +104,6 @@ internal fun getCustomerCenterConfigDataListener(
     override fun onError(error: PurchasesError) {
         onError(error)
     }
-}
-
-/**
- * This method will try to obtain the Store (Google/Amazon) country code in ISO-3166-1 alpha2.
- * If there is any error, it will return null and log said error.
- * @param [onSuccess] Will be called after the call has completed.
- * @param [onError] Will be called after the call has completed with an error.
- */
-@Suppress("unused")
-fun Purchases.getStorefrontCountryCodeWith(
-    onError: (error: PurchasesError) -> Unit = ON_ERROR_STUB,
-    onSuccess: (storefrontCountryCode: String) -> Unit,
-) {
-    getStorefrontCountryCode(object : GetStorefrontCallback {
-        override fun onReceived(storefrontCountryCode: String) {
-            onSuccess(storefrontCountryCode)
-        }
-
-        override fun onError(error: PurchasesError) {
-            onError(error)
-        }
-    })
 }
 
 /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CoroutinesExtensionsCommon.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CoroutinesExtensionsCommon.kt
@@ -236,3 +236,20 @@ suspend fun Purchases.awaitRestoreResult(): Result<CustomerInfo> {
         )
     }
 }
+
+/**
+ * This method will try to obtain the Store (Google/Amazon) country code in ISO-3166-1 alpha2.
+ * If there is any error, it will return null and log said error.
+ * Coroutine friendly version of [Purchases.getStorefrontCountryCode].
+ *
+ * @throws [PurchasesException] with a [PurchasesError] if there's an error retrieving the country code.
+ * @return The Store country code in ISO-3166-1 alpha2.
+ */
+suspend fun Purchases.awaitStorefrontCountryCode(): String {
+    return suspendCoroutine { continuation ->
+        getStorefrontCountryCodeWith(
+            onSuccess = continuation::resume,
+            onError = { continuation.resumeWithException(PurchasesException(it)) },
+        )
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ListenerConversionsCommon.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ListenerConversionsCommon.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases
 
 import com.revenuecat.purchases.interfaces.GetStoreProductsCallback
+import com.revenuecat.purchases.interfaces.GetStorefrontCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
@@ -140,4 +141,26 @@ fun Purchases.restorePurchasesWith(
     onSuccess: (customerInfo: CustomerInfo) -> Unit,
 ) {
     restorePurchases(receiveCustomerInfoCallback(onSuccess, onError))
+}
+
+/**
+ * This method will try to obtain the Store (Google/Amazon) country code in ISO-3166-1 alpha2.
+ * If there is any error, it will return null and log said error.
+ * @param [onSuccess] Will be called after the call has completed.
+ * @param [onError] Will be called after the call has completed with an error.
+ */
+@Suppress("unused")
+fun Purchases.getStorefrontCountryCodeWith(
+    onError: (error: PurchasesError) -> Unit = ON_ERROR_STUB,
+    onSuccess: (storefrontCountryCode: String) -> Unit,
+) {
+    getStorefrontCountryCode(object : GetStorefrontCallback {
+        override fun onReceived(storefrontCountryCode: String) {
+            onSuccess(storefrontCountryCode)
+        }
+
+        override fun onError(error: PurchasesError) {
+            onError(error)
+        }
+    })
 }

--- a/ui/revenuecatui/api.txt
+++ b/ui/revenuecatui/api.txt
@@ -337,12 +337,16 @@ package com.revenuecat.purchases.ui.revenuecatui.fonts {
 
 package com.revenuecat.purchases.ui.revenuecatui.views {
 
-  public final class CustomerCenterView extends androidx.compose.ui.platform.AbstractComposeView {
+  public final class CustomerCenterView extends androidx.compose.ui.platform.AbstractComposeView implements androidx.lifecycle.LifecycleOwner androidx.savedstate.SavedStateRegistryOwner androidx.lifecycle.ViewModelStoreOwner {
     ctor public CustomerCenterView(android.content.Context context);
     ctor public CustomerCenterView(android.content.Context context, android.util.AttributeSet? attrs);
     ctor public CustomerCenterView(android.content.Context context, android.util.AttributeSet? attrs, int defStyleAttr);
     ctor public CustomerCenterView(android.content.Context context, optional kotlin.jvm.functions.Function0<kotlin.Unit>? dismissHandler);
     method @androidx.compose.runtime.Composable public void Content();
+    method public androidx.lifecycle.Lifecycle getLifecycle();
+    method public androidx.savedstate.SavedStateRegistry getSavedStateRegistry();
+    method public androidx.lifecycle.ViewModelStore getViewModelStore();
+    method public void onBackPressed();
     method public void setDismissHandler(kotlin.jvm.functions.Function0<kotlin.Unit>? dismissHandler);
   }
 
@@ -372,7 +376,7 @@ package com.revenuecat.purchases.ui.revenuecatui.views {
     ctor @Deprecated public PaywallFooterView(android.content.Context context, optional com.revenuecat.purchases.Offering? offering, optional com.revenuecat.purchases.ui.revenuecatui.PaywallListener? listener, optional com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider? fontProvider, optional boolean condensed, optional kotlin.jvm.functions.Function0<kotlin.Unit>? dismissHandler);
   }
 
-  public final class PaywallView extends androidx.compose.ui.platform.AbstractComposeView {
+  public final class PaywallView extends androidx.compose.ui.platform.AbstractComposeView implements androidx.lifecycle.LifecycleOwner androidx.savedstate.SavedStateRegistryOwner androidx.lifecycle.ViewModelStoreOwner {
     ctor public PaywallView(android.content.Context context);
     ctor public PaywallView(android.content.Context context, android.util.AttributeSet? attrs);
     ctor public PaywallView(android.content.Context context, android.util.AttributeSet? attrs, int defStyleAttr);
@@ -382,6 +386,10 @@ package com.revenuecat.purchases.ui.revenuecatui.views {
     ctor public PaywallView(android.content.Context context, optional com.revenuecat.purchases.Offering? offering, optional com.revenuecat.purchases.ui.revenuecatui.PaywallListener? listener, optional com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider? fontProvider, optional Boolean? shouldDisplayDismissButton);
     ctor public PaywallView(android.content.Context context, optional com.revenuecat.purchases.Offering? offering, optional com.revenuecat.purchases.ui.revenuecatui.PaywallListener? listener, optional com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider? fontProvider, optional Boolean? shouldDisplayDismissButton, optional kotlin.jvm.functions.Function0<kotlin.Unit>? dismissHandler);
     method @androidx.compose.runtime.Composable public void Content();
+    method public androidx.lifecycle.Lifecycle getLifecycle();
+    method public androidx.savedstate.SavedStateRegistry getSavedStateRegistry();
+    method public androidx.lifecycle.ViewModelStore getViewModelStore();
+    method public void onBackPressed();
     method public void setDismissHandler(kotlin.jvm.functions.Function0<kotlin.Unit>? dismissHandler);
     method public void setDisplayDismissButton(boolean shouldDisplayDismissButton);
     method public void setFontProvider(com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider? fontProvider);


### PR DESCRIPTION
### Description
While CEC already had the `storefrontCountryCode`, this also adds the APIs `getStorefrontCountryCode` and `awaitStorefrontCountryCode` to the CEC flavor.