### PR TITLE
Revert kotlinCompilerExtensionVersion for MagicWeatherCompose and CustomEntitlementComputationSample

### DIFF
--- a/examples/CustomEntitlementComputationSample/app/build.gradle.kts
+++ b/examples/CustomEntitlementComputationSample/app/build.gradle.kts
@@ -54,7 +54,9 @@ android {
         compose = true
         buildConfig = true
     }
-
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.4.8"
+    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/examples/MagicWeatherCompose/app/build.gradle.kts
+++ b/examples/MagicWeatherCompose/app/build.gradle.kts
@@ -49,7 +49,9 @@ android {
         compose = true
         buildConfig = true
     }
-
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.4.8"
+    }
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"


### PR DESCRIPTION
Revert kotlinCompilerExtensionVersion for MagicWeatherCompose and CustomEntitlementComputationSample since they use Kotlin 1.9.x. Thanks for finding this out, @JayShortway 👍 #2691 