### PR TITLE
Add job to update golden test files for backend integration tests manually

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ orbs:
 parameters:
   action:
     type: enum
-    enum: [default, bump, paywall_tester_release, deploy_snapshot_release, update_paywall_templates]
+    enum: [default, bump, paywall_tester_release, deploy_snapshot_release, update_paywall_templates, update_golden_requests_backend_integration_tests]
     default: default
 
 commands:
@@ -706,6 +706,25 @@ jobs:
       - store_test_results:
           path: purchases/build/test-results
 
+  update-golden-requests-backend-integration-tests:
+    description: "Run backend integration tests and create PR if golden files change"
+    <<: *android-executor
+    steps:
+      - checkout
+      - install-sdkman
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
+      - revenuecat/setup-git-credentials
+      - revenuecat/trust-github-key
+      - android/restore_gradle_cache
+      - run:
+          name: Run backend integration tests and create PR if needed
+          command: |
+            bundle exec fastlane android update_golden_requests_backend_integration_tests
+      - android/save_build_cache
+      - store_test_results:
+          path: purchases/build/test-results
+
   record-and-upload-paparazzi-revenuecatui-snapshots:
     description: "Record new RevenueCatUI snapshots with Paparazzi and upload them to Emerge"
     <<: *android-executor
@@ -1082,3 +1101,9 @@ workflows:
       equal: [ update_paywall_templates, << pipeline.parameters.action >> ]
     jobs:
       - update-paywall-preview-resources-submodule
+
+  manual-update-golden-requests-backend-integration-tests:
+    when:
+      equal: [ update_golden_requests_backend_integration_tests, << pipeline.parameters.action >> ]
+    jobs:
+      - update-golden-requests-backend-integration-tests

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -263,6 +263,82 @@ platform :android do
     )
   end
 
+  desc "Run backend integration tests and create PR if golden files change"
+  lane :update_golden_requests_backend_integration_tests do |options|
+    run_backend_integration_tests
+
+    golden_files_path = "purchases/src/test/resources/backend_integration_tests_golden/"
+    
+    # Ensure we're in the project root for git operations
+    project_root = File.basename(Dir.pwd) == "fastlane" ? ".." : "."
+    
+    Dir.chdir(project_root) do
+      # Check if there are changes to golden test files (modified tracked files or new untracked files)
+      has_modified_files = false
+      has_untracked_files = false
+      
+      # Check for modified tracked files
+      begin
+        sh("git", "diff", "--quiet", golden_files_path)
+      rescue
+        has_modified_files = true
+      end
+      
+      # Check for untracked files in the golden files directory
+      untracked_files = sh("git", "ls-files", "--others", "--exclude-standard", golden_files_path).strip
+      has_untracked_files = !untracked_files.empty?
+      
+      has_changes = has_modified_files || has_untracked_files
+
+      if has_changes
+        UI.message("Golden test files have been modified. Creating PR...")
+
+        # Get the current branch name (the branch that triggered the workflow)
+        current_branch = sh("git", "rev-parse", "--abbrev-ref", "HEAD").strip
+        UI.message("Current branch: #{current_branch}")
+
+        # Create a unique branch name for the PR
+        timestamp = Time.now.strftime("%Y%m%d-%H%M%S")
+        pr_branch_name = "update-golden-requests-#{current_branch}-#{timestamp}"
+
+        UI.message("Creating branch: #{pr_branch_name}")
+
+        # Create or checkout the branch
+        create_or_checkout_branch(branch_name: pr_branch_name)
+
+        # Stage only the golden files
+        sh("git", "add", golden_files_path)
+
+        commit_message = "[Automated] Update golden test files for backend integration tests"
+        title = "[AUTOMATIC] Update golden test files for backend integration tests"
+        body = "This PR automatically updates the golden test files in `#{golden_files_path}` based on the latest backend integration test results.\n\n" \
+               "Generated from branch: `#{current_branch}`\n\n" \
+               "Please review the changes to ensure they are expected."
+
+        # Commit only the staged golden files
+        sh("git", "commit", "-m", commit_message)
+
+        # Push the branch
+        sh("git", "push", "-u", "origin", pr_branch_name)
+
+        # Create PR against the current branch (not main)
+        create_pr_if_necessary(
+          repo: repo_name,
+          branch_name: pr_branch_name,
+          title: title,
+          body: body,
+          base: current_branch,
+          labels: ["pr:other"],
+          team_reviewers: ["coresdk"]
+        )
+
+        UI.success("PR created successfully!")
+      else
+        UI.success("Golden test files verification passed - no changes detected")
+      end
+    end
+  end
+
   desc "Build and run purchases module integration tests"
   desc "This requires the google cloud cli to be installed and initialized."
   desc "Accepts a backend_environment parameter: 'production', 'load_shedder_us_east_1', 'load_shedder_us_east_2'"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -135,6 +135,14 @@ Build purchases module integration tests pointing to production
 
 Build purchases module integration tests pointing to production
 
+### android update_golden_requests_backend_integration_tests
+
+```sh
+[bundle exec] fastlane android update_golden_requests_backend_integration_tests
+```
+
+Run backend integration tests and create PR if golden files change
+
 ### android run_purchases_integration_tests
 
 ```sh


### PR DESCRIPTION
### Description
We added golden snapshots for requests and responses in backend integration tests in #2781. However, right now they need to be updated locally. This adds a new manual command that can be executed to update these files without having to run them locally.