### PR TITLE
Ignore `fallback_header` component

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/FallbackHeaderComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/FallbackHeaderComponent.kt
@@ -1,0 +1,10 @@
+package com.revenuecat.purchases.paywalls.components
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@InternalRevenueCatAPI
+@Serializable
+@SerialName("fallback_header")
+public object FallbackHeaderComponent : PaywallComponent

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/PaywallComponent.kt
@@ -54,6 +54,7 @@ internal class PaywallComponentSerializer : KSerializer<PaywallComponent> {
             "tabs" -> jsonDecoder.json.decodeFromString<TabsComponent>(json.toString())
             "video" -> jsonDecoder.json.decodeFromString<VideoComponent>(json.toString())
             "countdown" -> jsonDecoder.json.decodeFromString<CountdownComponent>(json.toString())
+            "fallback_header" -> FallbackHeaderComponent
             else -> json["fallback"]
                 ?.let { it as? JsonObject }
                 ?.toString()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentFilterExtension.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentFilterExtension.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.components.CarouselComponent
 import com.revenuecat.purchases.paywalls.components.CountdownComponent
+import com.revenuecat.purchases.paywalls.components.FallbackHeaderComponent
 import com.revenuecat.purchases.paywalls.components.HeaderComponent
 import com.revenuecat.purchases.paywalls.components.IconComponent
 import com.revenuecat.purchases.paywalls.components.ImageComponent
@@ -66,6 +67,7 @@ internal fun PaywallComponent.filter(predicate: (PaywallComponent) -> Boolean): 
                 current.fallback?.let { queue.add(it) }
             }
 
+            is FallbackHeaderComponent,
             is VideoComponent,
             is TabControlToggleComponent,
             is TabControlComponent,

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/FallbackComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/FallbackComponentTests.kt
@@ -60,6 +60,31 @@ internal class FallbackComponentTests {
     }
 
     @Test
