### PR TITLE
Add title/description/icon to timeline items

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/TimelineComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/TimelineComponent.kt
@@ -122,6 +122,12 @@ public class PartialTimelineComponentItem(
     @get:JvmSynthetic
     public val visible: Boolean? = null,
     @get:JvmSynthetic
+    public val title: PartialTextComponent? = null,
+    @get:JvmSynthetic
+    public val description: PartialTextComponent? = null,
+    @get:JvmSynthetic
+    public val icon: PartialIconComponent? = null,
+    @get:JvmSynthetic
     public val connector: TimelineComponent.Connector? = null,
 ) : PartialComponent
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/TimelineComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/TimelineComponentTests.kt
@@ -379,6 +379,16 @@ internal class TimelineComponentTests {
                         json = """
                         {
                           "visible": true,
+                            "title": {
+                                "visible": false,
+                                "font_size": 18
+                            },
+                            "description": {
+                                "font_weight": "extra_bold"
+                            },
+                            "icon": {
+                                "icon_name": "Updated icon name"
+                            },
                             "connector": {
                                 "width": 40,
                                 "margin": {
@@ -393,6 +403,16 @@ internal class TimelineComponentTests {
                         """.trimIndent(),
                         expected = PartialTimelineComponentItem(
                             visible = true,
+                            title = PartialTextComponent(
+                                visible = false,
+                                fontSize = 18,
+                            ),
+                            description = PartialTextComponent(
+                                fontWeight = com.revenuecat.purchases.paywalls.components.properties.FontWeight.EXTRA_BOLD,
+                            ),
+                            icon = PartialIconComponent(
+                                iconName = "Updated icon name",
+                            ),
                             connector = TimelineComponent.Connector(
                                 width = 40,
                                 margin = Padding(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedTimelinePartial.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedTimelinePartial.kt
@@ -1,17 +1,22 @@
 package com.revenuecat.purchases.ui.revenuecatui.components
 
 import com.revenuecat.purchases.ColorAlias
+import com.revenuecat.purchases.FontAlias
 import com.revenuecat.purchases.paywalls.components.PartialTimelineComponent
 import com.revenuecat.purchases.paywalls.components.PartialTimelineComponentItem
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.LocalizationDictionary
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toPaddingValues
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.toColorStyles
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.FontSpec
 import com.revenuecat.purchases.ui.revenuecatui.components.style.TimelineComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.errors.PaywallValidationError
 import com.revenuecat.purchases.ui.revenuecatui.helpers.NonEmptyList
+import com.revenuecat.purchases.ui.revenuecatui.helpers.NonEmptyMap
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Result
-import com.revenuecat.purchases.ui.revenuecatui.helpers.map
 import com.revenuecat.purchases.ui.revenuecatui.helpers.orSuccessfullyNull
+import com.revenuecat.purchases.ui.revenuecatui.helpers.zipOrAccumulate
 import dev.drewhamilton.poko.Poko
 
 @Poko
@@ -39,6 +44,9 @@ internal class PresentedTimelinePartial(
 @Poko
 internal class PresentedTimelineItemPartial(
     @get:JvmSynthetic val partial: PartialTimelineComponentItem,
+    @get:JvmSynthetic val title: LocalizedTextPartial?,
+    @get:JvmSynthetic val description: LocalizedTextPartial?,
+    @get:JvmSynthetic val icon: PresentedIconPartial?,
     @get:JvmSynthetic val connectorStyle: TimelineComponentStyle.ConnectorStyle?,
 ) : PresentedPartial<PresentedTimelineItemPartial> {
 
@@ -46,11 +54,27 @@ internal class PresentedTimelineItemPartial(
         @JvmSynthetic
         operator fun invoke(
             from: PartialTimelineComponentItem,
+            localizations: NonEmptyMap<LocaleId, LocalizationDictionary>,
             aliases: Map<ColorAlias, ColorScheme>,
+            fontAliases: Map<FontAlias, FontSpec>,
         ): Result<PresentedTimelineItemPartial, NonEmptyList<PaywallValidationError>> {
-            return from.connector?.color?.toColorStyles(aliases = aliases).orSuccessfullyNull().map { colorStyles ->
+            return zipOrAccumulate(
+                first = from.title
+                    ?.let { partial -> LocalizedTextPartial(partial, localizations, aliases, fontAliases) }
+                    .orSuccessfullyNull(),
+                second = from.description
+                    ?.let { partial -> LocalizedTextPartial(partial, localizations, aliases, fontAliases) }
+                    .orSuccessfullyNull(),
+                third = from.icon
+                    ?.let { partial -> PresentedIconPartial(partial, aliases) }
+                    .orSuccessfullyNull(),
+                fourth = from.connector?.color?.toColorStyles(aliases = aliases).orSuccessfullyNull(),
+            ) { title, description, icon, colorStyles ->
                 PresentedTimelineItemPartial(
                     partial = from,
+                    title = title,
+                    description = description,
+                    icon = icon,
                     connectorStyle = from.connector?.let { connector ->
                         if (colorStyles != null) {
                             TimelineComponentStyle.ConnectorStyle(
@@ -73,9 +97,17 @@ internal class PresentedTimelineItemPartial(
         return PresentedTimelineItemPartial(
             partial = PartialTimelineComponentItem(
                 visible = otherPartial?.visible ?: partial.visible,
+                title = otherPartial?.title ?: partial.title,
+                description = otherPartial?.description ?: partial.description,
+                icon = otherPartial?.icon ?: partial.icon,
                 connector = otherPartial?.connector ?: partial.connector,
             ),
+            title = title.combineOrReplace(with?.title),
+            description = description.combineOrReplace(with?.description),
+            icon = icon.combineOrReplace(with?.icon),
             connectorStyle = with?.connectorStyle ?: connectorStyle,
         )
     }
 }
+
+private fun <T : PresentedPartial<T>> T?.combineOrReplace(with: T?): T? = this?.combine(with) ?: with

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -985,7 +985,14 @@ internal class StyleFactory(
         item: TimelineComponent.Item,
     ): Result<TimelineComponentStyle.ItemStyle, NonEmptyList<PaywallValidationError>> = zipOrAccumulate(
         first = item.overrides
-            .toPresentedOverrides(stripRules) { partial -> PresentedTimelineItemPartial(partial, colorAliases) }
+            .toPresentedOverrides(stripRules) { partial ->
+                PresentedTimelineItemPartial(
+                    from = partial,
+                    localizations = localizations,
+                    aliases = colorAliases,
+                    fontAliases = fontAliases,
+                )
+            }
             .mapError { nonEmptyListOf(it) },
         second = createTextComponentStyle(item.title),
         third = item.description?.let { createTextComponentStyle(it) }.orSuccessfullyNull(),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/timeline/TimelineComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/timeline/TimelineComponentState.kt
@@ -12,10 +12,15 @@ import androidx.window.core.layout.WindowWidthSizeClass
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.components.ComponentViewState
 import com.revenuecat.purchases.ui.revenuecatui.components.ConditionContext
+import com.revenuecat.purchases.ui.revenuecatui.components.LocalizedTextPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedIconPartial
+import com.revenuecat.purchases.ui.revenuecatui.components.PresentedOverride
 import com.revenuecat.purchases.ui.revenuecatui.components.ScreenCondition
 import com.revenuecat.purchases.ui.revenuecatui.components.buildPresentedPartial
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toPaddingValues
 import com.revenuecat.purchases.ui.revenuecatui.components.state.PackageAwareDelegate
+import com.revenuecat.purchases.ui.revenuecatui.components.style.IconComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TextComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.TimelineComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.composables.OfferEligibility
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
@@ -177,13 +182,13 @@ internal class TimelineComponentState(
         val visible by derivedStateOf { presentedPartial?.partial?.visible ?: style.visible }
 
         @get:JvmSynthetic
-        val title by derivedStateOf { style.title }
+        val title by derivedStateOf { style.title.withAppliedOverride(presentedPartial?.title) }
 
         @get:JvmSynthetic
-        val description by derivedStateOf { style.description }
+        val description by derivedStateOf { style.description?.withAppliedOverride(presentedPartial?.description) }
 
         @get:JvmSynthetic
-        val icon by derivedStateOf { style.icon }
+        val icon by derivedStateOf { style.icon.withAppliedOverride(presentedPartial?.icon) }
 
         @get:JvmSynthetic
         val connector by derivedStateOf { presentedPartial?.connectorStyle ?: style.connector }
@@ -195,4 +200,52 @@ internal class TimelineComponentState(
             if (windowSize != null) this.windowSize = windowSize
         }
     }
+}
+
+private fun TextComponentStyle.withAppliedOverride(partial: LocalizedTextPartial?): TextComponentStyle {
+    if (partial == null) return this
+
+    return TextComponentStyle(
+        texts = texts,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        fontSpec = fontSpec,
+        textAlign = textAlign,
+        horizontalAlignment = horizontalAlignment,
+        backgroundColor = backgroundColor,
+        visible = visible,
+        size = size,
+        padding = padding,
+        margin = margin,
+        rcPackage = rcPackage,
+        resolvedOffer = resolvedOffer,
+        tabIndex = tabIndex,
+        offerEligibility = offerEligibility,
+        countdownDate = countdownDate,
+        countFrom = countFrom,
+        variableLocalizations = variableLocalizations,
+        overrides = overrides + PresentedOverride(conditions = emptyList(), properties = partial),
+    )
+}
+
+private fun IconComponentStyle.withAppliedOverride(partial: PresentedIconPartial?): IconComponentStyle {
+    if (partial == null) return this
+
+    return IconComponentStyle(
+        baseUrl = baseUrl,
+        iconName = iconName,
+        formats = formats,
+        visible = visible,
+        size = size,
+        color = color,
+        padding = padding,
+        margin = margin,
+        iconBackground = iconBackground,
+        rcPackage = rcPackage,
+        resolvedOffer = resolvedOffer,
+        tabIndex = tabIndex,
+        offerEligibility = offerEligibility,
+        overrides = overrides + PresentedOverride(conditions = emptyList(), properties = partial),
+    )
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedTimelineItemPartialTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PresentedTimelineItemPartialTests.kt
@@ -4,10 +4,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.paywalls.components.PartialTimelineComponentItem
+import com.revenuecat.purchases.paywalls.components.PartialTextComponent
 import com.revenuecat.purchases.paywalls.components.TimelineComponent
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
 import com.revenuecat.purchases.paywalls.components.properties.Padding
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.paywalls.components.common.LocalizationData
+import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
 import com.revenuecat.purchases.ui.revenuecatui.errors.PaywallValidationError
 import com.revenuecat.purchases.ui.revenuecatui.helpers.errorOrNull
@@ -15,9 +19,16 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
 import com.revenuecat.purchases.ui.revenuecatui.helpers.isError
 import com.revenuecat.purchases.ui.revenuecatui.helpers.isSuccess
 import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyListOf
+import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
 import org.junit.Test
 
 internal class PresentedTimelineItemPartialTests {
+
+    private val localizations = nonEmptyMapOf(
+        LocaleId("en_US") to nonEmptyMapOf(
+            LocalizationKey("title") to LocalizationData.Text("Title")
+        )
+    )
     
     @Test
     fun `Should accumulate errors if the ColorAlias is not found in the PresentedTimelineItemPartial`() {
@@ -36,11 +47,13 @@ internal class PresentedTimelineItemPartialTests {
                     color = ColorScheme(light = ColorInfo.Alias(missingConnectorColorKey))
                 ),
             ),
+            localizations = localizations,
             aliases = mapOf(
                 ColorAlias("existing-color-overlay-key") to ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
                 ColorAlias("existing-border-key") to ColorScheme(light = ColorInfo.Hex(Color.Green.toArgb())),
                 ColorAlias("existing-shadow-key") to ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
-            )
+            ),
+            fontAliases = emptyMap(),
         )
 
         // Assert
@@ -67,9 +80,11 @@ internal class PresentedTimelineItemPartialTests {
                     color = ColorScheme(light = ColorInfo.Alias(firstConnectorColorKey))
                 ),
             ),
+            localizations = localizations,
             aliases = mapOf(
                 firstConnectorColorKey to ColorScheme(light = ColorInfo.Alias(secondConnectorColorKey)),
-            )
+            ),
+            fontAliases = emptyMap(),
         )
 
         // Assert
@@ -93,9 +108,11 @@ internal class PresentedTimelineItemPartialTests {
                     color = ColorScheme(light = ColorInfo.Alias(existingConnectorColorKey))
                 ),
             ),
+            localizations = localizations,
             aliases = mapOf(
                 existingConnectorColorKey to ColorScheme(light = ColorInfo.Hex(expectedConnectorColor.toArgb())),
-            )
+            ),
+            fontAliases = emptyMap(),
         )
 
         // Assert
@@ -118,9 +135,11 @@ internal class PresentedTimelineItemPartialTests {
                     color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb()))
                 ),
             ),
+            localizations = localizations,
             aliases = mapOf(
                 ColorAlias("existing-color-overlay-key") to ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb()))
-            )
+            ),
+            fontAliases = emptyMap(),
         )
 
         // Assert
