### PR TITLE
Add 9.29.1 hotfix release to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ This release updates to Billing Library 8.3.0 with min SDK supported of Android 
 * Bump fastlane-plugin-revenuecat_internal from `5d6e93f` to `6289be1` (#3299) via dependabot[bot] (@dependabot[bot])
 * Bump fastlane-plugin-revenuecat_internal from `f11fe40` to `5d6e93f` (#3294) via dependabot[bot] (@dependabot[bot])
 
+## 9.29.1
+## RevenueCatUI SDK
+### Paywallv2
+#### ✨ New Features
+* PW-1178 | Support package-level visibility via visible property and overrides (#3279) via Facundo Menzella (@facumenzella)
+
 ## 9.29.0
 ## RevenueCat SDK
 ### ✨ New Features


### PR DESCRIPTION
## Summary
- Adds the missing 9.29.1 hotfix entry to CHANGELOG.md
- This release backported PW-1178 (package-level visibility support) to the 9.x line via #3320

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates release notes; no code or runtime behavior is affected.
> 
> **Overview**
> Adds the missing `9.29.1` release entry to `CHANGELOG.md`, documenting the RevenueCatUI Paywalls v2 hotfix for PW-1178 (package-level visibility support).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2881b15288cf62ba6a2e8c564419bd3948818adb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->