### PR TITLE
Add `sdk_originated` to POST receipt

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -329,6 +329,7 @@ internal class PostReceiptHelper(
                 initiationSource = initiationSource,
                 paywallPostReceiptData = paywallData,
                 purchasesAreCompletedBy = purchasesAreCompletedBy,
+                sdkOriginated = hasCachedTransactionMetadata,
                 onSuccess = { postReceiptResponse ->
                     if (hasCachedTransactionMetadata) {
                         localTransactionMetadataStore.clearLocalTransactionMetadata(setOf(purchaseToken))

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -251,6 +251,7 @@ internal class Backend(
         paywallPostReceiptData: PaywallPostReceiptData?,
         // This reflects the value at the time of the purchase, which might come from the LocalTransactionMetadataStore
         purchasesAreCompletedBy: PurchasesAreCompletedBy,
+        sdkOriginated: Boolean,
         onSuccess: PostReceiptDataSuccessCallback,
         onError: PostReceiptDataErrorCallback,
     ) {
@@ -262,6 +263,7 @@ internal class Backend(
             subscriberAttributes.toString(),
             receiptInfo.toString(),
             purchasesAreCompletedBy.toString(),
+            sdkOriginated.toString(),
         )
 
         val body = mapOf(
@@ -277,6 +279,7 @@ internal class Backend(
             },
             "observer_mode" to !finishTransactions,
             "purchase_completed_by" to purchasesAreCompletedBy.name.lowercase(),
+            "sdk_originated" to sdkOriginated,
             "price" to receiptInfo.price,
             "currency" to receiptInfo.currency,
             "attributes" to subscriberAttributes.takeUnless { it.isEmpty() || appConfig.customEntitlementComputation },

--- a/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostReceiptHelperTest.kt
@@ -208,6 +208,7 @@ class PostReceiptHelperTest {
                 receiptInfo = expectedReceiptInfo,
                 initiationSource = PostReceiptInitiationSource.PURCHASE,
                 paywallPostReceiptData = null,
+                sdkOriginated = true,
                 onSuccess = any(),
                 onError = any()
             )
@@ -243,6 +244,7 @@ class PostReceiptHelperTest {
                 receiptInfo = any(),
                 initiationSource = any(),
                 paywallPostReceiptData = null,
+                sdkOriginated = true,
                 onSuccess = any(),
                 onError = any()
             )
@@ -904,6 +906,7 @@ class PostReceiptHelperTest {
                 receiptInfo = testReceiptInfo,
                 initiationSource = PostReceiptInitiationSource.RESTORE,
                 paywallPostReceiptData = null,
+                sdkOriginated = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -936,6 +939,7 @@ class PostReceiptHelperTest {
                 receiptInfo = any(),
                 initiationSource = any(),
                 paywallPostReceiptData = null,
+                sdkOriginated = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -1448,6 +1452,7 @@ class PostReceiptHelperTest {
                 receiptInfo = any(),
                 initiationSource = any(),
                 paywallPostReceiptData = expectedPaywallData,
+                sdkOriginated = any(),
                 onSuccess = any(),
                 onError = any()
             )
@@ -1825,6 +1830,39 @@ class PostReceiptHelperTest {
     }
 
     @Test
+    fun `postTransactionAndConsumeIfNeeded posts sdkOriginated as false when there is no cached transaction metadata and initiation source is not purchase`() {
+        mockPostReceiptSuccess(postReceiptInitiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES)
+
+        postReceiptHelper.postTransactionAndConsumeIfNeeded(
+            purchase = mockStoreTransaction,
+            storeProduct = mockStoreProduct,
+            subscriptionOptionForProductIDs = null,
+            isRestore = true,
+            appUserID = appUserID,
+            initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+            onSuccess = { _, _ -> },
+            onError = { _, _ -> fail("Should succeed") }
+        )
+
+        verify(exactly = 1) {
+            backend.postReceiptData(
+                purchaseToken = any(),
+                appUserID = any(),
+                isRestore = any(),
+                finishTransactions = any(),
+                subscriberAttributes = any(),
+                receiptInfo = any(),
+                initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
+                paywallPostReceiptData = any(),
+                purchasesAreCompletedBy = any(),
+                sdkOriginated = false,
+                onSuccess = any(),
+                onError = any()
+            )
+        }
+    }
+
+    @Test
     fun `postTransactionAndConsumeIfNeeded uses cached paywall data when present paywall is null`() {
         val cachedPaywallData = event.toPaywallPostReceiptData()
         val cachedMetadata = LocalTransactionMetadata(
@@ -1859,6 +1897,7 @@ class PostReceiptHelperTest {
                 initiationSource = any(),
                 paywallPostReceiptData = cachedPaywallData,
                 purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+                sdkOriginated = true,
                 onSuccess = any(),
                 onError = any()
             )
@@ -1918,6 +1957,7 @@ class PostReceiptHelperTest {
                 initiationSource = any(),
                 paywallPostReceiptData = cachedPaywallData,
                 purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+                sdkOriginated = true,
                 onSuccess = any(),
                 onError = any()
             )
@@ -1959,6 +1999,7 @@ class PostReceiptHelperTest {
                 initiationSource = any(),
                 paywallPostReceiptData = any(),
                 purchasesAreCompletedBy = PurchasesAreCompletedBy.MY_APP,
+                sdkOriginated = true,
                 onSuccess = any(),
                 onError = any()
             )
@@ -2010,6 +2051,7 @@ class PostReceiptHelperTest {
                 initiationSource = any(),
                 paywallPostReceiptData = any(),
                 purchasesAreCompletedBy = PurchasesAreCompletedBy.MY_APP,
+                sdkOriginated = true,
                 onSuccess = any(),
                 onError = any()
             )
@@ -2050,6 +2092,7 @@ class PostReceiptHelperTest {
                 initiationSource = any(),
                 paywallPostReceiptData = any(),
                 purchasesAreCompletedBy = PurchasesAreCompletedBy.MY_APP,
+                sdkOriginated = true,
                 onSuccess = any(),
                 onError = any()
             )
@@ -2082,6 +2125,7 @@ class PostReceiptHelperTest {
                 initiationSource = any(),
                 paywallPostReceiptData = any(),
                 purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+                sdkOriginated = true,
                 onSuccess = any(),
                 onError = any()
             )
@@ -2134,7 +2178,7 @@ class PostReceiptHelperTest {
         assertThat(errorCallCount).isEqualTo(1)
         verify(exactly = 0) {
             backend.postReceiptData(
-                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
             )
         }
     }
@@ -2174,6 +2218,7 @@ class PostReceiptHelperTest {
                 initiationSource = postReceiptInitiationSource,
                 paywallPostReceiptData = any(),
                 purchasesAreCompletedBy = any(),
+                sdkOriginated = any(),
                 onSuccess = captureLambda(),
                 onError = any()
             )
@@ -2217,6 +2262,7 @@ class PostReceiptHelperTest {
                 initiationSource = initiationSource,
                 paywallPostReceiptData = any(),
                 purchasesAreCompletedBy = any(),
+                sdkOriginated = any(),
                 onSuccess = any(),
                 onError = captureLambda()
             )
@@ -2338,6 +2384,7 @@ class PostReceiptHelperTest {
                 initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
                 paywallPostReceiptData = paywallPostReceiptData,
                 purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+                sdkOriginated = any(),
                 onSuccess = captureLambda(),
                 onError = any()
             )
@@ -2392,6 +2439,7 @@ class PostReceiptHelperTest {
                 initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
                 paywallPostReceiptData = null,
                 purchasesAreCompletedBy = PurchasesAreCompletedBy.MY_APP,
+                sdkOriginated = any(),
                 onSuccess = captureLambda(),
                 onError = any()
             )
@@ -2446,6 +2494,7 @@ class PostReceiptHelperTest {
                 initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
                 paywallPostReceiptData = null,
                 purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+                sdkOriginated = any(),
                 onSuccess = captureLambda(),
                 onError = any()
             )
@@ -2491,6 +2540,7 @@ class PostReceiptHelperTest {
                 initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
                 paywallPostReceiptData = null,
                 purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+                sdkOriginated = any(),
                 onSuccess = any(),
                 onError = captureLambda()
             )
@@ -2554,6 +2604,7 @@ class PostReceiptHelperTest {
                 initiationSource = PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
                 paywallPostReceiptData = null,
                 purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+                sdkOriginated = any(),
                 onSuccess = captureLambda(),
                 onError = any()
             )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
@@ -706,6 +706,24 @@ class BackendTest {
     }
 
     @Test
+    fun `postReceipt posts sdk_originated`() {
+        mockPostReceiptResponseAndPost(
+            backend,
+            responseCode = 200,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            finishTransactions = false,
+            receiptInfo = createReceiptInfoFromProduct(productIDs = productIDs, storeProduct = storeProduct),
+            initiationSource = initiationSource,
+        )
+
+        assertThat(requestBodySlot.isCaptured).isTrue
+        assertThat(requestBodySlot.captured.keys).contains("sdk_originated")
+        assertThat(requestBodySlot.captured["sdk_originated"]).isEqualTo(true)
+    }
+
+    @Test
     fun postReceiptCallsFailsFor4XX() {
         mockPostReceiptResponseAndPost(
             backend,
@@ -2990,6 +3008,7 @@ class BackendTest {
         initiationSource: PostReceiptInitiationSource,
         delayed: Boolean = false,
         paywallPostReceiptData: PaywallPostReceiptData? = null,
+        sdkOriginated: Boolean = true,
         purchasesAreCompletedBy: PurchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
         onSuccess: (PostReceiptResponse) -> Unit = onReceivePostReceiptSuccessHandler,
         onError: PostReceiptDataErrorCallback = postReceiptErrorCallback
@@ -3015,6 +3034,7 @@ class BackendTest {
             receiptInfo = receiptInfo,
             initiationSource = initiationSource,
             paywallPostReceiptData = paywallPostReceiptData,
+            sdkOriginated = sdkOriginated,
             onSuccess = onSuccess,
             onError = onError
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/subscriberattributes/SubscriberAttributesBackendTests.kt
@@ -29,7 +29,6 @@ import io.mockk.unmockkObject
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
-import org.json.JSONObject
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -314,6 +313,7 @@ class SubscriberAttributesPosterTests {
             initiationSource = initiationSource,
             paywallPostReceiptData = null,
             purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+            sdkOriginated = true,
             onSuccess = expectedOnSuccessPostReceipt,
             onError = unexpectedOnErrorPostReceipt
         )
@@ -342,6 +342,7 @@ class SubscriberAttributesPosterTests {
             initiationSource = initiationSource,
             paywallPostReceiptData = null,
             purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+            sdkOriginated = true,
             onSuccess = expectedOnSuccessPostReceipt,
             onError = unexpectedOnErrorPostReceipt
         )
@@ -369,6 +370,7 @@ class SubscriberAttributesPosterTests {
             initiationSource = initiationSource,
             paywallPostReceiptData = null,
             purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+            sdkOriginated = true,
             onSuccess = expectedOnSuccessPostReceipt,
             onError = unexpectedOnErrorPostReceipt
         )
@@ -399,6 +401,7 @@ class SubscriberAttributesPosterTests {
             initiationSource = initiationSource,
             paywallPostReceiptData = null,
             purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+            sdkOriginated = true,
             onSuccess = expectedOnSuccessPostReceipt,
             onError = unexpectedOnErrorPostReceipt
         )
@@ -428,6 +431,7 @@ class SubscriberAttributesPosterTests {
             initiationSource = initiationSource,
             paywallPostReceiptData = null,
             purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+            sdkOriginated = true,
             onSuccess = unexpectedOnSuccessPostReceipt,
             onError = expectedOnErrorPostReceipt
         )
@@ -457,6 +461,7 @@ class SubscriberAttributesPosterTests {
             initiationSource = initiationSource,
             paywallPostReceiptData = null,
             purchasesAreCompletedBy = PurchasesAreCompletedBy.REVENUECAT,
+            sdkOriginated = true,
             onSuccess = unexpectedOnSuccessPostReceipt,
             onError = expectedOnErrorPostReceipt
         )


### PR DESCRIPTION
### Description
Adds a new convenience field to the body of the request so it's easier to know if the purchase was originated from the SDK, or at least while the SDK was configured even if it was performed outside while "PurchasesAreCompletedBy.MY_APP".
