### PR TITLE
Protect against developers excluding blockstore dependency

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/blockstore/BlockstoreHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/blockstore/BlockstoreHelperTest.kt
@@ -208,6 +208,26 @@ class BlockstoreHelperTest {
         verify(exactly = 0) { mockBlockstoreClient.storeBytes(any()) }
     }
 
+    @Test
+    fun `storeUserIdIfNeeded does nothing when no BlockstoreClient`() {
+        blockstoreHelper = BlockstoreHelper(
+            applicationContext = mockContext,
+            identityManager = mockIdentityManager,
+            blockstoreClient = null,
+            ioScope = testScope,
+            mainScope = testScope
+        )
+
+        val mockCustomerInfo = mockk<CustomerInfo> {
+            every { allPurchasedProductIds } returns setOf("product1")
+        }
+
+        blockstoreHelper.storeUserIdIfNeeded(mockCustomerInfo)
+
+        verify(exactly = 0) { mockIdentityManager.currentAppUserID }
+        verify(exactly = 0) { mockBlockstoreClient.retrieveBytes(any()) }
+    }
+
     // endregion storeUserIdIfNeeded
 
     // region aliasCurrentAndStoredUserIdsIfNeeded
@@ -419,6 +439,26 @@ class BlockstoreHelperTest {
         
         assertThat(callbackCalled).isTrue()
         verify(exactly = 1) { mockBlockstoreClient.deleteBytes(any()) }
+    }
+
+    @Test
+    fun `clearUserIdBackupIfNeeded does nothing if no BlockstoreClient`() {
+        blockstoreHelper = BlockstoreHelper(
+            applicationContext = mockContext,
+            identityManager = mockIdentityManager,
+            blockstoreClient = null,
+            ioScope = testScope,
+            mainScope = testScope
+        )
+
+        var callbackCalled = false
+        blockstoreHelper.clearUserIdBackupIfNeeded {
+            callbackCalled = true
+        }
+
+        assertThat(callbackCalled).isTrue()
+
+        verify(exactly = 0) { mockBlockstoreClient.deleteBytes(any()) }
     }
 
     // endregion clearUserIdBackupIfNeeded


### PR DESCRIPTION
### Description
We got a report of some crashes trying to find the Blockstore dependency. Looks like it was excluded from the runtime dependencies. While this seems like an invalid usage, the Blockstore dependency is not mandatory for usage of the SDK, so we can protect against it being excluded, same way we protect against the com.google.android.gms ads identifier library being excluded.

I've tested this by excluding the dependency and it doesn't crash with these changes.