### PR TITLE
fix: always upload CI test results even when tests fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,8 +284,14 @@ jobs:
                 command: ./gradlew purchases:koverXmlReportDefaultsBc8Release
             - codecov/upload:
                 file: purchases/build/reports/kover/reportDefaultsBc8Release.xml
+      - run:
+          name: Collect JUnit XMLs
+          when: always
+          command: |
+            mkdir -p build/test-results-collected
+            find . -path "*/build/test-results/*/TEST-*.xml" -exec cp --parents {} build/test-results-collected/ \;
       - store_test_results:
-          path: .
+          path: build/test-results-collected
       - store_artifacts:
           path: build/reports
 
@@ -329,8 +335,14 @@ jobs:
           name: Run Galaxy Unit Tests
           command: |
             ./gradlew testDefaultsBc8DebugUnitTest --parallel --no-daemon
+      - run:
+          name: Collect JUnit XMLs
+          when: always
+          command: |
+            mkdir -p build/test-results-collected
+            find . -path "*/build/test-results/*/TEST-*.xml" -exec cp --parents {} build/test-results-collected/ \;
       - store_test_results:
-          path: .
+          path: build/test-results-collected
       - store_artifacts:
           path: build/reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,8 +284,14 @@ jobs:
                 command: ./gradlew purchases:koverXmlReportDefaultsBc8Release
             - codecov/upload:
                 file: purchases/build/reports/kover/reportDefaultsBc8Release.xml
+      - run:
+          name: Collect JUnit XMLs
+          when: always
+          command: |
+            mkdir -p build/test-results-collected
+            find . -path "*/build/test-results/*/TEST-*.xml" -exec cp --parents {} build/test-results-collected/ \;
       - store_test_results:
-          path: "**/build/test-results"
+          path: build/test-results-collected
       - store_artifacts:
           path: build/reports
 
@@ -329,8 +335,14 @@ jobs:
           name: Run Galaxy Unit Tests
           command: |
             ./gradlew testDefaultsBc8DebugUnitTest --parallel --no-daemon
+      - run:
+          name: Collect JUnit XMLs
+          when: always
+          command: |
+            mkdir -p build/test-results-collected
+            find . -path "*/build/test-results/*/TEST-*.xml" -exec cp --parents {} build/test-results-collected/ \;
       - store_test_results:
-          path: "**/build/test-results"
+          path: build/test-results-collected
       - store_artifacts:
           path: build/reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,14 +286,17 @@ jobs:
                 file: purchases/build/reports/kover/reportDefaultsBc8Release.xml
       - run:
           name: Collect JUnit XMLs
+          when: always
           command: |
             RESULTS_DIR="build/test-results-<< parameters.flavor >>-<< parameters.bc_version >>-<< parameters.build_type >>"
             mkdir -p $RESULTS_DIR
             find . -path ./$RESULTS_DIR -prune -o -type f -regex ".*/build/test-results/.*xml" -exec cp --parents {} $RESULTS_DIR/ \;
       - store_test_results:
           path: build/test-results-<< parameters.flavor >>-<< parameters.bc_version >>-<< parameters.build_type >>
+          when: always
       - store_artifacts:
           path: build/reports
+          when: always
 
   test_dokka_hide_internal:
     <<: *android-executor
@@ -307,8 +310,10 @@ jobs:
           command: ./gradlew :dokka-hide-internal:test --parallel --no-daemon
       - store_test_results:
           path: dokka-hide-internal/build/test-results/test
+          when: always
       - store_artifacts:
           path: build/reports
+          when: always
 
   test-galaxy:
     <<: *android-executor
@@ -337,14 +342,17 @@ jobs:
             ./gradlew testDefaultsBc8DebugUnitTest --parallel --no-daemon
       - run:
           name: Collect JUnit XMLs
+          when: always
           command: |
             RESULTS_DIR="build/test-results-galaxy"
             mkdir -p $RESULTS_DIR
             find . -path ./$RESULTS_DIR -prune -o -type f -regex ".*/build/test-results/.*xml" -exec cp --parents {} $RESULTS_DIR/ \;
       - store_test_results:
           path: build/test-results-galaxy
