### PR TITLE
Handle error building `QueryProductDetailsParams` in some devices

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/QueryProductDetailsParamsBuilderException.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/QueryProductDetailsParamsBuilderException.kt
@@ -1,0 +1,6 @@
+package com.revenuecat.purchases.google
+
+internal class QueryProductDetailsParamsBuilderException(message: String?, cause: Throwable?) : Exception(
+    message,
+    cause,
+)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/billingClientParamBuilders.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/billingClientParamBuilders.kt
@@ -4,6 +4,7 @@ import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryPurchaseHistoryParams
 import com.android.billingclient.api.QueryPurchasesParams
+import com.revenuecat.purchases.common.errorLog
 
 internal fun @receiver:BillingClient.ProductType String.buildQueryPurchaseHistoryParams(): QueryPurchaseHistoryParams? {
     return when (this) {
@@ -32,6 +33,18 @@ internal fun @receiver:BillingClient.ProductType String.buildQueryProductDetails
             .setProductType(this)
             .build()
     }
-    return QueryProductDetailsParams.newBuilder()
-        .setProductList(productList).build()
+
+    return try {
+        QueryProductDetailsParams.newBuilder()
+            .setProductList(productList).build()
+    } catch (@Suppress("SwallowedException") e: ExceptionInInitializerError) {
+        // We've received reports that setProductList may throw an exception in some Chromebook devices
+        // This is a workaround to avoid the crash and return a proper error to the developer.
+        val errorMessage = "Error while building QueryProductDetailsParams in Billing client"
+        errorLog(e) { "$errorMessage: ${e.message}. Caused by: ${e.cause?.message}" }
+        throw QueryProductDetailsParamsBuilderException(
+            errorMessage,
+            e.cause,
+        )
+    }
 }


### PR DESCRIPTION
### Description
We've received reports of crashes in some Chromebook devices like this:
```
Exception java.lang.ExceptionInInitializerError:
  at com.google.android.gms.internal.play_billing.zzbt.zzi (com.android.billingclient:billing@@8.0.0:2)
  at com.google.android.gms.internal.play_billing.zzbt.zzj (com.android.billingclient:billing@@8.0.0:6)
  at com.android.billingclient.api.QueryProductDetailsParams$Builder.setProductList (com.android.billingclient:billing@@8.0.0:9)
  at com.google.android.gms.internal.play_billing.zzbt.zzj (com.android.billingclient:billing@@8.0.0:6)
  at com.android.billingclient.api.QueryProductDetailsParams$Builder.setProductList (com.android.billingclient:billing@@8.0.0:9)
  at com.revenuecat.purchases.google.BillingClientParamBuildersKt.buildQueryProductDetailsParams (billingClientParamBuilders.kt:36)
  at com.revenuecat.purchases.google.usecase.QueryProductDetailsUseCase.queryProductDetailsAsyncEnsuringOneResponse (QueryProductDetailsUseCase.kt:104)
  at com.revenuecat.purchases.google.usecase.QueryProductDetailsUseCase.access$convertUnfetchedProductStatusCodeToString (QueryProductDetailsUseCase.kt:33)
  at com.revenuecat.purchases.google.usecase.QueryProductDetailsUseCase.access$queryProductDetailsAsyncEnsuringOneResponse (QueryProductDetailsUseCase.kt:33)
  at com.revenuecat.purchases.google.usecase.QueryProductDetailsUseCase$executeAsync$2.invoke (QueryProductDetailsUseCase.kt:55)
  at com.revenuecat.purchases.google.usecase.QueryProductDetailsUseCase$executeAsync$2.invoke (QueryProductDetailsUseCase.kt:52)
  at com.revenuecat.purchases.google.BillingWrapper.withConnectedClient (BillingWrapper.kt:754)
  at com.revenuecat.purchases.google.BillingWrapper.access$getStackTrace (BillingWrapper.kt:76)
  at com.revenuecat.purchases.google.BillingWrapper.access$withConnectedClient (BillingWrapper.kt:76)
  at com.revenuecat.purchases.google.BillingWrapper$queryProductDetailsAsync$useCase$1.invoke (BillingWrapper.kt:225)
  at com.revenuecat.purchases.google.BillingWrapper$queryProductDetailsAsync$useCase$1.invoke (BillingWrapper.kt:225)
  at com.revenuecat.purchases.google.usecase.QueryProductDetailsUseCase.executeAsync (QueryProductDetailsUseCase.kt:52)
  at com.revenuecat.purchases.google.usecase.BillingClientUseCase$run$1.invoke (BillingClientUseCase.kt:51)
  at com.revenuecat.purchases.google.usecase.BillingClientUseCase$run$1.invoke (BillingClientUseCase.kt:49)
  at com.revenuecat.purchases.google.BillingWrapper.executePendingRequests$lambda$3$lambda$2$lambda$0 (BillingWrapper.kt:136)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:223)
  at android.app.ActivityThread.main (ActivityThread.java:7737)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:592)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:954)
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'int java.util.AbstractCollection.size()' on a null object reference
  at com.google.android.gms.internal.play_billing.zzbr.<init> (com.android.billingclient:billing@@8.0.0:1)
  at com.google.android.gms.internal.play_billing.zzbt.<clinit> (com.android.billingclient:billing@@8.0.0:1)
  at com.google.android.gms.internal.play_billing.zzbt.<clinit> (com.android.billingclient:billing@@8.0.0:1)
```

This seems to be an issue on the Billing client on some Chromebook devices. Unfortunately, there is not much we can do about it but we can avoid the crash and report the issue to developers with this. Created issuetracker for this here: https://issuetracker.google.com/issues/454504650