### PR TITLE
[WIP]: Fix CI for the Galaxy Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Or view / build our Android sample app:
 ## Requirements
 - Java 8+
 - Kotlin 1.8.0+
-- Minimum target: Android 5.0+ (API level 21+)
+- Minimum target: Android 6.0+ (API level 23+)
 
 ## SDK Reference
 Our full SDK reference [can be found here](https://sdk.revenuecat.com/android/index.html).

--- a/api-tester/src/main/java/com/revenuecat/apitester/java/StoreTransactionAPI.java
+++ b/api-tester/src/main/java/com/revenuecat/apitester/java/StoreTransactionAPI.java
@@ -74,6 +74,7 @@ final class StoreTransactionAPI {
             case GOOGLE_PURCHASE:
             case GOOGLE_RESTORED_PURCHASE:
             case AMAZON_PURCHASE:
+            case GALAXY_PURCHASE:
         }
     }
 }

--- a/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreTransactionAPI.kt
+++ b/api-tester/src/main/java/com/revenuecat/apitester/kotlin/StoreTransactionAPI.kt
@@ -72,6 +72,7 @@ private class StoreTransactionAPI {
             PurchaseType.GOOGLE_PURCHASE,
             PurchaseType.GOOGLE_RESTORED_PURCHASE,
             PurchaseType.AMAZON_PURCHASE,
+            PurchaseType.GALAXY_PURCHASE,
             -> {}
         }.exhaustive
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import java.net.URL
 
 buildscript {
     extra["compileVersion"] = 35
-    extra["minVersion"] = 21
+    extra["minVersion"] = 23
 }
 
 plugins {

--- a/examples/CustomEntitlementComputationSample/app/build.gradle.kts
+++ b/examples/CustomEntitlementComputationSample/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
 
     defaultConfig {
         applicationId = "com.revenuecat.purchases_sample"
-        minSdk = 21
+        minSdk = 23
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/examples/MagicWeatherCompose/app/build.gradle.kts
+++ b/examples/MagicWeatherCompose/app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId = "com.revenuecat.purchases_sample"
-        minSdk = 21
+        minSdk = 23
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/examples/web-purchase-redemption-sample/build.gradle.kts
+++ b/examples/web-purchase-redemption-sample/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.revenuecat.webpurchaseredemptionsample"
-        minSdk = 21
+        minSdk = 23
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -305,7 +305,7 @@ platform :android do
       task: ':purchases:testDefaultsBc8DebugUnitTest',
       properties: {
         "RUN_INTEGRATION_TESTS" => true,
-        "minSdkVersion" => 21,
+        "minSdkVersion" => 23,
       }
     )
   end
@@ -690,7 +690,7 @@ DESC
       version_name_new = "purchaseTesterVersionName=#{version_code}"
       sh("find ../ -name 'gradle.properties' -type f -exec sed -i '' 's/#{version_name_old}/#{version_name_new}/' {} \\;")
 
-      min_sdk_version_old = "purchaseTesterMinSdkVersion=21"
+      min_sdk_version_old = "purchaseTesterMinSdkVersion=23"
       min_sdk_version_new = "purchaseTesterMinSdkVersion=#{min_sdk_version}"
       sh("find ../ -name 'gradle.properties' -type f -exec sed -i '' 's/#{min_sdk_version_old}/#{min_sdk_version_new}/' {} \\;")
 
@@ -921,7 +921,7 @@ def build_purchases_android_test_apk(package_name, apk_name, build_type, flavor)
     properties: {
       "testApplicationId" => package_name,
       "testBuildType" => build_type,
-      "minSdkVersion" => 21
+      "minSdkVersion" => 23
     }
   )
   new_apk_path = "../purchases/build/outputs/apk/androidTest/#{flavor}/#{build_type}/#{apk_name}.apk"

--- a/feature/galaxy/build.gradle.kts
+++ b/feature/galaxy/build.gradle.kts
@@ -31,3 +31,7 @@ dependencies {
     testImplementation(libs.bundles.test)
     testImplementation("com.samsung.iap:samsung-iap:6.5.0@aar")
 }
