### PR TITLE
Add package fallback to tab selection when there's no default selected

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -245,7 +245,8 @@ internal sealed interface PaywallState {
                         ?: packages.packagesByTab[selectedTabIndex]?.firstOrNull()?.pkg?.also {
                             Logger.w(
                                 "Could not find default package for tab $selectedTabIndex. " +
-                                    "Using first package instead. This could be caused by not having any package marked as selected by default.",
+                                    "Using first package instead. " +
+                                    "This could be caused by not having any package marked as selected by default.",
                             )
                         }
                 }


### PR DESCRIPTION
We got a report of a paywall that in Android is not showing the Annual product and has some odd behavior when toggling on/off on the switch as the UI Footer moves up and down. iOS behaves as expected.

<img width="230" height="225" alt="Screenshot 2025-10-29 at 08 42 20" src="https://github.com/user-attachments/assets/6aec383d-d53a-402a-95ad-10a37d1b9af4" />

I pinpointed it to be related to the default package of the OFF tab. It looks like there's no default selected and that's making Android default to null package. 

<img width="346" height="137" alt="Screenshot 2025-10-29 at 08 42 56" src="https://github.com/user-attachments/assets/8664ff5a-6a21-4cb4-bf63-7dc2fc2a06ef" />

I looked at the iOS implementation and added a fallback here in the Android code.

https://linear.app/revenuecat/issue/DENG-1483/i-have-paywall-trial-paywall-1