### PR TITLE
Feat/support new key

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -479,6 +479,7 @@ data class CustomerCenterConfigData(
     data class ScreenOffering(
         val type: ScreenOfferingType,
         @SerialName("offering_id") val offeringId: String? = null,
+        @SerialName("button_text") val buttonText: String? = null,
     ) {
         @Serializable
         enum class ScreenOfferingType(val value: String) {

--- a/purchases/src/test/java/com/revenuecat/purchases/customercenter/ScreenOfferingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/customercenter/ScreenOfferingTest.kt
@@ -149,4 +149,106 @@ class ScreenOfferingTest {
         assertThat(CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.CURRENT.value).isEqualTo("CURRENT")
         assertThat(CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.SPECIFIC.value).isEqualTo("SPECIFIC")
     }
+
+    @Test
+    fun `ScreenOffering with buttonText - serialization and deserialization`() {
+        val screenOffering = CustomerCenterConfigData.ScreenOffering(
+            type = CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.CURRENT,
+            buttonText = "Get Started"
+        )
+
+        val serialized = json.encodeToString(screenOffering)
+        val deserialized = json.decodeFromString<CustomerCenterConfigData.ScreenOffering>(serialized)
+
+        assertThat(deserialized.type).isEqualTo(CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.CURRENT)
+        assertThat(deserialized.offeringId).isNull()
+        assertThat(deserialized.buttonText).isEqualTo("Get Started")
+    }
+
+    @Test
+    fun `ScreenOffering without buttonText - backward compatibility`() {
+        val screenOffering = CustomerCenterConfigData.ScreenOffering(
+            type = CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.SPECIFIC,
+            offeringId = "premium_plan"
+        )
+
+        val serialized = json.encodeToString(screenOffering)
+        val deserialized = json.decodeFromString<CustomerCenterConfigData.ScreenOffering>(serialized)
+
+        assertThat(deserialized.type).isEqualTo(CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.SPECIFIC)
+        assertThat(deserialized.offeringId).isEqualTo("premium_plan")
+        assertThat(deserialized.buttonText).isNull()
+    }
+
+    @Test
+    fun `ScreenOffering JSON parsing with button_text`() {
+        val jsonString = """
+        {
+            "type": "CURRENT",
+            "button_text": "Subscribe Now"
+        }
+        """.trimIndent()
+
+        val screenOffering = json.decodeFromString<CustomerCenterConfigData.ScreenOffering>(jsonString)
+
+        assertThat(screenOffering.type).isEqualTo(CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.CURRENT)
+        assertThat(screenOffering.offeringId).isNull()
+        assertThat(screenOffering.buttonText).isEqualTo("Subscribe Now")
+    }
+
+    @Test
+    fun `ScreenOffering JSON parsing without button_text - backward compatibility`() {
+        val jsonString = """
+        {
+            "type": "SPECIFIC",
+            "offering_id": "monthly_plan"
+        }
+        """.trimIndent()
+
+        val screenOffering = json.decodeFromString<CustomerCenterConfigData.ScreenOffering>(jsonString)
+
+        assertThat(screenOffering.type).isEqualTo(CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.SPECIFIC)
+        assertThat(screenOffering.offeringId).isEqualTo("monthly_plan")
+        assertThat(screenOffering.buttonText).isNull()
+    }
+
+    @Test
+    fun `Screen with offering containing buttonText - JSON parsing`() {
+        val jsonString = """
+        {
+            "type": "NO_ACTIVE",
+            "title": "No Active Screen",
+            "subtitle": "No active subscriptions",
+            "paths": [],
+            "offering": {
+                "type": "CURRENT",
+                "button_text": "Start Subscription"
+            }
+        }
+        """.trimIndent()
+
+        val screen = json.decodeFromString<CustomerCenterConfigData.Screen>(jsonString)
+
+        assertThat(screen.type).isEqualTo(CustomerCenterConfigData.Screen.ScreenType.NO_ACTIVE)
+        assertThat(screen.offering).isNotNull
+        assertThat(screen.offering?.type).isEqualTo(CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.CURRENT)
+        assertThat(screen.offering?.offeringId).isNull()
+        assertThat(screen.offering?.buttonText).isEqualTo("Start Subscription")
+    }
+
+    @Test
+    fun `ScreenOffering with all fields - serialization and deserialization`() {
+        val screenOffering = CustomerCenterConfigData.ScreenOffering(
+            type = CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.SPECIFIC,
+            offeringId = "premium_yearly",
+            buttonText = "Upgrade to Premium"
+        )
+
+        val serialized = json.encodeToString(screenOffering)
+        val deserialized = json.decodeFromString<CustomerCenterConfigData.ScreenOffering>(serialized)
+
+        assertThat(deserialized.type).isEqualTo(CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.SPECIFIC)
+        assertThat(deserialized.offeringId).isEqualTo("premium_yearly")
+        assertThat(deserialized.buttonText).isEqualTo("Upgrade to Premium")
+    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -476,11 +476,9 @@ private fun MainScreenContent(
     } else {
         configuration.getNoActiveScreen()?.let { noActiveScreen ->
             NoActiveUserManagementView(
-                screenTitle = noActiveScreen.title,
-                screenSubtitle = noActiveScreen.subtitle,
+                screen = noActiveScreen,
                 contactEmail = configuration.support.email,
                 localization = configuration.localization,
-                supportedPaths = noActiveScreen.paths,
                 offering = (state as? CustomerCenterState.Success)?.noActiveScreenOffering,
                 onAction = onAction,
             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/ScreenOfferingExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/ScreenOfferingExtensions.kt
@@ -27,3 +27,13 @@ internal suspend fun CustomerCenterConfigData.Screen.resolveOfferingSuspend(
         }
     }
 }
+
+@InternalRevenueCatAPI
+internal fun CustomerCenterConfigData.Screen.resolveButtonText(
+    localization: CustomerCenterConfigData.Localization,
+): String {
+    return offering?.buttonText
+        ?: localization.commonLocalizedString(
+            CustomerCenterConfigData.Localization.CommonLocalizedString.BUY_SUBSCRIPTION,
+        )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/NoActiveUserManagementView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/NoActiveUserManagementView.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
-import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.HelpPath
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenterConstants
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenterUIConstants.ContentUnavailableIconSize
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenterUIConstants.ContentUnavailableViewPaddingHorizontal
@@ -33,23 +32,22 @@ import com.revenuecat.purchases.ui.revenuecatui.customercenter.actions.CustomerC
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.composables.SettingsButton
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.composables.SettingsButtonStyle
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCenterConfigTestData
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.resolveButtonText
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.theme.CustomerCenterPreviewTheme
 
 @Suppress("LongParameterList")
 @Composable
 internal fun NoActiveUserManagementView(
-    screenTitle: String,
-    screenSubtitle: String?,
+    screen: CustomerCenterConfigData.Screen,
     contactEmail: String?,
     localization: CustomerCenterConfigData.Localization,
-    supportedPaths: List<HelpPath>,
     offering: Offering?,
     onAction: (CustomerCenterAction) -> Unit,
 ) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         ContentUnavailableView(
-            title = screenTitle,
-            description = screenSubtitle,
+            title = screen.title,
+            description = screen.subtitle,
             modifier = Modifier.padding(
                 top = ManagementViewHorizontalPadding,
                 start = ManagementViewHorizontalPadding,
@@ -61,9 +59,7 @@ internal fun NoActiveUserManagementView(
         offering?.let {
             SettingsButton(
                 onClick = { onAction(CustomerCenterAction.ShowPaywall) },
-                title = localization.commonLocalizedString(
-                    CustomerCenterConfigData.Localization.CommonLocalizedString.BUY_SUBSCRIPTION,
-                ),
+                title = screen.resolveButtonText(localization),
                 style = SettingsButtonStyle.FILLED,
                 modifier = Modifier.padding(
                     top = ManagementViewHorizontalPadding,
@@ -75,7 +71,7 @@ internal fun NoActiveUserManagementView(
 
         ManageSubscriptionsButtonsView(
             associatedPurchaseInformation = null,
-            supportedPaths = supportedPaths,
+            supportedPaths = screen.paths,
             localization = localization,
             contactEmail = contactEmail,
             addContactButton = true,
@@ -142,11 +138,9 @@ private fun NoActiveUserManagementView_Preview() {
                 .background(MaterialTheme.colorScheme.background),
         ) {
             NoActiveUserManagementView(
-                screenTitle = noActiveScreen.title,
-                screenSubtitle = noActiveScreen.subtitle,
+                screen = noActiveScreen,
                 contactEmail = "support@example.com",
                 localization = testData.localization,
-                supportedPaths = noActiveScreen.paths,
                 offering = null, // No offering in preview
                 onAction = { },
             )

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/ScreenOfferingExtensionsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/ScreenOfferingExtensionsTest.kt
@@ -1,0 +1,134 @@
+package com.revenuecat.purchases.ui.revenuecatui.customercenter
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class ScreenOfferingExtensionsTest {
+
+    private val localization = CustomerCenterConfigData.Localization(
+        locale = "en_US",
+        localizedStrings = mapOf("buy_subscription" to "Custom Buy Subscription Text")
+    )
+
+    @Test
+    fun `resolveButtonText returns custom buttonText when available`() {
+        val screenOffering = CustomerCenterConfigData.ScreenOffering(
+            type = CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.CURRENT,
+            buttonText = "Get Premium Now"
+        )
+        
+        val screen = CustomerCenterConfigData.Screen(
+            type = CustomerCenterConfigData.Screen.ScreenType.NO_ACTIVE,
+            title = "Test Screen",
+            paths = emptyList(),
+            offering = screenOffering
+        )
+
+        val result = screen.resolveButtonText(localization)
+
+        assertThat(result).isEqualTo("Get Premium Now")
+    }
+
+    @Test
+    fun `resolveButtonText falls back to BUY_SUBSCRIPTION when buttonText is null`() {
+        val screenOffering = CustomerCenterConfigData.ScreenOffering(
+            type = CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.CURRENT,
+            buttonText = null
+        )
+        
+        val screen = CustomerCenterConfigData.Screen(
+            type = CustomerCenterConfigData.Screen.ScreenType.NO_ACTIVE,
+            title = "Test Screen",
+            paths = emptyList(),
+            offering = screenOffering
+        )
+
+        val result = screen.resolveButtonText(localization)
+
+        assertThat(result).isEqualTo("Custom Buy Subscription Text")
+    }
+
+    @Test
+    fun `resolveButtonText falls back to BUY_SUBSCRIPTION when offering is null`() {
+        val screen = CustomerCenterConfigData.Screen(
+            type = CustomerCenterConfigData.Screen.ScreenType.NO_ACTIVE,
+            title = "Test Screen",
+            paths = emptyList(),
+            offering = null
+        )
+
+        val result = screen.resolveButtonText(localization)
+
+        assertThat(result).isEqualTo("Custom Buy Subscription Text")
+    }
+
+    @Test
+    fun `resolveButtonText uses default BUY_SUBSCRIPTION text when not in localization`() {
+        val emptyLocalization = CustomerCenterConfigData.Localization(
+            locale = "en_US",
+            localizedStrings = emptyMap()
+        )
+
+        val screenOffering = CustomerCenterConfigData.ScreenOffering(
+            type = CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.CURRENT,
+            buttonText = null
+        )
+        
+        val screen = CustomerCenterConfigData.Screen(
+            type = CustomerCenterConfigData.Screen.ScreenType.NO_ACTIVE,
+            title = "Test Screen",
+            paths = emptyList(),
+            offering = screenOffering
+        )
+
+        val result = screen.resolveButtonText(emptyLocalization)
+
+        // Should fall back to the default value defined in CommonLocalizedString.BUY_SUBSCRIPTION
+        assertThat(result).isEqualTo("Buy Subscription")
+    }
+
+    @Test
+    fun `resolveButtonText works with empty buttonText string`() {
+        val screenOffering = CustomerCenterConfigData.ScreenOffering(
+            type = CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.CURRENT,
+            buttonText = ""
+        )
+        
+        val screen = CustomerCenterConfigData.Screen(
+            type = CustomerCenterConfigData.Screen.ScreenType.NO_ACTIVE,
+            title = "Test Screen",
+            paths = emptyList(),
+            offering = screenOffering
+        )
+
+        val result = screen.resolveButtonText(localization)
+
+        assertThat(result).isEqualTo("")
+    }
+
+    @Test
+    fun `resolveButtonText works with different screen types`() {
+        val screenOffering = CustomerCenterConfigData.ScreenOffering(
+            type = CustomerCenterConfigData.ScreenOffering.ScreenOfferingType.SPECIFIC,
+            offeringId = "premium_monthly",
+            buttonText = "Upgrade to Monthly"
+        )
+        
+        val managementScreen = CustomerCenterConfigData.Screen(
+            type = CustomerCenterConfigData.Screen.ScreenType.MANAGEMENT,
+            title = "Management Screen",
+            paths = emptyList(),
+            offering = screenOffering
+        )
+
+        val result = managementScreen.resolveButtonText(localization)
+
+        assertThat(result).isEqualTo("Upgrade to Monthly")
+    }
+}


### PR DESCRIPTION
### Motivation
We want to be more explicit on how to edit the button text for the ScreenOffering.
 
[ios](https://github.com/RevenueCat/purchases-ios/pull/5501)

### Description
- Add button text to ScreenOffering

> This comes already translated. For backwards compatibility, we default to the key used right now.
