### PR TITLE
Fix test failures reported twice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ jobs:
           when: always
           command: |
             mkdir -p build/test-results-collected
-            find . -path "*/build/test-results/*/TEST-*.xml" -exec cp --parents {} build/test-results-collected/ \;
+            find . -path "*/build/test-results-collected" -prune -o -path "*/build/test-results/*/TEST-*.xml" -print0 | xargs -0 -I{} cp --parents {} build/test-results-collected/
       - store_test_results:
           path: build/test-results-collected
       - store_artifacts:
@@ -340,7 +340,7 @@ jobs:
           when: always
           command: |
             mkdir -p build/test-results-collected
-            find . -path "*/build/test-results/*/TEST-*.xml" -exec cp --parents {} build/test-results-collected/ \;
+            find . -path "*/build/test-results-collected" -prune -o -path "*/build/test-results/*/TEST-*.xml" -print0 | xargs -0 -I{} cp --parents {} build/test-results-collected/
       - store_test_results:
           path: build/test-results-collected
       - store_artifacts:

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -716,7 +716,7 @@ class PaywallViewModelTest {
         }
 
         assertThat(state.errorMessage)
-            .isNotEqualTo("The RevenueCat dashboard does not have a current offering configured.")
+            .isEqualTo("The RevenueCat dashboard does not have a current offering configured.")
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -716,7 +716,7 @@ class PaywallViewModelTest {
         }
 
         assertThat(state.errorMessage)
-            .isEqualTo("The RevenueCat dashboard does not have a current offering configured.")
+            .isNotEqualTo("The RevenueCat dashboard does not have a current offering configured.")
     }
 
     @Test


### PR DESCRIPTION
Example https://app.circleci.com/pipelines/gh/RevenueCat/purchases-android/21113/workflows/b4668dab-588c-43ca-a583-c57620f6449a/jobs/181575/steps

<img width="1232" height="527" alt="Captura de pantalla 2026-04-17 a las 16 35 23" src="https://github.com/user-attachments/assets/512718bc-1931-474d-a484-10059997f087" />

It was finding xml of the tests twice:

```
 * /home/circleci/project/build/test-results-collected/ui/revenuecatui/build/test-results/testDefaultsBc8DebugUnitTest/TEST-com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelTest.xml
 * /home/circleci/project/build/test-results-collected/build/test-results-collected/ui/revenuecatui/build/test-results/testDefaultsBc8DebugUnitTest/TEST-com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelTest.xml 
  ```
  
The second path has `build/test-results-collected/build/test-results-collected/...`, the copy of the copy. The test fails once, reported twice

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that tweaks how JUnit XML artifacts are gathered; main risk is missing test reports if the new `find | xargs cp` pipeline behaves differently in edge cases (e.g., unusual filenames).
> 
> **Overview**
> Prevents CircleCI from re-copying files under `build/test-results-collected` when gathering JUnit XMLs, eliminating duplicate test report entries.
> 
> Replaces the `find ... -exec cp` approach with a pruned `find ... -print0 | xargs -0 cp --parents` pipeline in both the main `test` job and `test-galaxy` job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6a0fdd02cacf1187d5ace8a2efed4609d804284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->