### PR TITLE
Galaxy Store: Product Caching Improvements

### DIFF
--- a/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/handler/ProductDataHandler.kt
+++ b/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/handler/ProductDataHandler.kt
@@ -40,7 +40,7 @@ internal class ProductDataHandler(
     )
 
     @get:Synchronized
-    internal val productMetadataCache = mutableMapOf<String, ProductVo>()
+    internal val productVoCache = mutableMapOf<String, ProductVo>()
 
     @GalaxySerialOperation
     override fun getProductDetails(
@@ -77,12 +77,12 @@ internal class ProductDataHandler(
             onError = onError,
         )
 
-        if (productMetadataCache.keys.containsAll(productIds)) {
-            val cachedProducts = productIds.mapNotNull(productMetadataCache::get)
+        if (productVoCache.keys.containsAll(productIds)) {
+            val cachedProducts = productIds.mapNotNull(productVoCache::get)
             this.inFlightRequest = request
             fetchPromotionEligibilityAndHandleStoreProducts(cachedProducts)
         } else {
-            val uncachedProductIds = productIds - productMetadataCache.keys
+            val uncachedProductIds = productIds - productVoCache.keys
             // When requesting products from the Samsung IAP SDK, the `_productIds` param is a string where
             // the following contents product the following results:
             // - An empty string: queries all products
@@ -119,10 +119,10 @@ internal class ProductDataHandler(
         }
 
         nonNullProducts.forEach { product ->
-            productMetadataCache[product.itemId] = product
+            productVoCache[product.itemId] = product
         }
         val requestedProductIds = inFlightRequest?.productIds.orEmpty()
-        val productsForRequest = requestedProductIds.mapNotNull(productMetadataCache::get)
+        val productsForRequest = requestedProductIds.mapNotNull(productVoCache::get)
         fetchPromotionEligibilityAndHandleStoreProducts(productsForRequest)
     }
 

--- a/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/handler/ProductDataHandler.kt
+++ b/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/handler/ProductDataHandler.kt
@@ -21,6 +21,7 @@ import com.samsung.android.sdk.iap.lib.vo.ErrorVo
 import com.samsung.android.sdk.iap.lib.vo.ProductVo
 import com.samsung.android.sdk.iap.lib.vo.PromotionEligibilityVo
 import java.util.ArrayList
+import java.util.LinkedHashMap
 
 @OptIn(InternalRevenueCatAPI::class)
 internal class ProductDataHandler(
@@ -35,6 +36,7 @@ internal class ProductDataHandler(
     private data class Request(
         val productIds: Set<String>,
         val productType: ProductType,
+        val cachedProducts: List<StoreProduct>,
         val onReceive: StoreProductsCallback,
         val onError: PurchasesErrorCallback,
     )
@@ -70,15 +72,18 @@ internal class ProductDataHandler(
 
         log(LogIntent.DEBUG) { GalaxyStrings.REQUESTING_PRODUCTS.format(productIds.joinToString()) }
 
+        val cachedProducts = productIds.mapNotNull(productsCache::get)
+        val missingProductIds = productIds - productsCache.keys
+
         val request = Request(
             productIds = productIds,
             productType = productType,
+            cachedProducts = cachedProducts,
             onReceive = onReceive,
             onError = onError,
         )
 
-        if (productsCache.keys.containsAll(productIds)) {
-            val cachedProducts = productIds.mapNotNull(productsCache::get)
+        if (missingProductIds.isEmpty()) {
             this.inFlightRequest = request
 
             handleStoreProducts(
@@ -90,7 +95,7 @@ internal class ProductDataHandler(
             // - An empty string: queries all products
             // - A string with one product ID in it: queries for that one product
             // - A string with multiple product IDs in it, delimited by a comma
-            val productIdRequestString = productIds.joinToString(separator = ",")
+            val productIdRequestString = missingProductIds.joinToString(separator = ",")
             iapHelper.getProductsDetails(
                 productIDs = productIdRequestString,
                 onGetProductsDetailsListener = this,
@@ -117,6 +122,8 @@ internal class ProductDataHandler(
         val nonNullProducts = products.mapNotNull { it }
         // The serial execution of this call is an extension of the serial execution of the parent
         // get products request
+
+        // TODO: We should check the promotion eligibilities for cached products too!!!
         promotionEligibilityResponseListener.getPromotionEligibilities(
             productIds = nonNullProducts.map { it.itemId },
             onSuccess = { promotionEligibilities ->
@@ -135,7 +142,13 @@ internal class ProductDataHandler(
                     productsCache[product.id] = product
                 }
 
-                handleStoreProducts(storeProducts = storeProducts)
+                val cachedProducts = inFlightRequest?.cachedProducts.orEmpty()
+                val combinedProducts = LinkedHashMap<String, StoreProduct>()
+                (cachedProducts + storeProducts).forEach { product ->
+                    combinedProducts[product.id] = product
+                }
+
+                handleStoreProducts(storeProducts = combinedProducts.values.toList())
             },
             onError = { error ->
                 val onError = inFlightRequest?.onError

--- a/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/handler/ProductDataHandler.kt
+++ b/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/handler/ProductDataHandler.kt
@@ -112,17 +112,18 @@ internal class ProductDataHandler(
     private fun handleSuccessfulProductsResponse(
         products: List<ProductVo?>,
     ) {
-        val nonNullProducts = products.mapNotNull { it }
-        if (nonNullProducts.isEmpty()) {
+        val requestedProductIds = inFlightRequest?.productIds.orEmpty()
+        val productsFromResponse = products.mapNotNull { it }
+        productsFromResponse.forEach { product ->
+            productVoCache[product.itemId] = product
+        }
+
+        val productsForRequest = requestedProductIds.mapNotNull(productVoCache::get)
+        if (productsForRequest.isEmpty()) {
             handleStoreProducts(storeProducts = emptyList())
             return
         }
 
-        nonNullProducts.forEach { product ->
-            productVoCache[product.itemId] = product
-        }
-        val requestedProductIds = inFlightRequest?.productIds.orEmpty()
-        val productsForRequest = requestedProductIds.mapNotNull(productVoCache::get)
         fetchPromotionEligibilityAndHandleStoreProducts(productsForRequest)
     }
 

--- a/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/handler/ProductDataHandlerTest.kt
+++ b/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/handler/ProductDataHandlerTest.kt
@@ -127,7 +127,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
 
         assertThat(receivedProducts).isNotNull
         assertThat(receivedProducts!!.map { it.id }).containsExactly("sub")
-        assertThat(productDataHandler.productMetadataCache).containsKeys("iap", "sub")
+        assertThat(productDataHandler.productVoCache).containsKeys("iap", "sub")
     }
 
     @OptIn(GalaxySerialOperation::class)
@@ -284,7 +284,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         val uncachedId = "uncached"
         val cachedProduct = createProductVo(itemId = cachedId, type = "subscription")
         val uncachedProduct = createProductVo(itemId = uncachedId, type = "subscription")
-        productDataHandler.productMetadataCache[cachedId] = cachedProduct
+        productDataHandler.productVoCache[cachedId] = cachedProduct
 
         var receivedProducts: List<StoreProduct>? = null
 

--- a/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/handler/ProductDataHandlerTest.kt
+++ b/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/handler/ProductDataHandlerTest.kt
@@ -78,6 +78,7 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
 
         assertThat(receivedError?.code).isEqualTo(PurchasesErrorCode.OperationAlreadyInProgressError)
         verify(exactly = 1) { iapHelperProvider.getProductsDetails(any(), any()) }
+        verify(exactly = 0) { iapHelperProvider.getPromotionEligibility(any(), any()) }
     }
 
     @OptIn(GalaxySerialOperation::class)

--- a/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/handler/ProductDataHandlerTest.kt
+++ b/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/handler/ProductDataHandlerTest.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.galaxy.GalaxyStoreTest
 import com.revenuecat.purchases.galaxy.IAPHelperProvider
 import com.revenuecat.purchases.galaxy.constants.GalaxyErrorCode
+import com.revenuecat.purchases.galaxy.conversions.toStoreProduct
 import com.revenuecat.purchases.galaxy.utils.GalaxySerialOperation
 import com.revenuecat.purchases.models.StoreProduct
 import com.samsung.android.sdk.iap.lib.listener.OnGetProductsDetailsListener
@@ -127,6 +128,53 @@ class ProductDataHandlerTest : GalaxyStoreTest() {
         assertThat(receivedProducts).isNotNull
         assertThat(receivedProducts!!.map { it.id }).containsExactly("sub")
         assertThat(productDataHandler.productsCache).containsKeys("iap", "sub")
+    }
+
+    @OptIn(GalaxySerialOperation::class)
+    @Test
+    fun `getProductDetails only requests missing products and returns cached results`() {
+        val capturedListener = slot<OnGetProductsDetailsListener>()
+        every { iapHelperProvider.getProductsDetails(any(), capture(capturedListener)) } returns Unit
+
+        val capturedPromotionEligibilityListener = slot<OnGetPromotionEligibilityListener>()
+        every {
+            iapHelperProvider.getPromotionEligibility(any(), capture(capturedPromotionEligibilityListener))
+        } returns true
+
+        val cachedProduct = createProductVo(itemId = "cached", type = "item").toStoreProduct()
+        productDataHandler.productsCache[cachedProduct.id] = cachedProduct
+
+        var receivedProducts: List<StoreProduct>? = null
+
+        productDataHandler.getProductDetails(
+            productIds = setOf("cached", "new"),
+            productType = ProductType.INAPP,
+            onReceive = { receivedProducts = it },
+            onError = unexpectedOnError,
+        )
+
+        verify(exactly = 1) { iapHelperProvider.getProductsDetails("new", any()) }
+
+        val successErrorVo = mockk<ErrorVo> {
+            every { errorCode } returns GalaxyErrorCode.IAP_ERROR_NONE.code
+        }
+        val newProduct = createProductVo(itemId = "new", type = "item")
+        capturedListener.captured.onGetProducts(successErrorVo, arrayListOf(newProduct))
+
+        verify(exactly = 1) {
+            iapHelperProvider.getPromotionEligibility(
+                itemIDs = "new",
+                onGetPromotionEligibilityListener = any(),
+            )
+        }
+
+        capturedPromotionEligibilityListener.captured.onGetPromotionEligibility(
+            successErrorVo,
+            arrayListOf(createPromotionEligibilityVo(itemId = "new", pricing = "None")),
+        )
+
+        assertThat(receivedProducts).isNotNull
+        assertThat(receivedProducts!!.map { it.id }).containsExactlyInAnyOrder("cached", "new")
     }
 
     @OptIn(GalaxySerialOperation::class)


### PR DESCRIPTION
### Description
This PR makes two adjustments to the caching logic that the SDK uses to cache Galaxy store products.

#### Bug Fix: Don't Cache Product Promotional Eligibilities
Before this PR, the SDK was caching promotional eligibilities for products, and would never invalidate the cached eligibilities. This could lead to us showing incorrect promotional eligibilities in certain circumstances when the eligibility changes but the products cache hasn't been updated.

This PR changes the SDK's product caching logic so that the SDK only caches the core product data (the `ProductVo`s received from the SDK), and then each time a product is requested, it recomputes the promotional eligibility for all requested products.

#### Optimization: Only Request Uncached Products
When a request was made for a mix of cached and uncached products, the SDK would ignore the cache and re-fetch all products from the Samsung SDK. This resulted in unnecessary overhead when requesting products. 

This PR updates the product fetching logic so that the SDK only requests the missing (uncached) products from the Samsung SDK. Once the uncached products are retrieved from the Samsung SDK, the code returns the fetched products along with the cached ones.
