### PR TITLE
Change paywall preview recorder name template

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -776,7 +776,7 @@ DESC
       record_paparazzi_screenshots(gradle_module: ":ui:revenuecatui", tests: "PaywallComponentsTemplatePreviewRecorder", output_dir: tmp_dir)
       # Loop over all PNG files in the tmp_dir, parse the offering ID from the file names, and move them into the target repository.
       sh("find #{tmp_dir} -name '*.png'").split("\n").each do |file_path|
-        if file_path =~ /\>\>(.*?)\<\</
+        if file_path =~ /\_\_\_(.*?)\_\_\_/
           offering_id = $1
           target_dir = "#{target_repository_path}/screenshots/templates/#{offering_id}"
           sh("mkdir -p \"#{target_dir}\"")

--- a/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
+++ b/ui/revenuecatui/src/testDebug/kotlin/com/revenuecat/purchases/ui/revenuecatui/snapshottests/PaywallComponentsTemplatePreviewRecorder.kt
@@ -38,8 +38,8 @@ class PaywallComponentsTemplatePreviewRecorder internal constructor(
 
     companion object {
         @JvmStatic
-        // Placing the offering ID in inverted double diamond brackets so we can easily parse it later.
-        @Parameters(name = ">>{0}<<")
+        // Placing the offering ID between triple underscores so we can easily parse it later.
+        @Parameters(name = "___{0}___")
         fun data(): List<Array<Any>> {
             // The PaywallResourcesProvider uses an OfferingParser under the hood, which logs.
             // We have to replace the log handler, as the default one uses android.util.Log, which gives an


### PR DESCRIPTION
### Description
Looks like in Paparazzi 2.0.0-alpha, the current diamond bracket symbol is not allowed. Instead, using triple underscores.

This is extracted from #2446, but wanted to do this in a separate PR so we make sure the templates don't change in that PR when rendering them, which was harder to see with the rename in Emerge.