### PR TITLE
Fix PaywallDialog going over screen size on Android 35+

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialog.kt
@@ -97,6 +97,10 @@ private fun DialogScaffold(paywallOptions: PaywallOptions, dialogBottomPadding: 
         modifier = Modifier
             .fillMaxWidth()
             .fillMaxHeight(getDialogMaxHeightPercentage()),
+        // This is needed for Android 35+ but using an older version of Compose. In those cases,
+        // the dialog doesn't properly extend edge to edge, leaving some spacing at the bottom since we changed
+        // the decorFitsSystemWindows setting of the Dialog. This is added to mimick the dim effect that we get
+        // at the top of the dialog in this case. This should be removed once we update Compose in the next major.
         containerColor = Color.Black.copy(alpha = 0.4f),
     ) { paddingValues ->
         val shouldApplyDialogBottomPadding = paddingValues.calculateBottomPadding() == 0.dp &&


### PR DESCRIPTION
### Description
There is an issue in our current version of compose that causes the Dialog composable to extend beyond the screen size in Android 35+ devices: https://issuetracker.google.com/issues/246909281. This was fixed in a newer version of Compose, however, that introduces a breaking change by forcing apps to compile against Android 35.

This PR introduces a workaround by applying some bottom padding that consists on the status bar + navigation bars sizes as bottom padding. It also makes the PaywallDialog go Edge to Edge on Android 35+, which is the default starting on that version. The current fix has been tested on Android <35 and >35 and also when the client app uses a higher version of compsoe with the fix.

| Issue in Android 35+ | Android < 35 | Android >= 35 with older compose version | Android >= 35 with newer compose version |
| ------ | ----- | ----- | ----- |
| <img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/5ceb3a20-c25c-419f-8aa2-2ac54f6e458e" />  | <img width="540" height="1200" alt="image" src="https://github.com/user-attachments/assets/06d2ec4b-da6e-471c-a471-d2950b651008" /> | <img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/8cd441a5-6e45-4ae8-bc11-228787189063" />  | <img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/adba21c1-d5f8-46e8-b3ed-c7623437353a" /> |
