### PR TITLE
Fix deadlock in `allowSharingPlayStoreAccount`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -188,8 +188,10 @@ internal class PurchasesOrchestrator(
     }
 
     var allowSharingPlayStoreAccount: Boolean
-        @Synchronized get() =
-            state.allowSharingPlayStoreAccount ?: identityManager.currentUserIsAnonymous()
+        get() {
+            val currentValue = synchronized(this) { state.allowSharingPlayStoreAccount }
+            return currentValue ?: identityManager.currentUserIsAnonymous()
+        }
 
         @Synchronized set(value) {
             state = state.copy(allowSharingPlayStoreAccount = value)


### PR DESCRIPTION
We believe this scenario can deadlock:
- `Purchases.logOut()` , acquires `IdentityManager` lock
- Calls `subscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers()` which does some stuff and actually has a `waitUntilIdle()`. It may need `PurchasesOrchestrator` lock for the operations to complete, but it might be held by the next step (`onAppForegrounded`)
- `onAppForegrounded` calls `allowSharingPlayStoreAccount` , acquires `PurchasesOrchestrator` lock
- it tries to call `identityManager.currentUserIsAnonymous()` but `IdentityManager` is locked
- at the same time `onBillingSetupFinished` and calls `PurchasesOrchestrator.getAllowSharingPlayStoreAccount` , which is locked on `PurchasesOrchestrator`

So basically, both `PurchasesOrchestrator` and `IdentityManager` get locked and never complete because they depend on each other

I think this nested lock situation (holds `PurchasesOrchestrator` then IdentityManager) can be problematic:
```
@Synchronized get() =
    state.allowSharingPlayStoreAccount ?: identityManager.currentUserIsAnonymous()
```    
    
This is the reported stacktrace:

main (onBillingSetupFinished)
```
"main" tid=1 Blocked
  at com.revenuecat.purchases.PurchasesOrchestrator.getAllowSharingPlayStoreAccount (unavailable)
  at com.revenuecat.purchases.PurchasesOrchestrator$3.onConnected (PurchasesOrchestrator.kt:207)
  at com.revenuecat.purchases.google.BillingWrapper.onBillingSetupFinished$lambda$34 (BillingWrapper.kt:594)
```

pool-5-thread-1 (onAppForegrounded)
```
"pool-5-thread-1" tid=52 Blocked
  at com.revenuecat.purchases.identity.IdentityManager.currentUserIsAnonymous (unavailable)
  at com.revenuecat.purchases.PurchasesOrchestrator.getAllowSharingPlayStoreAccount (PurchasesOrchestrator.kt:189)
  at com.revenuecat.purchases.PurchasesOrchestrator$onAppForegrounded$3.invoke (PurchasesOrchestrator.kt:263)
```

CapacitorPlugins (logOut)
```
"CapacitorPlugins" tid=37 Blocked
  at com.revenuecat.purchases.PurchasesOrchestrator$logOut$1.invoke (PurchasesOrchestrator.kt:630)
  at com.revenuecat.purchases.PurchasesOrchestrator$logOut$1.invoke (PurchasesOrchestrator.kt:626)
  at com.revenuecat.purchases.identity.IdentityManager$logOut$2.invoke (IdentityManager.kt:161)
  at com.revenuecat.purchases.identity.IdentityManager$logOut$2.invoke (IdentityManager.kt:158)
  at com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager$synchronizeSubscriberAttributesForAllUsers$1.invoke (SubscriberAttributesManager.kt:69)
  at com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager$synchronizeSubscriberAttributesForAllUsers$1.invoke (SubscriberAttributesManager.kt:60)
  at com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager$ObtainDeviceIdentifiersObservable.waitUntilIdle (SubscriberAttributesManager.kt:233)
  at com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers (SubscriberAttributesManager.kt:60)
  at com.revenuecat.purchases.identity.IdentityManager.logOut (IdentityManager.kt:158)
```