### PR TITLE
Improve error messages when displaying `CustomerCenterActivity` or `PaywallActivity` from other sources

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
@@ -20,9 +20,11 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallActivityLauncher
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResultHandler
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.ShowCustomerCenter
 
 class MainActivity : ComponentActivity(), PaywallResultHandler {
     private lateinit var paywallActivityLauncher: PaywallActivityLauncher
+    private val customerCenter = registerForActivityResult(ShowCustomerCenter()) {}
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -48,6 +50,10 @@ class MainActivity : ComponentActivity(), PaywallResultHandler {
 
     fun launchPaywall(offering: Offering? = null, edgeToEdge: Boolean = false) {
         paywallActivityLauncher.launch(offering, edgeToEdge = edgeToEdge)
+    }
+
+    fun launchCustomerCenter() {
+        customerCenter.launch(Unit)
     }
 
     fun launchPaywallFooterViewAsActivity(offering: Offering? = null) {

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.paywallstester.Constants
+import com.revenuecat.paywallstester.MainActivity
 import com.revenuecat.paywallstester.ui.screens.main.appinfo.AppInfoScreenViewModel.UiState
 import com.revenuecat.paywallstester.ui.screens.main.createCustomerCenterListener
 import com.revenuecat.purchases.ui.debugview.DebugRevenueCatBottomSheet
@@ -77,6 +78,7 @@ fun AppInfoScreen(
         verticalArrangement = Arrangement.Center,
     ) {
         val state by viewModel.state.collectAsState()
+        val activity = LocalContext.current as MainActivity
         val currentUserID by remember { derivedStateOf { state.appUserID } }
         val currentApiKeyDescription by remember { derivedStateOf { state.apiKeyDescription } }
         val currentActiveEntitlements by remember { derivedStateOf { state.activeEntitlements } }
@@ -105,6 +107,11 @@ fun AppInfoScreen(
             showCustomerCenterView = true
         }) {
             Text(text = "Customer Center (per-view Listener)")
+        }
+        Button(onClick = {
+            activity.launchCustomerCenter()
+        }) {
+            Text(text = "Customer Center (Activity)")
         }
         Spacer(modifier = Modifier.weight(1f))
         Button(onClick = { viewModel.refresh() }) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.googlefonts.Font
 import androidx.compose.ui.text.googlefonts.GoogleFont
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.models.StoreTransaction
@@ -99,6 +100,14 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
         restoreSdkConfigurationIfNeeded(this, savedInstanceState)
 
         val args = getArgs()
+        val wasLaunchedThroughSDK = args?.wasLaunchedThroughSDK ?: false
+        if (!wasLaunchedThroughSDK && !Purchases.isConfigured) {
+            throw IllegalStateException(
+                "PaywallActivity was not launched through the SDK. " +
+                    "Please use the SDK methods to open the Paywall.",
+            )
+        }
+
         val edgeToEdge = args?.edgeToEdge == true
         if (edgeToEdge) {
             enableEdgeToEdge()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityArgs.kt
@@ -18,6 +18,7 @@ internal data class PaywallActivityArgs(
     val fonts: Map<TypographyType, PaywallFontFamily?>? = null,
     val shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
     val edgeToEdge: Boolean = defaultEdgeToEdge,
+    val wasLaunchedThroughSDK: Boolean = true,
 ) : Parcelable {
     constructor(
         requiredEntitlementIdentifier: String? = null,
@@ -25,11 +26,13 @@ internal data class PaywallActivityArgs(
         fontProvider: ParcelizableFontProvider?,
         shouldDisplayDismissButton: Boolean = DEFAULT_DISPLAY_DISMISS_BUTTON,
         edgeToEdge: Boolean = defaultEdgeToEdge,
+        wasLaunchedThroughSDK: Boolean = true,
     ) : this(
         requiredEntitlementIdentifier,
         offeringIdAndPresentedOfferingContext,
         fontProvider?.let { TypographyType.values().associateBy({ it }, { fontProvider.getFont(it) }) },
         shouldDisplayDismissButton,
         edgeToEdge,
+        wasLaunchedThroughSDK,
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterActivity.kt
@@ -11,13 +11,18 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.Modifier
+import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.ui.revenuecatui.helpers.restoreSdkConfigurationIfNeeded
 import com.revenuecat.purchases.ui.revenuecatui.helpers.saveSdkConfiguration
 
 internal class CustomerCenterActivity : ComponentActivity() {
     companion object {
+        private const val EXTRA_WAS_LAUNCHED_THROUGH_SDK = "was_launched_through_sdk"
+
         internal fun createIntent(context: Context): Intent {
-            return Intent(context, CustomerCenterActivity::class.java)
+            return Intent(context, CustomerCenterActivity::class.java).apply {
+                putExtra(EXTRA_WAS_LAUNCHED_THROUGH_SDK, true)
+            }
         }
     }
 
@@ -25,6 +30,14 @@ internal class CustomerCenterActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         restoreSdkConfigurationIfNeeded(this, savedInstanceState)
+
+        val wasLaunchedThroughSDK = intent.getBooleanExtra(EXTRA_WAS_LAUNCHED_THROUGH_SDK, false)
+        if (!wasLaunchedThroughSDK && !Purchases.isConfigured) {
+            throw IllegalStateException(
+                "CustomerCenterActivity was not launched through the SDK. " +
+                    "Please use the SDK methods to open the Customer Center.",
+            )
+        }
 
         setContent {
             val isDarkTheme = isSystemInDarkTheme()


### PR DESCRIPTION
### Description
We got reports of some crashes that might seem to indicate that the activity was not being initiated correctly through the SDK. In order to better debug these situations, here we add a dummy parameter to the CustomerCenterActivity and PaywallActivity that, in case these activities are shown without it, it would fail with a more meaningful message.