### PR TITLE
Fix paywall crash when cached font files are evicted

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/FontLoader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/FontLoader.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.UiConfig.AppConfig.FontsConfig.FontInfo
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.verboseLog
+import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.paywalls.fonts.DownloadableFontInfo
 import com.revenuecat.purchases.paywalls.fonts.toDownloadableFontInfo
 import com.revenuecat.purchases.utils.DefaultUrlConnectionFactory
@@ -67,7 +68,7 @@ internal class FontLoader(
             if (cachedFontFamily.fonts.all { it.file.exists() }) {
                 return cachedFontFamily
             }
-            debugLog { "Cached font files missing for ${cachedFontFamily.family}, re-downloading" }
+            warnLog { "Cached font files missing for ${cachedFontFamily.family}, re-downloading" }
             synchronized(lock) {
                 cachedFontFamilyByFamilyName.remove(cachedFontFamily.family)
                 cachedFontFamilyByFontInfo.entries.removeAll { it.value == cachedFontFamily.family }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/FontLoader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/FontLoader.kt
@@ -57,11 +57,20 @@ internal class FontLoader(
             }
         }
 
+        val cachedFontFamily: DownloadedFontFamily?
         synchronized(lock) {
             val cachedFontFamilyName = cachedFontFamilyByFontInfo[fontInfoToDownload]
-            val cachedFontFamily = cachedFontFamilyByFamilyName[cachedFontFamilyName]
-            if (cachedFontFamily != null) {
+            cachedFontFamily = cachedFontFamilyByFamilyName[cachedFontFamilyName]
+        }
+
+        if (cachedFontFamily != null) {
+            if (cachedFontFamily.fonts.all { it.file.exists() }) {
                 return cachedFontFamily
+            }
+            debugLog { "Cached font files missing for ${cachedFontFamily.family}, re-downloading" }
+            synchronized(lock) {
+                cachedFontFamilyByFamilyName.remove(cachedFontFamily.family)
+                cachedFontFamilyByFontInfo.entries.removeAll { it.value == cachedFontFamily.family }
             }
         }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/FontLoader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/FontLoader.kt
@@ -70,8 +70,10 @@ internal class FontLoader(
             }
             warnLog { "Cached font files missing for ${cachedFontFamily.family}, re-downloading" }
             synchronized(lock) {
-                cachedFontFamilyByFamilyName.remove(cachedFontFamily.family)
-                cachedFontFamilyByFontInfo.entries.removeAll { it.value == cachedFontFamily.family }
+                if (cachedFontFamilyByFamilyName[cachedFontFamily.family] === cachedFontFamily) {
+                    cachedFontFamilyByFamilyName.remove(cachedFontFamily.family)
+                    cachedFontFamilyByFontInfo.entries.removeAll { it.value == cachedFontFamily.family }
+                }
             }
         }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/FontLoaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/FontLoaderTest.kt
@@ -211,6 +211,49 @@ class FontLoaderTest {
     }
 
     @Test
+    fun `getCachedFontFamilyOrStartDownload re-downloads when cached file is deleted from disk`() = runTest {
+        urlConnectionFactory = TestUrlConnectionFactory(
+            connectionProvider = { url ->
+                if (url == FONT_URL) {
+                    TestUrlConnection(
+                        responseCode = HttpURLConnection.HTTP_OK,
+                        inputStream = ByteArrayInputStream(FONT_FILE_CONTENT.toByteArray()),
+                    )
+                } else {
+                    throw IllegalArgumentException("No mocked connection for URL: $url")
+                }
+            },
+        )
+        fontLoader = FontLoader(
+            context = mockContext,
+            providedCacheDir = mockCacheDir,
+            ioScope = testScope,
+            urlConnectionFactory = urlConnectionFactory,
+        )
+
+        // First download
+        assertNull(fontLoader.getCachedFontFamilyOrStartDownload(fontInfo))
+        testScope.advanceUntilIdle()
+        val cachedFamily = fontLoader.getCachedFontFamilyOrStartDownload(fontInfo)
+        verifyDownloadedFontFamily(cachedFamily)
+
+        // Delete the cached file from disk (simulating Android cache eviction)
+        cachedFamily!!.fonts.forEach { it.file.delete() }
+
+        // Should detect missing file, return null, and trigger re-download
+        val afterDeletion = fontLoader.getCachedFontFamilyOrStartDownload(fontInfo)
+        assertNull(afterDeletion)
+
+        testScope.advanceUntilIdle()
+
+        // Font should be re-downloaded and available again
+        verifyDownloadedFontFamily(fontLoader.getCachedFontFamilyOrStartDownload(fontInfo))
+
+        // Should have created 2 connections total (original + re-download)
+        assertEquals(2, urlConnectionFactory.createdConnections.size)
+    }
+
+    @Test
     fun `getCachedFontFileOrStartDownload handles null cacheDir gracefully`() = runTest {
         val contextWithNullCacheDir = mockk<Context> {
             every { cacheDir } returns null

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/TestUrlConnectionFactory.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/TestUrlConnectionFactory.kt
@@ -19,7 +19,8 @@ internal class TestUrlConnection(
 }
 
 internal class TestUrlConnectionFactory(
-    private val mockedConnections: Map<String, TestUrlConnection>
+    private val mockedConnections: Map<String, TestUrlConnection> = emptyMap(),
+    private val connectionProvider: ((String) -> TestUrlConnection)? = null,
 ): UrlConnectionFactory {
     private val _createdConnections = mutableListOf<String>()
     val createdConnections: List<String>
@@ -27,7 +28,9 @@ internal class TestUrlConnectionFactory(
 
     override fun createConnection(url: String, requestMethod: String): UrlConnection {
         _createdConnections.add(url)
-        return mockedConnections[url] ?: throw IllegalArgumentException("No mocked connection for URL: $url")
+        return connectionProvider?.invoke(url)
+            ?: mockedConnections[url]
+            ?: throw IllegalArgumentException("No mocked connection for URL: $url")
     }
 
     fun clear() {


### PR DESCRIPTION
## Summary
- Fixes a crash (`IllegalStateException: Could not load font`) that occurs when Android evicts paywall font files from the cache directory while the in-memory `FontLoader` cache still holds stale references to them.
- Before returning a cached `DownloadedFontFamily`, we now verify all font files still exist on disk. If any are missing, the in-memory cache is invalidated and a re-download is triggered.
- File existence check (`stat()` syscall) runs outside the synchronized block to avoid holding the lock during I/O and minimize main thread impact.

## Test plan
- [x] Added unit test that simulates cache eviction (deletes font file after caching) and verifies re-download is triggered
- [x] Verified new test fails without the fix and passes with it
- [x] Existing `FontLoaderTest` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall font caching behavior by invalidating in-memory entries when underlying cache files are missing, which could affect font loading timing and concurrency but is scoped to the font loader path.
> 
> **Overview**
> Prevents paywall font load crashes when Android evicts cached font files by verifying cached `DownloadedFontFamily` files still exist before returning them.
> 
> If any cached font file is missing, `FontLoader` now logs a warning, invalidates the stale in-memory cache entries, and triggers a fresh download.
> 
> Adds a unit test that deletes cached font files to simulate eviction and asserts a re-download occurs, and extends `TestUrlConnectionFactory` to support dynamic per-request connection provisioning for this scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455ef8b54a66c1964e7002facf642fd098d5de36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->