### PR TITLE
add SubscriptionOption.copyWithPresentedOfferingContext()

### DIFF
--- a/api-tester/src/main/java/com/revenuecat/apitester/java/SubscriptionOptionAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/SubscriptionOptionAPI.java
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.models.GoogleSubscriptionOption;
 import com.revenuecat.purchases.models.InstallmentsInfo;
 import com.revenuecat.purchases.models.PricingPhase;
 import com.revenuecat.purchases.models.PurchasingData;
+import com.revenuecat.purchases.models.StoreProduct;
 import com.revenuecat.purchases.models.SubscriptionOption;
 
 import java.util.List;
@@ -24,6 +25,9 @@ final class SubscriptionOptionAPI {
         String id = subscriptionOption.getId();
         Boolean isPrepaid = subscriptionOption.isPrepaid();
         InstallmentsInfo installmentsInfo = subscriptionOption.getInstallmentsInfo();
+        SubscriptionOption copyWithContext = subscriptionOption.copyWithPresentedOfferingContext(
+                new PresentedOfferingContext("offeringId")
+        );
     }
 
     static void checkGoogleSubscriptionOption(GoogleSubscriptionOption googleSubscriptionOption) {
@@ -77,6 +81,10 @@ final class SubscriptionOptionAPI {
                 offerToken,
                 googleSubscriptionOption.getPresentedOfferingContext(),
                 installmentsInfo
+        );
+
+        SubscriptionOption copyWithContext = googleSubscriptionOption.copyWithPresentedOfferingContext(
+                new PresentedOfferingContext("offeringId")
         );
     }
 

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/SubscriptionOptionAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/SubscriptionOptionAPI.kt
@@ -17,6 +17,9 @@ private class SubscriptionOptionAPI {
         val presentedOfferingContext: PresentedOfferingContext? = subscriptionOption.presentedOfferingContext
         val isPrepaid: Boolean = subscriptionOption.isPrepaid
         val installmentsInfo: InstallmentsInfo? = subscriptionOption.installmentsInfo
+        val subscriptionOptionCopy: SubscriptionOption = subscriptionOption.copyWithPresentedOfferingContext(
+            PresentedOfferingContext(offeringIdentifier = "abc"),
+        )
     }
 
     fun checkGoogleSubscriptionOption(googleSubscriptionOption: GoogleSubscriptionOption) {
@@ -81,6 +84,10 @@ private class SubscriptionOptionAPI {
             offerToken,
             presentedOfferingContext = null,
             installmentsInfo,
+        )
+
+        val subscriptionOptionCopy: SubscriptionOption = googleSubscriptionOption.copyWithPresentedOfferingContext(
+            PresentedOfferingContext(offeringIdentifier = "abc"),
         )
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleSubscriptionOption.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/GoogleSubscriptionOption.kt
@@ -135,6 +135,27 @@ class GoogleSubscriptionOption @JvmOverloads constructor(
         )
 
     /**
+     * For internal RevenueCat use.
+     *
+     * Creates a copy of this `GoogleSubscriptionOption` with the specified `presentedOfferingContext` set on itself.
+     */
+    override fun copyWithPresentedOfferingContext(
+        presentedOfferingContext: PresentedOfferingContext?,
+    ): SubscriptionOption {
+        return GoogleSubscriptionOption(
+            productId = this.productId,
+            basePlanId = this.basePlanId,
+            offerId = this.offerId,
+            pricingPhases = this.pricingPhases,
+            tags = this.tags,
+            productDetails = this.productDetails,
+            offerToken = this.offerToken,
+            presentedOfferingContext = presentedOfferingContext,
+            installmentsInfo = this.installmentsInfo,
+        )
+    }
+
+    /**
      * The "primary" pricing phase for the description, defined by either the first infinitely recurring phase,
      * or if no infinitely recurring phase is found, then the last one.
      */

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/SubscriptionOption.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/SubscriptionOption.kt
@@ -100,4 +100,11 @@ interface SubscriptionOption {
      * Installment plans are only available for Google Play subscriptions.
      */
     val installmentsInfo: InstallmentsInfo?
+
+    /**
+     * For internal RevenueCat use.
+     *
+     * Creates a copy of this `SubscriptionOption` with the specified `presentedOfferingContext` set.
+     */
+    fun copyWithPresentedOfferingContext(presentedOfferingContext: PresentedOfferingContext?): SubscriptionOption
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/models/TestStoreProduct.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/models/TestStoreProduct.kt
@@ -169,4 +169,24 @@ private class TestSubscriptionOption(
 
     override val presentedOfferingIdentifier: String?
         get() = presentedOfferingContext.offeringIdentifier
+
+    /**
+     * For internal RevenueCat use.
+     *
+     * Creates a copy of this `TestSubscriptionOption` with the specified `presentedOfferingContext` set.
+     * Unlike other implementations of `SubscriptionOption.copyWithPresentedOfferingContext`, this one
+     * ignores the provided value if it is null.
+     */
+    override fun copyWithPresentedOfferingContext(
+        presentedOfferingContext: PresentedOfferingContext?,
+    ): SubscriptionOption {
+        return TestSubscriptionOption(
+            pricingPhases = this.pricingPhases,
+            basePlanId = this.basePlanId,
+            tags = this.tags,
+            presentedOfferingContext = presentedOfferingContext ?: this.presentedOfferingContext,
+            installmentsInfo = this.installmentsInfo,
+            purchasingData = this.purchasingData,
+        )
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -830,6 +830,13 @@ class BillingWrapperTest {
 
             override val installmentsInfo: InstallmentsInfo?
                 get() = null
+
+            override fun copyWithPresentedOfferingContext(
+                presentedOfferingContext: PresentedOfferingContext?
+            ): SubscriptionOption {
+                // Stub for testing
+                return this
+            }
         }
 
         wrapper.makePurchaseAsync(
@@ -890,6 +897,12 @@ class BillingWrapperTest {
                         get() = purchasingData
                     override val installmentsInfo: InstallmentsInfo?
                         get() = null
+                    override fun copyWithPresentedOfferingContext(
+                        presentedOfferingContext: PresentedOfferingContext?
+                    ): SubscriptionOption {
+                        // Stub for testing
+                        return this
+                    }
                 }
             override val purchasingData: PurchasingData
                 get() = purchasingData

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/productStubs.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/productStubs.kt
@@ -244,6 +244,12 @@ fun stubSubscriptionOption(
         )
     override val installmentsInfo: InstallmentsInfo?
         get() = installmentsInfo
+    override fun copyWithPresentedOfferingContext(
+        presentedOfferingContext: PresentedOfferingContext?
+    ): SubscriptionOption {
+        // Stub for testing
+        return this
+    }
 }
 
 fun stubFreeTrialPricingPhase(


### PR DESCRIPTION
### Description
This PR adds a new function, `SubscriptionOption.copyWithPresentedOfferingContext(presentedOfferingContext:)`, that makes a copy of the `SubscriptionOption`, but with the provided presented offering context.

This will come in handy when implementing add-ons with subscription options in PHC if we want to preserve the presented offering context for each add-on while moving it from the hybrid SDK to the native SDK.