### PR TITLE
Fix custom schemes on paywall purchase buttons

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -44,8 +44,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import java.net.MalformedURLException
-import java.net.URL
+import java.net.URI
+import java.net.URISyntaxException
 import java.util.Date
 import java.util.Locale
 import java.util.UUID
@@ -193,18 +193,18 @@ internal class PaywallViewModelImpl(
                 null to null
         }
         if (customUrl != null) {
-            val url = try {
-                URL(customUrl)
-            } catch (e: MalformedURLException) {
-                Logger.e("Invalid custom URL: $customUrl", e)
+            val uri = try {
+                URI(customUrl)
+            } catch (e: URISyntaxException) {
+                Logger.e("Invalid custom URI: $customUrl", e)
                 return null
             }
-            val finalUrl = if (packageParam != null && packageToUse != null) {
-                url.appendQueryParameter(packageParam, packageToUse.identifier)
+            val finalUri = if (packageParam != null && packageToUse != null) {
+                uri.appendQueryParameter(packageParam, packageToUse.identifier)
             } else {
-                url
+                uri
             }
-            return finalUrl.toString()
+            return finalUri.toString()
         }
         return packageToUse?.webCheckoutURL?.toString() ?: state.offering.webCheckoutURL.toString()
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URIExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URIExtensions.kt
@@ -1,0 +1,11 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.utils
+
+import java.net.URI
+
+@JvmSynthetic
+internal fun URI.appendQueryParameter(name: String, value: String): URI {
+    val separator = if (this.query == null) "?" else "&"
+    return URI("$this$separator$name=$value")
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URIExtensionsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URIExtensionsTest.kt
@@ -1,0 +1,36 @@
+package com.revenuecat.purchases.ui.revenuecatui.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.net.URI
+
+class URIExtensionsTest {
+
+    @Test
+    fun `appendQueryParameter appends parameter correctly to URI without existing query`() {
+        val uri = URI("https://example.com/path")
+        val updatedUri = uri.appendQueryParameter("key", "value")
+        assertEquals(updatedUri.toString(), "https://example.com/path?key=value")
+    }
+
+    @Test
+    fun `appendQueryParameter appends parameter correctly to URI with existing query`() {
+        val uri = URI("https://example.com/path?existing=param")
+        val updatedUri = uri.appendQueryParameter("key", "value")
+        assertEquals(updatedUri.toString(), "https://example.com/path?existing=param&key=value")
+    }
+
+    @Test
+    fun `appendQueryParameter works with custom URI schemes`() {
+        val uri = URI("revenuecatbilling://test")
+        val updatedUri = uri.appendQueryParameter("key", "value")
+        assertEquals(updatedUri.toString(), "revenuecatbilling://test?key=value")
+    }
+
+    @Test
+    fun `appendQueryParameter works with custom URI schemes and existing query`() {
+        val uri = URI("revenuecatbilling://test?rc_source=app")
+        val updatedUri = uri.appendQueryParameter("key", "value")
+        assertEquals(updatedUri.toString(), "revenuecatbilling://test?rc_source=app&key=value")
+    }
+}


### PR DESCRIPTION
### Description
If a user used a URL with a custom scheme in a purchase button deep link. It failed to parse using `URL`. Using `URI` instead to be more permissive.