### PR TITLE
Fixes `showInAppMessages` NPE when the Activity has no content View

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -834,6 +834,14 @@ internal class BillingWrapper(
                     debugLog { "Activity is null, not showing Google Play in-app message." }
                     return@withConnectedClient
                 }
+                if (activity.isFinishing) {
+                    debugLog { "Activity is finishing, not showing Google Play in-app message." }
+                    return@withConnectedClient
+                }
+                if (activity.isDestroyed) {
+                    debugLog { "Activity is destroyed, not showing Google Play in-app message." }
+                    return@withConnectedClient
+                }
                 showInAppMessages(activity, inAppMessageParams) { inAppMessageResult ->
                     when (val responseCode = inAppMessageResult.responseCode) {
                         InAppMessageResult.InAppMessageResponseCode.NO_ACTION_NEEDED -> {

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1519,6 +1519,8 @@ class BillingWrapperTest {
     @Test
     fun `showing inapp messages calls show inapp messages correctly`() {
         val activity = mockk<Activity>()
+        every { activity.isFinishing } returns false
+        every { activity.isDestroyed } returns false
         every { mockClient.showInAppMessages(activity, any(), any()) } returns billingClientOKResult
 
         wrapper.showInAppMessagesIfNeeded(activity, InAppMessageType.values().toList()) {
@@ -1531,6 +1533,8 @@ class BillingWrapperTest {
     @Test
     fun `showing inapp messages handles inapp messages listener response correctly when no messages`() {
         val activity = mockk<Activity>()
+        every { activity.isFinishing } returns false
+        every { activity.isDestroyed } returns false
         val listenerSlot = slot<InAppMessageResponseListener>()
         every { mockClient.showInAppMessages(activity, any(), capture(listenerSlot)) } returns billingClientOKResult
 
@@ -1550,6 +1554,8 @@ class BillingWrapperTest {
     @Test
     fun `showing inapp messages handles inapp messages listener response correctly when subscription updated`() {
         val activity = mockk<Activity>()
+        every { activity.isFinishing } returns false
+        every { activity.isDestroyed } returns false
         val listenerSlot = slot<InAppMessageResponseListener>()
         every { mockClient.showInAppMessages(activity, any(), capture(listenerSlot)) } returns billingClientOKResult
 
@@ -1566,6 +1572,34 @@ class BillingWrapperTest {
             )
         }
         assertThat(subscriptionStatusChanged).isTrue
+    }
+
+    @Test
+    fun `showing inapp messages does not show inapp messages when the Activity is finishing`() {
+        val activity = mockk<Activity>()
+        every { activity.isFinishing } returns true
+        every { activity.isDestroyed } returns false
+        every { mockClient.showInAppMessages(activity, any(), any()) } returns billingClientOKResult
+
+        wrapper.showInAppMessagesIfNeeded(activity, InAppMessageType.values().toList()) {
+            error("Unexpected subscription status change")
+        }
+
+        verify(exactly = 0) { mockClient.showInAppMessages(activity, any(), any()) }
+    }
+
+    @Test
+    fun `showing inapp messages does not show inapp messages when the Activity is destroyed`() {
+        val activity = mockk<Activity>()
+        every { activity.isFinishing } returns false
+        every { activity.isDestroyed } returns true
+        every { mockClient.showInAppMessages(activity, any(), any()) } returns billingClientOKResult
+
+        wrapper.showInAppMessagesIfNeeded(activity, InAppMessageType.values().toList()) {
+            error("Unexpected subscription status change")
+        }
+
+        verify(exactly = 0) { mockClient.showInAppMessages(activity, any(), any()) }
     }
 
     // endregion inapp messages


### PR DESCRIPTION
## Bug
A `NullPointerException` can occur in the Play Billing Library when calling `showInAppMessages`.

## Cause
This is caused by the Activity having no content View, as the content View is used to get a Window token.

## Fix
Common reasons for Activities to lack a content View are:
- the Activity is finishing
- the Activity is destroyed

The fix is to check if either of these conditions is true, and avoid calling `showInAppMessages` if so.

Fixes [256eb60b](https://play.google.com/sdk-console/accounts/3894912036640479868/sdks/8672516042485634097/crashes/256eb60b/details).