### PR TITLE
FIX ANR - Removed player.stop() + player.reset() from teardown.

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/video/VideoView.kt
@@ -237,15 +237,18 @@ private class TextureVideoView @JvmOverloads constructor(
 
     fun release() {
         if (released) return
-        controller?.hide()
-        safely(execute = {
-            player.stop()
-        })
-        safely(execute = {
-            player.reset()
-        })
-        player.release()
         released = true
+        controller?.hide()
+        controller = null
+        // Detach surface and release directly. reset()/stop() can block for network streams.
+        safely(execute = {
+            player.setSurface(null)
+        })
+        safely(execute = {
+            player.release()
+        }, failureMessage = { e ->
+            "Could not release media player: ${e.message}"
+        })
         if (viewTreeObserverListening) {
             viewTreeObserver.removeOnGlobalLayoutListener(layoutListener)
             viewTreeObserverListening = false


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests (module compile checks passed; full unit suite has unrelated existing failures)
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Main-thread teardown could stall (ANR-style) when dismissing a paywall video backed by HTTP media. The reported stack shows:
`TextureVideoView.release()` -> `MediaPlayer.reset()` -> `MediaHTTPConnection.disconnect()` on the main thread.

This blocks fragment transition / view detach and can surface as a crash report.


### Description
This PR updates `TextureVideoView.release()` in `VideoView.kt` to avoid synchronous disconnect work on the UI thread during detach:

- Remove `player.stop()` and `player.reset()` from teardown.
- Set `released = true` immediately to make teardown idempotent and guard re-entrant callbacks.
- Hide and clear `MediaController`.
- Detach the surface (`player.setSurface(null)`) and directly call `player.release()`.

Why not just dispatch `reset()` to a background thread?

- `reset()` is for reuse; this code path is disposal, so `reset()` is unnecessary.
- The player lifecycle is currently main-thread-owned. Dispatching only part of teardown to a worker introduces cross-thread state races (`pause` / `setSurface` / `start` callbacks vs `reset` / `release`).
- Moving only `reset()` may still leave UI stalls due to internal/native locking.
- A robust async approach would require moving the entire MediaPlayer lifecycle to a dedicated thread, which is a larger refactor.

This change is the smallest safe fix aligned with the observed stack trace.

### Validation
- `./gradlew :ui:revenuecatui:compileDefaultsBc8DebugKotlin`
- `./gradlew :ui:revenuecatui:compileDefaultsBc7DebugKotlin`
- `./gradlew :ui:revenuecatui:testDefaultsBc8DebugUnitTest` (fails due to pre-existing unrelated tests: `TextComponentViewVariablesTests`, `PaywallComponentsTemplatePreviewRecorder`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Android `MediaPlayer` lifecycle/teardown behavior, which can surface as playback edge cases if release ordering differs across devices/streams. Scope is small and localized to `VideoView` disposal.
> 
> **Overview**
> Prevents UI-thread stalls when dismissing paywall videos by changing `TextureVideoView.release()` to be idempotent earlier (`released = true` up front), hide/clear the `MediaController`, detach the surface (`setSurface(null)`), and then `release()` the `MediaPlayer`.
> 
> Removes teardown calls to `player.stop()` and `player.reset()`, which can block for network-backed streams, and adds a guarded error log message specifically for `MediaPlayer.release()` failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3be34e4a549a17329f1136f7824bd625c75c4a19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->