+          when: always
       - store_artifacts:
           path: build/reports
+          when: always
 
   detekt:
     <<: *android-executor
@@ -594,6 +602,7 @@ jobs:
       - android/save_build_cache
       - store_test_results:
           path: purchases/build/outputs/androidTest-results
+          when: always
 
   run-purchases-cec-integration-tests:
     description: "Run purchases module custom entitlement computation integration tests on CircleCI emulator."
@@ -620,6 +629,7 @@ jobs:
       - android/save_build_cache
       - store_test_results:
           path: purchases/build/outputs/androidTest-results
+          when: always
 
   emerge_purchases_ui_snapshot_tests:
     description: "Emerge purchases ui snapshot tests"
@@ -700,6 +710,7 @@ jobs:
       - android/save_build_cache
       - store_test_results:
           path: integration-tests/build/outputs/androidTest-results
+          when: always
 
   run-backend-integration-tests:
     description: "Run backend integration tests. All variants"
@@ -732,6 +743,7 @@ jobs:
       - android/save_build_cache
       - store_test_results:
           path: purchases/build/test-results
+          when: always
 
   update-golden-requests-backend-integration-tests:
     description: "Run backend integration tests and create PR if golden files change"
@@ -751,6 +763,7 @@ jobs:
       - android/save_build_cache
       - store_test_results:
           path: purchases/build/test-results
+          when: always
 
   record-and-upload-paparazzi-revenuecatui-snapshots:
     description: "Record new RevenueCatUI snapshots with Paparazzi and upload them to Emerge"
@@ -889,8 +902,10 @@ jobs:
             maestro test --format junit --output maestro/report.xml maestro/
       - store_artifacts:
           path: ~/.maestro/tests/
+          when: always
       - store_test_results:
           path: maestro/report.xml
+          when: always
 
   update-paywall-preview-resources-submodule:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,19 +284,10 @@ jobs:
                 command: ./gradlew purchases:koverXmlReportDefaultsBc8Release
             - codecov/upload:
                 file: purchases/build/reports/kover/reportDefaultsBc8Release.xml
-      - run:
-          name: Collect JUnit XMLs
-          when: always
-          command: |
-            RESULTS_DIR="build/test-results-<< parameters.flavor >>-<< parameters.bc_version >>-<< parameters.build_type >>"
-            mkdir -p $RESULTS_DIR
-            find . -path ./$RESULTS_DIR -prune -o -type f -regex ".*/build/test-results/.*xml" -exec cp --parents {} $RESULTS_DIR/ \;
       - store_test_results:
-          path: build/test-results-<< parameters.flavor >>-<< parameters.bc_version >>-<< parameters.build_type >>
-          when: always
+          path: .
       - store_artifacts:
           path: build/reports
-          when: always
 
   test_dokka_hide_internal:
     <<: *android-executor
@@ -310,10 +301,8 @@ jobs:
           command: ./gradlew :dokka-hide-internal:test --parallel --no-daemon
       - store_test_results:
           path: dokka-hide-internal/build/test-results/test
-          when: always
       - store_artifacts:
           path: build/reports
-          when: always
 
   test-galaxy:
     <<: *android-executor
@@ -340,19 +329,10 @@ jobs:
           name: Run Galaxy Unit Tests
           command: |
             ./gradlew testDefaultsBc8DebugUnitTest --parallel --no-daemon
-      - run:
-          name: Collect JUnit XMLs
-          when: always
-          command: |
-            RESULTS_DIR="build/test-results-galaxy"
-            mkdir -p $RESULTS_DIR
-            find . -path ./$RESULTS_DIR -prune -o -type f -regex ".*/build/test-results/.*xml" -exec cp --parents {} $RESULTS_DIR/ \;
       - store_test_results:
-          path: build/test-results-galaxy
-          when: always
+          path: .
       - store_artifacts:
           path: build/reports
-          when: always
 
   detekt:
     <<: *android-executor
@@ -602,7 +582,6 @@ jobs:
       - android/save_build_cache
       - store_test_results:
           path: purchases/build/outputs/androidTest-results
