### PR TITLE
Avoids consuming purchases by default

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -114,7 +114,7 @@ internal class PostReceiptHelper(
                     ?.values
                     ?.firstOrNull()
                     ?.shouldConsume
-                    ?: true
+                    ?: false
                 billing.consumeAndSave(finishTransactions, purchase, shouldConsume, initiationSource)
                 onSuccess?.let { it(purchase, postReceiptResponse.customerInfo) }
             },

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -1569,7 +1569,7 @@ class PostReceiptHelperTest {
     }
 
     @Test
-    fun `postTransactionAndConsumeIfNeeded tries to consume products if product data not available`() {
+    fun `postTransactionAndConsumeIfNeeded does not consume products if product data not available`() {
         mockPostReceiptSuccess(
             purchasedProductsInfo = mapOf()
         )
@@ -1589,14 +1589,14 @@ class PostReceiptHelperTest {
             billing.consumeAndSave(
                 finishTransactions = true,
                 purchase = mockStoreTransaction,
-                shouldConsume = true,
+                shouldConsume = false,
                 initiationSource = initiationSource
             )
         }
     }
 
     @Test
-    fun `postTransactionAndConsumeIfNeeded tries to consume products if product data product id does not match transactions`() {
+    fun `postTransactionAndConsumeIfNeeded does not consume products if product data product id does not match transactions`() {
         mockPostReceiptSuccess(
             purchasedProductsInfo = mapOf("other_product" to false)
         )
@@ -1616,7 +1616,7 @@ class PostReceiptHelperTest {
             billing.consumeAndSave(
                 finishTransactions = true,
                 purchase = mockStoreTransaction,
-                shouldConsume = true,
+                shouldConsume = false,
                 initiationSource = initiationSource
             )
         }


### PR DESCRIPTION
## Description
In case a backend bug would respond incomplete product data upon POST /receipt, we would default to consume. This PR switches that to default to not consume, which is less destructive. (To be clear, such a backend bug has never happened, but better safe than sorry.)

Resolves https://github.com/RevenueCat/purchases-android/issues/3001