### PR TITLE
Don't use reflection to instantiate AmazonDeviceIdentifiersFetcher

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/AttributionFetcherFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/AttributionFetcherFactory.kt
@@ -3,7 +3,6 @@ package com.revenuecat.purchases
 import com.revenuecat.purchases.amazon.attribution.AmazonDeviceIdentifiersFetcher
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.errorLog
-import com.revenuecat.purchases.common.subscriberattributes.DeviceIdentifiersFetcher
 import com.revenuecat.purchases.google.attribution.GoogleDeviceIdentifiersFetcher
 
 internal object AttributionFetcherFactory {


### PR DESCRIPTION
### Description
Follow-up PR from [this comment thread](https://github.com/RevenueCat/purchases-android/pull/2917#discussion_r2610896275) on PR https://github.com/RevenueCat/purchases-android/pull/2917.

We no longer need to use reflection to instantiate the `AmazonDeviceIdentifiersFetcher` class since it is now in the main module of the SDK, so this PR changes the `AmazonDeviceIdentifiersFetcher`'s instantiation from using reflection to using a normal constructor.