### PR TITLE
Update Emerge snapshots to best/latest practices

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -132,7 +132,7 @@ dokka-core = { module = "org.jetbrains.dokka:dokka-core", version.ref = "dokka" 
 dokka-testApi = { module = "org.jetbrains.dokka:dokka-test-api", version.ref = "dokka" }
 
 emerge-snapshots = { module = "com.emergetools.snapshots:snapshots", version.ref = "emergeSnapshots" }
-emerge-snapshots-annotations = { module = "com.emergetools.snapshots:snapshots-annotations", version.ref = "emergeSnapshots" }
+emerge-snapshots-runtime = { module = "com.emergetools.snapshots:snapshots-runtime", version.ref = "emergeSnapshots" }
 
 google-blockstore = { module = "com.google.android.gms:play-services-auth-blockstore", version.ref = "googleBlockstore" }
 hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest" }

--- a/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesuiandroidcompatibility/build.gradle.kts
@@ -75,7 +75,7 @@ emerge {
             prNumber.set(prNum)
         } else {
             // Don't set baseSha for main branch uploads
-            baseSha.set(null)
+            baseSha.set(null as String?)
         }
         gitHub {
             repoName.set("purchases-android")

--- a/ui/revenuecatui/build.gradle.kts
+++ b/ui/revenuecatui/build.gradle.kts
@@ -132,7 +132,7 @@ dependencies {
     implementation(libs.commonmark)
     implementation(libs.commonmark.strikethrough)
 
-    compileOnly(libs.emerge.snapshots.annotations)
+    compileOnly(libs.emerge.snapshots.runtime)
 
     debugImplementation(libs.compose.ui.tooling)
     debugImplementation(libs.androidx.test.compose.manifest)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/dialogs/RestorePurchasesDialog.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/dialogs/RestorePurchasesDialog.kt
@@ -14,7 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.emergetools.snapshots.annotations.IgnoreEmergeSnapshot
+import com.emergetools.snapshots.annotations.EmergeSnapshotConfig
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData.Localization
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.data.CustomerCenterConfigTestData
 
@@ -155,7 +155,7 @@ private fun PurchasesNotFoundDialog(
 }
 
 @Preview(showBackground = true)
-@IgnoreEmergeSnapshot
+@EmergeSnapshotConfig(ignore = true)
 @Composable
 private fun RestorePurchasesDialogRestoringPreview() {
     RestorePurchasesDialog(
@@ -168,7 +168,7 @@ private fun RestorePurchasesDialogRestoringPreview() {
 }
 
 @Preview(showBackground = true)
-@IgnoreEmergeSnapshot
+@EmergeSnapshotConfig(ignore = true)
 @Composable
 private fun RestorePurchasesDialogRecoveredPreview() {
     RestorePurchasesDialog(
@@ -181,7 +181,7 @@ private fun RestorePurchasesDialogRecoveredPreview() {
 }
 
 @Preview(showBackground = true)
-@IgnoreEmergeSnapshot
+@EmergeSnapshotConfig(ignore = true)
 @Composable
 private fun RestorePurchasesDialogNotFoundPreview() {
     RestorePurchasesDialog(


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
While working on solving a bug yesterday, I noticed Emerge snapshots are a few versions behind/not using latest best practices. This updates that!

### Description
Updates a few things to now follow best practices:
- Updates Emerge Gradle plugin to latest (4.4.0)
- Updates Emerge snapshots to latest (1.5.0)
- Replaces `emerge-snapshots-annotations` (deprecated) with `emerge-snapshots-runtime`.
- With above library change, updates to use latest `@EmergeSnapshotConfig` annotations in place of `IgnoreEmergeSnapshot`
- Sets `baseSha` to `null` on non-PR builds to avoid main branch failures, as `""` to us is a valid baseSha, which causes us to search for a non-existing build to compare against. This should cause main branch runs to show a green check now.