+
+tasks.named("preBuild") {
+    dependsOn(rootProject.tasks.named("getSamsungIapSdk"))
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ systemProp.org.gradle.internal.http.socketTimeout=120000
 purchaseTesterVersionCode=1
 purchaseTesterVersionName=1.0
 purchaseTesterSupportedStores=amazon,google
-purchaseTesterMinSdkVersion=21
+purchaseTesterMinSdkVersion=23
 
 paywallTesterVersionCode=1
 paywallTesterVersionName=1.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Android SDK versions
 android-compileSdk = "35"
-android-minSdk = "21"
+android-minSdk = "23"
 android-targetSdk = "35"
 
 agp = "8.13.2"

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -15,7 +15,7 @@ fun obtainTestBuildType(): String {
 android {
     defaultConfig {
         applicationId = "com.revenuecat.purchases.integrationtests"
-        minSdk = 21
+        minSdk = 23
         versionCode = 1
         versionName = "1.0"
 

--- a/purchases/api-defaults-bc7.txt
+++ b/purchases/api-defaults-bc7.txt
@@ -1040,6 +1040,24 @@ package com.revenuecat.purchases.galaxy {
     property public com.revenuecat.purchases.ProductType type;
   }
 
+  public final class GalaxySubscriptionOption implements com.revenuecat.purchases.models.SubscriptionOption {
+    ctor public GalaxySubscriptionOption(String id, java.util.List<com.revenuecat.purchases.models.PricingPhase> pricingPhases, java.util.List<java.lang.String> tags, com.revenuecat.purchases.PresentedOfferingContext? presentedOfferingContext, com.revenuecat.purchases.models.PurchasingData purchasingData, com.revenuecat.purchases.models.InstallmentsInfo? installmentsInfo);
+    method public String getId();
+    method public com.revenuecat.purchases.models.InstallmentsInfo? getInstallmentsInfo();
+    method public com.revenuecat.purchases.PresentedOfferingContext? getPresentedOfferingContext();
+    method @Deprecated public String? getPresentedOfferingIdentifier();
+    method public java.util.List<com.revenuecat.purchases.models.PricingPhase> getPricingPhases();
+    method public com.revenuecat.purchases.models.PurchasingData getPurchasingData();
+    method public java.util.List<java.lang.String> getTags();
+    property public String id;
+    property public com.revenuecat.purchases.models.InstallmentsInfo? installmentsInfo;
+    property public com.revenuecat.purchases.PresentedOfferingContext? presentedOfferingContext;
+    property @Deprecated public String? presentedOfferingIdentifier;
+    property public java.util.List<com.revenuecat.purchases.models.PricingPhase> pricingPhases;
+    property public com.revenuecat.purchases.models.PurchasingData purchasingData;
+    property public java.util.List<java.lang.String> tags;
+  }
+
 }
 
 package com.revenuecat.purchases.interfaces {
@@ -1381,6 +1399,7 @@ package com.revenuecat.purchases.models {
 
   public enum PurchaseType {
     enum_constant public static final com.revenuecat.purchases.models.PurchaseType AMAZON_PURCHASE;
+    enum_constant public static final com.revenuecat.purchases.models.PurchaseType GALAXY_PURCHASE;
     enum_constant public static final com.revenuecat.purchases.models.PurchaseType GOOGLE_PURCHASE;
     enum_constant public static final com.revenuecat.purchases.models.PurchaseType GOOGLE_RESTORED_PURCHASE;
   }
@@ -1630,3 +1649,4 @@ package com.revenuecat.purchases.virtualcurrencies {
   }
 
 }
+

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -1040,6 +1040,24 @@ package com.revenuecat.purchases.galaxy {
     property public com.revenuecat.purchases.ProductType type;
   }
 
+  public final class GalaxySubscriptionOption implements com.revenuecat.purchases.models.SubscriptionOption {
+    ctor public GalaxySubscriptionOption(String id, java.util.List<com.revenuecat.purchases.models.PricingPhase> pricingPhases, java.util.List<java.lang.String> tags, com.revenuecat.purchases.PresentedOfferingContext? presentedOfferingContext, com.revenuecat.purchases.models.PurchasingData purchasingData, com.revenuecat.purchases.models.InstallmentsInfo? installmentsInfo);
+    method public String getId();
+    method public com.revenuecat.purchases.models.InstallmentsInfo? getInstallmentsInfo();
+    method public com.revenuecat.purchases.PresentedOfferingContext? getPresentedOfferingContext();
+    method @Deprecated public String? getPresentedOfferingIdentifier();
+    method public java.util.List<com.revenuecat.purchases.models.PricingPhase> getPricingPhases();
+    method public com.revenuecat.purchases.models.PurchasingData getPurchasingData();
+    method public java.util.List<java.lang.String> getTags();
+    property public String id;
+    property public com.revenuecat.purchases.models.InstallmentsInfo? installmentsInfo;
+    property public com.revenuecat.purchases.PresentedOfferingContext? presentedOfferingContext;
+    property @Deprecated public String? presentedOfferingIdentifier;
+    property public java.util.List<com.revenuecat.purchases.models.PricingPhase> pricingPhases;
+    property public com.revenuecat.purchases.models.PurchasingData purchasingData;
+    property public java.util.List<java.lang.String> tags;
+  }
+
 }
 
 package com.revenuecat.purchases.interfaces {
@@ -1381,6 +1399,7 @@ package com.revenuecat.purchases.models {
 
   public enum PurchaseType {
     enum_constant public static final com.revenuecat.purchases.models.PurchaseType AMAZON_PURCHASE;
+    enum_constant public static final com.revenuecat.purchases.models.PurchaseType GALAXY_PURCHASE;
     enum_constant public static final com.revenuecat.purchases.models.PurchaseType GOOGLE_PURCHASE;
     enum_constant public static final com.revenuecat.purchases.models.PurchaseType GOOGLE_RESTORED_PURCHASE;
   }
@@ -1630,3 +1649,4 @@ package com.revenuecat.purchases.virtualcurrencies {
   }
 
 }
+

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -928,6 +928,24 @@ package com.revenuecat.purchases.galaxy {
     property public com.revenuecat.purchases.ProductType type;
   }
 
+  public final class GalaxySubscriptionOption implements com.revenuecat.purchases.models.SubscriptionOption {
+    ctor public GalaxySubscriptionOption(String id, java.util.List<com.revenuecat.purchases.models.PricingPhase> pricingPhases, java.util.List<java.lang.String> tags, com.revenuecat.purchases.PresentedOfferingContext? presentedOfferingContext, com.revenuecat.purchases.models.PurchasingData purchasingData, com.revenuecat.purchases.models.InstallmentsInfo? installmentsInfo);
+    method public String getId();
+    method public com.revenuecat.purchases.models.InstallmentsInfo? getInstallmentsInfo();
+    method public com.revenuecat.purchases.PresentedOfferingContext? getPresentedOfferingContext();
+    method @Deprecated public String? getPresentedOfferingIdentifier();
+    method public java.util.List<com.revenuecat.purchases.models.PricingPhase> getPricingPhases();
+    method public com.revenuecat.purchases.models.PurchasingData getPurchasingData();
+    method public java.util.List<java.lang.String> getTags();
+    property public String id;
+    property public com.revenuecat.purchases.models.InstallmentsInfo? installmentsInfo;
+    property public com.revenuecat.purchases.PresentedOfferingContext? presentedOfferingContext;
+    property @Deprecated public String? presentedOfferingIdentifier;
+    property public java.util.List<com.revenuecat.purchases.models.PricingPhase> pricingPhases;
+    property public com.revenuecat.purchases.models.PurchasingData purchasingData;
+    property public java.util.List<java.lang.String> tags;
+  }
+
 }
 
 package com.revenuecat.purchases.interfaces {
@@ -1269,6 +1287,7 @@ package com.revenuecat.purchases.models {
 
   public enum PurchaseType {
     enum_constant public static final com.revenuecat.purchases.models.PurchaseType AMAZON_PURCHASE;
+    enum_constant public static final com.revenuecat.purchases.models.PurchaseType GALAXY_PURCHASE;
     enum_constant public static final com.revenuecat.purchases.models.PurchaseType GOOGLE_PURCHASE;
     enum_constant public static final com.revenuecat.purchases.models.PurchaseType GOOGLE_RESTORED_PURCHASE;
   }
@@ -1518,3 +1537,4 @@ package com.revenuecat.purchases.virtualcurrencies {
   }
 
 }
+

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -75,11 +75,6 @@ android {
                 it.exclude("com/revenuecat/purchases/backend_integration_tests/**")
             }
         }
-
-        @Suppress("ForbiddenComment")
-        // TODO: Remove this when we figure out how to properly integrate the Samsung SDK
-        // Avoid merging Android manifests for JVM unit tests to prevent minSdk conflicts from optional AARs.
-        unitTests.isIncludeAndroidResources = false
     }
 }
 

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -292,6 +292,10 @@ tasks.dokkaHtmlPartial.configure {
     }
 }
 
