### PR TITLE
Fix purchase callback not firing for DEFERRED product changes with baePlanId in oldProductId

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchaseParams.kt
@@ -118,6 +118,9 @@ class PurchaseParams(val builder: Builder) {
          * only. If a string including `:` is passed in, we will assume the string is in the form
          * `productId:basePlanId` and anything after the `:` will be ignored.
          *
+         * Note: When using [GoogleReplacementMode.DEFERRED], the product ID is used to match the purchase callback
+         * with the transaction returned by Google Play.
+         *
          * Product changes are only available in the Play Store. Ignored for Amazon Appstore purchases.
          */
         fun oldProductId(oldProductId: String) = apply {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -1486,8 +1486,16 @@ internal class PurchasesOrchestrator(
             if (!state.purchaseCallbacksByProductId.containsKey(purchasingData.productId)) {
                 // When using DEFERRED proration mode, callback needs to be associated with the *old* product we are
                 // switching from, because the transaction we receive on successful purchase is for the old product.
+                // We also need to normalize oldProductId by stripping any basePlanId suffix
+                // (e.g., "productId:basePlanId" becomes "productId") to ensure the callback key matches the productId
+                // in the transaction returned by Google Play, which only contains the product ID without the base plan.
                 val productId = if (googleReplacementMode == GoogleReplacementMode.DEFERRED) {
-                    oldProductId
+                    if (oldProductId.contains(Constants.SUBS_ID_BASE_PLAN_ID_SEPARATOR)) {
+                        warnLog {
+                            PurchaseStrings.DEFERRED_PRODUCT_CHANGE_WITH_BASE_PLAN_ID.format(oldProductId)
+                        }
+                    }
+                    oldProductId.substringBefore(Constants.SUBS_ID_BASE_PLAN_ID_SEPARATOR)
                 } else {
                     purchasingData.productId
                 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/PurchaseStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/PurchaseStrings.kt
@@ -59,4 +59,6 @@ internal object PurchaseStrings {
         "base product."
     const val PURCHASING_ADD_ONS_ONLY_SUPPORTED_ON_PLAY_STORE = "Making a purchase with add-ons is only supported on" +
         " the Play Store."
+    const val DEFERRED_PRODUCT_CHANGE_WITH_BASE_PLAN_ID = "Passing a basePlanId in oldProductId (%s) during a " +
+        "DEFERRED product change is not recommended. The basePlanId will be stripped automatically."
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -842,6 +842,65 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
     }
 
     @Test
+    fun `when making a deferred product change with basePlanId in oldProductId, completion is still called`() {
+        val newProductId = listOf("newproduct")
+        val storeProduct = mockStoreProduct(newProductId, newProductId, ProductType.SUBS)
+
+        // The transaction has just the productId, without basePlanId
+        val oldProductId = "oldProductId"
+        val oldPurchase = getMockedStoreTransaction(
+            productId = oldProductId,
+            purchaseToken = "another_purchase_token",
+            productType = ProductType.SUBS
+        )
+
+        // User passes oldProductId with basePlanId suffix
+        val oldProductIdWithBasePlan = "$oldProductId:basePlan"
+
+        every {
+            mockBillingAbstract.findPurchaseInPurchaseHistory(
+                appUserID = appUserId,
+                productType = ProductType.SUBS,
+                // The SDK should strip the basePlanId when looking up the purchase
+                productId = oldProductId,
+                onCompletion = captureLambda(),
+                onError = any()
+            )
+        } answers {
+            lambda<(StoreTransaction) -> Unit>().captured.invoke(oldPurchase)
+        }
+
+        mockQueryingProductDetails(oldPurchase.productIds.first(), ProductType.SUBS, null)
+        every {
+            mockPostReceiptHelper.postTransactionAndConsumeIfNeeded(
+                oldPurchase, any(), any(), isRestore = false, appUserId, initiationSource, captureLambda(), any(),
+            )
+        } answers {
+            lambda<SuccessfulPurchaseCallback>().captured.invoke(oldPurchase, mockk(relaxed = true))
+        }
+        val productChangeParams = getPurchaseParams(
+            storeProduct.first().subscriptionOptions!!.first(),
+            oldProductIdWithBasePlan,
+            googleReplacementMode = GoogleReplacementMode.DEFERRED,
+        )
+        var callCount = 0
+        purchases.purchaseWith(
+            productChangeParams,
+            onError = { _, _ ->
+                fail("should be successful")
+            },
+            onSuccess = { purchase, _ ->
+                callCount++
+                assertThat(purchase).isEqualTo(oldPurchase)
+            }
+        )
+        // The transaction returned by Google has just the productId without basePlanId
+        capturedPurchasesUpdatedListener.captured.onPurchasesUpdated(listOf(oldPurchase))
+        // The callback should still be called because we strip the basePlanId when storing the callback
+        assertThat(callCount).isEqualTo(1)
+    }
+
+    @Test
     fun `upgrade defaults to ProrationMode IMMEDIATE_WITHOUT_PRORATION`() {
         val productId = "gold"
         val oldSubId = "oldSubID"


### PR DESCRIPTION
### Motivation
Fixes an issue where the purchase callback would never fire when performing a product change using `GoogleReplacementMode.DEFERRED` if the `oldProductId` contained a base plan ID suffix (e.g., `"productId:basePlanId"`).

Addresses https://github.com/RevenueCat/purchases-android/issues/2874

### Description

#### Root Cause

When using DEFERRED proration mode:
1. The callback was stored using the raw `oldProductId` (which could include `:basePlanId`)
2. Google Play returns a transaction containing only the product ID (without base plan)
3. The callback lookup failed because `"productId"` ≠ `"productId:basePlanId"`
