### PR TITLE
Add annotation experimental library to debug builds

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ androidxConstraintLayout = "2.1.3"
 androidxCore = "1.8.0"
 androidxNavigation = "2.5.3"
 annotation = "1.3.0"
+annotationExperimental = "1.5.1"
 appcompat = "1.4.1"
 assertJ = "3.22.0"
 browser = "1.8.0"
@@ -62,6 +63,7 @@ profileinstaller = "1.4.1"
 
 [libraries]
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+androidx-annotation-experimental = { module = "androidx.annotation:annotation-experimental", version.ref = "annotationExperimental" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -155,6 +155,8 @@ dependencies {
     compileOnly(libs.amazon.appstore.sdk)
     compileOnly(libs.coil.base)
 
+    debugImplementation(libs.androidx.annotation.experimental)
+
     dokkaPlugin(project(":dokka-hide-internal"))
 
     testImplementation(libs.coil.base)


### PR DESCRIPTION
### Description
At some point, we started getting issues in Android Studio indicating some issues:
<img width="1191" height="467" alt="image" src="https://github.com/user-attachments/assets/c0f1de76-b795-41c8-998c-e28e29cf4067" />

This doesn't actually affect builds, but it's annoying... Seems there is an [issue being tracked](https://issuetracker.google.com/issues/426642727) related to this but it's not been addressed yet. This seems to be a workaround that we can use for now. Only adding as a debug dependency for now