### PR TITLE
Improve event tracking reliability

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -493,7 +493,7 @@ internal class PurchasesFactory(
         override fun newThread(r: Runnable?): Thread {
             val wrapperRunnable = Runnable {
                 r?.let {
-                    android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_BACKGROUND)
+                    android.os.Process.setThreadPriority(Thread.NORM_PRIORITY)
                     r.run()
                 }
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -275,7 +275,7 @@ internal class PurchasesOrchestrator(
         log(LogIntent.DEBUG) { ConfigureStrings.APP_BACKGROUNDED }
         appConfig.isAppBackgrounded = true
         synchronizeSubscriberAttributesIfNeeded()
-        flushPaywallEvents(Delay.NONE)
+        flushEvents(Delay.NONE)
     }
 
     /** @suppress */
@@ -311,7 +311,7 @@ internal class PurchasesOrchestrator(
             postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount)
             synchronizeSubscriberAttributesIfNeeded()
             offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
-            flushPaywallEvents(Delay.DEFAULT)
+            flushEvents(Delay.DEFAULT)
             if (firstTimeInForeground && isAndroidNOrNewer()) {
                 diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
             }
@@ -322,6 +322,10 @@ internal class PurchasesOrchestrator(
         if (appConfig.showInAppMessagesAutomatically) {
             showInAppMessagesIfNeeded(activity, InAppMessageType.values().toList())
         }
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        flushEvents(Delay.NONE)
     }
 
     fun redeemWebPurchase(
@@ -1304,7 +1308,7 @@ internal class PurchasesOrchestrator(
                 )
 
                 // Synchronize paywall events after a new purchase
-                flushPaywallEvents(Delay.NONE)
+                flushEvents(Delay.NONE)
             }
 
             override fun onPurchasesFailedToUpdate(purchasesError: PurchasesError) {
@@ -1589,7 +1593,7 @@ internal class PurchasesOrchestrator(
         subscriberAttributesManager.synchronizeSubscriberAttributesForAllUsers(appUserID)
     }
 
-    private fun flushPaywallEvents(delay: Delay) {
+    private fun flushEvents(delay: Delay) {
         eventsManager.flushEvents(delay)
         adEventsManager.flushEvents(delay)
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/EventsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/EventsManager.kt
@@ -203,12 +203,12 @@ internal class EventsManager(
                 return@enqueue
             }
 
+            flushNextBatch(batchNumber = 1, delay = delay)
+
             if (!legacyFlushTriggered) {
                 legacyFlushTriggered = true
                 flushLegacyEvents()
             }
-
-            flushNextBatch(batchNumber = 1, delay = delay)
         }
     }
 


### PR DESCRIPTION
### Description
This modifies a few aspecs of our event tracking infrastructure to improve its reliability:
- It flushes events on any activity onPause, in addition to the application onStop.
- It increases the priority of the thread uses to flush events to a normal priority (before it was background priority).
- Changes the order of operations to flush events before flushing legacy events.