### PR TITLE
Enable Test Store

### DIFF
--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -43,12 +43,6 @@ android {
         testApplicationId = obtainTestApplicationId()
         testBuildType = obtainTestBuildType()
 
-        buildConfigField(
-            type = "boolean",
-            name = "ENABLE_SIMULATED_STORE",
-            value = (localProperties["ENABLE_SIMULATED_STORE"] as? String ?: "false").toString(),
-        )
-
         packagingOptions.resources.excludes.addAll(
             listOf("META-INF/LICENSE.md", "META-INF/LICENSE-notice.md"),
         )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -60,7 +60,6 @@ import java.util.concurrent.ThreadFactory
 internal class PurchasesFactory(
     private val isDebugBuild: IsDebugBuildProvider,
     private val apiKeyValidator: APIKeyValidator = APIKeyValidator(),
-    private val isSimulatedStoreEnabled: () -> Boolean = { BuildConfig.ENABLE_SIMULATED_STORE },
 ) {
 
     @Suppress("LongMethod", "LongParameterList", "CyclomaticComplexMethod")
@@ -77,7 +76,7 @@ internal class PurchasesFactory(
 
         with(configuration) {
             val finalStore = if (
-                apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE && isSimulatedStoreEnabled()
+                apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE
             ) {
                 Store.UNKNOWN_STORE // We should add a new store when we fully support the simulated store.
             } else {
@@ -427,7 +426,7 @@ internal class PurchasesFactory(
             val apiKeyValidationResult = apiKeyValidator.validateAndLog(apiKey, store)
 
             if (!isDebugBuild() &&
-                apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE && isSimulatedStoreEnabled()
+                apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE
             ) {
                 throw PurchasesException(
                     PurchasesError(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -140,7 +140,6 @@ internal class PurchasesOrchestrator(
         ),
     private val virtualCurrencyManager: VirtualCurrencyManager,
     val processLifecycleOwnerProvider: () -> LifecycleOwner = { ProcessLifecycleOwner.get() },
-    private val isSimulatedStoreEnabled: () -> Boolean = { BuildConfig.ENABLE_SIMULATED_STORE },
     private val blockstoreHelper: BlockstoreHelper = BlockstoreHelper(application, identityManager),
     private val backupManager: BackupManager = BackupManager(application),
 ) : LifecycleDelegate, CustomActivityLifecycleHandler {
@@ -365,9 +364,7 @@ internal class PurchasesOrchestrator(
     fun syncPurchases(
         listener: SyncPurchasesCallback? = null,
     ) {
-        if (isSimulatedStoreEnabled() &&
-            appConfig.apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE
-        ) {
+        if (appConfig.apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE) {
             log(LogIntent.DEBUG) { RestoreStrings.SYNC_PURCHASES_SIMULATED_STORE }
             getCustomerInfo(object : ReceiveCustomerInfoCallback {
                 override fun onReceived(customerInfo: CustomerInfo) {
@@ -557,9 +554,7 @@ internal class PurchasesOrchestrator(
         if (!allowSharingPlayStoreAccount) {
             log(LogIntent.WARNING) { RestoreStrings.SHARING_ACC_RESTORE_FALSE }
         }
-        if (isSimulatedStoreEnabled() &&
-            appConfig.apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE
-        ) {
+        if (appConfig.apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE) {
             log(LogIntent.DEBUG) { RestoreStrings.RESTORE_PURCHASES_SIMULATED_STORE }
             getCustomerInfo(callback)
             return

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -475,7 +475,6 @@ internal open class BasePurchasesTest {
             fontLoader = mockFontLoader,
             localeProvider = DefaultLocaleProvider(),
             virtualCurrencyManager = mockVirtualCurrencyManager,
-            isSimulatedStoreEnabled = { enableSimulatedStore },
             blockstoreHelper = mockBlockstoreHelper,
             backupManager = mockBackupManager,
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -101,7 +101,6 @@ class PurchasesFactoryTest {
         purchasesFactory = PurchasesFactory(
             isDebugBuild = { false },
             apiKeyValidator = apiKeyValidatorMock,
-            isSimulatedStoreEnabled = { true },
         )
 
         every {


### PR DESCRIPTION
This PR removes the ENABLE_SIMULATED_STORE build config to enable the Test Store functionality in the SDK