### PR TITLE
Pin GCP CLI version to fix run-firebase-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,9 @@ commands:
         type: string
     steps:
       - gcp-cli/setup:
+          # Pin to the version preinstalled in the gcp-cli executor image.
+          # Using "latest" can trigger an uninstall/reinstall path that fails because sudo is unavailable.
+          version: 559.0.0
           gcloud_service_key: GCLOUD_SERVICE_KEY
           google_compute_zone: GOOGLE_COMPUTE_ZONE
           google_project_id: GOOGLE_PROJECT_ID
@@ -666,6 +669,9 @@ jobs:
           cache-version: v1
       - gcp-cli/install
       - gcp-cli/setup:
+          # Pin to the version preinstalled in the gcp-cli executor image.
+          # Using "latest" can trigger an uninstall/reinstall path that fails because sudo is unavailable.
+          version: 559.0.0
           gcloud_service_key: GCLOUD_SERVICE_KEY
           google_compute_zone: GOOGLE_COMPUTE_ZONE
           google_project_id: GOOGLE_PROJECT_ID
@@ -690,6 +696,9 @@ jobs:
           cache-version: v1
       - gcp-cli/install
       - gcp-cli/setup:
+          # Pin to the version preinstalled in the gcp-cli executor image.
+          # Using "latest" can trigger an uninstall/reinstall path that fails because sudo is unavailable.
+          version: 559.0.0
           gcloud_service_key: GCLOUD_SERVICE_KEY
           google_compute_zone: GOOGLE_COMPUTE_ZONE
           google_project_id: GOOGLE_PROJECT_ID

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1124,7 +1124,7 @@ workflows:
       - run-maestro-e2e-tests:
           requires:
             - prepare-tests
-      - integration-tests-build: *release-branches
+      - integration-tests-build
       - run-firebase-tests-purchases-custom-entitlement-computation-integration-test:
           <<: *release-branches
       - run-firebase-tests-purchases-integration-tests:


### PR DESCRIPTION
### Description
The `run-firebase-tests` job in the native Android release pipeline is repeatedly failing today on the `Install latest gcloud CLI version if not available step` with the following failure message:

```bash
Failure:
/bin/bash: line 141: python: command not found
Detected platform: linux ()
The version installed (559.0.0) differs from the version requested (560.0.0).
Uninstalling v559.0.0...
sudo is required to uninstall the Google Cloud SDK.
Please install it and try again.
Failed to uninstall the current version.

Exited with code exit status 1
```

This address the failure by pinning the GCP CLI version used.