### PR TITLE
Add more proper error message when using test store API key in release builds

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesException.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesException.kt
@@ -1,6 +1,11 @@
 package com.revenuecat.purchases
 
-open class PurchasesException(val error: PurchasesError) : Exception() {
+open class PurchasesException internal constructor(
+    val error: PurchasesError,
+    internal val overridenMessage: String? = null,
+) : Exception() {
+
+    constructor(error: PurchasesError) : this(error, null)
 
     val code: PurchasesErrorCode
         get() = error.code
@@ -9,5 +14,5 @@ open class PurchasesException(val error: PurchasesError) : Exception() {
         get() = error.underlyingErrorMessage
 
     override val message: String
-        get() = error.message
+        get() = overridenMessage ?: error.message
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -433,11 +433,12 @@ internal class PurchasesFactory(
                 apiKeyValidationResult == APIKeyValidator.ValidationResult.SIMULATED_STORE
             ) {
                 throw PurchasesException(
-                    PurchasesError(
+                    error = PurchasesError(
                         code = PurchasesErrorCode.ConfigurationError,
-                        underlyingErrorMessage = "Please configure the Play Store/Amazon store app on the " +
-                            "RevenueCat dashboard and use its corresponding API key before releasing.",
                     ),
+                    overridenMessage = "Please configure the Play Store/Amazon store app on the " +
+                        "RevenueCat dashboard and use its corresponding API key before releasing. " +
+                        "Test Store is not supported in production builds.",
                 )
             }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -122,8 +122,8 @@ class PurchasesFactoryTest {
             fail("Expected error")
         } catch (e: PurchasesException) {
             assertThat(e.code).isEqualTo(PurchasesErrorCode.ConfigurationError)
-            assertThat(e.underlyingErrorMessage).isEqualTo(
-                "Please configure the Play Store/Amazon store app on the RevenueCat dashboard and use its corresponding API key before releasing."
+            assertThat(e.message).isEqualTo(
+                "Please configure the Play Store/Amazon store app on the RevenueCat dashboard and use its corresponding API key before releasing. Test Store is not supported in production builds."
             )
         }
     }


### PR DESCRIPTION
### Description
We were using the ConfigurationError code message and passing the details in the underlying error message. However, this made it so the proper error isn't that accessible, specially for hybrids developers. This modifies the exception message to be more precise instead of leaving the generic one. 

This is a different approach than the one in #2752