### PR TITLE
Fix ripple effect ignoring component shape and extending into margins

### DIFF
--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/SamplePaywalls.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/SamplePaywalls.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.models.RecurrenceMode
 import com.revenuecat.purchases.models.TestStoreProduct
 import com.revenuecat.purchases.paywalls.PaywallColor
 import com.revenuecat.purchases.paywalls.PaywallData
+import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.TextComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
@@ -907,25 +908,34 @@ object SamplePaywalls {
                                             size = Size(width = Fill, height = Fit),
                                             margin = Padding(top = 48.0, bottom = 8.0, leading = 0.0, trailing = 0.0),
                                         ),
-                                        StackComponent(
-                                            components = listOf(
-                                                TextComponent(
-                                                    text = LocalizationKey("cta"),
-                                                    color = ColorScheme(
-                                                        light = ColorInfo.Hex(Color.White.toArgb()),
+                                        ButtonComponent(
+                                            action = ButtonComponent.Action.RestorePurchases,
+                                            stack = StackComponent(
+                                                components = listOf(
+                                                    TextComponent(
+                                                        text = LocalizationKey("cta"),
+                                                        color = ColorScheme(
+                                                            light = ColorInfo.Hex(Color.White.toArgb()),
+                                                        ),
+                                                        fontName = font,
+                                                        fontWeight = FontWeight.BOLD,
                                                     ),
-                                                    fontName = font,
-                                                    fontWeight = FontWeight.BOLD,
                                                 ),
+                                                dimension = ZLayer(alignment = TwoDimensionalAlignment.CENTER),
+                                                size = Size(width = Fit, height = Fit),
+                                                backgroundColor = ColorScheme(
+                                                    light = ColorInfo.Hex(
+                                                        Color(red = 5, green = 124, blue = 91).toArgb(),
+                                                    ),
+                                                ),
+                                                padding = Padding(
+                                                    top = 8.0, bottom = 8.0, leading = 32.0, trailing = 32.0,
+                                                ),
+                                                margin = Padding(
+                                                    top = 8.0, bottom = 8.0, leading = 0.0, trailing = 0.0,
+                                                ),
+                                                shape = Shape.Pill,
                                             ),
-                                            dimension = ZLayer(alignment = TwoDimensionalAlignment.CENTER),
-                                            size = Size(width = Fit, height = Fit),
-                                            backgroundColor = ColorScheme(
-                                                light = ColorInfo.Hex(Color(red = 5, green = 124, blue = 91).toArgb()),
-                                            ),
-                                            padding = Padding(top = 8.0, bottom = 8.0, leading = 32.0, trailing = 32.0),
-                                            margin = Padding(top = 8.0, bottom = 8.0, leading = 0.0, trailing = 0.0),
-                                            shape = Shape.Pill,
                                         ),
                                         TextComponent(
                                             text = LocalizationKey("terms"),

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -126,21 +126,22 @@ internal fun ButtonComponentView(
                     // We're the button, so we're handling the click already.
                     clickHandler = { },
                     contentAlpha = animatedContentAlpha,
+                    interactionModifier = Modifier.clickable(enabled = !anyActionInProgress) {
+                        myActionInProgress = true
+                        state.update(actionInProgress = true)
+                        coroutineScope.launch {
+                            onClick(buttonState.action)
+                            myActionInProgress = false
+                            state.update(actionInProgress = false)
+                        }
+                    },
                 )
                 CircularProgressIndicator(
                     modifier = Modifier.alpha(animatedProgressAlpha),
                     color = progressColorFor(style.stackComponentStyle.background),
                 )
             },
-            modifier = modifier.clickable(enabled = !anyActionInProgress) {
-                myActionInProgress = true
-                state.update(actionInProgress = true)
-                coroutineScope.launch {
-                    onClick(buttonState.action)
-                    myActionInProgress = false
-                    state.update(actionInProgress = false)
-                }
-            },
+            modifier = modifier,
             measurePolicy = { measurables, constraints ->
                 val stack = measurables[0].measure(constraints)
                 // Ensure that the progress indicator is not bigger than the stack.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/pkg/PackageComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/pkg/PackageComponentView.kt
@@ -9,7 +9,6 @@ import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.stack.StackComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.style.PackageComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
-import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 
 @JvmSynthetic
 @Composable
@@ -30,10 +29,13 @@ internal fun PackageComponentView(
             // If this package is selectable, a click will select it. No need to pass the click to the clickHandler.
             if (!style.isSelectable) clickHandler(action)
         },
-        modifier = modifier.conditional(style.isSelectable) {
-            clickable(
+        modifier = modifier,
+        interactionModifier = if (style.isSelectable) {
+            Modifier.clickable(
                 enabled = state.selectedPackageInfo?.uniqueId != style.uniqueId,
             ) { state.update(selectedPackageUniqueId = style.uniqueId) }
+        } else {
+            Modifier
         },
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/stack/StackComponentView.kt
@@ -103,6 +103,7 @@ internal fun StackComponentView(
     clickHandler: suspend (PaywallAction) -> Unit,
     modifier: Modifier = Modifier,
     contentAlpha: Float = 1f,
+    interactionModifier: Modifier = Modifier,
 ) {
     // Get a StackComponentState that calculates the overridden properties we should use.
     val stackState = rememberUpdatedStackComponentState(
@@ -126,6 +127,7 @@ internal fun StackComponentView(
                     clickHandler,
                     contentAlpha,
                     modifier,
+                    interactionModifier = interactionModifier,
                 )
             }
 
@@ -141,6 +143,7 @@ internal fun StackComponentView(
                         clickHandler,
                         contentAlpha,
                         modifier,
+                        interactionModifier = interactionModifier,
                     )
 
                     else
@@ -152,15 +155,22 @@ internal fun StackComponentView(
                         clickHandler,
                         contentAlpha,
                         modifier,
+                        interactionModifier = interactionModifier,
                     )
                 }
             }
 
             Badge.Style.Nested ->
-                MainStackComponent(stackState, state, clickHandler, contentAlpha, modifier, badge)
+                MainStackComponent(
+                    stackState, state, clickHandler, contentAlpha, modifier, badge,
+                    interactionModifier = interactionModifier,
+                )
         }
     } else {
-        MainStackComponent(stackState, state, clickHandler, contentAlpha, modifier)
+        MainStackComponent(
+            stackState, state, clickHandler, contentAlpha, modifier,
+            interactionModifier = interactionModifier,
+        )
     }
 }
 
@@ -174,9 +184,13 @@ private fun StackWithOverlaidBadge(
     clickHandler: suspend (PaywallAction) -> Unit,
     contentAlpha: Float,
     modifier: Modifier = Modifier,
+    interactionModifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier) {
-        MainStackComponent(stackState, state, clickHandler, contentAlpha)
+        MainStackComponent(
+            stackState, state, clickHandler, contentAlpha,
+            interactionModifier = interactionModifier,
+        )
         val mainStackBorderWidthPx = with(LocalDensity.current) {
             stackState.border?.width?.toPx()
         }
@@ -203,6 +217,7 @@ private fun StackWithLongEdgeToEdgeBadge(
     clickHandler: suspend (PaywallAction) -> Unit,
     contentAlpha: Float,
     modifier: Modifier = Modifier,
+    interactionModifier: Modifier = Modifier,
 ) {
     val shadowStyle = stackState.shadow?.let { rememberShadowStyle(shadow = it) }
     val composeShape by remember(stackState.shape) { derivedStateOf { stackState.shape.toShape() } }
@@ -219,6 +234,7 @@ private fun StackWithLongEdgeToEdgeBadge(
                 clickHandler,
                 contentAlpha,
                 shouldApplyShadow = false,
+                interactionModifier = interactionModifier,
             )
         }.first()
         val stackPlaceable = stackMeasurable.measure(constraints)
@@ -367,6 +383,7 @@ private fun StackWithShortEdgeToEdgeBadge(
     clickHandler: suspend (PaywallAction) -> Unit,
     contentAlpha: Float,
     modifier: Modifier = Modifier,
+    interactionModifier: Modifier = Modifier,
 ) {
     val adjustedCornerRadiuses: CornerRadiuses = when (val badgeRectangleCorners = badgeStack.shape.cornerRadiuses) {
         is CornerRadiuses.Percentage -> {
@@ -437,7 +454,10 @@ private fun StackWithShortEdgeToEdgeBadge(
             }
         }
     }
-    MainStackComponent(stackState, state, clickHandler, contentAlpha, modifier) {
+    MainStackComponent(
+        stackState, state, clickHandler, contentAlpha, modifier,
+        interactionModifier = interactionModifier,
+    ) {
         StackComponentView(
             badgeStack.copy(shape = Shape.Rectangle(adjustedCornerRadiuses)),
             state,
@@ -483,6 +503,7 @@ private fun MainStackComponent(
     modifier: Modifier = Modifier,
     nestedBadge: BadgeStyle? = null,
     shouldApplyShadow: Boolean = true,
+    interactionModifier: Modifier = Modifier,
     overlay: (@Composable BoxScope.() -> Unit)? = null,
 ) {
     val safeDrawingInsets = WindowInsets.safeDrawing
@@ -629,6 +650,7 @@ private fun MainStackComponent(
                     .size(stackState.size)
                     .then(outerShapeModifier)
                     .clip(composeShape)
+                    .then(interactionModifier)
                     .then(borderModifier),
             ) {
                 stack(
@@ -645,6 +667,8 @@ private fun MainStackComponent(
         } else {
             stack(
                 outerShapeModifier
+                    .clip(composeShape)
+                    .then(interactionModifier)
                     .then(borderModifier)
                     .then(innerShapeModifier)
                     .conditional(stackState.applyBottomWindowInsets) {
@@ -660,6 +684,7 @@ private fun MainStackComponent(
             modifier = modifier
                 .then(outerShapeModifier)
                 .clip(composeShape)
+                .then(interactionModifier)
                 .then(borderModifier),
         ) {
             WithOptionalBackgroundOverlay(state, background = backgroundStyle) {
@@ -678,7 +703,8 @@ private fun MainStackComponent(
         Box(
             modifier = modifier
                 .then(outerShapeModifier)
-                .clip(composeShape),
+                .clip(composeShape)
+                .then(interactionModifier),
         ) {
             WithOptionalBackgroundOverlay(state, background = backgroundStyle) {
                 stack(borderModifier.then(innerShapeModifier))

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabControlButtonView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabControlButtonView.kt
@@ -20,6 +20,7 @@ internal fun TabControlButtonView(
         state = state,
         // We act like a button, so we're handling the click already.
         clickHandler = { },
-        modifier = modifier.clickable { state.update(selectedTabIndex = style.tabIndex) },
+        modifier = modifier,
+        interactionModifier = Modifier.clickable { state.update(selectedTabIndex = style.tabIndex) },
     )
 }


### PR DESCRIPTION
### Motivation

Resolves #3321

The ripple effect in Paywalls V2 ignores rounded corners and extends into the component's margin area. This happens because `Modifier.clickable()` is applied before `StackComponentView` applies `.clip(shape)` and margin internally — so the ripple fills the entire rectangular area including margins.

### Description

Introduces an `interactionModifier` parameter on `StackComponentView` that gets threaded down to `MainStackComponent` and applied **after** `.clip(composeShape)` in all 4 code paths (standard, video background, nested badge, overlay). This ensures the ripple is bounded by the component's actual shape.

Updated all callers:
- **ButtonComponentView** — moves `clickable` into `interactionModifier`
- **PackageComponentView** — moves conditional `clickable` into `interactionModifier`, removes unused `conditional` import
- **TabControlButtonView** — moves `clickable` into `interactionModifier`

Also adds a `ButtonComponent` to the bless sample paywall (#8) to make it easier to reproduce and verify the fix visually.

**Testing:** All existing unit tests pass — StackComponentViewTests, StackComponentViewWindowTests, ButtonComponentViewTests, PackageComponentViewTests, TabsComponentViewTests. Verified visually via the updated sample paywall.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `StackComponentView` container and changes where click/interaction modifiers are applied, which could subtly affect touch targets and interaction behavior across multiple paywall components. Functionality is UI-scoped (ripple/press feedback) with no data/auth implications.
> 
> **Overview**
> Fixes Compose ripple/press feedback on paywall components so it respects rounded corners and does not extend into margins by adding an `interactionModifier` to `StackComponentView` and applying it **after** `clip(shape)` across all rendering paths (standard, video background, nested badge, overlay/badge variants).
> 
> Updates callers (`ButtonComponentView`, `PackageComponentView`, `TabControlButtonView`) to pass their `Modifier.clickable` via `interactionModifier` (instead of on the outer `modifier`), and tweaks the paywall tester sample (#8) to use a `ButtonComponent` to make the issue easy to reproduce/verify.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7368b07999c1c11eb3e49404740709a91cfeebb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->