### PR TITLE
Add TEST_STORE to Store enum

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementInfoAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/EntitlementInfoAPI.kt
@@ -97,6 +97,7 @@ private class EntitlementInfoAPI {
             Store.RC_BILLING,
             Store.EXTERNAL,
             Store.PADDLE,
+            Store.TEST_STORE,
             -> {}
         }.exhaustive
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/BillingFactory.kt
@@ -25,17 +25,14 @@ internal object BillingFactory {
         stateProvider: PurchasesStateProvider,
         pendingTransactionsForPrepaidPlansEnabled: Boolean,
         backend: Backend,
-        apiKeyValidationResult: APIKeyValidator.ValidationResult,
     ): BillingAbstract {
-        if (apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE) {
-            return SimulatedStoreBillingWrapper(
+        return when (store) {
+            Store.TEST_STORE -> SimulatedStoreBillingWrapper(
                 deviceCache = cache,
                 mainHandler = Handler(application.mainLooper),
                 purchasesStateProvider = stateProvider,
                 backend = backend,
             )
-        }
-        return when (store) {
             Store.PLAY_STORE -> BillingWrapper(
                 BillingWrapper.ClientFactory(application, pendingTransactionsForPrepaidPlansEnabled),
                 Handler(application.mainLooper),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/EntitlementInfo.kt
@@ -238,14 +238,27 @@ enum class Store {
      */
     @SerialName("paddle")
     PADDLE,
+
+    @SerialName("simulated_store")
+    TEST_STORE,
     ;
 
     internal companion object {
         @JvmSynthetic
         fun fromString(text: String): Store {
-            return runCatching {
-                enumValueOf<Store>(text.uppercase())
-            }.getOrDefault(UNKNOWN_STORE)
+            return when (text) {
+                "app_store" -> APP_STORE
+                "mac_app_store" -> MAC_APP_STORE
+                "play_store" -> PLAY_STORE
+                "stripe" -> STRIPE
+                "promotional" -> PROMOTIONAL
+                "amazon" -> AMAZON
+                "rc_billing" -> RC_BILLING
+                "external" -> EXTERNAL
+                "paddle" -> PADDLE
+                "simulated_store" -> TEST_STORE
+                else -> UNKNOWN_STORE
+            }
         }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/OfferingParserFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/OfferingParserFactory.kt
@@ -9,12 +9,9 @@ internal object OfferingParserFactory {
 
     fun createOfferingParser(
         store: Store,
-        apiKeyValidationResult: APIKeyValidator.ValidationResult,
     ): OfferingParser {
-        if (apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE) {
-            return SimulatedStoreOfferingParser()
-        }
         return when (store) {
+            Store.TEST_STORE -> SimulatedStoreOfferingParser()
             Store.PLAY_STORE -> GoogleOfferingParser()
             Store.AMAZON -> {
                 try {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -80,7 +80,7 @@ internal class PurchasesFactory(
             val finalStore = if (
                 apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE
             ) {
-                Store.UNKNOWN_STORE // We should add a new store when we fully support the simulated store.
+                Store.TEST_STORE
             } else {
                 store
             }
@@ -206,7 +206,6 @@ internal class PurchasesFactory(
                 purchasesStateProvider,
                 pendingTransactionsForPrepaidPlansEnabled,
                 backend,
-                apiKeyValidationResult,
             )
 
             val subscriberAttributesPoster = SubscriberAttributesPoster(backendHelper)
@@ -294,7 +293,7 @@ internal class PurchasesFactory(
                 postPendingTransactionsHelper,
                 diagnosticsTracker,
             )
-            val offeringParser = OfferingParserFactory.createOfferingParser(finalStore, apiKeyValidationResult)
+            val offeringParser = OfferingParserFactory.createOfferingParser(finalStore)
 
             var diagnosticsSynchronizer: DiagnosticsSynchronizer? = null
             @Suppress("ComplexCondition")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/EntitlementInfoFactories.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/EntitlementInfoFactories.kt
@@ -53,18 +53,7 @@ internal fun JSONObject.buildEntitlementInfos(
     )
 }
 
-internal fun JSONObject.getStore(name: String) = when (getString(name)) {
-    "app_store" -> Store.APP_STORE
-    "mac_app_store" -> Store.MAC_APP_STORE
-    "play_store" -> Store.PLAY_STORE
-    "stripe" -> Store.STRIPE
-    "promotional" -> Store.PROMOTIONAL
-    "amazon" -> Store.AMAZON
-    "rc_billing" -> Store.RC_BILLING
-    "external" -> Store.EXTERNAL
-    "paddle" -> Store.PADDLE
-    else -> Store.UNKNOWN_STORE
-}
+internal fun JSONObject.getStore(name: String) = Store.fromString(getString(name))
 
 internal fun JSONObject.optPeriodType(name: String) = when (optString(name)) {
     "normal" -> PeriodType.NORMAL

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/customercenter/CustomerCenterConfigData.kt
@@ -253,6 +253,9 @@ data class CustomerCenterConfigData(
             @SerialName("unknown_store")
             UNKNOWN_STORE,
 
+            @SerialName("test_store")
+            TEST_STORE,
+
             @SerialName("card_store_promotional")
             CARD_STORE_PROMOTIONAL,
 
@@ -375,6 +378,7 @@ data class CustomerCenterConfigData(
                     AMAZON_STORE -> "Amazon Store"
                     WEB_STORE -> "Web"
                     UNKNOWN_STORE -> "Unknown"
+                    TEST_STORE -> "Test Store"
                     CARD_STORE_PROMOTIONAL -> "Via Support"
                     RESUBSCRIBE -> "Resubscribe"
                     TYPE_SUBSCRIPTION -> "Subscription"

--- a/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BillingFactoryTest.kt
@@ -6,9 +6,11 @@ import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BackendHelper
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
+import com.revenuecat.purchases.simulatedstore.SimulatedStoreBillingWrapper
 import io.mockk.mockk
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.test.assertIs
 
 @RunWith(AndroidJUnit4::class)
 class BillingFactoryTest {
@@ -31,8 +33,29 @@ class BillingFactoryTest {
             PurchasesStateCache(PurchasesState()),
             pendingTransactionsForPrepaidPlansEnabled = true,
             backend = mockBackend,
-            apiKeyValidationResult = APIKeyValidator.ValidationResult.VALID,
         )
+    }
+
+    @Test
+    fun `SimulatedStoreBillingWrapper gets created when store is test store`() {
+        val mockApplication = mockk<Application>(relaxed = true)
+        val mockBackendHelper = mockk<BackendHelper>(relaxed = true)
+        val mockCache = mockk<DeviceCache>(relaxed = true)
+        val mockDiagnosticsTracker = mockk<DiagnosticsTracker>(relaxed = true)
+        val mockBackend = mockk<Backend>(relaxed = true)
+
+        val simulatedBilling = BillingFactory.createBilling(
+            Store.TEST_STORE,
+            mockApplication,
+            mockBackendHelper,
+            mockCache,
+            finishTransactions = true,
+            mockDiagnosticsTracker,
+            PurchasesStateCache(PurchasesState()),
+            pendingTransactionsForPrepaidPlansEnabled = true,
+            backend = mockBackend,
+        )
+        assertIs<SimulatedStoreBillingWrapper>(simulatedBilling)
     }
 
     @Test
@@ -52,7 +75,6 @@ class BillingFactoryTest {
             PurchasesStateCache(PurchasesState()),
             pendingTransactionsForPrepaidPlansEnabled = true,
             backend = mockBackend,
-            apiKeyValidationResult = APIKeyValidator.ValidationResult.VALID,
         )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
@@ -43,7 +43,6 @@ class OfferingsTest {
 
     private val offeringsParser = OfferingParserFactory.createOfferingParser(
         Store.PLAY_STORE,
-        apiKeyValidationResult = APIKeyValidator.ValidationResult.VALID,
     )
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonOfferingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonOfferingsTest.kt
@@ -6,7 +6,6 @@
 package com.revenuecat.purchases.amazon
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.revenuecat.purchases.APIKeyValidator
 import com.revenuecat.purchases.OfferingParserFactory
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
@@ -43,7 +42,6 @@ class AmazonOfferingsTest {
 
     private val offeringsParser = OfferingParserFactory.createOfferingParser(
         Store.AMAZON,
-        apiKeyValidationResult = APIKeyValidator.ValidationResult.VALID,
     )
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/BillingFactoryAmazonTest.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases.amazon
 
 import android.app.Application
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.revenuecat.purchases.APIKeyValidator
 import com.revenuecat.purchases.BillingFactory
 import com.revenuecat.purchases.PurchasesState
 import com.revenuecat.purchases.PurchasesStateCache
@@ -36,7 +35,6 @@ class BillingFactoryAmazonTest {
             stateProvider = PurchasesStateCache(PurchasesState()),
             pendingTransactionsForPrepaidPlansEnabled = true,
             backend = mockBackend,
-            apiKeyValidationResult = APIKeyValidator.ValidationResult.VALID,
         )
     }
 
@@ -57,7 +55,6 @@ class BillingFactoryAmazonTest {
             stateProvider = PurchasesStateCache(PurchasesState()),
             pendingTransactionsForPrepaidPlansEnabled = true,
             backend = mockBackend,
-            apiKeyValidationResult = APIKeyValidator.ValidationResult.VALID,
         )
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseInformationCardView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseInformationCardView.kt
@@ -148,6 +148,7 @@ private fun getStoreText(store: Store, localization: CustomerCenterConfigData.Lo
         -> CustomerCenterConfigData.Localization.CommonLocalizedString.WEB_STORE
         Store.UNKNOWN_STORE,
         -> CustomerCenterConfigData.Localization.CommonLocalizedString.UNKNOWN_STORE
+        Store.TEST_STORE -> CustomerCenterConfigData.Localization.CommonLocalizedString.TEST_STORE
     }
     return localization.commonLocalizedString(key)
 }


### PR DESCRIPTION
### Description
This adds a new value to the `Store` enum: `TEST_STORE`. This will be the value used when using RevenueCat's test store.