### PR TITLE
Add option to disable automatic ID collection when setting attribution network IDs at configuration time

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesConfiguration.kt
@@ -35,6 +35,7 @@ open class PurchasesConfiguration(builder: Builder) {
     val dangerousSettings: DangerousSettings
     val verificationMode: EntitlementVerificationMode
     val pendingTransactionsForPrepaidPlansEnabled: Boolean
+    val enableIdentifierCollectionWhenUsingAttributionNetwork: Boolean
 
     init {
         this.context =
@@ -53,6 +54,8 @@ open class PurchasesConfiguration(builder: Builder) {
         this.dangerousSettings = builder.dangerousSettings
         this.showInAppMessagesAutomatically = builder.showInAppMessagesAutomatically
         this.pendingTransactionsForPrepaidPlansEnabled = builder.pendingTransactionsForPrepaidPlansEnabled
+        this.enableIdentifierCollectionWhenUsingAttributionNetwork =
+            builder.enableIdentifierCollectionWhenUsingAttributionNetwork
     }
 
     internal fun copy(
@@ -68,6 +71,9 @@ open class PurchasesConfiguration(builder: Builder) {
             .dangerousSettings(dangerousSettings)
             .showInAppMessagesAutomatically(showInAppMessagesAutomatically)
             .pendingTransactionsForPrepaidPlansEnabled(pendingTransactionsForPrepaidPlansEnabled)
+            .enableIdentifierCollectionWhenUsingAttributionNetwork(
+                enableIdentifierCollectionWhenUsingAttributionNetwork,
+            )
         if (service != null) {
             builder = builder.service(service)
         }
@@ -106,6 +112,9 @@ open class PurchasesConfiguration(builder: Builder) {
 
         @set:JvmSynthetic @get:JvmSynthetic
         internal var pendingTransactionsForPrepaidPlansEnabled: Boolean = false
+
+        @set:JvmSynthetic @get:JvmSynthetic
+        internal var enableIdentifierCollectionWhenUsingAttributionNetwork: Boolean = true
 
         /**
          * A unique id for identifying the user
@@ -254,6 +263,21 @@ open class PurchasesConfiguration(builder: Builder) {
          */
         fun pendingTransactionsForPrepaidPlansEnabled(pendingTransactionsForPrepaidPlansEnabled: Boolean) = apply {
             this.pendingTransactionsForPrepaidPlansEnabled = pendingTransactionsForPrepaidPlansEnabled
+        }
+
+        /**
+         * Enable this setting to allow the collection of identifiers when setting the identifier for an
+         * attribution network. For example, when calling [Purchases.setAdjustID] or [Purchases.setAppsflyerID],
+         * the SDK would collect the Android advertising ID, IP and device versions, if available, and send them
+         * to RevenueCat. This is required by some attribution networks to attribute installs and re-installs.
+         *
+         * Default is enabled.
+         */
+        fun enableIdentifierCollectionWhenUsingAttributionNetwork(
+            enableIdentifierCollectionWhenUsingAttributionNetwork: Boolean,
+        ) = apply {
+            this.enableIdentifierCollectionWhenUsingAttributionNetwork =
+                enableIdentifierCollectionWhenUsingAttributionNetwork
         }
 
         /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -209,6 +209,7 @@ internal class PurchasesFactory(
                 subscriberAttributesCache,
                 subscriberAttributesPoster,
                 attributionFetcher,
+                enableIdentifierCollectionWhenUsingAttributionNetwork,
             )
 
             val offlineCustomerInfoCalculator = OfflineCustomerInfoCalculator(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesManager.kt
@@ -17,6 +17,7 @@ internal class SubscriberAttributesManager(
     val deviceCache: SubscriberAttributesCache,
     val backend: SubscriberAttributesPoster,
     private val deviceIdentifiersFetcher: DeviceIdentifiersFetcher,
+    private val enableIdentifierCollectionWhenUsingAttributionNetwork: Boolean,
 ) {
 
     private val obtainingDeviceIdentifiersObservable = ObtainDeviceIdentifiersObservable()
@@ -178,9 +179,16 @@ internal class SubscriberAttributesManager(
         appUserID: String,
         applicationContext: Application,
     ) {
-        getDeviceIdentifiers(applicationContext) { deviceIdentifiers ->
+        val setAttributes: (deviceIdentifiers: Map<String, String?>) -> Unit = { deviceIdentifiers ->
             val attributesToSet = mapOf(attributionKey.backendKey to value) + deviceIdentifiers
             setAttributes(attributesToSet, appUserID)
+        }
+        if (enableIdentifierCollectionWhenUsingAttributionNetwork) {
+            getDeviceIdentifiers(applicationContext) { deviceIdentifiers ->
+                setAttributes(deviceIdentifiers)
+            }
+        } else {
+            setAttributes(emptyMap())
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesConfigurationTest.kt
@@ -48,6 +48,7 @@ class PurchasesConfigurationTest {
         assertThat(purchasesConfiguration.dangerousSettings).isEqualTo(DangerousSettings(autoSyncPurchases = true))
         assertThat(purchasesConfiguration.showInAppMessagesAutomatically).isTrue
         assertThat(purchasesConfiguration.pendingTransactionsForPrepaidPlansEnabled).isFalse
+        assertThat(purchasesConfiguration.enableIdentifierCollectionWhenUsingAttributionNetwork).isTrue
     }
 
     @Test
@@ -115,6 +116,12 @@ class PurchasesConfigurationTest {
         val dangerousSettings = DangerousSettings(autoSyncPurchases = false)
         val purchasesConfiguration = builder.dangerousSettings(dangerousSettings).build()
         assertThat(purchasesConfiguration.dangerousSettings).isEqualTo(dangerousSettings)
+    }
+
+    @Test
+    fun `PurchasesConfiguration sets enableIdentifierCollectionWhenUsingAttributionNetwork correctly`() {
+        val purchasesConfiguration = builder.enableIdentifierCollectionWhenUsingAttributionNetwork(false).build()
+        assertThat(purchasesConfiguration.enableIdentifierCollectionWhenUsingAttributionNetwork).isFalse
     }
 
     @Test


### PR DESCRIPTION
### Description
This adds a new API that can be used to disable automatic collection of Advertising ID, IP and device info when using one of the attribution networks we support like Adjust or Appsflyer. This can be set at configuration time like this:
```
val purchasesConfiguration = PurchasesConfiguration.Builder(context, "YOUR_API_KEY")
   .enableIdentifierCollectionWhenUsingAttributionNetwork(enabled)
   .build()
Purchases.configure(purchasesConfiguration)
```

Note that you can still collect these identifiers by calling `Purchases.sharedInstance.collectDeviceIdentifiers()`