### PR TITLE
Attempt to fix `AssertionError` "ms is denormalized" in `QueryPurchasesUseCaseTest`

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/google/usecase/BaseBillingUseCaseTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/usecase/BaseBillingUseCaseTest.kt
@@ -23,6 +23,7 @@ import io.mockk.slot
 import org.junit.After
 import org.junit.Before
 import java.util.Date
+import kotlin.time.Duration
 
 internal open class BaseBillingUseCaseTest {
 
@@ -108,13 +109,13 @@ internal open class BaseBillingUseCaseTest {
 
     private fun mockDiagnosticsTracker() {
         every {
-            mockDiagnosticsTracker.trackGoogleQueryProductDetailsRequest(any(), any(), any(), any(), any())
+            mockDiagnosticsTracker.trackGoogleQueryProductDetailsRequest(any(), any(), any(), any(), any<Duration>())
         } just Runs
         every {
-            mockDiagnosticsTracker.trackGoogleQueryPurchasesRequest(any(), any(), any(), any(), any())
+            mockDiagnosticsTracker.trackGoogleQueryPurchasesRequest(any(), any(), any(), any<Duration>(), any())
         } just Runs
         every {
-            mockDiagnosticsTracker.trackGoogleQueryPurchaseHistoryRequest(any(), any(), any(), any())
+            mockDiagnosticsTracker.trackGoogleQueryPurchaseHistoryRequest(any(), any(), any(), any<Duration>())
         } just Runs
         every {
             mockDiagnosticsTracker.trackProductDetailsNotSupported(any(), any())


### PR DESCRIPTION
### Motivation
This is an attempt to fix these failures https://app.circleci.com/pipelines/github/RevenueCat/purchases-android/21114/workflows/d18f7377-6a4e-4bab-b3bf-fb5104ae26ec/jobs/181586/tests#failed-test-0

Claude suggests it's an issue in mockk's `JvmSignatureValueGenerator` which fails to construct `kotlin.time.Duration` via reflection when recording `any()` matchers in `every { }` blocks. Kotlin 2.0's `Duration.constructor-impl` validates the raw `Long` value and throws `AssertionError: X ms is denormalized` for the arbitrary value mockk generates.

### Description
The attempted fix is to change the three `any()` matchers for `Duration` parameters in `BaseBillingUseCaseTest.mockDiagnosticsTracker()` to typed `any<Duration>()`, to give mockk explicit type information.

I have seen this crash happen at least 3 more times, and it seems random. The code changes are harmless and hopefully we don't see it again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that only affects how MockK matches `Duration` parameters; no production logic or runtime behavior is modified.
> 
> **Overview**
> Adjusts `BaseBillingUseCaseTest.mockDiagnosticsTracker()` to use typed MockK matchers (`any<Duration>()`) for `DiagnosticsTracker` calls that take a `kotlin.time.Duration`, and adds the needed `Duration` import.
> 
> This aims to avoid intermittent test failures caused by MockK attempting to synthesize invalid `Duration` values when recording untyped `any()` matchers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e03423760fa0b8fa8d001baaf0e4907b2a4403c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->