### PR TITLE
Add `payload_version` to POST /receipt

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -119,6 +119,12 @@ internal class Backend(
         private const val FETCH_TOKEN = "fetch_token"
         private const val NEW_APP_USER_ID = "new_app_user_id"
 
+        /**
+         * This version should be bumped whenever there is a change to the payload of POST receipt that the backend
+         * may need to handle differently. It should be kept in sync with the iOS SDK.
+         */
+        private const val POST_RECEIPT_PAYLOAD_VERSION = 1
+
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         internal val json = Json {
             ignoreUnknownKeys = true
@@ -287,6 +293,7 @@ internal class Backend(
             "initiation_source" to initiationSource.postReceiptFieldValue,
             "paywall" to paywallPostReceiptData?.toMap(),
             "sdk_originated" to receiptInfo.sdkOriginated,
+            "payload_version" to POST_RECEIPT_PAYLOAD_VERSION,
         ).filterNotNullValues()
 
         val postFieldsToSign = listOf(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendTest.kt
@@ -705,6 +705,24 @@ class BackendTest {
     }
 
     @Test
+    fun `postReceipt posts payload_version`() {
+        mockPostReceiptResponseAndPost(
+            backend,
+            responseCode = 200,
+            isRestore = false,
+            clientException = null,
+            resultBody = null,
+            finishTransactions = false,
+            receiptInfo = createReceiptInfoFromProduct(productIDs = productIDs, storeProduct = storeProduct, sdkOriginated = true),
+            initiationSource = initiationSource,
+        )
+
+        assertThat(requestBodySlot.isCaptured).isTrue
+        assertThat(requestBodySlot.captured.keys).contains("payload_version")
+        assertThat(requestBodySlot.captured["payload_version"]).isEqualTo(1)
+    }
+
+    @Test
     fun `postReceipt posts purchase_completed_by`() {
         mockPostReceiptResponseAndPost(
             backend,


### PR DESCRIPTION
### Description
In order to make it easier to track changes in the POST /receipt body and how the backend should handle it, we're introducing a new hardcoded property, that should be bumped when there is any change to requests that might require different handling by the backend. 
