### PR TITLE
Adds Maestro test making a purchase on a v2 Paywall

### DIFF
--- a/maestro/rc-api/v1/api.js
+++ b/maestro/rc-api/v1/api.js
@@ -1,0 +1,22 @@
+for (var EXPECTED_PARAMS = ['apiKey'], i = 0; i < EXPECTED_PARAMS.length; i++) {
+  if (!eval(EXPECTED_PARAMS[i])) throw new Error(EXPECTED_PARAMS[i] + ' is not provided');
+}
+
+function revokeGooglePlaySubscription(appUserId, productId) {
+  return http.post(
+    'https://api.revenuecat.com/v1/subscribers/' +
+      encodeURIComponent(appUserId) +
+      '/subscriptions/' +
+      encodeURIComponent(productId) +
+      '/revoke', {
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + apiKey,
+        },
+        body: ''
+      });
+}
+
+output.rcApiV1 = {
+  revokeGooglePlaySubscription: revokeGooglePlaySubscription
+}

--- a/maestro/subscribe/store/play-store.yml
+++ b/maestro/subscribe/store/play-store.yml
@@ -1,0 +1,16 @@
+appId: com.revenuecat.automatedsdktests
+---
+- tapOn: Subscribe
+- runFlow:
+    label: "Disable authentication for purchases"
+    when:
+      visible: ".*authentication.*"
+    commands:
+      - tapOn: "No, thanks"
+      - tapOn: OK
+- repeat:
+    label: "Disable notifications and emails from Google Play"
+    while:
+      visible: "Not now"
+    commands:
+      - tapOn: "Not now"

--- a/maestro/subscribe/subscribe.yml
+++ b/maestro/subscribe/subscribe.yml
@@ -1,0 +1,8 @@
+appId: com.revenuecat.automatedsdktests
+---
+- runFlow:
+    label: "Subscribe on Google Play"
+    when:
+      # Good enough for now.
+      platform: Android
+    file: store/play-store.yml

--- a/maestro/test_paywall_v2.yaml
+++ b/maestro/test_paywall_v2.yaml
@@ -1,0 +1,35 @@
+appId: com.revenuecat.automatedsdktests
+env:
+  PRODUCT_ID: subscription_monthly
+onFlowStart:
+  - runScript:
+      when:
+        platform: Android
+      label: "Load RevenueCat API v1"
+      file: ./rc-api/v1/api.js
+      env:
+        apiKey: ${RC_SECRET_API_KEY_V1}
+  - runFlow:
+      when:
+        platform: Android
+      label: "Log in with a Google account"
+      file: google-login/google-login.yml
+---
+- launchApp:
+    appId: com.revenuecat.automatedsdktests
+    clearState: true
+- tapOn: Offerings
+- tapOn: default
+- tapOn: Show Paywall
+- assertVisible: Paywall V2
+- tapOn: Monthly
+- tapOn: Continue
+- runFlow:
+    label: "Subscribe"
+    file: subscribe/subscribe.yml
+- tapOn: Customer Info
+- assertVisible: "pro: "
+- assertVisible: "${'Active: true, Product: ' + PRODUCT_ID}"
+- copyTextFrom:
+    id: "Original App User ID"
+- evalScript: ${output.rcApiV1.revokeGooglePlaySubscription(maestro.copiedText, PRODUCT_ID)}

--- a/test-apps/e2etests/build.gradle.kts
+++ b/test-apps/e2etests/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        applicationId = "com.revenuecat.e2etests"
+        applicationId = "com.revenuecat.automatedsdktests"
         minSdk = 24
         targetSdk = 36
         versionCode = 1

--- a/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/main/CustomerInfoPage.kt
+++ b/test-apps/e2etests/src/main/java/com/revenuecat/e2etests/main/CustomerInfoPage.kt
@@ -3,6 +3,7 @@ package com.revenuecat.e2etests.main
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -24,7 +25,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.CustomerInfo
@@ -203,11 +209,25 @@ private fun InfoSection(
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun InfoItem(label: String, value: String) {
-    Column {
+    Row {
         Text(
-            text = "$label: $value",
+            text = "$label: ",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Text(
+            text = value,
+            modifier = Modifier.semantics {
+                // Setting the label as testTag for the value Text is on purpose. It allows us to do thinks like this
+                // in Maestro:
+                // - copyTextFrom:
+                //    id: "Original App User ID"
+                // to extract the value.
+                testTag = label
+                testTagsAsResourceId = true
+            },
             style = MaterialTheme.typography.bodyMedium,
         )
     }


### PR DESCRIPTION
## Description
**Note:** based on https://github.com/RevenueCat/purchases-android/pull/2788. 

Adds a Maestro test that makes a Google Play purchase and immediately revokes it with the RevenueCat API, to allow testing again.

This can be merged, but it's just a POC. Still to do:
- aligning this with the existing iOS tests, and
- running this on CI.  