### PR TITLE
Rename `MultipleIntroOffers` override to `MultiplePhaseOffers`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverride.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/common/ComponentOverride.kt
@@ -30,7 +30,7 @@ class ComponentOverride<T : PartialComponent>(
         object IntroOffer : Condition
 
         @Serializable
-        object MultipleIntroOffers : Condition
+        object MultiplePhaseOffers : Condition
 
         @Serializable
         object Selected : Condition
@@ -48,7 +48,7 @@ internal object ConditionSerializer : SealedDeserializerWithDefault<Condition>(
         "medium" to { Condition.Medium.serializer() },
         "expanded" to { Condition.Expanded.serializer() },
         "intro_offer" to { Condition.IntroOffer.serializer() },
-        "multiple_intro_offers" to { Condition.MultipleIntroOffers.serializer() },
+        "multiple_intro_offers" to { Condition.MultiplePhaseOffers.serializer() },
         "selected" to { Condition.Selected.serializer() },
     ),
     defaultValue = { Condition.Unsupported },

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentOverridesTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/common/ComponentOverridesTests.kt
@@ -102,7 +102,7 @@ internal class ComponentOverridesTests {
                                 properties = PartialTextComponent(fontName = FontAlias("intro font")),
                             ),
                             ComponentOverride(
-                                conditions = listOf(ComponentOverride.Condition.MultipleIntroOffers),
+                                conditions = listOf(ComponentOverride.Condition.MultiplePhaseOffers),
                                 properties = PartialTextComponent(fontName = FontAlias("multiple intros font")),
                             ),
                             ComponentOverride(
@@ -218,7 +218,7 @@ internal class ComponentOverridesTests {
                                 properties = PartialImageComponent(overrideSourceLid = LocalizationKey("intro")),
                             ),
                             ComponentOverride(
-                                conditions = listOf(ComponentOverride.Condition.MultipleIntroOffers),
+                                conditions = listOf(ComponentOverride.Condition.MultiplePhaseOffers),
                                 properties = PartialImageComponent(
                                     overrideSourceLid = LocalizationKey("multiple_intros")
                                 ),
@@ -279,7 +279,7 @@ internal class ComponentOverridesTests {
                 arrayOf("{ \"type\": \"medium\" }", ComponentOverride.Condition.Medium),
                 arrayOf("{ \"type\": \"expanded\" }", ComponentOverride.Condition.Expanded),
                 arrayOf("{ \"type\": \"intro_offer\" }", ComponentOverride.Condition.IntroOffer),
-                arrayOf("{ \"type\": \"multiple_intro_offers\" }", ComponentOverride.Condition.MultipleIntroOffers),
+                arrayOf("{ \"type\": \"multiple_intro_offers\" }", ComponentOverride.Condition.MultiplePhaseOffers),
                 arrayOf("{ \"type\": \"selected\" }", ComponentOverride.Condition.Selected),
                 arrayOf("{ \"type\": \"unsupported\" }", ComponentOverride.Condition.Unsupported),
                 arrayOf("{ \"type\": \"some_future_unknown_value\" }", ComponentOverride.Condition.Unsupported),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedPartial.kt
@@ -104,7 +104,7 @@ private fun <T : PresentedPartial<T>> PresentedOverride<T>.shouldApply(
             -> {
                 if (!windowSize.applicableConditions.contains(condition)) return false
             }
-            ComponentOverride.Condition.MultipleIntroOffers -> {
+            ComponentOverride.Condition.MultiplePhaseOffers -> {
                 if (introOfferEligibility != IntroOfferEligibility.MULTIPLE_OFFERS_ELIGIBLE) return false
             }
             ComponentOverride.Condition.IntroOffer -> {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/BuildPresentedPartialTests.kt
@@ -158,7 +158,7 @@ internal class BuildPresentedPartialTests(@Suppress("UNUSED_PARAMETER") name: St
             }
             multipleIntroOffers?.let {
                 overrides.add(PresentedOverride(
-                    conditions = listOf(ComponentOverride.Condition.MultipleIntroOffers),
+                    conditions = listOf(ComponentOverride.Condition.MultiplePhaseOffers),
                     properties = it,
                 ))
             }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ToPresentedOverridesTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ToPresentedOverridesTests.kt
@@ -75,7 +75,7 @@ internal class ToPresentedOverridesTests(@Suppress("UNUSED_PARAMETER") name: Str
                 properties = PartialTextComponent(fontName = introOffer),
             ),
             ComponentOverride(
-                conditions = listOf(ComponentOverride.Condition.MultipleIntroOffers),
+                conditions = listOf(ComponentOverride.Condition.MultiplePhaseOffers),
                 properties = PartialTextComponent(fontName = multipleIntroOffers),
             ),
             ComponentOverride(
@@ -242,7 +242,7 @@ internal class ToPresentedOverridesTests(@Suppress("UNUSED_PARAMETER") name: Str
                                 ).getOrThrow(),
                             ),
                             PresentedOverride(
-                                conditions = listOf(ComponentOverride.Condition.MultipleIntroOffers),
+                                conditions = listOf(ComponentOverride.Condition.MultiplePhaseOffers),
                                 properties = LocalizedTextPartial(
                                     from = PartialTextComponent(fontName = multipleIntroOffers),
                                     using = nonEmptyMapOf(localeId to dummyLocalizationDictionary),

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentViewTests.kt
@@ -459,7 +459,7 @@ class StackComponentViewTests {
                     ),
                 ),
                 ComponentOverride(
-                    conditions = listOf(ComponentOverride.Condition.MultipleIntroOffers),
+                    conditions = listOf(ComponentOverride.Condition.MultiplePhaseOffers),
                     properties = PartialStackComponent(
                         backgroundColor = ColorScheme(
                             light = ColorInfo.Hex(expectedMultipleEligibleBackgroundColor.toArgb())
@@ -616,7 +616,7 @@ class StackComponentViewTests {
                     ),
                 ),
                 ComponentOverride(
-                    conditions = listOf(ComponentOverride.Condition.MultipleIntroOffers),
+                    conditions = listOf(ComponentOverride.Condition.MultiplePhaseOffers),
                     properties = PartialStackComponent(
                         backgroundColor = ColorScheme(
                             light = ColorInfo.Hex(expectedMultipleEligibleBackgroundColor.toArgb())

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/text/TextComponentViewTests.kt
@@ -473,7 +473,7 @@ class TextComponentViewTests {
                     )
                 ),
                 ComponentOverride(
-                    conditions = listOf(ComponentOverride.Condition.MultipleIntroOffers),
+                    conditions = listOf(ComponentOverride.Condition.MultiplePhaseOffers),
                     properties = PartialTextComponent(
                         text = multipleEligibleLocalizationKey,
                         color = ColorScheme(ColorInfo.Hex(expectedMultiEligibleTextColor.toArgb())),
@@ -538,7 +538,7 @@ class TextComponentViewTests {
                     )
                 ),
                 ComponentOverride(
-                    conditions = listOf(ComponentOverride.Condition.MultipleIntroOffers),
+                    conditions = listOf(ComponentOverride.Condition.MultiplePhaseOffers),
                     properties = PartialTextComponent(
                         text = multipleEligibleLocalizationKey,
                         color = ColorScheme(ColorInfo.Hex(expectedMultiEligibleTextColor.toArgb())),


### PR DESCRIPTION
Internal change extracted from #3063 to reduce the amount of files changed in that PR

Renames to `MultiplePhaseOffers` since, `MultipleIntroOffers` doesn't actually make much sense. `MultiplePhaseOffers` is triggered when a `SubscriptionOption` has both a free trial and a discounted price phase.