### PR TITLE
Stores backend integration test result on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -697,6 +697,8 @@ jobs:
           command: |
             bundle exec fastlane android run_backend_integration_tests
       - android/save_build_cache
+      - store_test_results: 
+          path: purchases/build/test-results
 
   record-and-upload-paparazzi-revenuecatui-snapshots:
     description: "Record new RevenueCatUI snapshots with Paparazzi and upload them to Emerge"


### PR DESCRIPTION
## Description
I noticed we weren't doing this. Should make analyzing failures a bit nicer. 