### PR TITLE
Add Airbridge device ID subscriber attribute

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -149,6 +149,7 @@ final class PurchasesAPI {
         purchases.setCampaign("");
         purchases.setCleverTapID("");
         purchases.setKochavaDeviceID("");
+        purchases.setAirbridgeDeviceID("");
         purchases.setTenjinAnalyticsInstallationID("");
         purchases.setPostHogUserId("");
         purchases.setAdGroup("");

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -208,6 +208,7 @@ private class PurchasesAPI {
             setCampaign("")
             setCleverTapID("")
             setKochavaDeviceID("")
+            setAirbridgeDeviceID("")
             setAdGroup("")
             setAd("")
             setKeyword("")

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -421,6 +421,7 @@ package com.revenuecat.purchases {
     method public void setFirebaseAppInstanceID(String? firebaseAppInstanceID);
     method public void setKeyword(String? keyword);
     method public void setKochavaDeviceID(String? kochavaDeviceID);
+    method public void setAirbridgeDeviceID(String? airbridgeDeviceID);
     method @kotlin.jvm.Synchronized public static void setLogHandler(com.revenuecat.purchases.LogHandler);
     method public static void setLogLevel(com.revenuecat.purchases.LogLevel);
     method public void setMediaSource(String? mediaSource);
@@ -1422,4 +1423,3 @@ package com.revenuecat.purchases.virtualcurrencies {
   }
 
 }
-

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -749,6 +749,16 @@ class Purchases internal constructor(
         purchasesOrchestrator.setKochavaDeviceID(kochavaDeviceID)
     }
 
+    /**
+     * Subscriber attribute associated with the Airbridge Device ID for the user
+     * Recommended for the RevenueCat Airbridge integration
+     *
+     * @param airbridgeDeviceID null or an empty string will delete the subscriber attribute.
+     */
+    fun setAirbridgeDeviceID(airbridgeDeviceID: String?) {
+        purchasesOrchestrator.setAirbridgeDeviceID(airbridgeDeviceID)
+    }
+
     // endregion
     // region Campaign parameters
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -946,6 +946,16 @@ internal class PurchasesOrchestrator(
         )
     }
 
+    fun setAirbridgeDeviceID(airbridgeDeviceID: String?) {
+        log(LogIntent.DEBUG) { AttributionStrings.METHOD_CALLED.format("setAirbridgeDeviceID") }
+        subscriberAttributesManager.setAttributionID(
+            SubscriberAttributeKey.AttributionIds.Airbridge,
+            airbridgeDeviceID,
+            appUserID,
+            application,
+        )
+    }
+
     // endregion
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/subscriberattributes/SpecialSubscriberAttributes.kt
@@ -31,6 +31,7 @@ internal enum class ReservedSubscriberAttribute(val value: String) {
     AIRSHIP_CHANNEL_ID("\$airshipChannelId"),
     CLEVER_TAP_ID("\$clevertapId"),
     KOCHAVA_DEVICE_ID("\$kochavaDeviceId"),
+    AIRBRIDGE_DEVICE_ID("\$airbridgeDeviceId"),
 
     /**
      * Integration IDs
@@ -73,6 +74,7 @@ internal sealed class SubscriberAttributeKey(val backendKey: String) {
         object Mparticle : AttributionIds(ReservedSubscriberAttribute.MPARTICLE_ID)
         object CleverTap : AttributionIds(ReservedSubscriberAttribute.CLEVER_TAP_ID)
         object Kochava : AttributionIds(ReservedSubscriberAttribute.KOCHAVA_DEVICE_ID)
+        object Airbridge : AttributionIds(ReservedSubscriberAttribute.AIRBRIDGE_DEVICE_ID)
     }
 
     sealed class IntegrationIds(backendKey: ReservedSubscriberAttribute) : SubscriberAttributeKey(backendKey.value) {

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -294,6 +294,13 @@ class SubscriberAttributesPurchasesTests {
         }
     }
 
+    @Test
+    fun `setAirbridgeDeviceID`() {
+        attributionIDTest(SubscriberAttributeKey.AttributionIds.Airbridge) { parameter ->
+            underTest.setAirbridgeDeviceID(parameter)
+        }
+    }
+
     // endregion
 
     // region Integration IDs


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

We are adding a native RC <-> Airbridge integration. The backend and frontend changes for the integration have been released. On the SDK side, we need a method to set the airbridge device ID captured by [Airbridge SDK](https://help.airbridge.io/en/developers/fetching-guide-for-android-sdk).

### Description

Expose a method so developers can set an Airbridge Device ID after capturing it from [Airbridge SDK](https://help.airbridge.io/en/developers/fetching-guide-for-android-sdk)

This works exactly the same way as the existing Kochava integration && `setKochavaDeviceID`