### PR TITLE
Only use obfuscated id during purchase when it is available

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/DefaultIAPHelperProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/DefaultIAPHelperProvider.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.galaxy
 
+import android.content.Context
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.galaxy.utils.GalaxySerialOperation
@@ -7,6 +8,7 @@ import com.samsung.android.sdk.iap.lib.constants.HelperDefine
 import com.samsung.android.sdk.iap.lib.helper.IapHelper
 import com.samsung.android.sdk.iap.lib.listener.OnGetProductsDetailsListener
 import com.samsung.android.sdk.iap.lib.listener.OnPaymentListener
+import com.samsung.android.sdk.iap.lib.util.HelperUtil
 
 internal class DefaultIAPHelperProvider(
     val iapHelper: IapHelper,
@@ -19,6 +21,10 @@ internal class DefaultIAPHelperProvider(
         iapHelper.setOperationMode(mode)
     }
 
+    override fun isObfuscatedIdAvailable(context: Context): Boolean {
+        return HelperUtil.isObfuscatedIdAvailable(context)
+    }
+
     @GalaxySerialOperation
     override fun getProductsDetails(
         productIDs: String,
@@ -27,6 +33,21 @@ internal class DefaultIAPHelperProvider(
         iapHelper.getProductsDetails(
             productIDs,
             onGetProductsDetailsListener,
+        )
+    }
+
+    @GalaxySerialOperation
+    override fun startPayment(
+        itemId: String,
+        onPaymentListener: OnPaymentListener,
+    ): Boolean {
+        // Return values:
+        // true: The request was sent to server successfully and the result will be sent
+        //       to OnPaymentListener interface listener.
+        // false: The request was not sent to server and was not processed.
+        return iapHelper.startPayment(
+            itemId,
+            onPaymentListener,
         )
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingWrapper.kt
@@ -49,6 +49,7 @@ internal class GalaxyBillingWrapper(
     private val purchaseHandler: PurchaseResponseListener =
         PurchaseHandler(
             iapHelper = iapHelperProvider,
+            context = context,
         ),
 ) : BillingAbstract(purchasesStateProvider = stateProvider) {
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/IAPHelperProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/IAPHelperProvider.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.galaxy
 
+import android.content.Context
 import com.revenuecat.purchases.galaxy.utils.GalaxySerialOperation
 import com.samsung.android.sdk.iap.lib.constants.HelperDefine
 import com.samsung.android.sdk.iap.lib.listener.OnGetProductsDetailsListener
@@ -11,11 +12,30 @@ internal interface IAPHelperProvider {
         mode: HelperDefine.OperationMode,
     )
 
+    /**
+     * Undocumented but public API that tells us if the obfuscated Id functionality is available.
+     */
+    fun isObfuscatedIdAvailable(context: Context): Boolean
+
     @GalaxySerialOperation
     fun getProductsDetails(
         productIDs: String,
         onGetProductsDetailsListener: OnGetProductsDetailsListener,
     )
+
+    /**
+     * Starts a purchase flow for the given product through Samsung IAP.
+     *
+     * @param itemId Galaxy Store product identifier.
+     * @param onPaymentListener Callback that receives purchase success or failure results.
+     * @return `true` if the request was dispatched to the store and a response will arrive
+     * through [OnPaymentListener]; `false` if the request could not be sent.
+     */
+    @GalaxySerialOperation
+    fun startPayment(
+        itemId: String,
+        onPaymentListener: OnPaymentListener
+    ): Boolean
 
     /**
      * Starts a purchase flow for the given product through Samsung IAP.

--- a/purchases/src/test/java/com/revenuecat/purchases/galaxy/handler/PurchaseHandlerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/galaxy/handler/PurchaseHandlerTest.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.galaxy.handler
 
+import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
@@ -27,6 +28,7 @@ class PurchaseHandlerTest {
     private lateinit var iapHelperProvider: IAPHelperProvider
     private lateinit var purchaseHandler: PurchaseHandler
     private lateinit var storeProduct: StoreProduct
+    private lateinit var context: Context
 
     private val appUserId = "user_id"
     private val onUnexpectedSuccess: (PurchaseVo) -> Unit = { fail("Expected onError to be called") }
@@ -35,7 +37,9 @@ class PurchaseHandlerTest {
     @BeforeTest
     fun setup() {
         iapHelperProvider = mockk(relaxed = true)
-        purchaseHandler = PurchaseHandler(iapHelperProvider)
+        context = mockk(relaxed = true)
+
+        purchaseHandler = PurchaseHandler(iapHelperProvider, context)
         storeProduct = mockk<StoreProduct> {
             every { id } returns "product_id"
         }


### PR DESCRIPTION
### Description
Modifies the Galaxy Store purchase flow to provide an obfuscated ID when the Samsung SDK's `HelperUtil.isObfuscatedIdAvailable()` says that the functionality is available.

`HelperUtil.isObfuscatedIdAvailable()` isn't documented, but is marked as publicly available.