### PR TITLE
Restore Purchases config automatically in CustomerCenter

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterActivity.kt
@@ -11,6 +11,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.Modifier
+import com.revenuecat.purchases.ui.revenuecatui.helpers.restoreSdkConfigurationIfNeeded
+import com.revenuecat.purchases.ui.revenuecatui.helpers.saveSdkConfiguration
 
 internal class CustomerCenterActivity : ComponentActivity() {
     companion object {
@@ -21,6 +23,8 @@ internal class CustomerCenterActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        restoreSdkConfigurationIfNeeded(this, savedInstanceState)
 
         setContent {
             val isDarkTheme = isSystemInDarkTheme()
@@ -38,5 +42,10 @@ internal class CustomerCenterActivity : ComponentActivity() {
                 )
             }
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        saveSdkConfiguration(outState)
+        super.onSaveInstanceState(outState)
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/SdkConfigurationState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/SdkConfigurationState.kt
@@ -1,0 +1,90 @@
+package com.revenuecat.purchases.ui.revenuecatui.helpers
+
+import android.content.Context
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcelable
+import com.revenuecat.purchases.DangerousSettings
+import com.revenuecat.purchases.EntitlementVerificationMode
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.PurchasesAreCompletedBy
+import com.revenuecat.purchases.PurchasesConfiguration
+import com.revenuecat.purchases.Store
+import kotlinx.parcelize.Parcelize
+
+private const val SDK_CONFIG_EXTRA = "sdk_config_args"
+
+@Parcelize
+internal data class SdkConfigurationState(
+    val apiKey: String,
+    val appUserId: String?,
+    val purchasesAreCompletedBy: PurchasesAreCompletedBy,
+    val showInAppMessagesAutomatically: Boolean,
+    val store: Store,
+    val diagnosticsEnabled: Boolean,
+    val verificationMode: EntitlementVerificationMode,
+    val dangerousSettings: DangerousSettings,
+    val pendingTransactionsForPrepaidPlansEnabled: Boolean,
+) : Parcelable {
+
+    companion object {
+        fun from(configuration: PurchasesConfiguration): SdkConfigurationState = SdkConfigurationState(
+            apiKey = configuration.apiKey,
+            appUserId = configuration.appUserID,
+            purchasesAreCompletedBy = configuration.purchasesAreCompletedBy,
+            showInAppMessagesAutomatically = configuration.showInAppMessagesAutomatically,
+            store = configuration.store,
+            diagnosticsEnabled = configuration.diagnosticsEnabled,
+            verificationMode = configuration.verificationMode,
+            dangerousSettings = configuration.dangerousSettings,
+            pendingTransactionsForPrepaidPlansEnabled = configuration.pendingTransactionsForPrepaidPlansEnabled,
+        )
+    }
+
+    fun toConfiguration(context: Context): PurchasesConfiguration {
+        return PurchasesConfiguration.Builder(context, apiKey)
+            .appUserID(appUserId)
+            .purchasesAreCompletedBy(purchasesAreCompletedBy)
+            .showInAppMessagesAutomatically(showInAppMessagesAutomatically)
+            .store(store)
+            .diagnosticsEnabled(diagnosticsEnabled)
+            .entitlementVerificationMode(verificationMode)
+            .dangerousSettings(dangerousSettings)
+            .pendingTransactionsForPrepaidPlansEnabled(pendingTransactionsForPrepaidPlansEnabled)
+            .build()
+    }
+}
+
+private fun Bundle.getSdkConfigurationState(): SdkConfigurationState? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelable(SDK_CONFIG_EXTRA, SdkConfigurationState::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelable(SDK_CONFIG_EXTRA)
+    }
+}
+
+internal fun saveSdkConfiguration(outState: Bundle) {
+    if (!Purchases.isConfigured) return
+    outState.putParcelable(
+        SDK_CONFIG_EXTRA,
+        SdkConfigurationState.from(Purchases.sharedInstance.currentConfiguration),
+    )
+}
+
+internal fun restoreSdkConfigurationIfNeeded(context: Context, savedInstanceState: Bundle?) {
+    val sdkConfigArgs = savedInstanceState?.getSdkConfigurationState() ?: return
+    val savedConfiguration = sdkConfigArgs.toConfiguration(context)
+
+    if (Purchases.isConfigured) {
+        val currentConfiguration = Purchases.sharedInstance.currentConfiguration
+        if (currentConfiguration == savedConfiguration) {
+            Logger.i("Skipping Purchases reconfiguration, configuration is unchanged.")
+        } else {
+            Logger.i("Purchases already configured with different parameters; not reconfiguring.")
+        }
+        return
+    }
+
+    Purchases.configure(savedConfiguration)
+}


### PR DESCRIPTION
### Motivation & Description
This is a follow-up of https://github.com/RevenueCat/purchases-android/pull/1872

We're getting some errors like this one in flutter:

```
Purchases$Companion.getSharedInstance
pf.K - There is no singleton instance. Make sure you configure Purchases before trying to get the default instance.
```

The theory is that this might be related to a similar bug we fixed for paywalls of the app getting backgrounded and killed while on the CustomerCenter activity, and then crashing when coming back