### PR TITLE
Fix null Placements when offering_ids_by_placement is absent

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/OfferingParser.kt
@@ -87,15 +87,12 @@ internal abstract class OfferingParser {
             val offeringIdsByPlacement = it.optJSONObject("offering_ids_by_placement")
                 ?.toMap<String?>()
                 ?.replaceJsonNullWithKotlinNull()
+                ?: emptyMap()
 
-            return@let offeringIdsByPlacement?.let {
-                Offerings.Placements(
-                    fallbackOfferingId = fallbackOfferingId,
-                    offeringIdsByPlacement = offeringIdsByPlacement,
-                )
-            } ?: run {
-                null
-            }
+            Offerings.Placements(
+                fallbackOfferingId = fallbackOfferingId,
+                offeringIdsByPlacement = offeringIdsByPlacement,
+            )
         }
 
         return Offerings(

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingsTest.kt
@@ -542,6 +542,53 @@ class OfferingsTest {
         assertThat(offerings.getCurrentOfferingForPlacement("does_not_exist_do_not_fall_back")).isNull()
     }
 
+    @Test
+    fun `createOfferings creates placement object with fallback but no offering_ids_by_placement`() {
+        val storeProductMonthly = getStoreProduct(productIdentifier, monthlyPeriod, monthlyBasePlanId)
+        val storeProductAnnual = getStoreProduct(productIdentifier, annualPeriod, annualBasePlanId)
+
+        // Simulates backend response when no specific placements are configured
+        // (e.g., "all placements" targeting rule or no targeting match)
+        val placementsJSON = JSONObject().apply {
+            put("fallback_offering_id", "offering_a")
+        }
+
+        val products = mapOf(productIdentifier to listOf(storeProductMonthly, storeProductAnnual))
+        val offeringsJson = getOfferingsJSON(placements = placementsJSON)
+
+        val offerings = offeringsParser.createOfferings(offeringsJson, products)
+        assertThat(offerings).isNotNull
+
+        assertThat(offerings.placements).isNotNull
+        assertThat(offerings.placements!!.fallbackOfferingId).isEqualTo("offering_a")
+        assertThat(offerings.placements!!.offeringIdsByPlacement).isEmpty()
+
+        assertThat(offerings.getCurrentOfferingForPlacement("any_placement")).isNotNull
+        assertThat(offerings.getCurrentOfferingForPlacement("any_placement")!!.identifier).isEqualTo("offering_a")
+    }
+
+    @Test
+    fun `createOfferings creates placement object with null fallback and no offering_ids_by_placement`() {
+        val storeProductMonthly = getStoreProduct(productIdentifier, monthlyPeriod, monthlyBasePlanId)
+        val storeProductAnnual = getStoreProduct(productIdentifier, annualPeriod, annualBasePlanId)
+
+        val placementsJSON = JSONObject().apply {
+            put("fallback_offering_id", JSONObject.NULL)
+        }
+
+        val products = mapOf(productIdentifier to listOf(storeProductMonthly, storeProductAnnual))
+        val offeringsJson = getOfferingsJSON(placements = placementsJSON)
+
+        val offerings = offeringsParser.createOfferings(offeringsJson, products)
+        assertThat(offerings).isNotNull
+
+        assertThat(offerings.placements).isNotNull
+        assertThat(offerings.placements!!.fallbackOfferingId).isNull()
+        assertThat(offerings.placements!!.offeringIdsByPlacement).isEmpty()
+
+        assertThat(offerings.getCurrentOfferingForPlacement("any_placement")).isNull()
+    }
+
     fun `createOfferings creates targeting object`() {
         val storeProductMonthly = getStoreProduct(productIdentifier, monthlyPeriod, monthlyBasePlanId)
         val storeProductAnnual = getStoreProduct(productIdentifier, annualPeriod, annualBasePlanId)


### PR DESCRIPTION
When the backend sends a placements object with only fallback_offering_id and no offering_ids_by_placement key (e.g., "all placements" targeting or no targeting match), the Android SDK was discarding the entire Placements object — including the fallback. This caused getCurrentOfferingForPlacement to return null instead of the fallback offering, diverging from iOS behavior.

Default offeringIdsByPlacement to an empty map when the key is missing, matching iOS's @DefaultDecodable.EmptyDictionary behavior.

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how backend JSON is interpreted for placements, which can affect which offering is returned for a placement. Scope is small and covered by new unit tests for the missing-key cases.
> 
> **Overview**
> Ensures `OfferingParser.createOfferings` always constructs an `Offerings.Placements` object when `placements` is present, defaulting `offeringIdsByPlacement` to `emptyMap()` if `offering_ids_by_placement` is absent so `fallback_offering_id` still applies.
> 
> Adds unit tests covering placements responses with only `fallback_offering_id` (including explicit `null`) to verify `getCurrentOfferingForPlacement` correctly falls back or returns `null` as expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddae70bf09123405fdff7d3afa13af828a277a15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->