### PR TITLE
Handle payment pending errors when restoring properly

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/errors.kt
@@ -32,6 +32,7 @@ internal enum class BackendErrorCode(val value: Int) {
     BackendInvalidSubscriberAttributes(7263),
     BackendInvalidSubscriberAttributesBody(7264),
     BackendSubscriberAttributesAreBeingUpdated(7629),
+    BackendPaymentNotComplete(7651),
     BackendRequestAlreadyInProgress(7638),
     BackendProductIDsMalformed(7662),
     BackendInvalidWebRedemptionToken(7849),
@@ -108,6 +109,7 @@ private fun BackendErrorCode.toPurchasesErrorCode(): PurchasesErrorCode {
         BackendErrorCode.BackendRequestAlreadyInProgress,
         BackendErrorCode.BackendSubscriberAttributesAreBeingUpdated,
         -> PurchasesErrorCode.OperationAlreadyInProgressError
+        BackendErrorCode.BackendPaymentNotComplete -> PurchasesErrorCode.PaymentPendingError
         BackendErrorCode.BackendCouldNotCreateAlias -> PurchasesErrorCode.ConfigurationError
         BackendErrorCode.BackendProductIDsMalformed -> PurchasesErrorCode.UnsupportedError
         BackendErrorCode.BackendInvalidWebRedemptionToken -> PurchasesErrorCode.PurchaseInvalidError


### PR DESCRIPTION
### Description
Until now, if trying to restore a purchase with a payment pending error, the SDK returned an unknown backend error code. This should be returned instead with a PaymentPendingError code for proper handling.

Note that restore errors return the error of the last post receipt with errors. If there were multiple errors, all might not be exposed right now.