### PR TITLE
Fix crash when context.cacheDir is null in FontLoader

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/FontLoaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/FontLoaderTest.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.UiConfig.AppConfig.FontsConfig.FontInfo
 import com.revenuecat.purchases.paywalls.components.properties.FontStyle
 import com.revenuecat.purchases.utils.TestUrlConnection
 import com.revenuecat.purchases.utils.TestUrlConnectionFactory
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
@@ -207,6 +208,40 @@ class FontLoaderTest {
                 FontToVerify(700, FontStyle.NORMAL, font2Content)
             )
         )
+    }
+
+    @Test
+    fun `getCachedFontFileOrStartDownload handles null cacheDir gracefully`() = runTest {
+        val contextWithNullCacheDir = mockk<Context> {
+            every { cacheDir } returns null
+        }
+        urlConnectionFactory = TestUrlConnectionFactory(
+            mockedConnections = mapOf(
+                FONT_URL to TestUrlConnection(
+                    responseCode = HttpURLConnection.HTTP_OK,
+                    inputStream = ByteArrayInputStream(FONT_FILE_CONTENT.toByteArray())
+                )
+            ),
+        )
+        fontLoader = FontLoader(
+            context = contextWithNullCacheDir,
+            providedCacheDir = null,
+            ioScope = testScope,
+            urlConnectionFactory = urlConnectionFactory,
+        )
+
+        // Should not crash, just return null and not attempt download
+        val result = fontLoader.getCachedFontFamilyOrStartDownload(fontInfo)
+        assertNull(result)
+
+        testScope.advanceUntilIdle()
+
+        // Should still be null since no download could happen
+        val result2 = fontLoader.getCachedFontFamilyOrStartDownload(fontInfo)
+        assertNull(result2)
+
+        // No connections should have been created since cacheDir was null
+        assertEquals(0, urlConnectionFactory.createdConnections.size)
     }
 
     private fun createFontInfo(


### PR DESCRIPTION
On some devices looks like especially Samsung and Android 16 maybe with aggressive battery optimization, context.cacheDir can return null when the app is in the background. 

This caused a `NullPointerException` at `FontLoader.kt:36.

This PR handles null `cacheDir` gracefully by logging an error and skipping the font download instead of crashing. The paywall will fall back to system fonts in this edge case.

This is the reported stacktrace:

```
 Fatal Exception: java.lang.NullPointerException:
at kotlin.UnsafeLazyImpl.getValue(Lazy.kt:98)
at com.revenuecat.purchases.paywalls.FontLoader.getCacheDirectory(FontLoader.kt:36)
at com.revenuecat.purchases.paywalls.FontLoader.ensureFoldersExist(FontLoader.kt:164)
at com.revenuecat.purchases.paywalls.FontLoader.access$getContext$p(FontLoader.kt:27)
at com.revenuecat.purchases.paywalls.FontLoader.access$ensureFoldersExist(FontLoader.kt:27)
at com.revenuecat.purchases.paywalls.FontLoader$startFontDownload$1.invokeSuspend(FontLoader.kt:77)
at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:124)
at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
```

And the stats:

```
Devices: 65% Samsung
Operating systems: 42% Android 16
Device states: 81% background
```