### PR TITLE
UI Paywalls: add {{ product.absolute_discount }} variable

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentView.kt
@@ -128,8 +128,13 @@ private fun rememberProcessedText(
                     pricePerMonthMicros = packageToUse.product.pricePerMonth()?.amountMicros,
                     mostExpensiveMicros = state.mostExpensivePricePerMonthMicros,
                 )
+                val absoluteDiscountMicros = discountAbsoluteMicros(
+                    pricePerMonthMicros = packageToUse.product.pricePerMonth()?.amountMicros,
+                    mostExpensiveMicros = state.mostExpensivePricePerMonthMicros,
+                )
                 val variableContext: VariableProcessor.PackageContext = VariableProcessor.PackageContext(
                     discountRelativeToMostExpensivePerMonth = discount,
+                    discountAbsoluteToMostExpensivePerMonthMicros = absoluteDiscountMicros,
                     showZeroDecimalPlacePrices = !state.showPricesWithDecimals,
                 )
 
@@ -160,6 +165,12 @@ private fun discountPercentage(pricePerMonthMicros: Long?, mostExpensiveMicros: 
     }
 
     return (mostExpensiveMicros - pricePerMonthMicros) / mostExpensiveMicros.toDouble()
+}
+
+private fun discountAbsoluteMicros(pricePerMonthMicros: Long?, mostExpensiveMicros: Long?): Long? {
+    if (pricePerMonthMicros == null || mostExpensiveMicros == null) return null
+    if (mostExpensiveMicros <= pricePerMonthMicros) return null
+    return (mostExpensiveMicros - pricePerMonthMicros)
 }
 
 @Preview(name = "Default")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/PackageConfigurationFactory.kt
@@ -213,6 +213,10 @@ internal object PackageConfigurationFactory {
                 it.product.pricePerMonth(),
                 mostExpensivePricePerMonth,
             )
+            val absoluteDiscountMicros = productAbsoluteDiscountMicros(
+                it.product.pricePerMonth(),
+                mostExpensivePricePerMonth,
+            )
 
             val shouldRound = if (storefrontCountryCode != null) {
                 paywallData.zeroDecimalPlaceCountries.contains(
@@ -226,7 +230,11 @@ internal object PackageConfigurationFactory {
                 rcPackage = it,
                 localization = ProcessedLocalizedConfiguration.create(
                     variableDataProvider = variableDataProvider,
-                    context = VariableProcessor.PackageContext(discountRelativeToMostExpensivePerMonth, shouldRound),
+                    context = VariableProcessor.PackageContext(
+                        discountRelativeToMostExpensivePerMonth,
+                        absoluteDiscountMicros,
+                        shouldRound,
+                    ),
                     localizedConfiguration = localization,
                     rcPackage = it,
                     locale = locale,
@@ -257,6 +265,10 @@ internal object PackageConfigurationFactory {
                     pricePerMonth = it.product.pricePerMonth(),
                     mostExpensive = mostExpensivePricePerMonth,
                 )
+                val absoluteDiscountMicros = productAbsoluteDiscountMicros(
+                    pricePerMonth = it.product.pricePerMonth(),
+                    mostExpensive = mostExpensivePricePerMonth,
+                )
 
                 val shouldRound = if (storefrontCountryCode != null) {
                     zeroDecimalPlaceCountries.contains(
@@ -270,7 +282,11 @@ internal object PackageConfigurationFactory {
                     rcPackage = it,
                     localization = ProcessedLocalizedConfiguration.create(
                         variableDataProvider = variableDataProvider,
-                        context = VariableProcessor.PackageContext(discount, shouldRound),
+                        context = VariableProcessor.PackageContext(
+                            discount,
+                            absoluteDiscountMicros,
+                            shouldRound,
+                        ),
                         localizedConfiguration = localization,
                         rcPackage = it,
                         locale = locale,
@@ -296,5 +312,12 @@ internal object PackageConfigurationFactory {
                 }
             }
         }
+    }
+
+    private fun productAbsoluteDiscountMicros(pricePerMonth: Price?, mostExpensive: Price?): Long? {
+        val price = pricePerMonth?.amountMicros ?: return null
+        val expensive = mostExpensive?.amountMicros ?: return null
+        if (price >= expensive) return null
+        return (expensive - price)
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/processed/VariableProcessor.kt
@@ -12,6 +12,7 @@ internal object VariableProcessor {
      */
     internal data class PackageContext(
         val discountRelativeToMostExpensivePerMonth: Double?,
+        val discountAbsoluteToMostExpensivePerMonthMicros: Long? = null,
         val showZeroDecimalPlacePrices: Boolean = false,
     )
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewVariablesTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewVariablesTests.kt
@@ -642,6 +642,17 @@ internal class TextComponentViewVariablesTests(
                     "83%"
                 )
 
+                Variable.PRODUCT_ABSOLUTE_DISCOUNT -> arrayOf(
+                    "{{ ${variableName.identifier} }}",
+                    Args(
+                        packages = listOf(packageYearlyUsdTwoOffers, packageMonthlyUsdOneOffer),
+                        locale = "en_US",
+                        storefrontCountryCode = "US",
+                        variableLocalizations = variableLocalizationKeysForEnUs(),
+                    ),
+                    "$0.83"
+                )
+
                 Variable.PRODUCT_STORE_PRODUCT_NAME -> arrayOf(
                     "{{ ${variableName.identifier} }}",
                     Args(


### PR DESCRIPTION

PR in case somebody wants to polish it up.

### Motivation
I have vibe-coded this formula for UI Paywalls as requested by some relevant enterprise customers, claiming that it improved 11% conversion versus our existing product, relative_discount.

### Description
It's a preliminary attempt in case someone wants to push it to the finish line (I don't have time to figure out how to properly test Khepri PR + SDK PR).
