### PR TITLE
[Galaxy]: Cache already acknowledged purchase tokens

### DIFF
--- a/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingWrapper.kt
+++ b/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingWrapper.kt
@@ -343,6 +343,11 @@ internal class GalaxyBillingWrapper(
                             GalaxyStrings.NOT_ACKNOWLEDGING_TRANSACTION_BECAUSE_ALREADY_ACKNOWLEDGED
                                 .format(storeTransaction.productIds.firstOrNull() ?: "none")
                         }
+
+                        // We still want to call onAcknowledged here because if the backend has acknowledged this before
+                        // the SDK does, we still want to mark the purchase as acknowledged here in the SDK so we
+                        // don't try to acknowledge it again in the future.
+                        onAcknowledged(storeTransaction.purchaseToken)
                         finish()
                     }
                 },

--- a/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingWrapper.kt
+++ b/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingWrapper.kt
@@ -344,9 +344,9 @@ internal class GalaxyBillingWrapper(
                                 .format(storeTransaction.productIds.firstOrNull() ?: "none")
                         }
 
-                        // We still want to call onAcknowledged here because if the backend has acknowledged this before
-                        // the SDK does, we still want to mark the purchase as acknowledged here in the SDK so we
-                        // don't try to acknowledge it again in the future.
+                        // We still want to call onAcknowledged here because if the store/backend flow has already
+                        // resulted in an acknowledged purchase, we still want to mark it as acknowledged locally
+                        // in the SDK so we don't try to acknowledge it again in the future.
                         onAcknowledged(storeTransaction.purchaseToken)
                         finish()
                     }

--- a/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/GalaxyBillingWrapperTest.kt
+++ b/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/GalaxyBillingWrapperTest.kt
@@ -1206,7 +1206,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
 
     @OptIn(GalaxySerialOperation::class)
     @Test
