### PR TITLE
Update CODEOWNERS default owner to @RevenueCat/sdk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS for purchases-android
 
 # Default owners
-* @RevenueCat/coresdk
+* @RevenueCat/sdk
 
 # Customer Center code and related UI tests
 /purchases/src/**/com/revenuecat/purchases/customercenter/** @RevenueCat/customer-center


### PR DESCRIPTION
## Summary
- Update the default code owner from `@RevenueCat/coresdk` to `@RevenueCat/sdk`
- The "Require review from Code Owners" branch protection setting is being enabled organization-wide. Since `@RevenueCat/coresdk` is a small team, this would create a bottleneck. Widening the designated code owner to the broader `@RevenueCat/sdk` team ensures PRs won't be blocked while still requiring a team member's approval.

## Test plan
- [x] Verify CODEOWNERS file syntax is valid

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to CODEOWNERS review routing; no runtime or build behavior is affected.
> 
> **Overview**
> Switches the `CODEOWNERS` default owner from `@RevenueCat/coresdk` to `@RevenueCat/sdk`, broadening who is auto-requested/required for review while leaving existing path-specific owners unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 490df872f49a32032ea69946e2ddd0d8edf68683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->