### PR TITLE
Track purchase button component interactions for component and legacy paywalls

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PurchaseButtonComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PurchaseButtonComponent.kt
@@ -19,6 +19,7 @@ public class PurchaseButtonComponent(
     @get:JvmSynthetic public val stack: StackComponent,
     @get:JvmSynthetic public val action: Action? = null,
     @get:JvmSynthetic public val method: Method? = null,
+    @get:JvmSynthetic public val name: String? = null,
 ) : PaywallComponent {
     @Serializable(with = ActionDeserializer::class)
     public enum class Action {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/PaywallEvent.kt
@@ -92,6 +92,9 @@ public enum class PaywallComponentType {
 
     @SerialName("package_selection_sheet")
     PACKAGE_SELECTION_SHEET,
+
+    @SerialName("purchase_button")
+    PURCHASE_BUTTON,
 }
 
 /**
@@ -355,6 +358,7 @@ internal fun PaywallComponentType.toWireString(): String = when (this) {
     PaywallComponentType.TEXT -> "text"
     PaywallComponentType.PACKAGE -> "package"
     PaywallComponentType.PACKAGE_SELECTION_SHEET -> "package_selection_sheet"
+    PaywallComponentType.PURCHASE_BUTTON -> "purchase_button"
 }
 
 /**

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventSerializationTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/PaywallEventSerializationTests.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.paywalls.events
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.PresentedOfferingContext
+import com.revenuecat.purchases.common.events.BackendStoredEvent
 import com.revenuecat.purchases.common.events.toBackendStoredEvent
 import kotlinx.serialization.encodeToString
 import org.assertj.core.api.Assertions.assertThat
@@ -369,7 +370,7 @@ class PaywallEventSerializationTests {
                 componentValue = "annual",
             ),
         )
-        val backend = event.toBackendStoredEvent("uid")!!.event
+        val backend = (event.toBackendStoredEvent("uid")!! as BackendStoredEvent.Paywalls).event
         assertThat(backend.type).isEqualTo("paywall_component_interacted")
         assertThat(backend.componentType).isEqualTo("tab")
         assertThat(backend.componentName).isEqualTo("tabs_main")
@@ -441,7 +442,7 @@ class PaywallEventSerializationTests {
                 resultingProductIdentifier = "com.annual",
             ),
         )
-        val backend = event.toBackendStoredEvent("uid")!!.event
+        val backend = (event.toBackendStoredEvent("uid")!! as BackendStoredEvent.Paywalls).event
         assertThat(backend.componentType).isEqualTo("package_selection_sheet")
         assertThat(backend.currentPackageIdentifier).isEqualTo("monthly")
         assertThat(backend.resultingPackageIdentifier).isEqualTo("annual")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
 package com.revenuecat.purchases.ui.revenuecatui
 
 import android.app.Activity
@@ -27,6 +29,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.events.PaywallComponentType
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant.defaultAnimation
@@ -49,6 +52,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.LocalPaywallComponentInt
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
 import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallLegacyComponentInteraction
+import com.revenuecat.purchases.ui.revenuecatui.helpers.paywallPurchaseButtonAction
 import com.revenuecat.purchases.ui.revenuecatui.helpers.getActivity
 import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toResourceProvider
@@ -187,6 +191,16 @@ private fun LoadedPaywall(state: PaywallState.Loaded.Legacy, viewModel: PaywallV
                 warning = state.validationWarning,
                 onSelectPackage = viewModel::selectPackage,
                 onPurchase = {
+                    val rcPackage = state.selectedPackage.value.rcPackage
+                    viewModel.trackComponentInteraction(
+                        paywallPurchaseButtonAction(
+                            componentName = PaywallLegacyComponentInteraction.PURCHASE_BUTTON_NAME,
+                            componentValue = PaywallLegacyComponentInteraction.Value.IN_APP_CHECKOUT,
+                            componentUrl = null,
+                            currentPackageIdentifier = rcPackage.identifier,
+                            currentProductIdentifier = rcPackage.product.id,
+                        ),
+                    )
                     viewModel.purchaseSelectedPackage(activity)
                 },
                 onRestore = {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.coerceIn
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.components.CountdownComponent
 import com.revenuecat.purchases.paywalls.events.PaywallComponentInteractionData
 import com.revenuecat.purchases.paywalls.events.PaywallComponentType
@@ -56,6 +57,8 @@ import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponent
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.LocalPaywallComponentInteractionTracker
+import com.revenuecat.purchases.ui.revenuecatui.helpers.paywallPurchaseButtonAction
+import com.revenuecat.purchases.ui.revenuecatui.helpers.purchaseButtonInteractionComponentUrl
 import kotlinx.coroutines.launch
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -140,7 +143,23 @@ internal fun ButtonComponentView(
             },
             modifier = modifier.clickable(enabled = !anyActionInProgress) {
                 val paywallAction = buttonState.action
-                if (!style.action.isPurchaseRelated()) {
+                if (style.action.isPurchaseRelated()) {
+                    val currentPackage = packageForPurchaseButtonInteraction(style.action, state)
+                    val componentUrl = purchaseButtonInteractionComponentUrl(
+                        paywallAction = paywallAction,
+                        currentPackage = currentPackage,
+                        state = state,
+                    )
+                    componentInteractionTracker.track(
+                        paywallPurchaseButtonAction(
+                            componentName = style.componentName,
+                            componentValue = style.action.description,
+                            componentUrl = componentUrl,
+                            currentPackageIdentifier = currentPackage?.identifier,
+                            currentProductIdentifier = currentPackage?.product?.id,
+                        ),
+                    )
+                } else {
                     val urlForEvent = paywallAction.navigateToUrlForComponentInteraction()
                     style.action.componentInteraction(urlForEvent)?.let { interaction ->
                         componentInteractionTracker.track(
@@ -264,6 +283,24 @@ private fun PaywallAction.navigateToUrlForComponentInteraction(): String? =
         }
         else -> null
     }
+
+/**
+ * Resolves the [Package] used for purchase / web-checkout analytics: explicit package on the button style when
+ * present, otherwise the paywall's currently selected package.
+ */
+private fun packageForPurchaseButtonInteraction(
+    action: ButtonComponentStyle.Action,
+    state: PaywallState.Loaded.Components,
+): Package? {
+    val actionPackage = when (action) {
+        is ButtonComponentStyle.Action.PurchasePackage -> action.rcPackage
+        is ButtonComponentStyle.Action.WebCheckout -> action.rcPackage
+        is ButtonComponentStyle.Action.CustomWebCheckout -> action.rcPackage
+        is ButtonComponentStyle.Action.WebProductSelection -> null
+        else -> null
+    }
+    return actionPackage ?: state.selectedPackageInfo?.rcPackage
+}
 
 @Preview
 @Composable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/PaywallButtonComponentInteraction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/PaywallButtonComponentInteraction.kt
@@ -42,7 +42,7 @@ private fun ButtonComponentStyle.Action.NavigateTo.Destination.componentInteract
     }
 
 /**
- * True for purchase / web checkout actions — these must not emit `paywall_component_interacted`
+ * True for purchase / web checkout actions.
  */
 internal fun ButtonComponentStyle.Action.isPurchaseRelated(): Boolean =
     when (this) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/carousel/CarouselComponentView.kt
@@ -65,6 +65,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.extensions.applyIfNotNull
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.helpers.LocalPaywallComponentInteractionTracker
+import com.revenuecat.purchases.ui.revenuecatui.helpers.CarouselPageChangeInteraction
 import com.revenuecat.purchases.ui.revenuecatui.helpers.paywallCarouselPageChange
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
@@ -139,12 +140,14 @@ internal fun CarouselComponentView(
                             style.pageContextNames.getOrNull(logical)?.takeUnless { it.isBlank() }
                         componentInteractionTracker.track(
                             paywallCarouselPageChange(
-                                componentName = style.componentName,
-                                destinationPageIndex = logicalDestination,
-                                originPageIndex = logicalOrigin,
-                                defaultPageIndex = style.initialPageIndex,
-                                originContextName = pageName(logicalOrigin),
-                                destinationContextName = pageName(logicalDestination),
+                                CarouselPageChangeInteraction(
+                                    componentName = style.componentName,
+                                    destinationPageIndex = logicalDestination,
+                                    originPageIndex = logicalOrigin,
+                                    defaultPageIndex = style.initialPageIndex,
+                                    originContextName = pageName(logicalOrigin),
+                                    destinationContextName = pageName(logicalDestination),
+                                ),
                             ),
                         )
                     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
@@ -26,6 +26,9 @@ internal data class ButtonComponentStyle(
     internal sealed interface Action {
         object RestorePurchases : Action
         object NavigateBack : Action
+        @get:JvmSynthetic
+        val description: String
+            get() = "unknown"
 
         /**
          * @param rcPackage The package that will be purchased by this button. Will purchase the globally-selected
@@ -34,23 +37,35 @@ internal data class ButtonComponentStyle(
         data class PurchasePackage(
             val rcPackage: Package?,
             val resolvedOffer: ResolvedOffer? = null,
-        ) : Action
+        ) : Action {
+            override val description: String
+                get() = "in_app_checkout"
+        }
         data class WebCheckout(
             val rcPackage: Package?,
             val autoDismiss: Boolean,
             val openMethod: ButtonComponent.UrlMethod,
-        ) : Action
+        ) : Action {
+            override val description: String
+                get() = "web_checkout"
+        }
         data class WebProductSelection(
             val autoDismiss: Boolean,
             val openMethod: ButtonComponent.UrlMethod,
-        ) : Action
+        ) : Action {
+            override val description: String
+                get() = "web_product_selection"
+        }
         data class CustomWebCheckout(
             val urls: NonEmptyMap<LocaleId, String>,
             val autoDismiss: Boolean,
             val openMethod: ButtonComponent.UrlMethod,
             val rcPackage: Package?,
             val packageParam: String?,
-        ) : Action
+        ) : Action {
+            override val description: String
+                get() = "custom_web_checkout"
+        }
 
         @Poko
         class NavigateTo(@get:JvmSynthetic val destination: Destination) : Action {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -639,7 +639,7 @@ internal class StyleFactory(
         ButtonComponentStyle(
             stackComponentStyle = stack,
             action = action,
-            componentName = null,
+            componentName = component.name,
         )
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/composables/PurchaseButton.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
 package com.revenuecat.purchases.ui.revenuecatui.composables
 
 import androidx.compose.animation.AnimatedVisibility
@@ -35,6 +37,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
@@ -43,7 +46,9 @@ import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.extensions.offerEligibility
 import com.revenuecat.purchases.ui.revenuecatui.helpers.LocalActivity
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallLegacyComponentInteraction
 import com.revenuecat.purchases.ui.revenuecatui.helpers.TestTag
+import com.revenuecat.purchases.ui.revenuecatui.helpers.paywallPurchaseButtonAction
 
 @Composable
 internal fun PurchaseButton(
@@ -124,7 +129,19 @@ private fun PurchaseButton(
                     brush = buttonBrush(primaryCTAColor, secondaryCTAColor),
                     shape = ButtonDefaults.shape,
                 ),
-            onClick = { viewModel.purchaseSelectedPackage(activity) },
+            onClick = {
+                val rcPackage = selectedPackage.value.rcPackage
+                viewModel.trackComponentInteraction(
+                    paywallPurchaseButtonAction(
+                        componentName = PaywallLegacyComponentInteraction.PURCHASE_BUTTON_NAME,
+                        componentValue = PaywallLegacyComponentInteraction.Value.IN_APP_CHECKOUT,
+                        componentUrl = null,
+                        currentPackageIdentifier = rcPackage.identifier,
+                        currentProductIdentifier = rcPackage.product.id,
+                    ),
+                )
+                viewModel.purchaseSelectedPackage(activity)
+            },
             colors = ButtonDefaults.buttonColors(
                 containerColor = Color.Transparent, // color set on background
                 contentColor = colors.callToActionForeground,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -50,19 +50,17 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.ResolvedOffer
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ResourceProvider
 import com.revenuecat.purchases.ui.revenuecatui.helpers.createLocaleFromString
 import com.revenuecat.purchases.ui.revenuecatui.helpers.fallbackPaywall
+import com.revenuecat.purchases.ui.revenuecatui.helpers.resolveWebCheckoutUrlForInteraction
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toComponentsPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toLegacyPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.validatedPaywall
 import com.revenuecat.purchases.ui.revenuecatui.isFullScreen
 import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorStrings
-import com.revenuecat.purchases.ui.revenuecatui.utils.appendQueryParameter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
-import java.net.URI
-import java.net.URISyntaxException
 import java.util.Date
 import java.util.Locale
 import java.util.UUID
@@ -267,36 +265,13 @@ internal class PaywallViewModelImpl(
         }
     }
 
-    @Suppress("ReturnCount")
     override fun getWebCheckoutUrl(launchWebCheckout: PaywallAction.External.LaunchWebCheckout): String? {
-        val customUrl = launchWebCheckout.customUrl
         val state = state.value as? PaywallState.Loaded.Components
         if (state == null) {
             Logger.e("Web checkout URL can only be constructed for loaded Components paywalls")
             return null
         }
-        val behavior = launchWebCheckout.packageParamBehavior
-        val (packageToUse, packageParam) = when (behavior) {
-            is PaywallAction.External.LaunchWebCheckout.PackageParamBehavior.Append ->
-                (behavior.rcPackage ?: state.selectedPackageInfo?.rcPackage) to behavior.packageParam
-            is PaywallAction.External.LaunchWebCheckout.PackageParamBehavior.DoNotAppend ->
-                null to null
-        }
-        if (customUrl != null) {
-            val uri = try {
-                URI(customUrl)
-            } catch (e: URISyntaxException) {
-                Logger.e("Invalid custom URI: $customUrl", e)
-                return null
-            }
-            val finalUri = if (packageParam != null && packageToUse != null) {
-                uri.appendQueryParameter(packageParam, packageToUse.identifier)
-            } else {
-                uri
-            }
-            return finalUri.toString()
-        }
-        return packageToUse?.webCheckoutURL?.toString() ?: state.offering.webCheckoutURL.toString()
+        return state.resolveWebCheckoutUrlForInteraction(launchWebCheckout)
     }
 
     override fun invalidateCustomerInfoCache() {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallComponentInteractionFactories.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallComponentInteractionFactories.kt
@@ -28,22 +28,44 @@ internal fun paywallTabControlButtonSelection(
 )
 
 @InternalRevenueCatAPI
-internal fun paywallCarouselPageChange(
+internal fun paywallPurchaseButtonAction(
     componentName: String?,
-    destinationPageIndex: Int,
-    originPageIndex: Int,
-    defaultPageIndex: Int,
-    originContextName: String?,
-    destinationContextName: String?,
+    componentValue: String,
+    componentUrl: String?,
+    currentPackageIdentifier: String?,
+    currentProductIdentifier: String?,
+): PaywallComponentInteractionData = PaywallComponentInteractionData(
+    componentType = PaywallComponentType.PURCHASE_BUTTON,
+    componentName = componentName,
+    componentValue = componentValue,
+    componentUrl = componentUrl,
+    currentPackageIdentifier = currentPackageIdentifier,
+    currentProductIdentifier = currentProductIdentifier,
+)
+
+@InternalRevenueCatAPI
+@Suppress("LongParameterList")
+internal data class CarouselPageChangeInteraction(
+    val componentName: String?,
+    val destinationPageIndex: Int,
+    val originPageIndex: Int,
+    val defaultPageIndex: Int,
+    val originContextName: String?,
+    val destinationContextName: String?,
+)
+
+@InternalRevenueCatAPI
+internal fun paywallCarouselPageChange(
+    interaction: CarouselPageChangeInteraction,
 ): PaywallComponentInteractionData = PaywallComponentInteractionData(
     componentType = PaywallComponentType.CAROUSEL,
-    componentName = componentName,
-    componentValue = destinationPageIndex.toString(),
-    originIndex = originPageIndex,
-    destinationIndex = destinationPageIndex,
-    originContextName = originContextName,
-    destinationContextName = destinationContextName,
-    defaultIndex = defaultPageIndex,
+    componentName = interaction.componentName,
+    componentValue = interaction.destinationPageIndex.toString(),
+    originIndex = interaction.originPageIndex,
+    destinationIndex = interaction.destinationPageIndex,
+    originContextName = interaction.originContextName,
+    destinationContextName = interaction.destinationContextName,
+    defaultIndex = interaction.defaultPageIndex,
 )
 
 @InternalRevenueCatAPI

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallComponentInteractionLocal.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/PaywallComponentInteractionLocal.kt
@@ -27,11 +27,13 @@ internal object PaywallLegacyComponentInteraction {
     const val TERMS_LINK_NAME = "terms_link"
     const val PRIVACY_LINK_NAME = "privacy_link"
     const val TIER_SELECTOR_NAME = "tier_selector"
+    const val PURCHASE_BUTTON_NAME = "purchase_button"
 
     object Value {
         const val TOGGLE_ALL_PLANS = "toggle_all_plans"
         const val RESTORE_PURCHASES = "restore_purchases"
         const val NAVIGATE_TO_TERMS = "navigate_to_terms"
         const val NAVIGATE_TO_PRIVACY_POLICY = "navigate_to_privacy_policy"
+        const val IN_APP_CHECKOUT = "in_app_checkout"
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/WebCheckoutUrlResolver.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/WebCheckoutUrlResolver.kt
@@ -1,0 +1,78 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.helpers
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.paywalls.components.ButtonComponent
+import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.utils.appendQueryParameter
+import java.net.URI
+import java.net.URISyntaxException
+
+/**
+ * Resolves the checkout URL that will be opened for [launchWebCheckout] (custom URL with optional package param,
+ * otherwise package Web Purchase Link, otherwise offering Web Purchase Link).
+ */
+@InternalRevenueCatAPI
+internal fun PaywallState.Loaded.Components.resolveWebCheckoutUrlForInteraction(
+    launchWebCheckout: PaywallAction.External.LaunchWebCheckout,
+): String? {
+    val customUrl = launchWebCheckout.customUrl
+    val behavior = launchWebCheckout.packageParamBehavior
+    val (packageToUse, packageParam) = when (behavior) {
+        is PaywallAction.External.LaunchWebCheckout.PackageParamBehavior.Append ->
+            (behavior.rcPackage ?: selectedPackageInfo?.rcPackage) to behavior.packageParam
+        is PaywallAction.External.LaunchWebCheckout.PackageParamBehavior.DoNotAppend ->
+            null to null
+    }
+    if (customUrl != null) {
+        val uri = try {
+            URI(customUrl)
+        } catch (e: URISyntaxException) {
+            Logger.e("Invalid custom URI: $customUrl", e)
+            return null
+        }
+        val finalUri = if (packageParam != null && packageToUse != null) {
+            uri.appendQueryParameter(packageParam, packageToUse.identifier)
+        } else {
+            uri
+        }
+        return finalUri.toString()
+    }
+    return packageToUse?.webCheckoutURL?.toString() ?: offering.webCheckoutURL?.toString()
+}
+
+/**
+ * URL string for purchase-button component interaction events.
+ *
+ * For [ButtonComponent.UrlMethod.EXTERNAL_BROWSER], this matches the fully resolved URL that will be opened.
+ * For in-app browser or deep link, analytics use the Web Purchase Link on the [currentPackage]
+ * or [PaywallState.Loaded.Components.offering], falling back to the localized custom URL template
+ * when there is no WPL on the package/offering.
+ */
+@InternalRevenueCatAPI
+internal fun purchaseButtonInteractionComponentUrl(
+    paywallAction: PaywallAction,
+    currentPackage: Package?,
+    state: PaywallState.Loaded.Components,
+): String? {
+    return when (paywallAction) {
+        is PaywallAction.External.LaunchWebCheckout -> {
+            when (paywallAction.openMethod) {
+                ButtonComponent.UrlMethod.EXTERNAL_BROWSER ->
+                    state.resolveWebCheckoutUrlForInteraction(paywallAction)
+                ButtonComponent.UrlMethod.IN_APP_BROWSER,
+                ButtonComponent.UrlMethod.DEEP_LINK,
+                -> {
+                    currentPackage?.webCheckoutURL?.toString()
+                        ?: state.offering.webCheckoutURL?.toString()
+                        ?: paywallAction.customUrl
+                }
+                ButtonComponent.UrlMethod.UNKNOWN -> null
+            }
+        }
+        else -> null
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -54,6 +54,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
 import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData.copy
 import com.revenuecat.purchases.ui.revenuecatui.extensions.copy
 import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallLegacyComponentInteraction
+import com.revenuecat.purchases.ui.revenuecatui.helpers.paywallPurchaseButtonAction
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ResolvedOffer
 import com.revenuecat.purchases.ui.revenuecatui.helpers.UiConfig
 import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
@@ -1302,6 +1303,37 @@ class PaywallViewModelTest {
                     assertThat(ci.componentName).isEqualTo("restore_button")
                     assertThat(ci.componentValue).isEqualTo("restore_purchases")
                     assertThat(ci.componentUrl).isNull()
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `trackComponentInteraction legacy purchase button matches purchase button spec`() {
+        val model = create()
+        model.trackPaywallImpressionIfNeeded()
+        val pkg = TestData.Packages.monthly
+        model.trackComponentInteraction(
+            paywallPurchaseButtonAction(
+                componentName = PaywallLegacyComponentInteraction.PURCHASE_BUTTON_NAME,
+                componentValue = PaywallLegacyComponentInteraction.Value.IN_APP_CHECKOUT,
+                componentUrl = null,
+                currentPackageIdentifier = pkg.identifier,
+                currentProductIdentifier = pkg.product.id,
+            ),
+        )
+        verify(exactly = 1) {
+            purchases.track(
+                withArg { event ->
+                    val paywallEvent = event as PaywallEvent
+                    assertThat(paywallEvent.type).isEqualTo(PaywallEventType.COMPONENT_INTERACTION)
+                    val ci = requireNotNull(paywallEvent.componentInteraction)
+                    assertThat(ci.componentType).isEqualTo(PaywallComponentType.PURCHASE_BUTTON)
+                    assertThat(ci.componentName).isEqualTo("purchase_button")
+                    assertThat(ci.componentValue).isEqualTo("in_app_checkout")
+                    assertThat(ci.componentUrl).isNull()
+                    assertThat(ci.currentPackageIdentifier).isEqualTo(pkg.identifier)
+                    assertThat(ci.currentProductIdentifier).isEqualTo(pkg.product.id)
                 },
             )
         }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Paywall component interaction analytics did not consistently record taps on purchase CTAs for Paywalls V2 (component JSON) or v1 template paywalls. Product and backend need a purchase_button interaction type with stable component_value, package/product identifiers, and URL semantics aligned with how checkout is opened (in-app vs web / browser mode).
Resolves: PWENG-32

### Description

- **V2 / component paywalls:** On purchase-related **`ButtonComponentStyle`** actions, emit **`PaywallComponentType.PURCHASE_BUTTON`** via **`paywallPurchaseButtonAction`**, using **`packageForPurchaseButtonInteraction`** for package/product IDs and **`purchaseButtonInteractionComponentUrl`** (built on **`resolveWebCheckoutUrlForInteraction`**) for **`component_url`** (external browser = fully resolved checkout URL; in-app / deep link = package/offering WPL + custom URL fallback as implemented).
- **Style factory:** Wire **`PurchaseButtonComponent.name`** into **`ButtonComponentStyle.componentName`** where applicable.
- **Legacy templates:** Track the same interaction shape from **`PurchaseButton`** and the validation-warning **`DefaultPaywallView`** purchase path, using **`PaywallLegacyComponentInteraction`** constants for stable **`component_name`** / **`component_value`**.
- **Serialization / backend:** Extend **`PaywallComponentType`** with **`purchase_button`** and keep backend flattening in sync; fix **`PaywallEventSerializationTests`** to cast **`BackendStoredEvent.Paywalls`** before reading **`event`**.
- **Detekt:** Collapse **`paywallCarouselPageChange`** parameters into **`CarouselPageChangeInteraction`** (with **`@Suppress("LongParameterList")`** on the data class constructor if needed).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall analytics emission and URL resolution for purchase-related buttons across both component (V2) and legacy paywalls, which could affect event payloads and downstream reporting. No purchase/entitlement logic is modified, but incorrect URL/package resolution could misattribute interactions.
> 
> **Overview**
> Adds a new paywall component interaction type, `PaywallComponentType.PURCHASE_BUTTON`, and wires backend flattening/serialization to emit the `purchase_button` wire value.
> 
> Updates RevenueCatUI to **track purchase CTA taps** for both component paywalls (purchase-related `ButtonComponentStyle` actions) and legacy templates (including the validation-warning/default paywall), emitting a standardized `purchase_button` interaction with stable `component_value`, optional `component_name`, `currentPackageIdentifier`/`currentProductIdentifier`, and consistent `component_url` semantics.
> 
> Refactors web-checkout URL construction into a shared resolver (`resolveWebCheckoutUrlForInteraction`) and adjusts carousel page-change tracking to use a `CarouselPageChangeInteraction` container to reduce parameter noise; tests are updated/added to validate the new purchase-button interaction shape and stored-event casting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02014eacaf418fd07f541263f469cfd9aab72c1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->