### PR TITLE
Migrate RC SharedPreferences data to a separate file

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.app.Application
 import android.content.Context
 import android.content.pm.PackageManager
-import android.preference.PreferenceManager
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.UserManagerCompat
 import com.revenuecat.purchases.api.BuildConfig
@@ -17,6 +16,7 @@ import com.revenuecat.purchases.common.FileHelper
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.PlatformInfo
+import com.revenuecat.purchases.common.SharedPreferencesManager
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsFileHelper
@@ -114,7 +114,7 @@ internal class PurchasesFactory(
             }
 
             val prefs = try {
-                PreferenceManager.getDefaultSharedPreferences(contextForStorage)
+                SharedPreferencesManager(contextForStorage).getSharedPreferences()
             } catch (e: IllegalStateException) {
                 @Suppress("MaxLineLength")
                 if (!UserManagerCompat.isUserUnlocked(context)) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -253,6 +253,7 @@ internal class PurchasesOrchestrator(
         log(LogIntent.DEBUG) { ConfigureStrings.APP_FOREGROUNDED }
         appConfig.isAppBackgrounded = false
 
+        // $RCAnonymousID:a36af41a15e844dc8786bd6f0386d4ad
         enqueue {
             if (shouldRefreshCustomerInfo(firstTimeInForeground)) {
                 log(LogIntent.DEBUG) { CustomerInfoStrings.CUSTOMERINFO_STALE_UPDATING_FOREGROUND }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -253,7 +253,6 @@ internal class PurchasesOrchestrator(
         log(LogIntent.DEBUG) { ConfigureStrings.APP_FOREGROUNDED }
         appConfig.isAppBackgrounded = false
 
-        // $RCAnonymousID:a36af41a15e844dc8786bd6f0386d4ad
         enqueue {
             if (shouldRefreshCustomerInfo(firstTimeInForeground)) {
                 log(LogIntent.DEBUG) { CustomerInfoStrings.CUSTOMERINFO_STALE_UPDATING_FOREGROUND }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/SharedPreferencesManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/SharedPreferencesManager.kt
@@ -5,8 +5,6 @@ import android.content.SharedPreferences
 import android.preference.PreferenceManager
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 
 /**
  * Provides an instance of SharedPreferences to be used by the RevenueCat SDK.
@@ -30,13 +28,11 @@ internal class SharedPreferencesManager(
         const val SHARED_PREFERENCES_PREFIX = "com.revenuecat.purchases."
     }
 
-    private val migrationLock = ReentrantLock()
-
     /**
      * Gets the appropriate shared preferences, performing migration if needed
      */
     fun getSharedPreferences(): SharedPreferences {
-        migrationLock.withLock {
+        synchronized(this) {
             if (shouldPerformMigration()) {
                 performMigration()
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/SharedPreferencesManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/SharedPreferencesManager.kt
@@ -40,25 +40,21 @@ internal class SharedPreferencesManager(
      * Gets the appropriate shared preferences, performing migration if needed
      */
     fun getSharedPreferences(): SharedPreferences {
-        synchronized(this) {
-            val alreadyHasVersion = hasRevenueCatVersion()
-            if (shouldPerformMigration(alreadyHasVersion)) {
-                performMigration()
-                updateSharedPreferencesVersion()
-            } else if (!alreadyHasVersion) {
-                updateSharedPreferencesVersion()
-            }
-        }
+        synchronized(this) { ensureMigrated() }
         return revenueCatSharedPreferences
     }
 
-    /**
-     * Checks if migration should be performed by checking if RevenueCat preferences are empty
-     * and legacy preferences contain RevenueCat data
-     */
-    private fun shouldPerformMigration(alreadyHasVersion: Boolean): Boolean {
-        return !alreadyHasVersion && legacySharedPreferences.value.all.keys.any { key ->
-            key.startsWith(SHARED_PREFERENCES_PREFIX)
+    private fun ensureMigrated() {
+        val alreadyHasVersion = hasRevenueCatVersion()
+        if (!alreadyHasVersion) {
+            if (legacySharedPreferences.value.all.keys.any {
+                        key ->
+                    key.startsWith(SHARED_PREFERENCES_PREFIX)
+                }
+            ) {
+                performMigration()
+            }
+            updateSharedPreferencesVersion()
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/SharedPreferencesManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/SharedPreferencesManager.kt
@@ -79,6 +79,10 @@ internal class SharedPreferencesManager(
                 }
             }
         }
+
+        log(
+            LogIntent.DEBUG,
+        ) { "Finished shared preferences migration from legacy to RevenueCat-specific preferences" }
     }
 
     private fun getRevenueCatKeysToMigrate(): List<String> {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/SharedPreferencesManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/SharedPreferencesManager.kt
@@ -63,27 +63,21 @@ internal class SharedPreferencesManager(
      * Performs the migration from legacy shared preferences to RevenueCat-specific ones
      */
     private fun performMigration() {
-        try {
-            log(
-                LogIntent.DEBUG,
-            ) { "Starting shared preferences migration from legacy to RevenueCat-specific preferences" }
+        log(
+            LogIntent.DEBUG,
+        ) { "Starting shared preferences migration from legacy to RevenueCat-specific preferences" }
 
-            val revenueCatKeys = getRevenueCatKeysToMigrate()
+        val revenueCatKeys = getRevenueCatKeysToMigrate()
 
-            val legacyPrefs = legacySharedPreferences
-            val revenueCatPrefs = revenueCatSharedPreferences
-            revenueCatPrefs.edit(commit = true) {
-                var migratedCount = 0
-                for (key in revenueCatKeys) {
-                    if (migratePreferenceValue(legacyPrefs, this, key)) {
-                        migratedCount++
-                    }
+        val legacyPrefs = legacySharedPreferences
+        val revenueCatPrefs = revenueCatSharedPreferences
+        revenueCatPrefs.edit(commit = true) {
+            var migratedCount = 0
+            for (key in revenueCatKeys) {
+                if (migratePreferenceValue(legacyPrefs, this, key)) {
+                    migratedCount++
                 }
             }
-        } catch (e: java.lang.IllegalStateException) {
-            errorLog(e) { "Failed to perform shared preferences migration due to invalid state" }
-        } catch (e: java.io.IOException) {
-            errorLog(e) { "Failed to perform shared preferences migration due to IO error" }
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/SharedPreferencesManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/SharedPreferencesManager.kt
@@ -68,11 +68,11 @@ internal class SharedPreferencesManager(
 
         val revenueCatKeys = getRevenueCatKeysToMigrate()
 
-        val legacyPrefs = legacySharedPreferences
+        val legacyPrefs by legacySharedPreferences
         val revenueCatPrefs = revenueCatSharedPreferences
         revenueCatPrefs.edit {
             for (key in revenueCatKeys) {
-                migratePreferenceValue(legacyPrefs.value, this, key)
+                migratePreferenceValue(legacyPrefs, this, key)
             }
         }
 
@@ -82,7 +82,7 @@ internal class SharedPreferencesManager(
     }
 
     private fun getRevenueCatKeysToMigrate(): List<String> {
-        val legacyPrefs = legacySharedPreferences.value
+        val legacyPrefs by legacySharedPreferences
         val revenueCatKeys = legacyPrefs.all.keys.filter { key ->
             key.startsWith(SHARED_PREFERENCES_PREFIX)
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/SharedPreferencesManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/SharedPreferencesManager.kt
@@ -1,0 +1,149 @@
+package com.revenuecat.purchases.common
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.preference.PreferenceManager
+import androidx.annotation.VisibleForTesting
+import androidx.core.content.edit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Provides an instance of SharedPreferences to be used by the RevenueCat SDK.
+ * It handles migration from legacy shared preferences to a dedicated RevenueCat-specific preferences file.
+ * The migration is performed only once, and it ensures that no data is lost during the process
+ */
+internal class SharedPreferencesManager(
+    context: Context,
+    private val revenueCatSharedPreferences: SharedPreferences = context.getSharedPreferences(
+        REVENUECAT_PREFS_FILE_NAME,
+        Context.MODE_PRIVATE,
+    ),
+    private val legacySharedPreferences: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context),
+) {
+
+    companion object {
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        const val REVENUECAT_PREFS_FILE_NAME = "com_revenuecat_purchases_preferences"
+
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        const val SHARED_PREFERENCES_PREFIX = "com.revenuecat.purchases."
+    }
+
+    private val migrationLock = ReentrantLock()
+
+    /**
+     * Gets the appropriate shared preferences, performing migration if needed
+     */
+    fun getSharedPreferences(): SharedPreferences {
+        migrationLock.withLock {
+            if (shouldPerformMigration()) {
+                performMigration()
+            }
+        }
+        return revenueCatSharedPreferences
+    }
+
+    /**
+     * Checks if migration should be performed by checking if RevenueCat preferences are empty
+     * and legacy preferences contain RevenueCat data
+     */
+    private fun shouldPerformMigration(): Boolean {
+        val revenueCatPrefs = revenueCatSharedPreferences
+        val legacyPrefs = legacySharedPreferences
+
+        // If RevenueCat preferences already have data, no migration needed
+        if (revenueCatPrefs.all.isNotEmpty()) {
+            return false
+        }
+
+        // Check if legacy preferences contain any RevenueCat data
+        return legacyPrefs.all.keys.any { key ->
+            key.startsWith(SHARED_PREFERENCES_PREFIX)
+        }
+    }
+
+    /**
+     * Performs the migration from legacy shared preferences to RevenueCat-specific ones
+     */
+    private fun performMigration() {
+        try {
+            log(
+                LogIntent.DEBUG,
+            ) { "Starting shared preferences migration from legacy to RevenueCat-specific preferences" }
+
+            val revenueCatKeys = getRevenueCatKeysToMigrate()
+
+            val legacyPrefs = legacySharedPreferences
+            val revenueCatPrefs = revenueCatSharedPreferences
+            revenueCatPrefs.edit(commit = true) {
+                var migratedCount = 0
+                for (key in revenueCatKeys) {
+                    if (migratePreferenceValue(legacyPrefs, this, key)) {
+                        migratedCount++
+                    }
+                }
+            }
+        } catch (e: java.lang.IllegalStateException) {
+            errorLog(e) { "Failed to perform shared preferences migration due to invalid state" }
+        } catch (e: java.io.IOException) {
+            errorLog(e) { "Failed to perform shared preferences migration due to IO error" }
+        }
+    }
+
+    private fun getRevenueCatKeysToMigrate(): List<String> {
+        val legacyPrefs = legacySharedPreferences
+        val revenueCatKeys = legacyPrefs.all.keys.filter { key ->
+            key.startsWith(SHARED_PREFERENCES_PREFIX)
+        }
+
+        log(LogIntent.DEBUG) { "Found ${revenueCatKeys.size} RevenueCat keys to migrate: $revenueCatKeys" }
+        return revenueCatKeys
+    }
+
+    private fun migratePreferenceValue(
+        legacyPrefs: SharedPreferences,
+        editor: SharedPreferences.Editor,
+        key: String,
+    ): Boolean {
+        return try {
+            val value = legacyPrefs.all[key]
+            when (value) {
+                is String -> {
+                    editor.putString(key, value)
+                    true
+                }
+                is Boolean -> {
+                    editor.putBoolean(key, value)
+                    true
+                }
+                is Int -> {
+                    editor.putInt(key, value)
+                    true
+                }
+                is Long -> {
+                    editor.putLong(key, value)
+                    true
+                }
+                is Float -> {
+                    editor.putFloat(key, value)
+                    true
+                }
+                is Set<*> -> {
+                    @Suppress("UNCHECKED_CAST")
+                    editor.putStringSet(key, value as? Set<String> ?: emptySet())
+                    true
+                }
+                else -> {
+                    log(
+                        LogIntent.WARNING,
+                    ) { "Unknown preference type for key $key: ${value?.javaClass?.simpleName}" }
+                    false
+                }
+            }
+        } catch (e: java.lang.ClassCastException) {
+            errorLog(e) { "Failed to migrate preference with key due to type casting: $key" }
+            false
+        }
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/diagnostics/DiagnosticsSynchronizer.kt
@@ -1,7 +1,5 @@
 package com.revenuecat.purchases.common.diagnostics
 
-import android.content.Context
-import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.Dispatcher
@@ -30,12 +28,6 @@ internal class DiagnosticsSynchronizer(
 
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         const val MAX_EVENTS_TO_SYNC_PER_REQUEST: Int = 200
-
-        fun initializeSharedPreferences(context: Context): SharedPreferences =
-            context.getSharedPreferences(
-                "com_revenuecat_purchases_${context.packageName}_preferences_diagnostics",
-                Context.MODE_PRIVATE,
-            )
     }
 
     val isSyncing = AtomicBoolean(false)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/SharedPreferencesManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/SharedPreferencesManagerTest.kt
@@ -1,0 +1,165 @@
+package com.revenuecat.purchases.common
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.preference.PreferenceManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SharedPreferencesManagerTest {
+
+    private lateinit var mockContext: Context
+    private lateinit var mockLegacyPrefs: SharedPreferences
+    private lateinit var mockRevenueCatPrefs: SharedPreferences
+    private lateinit var mockLegacyEditor: SharedPreferences.Editor
+    private lateinit var mockRevenueCatEditor: SharedPreferences.Editor
+
+    companion object {
+        private const val REVENUECAT_KEY_1 = "com.revenuecat.purchases.apikey1"
+        private const val REVENUECAT_KEY_2 = "com.revenuecat.purchases.apikey1.new"
+        private const val NON_REVENUECAT_KEY = "some.other.key"
+    }
+
+    @Before
+    fun setup() {
+        mockContext = mockk()
+        mockLegacyPrefs = mockk()
+        mockRevenueCatPrefs = mockk()
+        mockLegacyEditor = mockk(relaxed = true)
+        mockRevenueCatEditor = mockk(relaxed = true)
+
+        every { mockContext.getSharedPreferences(SharedPreferencesManager.REVENUECAT_PREFS_FILE_NAME, Context.MODE_PRIVATE) } returns mockRevenueCatPrefs
+        every { mockLegacyPrefs.edit() } returns mockLegacyEditor
+        every { mockRevenueCatPrefs.edit() } returns mockRevenueCatEditor
+        every { mockRevenueCatEditor.commit() } returns true
+
+        mockkStatic(PreferenceManager::class)
+        every { PreferenceManager.getDefaultSharedPreferences(mockContext) } returns mockLegacyPrefs
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `getSharedPreferences returns RevenueCat preferences when no migration needed`() {
+        // RevenueCat preferences have existing data
+        every { mockRevenueCatPrefs.all } returns mapOf("existing.key" to "existing.value")
+        every { mockLegacyPrefs.all } returns mapOf(REVENUECAT_KEY_1 to "value1")
+
+        val manager = SharedPreferencesManager(mockContext)
+        val result = manager.getSharedPreferences()
+
+        assertThat(result).isSameAs(mockRevenueCatPrefs)
+        // No migration should occur
+        verify(exactly = 0) { mockRevenueCatEditor.putString(any(), any()) }
+        verify(exactly = 0) { mockRevenueCatEditor.commit() }
+    }
+
+    @Test
+    fun `getSharedPreferences returns RevenueCat preferences when legacy has no RevenueCat data`() {
+        // RevenueCat preferences are empty, but legacy has no RevenueCat data
+        every { mockRevenueCatPrefs.all } returns emptyMap()
+        every { mockLegacyPrefs.all } returns mapOf(NON_REVENUECAT_KEY to "value")
+
+        val manager = SharedPreferencesManager(mockContext)
+        val result = manager.getSharedPreferences()
+
+        assertThat(result).isSameAs(mockRevenueCatPrefs)
+        // No migration should occur
+        verify(exactly = 0) { mockRevenueCatEditor.putString(any(), any()) }
+        verify(exactly = 0) { mockRevenueCatEditor.commit() }
+    }
+
+    @Test
+    fun `getSharedPreferences performs migration when RevenueCat prefs are empty and legacy has RevenueCat data`() {
+        // RevenueCat preferences are empty, legacy has RevenueCat data
+        every { mockRevenueCatPrefs.all } returns emptyMap()
+        every { mockLegacyPrefs.all } returns mapOf(
+            REVENUECAT_KEY_1 to "string_value",
+            NON_REVENUECAT_KEY to "should_not_migrate"
+        )
+
+        val manager = SharedPreferencesManager(mockContext)
+        val result = manager.getSharedPreferences()
+
+        assertThat(result).isSameAs(mockRevenueCatPrefs)
+        // Migration should occur for RevenueCat keys only
+        verify { mockRevenueCatEditor.putString(REVENUECAT_KEY_1, "string_value") }
+        verify(exactly = 0) { mockRevenueCatEditor.putString(NON_REVENUECAT_KEY, any()) }
+        verify { mockRevenueCatEditor.commit() }
+    }
+
+    @Test
+    fun `getSharedPreferences migrates different data types correctly`() {
+        every { mockRevenueCatPrefs.all } returns emptyMap()
+        every { mockLegacyPrefs.all } returns mapOf<String, Any>(
+            REVENUECAT_KEY_1 to "string_value",
+            REVENUECAT_KEY_2 to true,
+            "com.revenuecat.purchases.long_key" to 123L,
+            "com.revenuecat.purchases.int_key" to 456,
+            "com.revenuecat.purchases.float_key" to 78.9f,
+            "com.revenuecat.purchases.set_key" to setOf("a", "b", "c")
+        )
+
+        val manager = SharedPreferencesManager(mockContext)
+        val result = manager.getSharedPreferences()
+
+        assertThat(result).isSameAs(mockRevenueCatPrefs)
+        verify { mockRevenueCatEditor.putString(REVENUECAT_KEY_1, "string_value") }
+        verify { mockRevenueCatEditor.putBoolean(REVENUECAT_KEY_2, true) }
+        verify { mockRevenueCatEditor.putLong("com.revenuecat.purchases.long_key", 123L) }
+        verify { mockRevenueCatEditor.putInt("com.revenuecat.purchases.int_key", 456) }
+        verify { mockRevenueCatEditor.putFloat("com.revenuecat.purchases.float_key", 78.9f) }
+        verify { mockRevenueCatEditor.putStringSet("com.revenuecat.purchases.set_key", setOf("a", "b", "c")) }
+        verify { mockRevenueCatEditor.commit() }
+    }
+
+    @Test
+    fun `getSharedPreferences handles concurrent access safely`() {
+        // Test that multiple calls work correctly - first call should trigger migration
+        every { mockRevenueCatPrefs.all } returnsMany listOf(
+            emptyMap(), // First call - empty, triggers migration
+            mapOf(REVENUECAT_KEY_1 to "value1") // After migration - has data, no more migration
+        )
+        every { mockLegacyPrefs.all } returns mapOf(REVENUECAT_KEY_1 to "value1")
+
+        val manager = SharedPreferencesManager(mockContext)
+        
+        val result1 = manager.getSharedPreferences()
+        val result2 = manager.getSharedPreferences()
+
+        assertThat(result1).isSameAs(mockRevenueCatPrefs)
+        assertThat(result2).isSameAs(mockRevenueCatPrefs)
+        
+        // Migration should only happen once during the first call
+        verify(exactly = 1) { mockRevenueCatEditor.putString(REVENUECAT_KEY_1, "value1") }
+        verify(exactly = 1) { mockRevenueCatEditor.commit() }
+    }
+
+    @Test
+    fun `getSharedPreferences handles migration failure gracefully`() {
+        every { mockRevenueCatPrefs.all } returns emptyMap()
+        every { mockLegacyPrefs.all } returns mapOf(REVENUECAT_KEY_1 to "value1")
+        every { mockRevenueCatEditor.commit() } returns false
+
+        val manager = SharedPreferencesManager(mockContext)
+        val result = manager.getSharedPreferences()
+
+        // Should still return the RevenueCat preferences even if migration fails
+        assertThat(result).isSameAs(mockRevenueCatPrefs)
+        verify { mockRevenueCatEditor.putString(REVENUECAT_KEY_1, "value1") }
+        verify { mockRevenueCatEditor.commit() }
+    }
+}


### PR DESCRIPTION
### Description
We were storing data in the default shared preferences file, which could potentially be used by the app developer. That's a bad practice and it's more difficult to do some things with. This PR changes to a separate shared preferences file and adds a migration, so we migrate all RC data from the previous shared preferences file to the new one. We won't delete the data from the previous shared preferences file, but that will remain unused.

