### PR TITLE
Fixes more Icons crashing with `NoClassDefFoundError` when using Material 1.4.0

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/NoActiveUserManagementView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/NoActiveUserManagementView.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -34,6 +32,7 @@ import com.revenuecat.purchases.ui.revenuecatui.customercenter.composables.Setti
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCenterConfigTestData
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.resolveButtonText
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.theme.CustomerCenterPreviewTheme
+import com.revenuecat.purchases.ui.revenuecatui.icons.Info
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
 
 @Suppress("LongParameterList")
@@ -120,7 +119,7 @@ private fun ContentUnavailableView(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Icon(
-                imageVector = Icons.Rounded.Info,
+                imageVector = Info,
                 contentDescription = null,
                 modifier = Modifier.size(ContentUnavailableIconSize),
             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseInformationCardView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseInformationCardView.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -29,6 +27,7 @@ import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.PriceDetails
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.PurchaseInformation
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.theme.CustomerCenterPreviewTheme
 import com.revenuecat.purchases.ui.revenuecatui.extensions.applyIfNotNull
+import com.revenuecat.purchases.ui.revenuecatui.icons.KeyboardArrowRight
 
 @SuppressWarnings("LongParameterList", "LongMethod")
 @Composable
@@ -91,7 +90,7 @@ internal fun PurchaseInformationCardView(
                                 PurchaseStatusBadge(purchaseInformation, localization)
                             }
                             Icon(
-                                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                                imageVector = KeyboardArrowRight,
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.onSurface,
                             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/VirtualCurrenciesListView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/VirtualCurrenciesListView.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -33,6 +31,7 @@ import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCent
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.getColorForTheme
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.theme.CustomerCenterPreviewTheme
 import com.revenuecat.purchases.ui.revenuecatui.helpers.createLocaleFromString
+import com.revenuecat.purchases.ui.revenuecatui.icons.KeyboardArrowRight
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrency
 
@@ -212,7 +211,7 @@ private fun ShowAllVirtualCurrenciesRow(
                 color = MaterialTheme.colorScheme.primary,
             )
             Icon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                imageVector = KeyboardArrowRight,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.primary,
             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/VirtualCurrencyBalancesScreen.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/VirtualCurrencyBalancesScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -36,6 +34,7 @@ import com.revenuecat.purchases.ui.revenuecatui.customercenter.viewmodel.Virtual
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.viewmodel.VirtualCurrencyBalancesScreenViewModelFactory
 import com.revenuecat.purchases.ui.revenuecatui.data.PurchasesImpl
 import com.revenuecat.purchases.ui.revenuecatui.data.PurchasesType
+import com.revenuecat.purchases.ui.revenuecatui.icons.Warning
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrency
 
 @JvmSynthetic
@@ -149,7 +148,7 @@ private fun EmptyStateView(
         verticalArrangement = Arrangement.Center,
     ) {
         Icon(
-            imageVector = Icons.Default.Warning,
+            imageVector = Warning,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.size(48.dp),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/Info.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/Info.kt
@@ -1,0 +1,41 @@
+@file:Suppress("MagicNumber", "ObjectPropertyName")
+
+package com.revenuecat.purchases.ui.revenuecatui.icons
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Info: ImageVector
+    get() {
+        if (_info != null) {
+            return _info!!
+        }
+        _info = materialIcon(name = "Rounded.Info") {
+            materialPath {
+                moveTo(12.0f, 2.0f)
+                curveTo(6.48f, 2.0f, 2.0f, 6.48f, 2.0f, 12.0f)
+                reflectiveCurveToRelative(4.48f, 10.0f, 10.0f, 10.0f)
+                reflectiveCurveToRelative(10.0f, -4.48f, 10.0f, -10.0f)
+                reflectiveCurveTo(17.52f, 2.0f, 12.0f, 2.0f)
+                close()
+                moveTo(12.0f, 17.0f)
+                curveToRelative(-0.55f, 0.0f, -1.0f, -0.45f, -1.0f, -1.0f)
+                verticalLineToRelative(-4.0f)
+                curveToRelative(0.0f, -0.55f, 0.45f, -1.0f, 1.0f, -1.0f)
+                reflectiveCurveToRelative(1.0f, 0.45f, 1.0f, 1.0f)
+                verticalLineToRelative(4.0f)
+                curveToRelative(0.0f, 0.55f, -0.45f, 1.0f, -1.0f, 1.0f)
+                close()
+                moveTo(13.0f, 9.0f)
+                horizontalLineToRelative(-2.0f)
+                lineTo(11.0f, 7.0f)
+                horizontalLineToRelative(2.0f)
+                verticalLineToRelative(2.0f)
+                close()
+            }
+        }
+        return _info!!
+    }
+
+private var _info: ImageVector? = null

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/KeyboardArrowRight.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/KeyboardArrowRight.kt
@@ -1,0 +1,32 @@
+@file:Suppress("MagicNumber", "ObjectPropertyName")
+
+package com.revenuecat.purchases.ui.revenuecatui.icons
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val KeyboardArrowRight: ImageVector
+    get() {
+        if (_keyboardArrowRight != null) {
+            return _keyboardArrowRight!!
+        }
+        _keyboardArrowRight = materialIcon(
+            name = "AutoMirrored.Filled.KeyboardArrowRight",
+            autoMirror = true,
+        ) {
+            materialPath {
+                moveTo(8.59f, 16.59f)
+                lineTo(13.17f, 12.0f)
+                lineTo(8.59f, 7.41f)
+                lineTo(10.0f, 6.0f)
+                lineToRelative(6.0f, 6.0f)
+                lineToRelative(-6.0f, 6.0f)
+                lineToRelative(-1.41f, -1.41f)
+                close()
+            }
+        }
+        return _keyboardArrowRight!!
+    }
+
+private var _keyboardArrowRight: ImageVector? = null

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/Warning.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/icons/Warning.kt
@@ -1,0 +1,38 @@
+@file:Suppress("MagicNumber", "ObjectPropertyName")
+
+package com.revenuecat.purchases.ui.revenuecatui.icons
+
+import androidx.compose.material.icons.materialIcon
+import androidx.compose.material.icons.materialPath
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal val Warning: ImageVector
+    get() {
+        if (_warning != null) {
+            return _warning!!
+        }
+        _warning = materialIcon(name = "Filled.Warning") {
+            materialPath {
+                moveTo(1.0f, 21.0f)
+                horizontalLineToRelative(22.0f)
+                lineTo(12.0f, 2.0f)
+                lineTo(1.0f, 21.0f)
+                close()
+                moveTo(13.0f, 18.0f)
+                horizontalLineToRelative(-2.0f)
+                verticalLineToRelative(-2.0f)
+                horizontalLineToRelative(2.0f)
+                verticalLineToRelative(2.0f)
+                close()
+                moveTo(13.0f, 14.0f)
+                horizontalLineToRelative(-2.0f)
+                verticalLineToRelative(-4.0f)
+                horizontalLineToRelative(2.0f)
+                verticalLineToRelative(4.0f)
+                close()
+            }
+        }
+        return _warning!!
+    }
+
+private var _warning: ImageVector? = null


### PR DESCRIPTION
#2727 fixed some Icons, but I somehow missed some other `Icons` being used in other parts of the code. This PR adds the missing ones:

```
java.lang.NoClassDefFoundError: Failed resolution of: Landroidx/compose/material/icons/Icons$Rounded;
```