### PR TITLE
Fix CoroutineCreationDuringComposition lint error on AGP 8.13.0

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -81,7 +81,7 @@ internal fun InternalCustomerCenter(
     val isDark = isSystemInDarkTheme()
 
     LaunchedEffect(colorScheme, isDark) {
-        viewModel.refreshStateIfColorsChanged(colorScheme, isDark)
+        viewModel.refreshColors(colorScheme, isDark)
     }
 
     val state by viewModel.state.collectAsStateWithLifecycle()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/InternalCustomerCenter.kt
@@ -77,14 +77,19 @@ internal fun InternalCustomerCenter(
     ),
     onDismiss: () -> Unit,
 ) {
-    viewModel.refreshStateIfColorsChanged(MaterialTheme.colorScheme, isSystemInDarkTheme())
+    val colorScheme = MaterialTheme.colorScheme
+    val isDark = isSystemInDarkTheme()
+
+    LaunchedEffect(colorScheme, isDark) {
+        viewModel.refreshStateIfColorsChanged(colorScheme, isDark)
+    }
 
     val state by viewModel.state.collectAsStateWithLifecycle()
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
 
-    if (state is CustomerCenterState.NotLoaded) {
-        coroutineScope.launch {
+    LaunchedEffect(state !is CustomerCenterState.Success) {
+        if (state is CustomerCenterState.NotLoaded) {
             viewModel.loadCustomerCenter()
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -115,7 +115,7 @@ internal interface CustomerCenterViewModel {
 
     // trigger state refresh
     fun refreshStateIfLocaleChanged()
-    fun refreshStateIfColorsChanged(currentColorScheme: ColorScheme, isSystemInDarkTheme: Boolean)
+    fun refreshColors(currentColorScheme: ColorScheme, isSystemInDarkTheme: Boolean)
 
     // tracks customer center impression the first time is shown
     fun trackImpressionIfNeeded()
@@ -834,14 +834,12 @@ internal class CustomerCenterViewModelImpl(
         }
     }
 
-    override fun refreshStateIfColorsChanged(currentColorScheme: ColorScheme, isSystemInDarkTheme: Boolean) {
-        if (isDarkMode != isSystemInDarkTheme) {
-            isDarkMode = isSystemInDarkTheme
-        }
-
-        if (_colorScheme.value != currentColorScheme) {
-            _colorScheme.value = currentColorScheme
-        }
+    override fun refreshColors(
+        currentColorScheme: ColorScheme,
+        isSystemInDarkTheme: Boolean,
+    ) {
+        isDarkMode = isSystemInDarkTheme
+        _colorScheme.value = currentColorScheme
     }
 
     override fun trackImpressionIfNeeded() {


### PR DESCRIPTION
Fixes https://github.com/RevenueCat/purchases-android/pull/2588#issuecomment-3149306146

A new lint issue that starts happening when upgrading to AGP 8.13.0

Also wrapped the `refreshStateIfColorsChanged` in a LaunchedEffect keyed by the inputs, so it only runs when the theme actually changes.