### PR TITLE
Update CLAUDE code review workflow reference

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   claude-review:
-    uses: revenuecat/sdk-github-workflows/.github/workflows/claude-code-review.yml@03ed0eb1bb5061a2aa7c2882e58393b834b44cff
+    uses: revenuecat/sdk-github-workflows/.github/workflows/claude-code-review.yml@v5
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 


### PR DESCRIPTION
It looks like the `author_association` is returning `CONTRIBUTOR` even for me. Changing the workflow to be more permissive in `author_association` but checking if the user has write access