### PR TITLE
Synchronize `cacheDirectory` lazy property to fix `NullPointerException` on `UnsafeLazyImpl` 

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/FontLoader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/FontLoader.kt
@@ -33,7 +33,7 @@ internal class FontLoader(
 ) {
     private var hasCheckedFoldersExist: AtomicBoolean = AtomicBoolean(false)
 
-    private val cacheDirectory: File? by lazy {
+    private val cacheDirectory: File? by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
         providedCacheDir ?: context.cacheDir?.let { File(it, "rc_paywall_fonts") }
     }
 


### PR DESCRIPTION
 Fixes NPE in FontLoader.cacheDirectory caused by unsafe lazy initialization.
 
Related to https://github.com/RevenueCat/purchases-android/pull/2961

Three separate entries, but they’re very similar:
[RevenueCat SDK](https://play.google.com/sdk-console/accounts/3894912036640479868/sdks/8672516042485634097/crashes/d1f53f61/details?timeRange=LAST_28_DAYS&crashStatuses=SDK_CRASH_STATUS_UNSPECIFIED&affectedApps=AFFECTED_APPS_UNSPECIFIED)
[RevenueCatUI SDK](https://play.google.com/sdk-console/accounts/3894912036640479868/sdks/6507804763198446256/crashes/d1f53f61/details?timeRange=LAST_28_DAYS&crashStatuses=SDK_CRASH_STATUS_UNSPECIFIED&affectedApps=AFFECTED_APPS_UNSPECIFIED)
[PurchasesHybridCommon](https://play.google.com/sdk-console/accounts/3894912036640479868/sdks/9178691880686914701/crashes/cd7c0ade/details?timeRange=LAST_28_DAYS&crashStatuses=SDK_CRASH_STATUS_UNSPECIFIED&affectedApps=AFFECTED_APPS_UNSPECIFIED)

```
Exception java.lang.NullPointerException:
  at kotlin.UnsafeLazyImpl.getValue (Lazy.kt:98)
  at com.revenuecat.purchases.paywalls.FontLoader.getCacheDirectory (FontLoader.kt:36)
  [..] // Full stack trace in the links above
```

  The cacheDirectory property used `LazyThreadSafetyMode.NONE`, but is accessed from coroutines on `Dispatchers.IO` (which is a multi-threaded dispatcher). This caused a race condition in Kotlin's UnsafeLazyImpl:

  1. Thread A initializes the lazy value and sets `initializer = null`
  2. Thread B sees stale `UNINITIALIZED_VALUE` (no memory barrier) but sees updated `initializer = null`
  3. Thread B calls `initializer!!()` -> NPE
  
 
<img width="720" height="496" alt="image" src="https://github.com/user-attachments/assets/59aa52c3-8c71-4c4a-a298-401dd868ee68" />

  The fix removes `LazyThreadSafetyMode.NONE` to use the default `SYNCHRONIZED` mode, which uses locking. After initialization, subsequent accesses take the fast path with no synchronization overhead.