### PR TITLE
[DO NOT MERGE] Release/9.23.1-galaxy-beta.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,7 +425,7 @@ jobs:
           command: sudo pip install awscli
       - run:
           name: Deploy to S3
-          command: aws s3 sync ~/project/docs/9.24.0-SNAPSHOT s3://purchases-docs/android/9.24.0-SNAPSHOT --delete
+          command: aws s3 sync ~/project/docs/9.23.1-galaxy-beta.2 s3://purchases-docs/android/9.23.1-galaxy-beta.2 --delete
       - run:
           name: Update index.html
           command: aws s3 cp ~/project/docs/index.html s3://purchases-docs/android/index.html

--- a/.version
+++ b/.version
@@ -1,1 +1,1 @@
-9.24.0-SNAPSHOT
+9.23.1-galaxy-beta.2

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,9 +1,15 @@
-## RevenueCatUI SDK
-### Paywallv2
-#### 🐞 Bugfixes
-* Fix default value for `productChangeConfig` (#3153) via Cesar de la Vega (@vegaro)
+**This is an automatic release.**
 
-### 🔄 Other Changes
-* Add elapsed_millis to FLUSH_COMPLETED debug event (#3184) via Toni Rico (@tonidero)
-* Add priority flush with rate limiting and queuing (#3179) via Rick (@rickvdl)
-* Bypass billing in preview mode (#3162) via Monika Mateska (@MonikaMateska)
+> WARNING: The Galaxy Store features in this release are considered to be in beta and are subject to change at any time. If you'd like to try them out, please reach out to support and let us know.
+
+## RevenueCat SDK
+
+### ✨ New Features
+
+- Initial support for the Galaxy Store in the `purchases-android` SDK.
+
+### 🐞 Bugfixes
+
+- Fixed the deployment pipeline to include the `purchases-store-galaxy` modules in releases.
+
+## RevenueCatUI SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 9.23.1-galaxy-beta.2
+**This is an automatic release.**
+
+> WARNING: The Galaxy Store features in this release are considered to be in beta and are subject to change at any time. If you'd like to try them out, please reach out to support and let us know.
+
+## RevenueCat SDK
+
+### ✨ New Features
+
+- Initial support for the Galaxy Store in the `purchases-android` SDK.
+
+### 🐞 Bugfixes
+
+- Fixed the deployment pipeline to include the `purchases-store-galaxy` modules in releases.
+
+## RevenueCatUI SDK
+
 ## 9.23.1
 ## RevenueCatUI SDK
 ### Paywallv2

--- a/examples/CustomEntitlementComputationSample/gradle/libs.versions.toml
+++ b/examples/CustomEntitlementComputationSample/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.13.2"
 kotlin = "1.8.22"
-purchases = "9.24.0-SNAPSHOT"
+purchases = "9.23.1-galaxy-beta.2"
 androidxCore = "1.10.1"
 
 [plugins]

--- a/examples/MagicWeather/gradle/libs.versions.toml
+++ b/examples/MagicWeather/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.13.2"
 androidxNavigation = "2.6.0"
 kotlin = "1.9.0"
-purchases = "9.24.0-SNAPSHOT"
+purchases = "9.23.1-galaxy-beta.2"
 lifecycle = "2.6.1"
 androidxCore = "1.10.1"
 

--- a/examples/MagicWeatherCompose/gradle/libs.versions.toml
+++ b/examples/MagicWeatherCompose/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.13.2"
 androidxNavigation = "2.5.3"
 kotlin = "1.8.22"
-purchases = "9.24.0-SNAPSHOT"
+purchases = "9.23.1-galaxy-beta.2"
 lifecycle = "2.5.0"
 androidxCore = "1.10.1"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 #Fri Mar 31 10:31:20 PDT 2023
 GROUP=com.revenuecat.purchases
 
-VERSION_NAME=9.24.0-SNAPSHOT
+VERSION_NAME=9.23.1-galaxy-beta.2
 
 POM_DESCRIPTION=Mobile subscriptions in hours, not months.
 POM_URL=https://github.com/RevenueCat/purchases-android

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Config.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Config.kt
@@ -8,5 +8,5 @@ import com.revenuecat.purchases.api.BuildConfig
 public object Config {
     public var logLevel: LogLevel = LogLevel.debugLogsEnabled(BuildConfig.DEBUG)
 
-    internal const val frameworkVersion = "9.24.0-SNAPSHOT"
+    internal const val frameworkVersion = "9.23.1-galaxy-beta.2"
 }

--- a/test-apps/sdksizetesting/gradle/libs.versions.toml
+++ b/test-apps/sdksizetesting/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.12.2"
 composeBom = "2024.09.00"
-purchases = "9.24.0-SNAPSHOT"
+purchases = "9.23.1-galaxy-beta.2"
 emergeGradlePlugin = "4.4.0"
 
 [libraries]


### PR DESCRIPTION
**This is an automatic release.**

> WARNING: The Galaxy Store features in this release are considered to be in beta and are subject to change at any time. If you'd like to try them out, please reach out to support and let us know.

## RevenueCat SDK

### ✨ New Features

- Initial support for the Galaxy Store in the `purchases-android` SDK.

### 🐞 Bugfixes

- Fixed the deployment pipeline to include the `purchases-store-galaxy` modules in releases.

## RevenueCatUI SDK
