### PR TITLE
Add warning on V9 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@
 
 ## 9.0.0
 ## RevenueCat SDK
+
+> [!WARNING]  
+> If you don't have any login system in your app, please make sure your one time products have been correctly configured in the RevenueCat dashboard as non-consumables if needed. If not, our SDK will consume those purchases, and they won't be able to be restored starting on this version.
+
 This release updates the SDK to use Google Play Billing Library 8. This version of the Billing Library removed APIs to query for expired subscriptions and consumed one-time products, aside from other improvements. You can check the full list of changes here: https://developer.android.com/google/play/billing/release-notes#8-0-0
 
 Additionally, we've also updated Kotlin to 2.0.21 and our new minimum version is Kotlin 1.8.0+. If you were using an older version of Kotlin, you will need to update it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 
 > [!WARNING]  
 > If you don't have any login system in your app, please make sure your one time products have been correctly configured in the RevenueCat dashboard as non-consumables if needed. If not, our SDK will consume those purchases, and they won't be able to be restored starting on this version.
+> Non-consumables are products that are meant to be bought only once, for example, lifetime subscriptions.
 
 This release updates the SDK to use Google Play Billing Library 8. This version of the Billing Library removed APIs to query for expired subscriptions and consumed one-time products, aside from other improvements. You can check the full list of changes here: https://developer.android.com/google/play/billing/release-notes#8-0-0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 ## RevenueCat SDK
 
 > [!WARNING]  
-> If you don't have any login system in your app, please make sure your one-time purchase products have been correctly configured in the RevenueCat dashboard as non-consumables if needed. If not, our SDK will consume those purchases, and they won't be able to be restored starting on this version.
+> If you don't have any login system in your app, please make sure your one-time purchase products have been correctly configured in the RevenueCat dashboard as non-consumables if needed. If they're incorrectly configured as consumables, RevenueCat will consume these purchases. This means that users won't be able to restore them from version 9.0.0 onward.
 > Non-consumables are products that are meant to be bought only once, for example, lifetime subscriptions.
 
 This release updates the SDK to use Google Play Billing Library 8. This version of the Billing Library removed APIs to query for expired subscriptions and consumed one-time products, aside from other improvements. You can check the full list of changes here: https://developer.android.com/google/play/billing/release-notes#8-0-0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 ## RevenueCat SDK
 
 > [!WARNING]  
-> If you don't have any login system in your app, please make sure your one-time purchase products have been correctly configured in the RevenueCat dashboard as non-consumables if needed. If they're incorrectly configured as consumables, RevenueCat will consume these purchases. This means that users won't be able to restore them from version 9.0.0 onward.
+> If you don't have any login system in your app, please make sure your one-time purchase products have been correctly configured in the RevenueCat dashboard as either consumable or non-consumable. If they're incorrectly configured as consumables, RevenueCat will consume these purchases. This means that users won't be able to restore them from version 9.0.0 onward.
 > Non-consumables are products that are meant to be bought only once, for example, lifetime subscriptions.
 
 This release updates the SDK to use Google Play Billing Library 8. This version of the Billing Library removed APIs to query for expired subscriptions and consumed one-time products, aside from other improvements. You can check the full list of changes here: https://developer.android.com/google/play/billing/release-notes#8-0-0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 ## RevenueCat SDK
 
 > [!WARNING]  
-> If you don't have any login system in your app, please make sure your one time products have been correctly configured in the RevenueCat dashboard as non-consumables if needed. If not, our SDK will consume those purchases, and they won't be able to be restored starting on this version.
+> If you don't have any login system in your app, please make sure your one-time purchase products have been correctly configured in the RevenueCat dashboard as non-consumables if needed. If not, our SDK will consume those purchases, and they won't be able to be restored starting on this version.
 > Non-consumables are products that are meant to be bought only once, for example, lifetime subscriptions.
 
 This release updates the SDK to use Google Play Billing Library 8. This version of the Billing Library removed APIs to query for expired subscriptions and consumed one-time products, aside from other improvements. You can check the full list of changes here: https://developer.android.com/google/play/billing/release-notes#8-0-0


### PR DESCRIPTION
### Description
Some users have been facing issues on the V9 migration when using anonymous accounts and haven't configured their one time products correctly in the RevenueCat dashboard. This adds a warning to the changelog in an effort to make this issue a bit more visible before upgrading