-          when: always
 
   run-purchases-cec-integration-tests:
     description: "Run purchases module custom entitlement computation integration tests on CircleCI emulator."
@@ -629,7 +608,6 @@ jobs:
       - android/save_build_cache
       - store_test_results:
           path: purchases/build/outputs/androidTest-results
-          when: always
 
   emerge_purchases_ui_snapshot_tests:
     description: "Emerge purchases ui snapshot tests"
@@ -710,7 +688,6 @@ jobs:
       - android/save_build_cache
       - store_test_results:
           path: integration-tests/build/outputs/androidTest-results
-          when: always
 
   run-backend-integration-tests:
     description: "Run backend integration tests. All variants"
@@ -743,7 +720,6 @@ jobs:
       - android/save_build_cache
       - store_test_results:
           path: purchases/build/test-results
-          when: always
 
   update-golden-requests-backend-integration-tests:
     description: "Run backend integration tests and create PR if golden files change"
@@ -763,7 +739,6 @@ jobs:
       - android/save_build_cache
       - store_test_results:
           path: purchases/build/test-results
-          when: always
 
   record-and-upload-paparazzi-revenuecatui-snapshots:
     description: "Record new RevenueCatUI snapshots with Paparazzi and upload them to Emerge"
@@ -902,10 +877,8 @@ jobs:
             maestro test --format junit --output maestro/report.xml maestro/
       - store_artifacts:
           path: ~/.maestro/tests/
-          when: always
       - store_test_results:
           path: maestro/report.xml
-          when: always
 
   update-paywall-preview-resources-submodule:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,14 +284,8 @@ jobs:
                 command: ./gradlew purchases:koverXmlReportDefaultsBc8Release
             - codecov/upload:
                 file: purchases/build/reports/kover/reportDefaultsBc8Release.xml
-      - run:
-          name: Collect JUnit XMLs
-          when: always
-          command: |
-            mkdir -p build/test-results-collected
-            find . -path "*/build/test-results/*/TEST-*.xml" -exec cp --parents {} build/test-results-collected/ \;
       - store_test_results:
-          path: build/test-results-collected
+          path: "**/build/test-results"
       - store_artifacts:
           path: build/reports
 
@@ -335,14 +329,8 @@ jobs:
           name: Run Galaxy Unit Tests
           command: |
             ./gradlew testDefaultsBc8DebugUnitTest --parallel --no-daemon
-      - run:
-          name: Collect JUnit XMLs
-          when: always
-          command: |
-            mkdir -p build/test-results-collected
-            find . -path "*/build/test-results/*/TEST-*.xml" -exec cp --parents {} build/test-results-collected/ \;
       - store_test_results:
-          path: build/test-results-collected
+          path: "**/build/test-results"
       - store_artifacts:
           path: build/reports
 

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -55,7 +55,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         ) { }
 
         assertThat(capturedAcknowledgePurchaseParams.isCaptured).isTrue
-        assertThat(capturedAcknowledgePurchaseParams.captured.purchaseToken).isEqualTo("wrong_token")
+        assertThat(capturedAcknowledgePurchaseParams.captured.purchaseToken).isEqualTo(token)
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/AcknowledgePurchaseUseCaseTest.kt
@@ -55,7 +55,7 @@ internal class AcknowledgePurchaseUseCaseTest : BaseBillingUseCaseTest() {
         ) { }
 
         assertThat(capturedAcknowledgePurchaseParams.isCaptured).isTrue
-        assertThat(capturedAcknowledgePurchaseParams.captured.purchaseToken).isEqualTo(token)
+        assertThat(capturedAcknowledgePurchaseParams.captured.purchaseToken).isEqualTo("wrong_token")
     }
 
     @Test


### PR DESCRIPTION
### Motivation
CircleCI skips subsequent steps by default when a step exits non-zero. This meant the "Collect JUnit XMLs" step was never running when tests actually failed.

### Description
Added `when: always` to all "Collect JUnit XMLs" steps across every test job in the CircleCI config so that test results are always uploaded regardless of whether tests pass or fail.