### PR TITLE
Adds `.kotlin` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,5 @@ purchases-android-snapshots
 # Make sure we share the same Detekt IntelliJ plugin settings
 !.idea/detekt.xml
 
-# Kotlin error logs
-.kotlin/errors/
+# Kotlin Gradle plugin
+.kotlin


### PR DESCRIPTION
## Description

The entire `.kotlin` directory should be gitignored. See the [docs](https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects):
> Do not commit the .kotlin directory to version control. For example, if you are using Git, add .kotlin to your project's .gitignore file.