### PR TITLE
Revert "Cache isAutoRenewing to detect subscription changes without syncPurchases"

### DIFF
--- a/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingWrapper.kt
+++ b/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingWrapper.kt
@@ -186,9 +186,7 @@ internal class GalaxyBillingWrapper(
         initiationSource: PostReceiptInitiationSource,
     ) {
         if (!finishTransactions || purchase.type == ProductType.UNKNOWN) {
-            // Here, we hard-code isAutoRenewing to true because we only support subscriptions for now.
-            // We will need to update this when we add support for one time purchases.
-            deviceCache.addSuccessfullyPostedToken(purchase.purchaseToken, isAutoRenewing = true)
+            deviceCache.addSuccessfullyPostedToken(purchase.purchaseToken)
             return
         }
 
@@ -198,11 +196,7 @@ internal class GalaxyBillingWrapper(
         if (purchase.type == ProductType.SUBS) {
             acknowledgePurchase(
                 storeTransaction = purchase,
-                // Here, we hard-code isAutoRenewing to true because we only support subscriptions for now.
-                // We will need to update this when we add support for one time purchases.
-                onAcknowledged = { token ->
-                    deviceCache.addSuccessfullyPostedToken(token, isAutoRenewing = true)
-                },
+                onAcknowledged = deviceCache::addSuccessfullyPostedToken,
             )
         } else {
             log(LogIntent.GALAXY_WARNING) { GalaxyStrings.WARNING_CANNOT_CONSUME_NON_SUBS_PRODUCT_TYPES }

--- a/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/GalaxyBillingWrapperTest.kt
+++ b/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/GalaxyBillingWrapperTest.kt
@@ -895,7 +895,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
     fun `consumeAndSave caches token when finishTransactions is false`() {
         val acknowledgePurchaseHandler = mockk<AcknowledgePurchaseResponseListener>(relaxed = true)
         val wrapper = createWrapper(acknowledgePurchaseHandler = acknowledgePurchaseHandler)
-        every { deviceCache.addSuccessfullyPostedToken("token", isAutoRenewing = true) } returns Unit
+        every { deviceCache.addSuccessfullyPostedToken("token") } returns Unit
 
         wrapper.consumeAndSave(
             finishTransactions = false,
@@ -905,7 +905,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
         )
 
         verify(exactly = 0) { acknowledgePurchaseHandler.acknowledgePurchase(any(), any(), any()) }
-        verify(exactly = 1) { deviceCache.addSuccessfullyPostedToken("token", isAutoRenewing = true) }
+        verify(exactly = 1) { deviceCache.addSuccessfullyPostedToken("token") }
     }
 
     @OptIn(GalaxySerialOperation::class)
@@ -913,7 +913,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
     fun `consumeAndSave caches token for unknown product type`() {
         val acknowledgePurchaseHandler = mockk<AcknowledgePurchaseResponseListener>(relaxed = true)
         val wrapper = createWrapper(acknowledgePurchaseHandler = acknowledgePurchaseHandler)
-        every { deviceCache.addSuccessfullyPostedToken("token", isAutoRenewing = true) } returns Unit
+        every { deviceCache.addSuccessfullyPostedToken("token") } returns Unit
 
         wrapper.consumeAndSave(
             finishTransactions = true,
@@ -923,7 +923,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
         )
 
         verify(exactly = 0) { acknowledgePurchaseHandler.acknowledgePurchase(any(), any(), any()) }
-        verify(exactly = 1) { deviceCache.addSuccessfullyPostedToken("token", isAutoRenewing = true) }
+        verify(exactly = 1) { deviceCache.addSuccessfullyPostedToken("token") }
     }
 
     @OptIn(GalaxySerialOperation::class)
@@ -931,7 +931,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
     fun `consumeAndSave does nothing for pending purchases`() {
         val acknowledgePurchaseHandler = mockk<AcknowledgePurchaseResponseListener>(relaxed = true)
         val wrapper = createWrapper(acknowledgePurchaseHandler = acknowledgePurchaseHandler)
-        every { deviceCache.addSuccessfullyPostedToken(any(), isAutoRenewing = any()) } returns Unit
+        every { deviceCache.addSuccessfullyPostedToken(any()) } returns Unit
 
         wrapper.consumeAndSave(
             finishTransactions = true,
@@ -941,7 +941,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
         )
 
         verify(exactly = 0) { acknowledgePurchaseHandler.acknowledgePurchase(any(), any(), any()) }
-        verify(exactly = 0) { deviceCache.addSuccessfullyPostedToken(any(), isAutoRenewing = any()) }
+        verify(exactly = 0) { deviceCache.addSuccessfullyPostedToken(any()) }
     }
 
     @OptIn(GalaxySerialOperation::class)
@@ -952,7 +952,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
         val ownedListSuccessSlot = slot<(ArrayList<OwnedProductVo>) -> Unit>()
         val acknowledgePurchaseHandler = mockk<AcknowledgePurchaseResponseListener>()
         val getOwnedListHandler = mockk<GetOwnedListResponseListener>()
-        every { deviceCache.addSuccessfullyPostedToken(any(), isAutoRenewing = any()) } returns Unit
+        every { deviceCache.addSuccessfullyPostedToken(any()) } returns Unit
         every {
             getOwnedListHandler.getOwnedList(
                 onSuccess = capture(ownedListSuccessSlot),
@@ -999,7 +999,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
         verify(exactly = 1) { getOwnedListHandler.getOwnedList(any(), any()) }
         verify(exactly = 1) { acknowledgePurchaseHandler.acknowledgePurchase(any(), any(), any()) }
         assertThat(ackTransactionSlot.captured.purchaseToken).isEqualTo("token-sub")
-        verify(exactly = 1) { deviceCache.addSuccessfullyPostedToken("token-sub", isAutoRenewing = true) }
+        verify(exactly = 1) { deviceCache.addSuccessfullyPostedToken("token-sub") }
     }
 
     @OptIn(GalaxySerialOperation::class)
@@ -1008,7 +1008,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
         val ownedListSuccessSlot = slot<(ArrayList<OwnedProductVo>) -> Unit>()
         val acknowledgePurchaseHandler = mockk<AcknowledgePurchaseResponseListener>(relaxed = true)
         val getOwnedListHandler = mockk<GetOwnedListResponseListener>()
-        every { deviceCache.addSuccessfullyPostedToken(any(), isAutoRenewing = any()) } returns Unit
+        every { deviceCache.addSuccessfullyPostedToken(any()) } returns Unit
         every {
             getOwnedListHandler.getOwnedList(
                 onSuccess = capture(ownedListSuccessSlot),
@@ -1042,7 +1042,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
 
         verify(exactly = 1) { getOwnedListHandler.getOwnedList(any(), any()) }
         verify(exactly = 0) { acknowledgePurchaseHandler.acknowledgePurchase(any(), any(), any()) }
-        verify(exactly = 0) { deviceCache.addSuccessfullyPostedToken(any(), isAutoRenewing = any()) }
+        verify(exactly = 0) { deviceCache.addSuccessfullyPostedToken(any()) }
     }
 
     private fun createWrapper(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostPendingTransactionsHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostPendingTransactionsHelper.kt
@@ -6,7 +6,6 @@ import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.LogIntent
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.log
-import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.models.PurchaseState
 import com.revenuecat.purchases.models.StoreTransaction
@@ -55,20 +54,7 @@ internal class PostPendingTransactionsHelper(
                         }
                     }
                     deviceCache.cleanPreviouslySentTokens(purchasesByHashedToken.keys)
-                    val newPurchases = deviceCache.getActivePurchasesNotInCache(purchasesByHashedToken)
-                    val autoRenewingChanged = deviceCache.getPurchasesWithAutoRenewingChange(
-                        purchasesByHashedToken,
-                    )
-                    // Save auto-renewing status only for tokens NOT being re-synced due to a
-                    // change. Changed tokens' status is saved per-transaction on post success,
-                    // so a failed post preserves the old cached value for retry on next sync.
-                    val changedTokenHashes = autoRenewingChanged.map { it.purchaseToken.sha1() }
-                        .toSet()
-                    val unchangedTokens = purchasesByHashedToken.minus(changedTokenHashes)
-                    deviceCache.saveAutoRenewingStatus(unchangedTokens)
-                    val transactionsToSync = (newPurchases + autoRenewingChanged).distinctBy {
-                        it.purchaseToken
-                    }
+                    val transactionsToSync = deviceCache.getActivePurchasesNotInCache(purchasesByHashedToken)
                     val pendingTransactionsTokens = purchasesByHashedToken.values
                         .filter { it.purchaseState == PurchaseState.PENDING }
                         .map { it.purchaseToken }
@@ -157,11 +143,7 @@ internal class PostPendingTransactionsHelper(
                 appUserID,
                 PostReceiptInitiationSource.UNSYNCED_ACTIVE_PURCHASES,
                 sdkOriginated = false,
-                transactionPostSuccess = { transaction, customerInfo ->
-                    deviceCache.addSuccessfullyPostedToken(
-                        transaction.purchaseToken,
-                        transaction.isAutoRenewing,
-                    )
+                transactionPostSuccess = { _, customerInfo ->
                     results.add(Result.Success(customerInfo))
                     callCompletionFromResults(transactionsToSync, results, onError, onSuccess)
                 },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PostReceiptHelper.kt
@@ -57,7 +57,6 @@ constructor(
         initiationSource: PostReceiptInitiationSource,
         onSuccess: (CustomerInfo) -> Unit,
         onError: (PurchasesError) -> Unit,
-        isAutoRenewing: Boolean? = null,
     ) {
         postReceiptAndSubscriberAttributes(
             appUserID,
@@ -67,12 +66,12 @@ constructor(
             initiationSource,
             purchaseState = PurchaseState.UNSPECIFIED_STATE,
             onSuccess = { postReceiptResponse ->
-                deviceCache.addSuccessfullyPostedToken(purchaseToken, isAutoRenewing)
+                deviceCache.addSuccessfullyPostedToken(purchaseToken)
                 onSuccess(postReceiptResponse.customerInfo)
             },
             onError = { backendError, errorHandlingBehavior, _ ->
                 if (errorHandlingBehavior == PostReceiptErrorHandlingBehavior.SHOULD_BE_MARKED_SYNCED) {
-                    deviceCache.addSuccessfullyPostedToken(purchaseToken, isAutoRenewing)
+                    deviceCache.addSuccessfullyPostedToken(purchaseToken)
                 }
                 useOfflineEntitlementsCustomerInfoIfNeeded(
                     errorHandlingBehavior,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/SyncPurchasesHelper.kt
@@ -79,11 +79,11 @@ internal class SyncPurchasesHelper(
                             isRestore,
                             appUserID,
                             PostReceiptInitiationSource.RESTORE,
-                            onSuccess = {
+                            {
                                 log(LogIntent.PURCHASE) { PurchaseStrings.PURCHASE_SYNCED.format(purchase) }
                                 handleLastPurchase(purchase, lastPurchase)
                             },
-                            onError = { error ->
+                            { error ->
                                 log(LogIntent.RC_ERROR) {
                                     PurchaseStrings.SYNCING_PURCHASES_ERROR_DETAILS
                                         .format(purchase, error)
@@ -91,7 +91,6 @@ internal class SyncPurchasesHelper(
                                 errors.add(error)
                                 handleLastPurchase(purchase, lastPurchase)
                             },
-                            isAutoRenewing = purchase.isAutoRenewing,
                         )
                     }
                 } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonBilling.kt
@@ -241,7 +241,7 @@ internal class AmazonBilling(
             }
         }
 
-        cache.addSuccessfullyPostedToken(purchase.purchaseToken, purchase.isAutoRenewing)
+        cache.addSuccessfullyPostedToken(purchase.purchaseToken)
     }
 
     override fun findPurchaseInPurchaseHistory(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/amazon/AmazonCache.kt
@@ -40,7 +40,7 @@ internal class AmazonCache(
     }
 
     @Synchronized
-    fun addSuccessfullyPostedToken(token: String, isAutoRenewing: Boolean? = null) {
-        deviceCache.addSuccessfullyPostedToken(token, isAutoRenewing)
+    fun addSuccessfullyPostedToken(token: String) {
+        deviceCache.addSuccessfullyPostedToken(token)
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -30,10 +30,7 @@ import com.revenuecat.purchases.strings.VirtualCurrencyStrings
 import com.revenuecat.purchases.utils.optNullableString
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencies
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrenciesFactory
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.builtins.MapSerializer
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import org.json.JSONException
 import org.json.JSONObject
@@ -42,17 +39,7 @@ import kotlin.time.Duration.Companion.hours
 
 private val PRODUCT_ENTITLEMENT_MAPPING_CACHE_REFRESH_PERIOD = 25.hours
 private const val SHARED_PREFERENCES_PREFIX = "com.revenuecat.purchases."
-private val tokenMapSerializer = MapSerializer(String.serializer(), TokenCacheEntry.serializer())
 internal const val CUSTOMER_INFO_SCHEMA_VERSION = 3
-
-/**
- * Per-token metadata stored in the unified token cache.
- * Using a data class allows adding more fields in the future without a cache migration.
- */
-@Serializable
-internal data class TokenCacheEntry(
-    val isAutoRenewing: Boolean? = null,
-)
 
 @Suppress("TooManyFunctions")
 @InternalRevenueCatAPI
@@ -77,38 +64,8 @@ public open class DeviceCache(
     internal val appUserIDCacheKey: String by lazy { "$apiKeyPrefix.new" }
     internal val attributionCacheKey = "$SHARED_PREFERENCES_PREFIX.attribution"
 
-    /**
-     * Legacy key that stored sent token hashes as a `Set<String>` via `putStringSet`.
-     * Replaced by [tokensCacheKey] which stores a JSON map of `{ hashedToken: isAutoRenewing }`.
-     * Kept for migration: on first read, entries are migrated to the new key with `null`
-     * auto-renewing values, then this key is deleted.
-     */
-    internal val legacyTokensCacheKey: String by lazy { "$apiKeyPrefix.tokens" }
-
-    /**
-     * Unified token cache storing both "which tokens have been posted" (the key set) and
-     * per-token metadata (the values) as a JSON object.
-     *
-     * Format: `{ "hashedToken1": { "isAutoRenewing": true }, "hashedToken2": { "isAutoRenewing": null } }`
-     * - Keys = hashed tokens that have been successfully posted (replaces the old StringSet)
-     * - Values = JSON objects with cached metadata. Currently stores `isAutoRenewing` status
-     *   (`null` = unknown, e.g. migrated from legacy cache or posted via a path without the
-     *   StoreTransaction). The map format allows adding more fields in the future without
-     *   another migration.
-     *
-     * The `isAutoRenewing` values are used to detect subscription changes made outside the app
-     * (e.g., cancellations in Play Store management). When `queryPurchases` returns a different
-     * `isAutoRenewing` value than what's cached, the token is reposted so the backend can
-     * re-check the subscription status with Google — avoiding a full `syncPurchases` which
-     * reposts everything with `RESTORE` initiation source.
-     */
-    internal val tokensCacheKey: String by lazy { "$apiKeyPrefix.tokensV2" }
-
-    /**
-     * In-memory cache for the token map to avoid repeated JSON deserialization.
-     * Populated on first read, invalidated on writes via [saveTokenMap].
-     */
-    private var tokenMapCache: Map<String, TokenCacheEntry>? = null
+    @VisibleForTesting
+    internal val tokensCacheKey: String by lazy { "$apiKeyPrefix.tokens" }
 
     @VisibleForTesting
     internal val storefrontCacheKey: String by lazy { "storefrontCacheKey" }
@@ -441,77 +398,30 @@ public open class DeviceCache(
 
     // region purchase tokens
 
-    /**
-     * Returns the unified token map (hashedToken → metadata), migrating from legacy
-     * StringSet format if needed. The key set represents all previously sent tokens; the values
-     * contain per-token metadata (currently just isAutoRenewing, null = unknown).
-     */
-    @Synchronized
-    private fun getTokenMap(): Map<String, TokenCacheEntry> {
-        tokenMapCache?.let { return it }
-
-        val result = loadTokenMapFromPreferences()
-        tokenMapCache = result
-        return result
-    }
-
-    private fun loadTokenMapFromPreferences(): Map<String, TokenCacheEntry> {
-        val json = preferences.getString(tokensCacheKey, null)
-        if (json != null) {
-            return try {
-                Json.decodeFromString(tokenMapSerializer, json)
-            } catch (@Suppress("SwallowedException") e: SerializationException) {
-                emptyMap()
-            } catch (@Suppress("SwallowedException") e: IllegalArgumentException) {
-                emptyMap()
-            }
-        }
-        // Migrate from legacy StringSet if it exists
-        return try {
-            val legacyTokens = preferences.getStringSet(legacyTokensCacheKey, null)?.toSet()
-            if (legacyTokens != null) {
-                val migrated = legacyTokens.associateWith { TokenCacheEntry() }
-                saveTokenMap(migrated)
-                preferences.edit().remove(legacyTokensCacheKey).apply()
-                log(LogIntent.DEBUG) { ReceiptStrings.TOKENS_ALREADY_POSTED.format(migrated.keys) }
-                migrated
-            } else {
-                emptyMap()
-            }
-        } catch (@Suppress("SwallowedException") e: ClassCastException) {
-            emptyMap()
-        }
-    }
-
-    @Synchronized
-    private fun saveTokenMap(tokenMap: Map<String, TokenCacheEntry>) {
-        log(LogIntent.DEBUG) { ReceiptStrings.SAVING_TOKENS.format(tokenMap.keys) }
-        putString(tokensCacheKey, Json.encodeToString(tokenMapSerializer, tokenMap))
-        tokenMapCache = tokenMap
-    }
-
     @Synchronized
     internal fun getPreviouslySentHashedTokens(): Set<String> {
-        return getTokenMap().keys.also {
-            log(LogIntent.DEBUG) { ReceiptStrings.TOKENS_ALREADY_POSTED.format(it) }
+        return try {
+            (preferences.getStringSet(tokensCacheKey, emptySet())?.toSet() ?: emptySet()).also {
+                log(LogIntent.DEBUG) { ReceiptStrings.TOKENS_ALREADY_POSTED.format(it) }
+            }
+        } catch (e: ClassCastException) {
+            emptySet()
         }
     }
 
-    @InternalRevenueCatAPI
     @Synchronized
-    public fun addSuccessfullyPostedToken(token: String, isAutoRenewing: Boolean? = null) {
-        val hashedToken = token.sha1()
-        log(LogIntent.DEBUG) { ReceiptStrings.SAVING_TOKENS_WITH_HASH.format(token, hashedToken) }
-        val current = getTokenMap().toMutableMap()
-        log(LogIntent.DEBUG) { ReceiptStrings.TOKENS_IN_CACHE.format(current.keys) }
-        val existing = current[hashedToken]
-        if (existing == null) {
-            current[hashedToken] = TokenCacheEntry(isAutoRenewing = isAutoRenewing)
-            saveTokenMap(current)
-        } else if (isAutoRenewing != null && existing.isAutoRenewing != isAutoRenewing) {
-            current[hashedToken] = existing.copy(isAutoRenewing = isAutoRenewing)
-            saveTokenMap(current)
+    public fun addSuccessfullyPostedToken(token: String) {
+        log(LogIntent.DEBUG) { ReceiptStrings.SAVING_TOKENS_WITH_HASH.format(token, token.sha1()) }
+        getPreviouslySentHashedTokens().let {
+            log(LogIntent.DEBUG) { ReceiptStrings.TOKENS_IN_CACHE.format(it) }
+            setSavedTokenHashes(it.toMutableSet().apply { add(token.sha1()) })
         }
+    }
+
+    @Synchronized
+    private fun setSavedTokenHashes(newSet: Set<String>) {
+        log(LogIntent.DEBUG) { ReceiptStrings.SAVING_TOKENS.format(newSet) }
+        preferences.edit().putStringSet(tokensCacheKey, newSet).apply()
     }
 
     /**
@@ -523,9 +433,9 @@ public open class DeviceCache(
         hashedTokens: Set<String>,
     ) {
         log(LogIntent.DEBUG) { ReceiptStrings.CLEANING_PREV_SENT_HASHED_TOKEN }
-        val current = getTokenMap()
-        val cleaned = current.filterKeys { it in hashedTokens }
-        saveTokenMap(cleaned)
+        setSavedTokenHashes(
+            hashedTokens.intersect(getPreviouslySentHashedTokens()),
+        )
     }
 
     /**
@@ -541,47 +451,6 @@ public open class DeviceCache(
         return hashedTokens
             .minus(getPreviouslySentHashedTokens())
             .values.toList()
-    }
-
-    /**
-     * Returns purchases whose [StoreTransaction.isAutoRenewing] status has changed compared to
-     * the cached value. This detects subscription changes made outside the app (e.g., cancellations
-     * in Play Store subscription management) without requiring a full syncPurchases.
-     */
-    @Synchronized
-    internal fun getPurchasesWithAutoRenewingChange(
-        hashedTokens: Map<String, StoreTransaction>,
-    ): List<StoreTransaction> {
-        val tokenMap = getTokenMap()
-        return hashedTokens.filter { (hash, transaction) ->
-            val cachedEntry = tokenMap[hash]
-            cachedEntry != null &&
-                cachedEntry.isAutoRenewing != null &&
-                transaction.isAutoRenewing != null &&
-                transaction.isAutoRenewing != cachedEntry.isAutoRenewing
-        }.values.toList()
-    }
-
-    /**
-     * Saves the auto-renewing status for all given hashed tokens. Tokens already in the cache
-     * get their status updated; tokens not in the cache are ignored (they haven't been posted yet).
-     */
-    @Synchronized
-    internal fun saveAutoRenewingStatus(hashedTokens: Map<String, StoreTransaction>) {
-        val current = getTokenMap().toMutableMap()
-        var changed = false
-        for ((hash, transaction) in hashedTokens) {
-            val existing = current[hash]
-            if (existing != null && transaction.isAutoRenewing != null &&
-                existing.isAutoRenewing != transaction.isAutoRenewing
-            ) {
-                current[hash] = existing.copy(isAutoRenewing = transaction.isAutoRenewing)
-                changed = true
-            }
-        }
-        if (changed) {
-            saveTokenMap(current)
-        }
     }
 
     // endregion

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -479,36 +479,32 @@ internal class BillingWrapper(
         val alreadyAcknowledged = originalGooglePurchase?.isAcknowledged ?: false
         val isInAppProduct = purchase.type == ProductType.INAPP
 
-        val addToken = { token: String ->
-            deviceCache.addSuccessfullyPostedToken(token, purchase.isAutoRenewing)
-        }
-
         if (isInAppProduct) {
             if (finishTransactions && shouldConsume) {
                 consumePurchase(
                     purchase.purchaseToken,
                     initiationSource,
-                    onConsumed = addToken,
+                    onConsumed = deviceCache::addSuccessfullyPostedToken,
                 )
             } else if (finishTransactions && !alreadyAcknowledged) {
                 log(LogIntent.PURCHASE) { PurchaseStrings.NOT_CONSUMING_IN_APP_PURCHASE_ACCORDING_TO_BACKEND }
                 acknowledge(
                     purchase.purchaseToken,
                     initiationSource,
-                    onAcknowledged = addToken,
+                    onAcknowledged = deviceCache::addSuccessfullyPostedToken,
                 )
             } else {
-                addToken(purchase.purchaseToken)
+                deviceCache.addSuccessfullyPostedToken(purchase.purchaseToken)
             }
         } else {
             if (finishTransactions && !alreadyAcknowledged) {
                 acknowledge(
                     purchase.purchaseToken,
                     initiationSource,
-                    onAcknowledged = addToken,
+                    onAcknowledged = deviceCache::addSuccessfullyPostedToken,
                 )
             } else {
-                addToken(purchase.purchaseToken)
+                deviceCache.addSuccessfullyPostedToken(purchase.purchaseToken)
             }
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PostPendingTransactionsHelperTest.kt
@@ -66,8 +66,6 @@ class PostPendingTransactionsHelperTest {
             lambda<() -> Unit>().captured.invoke()
         }
 
-        every { deviceCache.addSuccessfullyPostedToken(any(), any()) } just Runs
-
         changeBillingConnected()
         changeAutoSyncEnabled(true)
 
@@ -370,10 +368,7 @@ class PostPendingTransactionsHelperTest {
                     lambda<SuccessfulPurchaseCallback>().captured.invoke(transaction, customerInfo!!)
                 }
             } ?: run {
-                lambda<SuccessfulPurchaseCallback>().captured.invoke(
-                    mockk(relaxed = true),
-                    customerInfo!!,
-                )
+                lambda<SuccessfulPurchaseCallback>().captured.invoke(mockk(), customerInfo!!)
             }
         }
     }
@@ -390,8 +385,7 @@ class PostPendingTransactionsHelperTest {
 
     private fun mockSuccessfulQueryPurchases(
         purchasesByHashedToken: Map<String, StoreTransaction>,
-        notInCache: List<StoreTransaction>,
-        autoRenewingChanged: List<StoreTransaction> = emptyList(),
+        notInCache: List<StoreTransaction>
     ) {
         every {
             deviceCache.cleanPreviouslySentTokens(purchasesByHashedToken.keys)
@@ -399,12 +393,6 @@ class PostPendingTransactionsHelperTest {
         every {
             deviceCache.getActivePurchasesNotInCache(purchasesByHashedToken)
         } returns notInCache
-        every {
-            deviceCache.getPurchasesWithAutoRenewingChange(purchasesByHashedToken)
-        } returns autoRenewingChanged
-        every {
-            deviceCache.saveAutoRenewingStatus(any())
-        } just Runs
 
         every {
             billing.queryPurchases(
@@ -730,224 +718,6 @@ class PostPendingTransactionsHelperTest {
         // Verify that only the pending transaction tokens are passed
         assertThat(pendingTokensSlot.captured).containsExactlyInAnyOrder("pendingToken1", "pendingToken2")
         assertThat(pendingTokensSlot.captured).doesNotContain("purchasedToken")
-    }
-
-    // endregion
-
-    // region auto-renewing change detection
-
-    @Test
-    fun `when auto-renewing status changes, transaction is synced`() {
-        val purchase = stubGooglePurchase(
-            purchaseToken = "token",
-            productIds = listOf("product"),
-            purchaseState = Purchase.PurchaseState.PURCHASED,
-        )
-        val transaction = purchase.toStoreTransaction(ProductType.SUBS)
-        val purchasesByHash = mapOf(purchase.purchaseToken.sha1() to transaction)
-
-        mockSuccessfulQueryPurchases(
-            purchasesByHashedToken = purchasesByHash,
-            notInCache = emptyList(),
-            autoRenewingChanged = listOf(transaction),
-        )
-
-        val customerInfoMock = mockk<CustomerInfo>()
-        mockPostTransactionsSuccessful(customerInfoMock)
-
-        syncAndAssertResult(SyncPendingPurchaseResult.Success(customerInfoMock))
-
-        verify(exactly = 1) {
-            postTransactionWithProductDetailsHelper.postTransactions(
-                transactions = listOf(transaction),
-                allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
-                appUserID = appUserId,
-                initiationSource = initiationSource,
-                sdkOriginated = false,
-                transactionPostSuccess = any(),
-                transactionPostError = any(),
-            )
-        }
-    }
-
-    @Test
-    fun `when auto-renewing status changes and there are new purchases, both are synced`() {
-        val existingPurchase = stubGooglePurchase(
-            purchaseToken = "existing-token",
-            productIds = listOf("product1"),
-            purchaseState = Purchase.PurchaseState.PURCHASED,
-        )
-        val existingTransaction = existingPurchase.toStoreTransaction(ProductType.SUBS)
-
-        val newPurchase = stubGooglePurchase(
-            purchaseToken = "new-token",
-            productIds = listOf("product2"),
-            purchaseState = Purchase.PurchaseState.PURCHASED,
-        )
-        val newTransaction = newPurchase.toStoreTransaction(ProductType.SUBS)
-
-        val purchasesByHash = mapOf(
-            existingPurchase.purchaseToken.sha1() to existingTransaction,
-            newPurchase.purchaseToken.sha1() to newTransaction,
-        )
-
-        mockSuccessfulQueryPurchases(
-            purchasesByHashedToken = purchasesByHash,
-            notInCache = listOf(newTransaction),
-            autoRenewingChanged = listOf(existingTransaction),
-        )
-
-        val customerInfoMock = mockk<CustomerInfo>()
-        val transactionsSlot = slot<List<StoreTransaction>>()
-        every {
-            postTransactionWithProductDetailsHelper.postTransactions(
-                transactions = capture(transactionsSlot),
-                allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
-                appUserID = appUserId,
-                initiationSource = initiationSource,
-                sdkOriginated = false,
-                transactionPostSuccess = captureLambda(),
-                transactionPostError = any(),
-            )
-        } answers {
-            val captured = transactionsSlot.captured
-            captured.forEach { transaction ->
-                lambda<SuccessfulPurchaseCallback>().captured.invoke(transaction, customerInfoMock)
-            }
-        }
-
-        syncAndAssertResult(SyncPendingPurchaseResult.Success(customerInfoMock))
-
-        assertThat(transactionsSlot.captured).hasSize(2)
-        assertThat(transactionsSlot.captured).containsExactlyInAnyOrder(newTransaction, existingTransaction)
-    }
-
-    @Test
-    fun `when no auto-renewing changes and no new purchases, no transactions synced`() {
-        val purchase = stubGooglePurchase(
-            purchaseToken = "token",
-            productIds = listOf("product"),
-            purchaseState = Purchase.PurchaseState.PURCHASED,
-        )
-        val transaction = purchase.toStoreTransaction(ProductType.SUBS)
-        val purchasesByHash = mapOf(purchase.purchaseToken.sha1() to transaction)
-
-        mockSuccessfulQueryPurchases(
-            purchasesByHashedToken = purchasesByHash,
-            notInCache = emptyList(),
-            autoRenewingChanged = emptyList(),
-        )
-
-        syncAndAssertResult(SyncPendingPurchaseResult.NoPendingPurchasesToSync)
-
-        verify(exactly = 0) {
-            postTransactionWithProductDetailsHelper.postTransactions(
-                transactions = any(),
-                allowSharingPlayStoreAccount = any(),
-                appUserID = any(),
-                initiationSource = any(),
-                sdkOriginated = any(),
-                transactionPostSuccess = any(),
-                transactionPostError = any(),
-            )
-        }
-    }
-
-    @Test
-    fun `auto-renewing status is saved for unchanged tokens`() {
-        val purchase = stubGooglePurchase(
-            purchaseToken = "token",
-            productIds = listOf("product"),
-            purchaseState = Purchase.PurchaseState.PURCHASED,
-        )
-        val transaction = purchase.toStoreTransaction(ProductType.SUBS)
-        val purchasesByHash = mapOf(purchase.purchaseToken.sha1() to transaction)
-
-        mockSuccessfulQueryPurchases(
-            purchasesByHashedToken = purchasesByHash,
-            notInCache = emptyList(),
-            autoRenewingChanged = emptyList(),
-        )
-
-        postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount)
-
-        verify(exactly = 1) {
-            deviceCache.saveAutoRenewingStatus(purchasesByHash)
-        }
-    }
-
-    @Test
-    fun `auto-renewing status is not eagerly saved for changed tokens`() {
-        val purchase = stubGooglePurchase(
-            purchaseToken = "token",
-            productIds = listOf("product"),
-            purchaseState = Purchase.PurchaseState.PURCHASED,
-        )
-        val transaction = purchase.toStoreTransaction(ProductType.SUBS)
-        val purchasesByHash = mapOf(purchase.purchaseToken.sha1() to transaction)
-
-        mockSuccessfulQueryPurchases(
-            purchasesByHashedToken = purchasesByHash,
-            notInCache = emptyList(),
-            autoRenewingChanged = listOf(transaction),
-        )
-
-        val customerInfoMock = mockk<CustomerInfo>()
-        mockPostTransactionsSuccessful(customerInfoMock, listOf(transaction))
-
-        postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount)
-
-        // Changed tokens are excluded from the eager save
-        verify(exactly = 1) {
-            deviceCache.saveAutoRenewingStatus(emptyMap())
-        }
-        // Instead, auto-renewing is saved per-transaction on post success
-        verify(exactly = 1) {
-            deviceCache.addSuccessfullyPostedToken(transaction.purchaseToken, transaction.isAutoRenewing)
-        }
-    }
-
-    @Test
-    fun `failed post of changed auto-renewing does not update cache`() {
-        val purchase = stubGooglePurchase(
-            purchaseToken = "token",
-            productIds = listOf("product"),
-            purchaseState = Purchase.PurchaseState.PURCHASED,
-        )
-        val transaction = purchase.toStoreTransaction(ProductType.SUBS)
-        val purchasesByHash = mapOf(purchase.purchaseToken.sha1() to transaction)
-
-        mockSuccessfulQueryPurchases(
-            purchasesByHashedToken = purchasesByHash,
-            notInCache = emptyList(),
-            autoRenewingChanged = listOf(transaction),
-        )
-
-        val error = PurchasesError(PurchasesErrorCode.NetworkError)
-        every {
-            postTransactionWithProductDetailsHelper.postTransactions(
-                transactions = any(),
-                allowSharingPlayStoreAccount = allowSharingPlayStoreAccount,
-                appUserID = appUserId,
-                initiationSource = initiationSource,
-                sdkOriginated = false,
-                transactionPostSuccess = any(),
-                transactionPostError = captureLambda(),
-            )
-        } answers {
-            lambda<ErrorPurchaseCallback>().captured.invoke(transaction, error)
-        }
-
-        postPendingTransactionsHelper.syncPendingPurchaseQueue(allowSharingPlayStoreAccount)
-
-        // Changed token excluded from eager save
-        verify(exactly = 1) {
-            deviceCache.saveAutoRenewingStatus(emptyMap())
-        }
-        // addSuccessfullyPostedToken NOT called since the post failed
-        verify(exactly = 0) {
-            deviceCache.addSuccessfullyPostedToken(any(), any())
-        }
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/SyncPurchasesHelperTest.kt
@@ -78,7 +78,7 @@ class SyncPurchasesHelperTest {
         assertThat(receivedCustomerInfo).isEqualTo(customerInfoMock)
         verify(exactly = 0) {
             postReceiptHelper.postTokenWithoutConsuming(
-                any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(),
             )
         }
     }
@@ -121,7 +121,6 @@ class SyncPurchasesHelperTest {
                 initiationSource = any(),
                 onSuccess = any(),
                 onError = any(),
-                isAutoRenewing = any(),
             )
         }
     }
@@ -134,7 +133,6 @@ class SyncPurchasesHelperTest {
             every { purchaseToken } returns "test-purchase-token-1"
             every { storeUserID } returns "test-store-user-id"
             every { marketplace } returns null
-            every { isAutoRenewing } returns true
         }
         val purchase2 = mockk<StoreTransaction>().apply {
             every { productIds } returns listOf("test-product-id-2")
@@ -142,7 +140,6 @@ class SyncPurchasesHelperTest {
             every { purchaseToken } returns "test-purchase-token-2"
             every { storeUserID } returns "test-store-user-id"
             every { marketplace } returns "test-marketplace"
-            every { isAutoRenewing } returns true
         }
         mockBillingQueryAllPurchasesSuccess(listOf(purchase1, purchase2))
 
@@ -155,7 +152,6 @@ class SyncPurchasesHelperTest {
                 initiationSource = any(),
                 onSuccess = captureLambda(),
                 onError = any(),
-                isAutoRenewing = any(),
             )
         } answers {
             lambda<(CustomerInfo) -> Unit>().captured.invoke(mockk())
@@ -178,8 +174,7 @@ class SyncPurchasesHelperTest {
                 appUserID = appUserID,
                 initiationSource = initiationSource,
                 onSuccess = any(),
-                onError = any(),
-                isAutoRenewing = any(),
+                onError = any()
             )
             postReceiptHelper.postTokenWithoutConsuming(
                 purchaseToken = "test-purchase-token-2",
@@ -190,8 +185,7 @@ class SyncPurchasesHelperTest {
                 appUserID = appUserID,
                 initiationSource = initiationSource,
                 onSuccess = any(),
-                onError = any(),
-                isAutoRenewing = any(),
+                onError = any()
             )
         }
     }
@@ -204,7 +198,6 @@ class SyncPurchasesHelperTest {
             every { purchaseToken } returns "test-purchase-token-1"
             every { storeUserID } returns "test-store-user-id"
             every { marketplace } returns null
-            every { isAutoRenewing } returns true
         }
         val purchase2 = mockk<StoreTransaction>().apply {
             every { productIds } returns listOf("test-product-id-2")
@@ -212,13 +205,12 @@ class SyncPurchasesHelperTest {
             every { purchaseToken } returns "test-purchase-token-2"
             every { storeUserID } returns "test-store-user-id"
             every { marketplace } returns "test-marketplace"
-            every { isAutoRenewing } returns true
         }
         mockBillingQueryAllPurchasesSuccess(listOf(purchase1, purchase2))
 
         every {
             postReceiptHelper.postTokenWithoutConsuming(
-                any(), any(), any(), any(), any(), any(), captureLambda(), any(),
+                any(), any(), any(), any(), any(), any(), captureLambda(),
             )
         } answers {
             lambda<(PurchasesError) -> Unit>().captured.invoke(testError)
@@ -243,8 +235,7 @@ class SyncPurchasesHelperTest {
                 appUserID = appUserID,
                 initiationSource = initiationSource,
                 onSuccess = any(),
-                onError = any(),
-                isAutoRenewing = any(),
+                onError = any()
             )
             postReceiptHelper.postTokenWithoutConsuming(
                 purchaseToken = "test-purchase-token-2",
@@ -255,8 +246,7 @@ class SyncPurchasesHelperTest {
                 appUserID = appUserID,
                 initiationSource = initiationSource,
                 onSuccess = any(),
-                onError = any(),
-                isAutoRenewing = any(),
+                onError = any()
             )
         }
     }

--- a/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/amazon/AmazonBillingTest.kt
@@ -577,7 +577,7 @@ class AmazonBillingTest {
         } just Runs
 
         every {
-            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId, any())
+            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
         } just Runs
 
         underTest.consumeAndSave(
@@ -600,7 +600,7 @@ class AmazonBillingTest {
         }
 
         verify(exactly = 1) {
-            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId, any())
+            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
         }
     }
 
@@ -614,7 +614,7 @@ class AmazonBillingTest {
         } just Runs
 
         every {
-            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId, any())
+            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
         } just Runs
 
         underTest.consumeAndSave(
@@ -637,7 +637,7 @@ class AmazonBillingTest {
         }
 
         verify(exactly = 1) {
-            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId, any())
+            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
         }
     }
 
@@ -651,7 +651,7 @@ class AmazonBillingTest {
         } just Runs
 
         every {
-            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId, any())
+            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
         } just Runs
 
         underTest.consumeAndSave(
@@ -674,7 +674,7 @@ class AmazonBillingTest {
         }
 
         verify(exactly = 1) {
-            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId, any())
+            mockCache.addSuccessfullyPostedToken(dummyReceipt.receiptId)
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -355,67 +355,72 @@ class DeviceCacheTest {
 
     @Test
     fun `getting sent tokens works`() {
-        mockTokenMap(tokenMapJson("token1" to null, "token2" to true))
+        val tokens = setOf("token1", "token2")
+        every {
+            mockPrefs.getStringSet(cache.tokensCacheKey, any())
+        } returns tokens
         val sentTokens = cache.getPreviouslySentHashedTokens()
-        assertThat(sentTokens).isEqualTo(setOf("token1", "token2"))
+        assertThat(sentTokens).isEqualTo(tokens)
     }
 
     @Test
     fun `token is hashed then added`() {
-        mockTokenMap(tokenMapJson("token1" to null, "token2" to true))
-        every { mockEditor.apply() } just runs
+        every {
+            mockPrefs.getStringSet(cache.tokensCacheKey, any())
+        } returns setOf("token1", "token2")
+        val sha1 = "token3".sha1()
+        every {
+            mockEditor.putStringSet(cache.tokensCacheKey, setOf("token1", "token2", sha1))
+        } returns mockEditor
+        every {
+            mockEditor.apply()
+        } just runs
 
         cache.addSuccessfullyPostedToken("token3")
-        val sha1 = "token3".sha1()
         verify {
-            mockEditor.putString(cache.tokensCacheKey, match { json ->
-                val obj = JSONObject(json)
-                obj.has("token1") && obj.has("token2") && obj.has(sha1)
-            })
-        }
-    }
-
-    @Test
-    fun `addSuccessfullyPostedToken does not overwrite existing token`() {
-        val sha1 = "token1".sha1()
-        mockTokenMap(tokenMapJson(sha1 to true))
-        cache.addSuccessfullyPostedToken("token1")
-        verify(exactly = 0) {
-            mockEditor.putString(cache.tokensCacheKey, any())
+            mockEditor.putStringSet(cache.tokensCacheKey, setOf("token1", "token2", sha1))
         }
     }
 
     @Test
     fun `if token is not active anymore, remove it from database`() {
-        mockTokenMap(tokenMapJson("token1" to null, "token2" to true, "token3" to false))
-        every { mockEditor.apply() } just runs
-
+        every {
+            mockEditor.putStringSet(cache.tokensCacheKey, setOf("token3"))
+        } returns mockEditor
+        every {
+            mockEditor.apply()
+        } just runs
+        every {
+            mockPrefs.getStringSet(cache.tokensCacheKey, any())
+        } returns setOf("token1", "token2", "token3")
         cache.cleanPreviouslySentTokens(setOf("token3", "token4"))
         verify {
-            mockEditor.putString(cache.tokensCacheKey, match { json ->
-                val obj = JSONObject(json)
-                obj.length() == 1 && obj.has("token3")
-            })
+            mockEditor.putStringSet(cache.tokensCacheKey, setOf("token3"))
         }
     }
 
     @Test
     fun `if all tokens are active, do not remove any`() {
-        mockTokenMap(tokenMapJson("token1" to null, "token2" to true))
-        every { mockEditor.apply() } just runs
-
+        every {
+            mockEditor.putStringSet(cache.tokensCacheKey, setOf("token1", "token2"))
+        } returns mockEditor
+        every {
+            mockEditor.apply()
+        } just runs
+        every {
+            mockPrefs.getStringSet(cache.tokensCacheKey, any())
+        } returns setOf("token1", "token2")
         cache.cleanPreviouslySentTokens(setOf("token1", "token2"))
         verify {
-            mockEditor.putString(cache.tokensCacheKey, match { json ->
-                val obj = JSONObject(json)
-                obj.length() == 2 && obj.has("token1") && obj.has("token2")
-            })
+            mockEditor.putStringSet(cache.tokensCacheKey, setOf("token1", "token2"))
         }
     }
 
     @Test
     fun `getting the tokens not in cache returns all the active tokens that have not been sent`() {
-        mockTokenMap(tokenMapJson("token1" to null, "hash2" to true, "token3" to false))
+        every {
+            mockPrefs.getStringSet(cache.tokensCacheKey, any())
+        } returns setOf("token1", "hash2", "token3")
         val activeSub = mockk<StoreTransaction>(relaxed = true).also {
             every { it.type } returns ProductType.SUBS
         }
@@ -521,10 +526,9 @@ class DeviceCacheTest {
     }
 
     @Test
-    fun `getPreviouslySentHashedTokens returns emptySet if ClassCastException on legacy migration`() {
-        mockString(cache.tokensCacheKey, null)
+    fun `getPreviouslySentHashedTokens returns an emptySet if there's a ClassCastException when calling getStringSet`() {
         every {
-            mockPrefs.getStringSet(cache.legacyTokensCacheKey, any())
+            mockPrefs.getStringSet(cache.tokensCacheKey, any())
         } throws ClassCastException("java.lang.String cannot be cast to java.util.Set")
         val sentTokens = cache.getPreviouslySentHashedTokens()
         assertThat(sentTokens).isEmpty()
@@ -888,316 +892,6 @@ class DeviceCacheTest {
         assertThat(vcs).`as`("cached VirtualCurrencies is null when JSONException is thrown").isNull()
     }
     // endregion virtualCurrencies
-
-    // region auto-renewing status
-
-    @Test
-    fun `getPurchasesWithAutoRenewingChange returns empty when auto-renewing is null (unknown)`() {
-        mockTokenMap(tokenMapJson("hash1" to null))
-
-        val transaction = mockk<StoreTransaction>(relaxed = true).also {
-            every { it.isAutoRenewing } returns false
-        }
-        val result = cache.getPurchasesWithAutoRenewingChange(mapOf("hash1" to transaction))
-        assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `getPurchasesWithAutoRenewingChange detects change from true to false`() {
-        mockTokenMap(tokenMapJson("hash1" to true))
-
-        val transaction = mockk<StoreTransaction>(relaxed = true).also {
-            every { it.isAutoRenewing } returns false
-        }
-        val result = cache.getPurchasesWithAutoRenewingChange(mapOf("hash1" to transaction))
-        assertThat(result).containsExactly(transaction)
-    }
-
-    @Test
-    fun `getPurchasesWithAutoRenewingChange detects change from false to true`() {
-        mockTokenMap(tokenMapJson("hash1" to false))
-
-        val transaction = mockk<StoreTransaction>(relaxed = true).also {
-            every { it.isAutoRenewing } returns true
-        }
-        val result = cache.getPurchasesWithAutoRenewingChange(mapOf("hash1" to transaction))
-        assertThat(result).containsExactly(transaction)
-    }
-
-    @Test
-    fun `getPurchasesWithAutoRenewingChange returns empty when status unchanged`() {
-        mockTokenMap(tokenMapJson("hash1" to true))
-
-        val transaction = mockk<StoreTransaction>(relaxed = true).also {
-            every { it.isAutoRenewing } returns true
-        }
-        val result = cache.getPurchasesWithAutoRenewingChange(mapOf("hash1" to transaction))
-        assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `getPurchasesWithAutoRenewingChange ignores tokens not in cache`() {
-        mockTokenMap(tokenMapJson("hash2" to true))
-
-        val transaction = mockk<StoreTransaction>(relaxed = true).also {
-            every { it.isAutoRenewing } returns false
-        }
-        val result = cache.getPurchasesWithAutoRenewingChange(mapOf("hash1" to transaction))
-        assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `getPurchasesWithAutoRenewingChange returns empty when transaction isAutoRenewing is null`() {
-        mockTokenMap(tokenMapJson("hash1" to true))
-
-        val transaction = mockk<StoreTransaction>(relaxed = true).also {
-            every { it.isAutoRenewing } returns null
-        }
-        val result = cache.getPurchasesWithAutoRenewingChange(mapOf("hash1" to transaction))
-        assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `saveAutoRenewingStatus updates existing tokens only`() {
-        mockTokenMap(tokenMapJson("hash1" to null, "hash2" to true))
-        every { mockEditor.apply() } just runs
-
-        val transaction = mockk<StoreTransaction>(relaxed = true).also {
-            every { it.isAutoRenewing } returns false
-        }
-        cache.saveAutoRenewingStatus(mapOf("hash1" to transaction, "hash3" to transaction))
-        verify {
-            mockEditor.putString(cache.tokensCacheKey, match { json ->
-                val obj = JSONObject(json)
-                obj.length() == 2 &&
-                    verifyTokenEntry(obj, "hash1", false) &&
-                    verifyTokenEntry(obj, "hash2", true)
-            })
-        }
-    }
-
-    @Test
-    fun `saveAutoRenewingStatus does not overwrite non-null cached value with null`() {
-        mockTokenMap(tokenMapJson("hash1" to true))
-
-        val transaction = mockk<StoreTransaction>(relaxed = true).also {
-            every { it.isAutoRenewing } returns null
-        }
-        cache.saveAutoRenewingStatus(mapOf("hash1" to transaction))
-        verify(exactly = 0) {
-            mockEditor.putString(cache.tokensCacheKey, any())
-        }
-    }
-
-    // endregion auto-renewing status
-
-    // region legacy token migration
-
-    @Test
-    fun `migrates legacy StringSet tokens to unified JSON map with null auto-renewing`() {
-        mockString(cache.tokensCacheKey, null)
-        every {
-            mockPrefs.getStringSet(cache.legacyTokensCacheKey, null)
-        } returns setOf("hash1", "hash2")
-        every { mockEditor.apply() } just runs
-        every { mockEditor.remove(any()) } returns mockEditor
-
-        val sentTokens = cache.getPreviouslySentHashedTokens()
-
-        assertThat(sentTokens).containsExactlyInAnyOrder("hash1", "hash2")
-        verify {
-            mockEditor.putString(cache.tokensCacheKey, match { json ->
-                val obj = JSONObject(json)
-                obj.length() == 2 &&
-                    verifyTokenEntry(obj, "hash1", null) &&
-                    verifyTokenEntry(obj, "hash2", null)
-            })
-        }
-        verify { mockEditor.remove(cache.legacyTokensCacheKey) }
-    }
-
-    @Test
-    fun `does not migrate if new key already exists`() {
-        mockTokenMap(tokenMapJson("hash1" to true))
-
-        val sentTokens = cache.getPreviouslySentHashedTokens()
-
-        assertThat(sentTokens).containsExactly("hash1")
-        verify(exactly = 0) { mockPrefs.getStringSet(cache.legacyTokensCacheKey, any()) }
-    }
-
-    @Test
-    fun `returns empty when neither legacy nor new key exists`() {
-        mockString(cache.tokensCacheKey, null)
-        every { mockPrefs.getStringSet(cache.legacyTokensCacheKey, null) } returns null
-
-        val sentTokens = cache.getPreviouslySentHashedTokens()
-        assertThat(sentTokens).isEmpty()
-    }
-
-    @Test
-    fun `migrated tokens with null auto-renewing are not detected as changed`() {
-        // After migration, tokens have null isAutoRenewing — they should NOT trigger change detection
-        mockTokenMap(tokenMapJson("hash1" to null))
-
-        val transaction = mockk<StoreTransaction>(relaxed = true).also {
-            every { it.isAutoRenewing } returns true
-        }
-        val result = cache.getPurchasesWithAutoRenewingChange(mapOf("hash1" to transaction))
-        assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `migrated tokens get auto-renewing populated after saveAutoRenewingStatus`() {
-        // Simulates: migration gave null, then saveAutoRenewingStatus populates the value
-        mockTokenMap(tokenMapJson("hash1" to null))
-        every { mockEditor.apply() } just runs
-
-        val transaction = mockk<StoreTransaction>(relaxed = true).also {
-            every { it.isAutoRenewing } returns true
-        }
-        cache.saveAutoRenewingStatus(mapOf("hash1" to transaction))
-        verify {
-            mockEditor.putString(cache.tokensCacheKey, match { json ->
-                val obj = JSONObject(json)
-                obj.length() == 1 && verifyTokenEntry(obj, "hash1", true)
-            })
-        }
-    }
-
-    @Test
-    fun `cleanPreviouslySentTokens preserves auto-renewing values`() {
-        mockTokenMap(tokenMapJson("hash1" to true, "hash2" to false, "hash3" to null))
-        every { mockEditor.apply() } just runs
-
-        cache.cleanPreviouslySentTokens(setOf("hash1", "hash3"))
-        verify {
-            mockEditor.putString(cache.tokensCacheKey, match { json ->
-                val obj = JSONObject(json)
-                obj.length() == 2 &&
-                    verifyTokenEntry(obj, "hash1", true) &&
-                    verifyTokenEntry(obj, "hash3", null)
-            })
-        }
-    }
-
-    @Test
-    fun `addSuccessfullyPostedToken updates auto-renewing for existing token`() {
-        val sha1 = "token1".sha1()
-        mockTokenMap(tokenMapJson(sha1 to null))
-        every { mockEditor.apply() } just runs
-
-        cache.addSuccessfullyPostedToken("token1", false)
-        verify {
-            mockEditor.putString(cache.tokensCacheKey, match { json ->
-                val obj = JSONObject(json)
-                obj.length() == 1 && verifyTokenEntry(obj, sha1, false)
-            })
-        }
-    }
-
-    @Test
-    fun `addSuccessfullyPostedToken does not overwrite with same value`() {
-        val sha1 = "token1".sha1()
-        mockTokenMap(tokenMapJson(sha1 to true))
-        cache.addSuccessfullyPostedToken("token1", true)
-        verify(exactly = 0) {
-            mockEditor.putString(cache.tokensCacheKey, any())
-        }
-    }
-
-    // endregion legacy token migration
-
-    // region in-memory token cache
-
-    @Test
-    fun `getTokenMap caches result in memory and avoids repeated deserialization`() {
-        mockTokenMap(tokenMapJson("hash1" to true))
-
-        cache.getPreviouslySentHashedTokens()
-        cache.getPreviouslySentHashedTokens()
-
-        verify(exactly = 1) {
-            mockPrefs.getString(cache.tokensCacheKey, isNull())
-        }
-    }
-
-    @Test
-    fun `addSuccessfullyPostedToken updates in-memory cache`() {
-        mockTokenMap(tokenMapJson())
-        every { mockEditor.apply() } just runs
-
-        cache.addSuccessfullyPostedToken("token1", true)
-
-        // Clear the mock so SharedPreferences would return null if called
-        every { mockPrefs.getString(cache.tokensCacheKey, isNull()) } returns null
-
-        val sentTokens = cache.getPreviouslySentHashedTokens()
-        assertThat(sentTokens).contains("token1".sha1())
-    }
-
-    @Test
-    fun `cleanPreviouslySentTokens updates in-memory cache`() {
-        mockTokenMap(tokenMapJson("hash1" to true, "hash2" to false))
-        every { mockEditor.apply() } just runs
-
-        cache.cleanPreviouslySentTokens(setOf("hash1"))
-
-        // Clear the mock so SharedPreferences would return null if called
-        every { mockPrefs.getString(cache.tokensCacheKey, isNull()) } returns null
-
-        val sentTokens = cache.getPreviouslySentHashedTokens()
-        assertThat(sentTokens).containsExactly("hash1")
-    }
-
-    @Test
-    fun `saveAutoRenewingStatus updates in-memory cache`() {
-        mockTokenMap(tokenMapJson("hash1" to true))
-        every { mockEditor.apply() } just runs
-
-        val transaction = mockk<StoreTransaction>(relaxed = true).also {
-            every { it.isAutoRenewing } returns false
-        }
-        cache.saveAutoRenewingStatus(mapOf("hash1" to transaction))
-
-        // Clear the mock so SharedPreferences would return null if called
-        every { mockPrefs.getString(cache.tokensCacheKey, isNull()) } returns null
-
-        // Should still detect the change from the in-memory cache
-        val changed = cache.getPurchasesWithAutoRenewingChange(mapOf("hash1" to transaction))
-        assertThat(changed).isEmpty() // false == false, no change
-    }
-
-    // endregion in-memory token cache
-
-    private fun mockTokenMap(json: String) {
-        mockString(cache.tokensCacheKey, json)
-    }
-
-    /**
-     * Builds a token map JSON string in the new nested format.
-     * Example: tokenMapJson("hash1" to true, "hash2" to null, "hash3" to false)
-     * produces: {"hash1":{"isAutoRenewing":true},"hash2":{"isAutoRenewing":null},"hash3":{"isAutoRenewing":false}}
-     */
-    private fun tokenMapJson(vararg entries: Pair<String, Boolean?>): String {
-        val obj = JSONObject()
-        for ((key, value) in entries) {
-            obj.put(key, JSONObject().apply {
-                put("isAutoRenewing", value ?: JSONObject.NULL)
-            })
-        }
-        return obj.toString()
-    }
-
-    private fun verifyTokenEntry(obj: JSONObject, key: String, expectedAutoRenewing: Boolean?): Boolean {
-        if (!obj.has(key)) return false
-        val entry = obj.getJSONObject(key)
-        return if (expectedAutoRenewing == null) {
-            entry.isNull("isAutoRenewing")
-        } else {
-            entry.getBoolean("isAutoRenewing") == expectedAutoRenewing
-        }
-    }
 
     private fun mockString(key: String, value: String?) {
         every {

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -64,7 +64,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         val token = googlePurchaseWrapper.purchaseToken
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -80,7 +80,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         )
 
         verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -90,7 +90,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         val token = googlePurchaseWrapper.purchaseToken
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -106,7 +106,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         )
 
         verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -116,7 +116,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         val token = googleRecordWrapper.purchaseToken
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -132,7 +132,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         )
 
         verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -154,7 +154,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         )
 
         verify(exactly = 0) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -176,7 +176,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         )
 
         verify(exactly = 0) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -186,7 +186,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         val token = googlePurchaseWrapper.purchaseToken
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -212,7 +212,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         val token = googlePurchaseWrapper.purchaseToken
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -242,7 +242,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         val token = googlePurchaseWrapper.purchaseToken
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -272,7 +272,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         val token = googlePurchaseWrapper.purchaseToken
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -292,7 +292,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         val token = googleRecordWrapper.purchaseToken
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -318,7 +318,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         val token = googlePurchaseWrapper.purchaseToken
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -333,7 +333,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         }
 
         verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -343,7 +343,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         val token = googleRecordWrapper.purchaseToken
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -358,7 +358,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         }
 
         verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -368,7 +368,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         val token = googlePurchaseWrapper.purchaseToken
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -383,7 +383,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         }
 
         verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/ConsumePurchaseUseCaseTest.kt
@@ -66,7 +66,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         )
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -79,7 +79,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         assertThat(capturedConsumeResponseListener.isCaptured).isTrue
 
         verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -94,7 +94,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         )
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -107,7 +107,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         assertThat(capturedConsumeResponseListener.isCaptured).isTrue
 
         verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -134,7 +134,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         assertThat(capturedConsumeResponseListener.isCaptured).isTrue
 
         verify(exactly = 0) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -161,7 +161,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         assertThat(capturedConsumeResponseListener.isCaptured).isTrue
 
         verify(exactly = 0) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -177,7 +177,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         )
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -209,7 +209,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         )
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -242,7 +242,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         )
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -257,7 +257,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         }
 
         verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -272,7 +272,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         )
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -287,7 +287,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         }
 
         verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -302,7 +302,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         )
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -317,7 +317,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         }
 
         verify(exactly = 1) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 
@@ -334,7 +334,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         )
 
         every {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         } just Runs
 
         wrapper.consumeAndSave(
@@ -353,7 +353,7 @@ internal class ConsumePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         }
 
         verify(exactly = 0) {
-            mockDeviceCache.addSuccessfullyPostedToken(token, any())
+            mockDeviceCache.addSuccessfullyPostedToken(token)
         }
     }
 


### PR DESCRIPTION
Reverts RevenueCat/purchases-android#3198, which appears to be causing a few integration test failures.