+    fun `Should deserialize fallback_header as FallbackHeaderComponent and not its fallback`() {
+        // Arrange
+        // language=json
+        val serialized = """
+        {
+          "type": "fallback_header",
+          "id": "abc123",
+          "name": "Fallback Header",
+          "fallback": {
+            "components": [],
+            "id": "inner",
+            "name": "Stack",
+            "type": "stack"
+          }
+        }
+        """.trimIndent()
+
+        // Act
+        val actual = JsonTools.json.decodeFromString<PaywallComponent>(serialized)
+
+        // Assert
+        assertThat(actual).isInstanceOf(FallbackHeaderComponent::class.java)
+    }
+
+    @Test
     fun `Should fail to deserialize an unknown type without a fallback`() {
         // Arrange
         // language=json

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.components.CarouselComponent
 import com.revenuecat.purchases.paywalls.components.CountdownComponent
+import com.revenuecat.purchases.paywalls.components.FallbackHeaderComponent
 import com.revenuecat.purchases.paywalls.components.HeaderComponent
 import com.revenuecat.purchases.paywalls.components.IconComponent
 import com.revenuecat.purchases.paywalls.components.ImageComponent
@@ -530,6 +531,7 @@ internal class StyleFactory(
             is TabControlComponent -> tabControl.errorIfNull(nonEmptyListOf(PaywallValidationError.TabControlNotInTab))
             is TabsComponent -> createTabsComponentStyle(component)
             is VideoComponent -> createVideoComponentStyle(component)
+            is FallbackHeaderComponent -> Result.Success(null)
             is CountdownComponent -> createCountdownComponentStyle(
                 component,
             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -228,6 +228,7 @@ internal class StyleFactory(
                         stillLookingForHeaderMedia = false
                     }
 
+                    is FallbackHeaderComponent -> { /* Skip: does not affect hero image detection. */ }
                     else -> stillLookingForHeaderMedia = false
                 }
             }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/OfferingToStateMapper.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.components.CarouselComponent
 import com.revenuecat.purchases.paywalls.components.CountdownComponent
+import com.revenuecat.purchases.paywalls.components.FallbackHeaderComponent
 import com.revenuecat.purchases.paywalls.components.HeaderComponent
 import com.revenuecat.purchases.paywalls.components.IconComponent
 import com.revenuecat.purchases.paywalls.components.ImageComponent
@@ -507,6 +508,7 @@ internal fun PaywallComponent.containsUnsupportedCondition(): Boolean = when (th
     is TabControlButtonComponent -> stack.containsUnsupportedCondition()
     is TabControlToggleComponent -> false
     is TabControlComponent -> false
+    is FallbackHeaderComponent -> false
 }
 
 @JvmSynthetic

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.FontAlias
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.components.FallbackHeaderComponent
+import com.revenuecat.purchases.paywalls.components.HeaderComponent
 import com.revenuecat.purchases.paywalls.components.ImageComponent
 import com.revenuecat.purchases.paywalls.components.PackageComponent
 import com.revenuecat.purchases.paywalls.components.PartialImageComponent
@@ -1170,6 +1171,52 @@ class StyleFactoryTests {
     }
 
     @Test
+    fun `Should apply top window insets to HeaderComponent when applyTopWindowInsets is true`() {
+        // Arrange
+        val headerComponent = HeaderComponent(
+            stack = StackComponent(
+                components = listOf(
+                    TextComponent(
+                        text = LOCALIZATION_KEY_TEXT_1,
+                        color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                    ),
+                ),
+            ),
+        )
+
+        // Act
+        val result = styleFactory.create(headerComponent, applyTopWindowInsets = true)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as HeaderComponentStyle
+        assertThat(style.stackComponentStyle.applyTopWindowInsets).isTrue()
+    }
+
+    @Test
+    fun `Should not apply top window insets to HeaderComponent when applyTopWindowInsets is false`() {
+        // Arrange
+        val headerComponent = HeaderComponent(
+            stack = StackComponent(
+                components = listOf(
+                    TextComponent(
+                        text = LOCALIZATION_KEY_TEXT_1,
+                        color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                    ),
+                ),
+            ),
+        )
+
+        // Act
+        val result = styleFactory.create(headerComponent, applyTopWindowInsets = false)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as HeaderComponentStyle
+        assertThat(style.stackComponentStyle.applyTopWindowInsets).isFalse()
+    }
+
+    @Test
     fun `Should filter out FallbackHeaderComponent from stack children`() {
         // Arrange
         val stackComponent = StackComponent(
@@ -1190,5 +1237,58 @@ class StyleFactoryTests {
         val style = (result as Result.Success).value.componentStyle as StackComponentStyle
         assertThat(style.children).hasSize(1)
         assertThat(style.children[0]).isInstanceOf(TextComponentStyle::class.java)
+    }
+
+    @Test
+    fun `FallbackHeaderComponent should not prevent hero image detection in subsequent ZLayer`() {
+        // Arrange
+        val imageUrls = ThemeImageUrls(
+            light = ImageUrls(
+                original = URL("https://assets.pawwalls.com/1151049_1732039548.png"),
+                webp = URL("https://assets.pawwalls.com/1151049_1732039548.webp"),
+                webpLowRes = URL("https://assets.pawwalls.com/1151049_low_res_1732039548.webp"),
+                width = 547.toUInt(),
+                height = 257.toUInt(),
+            ),
+        )
+        // FallbackHeaderComponent is injected as the first element of the body stack by the dashboard.
+        // It should not prematurely stop hero image detection.
+        val stackComponent = StackComponent(
+            components = listOf(
+                FallbackHeaderComponent,
+                StackComponent(
+                    components = listOf(
+                        ImageComponent(
+                            source = imageUrls,
+                            size = Size(width = SizeConstraint.Fill, height = SizeConstraint.Fit),
+                        ),
+                    ),
+                    dimension = Dimension.ZLayer(
+                        alignment = TwoDimensionalAlignment.TOP,
+                    ),
+                ),
+            ),
+            dimension = Dimension.Vertical(
+                alignment = HorizontalAlignment.LEADING,
+                distribution = FlexDistribution.CENTER,
+            ),
+        )
+
+        // Act
+        val result = styleFactory.create(stackComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val styleResult = (result as Result.Success).value
+        assertThat(styleResult.heroImageDetected).isTrue()
+        val style = styleResult.componentStyle as StackComponentStyle
+        // The root stack should not apply top window insets (the ZLayer child handles it).
+        assertThat(style.applyTopWindowInsets).isFalse()
+        // The ZLayer child should apply top window insets.
+        val zLayerStack = style.children[0] as StackComponentStyle
+        assertThat(zLayerStack.applyTopWindowInsets).isTrue()
+        // The hero image should ignore top window insets.
+        val heroImage = zLayerStack.children[0] as ImageComponentStyle
+        assertThat(heroImage.ignoreTopWindowInsets).isTrue()
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -8,6 +8,7 @@ import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.FontAlias
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
+import com.revenuecat.purchases.paywalls.components.FallbackHeaderComponent
 import com.revenuecat.purchases.paywalls.components.ImageComponent
 import com.revenuecat.purchases.paywalls.components.PackageComponent
 import com.revenuecat.purchases.paywalls.components.PartialImageComponent
@@ -1166,5 +1167,28 @@ class StyleFactoryTests {
         assertThat(firstImage.ignoreTopWindowInsets).isFalse()
         val secondImage = style.children[1] as ImageComponentStyle
         assertThat(secondImage.ignoreTopWindowInsets).isFalse()
+    }
+
+    @Test
+    fun `Should filter out FallbackHeaderComponent from stack children`() {
+        // Arrange
+        val stackComponent = StackComponent(
+            components = listOf(
+                FallbackHeaderComponent,
+                TextComponent(
+                    text = LOCALIZATION_KEY_TEXT_1,
+                    color = ColorScheme(light = ColorInfo.Hex(Color.Red.toArgb())),
+                ),
+            ),
+        )
+
+        // Act
+        val result = styleFactory.create(stackComponent)
+
+        // Assert
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as StackComponentStyle
+        assertThat(style.children).hasSize(1)
+        assertThat(style.children[0]).isInstanceOf(TextComponentStyle::class.java)
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentViewTests.kt
@@ -22,6 +22,7 @@ import com.revenuecat.purchases.models.TestStoreProduct
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.components.CarouselComponent
 import com.revenuecat.purchases.paywalls.components.CountdownComponent
+import com.revenuecat.purchases.paywalls.components.FallbackHeaderComponent
 import com.revenuecat.purchases.paywalls.components.IconComponent
 import com.revenuecat.purchases.paywalls.components.ImageComponent
 import com.revenuecat.purchases.paywalls.components.PackageComponent
@@ -1289,6 +1290,7 @@ class TabsComponentViewTests {
                     current.fallback?.let { queue.add(it) }
                 }
 
+                is FallbackHeaderComponent,
                 is TabControlToggleComponent,
                 is TabControlComponent,
                 is TimelineComponent,

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/ContainsUnsupportedConditionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/ContainsUnsupportedConditionTests.kt
@@ -3,6 +3,7 @@ package com.revenuecat.purchases.ui.revenuecatui.helpers
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.components.CarouselComponent
 import com.revenuecat.purchases.paywalls.components.CountdownComponent
+import com.revenuecat.purchases.paywalls.components.FallbackHeaderComponent
 import com.revenuecat.purchases.paywalls.components.IconComponent
 import com.revenuecat.purchases.paywalls.components.ImageComponent
 import com.revenuecat.purchases.paywalls.components.PackageComponent
@@ -352,6 +353,16 @@ internal class ContainsUnsupportedConditionTests {
         )
         val stack = emptyStack(components = listOf(header))
         assertTrue(stack.containsUnsupportedCondition())
+    }
+
+    // endregion
+
+    // region FallbackHeaderComponent
+
+    @Test
+    fun `FallbackHeaderComponent does not contain unsupported condition`() {
+        val stack = emptyStack(components = listOf(FallbackHeaderComponent))
+        assertFalse(stack.containsUnsupportedCondition())
     }
 
     // endregion


### PR DESCRIPTION
### Motivation

The dashboard now injects a `fallback_header` component (type `"fallback_header"`) as the first element of the paywall body stack on save. Its `fallback` property mirrors the header's stack so older SDKs that don't recognize `header` can still render it. New SDKs that already support `header` must ignore `fallback_header` to avoid rendering header content twice.

See RevenueCat/revenuecat-app#9235

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts paywall component deserialization and UI style-building to treat `fallback_header` as a no-op, which could affect paywall rendering and window-insets/hero-image handling if misinterpreted.
> 
> **Overview**
> Prevents double-rendering of header content by introducing a new `PaywallComponent` type, `fallback_header`, and explicitly deserializing it to `FallbackHeaderComponent` (ignoring its `fallback` payload).
> 
> Updates component tree traversal and UI style creation to **treat `FallbackHeaderComponent` as non-visual**: it is filtered out of stack children, excluded from unsupported-condition checks, and skipped in hero-image/top-insets detection so subsequent components are still evaluated. Adds targeted tests covering deserialization, filtering behavior, and hero-image detection when `fallback_header` precedes a Z-layer header image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c4e9e236addb90afaf9087d12041bb9d768b851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->