+tasks.named("preBuild") {
+    dependsOn(rootProject.tasks.named("getSamsungIapSdk"))
+}
+
 // Remove afterEvaluate
 // after https://github.com/Kotlin/kotlinx-kover/issues/362 is fixed
 afterEvaluate {

--- a/test-apps/testpurchasesandroidcompatibility/build.gradle.kts
+++ b/test-apps/testpurchasesandroidcompatibility/build.gradle.kts
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId = "com.revenuecat.testpurchasesandroidcompatibility"
-        minSdk = 21
+        minSdk = 23
         targetSdk = 33 // Keeping it at 33 to test compatibility with purchases-android
         versionCode = 1
         versionName = "1.0"

--- a/ui/debugview/build.gradle.kts
+++ b/ui/debugview/build.gradle.kts
@@ -20,7 +20,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 23
     }
 
     buildFeatures {


### PR DESCRIPTION
### Description
This PR makes a few adjustments to make the CI pipelines work with the changes for the Galaxy Store. A few notes:
- This is currently downloading the Samsung IAP SDK from Google Drive. We'll update this to pull from S3 soon
- To resolve the differences in minSDK versions between `purchases-android` and the Samsung IAP SDK, this PR bumps `purchases-android`'s minSDK version from 21 to 23. We may decide to revert this before merging into main, but it works for now.
- The PR updates a few API testers + API dump files that weren't updated earlier in development
- TODO: This PR doesn't yet address the tester apps
