### PR TITLE
[EXTERNAL] docs: fixed a typo on documentation about `Purchases.awaitPurchase` by @matteinn in #2593

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/CoroutinesExtensionsCommon.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/CoroutinesExtensionsCommon.kt
@@ -64,7 +64,7 @@ suspend fun Purchases.awaitOfferingsResult(): Result<Offerings> =
  *   - Falls back to use base plan
  *
  * @params [purchaseParams] The parameters configuring the purchase. See [PurchaseParams.Builder] for options.
- * @throws [PurchasesTransactionException] with a [PurchasesTransactionException] if there's an error when purchasing
+ * @throws [PurchasesTransactionException] with a [PurchasesError] if there's an error when purchasing
  * and a userCancelled boolean that indicates if the user cancelled the purchase flow.
  * @return The [StoreTransaction] for this purchase and the updated [CustomerInfo] for this user.
  */


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the
"Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
Documentation about the `Purchases.awaitPurchase` coroutine extension was misleading.
Fixes a typo on documentation where the wrong class is mentioned.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes --> Fixed the typo by linking the correct class (`PurchasesError`) embedded in the `PurchasesTransactionException` thrown in case of errors.


Contributed by @matteinn in #2593 