-    fun `consumeAndSave caches already acknowledged OTPs without re-acknowledging`() {
+    fun `consumeAndSave caches already acknowledged non-consumable OTPs without re-acknowledging`() {
         val ownedListSuccessSlot = slot<(ArrayList<OwnedProductVo>) -> Unit>()
         val acknowledgePurchaseHandler = mockk<AcknowledgePurchaseResponseListener>(relaxed = true)
         val getOwnedListHandler = mockk<GetOwnedListResponseListener>()

--- a/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/GalaxyBillingWrapperTest.kt
+++ b/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/GalaxyBillingWrapperTest.kt
@@ -1061,7 +1061,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
 
     @OptIn(GalaxySerialOperation::class)
     @Test
-    fun `consumeAndSave does not acknowledge already acknowledged subscriptions`() {
+    fun `consumeAndSave caches already acknowledged subscriptions without re-acknowledging`() {
         val ownedListSuccessSlot = slot<(ArrayList<OwnedProductVo>) -> Unit>()
         val acknowledgePurchaseHandler = mockk<AcknowledgePurchaseResponseListener>(relaxed = true)
         val getOwnedListHandler = mockk<GetOwnedListResponseListener>()
@@ -1098,7 +1098,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
         )
 
         verify(exactly = 0) { acknowledgePurchaseHandler.acknowledgePurchase(any(), any(), any()) }
-        verify(exactly = 0) { deviceCache.addSuccessfullyPostedToken(any(), isAutoRenewing = any()) }
+        verify(exactly = 1) { deviceCache.addSuccessfullyPostedToken("token-sub", isAutoRenewing = true) }
         verify(exactly = 1) { getOwnedListHandler.getOwnedList(any(), any()) }
     }
 
@@ -1201,6 +1201,52 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
         verify(exactly = 1) { getOwnedListHandler.getOwnedList(any(), any()) }
         verify(exactly = 1) { acknowledgePurchaseHandler.acknowledgePurchase(any(), any(), any()) }
         assertThat(ackTransactionSlot.captured.purchaseToken).isEqualTo("token-iap")
+        verify(exactly = 1) { deviceCache.addSuccessfullyPostedToken("token-iap", isAutoRenewing = false) }
+    }
+
+    @OptIn(GalaxySerialOperation::class)
+    @Test
+    fun `consumeAndSave caches already acknowledged OTPs without re-acknowledging`() {
+        val ownedListSuccessSlot = slot<(ArrayList<OwnedProductVo>) -> Unit>()
+        val acknowledgePurchaseHandler = mockk<AcknowledgePurchaseResponseListener>(relaxed = true)
+        val getOwnedListHandler = mockk<GetOwnedListResponseListener>()
+        val consumePurchaseHandler = mockk<ConsumePurchaseResponseListener>(relaxed = true)
+        every { deviceCache.addSuccessfullyPostedToken(any(), isAutoRenewing = any()) } returns Unit
+        every {
+            getOwnedListHandler.getOwnedList(
+                onSuccess = capture(ownedListSuccessSlot),
+                onError = any(),
+            )
+        } answers { }
+        val wrapper = createWrapper(
+            acknowledgePurchaseHandler = acknowledgePurchaseHandler,
+            consumePurchaseHandler = consumePurchaseHandler,
+            getOwnedListHandler = getOwnedListHandler,
+        )
+
+        val productId = "productId"
+        wrapper.consumeAndSave(
+            finishTransactions = true,
+            purchase = storeTransaction("token-iap", type = ProductType.INAPP, productId = productId),
+            shouldConsume = false,
+            initiationSource = PostReceiptInitiationSource.PURCHASE,
+        )
+
+        ownedListSuccessSlot.captured.invoke(
+            arrayListOf(
+                createOwnedProductVo(
+                    itemId = productId,
+                    purchaseId = "token-iap",
+                    type = "item",
+                    purchaseDate = "2024-02-02 00:00:00",
+                    acknowledgedStatus = HelperDefine.AcknowledgedStatus.ACKNOWLEDGED,
+                ),
+            ),
+        )
+
+        verify(exactly = 0) { consumePurchaseHandler.consumePurchase(any(), any(), any()) }
+        verify(exactly = 0) { acknowledgePurchaseHandler.acknowledgePurchase(any(), any(), any()) }
+        verify(exactly = 1) { getOwnedListHandler.getOwnedList(any(), any()) }
         verify(exactly = 1) { deviceCache.addSuccessfullyPostedToken("token-iap", isAutoRenewing = false) }
     }
 

--- a/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/GalaxyBillingWrapperTest.kt
+++ b/feature/galaxy/src/test/java/com/revenuecat/purchases/galaxy/GalaxyBillingWrapperTest.kt
@@ -1238,7 +1238,7 @@ class GalaxyBillingWrapperTest : GalaxyStoreTest() {
                     itemId = productId,
                     purchaseId = "token-iap",
                     type = "item",
-                    purchaseDate = "2024-02-02 00:00:00",
+                    purchaseDate = "2026-01-01 00:00:00",
                     acknowledgedStatus = HelperDefine.AcknowledgedStatus.ACKNOWLEDGED,
                 ),
             ),


### PR DESCRIPTION
### Description
Caches purchase tokens in the device cache for Galaxy purchases that have already been acknowledged so that we don't retry them again later. We're already doing this for Galaxy consumables, so this brings non-consumables in-line with what we're doing when consuming purchases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Galaxy purchase finalization behavior by caching tokens even when the store reports purchases as already acknowledged, which can affect retry/acknowledgement flows if the owned-list state is incorrect or stale.
> 
> **Overview**
> Galaxy purchase handling now **treats already-acknowledged purchases as locally acknowledged** by invoking the `onAcknowledged` callback even when the owned list reports `ACKNOWLEDGED`, so the SDK caches the purchase token and won’t attempt acknowledgement again.
> 
> Tests were updated to assert caching for already-acknowledged subscriptions, and a new test covers the same behavior for non-consumable in-app purchases (OTPs) without re-acknowledging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b80b2095debb2029813c76735a7b5dc6a5c7b539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->