### PR TITLE
Add retry mechanism to purchases integration tests

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -396,7 +396,7 @@ platform :android do
   desc "Accepts a backend_environment parameter: 'production', 'load_shedder_us_east_1', 'load_shedder_us_east_2'"
   lane :run_purchases_integration_tests do |options|
     backend_environment = options[:backend_environment] || UI.user_error!("Missing backend_environment parameter. Provide 'production', 'load_shedder_us_east_1', or 'load_shedder_us_east_2'")
-    
+
     unless ['production', 'load_shedder_us_east_1', 'load_shedder_us_east_2'].include?(backend_environment)
       UI.user_error!("Invalid backend_environment parameter. Must be 'production', 'load_shedder_us_east_1' or 'load_shedder_us_east_2'")
     end
@@ -417,25 +417,44 @@ platform :android do
       active_entitlements_to_verify = ENV['LOAD_SHEDDER_ACTIVE_ENTITLEMENTS_TO_VERIFY'] || ''
     end
 
-    begin
-      build_purchases_integration_tests(
-        app_name: app_name,
-        api_key: api_key,
-        google_purchase_token: google_purchase_token,
-        product_id_to_purchase: product_id_to_purchase,
-        base_plan_id_to_purchase: base_plan_id_to_purchase,
-        active_entitlements_to_verify: active_entitlements_to_verify,
-        backend_environment: backend_environment
-      )
+    build_purchases_integration_tests(
+      app_name: app_name,
+      api_key: api_key,
+      google_purchase_token: google_purchase_token,
+      product_id_to_purchase: product_id_to_purchase,
+      base_plan_id_to_purchase: base_plan_id_to_purchase,
+      active_entitlements_to_verify: active_entitlements_to_verify,
+      backend_environment: backend_environment
+    )
 
-      run_firebase_integration_tests(app_name)
-    rescue => exception
-      slack_backend_integration_test_results(environment: backend_environment, success: false)
-      raise
-    else
-      slack_backend_integration_test_results(environment: backend_environment, success: true)
-    ensure
-      ping_heartbeat_monitor(url: ENV['HEARTBEAT_MONITOR_URL_BACKEND_INTEGRATION_TESTS'])
+    max_retries = 3
+    success = false
+    last_exception = nil
+
+    (1..max_retries).each do |attempt|
+      begin
+        UI.message("Attempt #{attempt} of #{max_retries}")
+
+        run_firebase_integration_tests(app_name)
+
+        success = true
+        break
+      rescue => exception
+        last_exception = exception
+        UI.error("Attempt #{attempt} failed: #{exception.message}")
+
+        if attempt < max_retries
+          UI.message("Retrying...")
+        else
+          UI.error("All #{max_retries} attempts failed")
+        end
+      end
+    end
+
+    slack_backend_integration_test_results(environment: backend_environment, success: success)
+    ping_heartbeat_monitor(url: ENV['HEARTBEAT_MONITOR_URL_BACKEND_INTEGRATION_TESTS'])
+    if last_exception
+      raise last_exception
     end
   end
 


### PR DESCRIPTION
### Description
There is some flakyness in our purchases integration tests that we want to address... But for now until we have more time, we can do a couple retries before notifying anything is wrong.