@@ -139,10 +158,36 @@ internal class PresentedTimelineItemPartialTests {
                     color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb()))
                 ),
             ),
-            aliases = emptyMap()
+            localizations = localizations,
+            aliases = emptyMap(),
+            fontAliases = emptyMap(),
         )
 
         // Assert
         assert(actualResult.isSuccess)
+    }
+
+    @Test
+    fun `Should create successfully if the PartialTimelineItemComponent has title overrides`() {
+        val expectedTitleColor = Color.White
+
+        val actualResult = PresentedTimelineItemPartial(
+            from = PartialTimelineComponentItem(
+                title = PartialTextComponent(
+                    text = LocalizationKey("title"),
+                    color = ColorScheme(light = ColorInfo.Hex(expectedTitleColor.toArgb())),
+                ),
+            ),
+            localizations = localizations,
+            aliases = emptyMap(),
+            fontAliases = emptyMap(),
+        )
+
+        assert(actualResult.isSuccess)
+        val actual = actualResult.getOrThrow()
+        val actualTitleColor = actual.title?.color?.light ?: error("Expected title color")
+        actualTitleColor.let { it as ColorStyle.Solid }.also {
+            assert(it.color == expectedTitleColor)
+        }
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/VisibilityConditionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/VisibilityConditionTests.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.paywalls.components.PartialCarouselComponent
 import com.revenuecat.purchases.paywalls.components.PartialStackComponent
 import com.revenuecat.purchases.paywalls.components.PartialTextComponent
 import com.revenuecat.purchases.paywalls.components.PartialTimelineComponent
+import com.revenuecat.purchases.paywalls.components.PartialTimelineComponentItem
 import com.revenuecat.purchases.paywalls.components.PartialVideoComponent
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.StickyFooterComponent
@@ -61,6 +62,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.VideoComponentS
 import com.revenuecat.purchases.ui.revenuecatui.components.tabs.TabsComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.text.TextComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.timeline.TimelineComponentView
+import com.revenuecat.purchases.ui.revenuecatui.assertions.assertTextColorEquals
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.extensions.toComponentsPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.extensions.validatePaywallComponentsDataOrNull
@@ -276,6 +278,67 @@ class VisibilityConditionTests {
 
         // Timeline is hidden — item title should not exist
         onNodeWithText(timelineTitleValue).assertDoesNotExist()
+    }
+
+    @Test
+    fun `Timeline item title color override applies from item override`(): Unit = with(composeTestRule) {
+        val expectedBaseColor = Color.Black
+        val expectedOverrideColor = Color.White
+        val timeline = TimelineComponent(
+            itemSpacing = 8,
+            textSpacing = 4,
+            columnGutter = 12,
+            iconAlignment = TimelineComponent.IconAlignment.Title,
+            items = listOf(
+                TimelineComponent.Item(
+                    title = TextComponent(
+                        text = timelineTitleKey,
+                        color = ColorScheme(light = ColorInfo.Hex(expectedBaseColor.toArgb())),
+                    ),
+                    icon = IconComponent(
+                        baseUrl = "https://assets.example.com",
+                        iconName = "check",
+                        formats = IconComponent.Formats(webp = "check.webp"),
+                        size = Size(
+                            width = SizeConstraint.Fixed(24u),
+                            height = SizeConstraint.Fixed(24u),
+                        ),
+                    ),
+                    overrides = listOf(
+                        ComponentOverride(
+                            conditions = listOf(
+                                ComponentOverride.Condition.Variable(
+                                    operator = ComponentOverride.EqualityOperator.EQUALS,
+                                    variable = "light_text",
+                                    value = JsonPrimitive(true),
+                                ),
+                            ),
+                            properties = PartialTimelineComponentItem(
+                                title = PartialTextComponent(
+                                    color = ColorScheme(light = ColorInfo.Hex(expectedOverrideColor.toArgb())),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val state = FakePaywallState(
+            localizations = localizations,
+            defaultLocaleIdentifier = localeId,
+            components = listOf(timeline),
+            customVariables = mapOf("light_text" to CustomVariableValue.Boolean(true)),
+        )
+        val style = styleFactory.create(timeline).getOrThrow().componentStyle as TimelineComponentStyle
+
+        setContent {
+            TimelineComponentView(style = style, state = state)
+        }
+
+        onNodeWithText(timelineTitleValue)
+            .assertIsDisplayed()
+            .assertTextColorEquals(expectedOverrideColor)
     }
 
     // endregion


### PR DESCRIPTION
Add support for title, description and icon partials on PartialTimelineComponentItem and propagate them through presentation, styling and state. PresentedTimelineItemPartial now resolves localized text and icon partials (accepting localizations, color and font aliases) and accumulates errors; StyleFactory passes localizations and fontAliases when creating presented overrides. TimelineComponentState applies item-level overrides by adding PresentedOverride entries via withAppliedOverride helpers for TextComponentStyle and IconComponentStyle. Tests updated/added to cover parsing and override application, and small helpers (zipOrAccumulate, combineOrReplace) were introduced to merge presented partials.

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
