### PR TITLE
[Fix] Include parent tabs component_name in tab-control switch interaction events

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -1234,7 +1234,7 @@ internal class StyleFactory(
                 thumbColorOff = thumbColorOff,
                 trackColorOn = trackColorOn,
                 trackColorOff = trackColorOff,
-                componentName = component.name,
+                componentName = enclosingTabsComponentName ?: component.name,
             )
         }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -130,6 +130,7 @@ internal class StyleFactory(
         var tabIndex: Int? = null,
         /**
          * When building a [TabsComponent] subtree, holds that component's dashboard `name` for tab control analytics.
+         * Blank strings are treated as absent (same as [withTabsInteractionContext] input normalization).
          */
         var enclosingTabsComponentName: String? = null,
         var enclosingTabsOrderedTabIds: List<String> = emptyList(),
@@ -363,7 +364,7 @@ internal class StyleFactory(
             val previousIds = enclosingTabsOrderedTabIds
             val previousContextNames = enclosingTabContextNamesById
             val previousDefaultForInteraction = enclosingTabsDefaultTabIndexForInteraction
-            enclosingTabsComponentName = tabsComponentName
+            enclosingTabsComponentName = tabsComponentName?.takeUnless { it.isBlank() }
             enclosingTabsOrderedTabIds = tabs.map { it.id }
             enclosingTabContextNamesById = tabs.mapNotNull { tab ->
                 tab.name?.takeUnless { it.isBlank() }?.let { tab.id to it }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -809,6 +809,58 @@ class StyleFactoryTests {
     }
 
     @Test
+    fun `TabControlToggleComponentStyle componentName falls back to toggle name when TabsComponent name is blank`() {
+        val toggleOnlyName = "toggle_only"
+        val component = TabsComponent(
+            name = "",
+            tabs = listOf(
+                TabsComponent.Tab(
+                    id = "0",
+                    stack = StackComponent(
+                        components = listOf(
+                            StackComponent(
+                                components = listOf(TabControlComponent)
+                            )
+                        )
+                    )
+                ),
+                TabsComponent.Tab(
+                    id = "1",
+                    stack = StackComponent(
+                        components = listOf(
+                            StackComponent(
+                                components = listOf(TabControlComponent)
+                            )
+                        )
+                    )
+                ),
+            ),
+            control = TabsComponent.TabControl.Toggle(
+                stack = StackComponent(
+                    components = listOf(
+                        TabControlToggleComponent(
+                            name = toggleOnlyName,
+                            defaultValue = true,
+                            thumbColorOn = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                            thumbColorOff = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                            trackColorOn = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                            trackColorOff = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                        ),
+                    )
+                )
+            )
+        )
+
+        val result = styleFactory.create(component)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as TabsComponentStyle
+        val toggleControl = style.control as TabControlStyle.Toggle
+        val toggleStyle = toggleControl.stack.children.single() as TabControlToggleComponentStyle
+        assertThat(toggleStyle.componentName).isEqualTo(toggleOnlyName)
+    }
+
+    @Test
     fun `Should fail to create a TabControlComponent outside of a TabComponent`() {
         // Arrange
         // TabControlComponent has 2 Stack ancestors, but no Tab.

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -706,6 +706,109 @@ class StyleFactoryTests {
     }
 
     @Test
+    fun `TabControlToggleComponentStyle componentName matches enclosing TabsComponent name for analytics`() {
+        val tabsName = "plan_toggle_tabs"
+        val component = TabsComponent(
+            name = tabsName,
+            tabs = listOf(
+                TabsComponent.Tab(
+                    id = "0",
+                    stack = StackComponent(
+                        components = listOf(
+                            StackComponent(
+                                components = listOf(TabControlComponent)
+                            )
+                        )
+                    )
+                ),
+                TabsComponent.Tab(
+                    id = "1",
+                    stack = StackComponent(
+                        components = listOf(
+                            StackComponent(
+                                components = listOf(TabControlComponent)
+                            )
+                        )
+                    )
+                ),
+            ),
+            control = TabsComponent.TabControl.Toggle(
+                stack = StackComponent(
+                    components = listOf(
+                        TabControlToggleComponent(
+                            defaultValue = true,
+                            thumbColorOn = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                            thumbColorOff = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                            trackColorOn = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                            trackColorOff = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                        ),
+                    )
+                )
+            )
+        )
+
+        val result = styleFactory.create(component)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as TabsComponentStyle
+        val toggleControl = style.control as TabControlStyle.Toggle
+        val toggleStyle = toggleControl.stack.children.single() as TabControlToggleComponentStyle
+        assertThat(toggleStyle.componentName).isEqualTo(tabsName)
+    }
+
+    @Test
+    fun `TabControlToggleComponentStyle componentName falls back to toggle name when TabsComponent is unnamed`() {
+        val toggleOnlyName = "toggle_only"
+        val component = TabsComponent(
+            name = null,
+            tabs = listOf(
+                TabsComponent.Tab(
+                    id = "0",
+                    stack = StackComponent(
+                        components = listOf(
+                            StackComponent(
+                                components = listOf(TabControlComponent)
+                            )
+                        )
+                    )
+                ),
+                TabsComponent.Tab(
+                    id = "1",
+                    stack = StackComponent(
+                        components = listOf(
+                            StackComponent(
+                                components = listOf(TabControlComponent)
+                            )
+                        )
+                    )
+                ),
+            ),
+            control = TabsComponent.TabControl.Toggle(
+                stack = StackComponent(
+                    components = listOf(
+                        TabControlToggleComponent(
+                            name = toggleOnlyName,
+                            defaultValue = true,
+                            thumbColorOn = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                            thumbColorOff = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                            trackColorOn = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                            trackColorOff = ColorScheme(light = ColorInfo.Hex(Color.Blue.toArgb())),
+                        ),
+                    )
+                )
+            )
+        )
+
+        val result = styleFactory.create(component)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val style = (result as Result.Success).value.componentStyle as TabsComponentStyle
+        val toggleControl = style.control as TabControlStyle.Toggle
+        val toggleStyle = toggleControl.stack.children.single() as TabControlToggleComponentStyle
+        assertThat(toggleStyle.componentName).isEqualTo(toggleOnlyName)
+    }
+
+    @Test
     fun `Should fail to create a TabControlComponent outside of a TabComponent`() {
         // Arrange
         // TabControlComponent has 2 Stack ancestors, but no Tab.


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
`paywall_component_interacted` for tab control **toggle/switch** was missing `component_name` because we only used the optional `tab_control_toggle.name`. Paywall Builder usually sets `name` on the parent **Tabs** component (consistent with tab buttons and iOS).

Aligns Android with iOS (`TabControlContext.name`) and with tab-button events (`tabsComponentName`), so analytics consistently identify the tabs block.

### Description 
- When building `TabControlToggleComponentStyle`, set analytics `componentName` from the enclosing **Tabs** component name, with fallback to the toggle’s own `name` if the tabs component is unnamed
- Documented the meaning of `TabControlToggleComponentStyle.componentName`
- Added `StyleFactoryTests` for the tabs name and the fallback case

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to analytics metadata for tab-control toggle interactions and adds unit test coverage; main impact is changed `component_name` values in emitted events.
> 
> **Overview**
> Ensures tab-control *toggle/switch* interaction analytics use the enclosing `TabsComponent` dashboard `name` as `component_name`, instead of relying solely on the optional toggle’s own `name`.
> 
> Normalizes blank `TabsComponent` names to be treated as absent, and falls back to the toggle’s `name` when the parent tabs component is unnamed/blank. Adds `StyleFactoryTests` covering parent-name propagation and both fallback cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c34cf2c3bb4dc82b417ffd5b0ff1732a769b0e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->