### PR TITLE
Add annotation ExperimentalRevenueCatAPI

### DIFF
--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -171,7 +171,7 @@ class Purchases internal constructor(
      * The AdTracker used to track ad attribution data.
      */
     @get:JvmSynthetic
-    @InternalRevenueCatAPI
+    @ExperimentalRevenueCatAPI
     val adTracker: AdTracker
         get() = purchasesOrchestrator.adTracker
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ExperimentalRevenueCatAPI.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ExperimentalRevenueCatAPI.kt
@@ -1,0 +1,25 @@
+package com.revenuecat.purchases
+
+/**
+ * This annotation marks the experimental RevenueCat API.
+ * This API is in an experimental state and may change in future versions.
+ *
+ * Any usage of a declaration annotated with `@ExperimentalRevenueCatAPI` must be
+ * accepted either by annotating that usage with the [OptIn] annotation,
+ * e.g. `@OptIn(ExperimentalRevenueCatAPI::class)`, or by using the compiler argument
+ * `-Xopt-in=com.revenuecat.purchases.ExperimentalRevenueCatAPI`.
+ */
+@Retention(value = AnnotationRetention.BINARY)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This is an experimental RevenueCat API that may change in future versions. " +
+        "Use with caution.",
+)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.TYPEALIAS,
+    AnnotationTarget.CONSTRUCTOR,
+)
+annotation class ExperimentalRevenueCatAPI

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/AdEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/AdEvent.kt
@@ -1,9 +1,9 @@
-@file:OptIn(InternalRevenueCatAPI::class)
+@file:OptIn(ExperimentalRevenueCatAPI::class)
 @file:Suppress("LongParameterList")
 
 package com.revenuecat.purchases.ads.events
 
-import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ExperimentalRevenueCatAPI
 import com.revenuecat.purchases.ads.events.types.AdMediatorName
 import com.revenuecat.purchases.ads.events.types.AdRevenuePrecision
 import com.revenuecat.purchases.common.events.BackendEvent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/AdTracker.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/AdTracker.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.ads.events
 
-import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ExperimentalRevenueCatAPI
 import com.revenuecat.purchases.ads.events.types.AdDisplayedData
 import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData
 import com.revenuecat.purchases.ads.events.types.AdLoadedData
@@ -11,7 +11,7 @@ import com.revenuecat.purchases.common.events.EventsManager
 /**
  * Tracks ad-related events such as ad displays, opens, and revenue.
  */
-@InternalRevenueCatAPI
+@ExperimentalRevenueCatAPI
 class AdTracker internal constructor(
     private val eventsManager: EventsManager,
 ) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdDisplayedData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdDisplayedData.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.ads.events.types
 
-import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ExperimentalRevenueCatAPI
 import dev.drewhamilton.poko.Poko
 
 /**
@@ -12,7 +12,7 @@ import dev.drewhamilton.poko.Poko
  * @property adUnitId The ad unit ID.
  * @property impressionId The impression ID.
  */
-@InternalRevenueCatAPI
+@ExperimentalRevenueCatAPI
 @Poko
 class AdDisplayedData(
     val networkName: String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdFailedToLoadData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdFailedToLoadData.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.ads.events.types
 
-import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ExperimentalRevenueCatAPI
 import dev.drewhamilton.poko.Poko
 
 /**
@@ -12,7 +12,7 @@ import dev.drewhamilton.poko.Poko
  * @property adUnitId The ad unit ID.
  * @property mediatorErrorCode The mediator error code.
  */
-@InternalRevenueCatAPI
+@ExperimentalRevenueCatAPI
 @Poko
 class AdFailedToLoadData(
     val networkName: String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdLoadedData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdLoadedData.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.ads.events.types
 
-import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ExperimentalRevenueCatAPI
 import dev.drewhamilton.poko.Poko
 
 /**
@@ -12,7 +12,7 @@ import dev.drewhamilton.poko.Poko
  * @property adUnitId The ad unit ID.
  * @property impressionId The impression ID.
  */
-@InternalRevenueCatAPI
+@ExperimentalRevenueCatAPI
 @Poko
 class AdLoadedData(
     val networkName: String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdMediatorName.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdMediatorName.kt
@@ -1,11 +1,11 @@
 package com.revenuecat.purchases.ads.events.types
 
-import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ExperimentalRevenueCatAPI
 
 /**
  * Common ad mediator names.
  */
-@InternalRevenueCatAPI
+@ExperimentalRevenueCatAPI
 @JvmInline
 value class AdMediatorName internal constructor(internal val value: String) {
     companion object {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdOpenedData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdOpenedData.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.ads.events.types
 
-import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ExperimentalRevenueCatAPI
 import dev.drewhamilton.poko.Poko
 
 /**
@@ -12,7 +12,7 @@ import dev.drewhamilton.poko.Poko
  * @property adUnitId The ad unit ID.
  * @property impressionId The impression ID.
  */
-@InternalRevenueCatAPI
+@ExperimentalRevenueCatAPI
 @Poko
 class AdOpenedData(
     val networkName: String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdRevenueData.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdRevenueData.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.ads.events.types
 
-import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ExperimentalRevenueCatAPI
 import dev.drewhamilton.poko.Poko
 
 /**
@@ -15,7 +15,7 @@ import dev.drewhamilton.poko.Poko
  * @property currency The currency code for the revenue (e.g., "USD").
  * @property precision The precision of the revenue value. See [AdRevenuePrecision].
  */
-@InternalRevenueCatAPI
+@ExperimentalRevenueCatAPI
 @Poko
 class AdRevenueData(
     val networkName: String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdRevenuePrecision.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/ads/events/types/AdRevenuePrecision.kt
@@ -1,11 +1,11 @@
 package com.revenuecat.purchases.ads.events.types
 
-import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ExperimentalRevenueCatAPI
 
 /**
  * Common ad revenue precision values.
  */
-@InternalRevenueCatAPI
+@ExperimentalRevenueCatAPI
 @JvmInline
 value class AdRevenuePrecision internal constructor(internal val value: String) {
     companion object {


### PR DESCRIPTION
## Summary
Adds new annotation ExperimentalRevenueCatAPI.

## Changes
- **Created** new `ExperimentalRevenueCatAPI` annotation with `RequiresOptIn.Level.ERROR`
- **Updated** all ad events tracking classes and types to use `@ExperimentalRevenueCatAPI`:
  - `AdTracker` - Main tracking class
  - `AdEvent` and all event types (Displayed, Opened, Revenue, Loaded, FailedToLoad)
  - Data classes: `AdDisplayedData`, `AdRevenueData`, `AdLoadedData`, `AdOpenedData`, `AdFailedToLoadData`
  - Supporting types: `AdMediatorName`, `AdRevenuePrecision`
- **Updated** `Purchases.adTracker` property to use `@ExperimentalRevenueCatAPI`

## Testing
- All existing tests continue to pass without modification
- No behavioral changes, only annotation updates