### PR TITLE
Potential fix for variable not rendering until paywall interaction

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt
@@ -204,7 +204,7 @@ internal sealed interface PaywallState {
                 private set
 
             private val initialSelectedPackage = initialSelectedPackageOutsideTabs
-                ?: initialSelectedTabIndex?.let { selectedPackageByTab[it] }
+                ?: selectedPackageByTab[selectedTabIndex]
 
             private var selectedPackage by mutableStateOf(initialSelectedPackage)
 


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->


Price variables such as `{{ product.price_per_week }}` were displayed as literal text on initial paywall render, then correctly resolved after user interaction (e.g., tapping a tab, switch, or package).


### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->


## Root Cause

A logic inconsistency in `PaywallState.kt` where `selectedTabIndex` and `initialSelectedPackage` used different null-handling strategies for the `initialSelectedTabIndex` parameter.

### The Problem

```kotlin
// Line 203: Correctly defaults to 0 when initialSelectedTabIndex is null
var selectedTabIndex by mutableIntStateOf(initialSelectedTabIndex ?: 0)

// Lines 206-207: Uses ?.let which short-circuits when initialSelectedTabIndex is null
private val initialSelectedPackage = initialSelectedPackageOutsideTabs
    ?: initialSelectedTabIndex?.let { selectedPackageByTab[it] }  // BUG: Returns null!
```

When `initialSelectedTabIndex` is `null` (which occurs when a `TabsComponent` has no `defaultTabId` set):

| Variable | Value | Explanation |
|----------|-------|-------------|
| `selectedTabIndex` | `0` | Correctly defaults via `?: 0` |
| `initialSelectedTabIndex?.let { ... }` | `null` | `?.let` short-circuits on null receiver |
| `initialSelectedPackage` | `null` | Even though `selectedPackageByTab[0]` has a valid package |

### Impact

1. `selectedPackage` initialized to `null`
2. `selectedPackageInfo` becomes `null`
3. `TextComponentState.applicablePackage` becomes `null`
4. Variable processing is skipped in `TextComponentView.rememberProcessedText()`
5. Literal template text `{{ product.price_per_week }}` is displayed

After user interaction, `update()` is called with proper fallback logic that finds the package, triggering recomposition and correct variable processing.

## Fix

**File:** `ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallState.kt`

**Before:**
```kotlin
private val initialSelectedPackage = initialSelectedPackageOutsideTabs
    ?: initialSelectedTabIndex?.let { selectedPackageByTab[it] }
```

**After:**
```kotlin
private val initialSelectedPackage = initialSelectedPackageOutsideTabs
    ?: selectedPackageByTab[selectedTabIndex]
```

This ensures the package lookup uses `selectedTabIndex` (which already defaults to `0`) instead of relying on the nullable `initialSelectedTabIndex`.

## Affected Scenarios

Paywalls where:
- A `TabsComponent` exists without an explicit `defaultTabId`
- Text components with product variables are rendered outside of a `PackageComponent`
- The text relies on `selectedPackageProvider()` for package context

