### PR TITLE
Properly cleanup new shared preferences files between tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -996,9 +996,11 @@ workflows:
       - run-maestro-e2e-tests:
           requires:
             - prepare-tests
-      - integration-tests-build
-      - run-firebase-tests-purchases-custom-entitlement-computation-integration-test
+      - integration-tests-build: *release-branches
+      - run-firebase-tests-purchases-custom-entitlement-computation-integration-test:
+          <<: *release-branches
       - run-firebase-tests-purchases-integration-tests:
+          <<: *release-branches
           context:
             - slack-secrets
           matrix:


### PR DESCRIPTION
### Description
After the recent changes, we added a new shared preferences file but we were not clearing it between tests, causing some tests to fail. This fixes that.
