### PR TITLE
Extracted the currency locale matching logic from the PaywallState to the Purchases class for reuse

### DIFF
--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -373,6 +373,7 @@ package com.revenuecat.purchases {
     method public void getCustomerInfo(com.revenuecat.purchases.CacheFetchPolicy fetchPolicy, com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback callback);
     method public void getCustomerInfo(com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback callback);
     method @Deprecated public static boolean getDebugLogsEnabled();
+    method public static java.util.Locale getDefaultCurrencyLocale();
     method @Deprecated @kotlin.jvm.Synchronized public boolean getFinishTransactions();
     method public static String getFrameworkVersion();
     method @kotlin.jvm.Synchronized public static com.revenuecat.purchases.LogHandler getLogHandler();
@@ -484,6 +485,7 @@ package com.revenuecat.purchases {
     method public void canMakePayments(android.content.Context context, optional java.util.List<? extends com.revenuecat.purchases.models.BillingFeature> features, com.revenuecat.purchases.interfaces.Callback<java.lang.Boolean> callback);
     method public com.revenuecat.purchases.Purchases configure(com.revenuecat.purchases.PurchasesConfiguration configuration);
     method @Deprecated public boolean getDebugLogsEnabled();
+    method public java.util.Locale getDefaultCurrencyLocale();
     method public String getFrameworkVersion();
     method @kotlin.jvm.Synchronized public com.revenuecat.purchases.LogHandler getLogHandler();
     method public com.revenuecat.purchases.LogLevel getLogLevel();

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -334,6 +334,7 @@ package com.revenuecat.purchases {
     method public static com.revenuecat.purchases.Purchases configureInCustomEntitlementsComputationMode(android.content.Context context, String apiKey, String appUserID);
     method public static com.revenuecat.purchases.Purchases configureInCustomEntitlementsComputationMode(com.revenuecat.purchases.PurchasesConfigurationForCustomEntitlementsComputationMode configuration);
     method @kotlin.jvm.Synchronized public String getAppUserID();
+    method public static java.util.Locale getDefaultCurrencyLocale();
     method public static String getFrameworkVersion();
     method @kotlin.jvm.Synchronized public static com.revenuecat.purchases.LogHandler getLogHandler();
     method public static com.revenuecat.purchases.LogLevel getLogLevel();
@@ -376,6 +377,7 @@ package com.revenuecat.purchases {
     method public void canMakePayments(android.content.Context context, optional java.util.List<? extends com.revenuecat.purchases.models.BillingFeature> features, com.revenuecat.purchases.interfaces.Callback<java.lang.Boolean> callback);
     method public com.revenuecat.purchases.Purchases configureInCustomEntitlementsComputationMode(android.content.Context context, String apiKey, String appUserID);
     method public com.revenuecat.purchases.Purchases configureInCustomEntitlementsComputationMode(com.revenuecat.purchases.PurchasesConfigurationForCustomEntitlementsComputationMode configuration);
+    method public java.util.Locale getDefaultCurrencyLocale();
     method public String getFrameworkVersion();
     method @kotlin.jvm.Synchronized public com.revenuecat.purchases.LogHandler getLogHandler();
     method public com.revenuecat.purchases.LogLevel getLogLevel();

--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.strings.BillingStrings
 import com.revenuecat.purchases.strings.ConfigureStrings
 import com.revenuecat.purchases.utils.DefaultIsDebugBuildProvider
 import java.net.URL
+import java.util.Locale
 
 /**
  * Entry point for Purchases. It should be instantiated as soon as your app has a unique user id
@@ -342,6 +343,17 @@ class Purchases internal constructor(
                 @SuppressLint("RestrictedApi")
                 sharedInstance = it
             }
+        }
+
+        /**
+         * Returns the default currency locale for price formatting.
+         * If the Purchases singleton is configured, returns the best matching locale
+         * for the storefront country code and the device's preferred locale's
+         * Otherwise, returns the system default locale.
+         */
+        @JvmStatic
+        fun getDefaultCurrencyLocale(): Locale {
+            return PurchasesOrchestrator.getDefaultCurrencyLocale()
         }
 
         /**

--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -190,6 +190,20 @@ class Purchases internal constructor(
     fun getStorefrontCountryCode(callback: GetStorefrontCallback) {
         purchasesOrchestrator.getStorefrontCountryCode(callback)
     }
+
+    /**
+     * Determines the Locale used for formatting currencies based on the `storefrontCountryCode` and the device's
+     * available locale's. The `storefrontCountryCode` argument will be used instead of the cached
+     * `storefrontCountryCode` if provided. The `locale` argument is used as fallback in case no
+     * `storefrontCountryCode` is available or when there are no matching device locale's.
+     */
+    @InternalRevenueCatAPI
+    fun currencyLocaleForStorefrontCountryCode(
+        storefrontCountryCode: String? = null,
+        locale: Locale = Locale.getDefault(),
+    ): Locale {
+        return purchasesOrchestrator.currencyLocaleForStorefrontCountryCode(storefrontCountryCode, locale)
+    }
     //endregion
 
     /**

--- a/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/customEntitlementComputation/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -190,20 +190,6 @@ class Purchases internal constructor(
     fun getStorefrontCountryCode(callback: GetStorefrontCallback) {
         purchasesOrchestrator.getStorefrontCountryCode(callback)
     }
-
-    /**
-     * Determines the Locale used for formatting currencies based on the `storefrontCountryCode` and the device's
-     * available locale's. The `storefrontCountryCode` argument will be used instead of the cached
-     * `storefrontCountryCode` if provided. The `locale` argument is used as fallback in case no
-     * `storefrontCountryCode` is available or when there are no matching device locale's.
-     */
-    @InternalRevenueCatAPI
-    fun currencyLocaleForStorefrontCountryCode(
-        storefrontCountryCode: String? = null,
-        locale: Locale = Locale.getDefault(),
-    ): Locale {
-        return purchasesOrchestrator.currencyLocaleForStorefrontCountryCode(storefrontCountryCode, locale)
-    }
     //endregion
 
     /**

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -133,7 +133,7 @@ class Purchases internal constructor(
      * The `storefrontCountryCode` argument will be used instead of the cached `storefrontCountryCode` if provided
      * The `locale` argument is used as fallback in case no `storefrontCountryCode` is available or when there are no matching device locale's
      */
-    fun currencyLocaleForStorefrontCountryCode(storefrontCountryCode: String? = null, locale: Locale): Locale {
+    fun currencyLocaleForStorefrontCountryCode(storefrontCountryCode: String? = null, locale: Locale = Locale.getDefault()): Locale {
         val storefrontCountryCode = storefrontCountryCode ?: this.storefrontCountryCode;
         if (storefrontCountryCode.isNullOrBlank()) {
             return locale;

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -134,6 +134,7 @@ class Purchases internal constructor(
      * `storefrontCountryCode` if provided. The `locale` argument is used as fallback in case no
      * `storefrontCountryCode` is available or when there are no matching device locale's.
      */
+    @InternalRevenueCatAPI
     fun currencyLocaleForStorefrontCountryCode(
         storefrontCountryCode: String? = null,
         locale: Locale = Locale.getDefault(),

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -1113,6 +1113,17 @@ class Purchases internal constructor(
         }
 
         /**
+         * Returns the default currency locale for price formatting.
+         * If the Purchases singleton is configured, returns the best matching locale
+         * for the storefront country code and the device's preferred locale's
+         * Otherwise, returns the system default locale.
+         */
+        @JvmStatic
+        fun getDefaultCurrencyLocale(): Locale {
+            return PurchasesOrchestrator.getDefaultCurrencyLocale()
+        }
+
+        /**
          * Note: This method only works for the Google Play Store. There is no Amazon equivalent at this time.
          * Calling from an Amazon-configured app will return true.
          *

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -139,30 +139,7 @@ class Purchases internal constructor(
         storefrontCountryCode: String? = null,
         locale: Locale = Locale.getDefault(),
     ): Locale {
-        val storefrontCountryCode = storefrontCountryCode ?: this.storefrontCountryCode
-        if (storefrontCountryCode.isNullOrBlank()) {
-            return locale
-        }
-
-        // We find all available device locales with the same country as the storefront country.
-        val availableStorefrontCountryLocalesByLanguage: Map<String, Locale> = buildMap {
-            Locale.getAvailableLocales().forEach { availableLocale ->
-                if (availableLocale.country.equals(storefrontCountryCode, ignoreCase = true)) {
-                    put(availableLocale.language.lowercase(), availableLocale)
-                }
-            }
-        }
-
-        val deviceLanguageCode = locale.language.lowercase()
-
-        // We pick the one with the same language as the device if available. If not, we just pick the
-        // first. If the list is empty, we use the device locale with the storefront country.
-        return availableStorefrontCountryLocalesByLanguage[deviceLanguageCode]
-            ?: availableStorefrontCountryLocalesByLanguage.values.firstOrNull()
-            ?: Locale.Builder()
-                .setLocale(locale)
-                .setRegion(storefrontCountryCode.uppercase())
-                .build()
+        return purchasesOrchestrator.currencyLocaleForStorefrontCountryCode(storefrontCountryCode, locale)
     }
 
     /**

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -129,14 +129,18 @@ class Purchases internal constructor(
         }
 
     /**
-     * Determines the Locale used for formatting currencies based on the `storefrontCountryCode` and the device's available locale's
-     * The `storefrontCountryCode` argument will be used instead of the cached `storefrontCountryCode` if provided
-     * The `locale` argument is used as fallback in case no `storefrontCountryCode` is available or when there are no matching device locale's
+     * Determines the Locale used for formatting currencies based on the `storefrontCountryCode` and the device's
+     * available locale's. The `storefrontCountryCode` argument will be used instead of the cached
+     * `storefrontCountryCode` if provided. The `locale` argument is used as fallback in case no
+     * `storefrontCountryCode` is available or when there are no matching device locale's.
      */
-    fun currencyLocaleForStorefrontCountryCode(storefrontCountryCode: String? = null, locale: Locale = Locale.getDefault()): Locale {
-        val storefrontCountryCode = storefrontCountryCode ?: this.storefrontCountryCode;
+    fun currencyLocaleForStorefrontCountryCode(
+        storefrontCountryCode: String? = null,
+        locale: Locale = Locale.getDefault(),
+    ): Locale {
+        val storefrontCountryCode = storefrontCountryCode ?: this.storefrontCountryCode
         if (storefrontCountryCode.isNullOrBlank()) {
-            return locale;
+            return locale
         }
 
         // We find all available device locales with the same country as the storefront country.

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -129,20 +129,6 @@ class Purchases internal constructor(
         }
 
     /**
-     * Determines the Locale used for formatting currencies based on the `storefrontCountryCode` and the device's
-     * available locale's. The `storefrontCountryCode` argument will be used instead of the cached
-     * `storefrontCountryCode` if provided. The `locale` argument is used as fallback in case no
-     * `storefrontCountryCode` is available or when there are no matching device locale's.
-     */
-    @InternalRevenueCatAPI
-    fun currencyLocaleForStorefrontCountryCode(
-        storefrontCountryCode: String? = null,
-        locale: Locale = Locale.getDefault(),
-    ): Locale {
-        return purchasesOrchestrator.currencyLocaleForStorefrontCountryCode(storefrontCountryCode, locale)
-    }
-
-    /**
      * Listener that receives callbacks for Customer Center events such as restore initiated,
      * subscription cancellations, and customer feedback submission.
      *

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -129,6 +129,38 @@ class Purchases internal constructor(
         }
 
     /**
+     * Determines the Locale used for formatting currencies based on the `storefrontCountryCode` and the device's available locale's
+     * The `storefrontCountryCode` argument will be used instead of the cached `storefrontCountryCode` if provided
+     * The `locale` argument is used as fallback in case no `storefrontCountryCode` is available or when there are no matching device locale's
+     */
+    fun currencyLocaleForStorefrontCountryCode(storefrontCountryCode: String? = null, locale: Locale): Locale {
+        val storefrontCountryCode = storefrontCountryCode ?: this.storefrontCountryCode;
+        if (storefrontCountryCode.isNullOrBlank()) {
+            return locale;
+        }
+
+        // We find all available device locales with the same country as the storefront country.
+        val availableStorefrontCountryLocalesByLanguage: Map<String, Locale> = buildMap {
+            Locale.getAvailableLocales().forEach { availableLocale ->
+                if (availableLocale.country.equals(storefrontCountryCode, ignoreCase = true)) {
+                    put(availableLocale.language.lowercase(), availableLocale)
+                }
+            }
+        }
+
+        val deviceLanguageCode = locale.language.lowercase()
+
+        // We pick the one with the same language as the device if available. If not, we just pick the
+        // first. If the list is empty, we use the device locale with the storefront country.
+        return availableStorefrontCountryLocalesByLanguage[deviceLanguageCode]
+            ?: availableStorefrontCountryLocalesByLanguage.values.firstOrNull()
+            ?: Locale.Builder()
+                .setLocale(locale)
+                .setRegion(storefrontCountryCode.uppercase())
+                .build()
+    }
+
+    /**
      * Listener that receives callbacks for Customer Center events such as restore initiated,
      * subscription cancellations, and customer feedback submission.
      *

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -93,6 +93,7 @@ import com.revenuecat.purchases.strings.PurchaseStrings
 import com.revenuecat.purchases.strings.RestoreStrings
 import com.revenuecat.purchases.strings.SyncAttributesAndOfferingsStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
+import com.revenuecat.purchases.utils.CurrencyLocaleResolver
 import com.revenuecat.purchases.utils.CustomActivityLifecycleHandler
 import com.revenuecat.purchases.utils.PurchaseParamsValidator
 import com.revenuecat.purchases.utils.RateLimiter
@@ -1670,6 +1671,25 @@ internal class PurchasesOrchestrator(
             } else {
                 currentImageLoader
             }
+        }
+
+        /**
+         * Returns the default currency locale for price formatting.
+         * If the Purchases singleton is configured, returns the locale for the storefront country code.
+         * Otherwise, returns the system default locale.
+         */
+        @OptIn(InternalRevenueCatAPI::class)
+        @JvmStatic
+        fun getDefaultCurrencyLocale(): Locale {
+            val storefrontCountryCode = if (Purchases.isConfigured) {
+                Purchases.sharedInstance.storefrontCountryCode
+            } else {
+                null
+            }
+            return CurrencyLocaleResolver.resolve(
+                storefrontCountryCode = storefrontCountryCode,
+                locale = Locale.getDefault(),
+            )
         }
 
         /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -363,43 +363,6 @@ internal class PurchasesOrchestrator(
         )
     }
 
-    /**
-     * Determines the Locale used for formatting currencies based on the `storefrontCountryCode` and the device's
-     * available locale's. The `storefrontCountryCode` argument will be used instead of the cached
-     * `storefrontCountryCode` if provided. The `locale` argument is used as fallback in case no
-     * `storefrontCountryCode` is available or when there are no matching device locale's.
-     */
-    @InternalRevenueCatAPI
-    fun currencyLocaleForStorefrontCountryCode(
-        storefrontCountryCode: String? = null,
-        locale: Locale = Locale.getDefault(),
-    ): Locale {
-        val storefrontCountryCode = storefrontCountryCode ?: this.storefrontCountryCode
-        if (storefrontCountryCode.isNullOrBlank()) {
-            return locale
-        }
-
-        // We find all available device locales with the same country as the storefront country.
-        val availableStorefrontCountryLocalesByLanguage: Map<String, Locale> = buildMap {
-            Locale.getAvailableLocales().forEach { availableLocale ->
-                if (availableLocale.country.equals(storefrontCountryCode, ignoreCase = true)) {
-                    put(availableLocale.language.lowercase(), availableLocale)
-                }
-            }
-        }
-
-        val deviceLanguageCode = locale.language.lowercase()
-
-        // We pick the one with the same language as the device if available. If not, we just pick the
-        // first. If the list is empty, we use the device locale with the storefront country.
-        return availableStorefrontCountryLocalesByLanguage[deviceLanguageCode]
-            ?: availableStorefrontCountryLocalesByLanguage.values.firstOrNull()
-            ?: Locale.Builder()
-                .setLocale(locale)
-                .setRegion(storefrontCountryCode.uppercase())
-                .build()
-    }
-
     fun syncAttributesAndOfferingsIfNeeded(
         callback: SyncAttributesAndOfferingsCallback,
     ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -363,6 +363,43 @@ internal class PurchasesOrchestrator(
         )
     }
 
+    /**
+     * Determines the Locale used for formatting currencies based on the `storefrontCountryCode` and the device's
+     * available locale's. The `storefrontCountryCode` argument will be used instead of the cached
+     * `storefrontCountryCode` if provided. The `locale` argument is used as fallback in case no
+     * `storefrontCountryCode` is available or when there are no matching device locale's.
+     */
+    @InternalRevenueCatAPI
+    fun currencyLocaleForStorefrontCountryCode(
+        storefrontCountryCode: String? = null,
+        locale: Locale = Locale.getDefault(),
+    ): Locale {
+        val storefrontCountryCode = storefrontCountryCode ?: this.storefrontCountryCode
+        if (storefrontCountryCode.isNullOrBlank()) {
+            return locale
+        }
+
+        // We find all available device locales with the same country as the storefront country.
+        val availableStorefrontCountryLocalesByLanguage: Map<String, Locale> = buildMap {
+            Locale.getAvailableLocales().forEach { availableLocale ->
+                if (availableLocale.country.equals(storefrontCountryCode, ignoreCase = true)) {
+                    put(availableLocale.language.lowercase(), availableLocale)
+                }
+            }
+        }
+
+        val deviceLanguageCode = locale.language.lowercase()
+
+        // We pick the one with the same language as the device if available. If not, we just pick the
+        // first. If the list is empty, we use the device locale with the storefront country.
+        return availableStorefrontCountryLocalesByLanguage[deviceLanguageCode]
+            ?: availableStorefrontCountryLocalesByLanguage.values.firstOrNull()
+            ?: Locale.Builder()
+                .setLocale(locale)
+                .setRegion(storefrontCountryCode.uppercase())
+                .build()
+    }
+
     fun syncAttributesAndOfferingsIfNeeded(
         callback: SyncAttributesAndOfferingsCallback,
     ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/PricingPhase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/PricingPhase.kt
@@ -1,9 +1,7 @@
 package com.revenuecat.purchases.models
 
 import android.os.Parcelable
-import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
-import com.revenuecat.purchases.utils.CurrencyLocaleResolver
 import com.revenuecat.purchases.utils.pricePerDay
 import com.revenuecat.purchases.utils.pricePerMonth
 import com.revenuecat.purchases.utils.pricePerWeek
@@ -69,7 +67,7 @@ class PricingPhase(
      * @param locale Locale to use for formatting the price. Default is the system default locale.
      */
     @JvmOverloads
-    fun pricePerDay(locale: Locale = defaultCurrencyLocale()): Price =
+    fun pricePerDay(locale: Locale = Purchases.getDefaultCurrencyLocale()): Price =
         price.pricePerDay(billingPeriod, locale)
 
     /**
@@ -79,7 +77,7 @@ class PricingPhase(
      * @param locale Locale to use for formatting the price. Default is the system default locale.
      */
     @JvmOverloads
-    fun pricePerWeek(locale: Locale = defaultCurrencyLocale()): Price =
+    fun pricePerWeek(locale: Locale = Purchases.getDefaultCurrencyLocale()): Price =
         price.pricePerWeek(billingPeriod, locale)
 
     /**
@@ -89,7 +87,7 @@ class PricingPhase(
      * @param locale Locale to use for formatting the price. Default is the system default locale.
      */
     @JvmOverloads
-    fun pricePerMonth(locale: Locale = defaultCurrencyLocale()): Price =
+    fun pricePerMonth(locale: Locale = Purchases.getDefaultCurrencyLocale()): Price =
         price.pricePerMonth(billingPeriod, locale)
 
     /**
@@ -99,7 +97,7 @@ class PricingPhase(
      * @param locale Locale to use for formatting the price. Default is the system default locale.
      */
     @JvmOverloads
-    fun pricePerYear(locale: Locale = defaultCurrencyLocale()): Price =
+    fun pricePerYear(locale: Locale = Purchases.getDefaultCurrencyLocale()): Price =
         price.pricePerYear(billingPeriod, locale)
 
     /**
@@ -119,28 +117,7 @@ class PricingPhase(
         replaceWith = ReplaceWith("pricePerMonth(locale).formatted"),
     )
     @JvmOverloads
-    fun formattedPriceInMonths(locale: Locale = defaultCurrencyLocale()): String {
+    fun formattedPriceInMonths(locale: Locale = Purchases.getDefaultCurrencyLocale()): String {
         return pricePerMonth(locale).formatted
-    }
-
-    companion object {
-        /**
-         * Returns the default currency locale for price formatting.
-         * If the Purchases singleton is configured, returns the locale for the storefront country code.
-         * Otherwise, returns the system default locale.
-         */
-        @OptIn(InternalRevenueCatAPI::class)
-        @JvmStatic
-        fun defaultCurrencyLocale(): Locale {
-            val storefrontCountryCode = if (Purchases.isConfigured) {
-                Purchases.sharedInstance.storefrontCountryCode
-            } else {
-                null
-            }
-            return CurrencyLocaleResolver.resolve(
-                storefrontCountryCode = storefrontCountryCode,
-                locale = Locale.getDefault(),
-            )
-        }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/PricingPhase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/PricingPhase.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.models
 import android.os.Parcelable
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.utils.CurrencyLocaleResolver
 import com.revenuecat.purchases.utils.pricePerDay
 import com.revenuecat.purchases.utils.pricePerMonth
 import com.revenuecat.purchases.utils.pricePerWeek
@@ -131,10 +132,15 @@ class PricingPhase(
         @OptIn(InternalRevenueCatAPI::class)
         @JvmStatic
         fun defaultCurrencyLocale(): Locale {
-            if (Purchases.isConfigured) {
-                return Purchases.sharedInstance.currencyLocaleForStorefrontCountryCode()
+            val storefrontCountryCode = if (Purchases.isConfigured) {
+                Purchases.sharedInstance.storefrontCountryCode
+            } else {
+                null
             }
-            return Locale.getDefault()
+            return CurrencyLocaleResolver.resolve(
+                storefrontCountryCode = storefrontCountryCode,
+                locale = Locale.getDefault(),
+            )
         }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/PricingPhase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/PricingPhase.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.models
 
 import android.os.Parcelable
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.utils.pricePerDay
 import com.revenuecat.purchases.utils.pricePerMonth
@@ -127,6 +128,7 @@ class PricingPhase(
          * If the Purchases singleton is configured, returns the locale for the storefront country code.
          * Otherwise, returns the system default locale.
          */
+        @OptIn(InternalRevenueCatAPI::class)
         @JvmStatic
         fun defaultCurrencyLocale(): Locale {
             if (Purchases.isConfigured) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/PricingPhase.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/PricingPhase.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.models
 
 import android.os.Parcelable
+import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.utils.pricePerDay
 import com.revenuecat.purchases.utils.pricePerMonth
 import com.revenuecat.purchases.utils.pricePerWeek
@@ -66,7 +67,7 @@ class PricingPhase(
      * @param locale Locale to use for formatting the price. Default is the system default locale.
      */
     @JvmOverloads
-    fun pricePerDay(locale: Locale = Locale.getDefault()): Price =
+    fun pricePerDay(locale: Locale = defaultCurrencyLocale()): Price =
         price.pricePerDay(billingPeriod, locale)
 
     /**
@@ -76,7 +77,7 @@ class PricingPhase(
      * @param locale Locale to use for formatting the price. Default is the system default locale.
      */
     @JvmOverloads
-    fun pricePerWeek(locale: Locale = Locale.getDefault()): Price =
+    fun pricePerWeek(locale: Locale = defaultCurrencyLocale()): Price =
         price.pricePerWeek(billingPeriod, locale)
 
     /**
@@ -86,7 +87,7 @@ class PricingPhase(
      * @param locale Locale to use for formatting the price. Default is the system default locale.
      */
     @JvmOverloads
-    fun pricePerMonth(locale: Locale = Locale.getDefault()): Price =
+    fun pricePerMonth(locale: Locale = defaultCurrencyLocale()): Price =
         price.pricePerMonth(billingPeriod, locale)
 
     /**
@@ -96,7 +97,7 @@ class PricingPhase(
      * @param locale Locale to use for formatting the price. Default is the system default locale.
      */
     @JvmOverloads
-    fun pricePerYear(locale: Locale = Locale.getDefault()): Price =
+    fun pricePerYear(locale: Locale = defaultCurrencyLocale()): Price =
         price.pricePerYear(billingPeriod, locale)
 
     /**
@@ -116,7 +117,22 @@ class PricingPhase(
         replaceWith = ReplaceWith("pricePerMonth(locale).formatted"),
     )
     @JvmOverloads
-    fun formattedPriceInMonths(locale: Locale = Locale.getDefault()): String {
+    fun formattedPriceInMonths(locale: Locale = defaultCurrencyLocale()): String {
         return pricePerMonth(locale).formatted
+    }
+
+    companion object {
+        /**
+         * Returns the default currency locale for price formatting.
+         * If the Purchases singleton is configured, returns the locale for the storefront country code.
+         * Otherwise, returns the system default locale.
+         */
+        @JvmStatic
+        fun defaultCurrencyLocale(): Locale {
+            if (Purchases.isConfigured) {
+                return Purchases.sharedInstance.currencyLocaleForStorefrontCountryCode()
+            }
+            return Locale.getDefault()
+        }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.models
 
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.Purchases
@@ -207,6 +208,7 @@ interface StoreProduct {
          * If the Purchases singleton is configured, returns the locale for the storefront country code.
          * Otherwise, returns the system default locale.
          */
+        @OptIn(InternalRevenueCatAPI::class)
         @JvmStatic
         fun defaultCurrencyLocale(): Locale {
             if (Purchases.isConfigured) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
@@ -1,8 +1,8 @@
 package com.revenuecat.purchases.models
 
-import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
+import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.utils.pricePerDay
 import com.revenuecat.purchases.utils.pricePerMonth
 import com.revenuecat.purchases.utils.pricePerWeek
@@ -13,7 +13,6 @@ import java.util.Locale
  * Represents an in-app product's or subscription's listing details.
  */
 interface StoreProduct {
-    
     /**
      * The product ID.
      * Google INAPP: "<productId>"
@@ -143,7 +142,8 @@ interface StoreProduct {
      * It uses a currency formatter to format the price in the given locale.
      * Note that this value may be an approximation.
      * For Google subscriptions, this value will use the basePlan to calculate the value.
-     * @param locale Locale to use for formatting the price. The default is the best matching locale for the current storefront country and configured device locale, with a fallback to system default locale.
+     * @param locale Locale to use for formatting the price. The default is the best matching locale for the
+     * current storefront country and configured device locale, with a fallback to system default locale.
      */
     fun pricePerDay(locale: Locale = defaultCurrencyLocale()): Price? {
         return period?.let { price.pricePerDay(it, locale) }
@@ -155,7 +155,8 @@ interface StoreProduct {
      * It uses a currency formatter to format the price in the given locale.
      * Note that this value may be an approximation.
      * For Google subscriptions, this value will use the basePlan to calculate the value.
-     * @param locale Locale to use for formatting the price. The default is the best matching locale for the current storefront country and configured device locale, with a fallback to system default locale.
+     * @param locale Locale to use for formatting the price. The default is the best matching locale for the
+     * current storefront country and configured device locale, with a fallback to system default locale.
      */
     fun pricePerWeek(locale: Locale = defaultCurrencyLocale()): Price? {
         return period?.let { price.pricePerWeek(it, locale) }
@@ -167,7 +168,8 @@ interface StoreProduct {
      * It uses a currency formatter to format the price in the given locale.
      * Note that this value may be an approximation.
      * For Google subscriptions, this value will use the basePlan to calculate the value.
-     * @param locale Locale to use for formatting the price. The default is the best matching locale for the current storefront country and configured device locale, with a fallback to system default locale.
+     * @param locale Locale to use for formatting the price. The default is the best matching locale for the
+     * current storefront country and configured device locale, with a fallback to system default locale.
      */
     fun pricePerMonth(locale: Locale = defaultCurrencyLocale()): Price? {
         return period?.let { price.pricePerMonth(it, locale) }
@@ -179,7 +181,8 @@ interface StoreProduct {
      * It uses a currency formatter to format the price in the given locale.
      * Note that this value may be an approximation.
      * For Google subscriptions, this value will use the basePlan to calculate the value.
-     * @param locale Locale to use for formatting the price. The default is the best matching locale for the current storefront country and configured device locale, with a fallback to system default locale.
+     * @param locale Locale to use for formatting the price. The default is the best matching locale for the
+     * current storefront country and configured device locale, with a fallback to system default locale.
      */
     fun pricePerYear(locale: Locale = defaultCurrencyLocale()): Price? {
         return period?.let { price.pricePerYear(it, locale) }
@@ -191,7 +194,8 @@ interface StoreProduct {
      * It uses a currency formatter to format the price in the given locale.
      * Note that this value may be an approximation.
      * For Google subscriptions, this value will use the basePlan to calculate the value.
-     * @param locale Locale to use for formatting the price. The default is the best matching locale for the current storefront country and configured device locale, with a fallback to system default locale.
+     * @param locale Locale to use for formatting the price. The default is the best matching locale for the
+     * current storefront country and configured device locale, with a fallback to system default locale.
      */
     fun formattedPricePerMonth(locale: Locale = defaultCurrencyLocale()): String? {
         return pricePerMonth(locale)?.formatted

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
@@ -1,10 +1,8 @@
 package com.revenuecat.purchases.models
 
-import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.Purchases
-import com.revenuecat.purchases.utils.CurrencyLocaleResolver
 import com.revenuecat.purchases.utils.pricePerDay
 import com.revenuecat.purchases.utils.pricePerMonth
 import com.revenuecat.purchases.utils.pricePerWeek
@@ -147,7 +145,7 @@ interface StoreProduct {
      * @param locale Locale to use for formatting the price. The default is the best matching locale for the
      * current storefront country and configured device locale, with a fallback to system default locale.
      */
-    fun pricePerDay(locale: Locale = defaultCurrencyLocale()): Price? {
+    fun pricePerDay(locale: Locale = Purchases.getDefaultCurrencyLocale()): Price? {
         return period?.let { price.pricePerDay(it, locale) }
     }
 
@@ -160,7 +158,7 @@ interface StoreProduct {
      * @param locale Locale to use for formatting the price. The default is the best matching locale for the
      * current storefront country and configured device locale, with a fallback to system default locale.
      */
-    fun pricePerWeek(locale: Locale = defaultCurrencyLocale()): Price? {
+    fun pricePerWeek(locale: Locale = Purchases.getDefaultCurrencyLocale()): Price? {
         return period?.let { price.pricePerWeek(it, locale) }
     }
 
@@ -173,7 +171,7 @@ interface StoreProduct {
      * @param locale Locale to use for formatting the price. The default is the best matching locale for the
      * current storefront country and configured device locale, with a fallback to system default locale.
      */
-    fun pricePerMonth(locale: Locale = defaultCurrencyLocale()): Price? {
+    fun pricePerMonth(locale: Locale = Purchases.getDefaultCurrencyLocale()): Price? {
         return period?.let { price.pricePerMonth(it, locale) }
     }
 
@@ -186,7 +184,7 @@ interface StoreProduct {
      * @param locale Locale to use for formatting the price. The default is the best matching locale for the
      * current storefront country and configured device locale, with a fallback to system default locale.
      */
-    fun pricePerYear(locale: Locale = defaultCurrencyLocale()): Price? {
+    fun pricePerYear(locale: Locale = Purchases.getDefaultCurrencyLocale()): Price? {
         return period?.let { price.pricePerYear(it, locale) }
     }
 
@@ -199,28 +197,7 @@ interface StoreProduct {
      * @param locale Locale to use for formatting the price. The default is the best matching locale for the
      * current storefront country and configured device locale, with a fallback to system default locale.
      */
-    fun formattedPricePerMonth(locale: Locale = defaultCurrencyLocale()): String? {
+    fun formattedPricePerMonth(locale: Locale = Purchases.getDefaultCurrencyLocale()): String? {
         return pricePerMonth(locale)?.formatted
-    }
-
-    companion object {
-        /**
-         * Returns the default currency locale for price formatting.
-         * If the Purchases singleton is configured, returns the locale for the storefront country code.
-         * Otherwise, returns the system default locale.
-         */
-        @OptIn(InternalRevenueCatAPI::class)
-        @JvmStatic
-        fun defaultCurrencyLocale(): Locale {
-            val storefrontCountryCode = if (Purchases.isConfigured) {
-                Purchases.sharedInstance.storefrontCountryCode
-            } else {
-                null
-            }
-            return CurrencyLocaleResolver.resolve(
-                storefrontCountryCode = storefrontCountryCode,
-                locale = Locale.getDefault(),
-            )
-        }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.utils.CurrencyLocaleResolver
 import com.revenuecat.purchases.utils.pricePerDay
 import com.revenuecat.purchases.utils.pricePerMonth
 import com.revenuecat.purchases.utils.pricePerWeek
@@ -211,10 +212,15 @@ interface StoreProduct {
         @OptIn(InternalRevenueCatAPI::class)
         @JvmStatic
         fun defaultCurrencyLocale(): Locale {
-            if (Purchases.isConfigured) {
-                return Purchases.sharedInstance.currencyLocaleForStorefrontCountryCode()
+            val storefrontCountryCode = if (Purchases.isConfigured) {
+                Purchases.sharedInstance.storefrontCountryCode
+            } else {
+                null
             }
-            return Locale.getDefault()
+            return CurrencyLocaleResolver.resolve(
+                storefrontCountryCode = storefrontCountryCode,
+                locale = Locale.getDefault(),
+            )
         }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/StoreProduct.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.models
 
+import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.utils.pricePerDay
@@ -12,6 +13,7 @@ import java.util.Locale
  * Represents an in-app product's or subscription's listing details.
  */
 interface StoreProduct {
+    
     /**
      * The product ID.
      * Google INAPP: "<productId>"
@@ -141,9 +143,9 @@ interface StoreProduct {
      * It uses a currency formatter to format the price in the given locale.
      * Note that this value may be an approximation.
      * For Google subscriptions, this value will use the basePlan to calculate the value.
-     * @param locale Locale to use for formatting the price. Default is the system default locale.
+     * @param locale Locale to use for formatting the price. The default is the best matching locale for the current storefront country and configured device locale, with a fallback to system default locale.
      */
-    fun pricePerDay(locale: Locale = Locale.getDefault()): Price? {
+    fun pricePerDay(locale: Locale = defaultCurrencyLocale()): Price? {
         return period?.let { price.pricePerDay(it, locale) }
     }
 
@@ -153,9 +155,9 @@ interface StoreProduct {
      * It uses a currency formatter to format the price in the given locale.
      * Note that this value may be an approximation.
      * For Google subscriptions, this value will use the basePlan to calculate the value.
-     * @param locale Locale to use for formatting the price. Default is the system default locale.
+     * @param locale Locale to use for formatting the price. The default is the best matching locale for the current storefront country and configured device locale, with a fallback to system default locale.
      */
-    fun pricePerWeek(locale: Locale = Locale.getDefault()): Price? {
+    fun pricePerWeek(locale: Locale = defaultCurrencyLocale()): Price? {
         return period?.let { price.pricePerWeek(it, locale) }
     }
 
@@ -165,9 +167,9 @@ interface StoreProduct {
      * It uses a currency formatter to format the price in the given locale.
      * Note that this value may be an approximation.
      * For Google subscriptions, this value will use the basePlan to calculate the value.
-     * @param locale Locale to use for formatting the price. Default is the system default locale.
+     * @param locale Locale to use for formatting the price. The default is the best matching locale for the current storefront country and configured device locale, with a fallback to system default locale.
      */
-    fun pricePerMonth(locale: Locale = Locale.getDefault()): Price? {
+    fun pricePerMonth(locale: Locale = defaultCurrencyLocale()): Price? {
         return period?.let { price.pricePerMonth(it, locale) }
     }
 
@@ -177,9 +179,9 @@ interface StoreProduct {
      * It uses a currency formatter to format the price in the given locale.
      * Note that this value may be an approximation.
      * For Google subscriptions, this value will use the basePlan to calculate the value.
-     * @param locale Locale to use for formatting the price. Default is the system default locale.
+     * @param locale Locale to use for formatting the price. The default is the best matching locale for the current storefront country and configured device locale, with a fallback to system default locale.
      */
-    fun pricePerYear(locale: Locale = Locale.getDefault()): Price? {
+    fun pricePerYear(locale: Locale = defaultCurrencyLocale()): Price? {
         return period?.let { price.pricePerYear(it, locale) }
     }
 
@@ -189,9 +191,24 @@ interface StoreProduct {
      * It uses a currency formatter to format the price in the given locale.
      * Note that this value may be an approximation.
      * For Google subscriptions, this value will use the basePlan to calculate the value.
-     * @param locale Locale to use for formatting the price. Default is the system default locale.
+     * @param locale Locale to use for formatting the price. The default is the best matching locale for the current storefront country and configured device locale, with a fallback to system default locale.
      */
-    fun formattedPricePerMonth(locale: Locale = Locale.getDefault()): String? {
+    fun formattedPricePerMonth(locale: Locale = defaultCurrencyLocale()): String? {
         return pricePerMonth(locale)?.formatted
+    }
+
+    companion object {
+        /**
+         * Returns the default currency locale for price formatting.
+         * If the Purchases singleton is configured, returns the locale for the storefront country code.
+         * Otherwise, returns the system default locale.
+         */
+        @JvmStatic
+        fun defaultCurrencyLocale(): Locale {
+            if (Purchases.isConfigured) {
+                return Purchases.sharedInstance.currencyLocaleForStorefrontCountryCode()
+            }
+            return Locale.getDefault()
+        }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CurrencyLocaleResolver.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/CurrencyLocaleResolver.kt
@@ -1,0 +1,53 @@
+package com.revenuecat.purchases.utils
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import java.util.Locale
+
+/**
+ * Utility class for resolving the appropriate Locale for currency formatting based on storefront country code
+ * and device locales.
+ */
+@InternalRevenueCatAPI
+object CurrencyLocaleResolver {
+
+    /**
+     * Determines the Locale used for formatting currencies based on the `storefrontCountryCode` and the device's
+     * available locale's. The `storefrontCountryCode` argument will be used instead of the cached
+     * `storefrontCountryCode` if provided. The `locale` argument is used as fallback in case no
+     * `storefrontCountryCode` is available or when there are no matching device locale's.
+     *
+     * @param storefrontCountryCode The storefront country code (e.g., "US", "NL"). If null, only the locale
+     * parameter is returned.
+     * @param locale The device locale to use as a fallback. Defaults to system default locale.
+     * @return The best matching locale for currency formatting.
+     */
+    @JvmStatic
+    fun resolve(
+        storefrontCountryCode: String?,
+        locale: Locale = Locale.getDefault(),
+    ): Locale {
+        if (storefrontCountryCode.isNullOrBlank()) {
+            return locale
+        }
+
+        // We find all available device locales with the same country as the storefront country.
+        val availableStorefrontCountryLocalesByLanguage: Map<String, Locale> = buildMap {
+            Locale.getAvailableLocales().forEach { availableLocale ->
+                if (availableLocale.country.equals(storefrontCountryCode, ignoreCase = true)) {
+                    put(availableLocale.language.lowercase(), availableLocale)
+                }
+            }
+        }
+
+        val deviceLanguageCode = locale.language.lowercase()
+
+        // We pick the one with the same language as the device if available. If not, we just pick the
+        // first. If the list is empty, we use the device locale with the storefront country.
+        return availableStorefrontCountryLocalesByLanguage[deviceLanguageCode]
+            ?: availableStorefrontCountryLocalesByLanguage.values.firstOrNull()
+            ?: Locale.Builder()
+                .setLocale(locale)
+                .setRegion(storefrontCountryCode.uppercase())
+                .build()
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -436,8 +436,9 @@ class StoreProductTest {
         every { mockPurchases.currencyLocaleForStorefrontCountryCode(null, any()) } returns Locale("es", "MX")
 
         // Create a product with MXN currency (Mexican storefront)
+        val period = Period.create("P1M")
         val product = createSubscriptionStoreProductWithPrice(
-            period = Period.create("P1M"),
+            period = period,
             price = Price(
                 formatted = "$1.00",
                 amountMicros = 1_000_000,
@@ -452,6 +453,20 @@ class StoreProductTest {
         // If we explicitly pass US for formatting the currency we expect MX$
         val formattedPrice2 = product.formattedPricePerMonth(Locale.US)
         assertThat(formattedPrice2).isEqualTo("MX$1.00")
+
+        val pricingPhase = product.subscriptionOptions?.basePlan?.pricingPhases?.last()
+
+        assertThat(pricingPhase?.pricePerDay()?.formatted).contains("$")
+        assertThat(pricingPhase?.pricePerDay()?.formatted).doesNotContain("MX$")
+
+        assertThat(pricingPhase?.pricePerWeek()?.formatted).contains("$")
+        assertThat(pricingPhase?.pricePerWeek()?.formatted).doesNotContain("MX$")
+
+        assertThat(pricingPhase?.pricePerMonth()?.formatted).contains("$")
+        assertThat(pricingPhase?.pricePerMonth()?.formatted).doesNotContain("MX$")
+
+        assertThat(pricingPhase?.pricePerYear()?.formatted).contains("$")
+        assertThat(pricingPhase?.pricePerYear()?.formatted).doesNotContain("MX$")
     }
 
     private fun createSubscriptionStoreProductWithPrice(

--- a/purchases/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/StoreProductTest.kt
@@ -428,12 +428,12 @@ class StoreProductTest {
     @Test
     fun `formattedPricePerMonth uses storefront country locale when Purchases is configured`() {
 
-        // Mock Purchases singleton to return Dutch locale for storefront country
+        // Mock Purchases singleton to return Mexican storefront country code
         val mockPurchases = mockk<Purchases>(relaxed = true)
         mockkObject(Purchases)
         every { Purchases.isConfigured } returns true
         every { Purchases.sharedInstance } returns mockPurchases
-        every { mockPurchases.currencyLocaleForStorefrontCountryCode(null, any()) } returns Locale("es", "MX")
+        every { mockPurchases.storefrontCountryCode } returns "MX"
 
         // Create a product with MXN currency (Mexican storefront)
         val period = Period.create("P1M")

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/CurrencyLocaleResolverTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/CurrencyLocaleResolverTest.kt
@@ -1,0 +1,166 @@
+package com.revenuecat.purchases.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+
+@RunWith(AndroidJUnit4::class)
+class CurrencyLocaleResolverTest {
+
+    @Test
+    fun `when storefront country matches device locale country, returns device locale`() {
+        val deviceLocale = Locale("en", "US")
+        val result = CurrencyLocaleResolver.resolve(
+            storefrontCountryCode = "US",
+            locale = deviceLocale,
+        )
+
+        assertThat(result.language).isEqualTo("en")
+        assertThat(result.country).isEqualTo("US")
+    }
+
+    @Test
+    fun `when storefront country differs but language matches, returns locale with storefront country and device language`() {
+        // Device is set to en-US, but storefront is NL (Netherlands)
+        val deviceLocale = Locale("en", "US")
+        val result = CurrencyLocaleResolver.resolve(
+            storefrontCountryCode = "NL",
+            locale = deviceLocale,
+        )
+
+        // Should find en_NL in available locales (if it exists on the device)
+        // or create a locale with en language and NL country
+        assertThat(result.language).isEqualTo("en")
+        assertThat(result.country).isEqualTo("NL")
+    }
+
+    @Test
+    fun `when storefront country is DE and device is en-US, returns en-DE`() {
+        val deviceLocale = Locale("en", "US")
+        val result = CurrencyLocaleResolver.resolve(
+            storefrontCountryCode = "DE",
+            locale = deviceLocale,
+        )
+
+        assertThat(result.language).isEqualTo("en")
+        assertThat(result.country).isEqualTo("DE")
+    }
+
+    @Test
+    fun `when device locale is Spanish Mexico but storefront is Spain, returns es-ES`() {
+        val deviceLocale = Locale("es", "MX")
+        val result = CurrencyLocaleResolver.resolve(
+            storefrontCountryCode = "ES",
+            locale = deviceLocale,
+        )
+
+        // Should find es_ES in available locales (Spanish Spain)
+        assertThat(result.language).isEqualTo("es")
+        assertThat(result.country).isEqualTo("ES")
+    }
+
+    @Test
+    fun `when storefront country is null, returns device locale unchanged`() {
+        val deviceLocale = Locale("nl", "NL")
+        val result = CurrencyLocaleResolver.resolve(
+            storefrontCountryCode = null,
+            locale = deviceLocale,
+        )
+
+        assertThat(result).isEqualTo(deviceLocale)
+        assertThat(result.language).isEqualTo("nl")
+        assertThat(result.country).isEqualTo("NL")
+    }
+
+    @Test
+    fun `when storefront country is empty string, returns device locale unchanged`() {
+        val deviceLocale = Locale("fr", "FR")
+        val result = CurrencyLocaleResolver.resolve(
+            storefrontCountryCode = "",
+            locale = deviceLocale,
+        )
+
+        assertThat(result).isEqualTo(deviceLocale)
+        assertThat(result.language).isEqualTo("fr")
+        assertThat(result.country).isEqualTo("FR")
+    }
+
+    @Test
+    fun `when storefront country is blank, returns device locale unchanged`() {
+        val deviceLocale = Locale("de", "DE")
+        val result = CurrencyLocaleResolver.resolve(
+            storefrontCountryCode = "  ",
+            locale = deviceLocale,
+        )
+
+        assertThat(result).isEqualTo(deviceLocale)
+        assertThat(result.language).isEqualTo("de")
+        assertThat(result.country).isEqualTo("DE")
+    }
+
+    @Test
+    fun `storefront country takes precedence over device locale country for currency determination`() {
+        // Device is in Mexico (MXN currency), but storefront is US (USD currency)
+        val deviceLocale = Locale("es", "MX")
+        val result = CurrencyLocaleResolver.resolve(
+            storefrontCountryCode = "US",
+            locale = deviceLocale,
+        )
+
+        // Country should be US (which determines currency as USD)
+        assertThat(result.country).isEqualTo("US")
+        // Language might be es if es_US exists in available locales, or en otherwise
+        // The important part is the country is correct for currency determination
+    }
+
+    @Test
+    fun `when device locale is French Canada but storefront is Switzerland, returns locale with CH country`() {
+        val deviceLocale = Locale("fr", "CA")
+        val result = CurrencyLocaleResolver.resolve(
+            storefrontCountryCode = "CH",
+            locale = deviceLocale,
+        )
+
+        // Should create/find fr_CH (French Switzerland)
+        assertThat(result.language).isEqualTo("fr")
+        assertThat(result.country).isEqualTo("CH")
+    }
+
+    @Test
+    fun `when storefront country is lowercase, it still works correctly`() {
+        val deviceLocale = Locale("en", "US")
+        val result = CurrencyLocaleResolver.resolve(
+            storefrontCountryCode = "gb",
+            locale = deviceLocale,
+        )
+
+        // Should handle lowercase and return en_GB
+        assertThat(result.language).isEqualTo("en")
+        assertThat(result.country).isEqualTo("GB")
+    }
+
+    @Test
+    fun `when device has no country code, storefront country is used`() {
+        val deviceLocale = Locale("en") // No country specified
+        val result = CurrencyLocaleResolver.resolve(
+            storefrontCountryCode = "AU",
+            locale = deviceLocale,
+        )
+
+        assertThat(result.language).isEqualTo("en")
+        assertThat(result.country).isEqualTo("AU")
+    }
+
+    @Test
+    fun `when no locale parameter provided, uses system default`() {
+        // This test verifies the default parameter works
+        val result = CurrencyLocaleResolver.resolve(
+            storefrontCountryCode = "JP",
+        )
+
+        // Should use Locale.getDefault() and apply JP country
+        assertThat(result.country).isEqualTo("JP")
+    }
+}

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -232,6 +232,58 @@ internal class PurchasesTest : BasePurchasesTest() {
 
     // endregion storefrontCountryCode
 
+    // region currencyLocaleForStorefrontCountryCode
+
+    @Test
+    fun `for the US storefront and a en-US device locale the currency locale should also be en-US `() {
+        assertThat(purchases.storefrontCountryCode).isNull()
+
+        val currencyLocale = purchases.currencyLocaleForStorefrontCountryCode(storefrontCountryCode = "US", locale = Locale("en", "US"))
+
+        assertThat(currencyLocale.language).isEqualTo("en")
+        assertThat(currencyLocale.country).isEqualTo("US")
+    }
+
+    @Test
+    fun `for the NL sotrefront and a en-US device locale the currency locale should be en-NL`() {
+        assertThat(purchases.storefrontCountryCode).isNull()
+
+        val currencyLocale = purchases.currencyLocaleForStorefrontCountryCode(storefrontCountryCode = "NL", locale = Locale("en", "US"))
+
+        assertThat(currencyLocale.language).isEqualTo("en")
+        assertThat(currencyLocale.country).isEqualTo("NL")
+    }
+
+    @Test
+    fun `when no storefrontCountryCode is passed and no storefrontCountryCode cached the fallback locale should be used`() {
+        assertThat(purchases.storefrontCountryCode).isNull()
+
+        val currencyLocale = purchases.currencyLocaleForStorefrontCountryCode(locale = Locale("nl", "NL"))
+
+        assertThat(currencyLocale.language).isEqualTo("nl")
+        assertThat(currencyLocale.country).isEqualTo("NL")
+    }
+
+    @Test
+    fun `when no storefrontCountryCode is passed and the storefrontCountryCode is cached the cached storefrontCountryCode should be used`() {
+        assertThat(purchases.storefrontCountryCode).isNull()
+
+        every { mockBillingAbstract.getStorefront(captureLambda(), any()) }.answers {
+            lambda<(String) -> Unit>().captured.invoke("DE")
+        }
+
+        purchases.getStorefrontCountryCodeWith {  }
+
+        assertThat(purchases.storefrontCountryCode).isEqualTo("DE")
+
+        val currencyLocale = purchases.currencyLocaleForStorefrontCountryCode(locale = Locale("en", "US"))
+
+        assertThat(currencyLocale.language).isEqualTo("en")
+        assertThat(currencyLocale.country).isEqualTo("DE")
+    }
+
+    // endregion currencyLocaleForStorefrontCountryCode
+
     // region purchasing
 
     @Test

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -27,6 +27,7 @@ import com.revenuecat.purchases.models.GoogleReplacementMode
 import com.revenuecat.purchases.models.PurchasingData
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
+import com.revenuecat.purchases.utils.CurrencyLocaleResolver
 import com.revenuecat.purchases.paywalls.DownloadedFontFamily
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventType
@@ -238,7 +239,7 @@ internal class PurchasesTest : BasePurchasesTest() {
     fun `for the US storefront and a en-US device locale the currency locale should also be en-US `() {
         assertThat(purchases.storefrontCountryCode).isNull()
 
-        val currencyLocale = purchases.currencyLocaleForStorefrontCountryCode(storefrontCountryCode = "US", locale = Locale("en", "US"))
+        val currencyLocale = CurrencyLocaleResolver.resolve(storefrontCountryCode = "US", locale = Locale("en", "US"))
 
         assertThat(currencyLocale.language).isEqualTo("en")
         assertThat(currencyLocale.country).isEqualTo("US")
@@ -248,7 +249,7 @@ internal class PurchasesTest : BasePurchasesTest() {
     fun `for the NL storefront and a en-US device locale the currency locale should be en-NL`() {
         assertThat(purchases.storefrontCountryCode).isNull()
 
-        val currencyLocale = purchases.currencyLocaleForStorefrontCountryCode(storefrontCountryCode = "NL", locale = Locale("en", "US"))
+        val currencyLocale = CurrencyLocaleResolver.resolve(storefrontCountryCode = "NL", locale = Locale("en", "US"))
 
         assertThat(currencyLocale.language).isEqualTo("en")
         assertThat(currencyLocale.country).isEqualTo("NL")
@@ -258,7 +259,7 @@ internal class PurchasesTest : BasePurchasesTest() {
     fun `when no storefrontCountryCode is passed and no storefrontCountryCode cached the fallback locale should be used`() {
         assertThat(purchases.storefrontCountryCode).isNull()
 
-        val currencyLocale = purchases.currencyLocaleForStorefrontCountryCode(locale = Locale("nl", "NL"))
+        val currencyLocale = CurrencyLocaleResolver.resolve(storefrontCountryCode = null, locale = Locale("nl", "NL"))
 
         assertThat(currencyLocale.language).isEqualTo("nl")
         assertThat(currencyLocale.country).isEqualTo("NL")
@@ -276,7 +277,7 @@ internal class PurchasesTest : BasePurchasesTest() {
 
         assertThat(purchases.storefrontCountryCode).isEqualTo("DE")
 
-        val currencyLocale = purchases.currencyLocaleForStorefrontCountryCode(locale = Locale("en", "US"))
+        val currencyLocale = CurrencyLocaleResolver.resolve(storefrontCountryCode = purchases.storefrontCountryCode, locale = Locale("en", "US"))
 
         assertThat(currencyLocale.language).isEqualTo("en")
         assertThat(currencyLocale.country).isEqualTo("DE")

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -245,7 +245,7 @@ internal class PurchasesTest : BasePurchasesTest() {
     }
 
     @Test
-    fun `for the NL sotrefront and a en-US device locale the currency locale should be en-NL`() {
+    fun `for the NL storefront and a en-US device locale the currency locale should be en-NL`() {
         assertThat(purchases.storefrontCountryCode).isNull()
 
         val currencyLocale = purchases.currencyLocaleForStorefrontCountryCode(storefrontCountryCode = "NL", locale = Locale("en", "US"))

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
@@ -114,7 +114,7 @@ private fun rememberProcessedText(
         derivedStateOf {
             textState.applicablePackage?.let { packageToUse ->
                 val dateLocale = state.locale.toJavaLocale()
-                val currencyLocale = state.currencyLocale.toJavaLocale()
+                val currencyLocale = state.currencyLocale
 
                 val introEligibility = packageToUse.introEligibility
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -11,7 +11,6 @@ import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
-import java.util.Locale
 
 /**
  * Mock implementation of [PurchasesType] for previews and test data
@@ -54,10 +53,5 @@ internal class MockPurchasesType(
     }
     override fun syncPurchases() {
         // No-op for mock
-    }
-
-    override fun currencyLocaleForStorefrontCountryCode(storefrontCountryCode: String?, locale: Locale): Locale {
-        // Just return the current locale for mock
-        return locale
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -16,7 +16,6 @@ import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
  * Mock implementation of [PurchasesType] for previews and test data
  * NOTE: This is only used for UI previews and test data, not for actual testing
  */
-@Suppress("TooManyFunctions")
 internal class MockPurchasesType(
     override val preferredUILocaleOverride: String? = null,
     override val purchasesAreCompletedBy: PurchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -11,11 +11,12 @@ import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
-
+import java.util.Locale
 /**
  * Mock implementation of [PurchasesType] for previews and test data
  * NOTE: This is only used for UI previews and test data, not for actual testing
  */
+@Suppress("TooManyFunctions")
 internal class MockPurchasesType(
     override val preferredUILocaleOverride: String? = null,
     override val purchasesAreCompletedBy: PurchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
@@ -52,5 +53,8 @@ internal class MockPurchasesType(
     }
     override fun syncPurchases() {
         // No-op for mock
+    }
+    override fun getDefaultCurrencyLocale(): Locale {
+        return Locale.getDefault()
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
+import java.util.Locale
 
 /**
  * Mock implementation of [PurchasesType] for previews and test data
@@ -52,5 +53,10 @@ internal class MockPurchasesType(
     }
     override fun syncPurchases() {
         // No-op for mock
+    }
+
+    override fun currencyLocaleForStorefrontCountryCode(storefrontCountryCode: String?, locale: Locale): Locale {
+        // Just return the current locale for mock
+        return locale
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -17,6 +17,7 @@ import java.util.Locale
  * Mock implementation of [PurchasesType] for previews and test data
  * NOTE: This is only used for UI previews and test data, not for actual testing
  */
+@Suppress("TooManyFunctions")
 internal class MockPurchasesType(
     override val preferredUILocaleOverride: String? = null,
     override val purchasesAreCompletedBy: PurchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.text.intl.LocaleList
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.UiConfig.VariableConfig
-import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.getBestMatch
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toComposeLocale
@@ -161,7 +160,7 @@ internal sealed interface PaywallState {
             val currencyLocale by derivedStateOf {
                 purchases.currencyLocaleForStorefrontCountryCode(
                     storefrontCountryCode = storefrontCountryCode,
-                    locale = locale.toJavaLocale()
+                    locale = locale.toJavaLocale(),
                 )
             }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -160,7 +160,7 @@ internal sealed interface PaywallState {
              */
             val currencyLocale by derivedStateOf {
                 CurrencyLocaleResolver.resolve(
-                    storefrontCountryCode = storefrontCountryCode,
+                    storefrontCountryCode,
                     locale = locale.toJavaLocale(),
                 )
             }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -30,6 +30,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.helpers.NonEmptySet
 import com.revenuecat.purchases.ui.revenuecatui.helpers.createLocaleFromString
 import com.revenuecat.purchases.ui.revenuecatui.isFullScreen
+import com.revenuecat.purchases.utils.CurrencyLocaleResolver
 import java.util.Date
 import android.os.LocaleList as FrameworkLocaleList
 
@@ -158,7 +159,7 @@ internal sealed interface PaywallState {
              * avoid discrepancies between calculated prices (per period) and the price coming directly from the store.
              */
             val currencyLocale by derivedStateOf {
-                purchases.currencyLocaleForStorefrontCountryCode(
+                CurrencyLocaleResolver.resolve(
                     storefrontCountryCode = storefrontCountryCode,
                     locale = locale.toJavaLocale(),
                 )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.text.intl.LocaleList
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.UiConfig.VariableConfig
+import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.getBestMatch
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toComposeLocale
@@ -31,7 +32,6 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.NonEmptySet
 import com.revenuecat.purchases.ui.revenuecatui.helpers.createLocaleFromString
 import com.revenuecat.purchases.ui.revenuecatui.isFullScreen
 import java.util.Date
-import java.util.Locale
 import android.os.LocaleList as FrameworkLocaleList
 
 @Stable
@@ -149,21 +149,6 @@ internal sealed interface PaywallState {
 
             private var localeId by mutableStateOf(initialLocaleList.toLocaleId())
 
-            // We find all available device locales with the same country as the storefront country.
-            private val availableStorefrontCountryLocalesByLanguage: Map<String, Locale> by lazy {
-                if (storefrontCountryCode.isNullOrBlank()) {
-                    emptyMap()
-                } else {
-                    buildMap {
-                        Locale.getAvailableLocales().forEach { availableLocale ->
-                            if (availableLocale.country.equals(storefrontCountryCode, ignoreCase = true)) {
-                                put(availableLocale.language.lowercase(), availableLocale)
-                            }
-                        }
-                    }
-                }
-            }
-
             /**
              * The locale to use for the paywall's localized content, such as text.
              */
@@ -174,22 +159,10 @@ internal sealed interface PaywallState {
              * avoid discrepancies between calculated prices (per period) and the price coming directly from the store.
              */
             val currencyLocale by derivedStateOf {
-                if (storefrontCountryCode.isNullOrBlank()) {
-                    locale
-                } else {
-                    val deviceLanguageCode = locale.language.lowercase()
-
-                    // We pick the one with the same language as the device if available. If not, we just pick the
-                    // first. If the list is empty, we use the device locale with the storefront country.
-                    val javaLocale = availableStorefrontCountryLocalesByLanguage[deviceLanguageCode]
-                        ?: availableStorefrontCountryLocalesByLanguage.values.firstOrNull()
-                        ?: Locale.Builder()
-                            .setLocale(locale.toJavaLocale())
-                            .setRegion(storefrontCountryCode.uppercase())
-                            .build()
-
-                    javaLocale.toComposeLocale()
-                }
+                purchases.currencyLocaleForStorefrontCountryCode(
+                    storefrontCountryCode = storefrontCountryCode,
+                    locale = locale.toJavaLocale()
+                )
             }
 
             private val selectedPackageByTab = mutableStateMapOf<Int, Package?>().apply {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -21,7 +21,6 @@ import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.googleProduct
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
-import java.util.Locale
 
 /**
  * Abstraction over [Purchases] that can be mocked.
@@ -54,8 +53,6 @@ internal interface PurchasesType {
     fun syncPurchases()
 
     val storefrontCountryCode: String?
-
-    fun currencyLocaleForStorefrontCountryCode(storefrontCountryCode: String? = null, locale: Locale): Locale
 
     val customerCenterListener: CustomerCenterListener?
 
@@ -123,8 +120,4 @@ internal class PurchasesImpl(private val purchases: Purchases = Purchases.shared
 
     override val preferredUILocaleOverride: String?
         get() = purchases.preferredUILocaleOverride
-
-    override fun currencyLocaleForStorefrontCountryCode(storefrontCountryCode: String?, locale: Locale): Locale {
-        return purchases.currencyLocaleForStorefrontCountryCode(storefrontCountryCode, locale)
-    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -21,10 +21,11 @@ import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.googleProduct
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
-
+import java.util.Locale
 /**
  * Abstraction over [Purchases] that can be mocked.
  */
+@Suppress("TooManyFunctions")
 internal interface PurchasesType {
     suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult
 
@@ -56,8 +57,11 @@ internal interface PurchasesType {
     val customerCenterListener: CustomerCenterListener?
 
     val preferredUILocaleOverride: String?
+
+    fun getDefaultCurrencyLocale(): Locale
 }
 
+@Suppress("TooManyFunctions")
 internal class PurchasesImpl(private val purchases: Purchases = Purchases.sharedInstance) : PurchasesType {
     override suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult {
         return purchases.awaitPurchase(purchaseParams.build())
@@ -118,4 +122,8 @@ internal class PurchasesImpl(private val purchases: Purchases = Purchases.shared
 
     override val preferredUILocaleOverride: String?
         get() = purchases.preferredUILocaleOverride
+
+    override fun getDefaultCurrencyLocale(): Locale {
+        return Purchases.getDefaultCurrencyLocale()
+    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -25,7 +25,6 @@ import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
 /**
  * Abstraction over [Purchases] that can be mocked.
  */
-@Suppress("TooManyFunctions")
 internal interface PurchasesType {
     suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult
 
@@ -59,7 +58,6 @@ internal interface PurchasesType {
     val preferredUILocaleOverride: String?
 }
 
-@Suppress("TooManyFunctions")
 internal class PurchasesImpl(private val purchases: Purchases = Purchases.sharedInstance) : PurchasesType {
     override suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult {
         return purchases.awaitPurchase(purchaseParams.build())

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -21,6 +21,7 @@ import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.googleProduct
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
+import java.util.Locale
 
 /**
  * Abstraction over [Purchases] that can be mocked.
@@ -52,6 +53,8 @@ internal interface PurchasesType {
     fun syncPurchases()
 
     val storefrontCountryCode: String?
+
+    fun currencyLocaleForStorefrontCountryCode(storefrontCountryCode: String? = null, locale: Locale): Locale
 
     val customerCenterListener: CustomerCenterListener?
 
@@ -118,4 +121,8 @@ internal class PurchasesImpl(private val purchases: Purchases = Purchases.shared
 
     override val preferredUILocaleOverride: String?
         get() = purchases.preferredUILocaleOverride
+
+    override fun currencyLocaleForStorefrontCountryCode(storefrontCountryCode: String?, locale: Locale): Locale {
+        return purchases.currencyLocaleForStorefrontCountryCode(storefrontCountryCode, locale)
+    }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PurchasesType.kt
@@ -26,6 +26,7 @@ import java.util.Locale
 /**
  * Abstraction over [Purchases] that can be mocked.
  */
+@Suppress("TooManyFunctions")
 internal interface PurchasesType {
     suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult
 
@@ -61,6 +62,7 @@ internal interface PurchasesType {
     val preferredUILocaleOverride: String?
 }
 
+@Suppress("TooManyFunctions")
 internal class PurchasesImpl(private val purchases: Purchases = Purchases.sharedInstance) : PurchasesType {
     override suspend fun awaitPurchase(purchaseParams: PurchaseParams.Builder): PurchaseResult {
         return purchases.awaitPurchase(purchaseParams.build())

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -52,9 +52,4 @@ internal class MockPurchasesType(
     override fun syncPurchases() {
         // No-op for mock
     }
-
-    override fun currencyLocaleForStorefrontCountryCode(storefrontCountryCode: String?, locale: Locale): Locale {
-        // Just return the current locale for mock
-        return locale
-    }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -11,7 +11,6 @@ import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
-import java.util.Locale
 
 /**
  * Mock implementation of [PurchasesType] for tests and previews

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -11,10 +11,12 @@ import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
+import java.util.Locale
 
 /**
  * Mock implementation of [PurchasesType] for tests and previews
  */
+@Suppress("TooManyFunctions")
 internal class MockPurchasesType(
     override val preferredUILocaleOverride: String? = null,
     override val purchasesAreCompletedBy: PurchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
@@ -50,5 +52,8 @@ internal class MockPurchasesType(
     }
     override fun syncPurchases() {
         // No-op for mock
+    }
+    override fun getDefaultCurrencyLocale(): Locale {
+        throw NotImplementedError("Mock implementation")
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/MockPurchasesType.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterListener
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
+import java.util.Locale
 
 /**
  * Mock implementation of [PurchasesType] for tests and previews
@@ -50,5 +51,10 @@ internal class MockPurchasesType(
     }
     override fun syncPurchases() {
         // No-op for mock
+    }
+
+    override fun currencyLocaleForStorefrontCountryCode(storefrontCountryCode: String?, locale: Locale): Locale {
+        // Just return the current locale for mock
+        return locale
     }
 }


### PR DESCRIPTION
### Context

The public APIs for getting the price string of a product take `Locale` which is used for formatting the price. These methods also have a default value for the locale, which is `Locale.getDefault()`. Which seems fine, since it will format the price according to the user's locale. 

### The problem
The problem here arises when the `storefrontCountryCode` is different from the country/region in the user's locale. This can cause situations where price is formatted using the store's currency code, but using the user's locale. Whereas the localized price string returned by the store is using the storefront's country code as the region for formatting the price string.

### The solution
In https://github.com/RevenueCat/purchases-android/pull/2604 a fix was made specifically for paywalls which added some logic to find the best matching locale between the `storefrontCountryCode` and the user's device locale. 

In this PR this logic was extracted to `CurrencyLocaleResolver` and reused across paywalls, `StoreProduct` and `PricingPhase`. Making sure all APIs (AFAK) are using the same locale for formatting prices.

### Changes introduces
- `CurrencyLocaleResolver` centralizes the logic introduced in https://github.com/RevenueCat/purchases-android/pull/2604
- Public APIs in `StoreProduct` and `PricingPhase` use the value derived from `CurrencyLocaleResolver` instead of `Locale.getDefault()` as default locale
- Added unit tests for `CurrencyLocaleProvider` and it's uses

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids
