### PR TITLE
Add elevation to surfaces in Customer Center to fix default appearance

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/NoActiveUserManagementView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/NoActiveUserManagementView.kt
@@ -111,6 +111,7 @@ private fun ContentUnavailableView(
         modifier = modifier,
         shape = RoundedCornerShape(CustomerCenterConstants.Card.ROUNDED_CORNER_SIZE),
         color = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp),
+        contentColor = MaterialTheme.colorScheme.onSurface,
     ) {
         Column(
             modifier = Modifier
@@ -124,12 +125,14 @@ private fun ContentUnavailableView(
             Icon(
                 imageVector = Icons.Rounded.Info,
                 contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.size(ContentUnavailableIconSize),
             )
 
             Text(
                 text = title,
                 style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.padding(top = ContentUnavailableViewPaddingText),
             )
 
@@ -137,6 +140,7 @@ private fun ContentUnavailableView(
                 Text(
                     text = it,
                     style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
                     textAlign = TextAlign.Center,
                     modifier = Modifier.padding(top = ContentUnavailableViewPaddingText),
                 )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseInformationCardView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/PurchaseInformationCardView.kt
@@ -63,6 +63,7 @@ internal fun PurchaseInformationCardView(
         modifier = modifier,
         shape = shape,
         color = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp),
+        contentColor = MaterialTheme.colorScheme.onSurface,
     ) {
         Column(
             modifier = Modifier
@@ -79,6 +80,7 @@ internal fun PurchaseInformationCardView(
                 Text(
                     text = purchaseInformation.title ?: purchaseInformation.product?.title ?: "",
                     style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.weight(1f),
                 )
                 when {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/VirtualCurrenciesListView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/views/VirtualCurrenciesListView.kt
@@ -154,6 +154,7 @@ internal fun VirtualCurrencyRow(
         modifier = modifier.fillMaxWidth(),
         shape = shape,
         color = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp),
+        contentColor = MaterialTheme.colorScheme.onSurface,
     ) {
         Row(
             modifier = Modifier.padding(
@@ -193,6 +194,7 @@ private fun ShowAllVirtualCurrenciesRow(
             bottomEnd = CustomerCenterConstants.Card.ROUNDED_CORNER_SIZE,
         ),
         color = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp),
+        contentColor = MaterialTheme.colorScheme.onSurface,
     ) {
         Row(
             modifier = Modifier


### PR DESCRIPTION
Alternative solution to #2731 

After analyzing solutions I think I prefer this solution because it won't be as breaking as the other one:
1. It creates less drastic changes for custom themes since it's based off `surface`
2. Still fixes the default theme issue (cards now visible)
---
**Option 1: `surfaceColorAtElevation(2.dp)` (This PR)**

  Pros:
  - Respects custom surface colors, adds subtle tint instead of replacing entirely
  - Developers with surfaceTint = Color.Transparent see no change (backward compatible)
  - Smaller visual delta for custom themes (their color + tint vs completely different color)
  - Better preserves branding (orange stays orange, just slightly tinted)
  - It's easier to explain it was a bug (We were missing elevation)

  Cons:
  - Ignores explicit surfaceContainer customizations (rare and not a problem because we were not using it and we didn't document it anywhere)
  - Adds tint to custom surface colors (minimal but visible)
  - Might be a bit harder to explain in docs?

  Migration to preserve behavior:
```
  colorScheme = colorScheme.copy(surfaceTint = Color.Transparent)
```

  ---
  **Option 2: `surfaceContainer`**

  Pros:
  - Simpler concept and documentation (no need to explain elevation, it's just a color)

  Cons:
  - Completely replaces custom surface colors with unrelated default value
  - Breaks branding for apps that customized `surface`
  - Higher visual change

  Migration to preserve behavior:
  
```
  colorScheme = colorScheme.copy(surfaceContainer = surface)
```
