### PR TITLE
Keep cache logic similar to iOS + ensure path extension is on file

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/storage/DefaultFileRepository.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/storage/DefaultFileRepository.kt
@@ -209,12 +209,11 @@ internal class DefaultFileCache(
 
     override fun generateLocalFilesystemURI(remoteURL: URL, checksum: Checksum?): URI? {
         val urlHash = md5Hex(remoteURL.toString().toByteArray())
-        val fileName = File(urlHash).name
+        // Use checksum value as part of the file name (like iOS)
+        val fileName = File(urlHash).name + (checksum?.value ?: "")
         if (fileName.isEmpty()) return null
 
-        // Use checksum value as extension (like iOS), fallback to URL extension
-        val extension = (checksum?.value ?: "") + remoteURL
-            .path.substringAfterLast('.', "")
+        val extension = remoteURL.path.substringAfterLast('.', "")
         val fileWithExtension = "$fileName.$extension"
 
         return File(cacheDir, fileWithExtension).toURI()

--- a/purchases/src/test/java/com/revenuecat/purchases/storage/DefaultFileCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/storage/DefaultFileCacheTest.kt
@@ -268,13 +268,13 @@ class DefaultFileCacheTest {
     }
 
     @Test
-    fun `generateLocalFilesystemURI uses checksum as extension`() {
+    fun `generateLocalFilesystemURI uses checksum as part of the filename and retains the file extension`() {
         val url = URL("https://example.com/video.mp4")
         val checksum = Checksum(Checksum.Algorithm.SHA256, "abc123def456")
 
         val uri = cache.generateLocalFilesystemURI(url, checksum)
 
-        assertThat(uri.toString()).endsWith(".abc123def456")
+        assertThat(uri.toString()).endsWith("abc123def456.mp4")
     }
 
     @Test


### PR DESCRIPTION
This mainly is to keep the logic as similar as possible, but if for some reason there are specific versions of android that fail like iOS did when the file extension was not on the file, this will fix that.