### PR TITLE
Add placement and targeting context to paywall events

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
@@ -100,7 +100,7 @@ internal sealed class BackendEvent : Event {
         @SerialName("locale")
         val localeIdentifier: String,
         @SerialName("presented_offering_context")
-        val presentedOfferingContext: PresentedOfferingContextBackend? = null,
+        val presentedOfferingContext: PresentedOfferingContextData? = null,
         @SerialName("exit_offer_type")
         val exitOfferType: String? = null,
         @SerialName("exit_offering_id")
@@ -154,7 +154,7 @@ internal sealed class BackendEvent : Event {
     ) : BackendEvent()
 
     @Serializable
-    data class PresentedOfferingContextBackend(
+    data class PresentedOfferingContextData(
         @SerialName("placement_identifier")
         val placementIdentifier: String? = null,
         @SerialName("targeting_revision")
@@ -165,11 +165,11 @@ internal sealed class BackendEvent : Event {
         companion object {
             fun fromContext(
                 context: com.revenuecat.purchases.PresentedOfferingContext,
-            ): PresentedOfferingContextBackend? {
+            ): PresentedOfferingContextData? {
                 if (context.placementIdentifier == null && context.targetingContext == null) {
                     return null
                 }
-                return PresentedOfferingContextBackend(
+                return PresentedOfferingContextData(
                     placementIdentifier = context.placementIdentifier,
                     targetingRevision = context.targetingContext?.revision,
                     targetingRuleId = context.targetingContext?.ruleId,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.common.events
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.events.CustomerCenterDisplayMode
 import com.revenuecat.purchases.customercenter.events.CustomerCenterEventType
@@ -164,7 +165,7 @@ internal sealed class BackendEvent : Event {
     ) {
         companion object {
             fun fromContext(
-                context: com.revenuecat.purchases.PresentedOfferingContext,
+                context: PresentedOfferingContext,
             ): PresentedOfferingContextData? {
                 if (context.placementIdentifier == null && context.targetingContext == null) {
                     return null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
@@ -161,7 +161,22 @@ internal sealed class BackendEvent : Event {
         val targetingRevision: Int? = null,
         @SerialName("targeting_rule_id")
         val targetingRuleId: String? = null,
-    )
+    ) {
+        companion object {
+            fun fromContext(
+                context: com.revenuecat.purchases.PresentedOfferingContext,
+            ): PresentedOfferingContextBackend? {
+                if (context.placementIdentifier == null && context.targetingContext == null) {
+                    return null
+                }
+                return PresentedOfferingContextBackend(
+                    placementIdentifier = context.placementIdentifier,
+                    targetingRevision = context.targetingContext?.revision,
+                    targetingRuleId = context.targetingContext?.ruleId,
+                )
+            }
+        }
+    }
 
     /**
      * Represents an event related to a custom paywall.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
@@ -99,6 +99,8 @@ internal sealed class BackendEvent : Event {
         val darkMode: Boolean,
         @SerialName("locale")
         val localeIdentifier: String,
+        @SerialName("presented_offering_context")
+        val presentedOfferingContext: PresentedOfferingContextBackend? = null,
         @SerialName("exit_offer_type")
         val exitOfferType: String? = null,
         @SerialName("exit_offering_id")
@@ -150,6 +152,16 @@ internal sealed class BackendEvent : Event {
         @SerialName("resulting_product_id")
         val resultingProductIdentifier: String? = null,
     ) : BackendEvent()
+
+    @Serializable
+    data class PresentedOfferingContextBackend(
+        @SerialName("placement_identifier")
+        val placementIdentifier: String? = null,
+        @SerialName("targeting_revision")
+        val targetingRevision: Int? = null,
+        @SerialName("targeting_rule_id")
+        val targetingRuleId: String? = null,
+    )
 
     /**
      * Represents an event related to a custom paywall.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -88,6 +88,18 @@ internal fun PaywallEvent.toBackendStoredEvent(
         return null
     }
     val backendComponentFields = componentInteraction.toBackendComponentFields()
+    val context = data.presentedOfferingContext
+    val presentedContext = if (
+        context.placementIdentifier != null || context.targetingContext != null
+    ) {
+        BackendEvent.PresentedOfferingContextBackend(
+            placementIdentifier = context.placementIdentifier,
+            targetingRevision = context.targetingContext?.revision,
+            targetingRuleId = context.targetingContext?.ruleId,
+        )
+    } else {
+        null
+    }
     return BackendStoredEvent.Paywalls(
         BackendEvent.Paywalls(
             id = creationData.id.toString(),
@@ -102,6 +114,7 @@ internal fun PaywallEvent.toBackendStoredEvent(
             displayMode = data.displayMode,
             darkMode = data.darkMode,
             localeIdentifier = data.localeIdentifier,
+            presentedOfferingContext = presentedContext,
             exitOfferType = data.exitOfferType?.value,
             exitOfferingID = data.exitOfferingIdentifier,
             packageID = data.packageIdentifier,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -102,7 +102,7 @@ internal fun PaywallEvent.toBackendStoredEvent(
             displayMode = data.displayMode,
             darkMode = data.darkMode,
             localeIdentifier = data.localeIdentifier,
-            presentedOfferingContext = BackendEvent.PresentedOfferingContextBackend.fromContext(
+            presentedOfferingContext = BackendEvent.PresentedOfferingContextData.fromContext(
                 data.presentedOfferingContext,
             ),
             exitOfferType = data.exitOfferType?.value,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -88,18 +88,6 @@ internal fun PaywallEvent.toBackendStoredEvent(
         return null
     }
     val backendComponentFields = componentInteraction.toBackendComponentFields()
-    val context = data.presentedOfferingContext
-    val presentedContext = if (
-        context.placementIdentifier != null || context.targetingContext != null
-    ) {
-        BackendEvent.PresentedOfferingContextBackend(
-            placementIdentifier = context.placementIdentifier,
-            targetingRevision = context.targetingContext?.revision,
-            targetingRuleId = context.targetingContext?.ruleId,
-        )
-    } else {
-        null
-    }
     return BackendStoredEvent.Paywalls(
         BackendEvent.Paywalls(
             id = creationData.id.toString(),
@@ -114,7 +102,9 @@ internal fun PaywallEvent.toBackendStoredEvent(
             displayMode = data.displayMode,
             darkMode = data.darkMode,
             localeIdentifier = data.localeIdentifier,
-            presentedOfferingContext = presentedContext,
+            presentedOfferingContext = BackendEvent.PresentedOfferingContextBackend.fromContext(
+                data.presentedOfferingContext,
+            ),
             exitOfferType = data.exitOfferType?.value,
             exitOfferingID = data.exitOfferingIdentifier,
             packageID = data.packageIdentifier,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallStoredEvent.kt
@@ -23,6 +23,18 @@ internal data class PaywallStoredEvent(
     @OptIn(InternalRevenueCatAPI::class)
     fun toBackendEvent(): BackendEvent.Paywalls {
         val backendComponentFields = event.componentInteraction.toBackendComponentFields()
+        val context = event.data.presentedOfferingContext
+        val presentedContext = if (
+            context.placementIdentifier != null || context.targetingContext != null
+        ) {
+            BackendEvent.PresentedOfferingContextBackend(
+                placementIdentifier = context.placementIdentifier,
+                targetingRevision = context.targetingContext?.revision,
+                targetingRuleId = context.targetingContext?.ruleId,
+            )
+        } else {
+            null
+        }
         return BackendEvent.Paywalls(
             id = event.creationData.id.toString(),
             version = BackendEvent.PAYWALL_EVENT_SCHEMA_VERSION,
@@ -36,6 +48,7 @@ internal data class PaywallStoredEvent(
             displayMode = event.data.displayMode,
             darkMode = event.data.darkMode,
             localeIdentifier = event.data.localeIdentifier,
+            presentedOfferingContext = presentedContext,
             exitOfferType = event.data.exitOfferType?.value,
             exitOfferingID = event.data.exitOfferingIdentifier,
             packageID = event.data.packageIdentifier,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallStoredEvent.kt
@@ -23,18 +23,6 @@ internal data class PaywallStoredEvent(
     @OptIn(InternalRevenueCatAPI::class)
     fun toBackendEvent(): BackendEvent.Paywalls {
         val backendComponentFields = event.componentInteraction.toBackendComponentFields()
-        val context = event.data.presentedOfferingContext
-        val presentedContext = if (
-            context.placementIdentifier != null || context.targetingContext != null
-        ) {
-            BackendEvent.PresentedOfferingContextBackend(
-                placementIdentifier = context.placementIdentifier,
-                targetingRevision = context.targetingContext?.revision,
-                targetingRuleId = context.targetingContext?.ruleId,
-            )
-        } else {
-            null
-        }
         return BackendEvent.Paywalls(
             id = event.creationData.id.toString(),
             version = BackendEvent.PAYWALL_EVENT_SCHEMA_VERSION,
@@ -48,7 +36,9 @@ internal data class PaywallStoredEvent(
             displayMode = event.data.displayMode,
             darkMode = event.data.darkMode,
             localeIdentifier = event.data.localeIdentifier,
-            presentedOfferingContext = presentedContext,
+            presentedOfferingContext = BackendEvent.PresentedOfferingContextBackend.fromContext(
+                event.data.presentedOfferingContext,
+            ),
             exitOfferType = event.data.exitOfferType?.value,
             exitOfferingID = event.data.exitOfferingIdentifier,
             packageID = event.data.packageIdentifier,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallStoredEvent.kt
@@ -36,7 +36,7 @@ internal data class PaywallStoredEvent(
             displayMode = event.data.displayMode,
             darkMode = event.data.darkMode,
             localeIdentifier = event.data.localeIdentifier,
-            presentedOfferingContext = BackendEvent.PresentedOfferingContextBackend.fromContext(
+            presentedOfferingContext = BackendEvent.PresentedOfferingContextData.fromContext(
                 event.data.presentedOfferingContext,
             ),
             exitOfferType = event.data.exitOfferType?.value,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
@@ -440,10 +440,25 @@ class BackendPaywallEventTest {
 
         val backendEvent = (storedEvent as BackendStoredEvent.Paywalls).event
         assertThat(backendEvent.offeringID).isEqualTo("offeringID")
-        assertThat(backendEvent.presentedOfferingContext).isNotNull
-        assertThat(backendEvent.presentedOfferingContext?.placementIdentifier).isEqualTo("home_banner")
-        assertThat(backendEvent.presentedOfferingContext?.targetingRevision).isEqualTo(3)
-        assertThat(backendEvent.presentedOfferingContext?.targetingRuleId).isEqualTo("rule_abc123")
+        assertThat(backendEvent.presentedOfferingContext).isEqualTo(
+            BackendEvent.PresentedOfferingContextData(
+                placementIdentifier = "home_banner",
+                targetingRevision = 3,
+                targetingRuleId = "rule_abc123",
+            )
+        )
+    }
+
+    @Test
+    fun `old stored BackendStoredEvent without presentedOfferingContext deserializes correctly`() {
+        val oldJson = """
+            {"discriminator":"paywalls","event":{"discriminator":"paywalls","id":"test-id","version":1,"type":"paywall_impression","app_user_id":"appUserID","session_id":"sessionID","offering_id":"offeringID","paywall_id":"paywallID","paywall_revision":5,"timestamp":123456789,"display_mode":"full_screen","dark_mode":true,"locale":"es_ES"}}
+        """.trimIndent()
+        val deserialized = JsonProvider.defaultJson.decodeFromString<BackendStoredEvent>(oldJson)
+        assertThat(deserialized).isInstanceOf(BackendStoredEvent.Paywalls::class.java)
+        val event = (deserialized as BackendStoredEvent.Paywalls).event
+        assertThat(event.presentedOfferingContext).isNull()
+        assertThat(event.offeringID).isEqualTo("offeringID")
     }
 
     private fun verifyCallWithBody(body: String) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
@@ -9,10 +9,13 @@ import com.revenuecat.purchases.common.Delay
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.SyncDispatcher
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.common.events.BackendEvent
 import com.revenuecat.purchases.common.events.BackendStoredEvent
 import com.revenuecat.purchases.common.events.EventsRequest
 import com.revenuecat.purchases.common.events.toBackendEvent
+import com.revenuecat.purchases.common.events.toBackendStoredEvent
+import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.common.networking.Endpoint
 import com.revenuecat.purchases.common.networking.HTTPResult
 import com.revenuecat.purchases.common.networking.RCHTTPStatusCodes
@@ -33,6 +36,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
+import java.util.Date
+import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
@@ -401,6 +406,44 @@ class BackendPaywallEventTest {
                 requestHeaders = any(),
             )
         }
+    }
+
+    @Test
+    fun `toBackendStoredEvent preserves placement and targeting from PresentedOfferingContext`() {
+        val paywallEvent = PaywallEvent(
+            creationData = PaywallEvent.CreationData(
+                id = UUID.fromString("298207f4-87af-4b57-a581-eb27bcc6e009"),
+                date = Date(1699270688884)
+            ),
+            data = PaywallEvent.Data(
+                paywallIdentifier = "paywallID",
+                presentedOfferingContext = PresentedOfferingContext(
+                    offeringIdentifier = "offeringID",
+                    placementIdentifier = "home_banner",
+                    targetingContext = PresentedOfferingContext.TargetingContext(
+                        revision = 3,
+                        ruleId = "rule_abc123",
+                    ),
+                ),
+                paywallRevision = 5,
+                sessionIdentifier = UUID.fromString("315107f4-98bf-4b68-a582-eb27bcb6e111"),
+                displayMode = "footer",
+                localeIdentifier = "es_ES",
+                darkMode = true
+            ),
+            type = PaywallEventType.IMPRESSION,
+        )
+
+        val storedEvent = paywallEvent.toBackendStoredEvent("testAppUserId")
+        assertThat(storedEvent).isNotNull
+        assertThat(storedEvent).isInstanceOf(BackendStoredEvent.Paywalls::class.java)
+
+        val backendEvent = (storedEvent as BackendStoredEvent.Paywalls).event
+        assertThat(backendEvent.offeringID).isEqualTo("offeringID")
+        assertThat(backendEvent.presentedOfferingContext).isNotNull
+        assertThat(backendEvent.presentedOfferingContext?.placementIdentifier).isEqualTo("home_banner")
+        assertThat(backendEvent.presentedOfferingContext?.targetingRevision).isEqualTo(3)
+        assertThat(backendEvent.presentedOfferingContext?.targetingRuleId).isEqualTo("rule_abc123")
     }
 
     private fun verifyCallWithBody(body: String) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
@@ -80,7 +80,7 @@ class BackendPaywallEventTest {
                 displayMode = "full_screen",
                 darkMode = true,
                 localeIdentifier = "es_ES",
-                presentedOfferingContext = BackendEvent.PresentedOfferingContextBackend(
+                presentedOfferingContext = BackendEvent.PresentedOfferingContextData(
                     placementIdentifier = "home_banner",
                     targetingRevision = 3,
                     targetingRuleId = "rule_abc123",

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendPaywallEventTest.kt
@@ -60,6 +60,30 @@ class BackendPaywallEventTest {
         )
     ).map { it.toBackendEvent() })
 
+    private val placementTargetingEventRequest = EventsRequest(listOf(
+        BackendStoredEvent.Paywalls(
+            BackendEvent.Paywalls(
+                id = "placement-id",
+                version = 1,
+                type = PaywallEventType.IMPRESSION.value,
+                appUserID = "appUserID",
+                sessionID = "sessionID",
+                offeringID = "offeringID",
+                paywallID = "paywallID",
+                paywallRevision = 5,
+                timestamp = 123456789,
+                displayMode = "full_screen",
+                darkMode = true,
+                localeIdentifier = "es_ES",
+                presentedOfferingContext = BackendEvent.PresentedOfferingContextBackend(
+                    placementIdentifier = "home_banner",
+                    targetingRevision = 3,
+                    targetingRuleId = "rule_abc123",
+                ),
+            )
+        )
+    ).map { it.toBackendEvent() })
+
     private val exitOfferEventRequest = EventsRequest(listOf(
         BackendStoredEvent.Paywalls(
             BackendEvent.Paywalls(
@@ -144,6 +168,44 @@ class BackendPaywallEventTest {
                         "\"display_mode\":\"footer\"," +
                         "\"dark_mode\":true," +
                         "\"locale\":\"en_US\"" +
+                    "}" +
+                "]" +
+            "}"
+        )
+    }
+
+    @Test
+    fun `postPaywallEvents posts events with placement and targeting correctly`() {
+        mockHttpResult()
+        backend.postEvents(
+            placementTargetingEventRequest,
+            baseURL = AppConfig.paywallEventsURL,
+            delay = Delay.DEFAULT,
+            onSuccessHandler = {},
+            onErrorHandler = { _, _ -> },
+        )
+        verifyCallWithBody(
+            "{" +
+                "\"events\":[" +
+                    "{" +
+                        "\"discriminator\":\"paywalls\"," +
+                        "\"id\":\"placement-id\"," +
+                        "\"version\":1," +
+                        "\"type\":\"paywall_impression\"," +
+                        "\"app_user_id\":\"appUserID\"," +
+                        "\"session_id\":\"sessionID\"," +
+                        "\"offering_id\":\"offeringID\"," +
+                        "\"paywall_id\":\"paywallID\"," +
+                        "\"paywall_revision\":5," +
+                        "\"timestamp\":123456789," +
+                        "\"display_mode\":\"full_screen\"," +
+                        "\"dark_mode\":true," +
+                        "\"locale\":\"es_ES\"," +
+                        "\"presented_offering_context\":{" +
+                            "\"placement_identifier\":\"home_banner\"," +
+                            "\"targeting_revision\":3," +
+                            "\"targeting_rule_id\":\"rule_abc123\"" +
+                        "}" +
                     "}" +
                 "]" +
             "}"

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventSerializationTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventSerializationTests.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.paywalls.events
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.PresentedOfferingContext
+import com.revenuecat.purchases.common.events.BackendEvent
 import com.revenuecat.purchases.common.events.BackendStoredEvent
 import com.revenuecat.purchases.common.events.toBackendStoredEvent
 import kotlinx.serialization.encodeToString
@@ -145,11 +146,13 @@ class PaywallEventSerializationTests {
         val decodedEvent = PaywallStoredEvent.fromString(eventString)
         val backendEvent = decodedEvent.toBackendEvent()
 
-        val context = backendEvent.presentedOfferingContext
-        assertThat(context).isNotNull
-        assertThat(context?.placementIdentifier).isEqualTo("placementID")
-        assertThat(context?.targetingRevision).isEqualTo(5)
-        assertThat(context?.targetingRuleId).isEqualTo("ruleID")
+        assertThat(backendEvent.presentedOfferingContext).isEqualTo(
+            BackendEvent.PresentedOfferingContextData(
+                placementIdentifier = "placementID",
+                targetingRevision = 5,
+                targetingRuleId = "ruleID",
+            )
+        )
     }
 
     @Test
@@ -312,11 +315,11 @@ class PaywallEventSerializationTests {
         val decodedEvent = PaywallStoredEvent.fromString(eventString)
         val backendEvent = decodedEvent.toBackendEvent()
 
-        val context = backendEvent.presentedOfferingContext
-        assertThat(context).isNotNull
-        assertThat(context?.placementIdentifier).isEqualTo("placementID")
-        assertThat(context?.targetingRevision).isNull()
-        assertThat(context?.targetingRuleId).isNull()
+        assertThat(backendEvent.presentedOfferingContext).isEqualTo(
+            BackendEvent.PresentedOfferingContextData(
+                placementIdentifier = "placementID",
+            )
+        )
     }
 
     @Test
@@ -351,11 +354,12 @@ class PaywallEventSerializationTests {
         val decodedEvent = PaywallStoredEvent.fromString(eventString)
         val backendEvent = decodedEvent.toBackendEvent()
 
-        val context = backendEvent.presentedOfferingContext
-        assertThat(context).isNotNull
-        assertThat(context?.placementIdentifier).isNull()
-        assertThat(context?.targetingRevision).isEqualTo(7)
-        assertThat(context?.targetingRuleId).isEqualTo("targetingRuleID")
+        assertThat(backendEvent.presentedOfferingContext).isEqualTo(
+            BackendEvent.PresentedOfferingContextData(
+                targetingRevision = 7,
+                targetingRuleId = "targetingRuleID",
+            )
+        )
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventSerializationTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventSerializationTests.kt
@@ -140,6 +140,47 @@ class PaywallEventSerializationTests {
     }
 
     @Test
+    fun `round trip serialization preserves placement and targeting in backend event`() {
+        val eventString = PaywallStoredEvent.json.encodeToString(impressionEvent)
+        val decodedEvent = PaywallStoredEvent.fromString(eventString)
+        val backendEvent = decodedEvent.toBackendEvent()
+
+        val context = backendEvent.presentedOfferingContext
+        assertThat(context).isNotNull
+        assertThat(context?.placementIdentifier).isEqualTo("placementID")
+        assertThat(context?.targetingRevision).isEqualTo(5)
+        assertThat(context?.targetingRuleId).isEqualTo("ruleID")
+    }
+
+    @Test
+    fun `round trip serialization without placement produces null backend context`() {
+        val eventWithoutPlacement = PaywallStoredEvent(
+            event = PaywallEvent(
+                creationData = PaywallEvent.CreationData(
+                    id = UUID.fromString("298207f4-87af-4b57-a581-eb27bcc6e009"),
+                    date = Date(1699270688884)
+                ),
+                data = PaywallEvent.Data(
+                    paywallIdentifier = "paywallID",
+                    presentedOfferingContext = PresentedOfferingContext("offeringID"),
+                    paywallRevision = 5,
+                    sessionIdentifier = UUID.fromString("315107f4-98bf-4b68-a582-eb27bcb6e111"),
+                    displayMode = "footer",
+                    localeIdentifier = "es_ES",
+                    darkMode = true
+                ),
+                type = PaywallEventType.IMPRESSION,
+            ),
+            userID = "testAppUserId",
+        )
+        val eventString = PaywallStoredEvent.json.encodeToString(eventWithoutPlacement)
+        val decodedEvent = PaywallStoredEvent.fromString(eventString)
+        val backendEvent = decodedEvent.toBackendEvent()
+
+        assertThat(backendEvent.presentedOfferingContext).isNull()
+    }
+
+    @Test
     fun `can decode old cached event with offeringIdentifier string field`() {
         // Old format with "offeringIdentifier" as a string field instead of "presentedOfferingContext" object
         val oldFormatJson = """

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventSerializationTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventSerializationTests.kt
@@ -284,6 +284,81 @@ class PaywallEventSerializationTests {
     }
 
     @Test
+    fun `round trip serialization with placement only preserves placement in backend event`() {
+        val eventWithPlacementOnly = PaywallStoredEvent(
+            event = PaywallEvent(
+                creationData = PaywallEvent.CreationData(
+                    id = UUID.fromString("298207f4-87af-4b57-a581-eb27bcc6e009"),
+                    date = Date(1699270688884)
+                ),
+                data = PaywallEvent.Data(
+                    paywallIdentifier = "paywallID",
+                    presentedOfferingContext = PresentedOfferingContext(
+                        offeringIdentifier = "offeringID",
+                        placementIdentifier = "placementID",
+                        targetingContext = null,
+                    ),
+                    paywallRevision = 5,
+                    sessionIdentifier = UUID.fromString("315107f4-98bf-4b68-a582-eb27bcb6e111"),
+                    displayMode = "footer",
+                    localeIdentifier = "es_ES",
+                    darkMode = true
+                ),
+                type = PaywallEventType.IMPRESSION,
+            ),
+            userID = "testAppUserId",
+        )
+        val eventString = PaywallStoredEvent.json.encodeToString(eventWithPlacementOnly)
+        val decodedEvent = PaywallStoredEvent.fromString(eventString)
+        val backendEvent = decodedEvent.toBackendEvent()
+
+        val context = backendEvent.presentedOfferingContext
+        assertThat(context).isNotNull
+        assertThat(context?.placementIdentifier).isEqualTo("placementID")
+        assertThat(context?.targetingRevision).isNull()
+        assertThat(context?.targetingRuleId).isNull()
+    }
+
+    @Test
+    fun `round trip serialization with targeting only preserves targeting in backend event`() {
+        val eventWithTargetingOnly = PaywallStoredEvent(
+            event = PaywallEvent(
+                creationData = PaywallEvent.CreationData(
+                    id = UUID.fromString("298207f4-87af-4b57-a581-eb27bcc6e009"),
+                    date = Date(1699270688884)
+                ),
+                data = PaywallEvent.Data(
+                    paywallIdentifier = "paywallID",
+                    presentedOfferingContext = PresentedOfferingContext(
+                        offeringIdentifier = "offeringID",
+                        placementIdentifier = null,
+                        targetingContext = PresentedOfferingContext.TargetingContext(
+                            revision = 7,
+                            ruleId = "targetingRuleID",
+                        ),
+                    ),
+                    paywallRevision = 5,
+                    sessionIdentifier = UUID.fromString("315107f4-98bf-4b68-a582-eb27bcb6e111"),
+                    displayMode = "footer",
+                    localeIdentifier = "es_ES",
+                    darkMode = true
+                ),
+                type = PaywallEventType.IMPRESSION,
+            ),
+            userID = "testAppUserId",
+        )
+        val eventString = PaywallStoredEvent.json.encodeToString(eventWithTargetingOnly)
+        val decodedEvent = PaywallStoredEvent.fromString(eventString)
+        val backendEvent = decodedEvent.toBackendEvent()
+
+        val context = backendEvent.presentedOfferingContext
+        assertThat(context).isNotNull
+        assertThat(context?.placementIdentifier).isNull()
+        assertThat(context?.targetingRevision).isEqualTo(7)
+        assertThat(context?.targetingRuleId).isEqualTo("targetingRuleID")
+    }
+
+    @Test
     fun `old format with purchase error fields can be decoded`() {
         val oldFormatJson = """
             {


### PR DESCRIPTION
Include presentedOfferingContext (placementIdentifier, targetingRevision, targetingRuleId) in paywall event serialization so that events & charts can utilize those dimensions.

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the schema of emitted paywall events (new optional field), which could impact backend analytics/parsing if assumptions are strict, though the field is nullable and covered by compatibility tests.
> 
> **Overview**
> Paywall backend event payloads now optionally include a nested `presented_offering_context` object (placement + targeting metadata) so downstream processing can segment paywall events by placement/targeting.
> 
> Conversion paths (`PaywallEvent.toBackendStoredEvent` and `PaywallStoredEvent.toBackendEvent`) populate this new field via `PresentedOfferingContextData.fromContext`, which omits the object entirely when no placement/targeting is present, and tests were added to validate request JSON, round-trip serialization, and backward-compatible deserialization of older stored events without the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e64fda053deb6e92584c02849fe045b51bc4d1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->