### PR TITLE
FIX: Video component - felt slow on first appearance

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoComponentView.kt
@@ -57,7 +57,7 @@ internal fun VideoComponentView(
                 .clip(composeShape)
                 .applyIfNotNull(borderStyle) { border(it, composeShape).padding(it.width) },
         ) {
-            if (videoUrl == null && fallbackImageViewStyle != null) {
+            if (fallbackImageViewStyle != null) {
                 ImageComponentView(fallbackImageViewStyle, state, modifier)
             }
 
@@ -123,6 +123,8 @@ private fun rememberVideoContentState(
 
             val url = repository.generateOrGetCachedFileURL(videoUrls.url, videoUrls.checksum)
             videoUrl = url
+            // If we have a cached video, no need to display a fallback image
+            fallbackImageViewStyle = null
         } catch (_: Exception) {
             videoUrl = videoUrls.url.toString().let(::URI)
         }
@@ -133,10 +135,19 @@ private fun rememberVideoContentState(
             ?.takeIf { it != videoUrls.url }
             ?.run {
                 videoUrl = repository.getFile(this, videoUrls.checksumLowRes)
+
+                if (videoUrl != null) {
+                    // If we have a cached video, no need to display a fallback image
+                    fallbackImageViewStyle = null
+                }
+
                 LaunchedEffect(Unit) {
-                    fetchVideoUrl(setLowResVideoURLFirst = false)
+                    fetchVideoUrl(setLowResVideoURLFirst = videoUrl == null)
                 }
             }
+    } else {
+        // If we have a cached video, no need to display a fallback image
+        fallbackImageViewStyle = null
     }
 
     if (videoUrl == null) {


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->


The image would not render when the low-res video was starting to load before the initial cache was populated. So we need to explicitly set and unset the image at the appropriate times.


### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
