### PR TITLE
Remove unused kotlinCompilerExtensionVersion

### DIFF
--- a/api-tester/build.gradle.kts
+++ b/api-tester/build.gradle.kts
@@ -29,10 +29,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.8"
-    }
-
     buildFeatures {
         compose = true
     }

--- a/examples/CustomEntitlementComputationSample/app/build.gradle.kts
+++ b/examples/CustomEntitlementComputationSample/app/build.gradle.kts
@@ -54,9 +54,7 @@ android {
         compose = true
         buildConfig = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.8"
-    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/examples/MagicWeatherCompose/app/build.gradle.kts
+++ b/examples/MagicWeatherCompose/app/build.gradle.kts
@@ -49,9 +49,7 @@ android {
         compose = true
         buildConfig = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.8"
-    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/examples/paywall-tester/build.gradle.kts
+++ b/examples/paywall-tester/build.gradle.kts
@@ -64,10 +64,6 @@ android {
         viewBinding = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.8"
-    }
-
     packaging {
         resources {
             excludes += setOf("/META-INF/{AL2.0,LGPL2.1}")

--- a/examples/web-purchase-redemption-sample/build.gradle.kts
+++ b/examples/web-purchase-redemption-sample/build.gradle.kts
@@ -35,9 +35,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.8"
-    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -37,9 +37,6 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.8"
-    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/ui/debugview/build.gradle.kts
+++ b/ui/debugview/build.gradle.kts
@@ -29,10 +29,6 @@ android {
     buildFeatures {
         compose = true
     }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.8"
-    }
 }
 
 dependencies {

--- a/ui/revenuecatui/build.gradle.kts
+++ b/ui/revenuecatui/build.gradle.kts
@@ -56,10 +56,6 @@ android {
         compose = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.8"
-    }
-
     packaging {
         resources {
             excludes += setOf(


### PR DESCRIPTION
Since Kotlin version 2.0.0, the `kotlinCompilerExtensionVersion` is no longer required to be configured in composeOptions and can be removed: https://android-developers.googleblog.com/2024/04/jetpack-compose-compiler-moving-to-kotlin-repository.html


