### PR TITLE
Conditional visibility -- app version condition

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverride.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverride.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.components.PartialComponent
 import com.revenuecat.purchases.paywalls.components.common.ComponentOverride.Condition
 import com.revenuecat.purchases.utils.serializers.SealedDeserializerWithDefault
+import com.revenuecat.purchases.utils.serializers.VersionIntSerializer
 import dev.drewhamilton.poko.Poko
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -105,8 +106,9 @@ class ComponentOverride<T : PartialComponent>(
         @Serializable
         data class AppVersion(
             @SerialName("operator") val operator: ComparisonOperatorType,
-            // TODO Make a serializes that converts a string to an int, filtering by 0...9 and just keeping the #'s
-            @SerialName("android_version") val version: Int,
+            @SerialName("android_version")
+            @Serializable(with = VersionIntSerializer::class)
+            val version: Int,
         ) : Condition
 
         @Serializable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverride.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverride.kt
@@ -99,6 +99,16 @@ class ComponentOverride<T : PartialComponent>(
             @SerialName("packages") val packages: List<String>,
         ) : Condition
 
+        /**
+         * Compares the app version against the [version].
+         * */
+        @Serializable
+        data class AppVersion(
+            @SerialName("operator") val operator: ComparisonOperatorType,
+            // TODO Make a serializes that converts a string to an int, filtering by 0...9 and just keeping the #'s
+            @SerialName("android_version") val version: Int,
+        ) : Condition
+
         @Serializable
         enum class ArrayOperatorType {
             @SerialName("in")
@@ -115,6 +125,24 @@ class ComponentOverride<T : PartialComponent>(
 
             @SerialName("!=")
             NOT_EQUALS,
+        }
+
+        @Serializable
+        enum class ComparisonOperatorType {
+            @SerialName("=")
+            EQUALS,
+
+            @SerialName("<")
+            LESS_THAN,
+
+            @SerialName("<=")
+            LESS_THAN_OR_EQUAL_TO,
+
+            @SerialName(">")
+            GREATER_THAN,
+
+            @SerialName(">=")
+            GREATER_THAN_OR_EQUAL_TO,
         }
 
         @Serializable
@@ -140,6 +168,7 @@ internal object ConditionSerializer : SealedDeserializerWithDefault<Condition>(
         "orientation" to { Condition.Orientation.serializer() },
         "screen_size" to { Condition.ScreenSize.serializer() },
         "selected_package" to { Condition.SelectedPackage.serializer() },
+        "app_version" to { Condition.AppVersion.serializer() },
     ),
     defaultValue = { Condition.Unsupported },
 )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/VersionIntSerializer.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/serializers/VersionIntSerializer.kt
@@ -1,0 +1,34 @@
+package com.revenuecat.purchases.utils.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Serializer that converts version strings like "3.2.0" to integers like 320 by keeping only digits.
+ * Also handles integer inputs directly for backward compatibility.
+ */
+internal object VersionIntSerializer : KSerializer<Int> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("VersionInt", PrimitiveKind.INT)
+
+    override fun deserialize(decoder: Decoder): Int = (decoder as? JsonDecoder)?.let { jsonDecoder ->
+        val element = jsonDecoder.decodeJsonElement().jsonPrimitive
+
+        // If it's already an integer, return it directly
+        // Otherwise, treat it as a string and filter to digits only
+        element.intOrNull?.let { it }
+            ?: element.content.filter { it.isDigit() }.toIntOrNull()
+            ?: 0
+    } ?: decoder.decodeInt()
+
+    override fun serialize(encoder: Encoder, value: Int) {
+        encoder.encodeInt(value)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentOverridesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentOverridesTests.kt
@@ -129,6 +129,18 @@ internal class ComponentOverridesTests {
                                 "properties": {
                                   "font_name": "selected package font"
                                 }
+                              },
+                              {
+                                "conditions": [
+                                  {
+                                    "type": "app_version",
+                                    "operator": ">=",
+                                    "android_version": 200
+                                  }
+                                ],
+                                "properties": {
+                                  "font_name": "app version font"
+                                }
                               }
                             ]
                         """.trimIndent(),
@@ -217,6 +229,15 @@ internal class ComponentOverridesTests {
                                     )
                                 ),
                                 properties = PartialTextComponent(fontName = FontAlias("selected package font")),
+                            ),
+                            ComponentOverride(
+                                conditions = listOf(
+                                    ComponentOverride.Condition.AppVersion(
+                                        operator = ComponentOverride.Condition.ComparisonOperatorType.GREATER_THAN_OR_EQUAL_TO,
+                                        version = 200,
+                                    )
+                                ),
+                                properties = PartialTextComponent(fontName = FontAlias("app version font")),
                             ),
                         )
                     )
@@ -466,6 +487,42 @@ internal class ComponentOverridesTests {
                 arrayOf("{ \"type\": \"selected\" }", ComponentOverride.Condition.Selected),
                 arrayOf("{ \"type\": \"unsupported\" }", ComponentOverride.Condition.Unsupported),
                 arrayOf("{ \"type\": \"some_future_unknown_value\" }", ComponentOverride.Condition.Unsupported),
+                // AppVersion conditions with all comparison operators
+                arrayOf(
+                    "{ \"type\": \"app_version\", \"operator\": \"=\", \"android_version\": 100 }",
+                    ComponentOverride.Condition.AppVersion(
+                        operator = ComponentOverride.Condition.ComparisonOperatorType.EQUALS,
+                        version = 100,
+                    )
+                ),
+                arrayOf(
+                    "{ \"type\": \"app_version\", \"operator\": \"<\", \"android_version\": 200 }",
+                    ComponentOverride.Condition.AppVersion(
+                        operator = ComponentOverride.Condition.ComparisonOperatorType.LESS_THAN,
+                        version = 200,
+                    )
+                ),
+                arrayOf(
+                    "{ \"type\": \"app_version\", \"operator\": \"<=\", \"android_version\": 200 }",
+                    ComponentOverride.Condition.AppVersion(
+                        operator = ComponentOverride.Condition.ComparisonOperatorType.LESS_THAN_OR_EQUAL_TO,
+                        version = 200,
+                    )
+                ),
+                arrayOf(
+                    "{ \"type\": \"app_version\", \"operator\": \">\", \"android_version\": 100 }",
+                    ComponentOverride.Condition.AppVersion(
+                        operator = ComponentOverride.Condition.ComparisonOperatorType.GREATER_THAN,
+                        version = 100,
+                    )
+                ),
+                arrayOf(
+                    "{ \"type\": \"app_version\", \"operator\": \">=\", \"android_version\": 100 }",
+                    ComponentOverride.Condition.AppVersion(
+                        operator = ComponentOverride.Condition.ComparisonOperatorType.GREATER_THAN_OR_EQUAL_TO,
+                        version = 100,
+                    )
+                ),
             )
         }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentOverridesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentOverridesTests.kt
@@ -489,38 +489,59 @@ internal class ComponentOverridesTests {
                 arrayOf("{ \"type\": \"some_future_unknown_value\" }", ComponentOverride.Condition.Unsupported),
                 // AppVersion conditions with all comparison operators
                 arrayOf(
-                    "{ \"type\": \"app_version\", \"operator\": \"=\", \"android_version\": 100 }",
+                    "{ \"type\": \"app_version\", \"operator\": \"=\", \"android_version\": \"100\" }",
                     ComponentOverride.Condition.AppVersion(
                         operator = ComponentOverride.Condition.ComparisonOperatorType.EQUALS,
                         version = 100,
                     )
                 ),
                 arrayOf(
-                    "{ \"type\": \"app_version\", \"operator\": \"<\", \"android_version\": 200 }",
+                    "{ \"type\": \"app_version\", \"operator\": \"<\", \"android_version\": \"200\" }",
                     ComponentOverride.Condition.AppVersion(
                         operator = ComponentOverride.Condition.ComparisonOperatorType.LESS_THAN,
                         version = 200,
                     )
                 ),
                 arrayOf(
-                    "{ \"type\": \"app_version\", \"operator\": \"<=\", \"android_version\": 200 }",
+                    "{ \"type\": \"app_version\", \"operator\": \"<=\", \"android_version\": \"200\" }",
                     ComponentOverride.Condition.AppVersion(
                         operator = ComponentOverride.Condition.ComparisonOperatorType.LESS_THAN_OR_EQUAL_TO,
                         version = 200,
                     )
                 ),
                 arrayOf(
-                    "{ \"type\": \"app_version\", \"operator\": \">\", \"android_version\": 100 }",
+                    "{ \"type\": \"app_version\", \"operator\": \">\", \"android_version\": \"100\" }",
                     ComponentOverride.Condition.AppVersion(
                         operator = ComponentOverride.Condition.ComparisonOperatorType.GREATER_THAN,
                         version = 100,
                     )
                 ),
                 arrayOf(
-                    "{ \"type\": \"app_version\", \"operator\": \">=\", \"android_version\": 100 }",
+                    "{ \"type\": \"app_version\", \"operator\": \">=\", \"android_version\": \"100\" }",
                     ComponentOverride.Condition.AppVersion(
                         operator = ComponentOverride.Condition.ComparisonOperatorType.GREATER_THAN_OR_EQUAL_TO,
                         version = 100,
+                    )
+                ),
+                arrayOf(
+                    "{ \"type\": \"app_version\", \"operator\": \">=\", \"android_version\": \"3.2.0\" }",
+                    ComponentOverride.Condition.AppVersion(
+                        operator = ComponentOverride.Condition.ComparisonOperatorType.GREATER_THAN_OR_EQUAL_TO,
+                        version = 320,
+                    )
+                ),
+                arrayOf(
+                    "{ \"type\": \"app_version\", \"operator\": \"<\", \"android_version\": \"1.0.0-beta1\" }",
+                    ComponentOverride.Condition.AppVersion(
+                        operator = ComponentOverride.Condition.ComparisonOperatorType.LESS_THAN,
+                        version = 1001,
+                    )
+                ),
+                arrayOf(
+                    "{ \"type\": \"app_version\", \"operator\": \"=\", \"android_version\": \"0012.34.56\" }",
+                    ComponentOverride.Condition.AppVersion(
+                        operator = ComponentOverride.Condition.ComparisonOperatorType.EQUALS,
+                        version = 123456,
                     )
                 ),
             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PreviewHelpers.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PreviewHelpers.kt
@@ -304,6 +304,7 @@ internal fun Offering.validatePaywallComponentsDataOrNullForPreviews(): Result<P
             applicationName = "RevenueCatUI Previews",
             packageName = "com.revenuecat.purchases.ui.revenuecatui",
             resources = LocalContext.current.resources,
+            appVersionInt = null,
         ),
     )
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentState.kt
@@ -38,17 +38,20 @@ internal fun rememberUpdatedCarouselComponentState(
             hasAnyIntroOfferEligiblePackage = paywallState.hasAnyIntroOfferEligiblePackage,
             hasAnyMultipleIntroOffersEligiblePackage = paywallState.hasAnyMultipleIntroOffersEligiblePackage,
         ),
+        appVersionIntProvider = { paywallState.appVersionInt },
     )
 
 @Stable
 @JvmSynthetic
 @Composable
+@Suppress("LongParameterList")
 private fun rememberUpdatedCarouselComponentState(
     style: CarouselComponentStyle,
     selectedPackageProvider: () -> Package?,
     selectedTabIndexProvider: () -> Int,
     screenConditionProvider: () -> ScreenCondition,
     introOfferAvailability: IntroOfferAvailability,
+    appVersionIntProvider: () -> Int? = { null },
 ): CarouselComponentState {
     val screenCondition = screenConditionProvider()
 
@@ -59,6 +62,7 @@ private fun rememberUpdatedCarouselComponentState(
             selectedPackageProvider = selectedPackageProvider,
             selectedTabIndexProvider = selectedTabIndexProvider,
             introOfferAvailability = introOfferAvailability,
+            appVersionIntProvider = appVersionIntProvider,
         )
     }.apply {
         update(
@@ -74,6 +78,7 @@ internal class CarouselComponentState(
     private val selectedPackageProvider: () -> Package?,
     private val selectedTabIndexProvider: () -> Int,
     private val introOfferAvailability: IntroOfferAvailability,
+    private val appVersionIntProvider: () -> Int?,
 ) {
 
     private var screenConditionSnapshot by mutableStateOf(initialScreenCondition)
@@ -104,6 +109,7 @@ internal class CarouselComponentState(
             introOfferSnapshot = introOfferSnapshot,
             state = componentState,
             selectedPackageIdentifier = applicablePackage?.identifier,
+            appVersion = appVersionIntProvider(),
         )
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/iconcomponent/IconComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/iconcomponent/IconComponentState.kt
@@ -42,17 +42,20 @@ internal fun rememberUpdatedIconComponentState(
             hasAnyIntroOfferEligiblePackage = paywallState.hasAnyIntroOfferEligiblePackage,
             hasAnyMultipleIntroOffersEligiblePackage = paywallState.hasAnyMultipleIntroOffersEligiblePackage,
         ),
+        appVersionIntProvider = { paywallState.appVersionInt },
     )
 
 @Stable
 @JvmSynthetic
 @Composable
+@Suppress("LongParameterList")
 private fun rememberUpdatedIconComponentState(
     style: IconComponentStyle,
     selectedPackageProvider: () -> Package?,
     selectedTabIndexProvider: () -> Int,
     screenConditionProvider: () -> ScreenCondition,
     introOfferAvailability: IntroOfferAvailability = IntroOfferAvailability(),
+    appVersionIntProvider: () -> Int? = { null },
 ): IconComponentState {
     val screenCondition = screenConditionProvider()
     val layoutDirection = LocalLayoutDirection.current
@@ -65,6 +68,7 @@ private fun rememberUpdatedIconComponentState(
             selectedPackageProvider = selectedPackageProvider,
             selectedTabIndexProvider = selectedTabIndexProvider,
             introOfferAvailability = introOfferAvailability,
+            appVersionIntProvider = appVersionIntProvider,
         )
     }.apply {
         update(
@@ -81,6 +85,7 @@ internal class IconComponentState(
     private val selectedPackageProvider: () -> Package?,
     private val selectedTabIndexProvider: () -> Int,
     private val introOfferAvailability: IntroOfferAvailability,
+    private val appVersionIntProvider: () -> Int?,
 ) {
     private var screenConditionSnapshot by mutableStateOf(initialScreenCondition)
     private var layoutDirection by mutableStateOf(initialLayoutDirection)
@@ -109,6 +114,7 @@ internal class IconComponentState(
             introOfferSnapshot = introOfferSnapshot,
             state = componentState,
             selectedPackageIdentifier = applicablePackage?.identifier,
+            appVersion = appVersionIntProvider(),
         )
     }
     private val baseUrl: String by derivedStateOf {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/iconcomponent/IconComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/iconcomponent/IconComponentState.kt
@@ -78,6 +78,7 @@ private fun rememberUpdatedIconComponentState(
 }
 
 @Stable
+@Suppress("LongParameterList")
 internal class IconComponentState(
     initialScreenCondition: ScreenCondition,
     initialLayoutDirection: LayoutDirection,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/image/ImageComponentState.kt
@@ -59,6 +59,7 @@ internal fun rememberUpdatedImageComponentState(
             hasAnyIntroOfferEligiblePackage = paywallState.hasAnyIntroOfferEligiblePackage,
             hasAnyMultipleIntroOffersEligiblePackage = paywallState.hasAnyMultipleIntroOffersEligiblePackage,
         ),
+        appVersionIntProvider = { paywallState.appVersionInt },
     )
 
 @Stable
@@ -72,6 +73,7 @@ internal fun rememberUpdatedImageComponentState(
     selectedTabIndexProvider: () -> Int,
     screenConditionProvider: () -> ScreenCondition,
     introOfferAvailability: IntroOfferAvailability = IntroOfferAvailability(),
+    appVersionIntProvider: () -> Int? = { null },
 ): ImageComponentState {
     val screenCondition = screenConditionProvider()
     val density = LocalDensity.current
@@ -89,6 +91,7 @@ internal fun rememberUpdatedImageComponentState(
             selectedPackageProvider = selectedPackageProvider,
             selectedTabIndexProvider = selectedTabIndexProvider,
             introOfferAvailability = introOfferAvailability,
+            appVersionIntProvider = appVersionIntProvider,
         )
     }.apply {
         update(
@@ -112,6 +115,7 @@ internal class ImageComponentState(
     private val selectedPackageProvider: () -> Package?,
     private val selectedTabIndexProvider: () -> Int,
     private val introOfferAvailability: IntroOfferAvailability,
+    private val appVersionIntProvider: () -> Int?,
 ) {
     private var screenConditionSnapshot by mutableStateOf(initialScreenCondition)
     private val selected by derivedStateOf {
@@ -147,6 +151,7 @@ internal class ImageComponentState(
             introOfferSnapshot = introOfferSnapshot,
             state = componentState,
             selectedPackageIdentifier = applicablePackage?.identifier,
+            appVersion = appVersionIntProvider(),
         )
     }
     private val themeImageUrls: ThemeImageUrls by derivedStateOf {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
@@ -83,6 +83,7 @@ internal fun rememberUpdatedStackComponentState(
 }
 
 @Stable
+@Suppress("LongParameterList")
 internal class StackComponentState(
     initialScreenCondition: ScreenCondition,
     initialLayoutDirection: LayoutDirection,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentState.kt
@@ -46,17 +46,20 @@ internal fun rememberUpdatedStackComponentState(
             hasAnyIntroOfferEligiblePackage = paywallState.hasAnyIntroOfferEligiblePackage,
             hasAnyMultipleIntroOffersEligiblePackage = paywallState.hasAnyMultipleIntroOffersEligiblePackage,
         ),
+        appVersionIntProvider = { paywallState.appVersionInt },
     )
 
 @Stable
 @JvmSynthetic
 @Composable
+@Suppress("LongParameterList")
 internal fun rememberUpdatedStackComponentState(
     style: StackComponentStyle,
     selectedPackageProvider: () -> Package?,
     selectedTabIndexProvider: () -> Int,
     screenConditionProvider: () -> ScreenCondition,
     introOfferAvailability: IntroOfferAvailability = IntroOfferAvailability(),
+    appVersionIntProvider: () -> Int? = { null },
 ): StackComponentState {
     val layoutDirection = LocalLayoutDirection.current
     val screenCondition = screenConditionProvider()
@@ -69,6 +72,7 @@ internal fun rememberUpdatedStackComponentState(
             selectedPackageProvider = selectedPackageProvider,
             selectedTabIndexProvider = selectedTabIndexProvider,
             introOfferAvailability = introOfferAvailability,
+            appVersionIntProvider = appVersionIntProvider,
         )
     }.apply {
         update(
@@ -86,6 +90,7 @@ internal class StackComponentState(
     private val selectedPackageProvider: () -> Package?,
     private val selectedTabIndexProvider: () -> Int,
     private val introOfferAvailability: IntroOfferAvailability,
+    private val appVersionIntProvider: () -> Int?,
 ) {
     private var screenConditionSnapshot by mutableStateOf(initialScreenCondition)
     private var layoutDirection by mutableStateOf(initialLayoutDirection)
@@ -118,6 +123,7 @@ internal class StackComponentState(
             introOfferSnapshot = introOfferSnapshot,
             state = componentState,
             selectedPackageIdentifier = applicablePackage?.identifier,
+            appVersion = appVersionIntProvider(),
         )
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentState.kt
@@ -37,6 +37,7 @@ internal fun rememberUpdatedTabsComponentState(
             hasAnyIntroOfferEligiblePackage = paywallState.hasAnyIntroOfferEligiblePackage,
             hasAnyMultipleIntroOffersEligiblePackage = paywallState.hasAnyMultipleIntroOffersEligiblePackage,
         ),
+        appVersionIntProvider = { paywallState.appVersionInt },
     )
 
 @Stable
@@ -47,6 +48,7 @@ internal fun rememberUpdatedTabsComponentState(
     selectedPackageProvider: () -> Package?,
     screenConditionProvider: () -> ScreenCondition,
     introOfferAvailability: IntroOfferAvailability = IntroOfferAvailability(),
+    appVersionIntProvider: () -> Int? = { null },
 ): TabsComponentState {
     val screenCondition = screenConditionProvider()
 
@@ -56,6 +58,7 @@ internal fun rememberUpdatedTabsComponentState(
             style = style,
             selectedPackageProvider = selectedPackageProvider,
             introOfferAvailability = introOfferAvailability,
+            appVersionIntProvider = appVersionIntProvider,
         )
     }.apply {
         update(
@@ -70,6 +73,7 @@ internal class TabsComponentState(
     private val style: TabsComponentStyle,
     private val selectedPackageProvider: () -> Package?,
     private val introOfferAvailability: IntroOfferAvailability,
+    private val appVersionIntProvider: () -> Int?,
 ) {
     private var screenConditionSnapshot by mutableStateOf(initialScreenCondition)
 
@@ -90,6 +94,7 @@ internal class TabsComponentState(
             introOfferSnapshot = introOfferSnapshot,
             state = componentState,
             selectedPackageIdentifier = applicablePackage?.identifier,
+            appVersion = appVersionIntProvider(),
         )
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentState.kt
@@ -50,6 +50,7 @@ internal fun rememberUpdatedTextComponentState(
             hasAnyIntroOfferEligiblePackage = paywallState.hasAnyIntroOfferEligiblePackage,
             hasAnyMultipleIntroOffersEligiblePackage = paywallState.hasAnyMultipleIntroOffersEligiblePackage,
         ),
+        appVersionIntProvider = { paywallState.appVersionInt },
     )
 }
 
@@ -64,6 +65,7 @@ internal fun rememberUpdatedTextComponentState(
     selectedTabIndexProvider: () -> Int,
     screenConditionProvider: () -> ScreenCondition,
     introOfferAvailability: IntroOfferAvailability = IntroOfferAvailability(),
+    appVersionIntProvider: () -> Int? = { null },
 ): TextComponentState {
     val screenCondition = screenConditionProvider()
 
@@ -80,6 +82,7 @@ internal fun rememberUpdatedTextComponentState(
             selectedPackageProvider = selectedPackageProvider,
             selectedTabIndexProvider = selectedTabIndexProvider,
             introOfferAvailability = introOfferAvailability,
+            appVersionIntProvider = appVersionIntProvider,
         )
     }.apply {
         update(
@@ -97,6 +100,7 @@ internal class TextComponentState(
     private val selectedPackageProvider: () -> Package?,
     private val selectedTabIndexProvider: () -> Int,
     private val introOfferAvailability: IntroOfferAvailability,
+    private val appVersionIntProvider: () -> Int?,
 ) {
     private var screenConditionSnapshot by mutableStateOf(initialScreenCondition)
 
@@ -148,6 +152,7 @@ internal class TextComponentState(
             introOfferSnapshot = introOfferSnapshot,
             state = componentState,
             selectedPackageIdentifier = applicablePackage?.identifier,
+            appVersion = appVersionIntProvider(),
         )
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentState.kt
@@ -93,6 +93,7 @@ internal fun rememberUpdatedTextComponentState(
 }
 
 @Stable
+@Suppress("LongParameterList")
 internal class TextComponentState(
     initialScreenCondition: ScreenCondition,
     private val style: TextComponentStyle,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/timeline/TimelineComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/timeline/TimelineComponentState.kt
@@ -35,17 +35,20 @@ internal fun rememberUpdatedTimelineComponentState(
             hasAnyIntroOfferEligiblePackage = paywallState.hasAnyIntroOfferEligiblePackage,
             hasAnyMultipleIntroOffersEligiblePackage = paywallState.hasAnyMultipleIntroOffersEligiblePackage,
         ),
+        appVersionIntProvider = { paywallState.appVersionInt },
     )
 
 @Stable
 @JvmSynthetic
 @Composable
+@Suppress("LongParameterList")
 private fun rememberUpdatedTimelineComponentState(
     style: TimelineComponentStyle,
     selectedPackageProvider: () -> Package?,
     selectedTabIndexProvider: () -> Int,
     screenConditionProvider: () -> ScreenCondition,
     introOfferAvailability: IntroOfferAvailability = IntroOfferAvailability(),
+    appVersionIntProvider: () -> Int? = { null },
 ): TimelineComponentState {
     val screenCondition = screenConditionProvider()
 
@@ -56,6 +59,7 @@ private fun rememberUpdatedTimelineComponentState(
             selectedPackageProvider = selectedPackageProvider,
             selectedTabIndexProvider = selectedTabIndexProvider,
             introOfferAvailability = introOfferAvailability,
+            appVersionIntProvider = appVersionIntProvider,
         )
     }.apply {
         update(
@@ -71,6 +75,7 @@ internal class TimelineComponentState(
     private val selectedPackageProvider: () -> Package?,
     private val selectedTabIndexProvider: () -> Int,
     private val introOfferAvailability: IntroOfferAvailability,
+    private val appVersionIntProvider: () -> Int?,
 ) {
 
     private var screenConditionSnapshot by mutableStateOf(initialScreenCondition)
@@ -101,6 +106,7 @@ internal class TimelineComponentState(
             introOfferSnapshot = introOfferSnapshot,
             state = componentState,
             selectedPackageIdentifier = applicablePackage?.identifier,
+            appVersion = appVersionIntProvider(),
         )
     }
 
@@ -137,6 +143,7 @@ internal class TimelineComponentState(
                 selectedPackageProvider = selectedPackageProvider,
                 selectedTabIndexProvider = selectedTabIndexProvider,
                 introOfferAvailability = introOfferAvailability,
+                appVersionIntProvider = appVersionIntProvider,
             )
         }
     }
@@ -155,6 +162,7 @@ internal class TimelineComponentState(
         private val selectedPackageProvider: () -> Package?,
         private val selectedTabIndexProvider: () -> Int,
         private val introOfferAvailability: IntroOfferAvailability,
+        private val appVersionIntProvider: () -> Int?,
     ) {
 
         private var screenConditionSnapshot by mutableStateOf(initialScreenCondition)
@@ -185,6 +193,7 @@ internal class TimelineComponentState(
                 introOfferSnapshot = introOfferSnapshot,
                 state = componentState,
                 selectedPackageIdentifier = applicablePackage?.identifier,
+                appVersion = appVersionIntProvider(),
             )
         }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoComponentState.kt
@@ -54,6 +54,7 @@ internal class VideoComponentState(
     private val selectedPackageProvider: () -> com.revenuecat.purchases.Package?,
     private val selectedTabIndexProvider: () -> Int,
     private val introOfferAvailability: IntroOfferAvailability,
+    private val appVersionIntProvider: () -> Int?,
 ) {
     private val selected by derivedStateOf {
         if (style.rcPackage != null) {
@@ -88,6 +89,7 @@ internal class VideoComponentState(
             introOfferSnapshot = introOfferSnapshot,
             state = componentState,
             selectedPackageIdentifier = applicablePackage?.identifier,
+            appVersion = appVersionIntProvider(),
         )
     }
 
@@ -317,6 +319,7 @@ internal fun rememberUpdatedVideoComponentState(
             hasAnyIntroOfferEligiblePackage = paywallState.hasAnyIntroOfferEligiblePackage,
             hasAnyMultipleIntroOffersEligiblePackage = paywallState.hasAnyMultipleIntroOffersEligiblePackage,
         ),
+        appVersionIntProvider = { paywallState.appVersionInt },
     )
 
 @Stable
@@ -330,6 +333,7 @@ internal fun rememberUpdatedVideoComponentState(
     selectedTabIndexProvider: () -> Int,
     screenConditionProvider: () -> ScreenCondition,
     introOfferAvailability: IntroOfferAvailability = IntroOfferAvailability(),
+    appVersionIntProvider: () -> Int? = { null },
 ): VideoComponentState {
     val screenCondition = screenConditionProvider()
     val density = LocalDensity.current
@@ -346,6 +350,7 @@ internal fun rememberUpdatedVideoComponentState(
             selectedPackageProvider = selectedPackageProvider,
             selectedTabIndexProvider = selectedTabIndexProvider,
             introOfferAvailability = introOfferAvailability,
+            appVersionIntProvider = appVersionIntProvider,
         )
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -107,6 +107,11 @@ internal sealed interface PaywallState {
             initialSheetState: SimpleSheetState = SimpleSheetState(),
             private val purchases: PurchasesType,
             val screenSizes: List<UiConfig.AppConfig.ScreenSize>?,
+            /**
+             * The app version as an integer, derived from the version name by keeping only digits.
+             * For example: "3.2.0" -> 320. Used for conditional visibility based on app version.
+             */
+            val appVersionInt: Int? = null,
         ) : Loaded {
 
             var screenCondition by mutableStateOf(ScreenCondition())

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -526,6 +526,7 @@ internal class PaywallViewModelImpl(
                 storefrontCountryCode = storefrontCountryCode,
                 dateProvider = { Date() },
                 purchases = purchases,
+                appVersionInt = resourceProvider.getAppVersionInt(),
             )
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -483,6 +483,10 @@ internal class MockResourceProvider(
     override fun getAssetManager(): AssetManager? {
         return mockAssetManager
     }
+
+    override fun getAppVersionInt(): Int? {
+        return null
+    }
 }
 
 @Suppress("TooManyFunctions")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -307,6 +307,7 @@ internal fun Offering.toComponentsPaywallState(
     storefrontCountryCode: String?,
     dateProvider: () -> Date,
     purchases: PurchasesType,
+    appVersionInt: Int? = null,
 ): PaywallState.Loaded.Components {
     val showPricesWithDecimals = storefrontCountryCode?.let {
         !validationResult.zeroDecimalPlaceCountries.contains(it)
@@ -327,6 +328,7 @@ internal fun Offering.toComponentsPaywallState(
         initialSelectedTabIndex = validationResult.initialSelectedTabIndex,
         purchases = purchases,
         screenSizes = validationResult.screenSizes,
+        appVersionInt = appVersionInt,
     )
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallResourceProvider.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallResourceProvider.kt
@@ -30,16 +30,23 @@ internal interface ResourceProvider {
         fontInfo: UiConfig.AppConfig.FontsConfig.FontInfo.Name,
     ): DownloadedFontFamily?
     fun getAssetManager(): AssetManager?
+    fun getAppVersionInt(): Int?
 }
 
 internal class PaywallResourceProvider(
     private val applicationName: String,
     private val packageName: String,
     private val resources: Resources,
+    private val appVersionInt: Int?,
 ) : ResourceProvider {
     constructor(
         context: Context,
-    ) : this(context.applicationContext.applicationName(), context.packageName, context.resources)
+    ) : this(
+        context.applicationContext.applicationName(),
+        context.packageName,
+        context.resources,
+        context.versionInt,
+    )
 
     override fun getApplicationName(): String {
         return applicationName
@@ -112,6 +119,10 @@ internal class PaywallResourceProvider(
 
     override fun getAssetManager(): AssetManager? {
         return resources.assets
+    }
+
+    override fun getAppVersionInt(): Int? {
+        return appVersionInt
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/VersionUtils.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/VersionUtils.kt
@@ -1,0 +1,26 @@
+package com.revenuecat.purchases.ui.revenuecatui.helpers
+
+import android.content.Context
+
+/**
+ * Converts a version string to an integer by keeping only numeric characters.
+ * For example: "3.2.0" -> 320, "1.0.0-beta1" -> 1001
+ * Returns null if the resulting string is empty or cannot be parsed.
+ */
+internal fun String.toVersionInt(): Int? {
+    val digitsOnly = this.filter { it.isDigit() }
+    return digitsOnly.toIntOrNull()
+}
+
+/**
+ * Gets the app's version name from the package info.
+ */
+internal val Context.versionName: String?
+    get() = this.packageManager.getPackageInfo(this.packageName, 0).versionName
+
+/**
+ * Gets the app's version as an integer from the package info.
+ * Converts the version name to an integer by keeping only numeric characters.
+ */
+internal val Context.versionInt: Int?
+    get() = versionName?.toVersionInt()

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
@@ -34,6 +34,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
         val selectedPackageIdentifier: String? = null,
         val hasAnyIntroOfferEligiblePackage: Boolean = false,
         val hasAnyMultipleIntroOffersEligiblePackage: Boolean = false,
+        val appVersion: Int? = null,
     )
 
     @Suppress("LargeClass")
@@ -882,6 +883,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
             ),
             state = args.state,
             selectedPackageIdentifier = args.selectedPackageIdentifier,
+            appVersion = args.appVersion,
         )
 
         // Assert

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/ToVersionIntTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/ToVersionIntTests.kt
@@ -1,0 +1,42 @@
+package com.revenuecat.purchases.ui.revenuecatui.helpers
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class ToVersionIntTests(
+    @Suppress("UNUSED_PARAMETER") name: String,
+    private val input: String,
+    private val expected: Int?,
+) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun parameters(): Collection<Array<Any?>> = listOf(
+            arrayOf("simple version string", "1.0.0", 100),
+            arrayOf("version with single digits", "3.2.1", 321),
+            arrayOf("version with larger numbers", "12.34.56", 123456),
+            arrayOf("version with beta suffix", "1.0.0-beta1", 1001),
+            arrayOf("version with alpha suffix", "2.5.3-alpha", 253),
+            arrayOf("version with rc suffix", "1.2.3-rc1", 1231),
+            arrayOf("version with build number", "1.0.0+build123", 100123),
+            arrayOf("empty string", "", null),
+            arrayOf("only dots", "...", null),
+            arrayOf("only letters", "abc", null),
+            arrayOf("single digit", "1", 1),
+            arrayOf("two part version", "1.2", 12),
+            arrayOf("version with leading zeros", "01.02.03", 10203),
+            arrayOf("version with spaces", "1 . 2 . 3", 123),
+            arrayOf("version with v prefix", "v1.2.3", 123),
+        )
+    }
+
+    @Test
+    fun `toVersionInt converts version string to integer correctly`() {
+        val actual = input.toVersionInt()
+        assertThat(actual).isEqualTo(expected)
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation

As we evolve the conditional visibility feature and add new conditions, our users will likely wind up in a spot where their paywalls don't render in an expected way. We need to provide an option to allow them to account for old SDKs and to control how their paywall renders if they use newer conditions that old SDKs are unaware of.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

Adds the ability for users to create a condition that will only show the component for a given app version