### PR TITLE
fix: reduce precision for flaky HeaderDirectHeroImage snapshot

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponentsPreviews.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponentsPreviews.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.tooling.preview.Preview
+import com.emergetools.snapshots.annotations.EmergeSnapshotConfig
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.components.HeaderComponent
@@ -212,6 +213,7 @@ private fun LoadedPaywallComponents_Header_ZLayer_Preview() {
 }
 
 @Suppress("LongMethod", "MagicNumber")
+@EmergeSnapshotConfig(precision = 0.99f)
 @Preview(showSystemUi = true)
 @Composable
 private fun LoadedPaywallComponents_Preview_HeaderDirectHeroImage() {


### PR DESCRIPTION
### Motivation
The `LoadedPaywallComponents_Preview_HeaderDirectHeroImage` Emerge snapshot was flaky due to minor differences in one of the components. See the top right image in one of the failures https://www.emergetools.com/snapshot/8508c1a8-c118-47c6-96bf-8560bd509be2?tab=changed

Added `@EmergeSnapshotConfig(precision = 0.99f)` to the flaky preview to allow a 1% pixel difference tolerance, as we do in other previews.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Emerge snapshot test configuration for a single Compose preview, with no runtime behavior changes.
> 
> **Overview**
> Reduces flakiness in the `LoadedPaywallComponents_Preview_HeaderDirectHeroImage` Emerge snapshot by adding `@EmergeSnapshotConfig(precision = 0.99f)` (and its import) to tolerate small pixel diffs during snapshot comparisons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 755270fcb40672c2a3a92d310effb77ae93b1f9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->