### PR TITLE
Add retry mechanism to purchases integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1000,6 +1000,7 @@ workflows:
       - run-firebase-tests-purchases-custom-entitlement-computation-integration-test:
           <<: *release-branches
       - run-firebase-tests-purchases-integration-tests:
+          <<: *release-branches
           context:
             - slack-secrets
           matrix:


### PR DESCRIPTION
### Description
There is some flakyness in our purchases integration tests that we want to address... But for now until we have more time, we can do a couple retries before notifying anything is wrong.
