### PR TITLE
Fix promo offer button CTA in Customer Center

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -38,6 +38,11 @@ data class CustomerCenterConfigData(
             SUB_OFFER_DURATION_2("sub_offer_duration_2"),
             SUB_OFFER_PRICE("sub_offer_price"),
             SUB_OFFER_PRICE_2("sub_offer_price_2"),
+            SUB_OFFER_PRICE_PER_PERIOD("sub_offer_price_per_period"),
+            SUB_OFFER_PRICE_PER_PERIOD_2("sub_offer_price_per_period_2"),
+            SUB_OFFER_BILLING_PERIOD("sub_offer_billing_period"),
+            SUB_OFFER_BILLING_CYCLES("sub_offer_billing_cycles"),
+            SUB_OFFER_BILLING_CYCLE_COUNT("sub_offer_billing_cycle_count"),
             ;
 
             companion object {
@@ -197,6 +202,12 @@ data class CustomerCenterConfigData(
             @SerialName("free_trial_discounted_then_price")
             FREE_TRIAL_DISCOUNTED_THEN_PRICE,
 
+            @SerialName("discounted_recurring_price_per_period_then_price")
+            DISCOUNTED_RECURRING_PRICE_PER_PERIOD_THEN_PRICE,
+
+            @SerialName("free_trial_discounted_price_per_period_then_price")
+            FREE_TRIAL_DISCOUNTED_PRICE_PER_PERIOD_THEN_PRICE,
+
             @SerialName("done")
             DONE,
 
@@ -340,8 +351,16 @@ data class CustomerCenterConfigData(
                         "Try {{ sub_offer_duration }} for free, then {{ sub_offer_duration_2 }} for" +
                             " {{ sub_offer_price_2 }}, and {{ price }} thereafter"
                     FREE_TRIAL_DISCOUNTED_THEN_PRICE ->
-                        "Try {{ sub_offer_duration }} for free, then {{ sub_offer_price_2 }} " +
-                            "during {{ sub_offer_duration_2 }}, and {{ price }} thereafter"
+                        "Try {{ sub_offer_duration }} for free, " +
+                            "then {{ sub_offer_price_2 }} during {{ sub_offer_duration_2 }}, " +
+                            "and {{ price }} thereafter"
+                    DISCOUNTED_RECURRING_PRICE_PER_PERIOD_THEN_PRICE ->
+                        "{{ sub_offer_price_per_period }} for {{ sub_offer_billing_cycle_count }} periods, " +
+                            "then {{ price }}"
+                    FREE_TRIAL_DISCOUNTED_PRICE_PER_PERIOD_THEN_PRICE ->
+                        "Try {{ sub_offer_duration }} for free, " +
+                            "then {{ sub_offer_price_per_period_2 }} for " +
+                            "{{ sub_offer_billing_cycle_count }} periods, and {{ price }} thereafter"
                     DONE -> "Done"
                     RENEWS_ON_DATE_FOR_PRICE -> "Your next charge is {{ price }} on {{ date }}."
                     RENEWS_ON_DATE -> "Renews on {{ date }}"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -40,8 +40,6 @@ data class CustomerCenterConfigData(
             SUB_OFFER_PRICE_2("sub_offer_price_2"),
             SUB_OFFER_PRICE_PER_PERIOD("sub_offer_price_per_period"),
             SUB_OFFER_PRICE_PER_PERIOD_2("sub_offer_price_per_period_2"),
-            SUB_OFFER_BILLING_PERIOD("sub_offer_billing_period"),
-            SUB_OFFER_BILLING_CYCLES("sub_offer_billing_cycles"),
             SUB_OFFER_BILLING_CYCLE_COUNT("sub_offer_billing_cycle_count"),
             ;
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -38,9 +38,8 @@ data class CustomerCenterConfigData(
             SUB_OFFER_DURATION_2("sub_offer_duration_2"),
             SUB_OFFER_PRICE("sub_offer_price"),
             SUB_OFFER_PRICE_2("sub_offer_price_2"),
-            SUB_OFFER_PRICE_PER_PERIOD("sub_offer_price_per_period"),
-            SUB_OFFER_PRICE_PER_PERIOD_2("sub_offer_price_per_period_2"),
-            SUB_OFFER_BILLING_CYCLE_COUNT("sub_offer_billing_cycle_count"),
+            DISCOUNTED_RECURRING_PAYMENT_PRICE_PER_PERIOD("discounted_recurring_payment_price_per_period"),
+            DISCOUNTED_RECURRING_PAYMENT_CYCLES("discounted_recurring_payment_cycles"),
             ;
 
             companion object {
@@ -200,11 +199,11 @@ data class CustomerCenterConfigData(
             @SerialName("free_trial_discounted_then_price")
             FREE_TRIAL_DISCOUNTED_THEN_PRICE,
 
-            @SerialName("discounted_recurring_price_per_period_then_price")
-            DISCOUNTED_RECURRING_PRICE_PER_PERIOD_THEN_PRICE,
+            @SerialName("discounted_recurring_payment_then_price")
+            DISCOUNTED_RECURRING_PAYMENT_THEN_PRICE,
 
-            @SerialName("free_trial_discounted_price_per_period_then_price")
-            FREE_TRIAL_DISCOUNTED_PRICE_PER_PERIOD_THEN_PRICE,
+            @SerialName("free_trial_discounted_recurring_payment_then_price")
+            FREE_TRIAL_DISCOUNTED_RECURRING_PAYMENT_THEN_PRICE,
 
             @SerialName("done")
             DONE,
@@ -352,13 +351,14 @@ data class CustomerCenterConfigData(
                         "Try {{ sub_offer_duration }} for free, " +
                             "then {{ sub_offer_price_2 }} during {{ sub_offer_duration_2 }}, " +
                             "and {{ price }} thereafter"
-                    DISCOUNTED_RECURRING_PRICE_PER_PERIOD_THEN_PRICE ->
-                        "{{ sub_offer_price_per_period }} for {{ sub_offer_billing_cycle_count }} periods, " +
+                    DISCOUNTED_RECURRING_PAYMENT_THEN_PRICE ->
+                        "{{ discounted_recurring_payment_price_per_period }} for " +
+                            "{{ discounted_recurring_payment_cycles }} periods, " +
                             "then {{ price }}"
-                    FREE_TRIAL_DISCOUNTED_PRICE_PER_PERIOD_THEN_PRICE ->
+                    FREE_TRIAL_DISCOUNTED_RECURRING_PAYMENT_THEN_PRICE ->
                         "Try {{ sub_offer_duration }} for free, " +
-                            "then {{ sub_offer_price_per_period_2 }} for " +
-                            "{{ sub_offer_billing_cycle_count }} periods, and {{ price }} thereafter"
+                            "then {{ discounted_recurring_payment_price_per_period }} for " +
+                            "{{ discounted_recurring_payment_cycles }} periods, and {{ price }} thereafter"
                     DONE -> "Done"
                     RENEWS_ON_DATE_FOR_PRICE -> "Your next charge is {{ price }} on {{ date }}."
                     RENEWS_ON_DATE -> "Renews on {{ date }}"

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/extensions/SubscriptionOptionExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/extensions/SubscriptionOptionExtensions.kt
@@ -27,7 +27,7 @@ internal fun SubscriptionOption.getLocalizedDescription(
     }
 }
 
-private fun PricingPhase.localizedDuration(
+private fun PricingPhase.localizedTotalDuration(
     locale: Locale,
 ): String {
     val duration = (billingCycleCount ?: 1) * billingPeriod.value
@@ -41,7 +41,7 @@ private fun SubscriptionOption.getTwoPhaseDescription(
     locale: Locale,
 ): String {
     val phase = pricingPhases.first()
-    val duration = phase.localizedDuration(locale)
+    val duration = phase.localizedTotalDuration(locale)
     val fullPricePhase = this.pricingPhases.last()
     val basePrice = fullPricePhase.price.localizedPerPeriod(
         fullPricePhase.billingPeriod,
@@ -114,8 +114,8 @@ private fun SubscriptionOption.getThreePhaseDescription(
         return this.getTwoPhaseDescription(localization, locale)
     }
 
-    val trialDuration = firstPhase.localizedDuration(locale)
-    val secondDuration = secondPhase.localizedDuration(locale)
+    val trialDuration = firstPhase.localizedTotalDuration(locale)
+    val secondDuration = secondPhase.localizedTotalDuration(locale)
 
     // For discounted recurring, add billing period and cycle info
     val secondBillingCycleCount = secondPhase.billingCycleCount ?: 1

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/extensions/SubscriptionOptionExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/extensions/SubscriptionOptionExtensions.kt
@@ -59,9 +59,9 @@ private fun SubscriptionOption.getTwoPhaseDescription(
     val replacements = mapOf(
         Localization.VariableName.SUB_OFFER_DURATION to duration,
         Localization.VariableName.SUB_OFFER_PRICE to phase.price.formatted,
-        Localization.VariableName.SUB_OFFER_PRICE_PER_PERIOD to pricePerPeriod,
         Localization.VariableName.PRICE to basePrice,
-        Localization.VariableName.SUB_OFFER_BILLING_CYCLE_COUNT to billingCycleCount.toString(),
+        Localization.VariableName.DISCOUNTED_RECURRING_PAYMENT_PRICE_PER_PERIOD to pricePerPeriod,
+        Localization.VariableName.DISCOUNTED_RECURRING_PAYMENT_CYCLES to billingCycleCount.toString(),
     )
 
     return when (phase.offerPaymentMode) {
@@ -87,7 +87,7 @@ private fun SubscriptionOption.getTwoPhaseDescription(
             // "$0.99/mth for 2 periods, then $3.99/mth" (always billingCycleCount >= 2)
             val commonLocalizedString =
                 localization.commonLocalizedString(
-                    Localization.CommonLocalizedString.DISCOUNTED_RECURRING_PRICE_PER_PERIOD_THEN_PRICE,
+                    Localization.CommonLocalizedString.DISCOUNTED_RECURRING_PAYMENT_THEN_PRICE,
                 )
             replaceVariables(commonLocalizedString, replacements)
         }
@@ -129,9 +129,9 @@ private fun SubscriptionOption.getThreePhaseDescription(
         Localization.VariableName.SUB_OFFER_DURATION to trialDuration,
         Localization.VariableName.SUB_OFFER_DURATION_2 to secondDuration,
         Localization.VariableName.SUB_OFFER_PRICE_2 to secondPhase.price.formatted,
-        Localization.VariableName.SUB_OFFER_PRICE_PER_PERIOD_2 to secondPricePerPeriod,
+        Localization.VariableName.DISCOUNTED_RECURRING_PAYMENT_PRICE_PER_PERIOD to secondPricePerPeriod,
         Localization.VariableName.PRICE to basePrice,
-        Localization.VariableName.SUB_OFFER_BILLING_CYCLE_COUNT to secondBillingCycleCount.toString(),
+        Localization.VariableName.DISCOUNTED_RECURRING_PAYMENT_CYCLES to secondBillingCycleCount.toString(),
     )
 
     return when (secondPhase.offerPaymentMode) {
@@ -147,7 +147,7 @@ private fun SubscriptionOption.getThreePhaseDescription(
             // "Try X for free, then $0.99/mth for 2 periods, and $3.99/mth thereafter" (always billingCycleCount >= 2)
             val commonLocalizedString =
                 localization.commonLocalizedString(
-                    Localization.CommonLocalizedString.FREE_TRIAL_DISCOUNTED_PRICE_PER_PERIOD_THEN_PRICE,
+                    Localization.CommonLocalizedString.FREE_TRIAL_DISCOUNTED_RECURRING_PAYMENT_THEN_PRICE,
                 )
             replaceVariables(commonLocalizedString, replacements)
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/extensions/SubscriptionOptionExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/extensions/SubscriptionOptionExtensions.kt
@@ -9,7 +9,6 @@ import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Localiza
 import com.revenuecat.purchases.models.OfferPaymentMode
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.SubscriptionOption
-import com.revenuecat.purchases.ui.revenuecatui.extensions.localizedAbbreviatedPeriod
 import com.revenuecat.purchases.ui.revenuecatui.extensions.localizedPerPeriod
 import com.revenuecat.purchases.ui.revenuecatui.extensions.measureUnit
 import java.util.Locale
@@ -50,8 +49,6 @@ private fun SubscriptionOption.getTwoPhaseDescription(
         showZeroDecimalPlacePrices = false,
     )
 
-    val billingPeriod = phase.billingPeriod.localizedAbbreviatedPeriod(locale)
-    val billingCycles = if ((phase.billingCycleCount ?: 1) == 1) "" else " for ${phase.billingCycleCount} periods"
     val billingCycleCount = phase.billingCycleCount ?: 1
     val pricePerPeriod = phase.price.localizedPerPeriod(
         phase.billingPeriod,
@@ -64,8 +61,6 @@ private fun SubscriptionOption.getTwoPhaseDescription(
         Localization.VariableName.SUB_OFFER_PRICE to phase.price.formatted,
         Localization.VariableName.SUB_OFFER_PRICE_PER_PERIOD to pricePerPeriod,
         Localization.VariableName.PRICE to basePrice,
-        Localization.VariableName.SUB_OFFER_BILLING_PERIOD to billingPeriod,
-        Localization.VariableName.SUB_OFFER_BILLING_CYCLES to billingCycles,
         Localization.VariableName.SUB_OFFER_BILLING_CYCLE_COUNT to billingCycleCount.toString(),
     )
 
@@ -123,9 +118,6 @@ private fun SubscriptionOption.getThreePhaseDescription(
     val secondDuration = secondPhase.localizedDuration(locale)
 
     // For discounted recurring, add billing period and cycle info
-    val secondBillingPeriod = secondPhase.billingPeriod.localizedAbbreviatedPeriod(locale)
-    val secondBillingCycles =
-        if ((secondPhase.billingCycleCount ?: 1) == 1) "" else " for ${secondPhase.billingCycleCount} periods"
     val secondBillingCycleCount = secondPhase.billingCycleCount ?: 1
     val secondPricePerPeriod = secondPhase.price.localizedPerPeriod(
         secondPhase.billingPeriod,
@@ -139,8 +131,6 @@ private fun SubscriptionOption.getThreePhaseDescription(
         Localization.VariableName.SUB_OFFER_PRICE_2 to secondPhase.price.formatted,
         Localization.VariableName.SUB_OFFER_PRICE_PER_PERIOD_2 to secondPricePerPeriod,
         Localization.VariableName.PRICE to basePrice,
-        Localization.VariableName.SUB_OFFER_BILLING_PERIOD to secondBillingPeriod,
-        Localization.VariableName.SUB_OFFER_BILLING_CYCLES to secondBillingCycles,
         Localization.VariableName.SUB_OFFER_BILLING_CYCLE_COUNT to secondBillingCycleCount.toString(),
     )
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/extensions/SubscriptionOptionExtensionsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/extensions/SubscriptionOptionExtensionsTest.kt
@@ -1,8 +1,8 @@
 package com.revenuecat.purchases.ui.revenuecatui.customercenter.extensions
 
 import com.android.billingclient.api.ProductDetails
-import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
+import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Localization.CommonLocalizedString
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.PricingPhase
 import com.revenuecat.purchases.models.SubscriptionOption
@@ -33,16 +33,29 @@ class SubscriptionOptionExtensionsTest(
         fun data(): Collection<Array<Any>> {
             val mockLocalization = mockk<CustomerCenterConfigData.Localization>()
 
-            // Setup common test data
             val trialPhase = previewPricingPhase(
-                billingPeriod = Period.create("P1M"),
+                billingPeriod = Period.create("P2M"),
                 priceCurrencyCodeValue = "USD",
                 price = 0.0,
                 recurrenceMode = ProductDetails.RecurrenceMode.FINITE_RECURRING,
-                billingCycleCount = 2,
+                billingCycleCount = 1,
+            )
+            val trial3DPhase = previewPricingPhase(
+                billingPeriod = Period.create("P3D"),
+                priceCurrencyCodeValue = "USD",
+                price = 0.0,
+                recurrenceMode = ProductDetails.RecurrenceMode.FINITE_RECURRING,
+                billingCycleCount = 1,
             )
             val discountPhase = previewPricingPhase(
                 billingPeriod = Period.create("P1M"),
+                priceCurrencyCodeValue = "USD",
+                price = 0.99,
+                recurrenceMode = ProductDetails.RecurrenceMode.FINITE_RECURRING,
+                billingCycleCount = 2,
+            )
+            val discount6MPhase = previewPricingPhase(
+                billingPeriod = Period.create("P6M"),
                 priceCurrencyCodeValue = "USD",
                 price = 0.99,
                 recurrenceMode = ProductDetails.RecurrenceMode.FINITE_RECURRING,
@@ -55,8 +68,29 @@ class SubscriptionOptionExtensionsTest(
                 recurrenceMode = ProductDetails.RecurrenceMode.FINITE_RECURRING,
                 billingCycleCount = 1,
             )
+            val single6MPaymentPhase = previewPricingPhase(
+                billingPeriod = Period.create("P6M"),
+                priceCurrencyCodeValue = "USD",
+                price = 1.99,
+                recurrenceMode = ProductDetails.RecurrenceMode.FINITE_RECURRING,
+                billingCycleCount = 1,
+            )
+            val single6YPaymentPhase = previewPricingPhase(
+                billingPeriod = Period.create("P6Y"),
+                priceCurrencyCodeValue = "USD",
+                price = 1.99,
+                recurrenceMode = ProductDetails.RecurrenceMode.FINITE_RECURRING,
+                billingCycleCount = 1,
+            )
             val fullPricePhase = previewPricingPhase(
                 billingPeriod = Period.create("P1M"),
+                priceCurrencyCodeValue = "USD",
+                price = 3.99,
+                recurrenceMode = ProductDetails.RecurrenceMode.INFINITE_RECURRING,
+                billingCycleCount = null,
+            )
+            val full6MPricePhase = previewPricingPhase(
+                billingPeriod = Period.create("P6M"),
                 priceCurrencyCodeValue = "USD",
                 price = 3.99,
                 recurrenceMode = ProductDetails.RecurrenceMode.INFINITE_RECURRING,
@@ -65,53 +99,55 @@ class SubscriptionOptionExtensionsTest(
 
             // Setup localization mock responses
             every {
-                mockLocalization.commonLocalizedString(
-                    CustomerCenterConfigData.Localization.CommonLocalizedString.FREE_TRIAL_THEN_PRICE
-                )
-            } returns CustomerCenterConfigData.Localization.CommonLocalizedString.FREE_TRIAL_THEN_PRICE.defaultValue
+                mockLocalization.commonLocalizedString(CommonLocalizedString.FREE_TRIAL_THEN_PRICE)
+            } returns CommonLocalizedString.FREE_TRIAL_THEN_PRICE.defaultValue
+
+            every {
+                mockLocalization.commonLocalizedString(CommonLocalizedString.DISCOUNTED_RECURRING_THEN_PRICE)
+            } returns CommonLocalizedString.DISCOUNTED_RECURRING_THEN_PRICE.defaultValue
+
+            every {
+                mockLocalization.commonLocalizedString(CommonLocalizedString.FREE_TRIAL_SINGLE_PAYMENT_THEN_PRICE)
+            } returns CommonLocalizedString.FREE_TRIAL_SINGLE_PAYMENT_THEN_PRICE.defaultValue
+
+            every {
+                mockLocalization.commonLocalizedString(CommonLocalizedString.FREE_TRIAL_DISCOUNTED_THEN_PRICE)
+            } returns CommonLocalizedString.FREE_TRIAL_DISCOUNTED_THEN_PRICE.defaultValue
+
+            every {
+                mockLocalization.commonLocalizedString(CommonLocalizedString.SINGLE_PAYMENT_THEN_PRICE)
+            } returns CommonLocalizedString.SINGLE_PAYMENT_THEN_PRICE.defaultValue
 
             every {
                 mockLocalization.commonLocalizedString(
-                    CustomerCenterConfigData.Localization.CommonLocalizedString.DISCOUNTED_RECURRING_THEN_PRICE
+                    CommonLocalizedString.DISCOUNTED_RECURRING_PRICE_PER_PERIOD_THEN_PRICE,
                 )
-            } returns CustomerCenterConfigData.Localization.CommonLocalizedString.DISCOUNTED_RECURRING_THEN_PRICE.defaultValue
+            } returns CommonLocalizedString.DISCOUNTED_RECURRING_PRICE_PER_PERIOD_THEN_PRICE.defaultValue
 
             every {
                 mockLocalization.commonLocalizedString(
-                    CustomerCenterConfigData.Localization.CommonLocalizedString.FREE_TRIAL_SINGLE_PAYMENT_THEN_PRICE
+                    CommonLocalizedString.FREE_TRIAL_DISCOUNTED_PRICE_PER_PERIOD_THEN_PRICE,
                 )
-            } returns CustomerCenterConfigData.Localization.CommonLocalizedString.FREE_TRIAL_SINGLE_PAYMENT_THEN_PRICE.defaultValue
-
-            every {
-                mockLocalization.commonLocalizedString(
-                    CustomerCenterConfigData.Localization.CommonLocalizedString.FREE_TRIAL_DISCOUNTED_THEN_PRICE
-                )
-            } returns CustomerCenterConfigData.Localization.CommonLocalizedString.FREE_TRIAL_DISCOUNTED_THEN_PRICE.defaultValue
-
-            every {
-                mockLocalization.commonLocalizedString(
-                    CustomerCenterConfigData.Localization.CommonLocalizedString.SINGLE_PAYMENT_THEN_PRICE
-                )
-            } returns CustomerCenterConfigData.Localization.CommonLocalizedString.SINGLE_PAYMENT_THEN_PRICE.defaultValue
+            } returns CommonLocalizedString.FREE_TRIAL_DISCOUNTED_PRICE_PER_PERIOD_THEN_PRICE.defaultValue
 
             return listOf(
-                arrayOf(
-                    "Single phase - full price",
-                    TestCase(
-                        pricingPhases = listOf(fullPricePhase),
-                        localization = mockLocalization,
-                        locale = Locale.US,
-                        expectedDescription = "$3.99"
-                    )
-                ),
                 arrayOf(
                     "Two phases - free trial then full price",
                     TestCase(
                         pricingPhases = listOf(trialPhase, fullPricePhase),
                         localization = mockLocalization,
                         locale = Locale.US,
-                        expectedDescription = "First 2 months free, then $3.99/mth"
-                    )
+                        expectedDescription = "First 2 months free, then $3.99/mth",
+                    ),
+                ),
+                arrayOf(
+                    "Two phases - free 3 days trial then full price",
+                    TestCase(
+                        pricingPhases = listOf(trial3DPhase, fullPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "First 3 days free, then $3.99/mth",
+                    ),
                 ),
                 arrayOf(
                     "Two phases - discounted then full price",
@@ -119,8 +155,17 @@ class SubscriptionOptionExtensionsTest(
                         pricingPhases = listOf(discountPhase, fullPricePhase),
                         localization = mockLocalization,
                         locale = Locale.US,
-                        expectedDescription = "$0.99 during 2 months, then $3.99/mth"
-                    )
+                        expectedDescription = "$0.99/mth for 2 periods, then $3.99/mth",
+                    ),
+                ),
+                arrayOf(
+                    "Two phases - discounted then full 6 month price",
+                    TestCase(
+                        pricingPhases = listOf(discount6MPhase, full6MPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "$0.99/6 mths for 2 periods, then $3.99/6 mths",
+                    ),
                 ),
                 arrayOf(
                     "Two phases - single payment then full price",
@@ -128,8 +173,26 @@ class SubscriptionOptionExtensionsTest(
                         pricingPhases = listOf(singlePaymentPhase, fullPricePhase),
                         localization = mockLocalization,
                         locale = Locale.US,
-                        expectedDescription = "1 month for $1.99, then $3.99/mth"
-                    )
+                        expectedDescription = "1 month for $1.99, then $3.99/mth",
+                    ),
+                ),
+                arrayOf(
+                    "Two phases - single 6 months payment then full price",
+                    TestCase(
+                        pricingPhases = listOf(single6MPaymentPhase, fullPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "6 months for $1.99, then $3.99/mth",
+                    ),
+                ),
+                arrayOf(
+                    "Two phases - single 6 years payment then full price",
+                    TestCase(
+                        pricingPhases = listOf(single6YPaymentPhase, fullPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "6 years for $1.99, then $3.99/mth",
+                    ),
                 ),
                 arrayOf(
                     "Three phases - free trial, single payment, then full price",
@@ -137,8 +200,114 @@ class SubscriptionOptionExtensionsTest(
                         pricingPhases = listOf(trialPhase, singlePaymentPhase, fullPricePhase),
                         localization = mockLocalization,
                         locale = Locale.US,
-                        expectedDescription = "Try 2 months for free, then 1 month for $1.99, and $3.99/mth thereafter"
-                    )
+                        expectedDescription = "Try 2 months for free, then 1 month for $1.99, and $3.99/mth thereafter",
+                    ),
+                ),
+                arrayOf(
+                    "Three phases - free 3 days trial, single payment, then full price",
+                    TestCase(
+                        pricingPhases = listOf(trial3DPhase, singlePaymentPhase, fullPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "Try 3 days for free, then 1 month for $1.99, and $3.99/mth thereafter",
+                    ),
+                ),
+                arrayOf(
+                    "Three phases - free trial, single 6M payment, then full price",
+                    TestCase(
+                        pricingPhases = listOf(trialPhase, single6MPaymentPhase, fullPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "Try 2 months for free, then 6 months for $1.99, and $3.99/mth " +
+                            "thereafter",
+                    ),
+                ),
+                arrayOf(
+                    "Three phases - free 3 days trial, single 6M payment, then full price",
+                    TestCase(
+                        pricingPhases = listOf(trial3DPhase, single6MPaymentPhase, fullPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "Try 3 days for free, then 6 months for $1.99, and $3.99/mth thereafter",
+                    ),
+                ),
+                arrayOf(
+                    "Three phases - free trial, single payment, then full price",
+                    TestCase(
+                        pricingPhases = listOf(trialPhase, single6YPaymentPhase, fullPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "Try 2 months for free, then 6 years for $1.99, and $3.99/mth thereafter",
+                    ),
+                ),
+                arrayOf(
+                    "Three phases - free 3 days trial, single 6Y payment, then full price",
+                    TestCase(
+                        pricingPhases = listOf(trial3DPhase, single6YPaymentPhase, fullPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "Try 3 days for free, then 6 years for $1.99, and $3.99/mth thereafter",
+                    ),
+                ),
+                arrayOf(
+                    "Three phases - free trial, single payment, then full 6M price",
+                    TestCase(
+                        pricingPhases = listOf(trialPhase, singlePaymentPhase, full6MPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "Try 2 months for free, then 1 month for $1.99, and " +
+                            "$3.99/6 mths thereafter",
+                    ),
+                ),
+                arrayOf(
+                    "Three phases - free 3 days trial, single payment, then full 6M price",
+                    TestCase(
+                        pricingPhases = listOf(trial3DPhase, singlePaymentPhase, full6MPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "Try 3 days for free, then 1 month for $1.99, and " +
+                            "$3.99/6 mths thereafter",
+                    ),
+                ),
+                arrayOf(
+                    "Three phases - free trial, single 6M payment, then full 6M price",
+                    TestCase(
+                        pricingPhases = listOf(trialPhase, single6MPaymentPhase, full6MPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "Try 2 months for free, then 6 months for $1.99, and " +
+                            "$3.99/6 mths thereafter",
+                    ),
+                ),
+                arrayOf(
+                    "Three phases - free 3 days trial, single 6M payment, then full 6M price",
+                    TestCase(
+                        pricingPhases = listOf(trial3DPhase, single6MPaymentPhase, full6MPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "Try 3 days for free, then 6 months for $1.99, and " +
+                            "$3.99/6 mths thereafter",
+                    ),
+                ),
+                arrayOf(
+                    "Three phases - free trial, single payment, then full 6M price",
+                    TestCase(
+                        pricingPhases = listOf(trialPhase, single6YPaymentPhase, full6MPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "Try 2 months for free, then 6 years for $1.99, and " +
+                            "$3.99/6 mths thereafter",
+                    ),
+                ),
+                arrayOf(
+                    "Three phases - free 3 days trial, single 6Y payment, then full 6M price",
+                    TestCase(
+                        pricingPhases = listOf(trial3DPhase, single6YPaymentPhase, full6MPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "Try 3 days for free, then 6 years for $1.99, and " +
+                            "$3.99/6 mths thereafter",
+                    ),
                 ),
                 arrayOf(
                     "Three phases - free trial, discounted recurring, then full price",
@@ -146,30 +315,39 @@ class SubscriptionOptionExtensionsTest(
                         pricingPhases = listOf(trialPhase, discountPhase, fullPricePhase),
                         localization = mockLocalization,
                         locale = Locale.US,
-                        expectedDescription = "Try 2 months for free, then $0.99 during 2 months, and $3.99/mth thereafter"
-                    )
+                        expectedDescription = "Try 2 months for free, then $0.99/mth " +
+                            "for 2 periods, and $3.99/mth thereafter",
+                    ),
                 ),
                 arrayOf(
-                    "Three phases - first phase not free trial falls back to two phase",
+                    "Three phases - free 3 days trial, discounted recurring, then full price",
                     TestCase(
-                        pricingPhases = listOf(discountPhase, singlePaymentPhase, fullPricePhase),
+                        pricingPhases = listOf(trial3DPhase, discountPhase, fullPricePhase),
                         localization = mockLocalization,
                         locale = Locale.US,
-                        expectedDescription = "$0.99 during 2 months, then $3.99/mth"
-                    )
+                        expectedDescription = "Try 3 days for free, then $0.99/mth " +
+                            "for 2 periods, and $3.99/mth thereafter",
+                    ),
                 ),
                 arrayOf(
-                    "Three phases - second phase unexpected payment mode falls back to base price",
+                    "Three phases - free trial, discounted recurring, then full price",
                     TestCase(
-                        pricingPhases = listOf(
-                            trialPhase,
-                            trialPhase,
-                            fullPricePhase
-                        ),
+                        pricingPhases = listOf(trialPhase, discount6MPhase, full6MPricePhase),
                         localization = mockLocalization,
                         locale = Locale.US,
-                        expectedDescription = "$3.99/mth"
-                    )
+                        expectedDescription = "Try 2 months for free, then $0.99/6 mths " +
+                            "for 2 periods, and $3.99/6 mths thereafter",
+                    ),
+                ),
+                arrayOf(
+                    "Three phases - free 3 days trial, discounted recurring, then full price",
+                    TestCase(
+                        pricingPhases = listOf(trial3DPhase, discount6MPhase, full6MPricePhase),
+                        localization = mockLocalization,
+                        locale = Locale.US,
+                        expectedDescription = "Try 3 days for free, then $0.99/6 mths " +
+                            "for 2 periods, and $3.99/6 mths thereafter",
+                    ),
                 ),
             )
         }
@@ -182,7 +360,7 @@ class SubscriptionOptionExtensionsTest(
 
         val result = subscriptionOption.getLocalizedDescription(
             testCase.localization,
-            testCase.locale
+            testCase.locale,
         )
 
         assertThat(result).isEqualTo(testCase.expectedDescription)

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/extensions/SubscriptionOptionExtensionsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/extensions/SubscriptionOptionExtensionsTest.kt
@@ -120,15 +120,15 @@ class SubscriptionOptionExtensionsTest(
 
             every {
                 mockLocalization.commonLocalizedString(
-                    CommonLocalizedString.DISCOUNTED_RECURRING_PRICE_PER_PERIOD_THEN_PRICE,
+                    CommonLocalizedString.DISCOUNTED_RECURRING_PAYMENT_THEN_PRICE,
                 )
-            } returns CommonLocalizedString.DISCOUNTED_RECURRING_PRICE_PER_PERIOD_THEN_PRICE.defaultValue
+            } returns CommonLocalizedString.DISCOUNTED_RECURRING_PAYMENT_THEN_PRICE.defaultValue
 
             every {
                 mockLocalization.commonLocalizedString(
-                    CommonLocalizedString.FREE_TRIAL_DISCOUNTED_PRICE_PER_PERIOD_THEN_PRICE,
+                    CommonLocalizedString.FREE_TRIAL_DISCOUNTED_RECURRING_PAYMENT_THEN_PRICE,
                 )
-            } returns CommonLocalizedString.FREE_TRIAL_DISCOUNTED_PRICE_PER_PERIOD_THEN_PRICE.defaultValue
+            } returns CommonLocalizedString.FREE_TRIAL_DISCOUNTED_RECURRING_PAYMENT_THEN_PRICE.defaultValue
 
             return listOf(
                 arrayOf(

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/extensions/SubscriptionOptionExtensionsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/extensions/SubscriptionOptionExtensionsTest.kt
@@ -330,7 +330,7 @@ class SubscriptionOptionExtensionsTest(
                     ),
                 ),
                 arrayOf(
-                    "Three phases - free trial, discounted recurring, then full price",
+                    "Three phases - free trial, discounted recurring, then full 6M price",
                     TestCase(
                         pricingPhases = listOf(trialPhase, discount6MPhase, full6MPricePhase),
                         localization = mockLocalization,


### PR DESCRIPTION
Fix multiple cases:

Broken trials when more than one period unit:
**Before (P2M):** `First 1 month free, then $3.99/mth`
**After:** `First 2 months free, then $3.99/mth`
**Before (P3D):** `First 1 day free, then $3.99/mth`
**After:** `First 3 days free, then $3.99/mth`

Broken discounted recurring price :
**Before (2 P6M):** `$0.99 during 2 months, then $3.99/6 mths`
**After:** `$0.99/6 mths for 2 periods, then $3.99/6 mths`

This case was not broken but it's more clear now:
**Before (2 P1M):** `$0.99 during 2 months, then $3.99/mth`
**After:** `$0.99/mth for 2 periods, then $3.99/mth`

Single discounted payment when more than one period unit:
**Before (P6M):** `1 month for $1.99, then $3.99/mth`
**After:** `6 months for $1.99, then $3.99/mth`
**Before (P6Y):** `1 year for $1.99, then $3.99/mth`
**After:** `6 years for $1.99, then $3.99/mth`

Three phases were broken as well. Some examples:
**Before (P2M trial, 1M single payment):** `Try 1 month for free, then 1 month for $1.99, and $3.99/mth thereafter`
**After:** `Try 2 months for free, then 1 month for $1.99, and $3.99/mth thereafter`
**Before (P3D trial, 1M single payment):** `Try 1 day for free, then 1 month for $1.99, and $3.99/mth thereafter`
**After:** `Try 3 days for free, then 1 month for $1.99, and $3.99/mth thereafter`
**Before (P2M trial, 6M single payment):** `Try 1 month for free, then 1 month for $1.99, and $3.99/mth thereafter`
**After:** `Try 2 months for free, then 6 months for $1.99, and $3.99/mth thereafter`
**Before (P3D trial, 6M single payment):** `Try 1 day for free, then 1 month for $1.99, and $3.99/mth thereafter`
**After:** `Try 3 days for free, then 6 months for $1.99, and $3.99/mth thereafter`
**Before (P2M trial, 2 months discounted):** `Try 1 month for free, then $0.99 during 2 months, and $3.99/mth thereafter`
**After:** `Try 2 months for free, then $0.99/mth for 2 periods, and $3.99/mth thereafter`
**Before (P2M trial, 2 6-month discounted):** `Try 1 month for free, then $0.99 during 2 months, and $3.99/6 mths thereafter`
**After:** `Try 2 months for free, then $0.99/6 mths for 2 periods, and $3.99/6 mths thereafter`


