### PR TITLE
Add better error message when opening SimulatedStoreErrorDialogActivity from non-supported sources

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/SimulatedStoreErrorDialogActivity.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/SimulatedStoreErrorDialogActivity.kt
@@ -61,7 +61,7 @@ internal class SimulatedStoreErrorDialogActivity : Activity() {
             throw IllegalStateException(
                 "SimulatedStoreErrorDialogActivity was not launched through the SDK. " +
                     "Please use the SDK methods to open the SimulatedStoreErrorDialogActivity. " +
-                    "This might happen on some Google automated testing, but shouldn't happen to customers.",
+                    "This might happen on some Google automated testing, but shouldn't happen to users.",
             )
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivity.kt
@@ -105,7 +105,7 @@ internal class PaywallActivity : ComponentActivity(), PaywallListener {
             throw IllegalStateException(
                 "PaywallActivity was not launched through the SDK. " +
                     "Please use the SDK methods to open the Paywall. " +
-                    "This might happen on some Google automated testing, but shouldn't happen to customers.",
+                    "This might happen on some Google automated testing, but shouldn't happen to users.",
             )
         }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterActivity.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/CustomerCenterActivity.kt
@@ -36,7 +36,7 @@ internal class CustomerCenterActivity : ComponentActivity() {
             throw IllegalStateException(
                 "CustomerCenterActivity was not launched through the SDK. " +
                     "Please use the SDK methods to open the Customer Center. " +
-                    "This might happen on some Google automated testing, but shouldn't happen to customers.",
+                    "This might happen on some Google automated testing, but shouldn't happen to users.",
             )
         }
 


### PR DESCRIPTION
### Description
This improves the error message in some situations that seem to be attributed to Google's automated testing opening activities when it shouldn't.