### PR TITLE
Fix Expired badge in Customer Center dark mode

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterConstants.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterConstants.kt
@@ -14,8 +14,7 @@ internal object CustomerCenterConstants {
         const val COLOR_BADGE_CANCELLED = 0x33F2545B
         const val COLOR_BADGE_FREE_TRIAL = 0x5BF5CA5C
         const val COLOR_BADGE_ACTIVE = 0x9911D483
-        const val COLOR_BADGE_EXPIRED = 0xFFF2F2F7
-        const val COLOR_LIFETIME_BORDER = 0xFF3C3C43
+        const val COLOR_BADGE_EXPIRED = 0x1A1D1B20
         const val LIFETIME_BORDER_ALPHA = 0.29f
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterConfigTestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/data/CustomerCenterConfigTestData.kt
@@ -206,6 +206,27 @@ internal object CustomerCenterConfigTestData {
         isLifetime = true,
     )
 
+    val purchaseInformationFreeTrial = PurchaseInformation(
+        title = "Premium",
+        pricePaid = PriceDetails.Free,
+        expirationOrRenewal = ExpirationOrRenewal.Expiration("June 15th, 2024"),
+        store = Store.PLAY_STORE,
+        managementURL = Uri.parse("https://play.google.com/store/account/subscriptions"),
+        product = TestStoreProduct(
+            "premium_yearly_product_id",
+            "Premium",
+            "title",
+            "description",
+            Price("$59.99", 59_990_000, "US"),
+            Period(1, Period.Unit.YEAR, "P1Y"),
+        ),
+        isSubscription = true,
+        isExpired = false,
+        isTrial = true,
+        isCancelled = false,
+        isLifetime = false,
+    )
+
     val purchaseInformationPromotional = PurchaseInformation(
         title = "rc_promo_Test1_lifetime",
         pricePaid = PriceDetails.Free,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseInformationCardView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseInformationCardView.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.customercenter.views
 
+import android.content.res.Configuration
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -16,7 +17,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -27,6 +27,7 @@ import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCent
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.ExpirationOrRenewal
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.PriceDetails
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.PurchaseInformation
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.theme.CustomerCenterPreviewTheme
 import com.revenuecat.purchases.ui.revenuecatui.extensions.applyIfNotNull
 
 @SuppressWarnings("LongParameterList", "LongMethod")
@@ -186,13 +187,12 @@ private class PurchaseInformationProvider : PreviewParameterProvider<PurchaseInf
 }
 
 @Preview(group = "scale = 1", fontScale = 1F)
+@Preview(group = "scale = 1", fontScale = 1F, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PurchaseInformationCardView_Preview(
     @PreviewParameter(PurchaseInformationProvider::class) details: PurchaseInformation,
 ) {
-    Surface(
-        color = Color.White,
-    ) {
+    CustomerCenterPreviewTheme {
         PurchaseInformationCardView(
             purchaseInformation = details,
             localization = CustomerCenterConfigTestData.customerCenterData(
@@ -204,13 +204,12 @@ private fun PurchaseInformationCardView_Preview(
 }
 
 @Preview(group = "scale = 2", fontScale = 2F)
+@Preview(group = "scale = 2", fontScale = 2F, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PurchaseInformationCardView_Preview_Scale2(
     @PreviewParameter(PurchaseInformationProvider::class) details: PurchaseInformation,
 ) {
-    Surface(
-        color = Color.White,
-    ) {
+    CustomerCenterPreviewTheme {
         PurchaseInformationCardView(
             purchaseInformation = details,
             localization = CustomerCenterConfigTestData.customerCenterData(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseInformationCardView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseInformationCardView.kt
@@ -178,6 +178,7 @@ private class PurchaseInformationProvider : PreviewParameterProvider<PurchaseInf
         CustomerCenterConfigTestData.purchaseInformationMonthlyRenewing,
         CustomerCenterConfigTestData.purchaseInformationYearlyExpiring,
         CustomerCenterConfigTestData.purchaseInformationYearlyExpired,
+        CustomerCenterConfigTestData.purchaseInformationFreeTrial,
         CustomerCenterConfigTestData.purchaseInformationPromotional,
         CustomerCenterConfigTestData.purchaseInformationLifetime,
         CustomerCenterConfigTestData.purchaseInformationMonthlyRenewing.copy(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseStatusBadge.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseStatusBadge.kt
@@ -51,6 +51,7 @@ private data class BadgeInfo(
     val textColor: Color? = null,
 )
 
+@Composable
 private fun getBadgeInfo(
     status: PurchaseStatus,
     localization: CustomerCenterConfigData.Localization,
@@ -87,7 +88,7 @@ private fun getBadgeInfo(
             color = Color.Transparent,
             border = BorderStroke(
                 1.dp,
-                Color(CustomerCenterConstants.Card.COLOR_LIFETIME_BORDER).copy(
+                MaterialTheme.colorScheme.onSurface.copy(
                     alpha = CustomerCenterConstants.Card.LIFETIME_BORDER_ALPHA,
                 ),
             ),


### PR DESCRIPTION
Reported in https://github.com/RevenueCat/purchases-android/issues/2681

- I added some opacity to the Expired badge, so it shows some contrast against the background, in case it's the same color as `onSurface`. This is the same for Cancelled and Active.
- Added previews for dark mode.
- Improved the border of lifetime, so it's based off the `onSurface` color with an opacity and not a hardcoded color