### PR TITLE
Notify phc of new releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,14 @@ aliases:
       branches:
         ignore: /.*/
 
+  stable-release-tags: &stable-release-tags
+    filters:
+      tags:
+        ignore:
+          - /^.*-.*$/
+      branches:
+        ignore: /.*/
+
   release-branches: &release-branches
     filters:
       tags:
@@ -380,6 +388,17 @@ jobs:
             bundle exec fastlane android deploy
       - android/save_gradle_cache
       - android/save_build_cache
+
+  trigger-hybrid-common-update:
+    <<: *android-executor
+    steps:
+      - checkout
+      - install-sdkman
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
+      - run:
+          name: Trigger dependency update in purchases-hybrid-common
+          command: bundle exec fastlane trigger_hybrid_common_update
 
   prepare-next-version:
     <<: *android-executor
@@ -1046,6 +1065,10 @@ workflows:
               - deploy
               - docs-deploy
           <<: *release-tags
+      - trigger-hybrid-common-update:
+          requires:
+            - deploy
+          <<: *stable-release-tags
 
   on-main-branch:
     when:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -777,6 +777,11 @@ DESC
     trigger_action_in_circle_ci(action: 'bump', repo_name: repo_name)
   end
 
+  desc "Trigger dependency update in purchases-hybrid-common"
+  lane :trigger_hybrid_common_update do
+    trigger_action_in_circle_ci(action: 'dependency-update', repo_name: 'purchases-hybrid-common')
+  end
+
   desc "Records Paywall template screenshots and pushes them to the repository at target_repository_path"
   lane :record_and_push_paywall_template_screenshots do |options|
     UI.user_error!("Please provide the target_repository_path, and make sure it is cloned.") unless options[:target_repository_path]


### PR DESCRIPTION
Following what we do in phc to notify hybrids, I think we should notify phc when we release purchases-ios and purchases-android. Right now we automatically bump on Mondays, but now we are releasing phc more often and I don't see a problem on doing it on every release.