### PR TITLE
Allow passing old purchase id and GoogleReplacementMode to paywalls purchase flow

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallDialogOptions.kt
@@ -17,6 +17,7 @@ class PaywallDialogOptions internal constructor(
     val fontProvider: FontProvider?,
     val listener: PaywallListener?,
     val purchaseLogic: PurchaseLogic?,
+    val replaceProductData: ReplaceProductData?,
 ) {
 
     constructor(builder: Builder) : this(
@@ -27,6 +28,7 @@ class PaywallDialogOptions internal constructor(
         fontProvider = builder.fontProvider,
         listener = builder.listener,
         purchaseLogic = builder.purchaseLogic,
+        replaceProductData = builder.replaceProductData,
     )
 
     internal fun toPaywallOptions(dismissRequest: () -> Unit): PaywallOptions {
@@ -39,6 +41,7 @@ class PaywallDialogOptions internal constructor(
             .setFontProvider(fontProvider)
             .setListener(listener)
             .setPurchaseLogic(purchaseLogic)
+            .setReplaceProductData(replaceProductData)
             .build()
     }
 
@@ -50,6 +53,7 @@ class PaywallDialogOptions internal constructor(
         internal var fontProvider: FontProvider? = null
         internal var listener: PaywallListener? = null
         internal var purchaseLogic: PurchaseLogic? = null
+        internal var replaceProductData: ReplaceProductData? = null
 
         /**
          * Allows to configure whether to display the paywall dialog depending on operations on the CustomerInfo
@@ -97,6 +101,13 @@ class PaywallDialogOptions internal constructor(
 
         fun setCustomPurchaseLogic(purchaseLogic: PurchaseLogic?) = apply {
             this.purchaseLogic = purchaseLogic
+        }
+
+        /**
+         * Sets [ReplaceProductData] to the builder to start the correct product upgrade flow.
+         */
+        fun setReplaceProductData(replaceProductData: ReplaceProductData?) = apply {
+            this.replaceProductData = replaceProductData
         }
 
         fun build(): PaywallDialogOptions {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/PaywallOptions.kt
@@ -50,6 +50,7 @@ class PaywallOptions internal constructor(
     val purchaseLogic: PurchaseLogic?,
     internal val mode: PaywallMode,
     val dismissRequest: () -> Unit,
+    val replaceProductData: ReplaceProductData?,
 ) {
     companion object {
         private const val hashMultiplier = 31
@@ -63,10 +64,11 @@ class PaywallOptions internal constructor(
         purchaseLogic = builder.purchaseLogic,
         mode = builder.mode,
         dismissRequest = builder.dismissRequest,
+        replaceProductData = builder.replaceProductData,
     )
 
     // Only key fields that affect the paywall's identity and rendering logic are used in hashCode.
-    // Fields like fontProvider, listener, purchaseLogic, and dismissRequest are excluded because
+    // Fields like fontProvider, listener, purchaseLogic, dismissRequest, and replaceProductData are excluded because
     // they don't influence visual/structural uniqueness and may not be reliably hashable.
     override fun hashCode(): Int {
         var result = offeringSelection.offeringIdentifier.hashCode()
@@ -86,6 +88,7 @@ class PaywallOptions internal constructor(
             this.listener != other.listener -> false
             this.purchaseLogic != other.purchaseLogic -> false
             this.mode != other.mode -> false
+            this.replaceProductData != other.replaceProductData -> false
             else -> this.dismissRequest == other.dismissRequest
         }
     }
@@ -98,6 +101,7 @@ class PaywallOptions internal constructor(
         purchaseLogic: PurchaseLogic? = this.purchaseLogic,
         mode: PaywallMode = this.mode,
         dismissRequest: () -> Unit = this.dismissRequest,
+        replaceProductData: ReplaceProductData? = this.replaceProductData,
     ): PaywallOptions = PaywallOptions(
         offeringSelection = offeringSelection,
         shouldDisplayDismissButton = shouldDisplayDismissButton,
@@ -106,6 +110,7 @@ class PaywallOptions internal constructor(
         purchaseLogic = purchaseLogic,
         mode = mode,
         dismissRequest = dismissRequest,
+        replaceProductData = replaceProductData,
     )
 
     class Builder(
@@ -117,6 +122,7 @@ class PaywallOptions internal constructor(
         internal var listener: PaywallListener? = null
         internal var purchaseLogic: PurchaseLogic? = null
         internal var mode: PaywallMode = PaywallMode.default
+        internal var replaceProductData: ReplaceProductData? = null
 
         fun setOffering(offering: Offering?) = apply {
             this.offeringSelection = offering?.let { OfferingSelection.OfferingType(it) }
@@ -152,6 +158,13 @@ class PaywallOptions internal constructor(
 
         fun setPurchaseLogic(purchaseLogic: PurchaseLogic?) = apply {
             this.purchaseLogic = purchaseLogic
+        }
+
+        /**
+         * Sets [ReplaceProductData] to the builder to start the correct product upgrade flow.
+         */
+        fun setReplaceProductData(replaceProductData: ReplaceProductData?) = apply {
+            this.replaceProductData = replaceProductData
         }
 
         internal fun setMode(mode: PaywallMode) = apply {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ReplaceProductData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/ReplaceProductData.kt
@@ -1,0 +1,10 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import com.revenuecat.purchases.models.GoogleReplacementMode
+
+/**
+ * Data class used to start the correct product upgrade flow for paywalls.
+ * @param oldProductId Product ID (i.e. sku) for the previous subscription
+ * @param googleReplacementMode [GoogleReplacementMode] mode to be used for the upgrade flow
+ */
+data class ReplaceProductData(val oldProductId: String, val googleReplacementMode: GoogleReplacementMode)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -396,9 +396,12 @@ internal class PaywallViewModelImpl(
                                 "myAppPurchaseLogic.performPurchase will not be executed.",
                         )
                     }
-                    val purchaseResult = purchases.awaitPurchase(
-                        PurchaseParams.Builder(activity, packageToPurchase),
-                    )
+                    val purchaseParamBuilder = PurchaseParams.Builder(activity, packageToPurchase)
+                    options.replaceProductData?.let {
+                        purchaseParamBuilder.oldProductId(it.oldProductId)
+                        purchaseParamBuilder.googleReplacementMode(it.googleReplacementMode)
+                    }
+                    val purchaseResult = purchases.awaitPurchase(purchaseParamBuilder)
                     listener?.onPurchaseCompleted(purchaseResult.customerInfo, purchaseResult.storeTransaction)
                     Logger.d("Dismissing paywall after purchase")
                     options.dismissRequest()


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
As per this issue #2479 , setting the `GoogleReplacementMode` is currently not possible when using Paywalls v2. This PR allows developers to change the proration mode and pass the old purchase id to the purchasing flow.

### Description
* Add new `ReplaceProductData` data class
* Pass data to `PurchaseParamsBuilder` on purchase
* Extend `PaywallOptions` and `PaywallDialogOptions` to support new parameter
* Add tests in `PaywallViewModelTest` to verify correct parameters are passed to purchase flow

