### PR TITLE
Fix Slack notifications for nightly integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -590,9 +590,7 @@ jobs:
       - run:
           name: Build and run purchases integration tests
           command: |
-            bundle exec fastlane android run_purchases_integration_tests backend_environment:'<< parameters.backend_environment >>'
-          environment:
-            NOTIFY_SLACK: "<< parameters.notify_slack >>"
+            bundle exec fastlane android run_purchases_integration_tests backend_environment:'<< parameters.backend_environment >>' notify_slack:'<< parameters.notify_slack >>'
       - android/save_build_cache
       - store_test_results:
           path: purchases/build/outputs/androidTest-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1070,6 +1070,15 @@ workflows:
           matrix:
             parameters:
               backend_environment: ["production", "load_shedder_us_east_1", "load_shedder_us_east_2"]
+      # TEMP: test notify_slack fix - revert after verifying
+      - run-purchases-integration-tests:
+          name: run-purchases-integration-tests-notify-slack-test
+          backend_environment: "load_shedder_us_east_1"
+          notify_slack: true
+          requires:
+            - prepare-tests
+          context:
+            - slack-secrets
       - hold:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1070,15 +1070,6 @@ workflows:
           matrix:
             parameters:
               backend_environment: ["production", "load_shedder_us_east_1", "load_shedder_us_east_2"]
-      # TEMP: test notify_slack fix - revert after verifying
-      - run-purchases-integration-tests:
-          name: run-purchases-integration-tests-notify-slack-test
-          backend_environment: "load_shedder_us_east_1"
-          notify_slack: true
-          requires:
-            - prepare-tests
-          context:
-            - slack-secrets
       - hold:
           type: approval
           requires:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -574,7 +574,7 @@ platform :android do
       end
     end
 
-    if ENV['NOTIFY_SLACK'] == 'true'
+    if options[:notify_slack]&.to_s == 'true'
       slack_backend_integration_test_results(environment: backend_environment, success: success)
     end
     ping_heartbeat_monitor(url: ENV['HEARTBEAT_MONITOR_URL_BACKEND_INTEGRATION_TESTS'])


### PR DESCRIPTION
## Summary
Slack notifications for daily integration tests weren't working since #3242. This PR introduces a fix for that.

- Pass `notify_slack` as a Fastlane command-line option instead of a CircleCI step-level environment variable
- The `NOTIFY_SLACK` env var approach (introduced in #3242, patched in #3259) was unreliable due to CircleCI boolean parameter rendering in the `environment` block
- Uses the same proven mechanism as `backend_environment` (Fastlane option), which already works correctly

## Test plan
- [ ] Verify the `run-purchases-integration-tests-notify-slack-test` job sends a Slack notification
- [ ] Revert the temp test commit before merging
- [ ] Verify nightly scheduled run sends Slack after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CI/Fastlane wiring change that only affects whether Slack notifications are sent after integration tests.
> 
> **Overview**
> Fixes Slack notifications for scheduled purchases integration tests by passing `notify_slack` into the `run_purchases_integration_tests` Fastlane lane as a command-line option from CircleCI, instead of relying on a step-level `NOTIFY_SLACK` environment variable.
> 
> Updates the Fastlane lane to gate Slack result posting on `options[:notify_slack]`, ensuring the workflow’s boolean parameter is interpreted consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f80ef442b0afc3a709717af14cd3081a12f87f0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->