### PR TITLE
Fix predownloading of fonts if first offering doesn't have paywall components

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/OfferingFontPreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/OfferingFontPreDownloader.kt
@@ -29,14 +29,17 @@ internal class OfferingFontPreDownloader(
     fun preDownloadOfferingFontsIfNeeded(offerings: Offerings) {
         // Getting the first offering's paywall components to check for fonts.
         // All offerings are expected to have the same fonts.
-        val fontInfosToDownload = offerings.all.values.firstOrNull()?.paywallComponents?.uiConfig?.app?.fonts?.values
-            ?.map { it.android }
-            ?.filterIsInstance<FontInfo.Name>()
-            ?.filter {
+        val fontsToCheck = offerings.all.values
+            .firstNotNullOfOrNull { it.paywallComponents?.uiConfig?.app?.fonts?.values }
+            ?: emptyList()
+        val fontInfosToDownload = fontsToCheck
+            .map { it.android }
+            .filterIsInstance<FontInfo.Name>()
+            .filter {
                 it.toDownloadableFontInfo() is Result.Success &&
                     !isBundled(it)
             }
-            ?.filter {
+            .filter {
                 try {
                     URL(it.url)
                     true
@@ -44,7 +47,7 @@ internal class OfferingFontPreDownloader(
                     errorLog(e) { "Malformed URL for font: ${it.value}. Skipping download." }
                     false
                 }
-            } ?: emptyList()
+            }
 
         for (fontToDownload in fontInfosToDownload) {
             fontLoader.getCachedFontFamilyOrStartDownload(fontToDownload)

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/OfferingFontPreDownloaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/OfferingFontPreDownloaderTest.kt
@@ -209,4 +209,53 @@ class OfferingFontPreDownloaderTest {
             fontLoader.getCachedFontFamilyOrStartDownload(any())
         }
     }
+
+    @Test
+    fun `preDownloadOfferingFontsIfNeeded still downloads when first offering lacks paywall components`() {
+        val downloadableFont = FontsConfig(
+            android = FontInfo.Name(
+                value = "remoteFont",
+                family = "test-family",
+                weight = 400,
+                style = FontStyle.NORMAL,
+                url = "https://example.com/font.ttf",
+                hash = "hash123",
+            ),
+        )
+        val offeringWithPaywall = Offering(
+            identifier = "with-paywall",
+            serverDescription = "description",
+            metadata = emptyMap(),
+            availablePackages = emptyList(),
+            paywallComponents = Offering.PaywallComponents(
+                uiConfig = UiConfig(
+                    app = AppConfig(
+                        fonts = mapOf(FontAlias("downloadableFont") to downloadableFont)
+                    )
+                ),
+                data = mockk(),
+            ),
+        )
+        val offeringWithoutPaywall = Offering(
+            identifier = "no-paywall",
+            serverDescription = "description",
+            metadata = emptyMap(),
+            availablePackages = emptyList(),
+            paywallComponents = null,
+        )
+
+        preDownloader.preDownloadOfferingFontsIfNeeded(
+            Offerings(
+                current = null,
+                all = linkedMapOf(
+                    "no-paywall" to offeringWithoutPaywall,
+                    "with-paywall" to offeringWithPaywall,
+                ),
+            )
+        )
+
+        verify(exactly = 1) {
+            fontLoader.getCachedFontFamilyOrStartDownload(downloadableFont.android as FontInfo.Name)
+        }
+    }
 } 


### PR DESCRIPTION
I noticed that if the first offering returned by the backend doesn't have paywall components, we were not pre-downloading the fonts. This PR should prevent that. The added test doesn't pass in `main`