### PR TITLE
Load Samsung IAP aar from libs Directory

### DIFF
--- a/feature/galaxy/build.gradle.kts
+++ b/feature/galaxy/build.gradle.kts
@@ -1,5 +1,3 @@
-import java.io.FileInputStream
-import java.util.Properties
 
 plugins {
     id("revenuecat-public-library")
@@ -26,26 +24,10 @@ android {
     }
 }
 
-// TO DO: Bring in Samsung SDK from somewhere else
-val samsungIapAar: File? =
-    sequenceOf(
-        providers.gradleProperty("samsungIapSdkPath").orNull,
-        providers.environmentVariable("SAMSUNG_IAP_SDK_PATH").orNull,
-        rootProject.file("../samsung-iap-6.5.0.aar").takeIf { it.exists() }?.path,
-    )
-        .firstOrNull { !it.isNullOrBlank() }
-        ?.let { path ->
-            val aar = file(path)
-            check(aar.exists()) {
-                "Samsung IAP SDK AAR not found at $path. Override with samsungIapSdkPath property, " +
-                    "SAMSUNG_IAP_SDK_PATH env var, or local.properties"
-            }
-            aar
-        }
-
 dependencies {
     implementation(project(":purchases"))
 
-    compileOnly(files(samsungIapAar))
+    compileOnly("com.samsung.iap:samsung-iap:6.5.0@aar")
     testImplementation(libs.bundles.test)
+    testImplementation("com.samsung.iap:samsung-iap:6.5.0@aar")
 }

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -160,23 +160,6 @@ fun obtainTestBuildType(): String =
         "debug"
     }
 
-// TO DO: Bring in Samsung SDK from somewhere else
-val samsungIapAar: File? =
-    sequenceOf(
-        providers.gradleProperty("samsungIapSdkPath").orNull,
-        providers.environmentVariable("SAMSUNG_IAP_SDK_PATH").orNull,
-        rootProject.file("../samsung-iap-6.5.0.aar").takeIf { it.exists() }?.path,
-    )
-        .firstOrNull { !it.isNullOrBlank() }
-        ?.let { path ->
-            val aar = file(path)
-            check(aar.exists()) {
-                "Samsung IAP SDK AAR not found at $path. Override with samsungIapSdkPath property, " +
-                    "SAMSUNG_IAP_SDK_PATH env var, or local.properties"
-            }
-            aar
-        }
-
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
@@ -195,7 +178,7 @@ dependencies {
 
     compileOnly(libs.compose.annotations)
     compileOnly(libs.amazon.appstore.sdk)
-    compileOnly(files(samsungIapAar))
+    compileOnly("com.samsung.iap:samsung-iap:6.5.0@aar")
     compileOnly(libs.coil.base)
 
     debugImplementation(libs.androidx.annotation.experimental)
@@ -208,7 +191,7 @@ dependencies {
     "testBc7Implementation"(libs.billing.bc7)
     testImplementation(libs.coroutines.test)
     testImplementation(libs.amazon.appstore.sdk)
-    samsungIapAar?.let { testImplementation(files(it)) }
+    testImplementation("com.samsung.iap:samsung-iap:6.5.0@aar")
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.playServices.ads.identifier)
     testImplementation(libs.testJUnitParams)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,12 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 
+    val samsungIapSdkDir: File = run {
+        val fromProp = gradle.startParameter.projectProperties["samsungIapSdkDir"]
+        val fromEnv = System.getenv("SAMSUNG_IAP_SDK_DIR")
+        file(fromProp ?: fromEnv ?: "$rootDir/libs")
+    }
+
     repositories {
         // fetch plugins from google maven (https://maven.google.com)
         google {
@@ -49,6 +55,11 @@ dependencyResolutionManagement {
 
         // fallback for the rest of the dependencies
         mavenCentral()
+
+        // Local Samsung IAP SDK AAR
+        flatDir {
+            dirs(samsungIapSdkDir)
+        }
     }
 }
 


### PR DESCRIPTION
### Description
This PR switches the Samsung IAP library loading mechanism from a `local.properties` path dependency to a relative directory lookup. This ensures that the Samsung SDK is correctly resolved when building the SDK or purchase-tester.

To add the Samsung SDK to the RevenueCat SDK:
1. Clone the `samsung-dev` branch of `purchases-android`
2. Place the Samsung IAP SDK's `aar` file in the `purchases-android/libs` directory

This is likely not the final iteration of how we will include the Samsung SDK with the RC SDK, but it unblocks apps that want to try out the dev branch as it stands today.