### PR TITLE
Fix SDK size testing app version

### DIFF
--- a/test-apps/sdksizetesting/gradle/libs.versions.toml
+++ b/test-apps/sdksizetesting/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.12.2"
 composeBom = "2024.09.00"
-purchases = "9.18.0-SNAPSHOT"
+purchases = "9.19.0-SNAPSHOT"
 emergeGradlePlugin = "4.4.0"
 
 [libraries]


### PR DESCRIPTION
### Description
Looks like there was a mixup between merging #2956 and the latest version being released, causing the version in this app to be wrong, making tests fail in main. This should fix it and get updated for versions moving forward.