### PR TITLE
Dont use reflection to instantiate AmazonOfferingParser

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/OfferingParserFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/OfferingParserFactory.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases
 
+import com.revenuecat.purchases.amazon.AmazonOfferingParser
 import com.revenuecat.purchases.common.GoogleOfferingParser
 import com.revenuecat.purchases.common.OfferingParser
 import com.revenuecat.purchases.common.errorLog
@@ -13,15 +14,7 @@ internal object OfferingParserFactory {
         return when (store) {
             Store.TEST_STORE -> SimulatedStoreOfferingParser()
             Store.PLAY_STORE -> GoogleOfferingParser()
-            Store.AMAZON -> {
-                try {
-                    Class.forName("com.revenuecat.purchases.amazon.AmazonOfferingParser")
-                        .getConstructor().newInstance() as OfferingParser
-                } catch (e: ClassNotFoundException) {
-                    errorLog(e) { "Make sure purchases-amazon is added as dependency" }
-                    throw e
-                }
-            }
+            Store.AMAZON -> AmazonOfferingParser()
             else -> {
                 errorLog { "Incompatible store ($store) used" }
                 throw IllegalArgumentException("Couldn't configure SDK. Incompatible store ($store) used")


### PR DESCRIPTION
### Description
We no longer need to use reflection to instantiate the `AmazonOfferingParser`, so this PR updates its instantiation to use a normal constructor.

Similar to https://github.com/RevenueCat/purchases-android/pull/2919