### PR TITLE
Remove unused `BuildConfig. ENABLE_VIDEO_COMPONENT `

### DIFF
--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -52,11 +52,6 @@ android {
 
         buildConfigField(
             type = "boolean",
-            name = "ENABLE_VIDEO_COMPONENT",
-            value = (localProperties["ENABLE_VIDEO_COMPONENT"] as? String ?: "false"),
-        )
-        buildConfigField(
-            type = "boolean",
             name = "ENABLE_EXTRA_REQUEST_LOGGING",
             value = (localProperties["ENABLE_EXTRA_REQUEST_LOGGING"] as? String ?: "false"),
         )


### PR DESCRIPTION
### Description
Just noticed we never removed the build config for the video component. This just cleans that up.