### PR TITLE
Support setting null offering id on PaywallView

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/OriginalTemplatePaywallFooterView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/OriginalTemplatePaywallFooterView.kt
@@ -149,15 +149,19 @@ open class OriginalTemplatePaywallFooterView : FrameLayout {
 
     @InternalRevenueCatAPI
     fun setOfferingIdAndPresentedOfferingContext(
-        offeringId: String,
-        presentedOfferingContext: PresentedOfferingContext,
+        offeringId: String?,
+        presentedOfferingContext: PresentedOfferingContext?,
     ) {
-        paywallOptions = paywallOptions.copy(
-            offeringSelection = OfferingSelection.IdAndPresentedOfferingContext(
-                offeringId = offeringId,
-                presentedOfferingContext = presentedOfferingContext,
-            ),
-        )
+        if (offeringId == null) {
+            paywallOptions = paywallOptions.copy(offeringSelection = OfferingSelection.None)
+        } else {
+            paywallOptions = paywallOptions.copy(
+                offeringSelection = OfferingSelection.IdAndPresentedOfferingContext(
+                    offeringId = offeringId,
+                    presentedOfferingContext = presentedOfferingContext,
+                ),
+            )
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
Follow-up to #2610. We had a non-null offeringIdentifier parameter, which doesn't allow us to reset the offering selection to none. This would be very uncommon, but we should still support it.