### PR TITLE
Implement GalaxyOfferingParser

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/OfferingParserFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/OfferingParserFactory.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases
 import com.revenuecat.purchases.common.GoogleOfferingParser
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.galaxy.GalaxyOfferingParser
 import com.revenuecat.purchases.simulatedstore.SimulatedStoreOfferingParser
 
 internal object OfferingParserFactory {
@@ -22,6 +23,7 @@ internal object OfferingParserFactory {
                     throw e
                 }
             }
+            Store.GALAXY -> GalaxyOfferingParser()
             else -> {
                 errorLog { "Incompatible store ($store) used" }
                 throw IllegalArgumentException("Couldn't configure SDK. Incompatible store ($store) used")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyOfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyOfferingParser.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.purchases.galaxy
+
+import com.revenuecat.purchases.common.OfferingParser
+import com.revenuecat.purchases.models.StoreProduct
+import org.json.JSONObject
+
+internal class GalaxyOfferingParser : OfferingParser() {
+    override fun findMatchingProduct(
+        productsById: Map<String, List<StoreProduct>>,
+        packageJson: JSONObject,
+    ): StoreProduct? {
+        val productIdentifier = packageJson.getString("platform_product_identifier")
+        return productsById[productIdentifier]?.firstOrNull()
+    }
+}


### PR DESCRIPTION
### Description
Without an offering parser for the Galaxy Store, the SDK will crash when configured with the Galaxy Store. This PR adds and registers a `GalaxyOfferingParser`, which has an implementation identical to the `AmazonOfferingParser`, since the Galaxy Store's products just have a product ID and no options.

In a follow-up PR into main, we should remove the reflection used to instantiate the `AmazonOfferingParser`.