### PR TITLE
Add `TestStoreSimulatedPurchaseError` error code

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesErrorAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/PurchasesErrorAPI.kt
@@ -40,6 +40,7 @@ private class PurchasesErrorAPI {
             PurchasesErrorCode.EmptySubscriberAttributesError,
             PurchasesErrorCode.CustomerInfoError,
             PurchasesErrorCode.SignatureVerificationError,
+            PurchasesErrorCode.TestStoreSimulatedPurchaseError,
             -> {}
         }.exhaustive
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/logUtils.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/logUtils.kt
@@ -66,6 +66,7 @@ internal fun errorLog(error: PurchasesError) {
         PurchasesErrorCode.CustomerInfoError,
         PurchasesErrorCode.SignatureVerificationError,
         PurchasesErrorCode.InvalidSubscriberAttributesError,
+        PurchasesErrorCode.TestStoreSimulatedPurchaseError,
         -> log(LogIntent.RC_ERROR) { error.toString() }
 
         PurchasesErrorCode.PurchaseCancelledError,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/errors.kt
@@ -92,4 +92,5 @@ enum class PurchasesErrorCode(val code: Int, val description: String) {
         36,
         "Request failed signature verification. Please see https://rev.cat/trusted-entitlements for more info.",
     ),
+    TestStoreSimulatedPurchaseError(42, "Purchase failure simulated successfully in Test Store."),
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/simulatedstore/SimulatedStoreBillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/simulatedstore/SimulatedStoreBillingWrapper.kt
@@ -194,8 +194,8 @@ internal class SimulatedStoreBillingWrapper(
             onNegativeButtonClicked = {
                 purchasesUpdatedListener?.onPurchasesFailedToUpdate(
                     PurchasesError(
-                        PurchasesErrorCode.ProductNotAvailableForPurchaseError,
-                        "Test purchase failure: no real transaction occurred",
+                        PurchasesErrorCode.TestStoreSimulatedPurchaseError,
+                        "Simulated error successfully.",
                     ),
                 )
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/simulatedstore/SimulatedStoreBillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/simulatedstore/SimulatedStoreBillingWrapperTest.kt
@@ -128,6 +128,53 @@ class SimulatedStoreBillingWrapperTest {
     }
 
     @Test
+    fun `makePurchaseAsync with dialog simulated error calls onPurchasesFailedToUpdate with simulated error`() {
+        // Given
+        val activity = mockk<Activity>()
+        val productId = "test_product_123"
+        val presentedOfferingContext = mockk<PresentedOfferingContext>()
+
+        // Mock product response from backend
+        val productResponse = createMockProductResponse(productId)
+        val product = SimulatedStoreProductConverter.convertToStoreProduct(productResponse)
+        val purchasingData = product.purchasingData
+        val billingResponse = WebBillingProductsResponse(listOf(productResponse))
+
+        every { deviceCache.getCachedAppUserID() } returns "test_user"
+        every { backend.getWebBillingProducts(any(), any(), any(), any()) } answers {
+            val onSuccess = thirdArg<(WebBillingProductsResponse) -> Unit>()
+            onSuccess(billingResponse)
+        }
+
+        // Mock dialog helper to simulate cancellation
+        every {
+            purchaseDialogHelper.showDialog(
+                any(), any(), any(), any(), any(), any(), any(), onNegativeButtonClicked = captureLambda(), any(),
+            )
+        } answers {
+            lambda<() -> Unit>().captured.invoke()
+        }
+
+        // When
+        testStoreBilling.makePurchaseAsync(
+            activity = activity,
+            appUserID = "test_user",
+            purchasingData = purchasingData,
+            replaceProductInfo = null,
+            presentedOfferingContext = presentedOfferingContext,
+            isPersonalizedPrice = null
+        )
+
+        // Then
+        val listenerImpl = purchasesUpdatedListener as TestPurchasesListener
+        assertThat(listenerImpl.lastError).isNotNull()
+        assertThat(listenerImpl.lastError?.code).isEqualTo(PurchasesErrorCode.TestStoreSimulatedPurchaseError)
+        assertThat(listenerImpl.lastError?.message).isEqualTo("Purchase failure simulated successfully in Test Store.")
+        assertThat(listenerImpl.lastError?.underlyingErrorMessage).isEqualTo("Simulated error successfully.")
+        assertThat(listenerImpl.lastPurchases).isNull()
+    }
+
+    @Test
     fun `makePurchaseAsync with dialog cancellation calls onPurchasesFailedToUpdate with cancelled error`() {
         // Given
         val activity = mockk<Activity>()
@@ -152,8 +199,8 @@ class SimulatedStoreBillingWrapperTest {
                 any(), any(), any(), any(), any(), any(), any(), any(), any(),
             ) 
         } answers {
-            val onNegativeClicked = lastArg<() -> Unit>()
-            onNegativeClicked()
+            val onNeutralClicked = lastArg<() -> Unit>()
+            onNeutralClicked()
         }
         
         // When
@@ -167,7 +214,7 @@ class SimulatedStoreBillingWrapperTest {
         )
         
         // Then
-        val listenerImpl = purchasesUpdatedListener as SimulatedStoreBillingWrapperTest.TestPurchasesListener
+        val listenerImpl = purchasesUpdatedListener as TestPurchasesListener
         assertThat(listenerImpl.lastError).isNotNull()
         assertThat(listenerImpl.lastError?.code).isEqualTo(PurchasesErrorCode.PurchaseCancelledError)
         assertThat(listenerImpl.lastError?.underlyingErrorMessage).isEqualTo("Purchase cancelled by user")


### PR DESCRIPTION
### Description
Adds a new error code to be used when simulating purchase errors in the test store.
