### PR TITLE
Avoids the `PaywallComponentsTemplate_Preview` from being rendered by Emerge

### DIFF
--- a/ui/revenuecatui/src/debug/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/TemplatePreviews.kt
+++ b/ui/revenuecatui/src/debug/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/TemplatePreviews.kt
@@ -15,6 +15,7 @@ import androidx.core.graphics.drawable.toDrawable
 import coil.ImageLoader
 import coil.decode.DataSource
 import coil.request.SuccessResult
+import com.emergetools.snapshots.annotations.EmergeSnapshotConfig
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.models.StoreProduct
@@ -163,7 +164,11 @@ internal class PaywallResourcesProvider : PreviewParameterProvider<PaywallResour
  * 2. `git submodule update upstream/paywall-preview-resources`
  *
  * You'll need to run step 2 every time paywall-preview-resources is updated.
+ *
+ * Regardless of the `@EmergeSnapshotConfig(ignore = true)` annotation, this preview still ends up on Emerge via the
+ * `record-and-upload-paparazzi-revenuecatui-snapshots` CI job, and `PaywallComponentsTemplatePreviewRecorder`.
  */
+@EmergeSnapshotConfig(ignore = true)
 @Preview
 @Composable
 internal fun PaywallComponentsTemplate_Preview(


### PR DESCRIPTION
## Description
We have some inexplicable rendering failures for `PaywallComponentsTemplate_Preview` on Emerge. This PR makes Emerge ignore this preview when rendering. We're still rendering it via Paparazzi, and uploading those to Emerge, so we're not losing much by disabling this. 