### PR TITLE
[EXTERNAL] fix(google): guard showInAppMessages against BillingClient runtime crashes (#3367) by @matteinn

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -788,7 +788,10 @@ internal class BillingWrapper(
                     return@withConnectedClient
                 }
                 try {
-                    showInAppMessages(activity, inAppMessageParams) { inAppMessageResult ->
+                    showInAppMessages(
+                        activity,
+                        inAppMessageParams,
+                    ) { inAppMessageResult ->
                         when (val responseCode = inAppMessageResult.responseCode) {
                             InAppMessageResult.InAppMessageResponseCode.NO_ACTION_NEEDED -> {
                                 verboseLog { BillingStrings.BILLING_INAPP_MESSAGE_NONE }
@@ -799,10 +802,14 @@ internal class BillingWrapper(
                                 subscriptionStatusChange()
                             }
 
-                            else -> errorLog { BillingStrings.BILLING_INAPP_MESSAGE_UNEXPECTED_CODE.format(responseCode) }
+                            else -> errorLog {
+                                BillingStrings.BILLING_INAPP_MESSAGE_UNEXPECTED_CODE.format(
+                                    responseCode,
+                                )
+                            }
                         }
                     }
-                } catch (e: RuntimeException) {
+                } catch (@SuppressWarnings("TooGenericExceptionCaught") e: RuntimeException) {
                     errorLog(e) { BillingStrings.BILLING_INAPP_MESSAGE_SHOW_EXCEPTION.format(e) }
                 }
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/google/BillingWrapper.kt
@@ -787,19 +787,23 @@ internal class BillingWrapper(
                     debugLog { "Activity is not attached to a window, not showing Google Play in-app message." }
                     return@withConnectedClient
                 }
-                showInAppMessages(activity, inAppMessageParams) { inAppMessageResult ->
-                    when (val responseCode = inAppMessageResult.responseCode) {
-                        InAppMessageResult.InAppMessageResponseCode.NO_ACTION_NEEDED -> {
-                            verboseLog { BillingStrings.BILLING_INAPP_MESSAGE_NONE }
-                        }
+                try {
+                    showInAppMessages(activity, inAppMessageParams) { inAppMessageResult ->
+                        when (val responseCode = inAppMessageResult.responseCode) {
+                            InAppMessageResult.InAppMessageResponseCode.NO_ACTION_NEEDED -> {
+                                verboseLog { BillingStrings.BILLING_INAPP_MESSAGE_NONE }
+                            }
 
-                        InAppMessageResult.InAppMessageResponseCode.SUBSCRIPTION_STATUS_UPDATED -> {
-                            debugLog { BillingStrings.BILLING_INAPP_MESSAGE_UPDATE }
-                            subscriptionStatusChange()
-                        }
+                            InAppMessageResult.InAppMessageResponseCode.SUBSCRIPTION_STATUS_UPDATED -> {
+                                debugLog { BillingStrings.BILLING_INAPP_MESSAGE_UPDATE }
+                                subscriptionStatusChange()
+                            }
 
-                        else -> errorLog { BillingStrings.BILLING_INAPP_MESSAGE_UNEXPECTED_CODE.format(responseCode) }
+                            else -> errorLog { BillingStrings.BILLING_INAPP_MESSAGE_UNEXPECTED_CODE.format(responseCode) }
+                        }
                     }
+                } catch (e: RuntimeException) {
+                    errorLog(e) { BillingStrings.BILLING_INAPP_MESSAGE_SHOW_EXCEPTION.format(e) }
                 }
             }
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/strings/BillingStrings.kt
@@ -39,6 +39,7 @@ internal object BillingStrings {
     const val BILLING_INAPP_MESSAGE_NONE = "No Google Play in-app message was available."
     const val BILLING_INAPP_MESSAGE_UPDATE = "Subscription status was updated from in-app message."
     const val BILLING_INAPP_MESSAGE_UNEXPECTED_CODE = "Unexpected billing code: %s"
+    const val BILLING_INAPP_MESSAGE_SHOW_EXCEPTION = "Error showing Google Play in-app message: %s"
     const val BILLING_UNSPECIFIED_INAPP_MESSAGE_TYPES = "Tried to show in-app messages without specifying any types. " +
         "Please add what types of in-app message you want to display."
     const val BILLING_CLIENT_RETRY_ALREADY_SCHEDULED = "BillingClient connection retry already scheduled. Ignoring"

--- a/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/google/BillingWrapperTest.kt
@@ -1525,6 +1525,21 @@ class BillingWrapperTest {
     }
 
     @Test
+    fun `showing inapp messages does not crash when billing client throws runtime exception`() {
+        val activity = mockAttachedActivity()
+        val exception = NullPointerException("Attempt to invoke virtual method on a null object reference")
+        every { mockClient.showInAppMessages(activity, any(), any()) } throws exception
+
+        assertErrorLog(BillingStrings.BILLING_INAPP_MESSAGE_SHOW_EXCEPTION.format(exception), exception) {
+            wrapper.showInAppMessagesIfNeeded(activity, InAppMessageType.values().toList()) {
+                error("Unexpected subscription status change")
+            }
+        }
+
+        verify(exactly = 1) { mockClient.showInAppMessages(activity, any(), any()) }
+    }
+
+    @Test
     fun `showing inapp messages handles inapp messages listener response correctly when no messages`() {
         val activity = mockAttachedActivity()
         val listenerSlot = slot<InAppMessageResponseListener>()


### PR DESCRIPTION

<!-- Thank you for contributing to Purchases! Before pressing the
"Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
This PR hardens `showInAppMessagesIfNeeded` against a remaining Play Billing crash path.
Resolves https://github.com/RevenueCat/purchases-android/issues/3273, which has not been fully solved by a previous
[tentative](https://github.com/RevenueCat/purchases-android/pull/3274).

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

Even after lifecycle/window attachment checks,
`BillingClient.showInAppMessages(...)` can still throw a `RuntimeException` (including `NullPointerException`) due to an internal race in Play Billing.

This is a defensive boundary around third-party BillingClient behavior: it complements previous activity/window checks by handling exceptions that can still occur between pre-checks and BillingClient’s internal view/token access.

Here's exactly what changed:
- Wrapped the `showInAppMessages(...)` invocation in `BillingWrapper` with a try/catch
- On exception, log the error and skip showing the in-app message instead of crashing the app
- Added new log string: BILLING_INAPP_MESSAGE_SHOW_EXCEPTION
- Added a regression unit test that simulates `showInAppMessages(...)` throwing a `NullPointerException` and verifies that there are no crash and that the error is logged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change limited to in-app message display: it only adds exception handling and logging, plus a unit test, with minimal behavior impact beyond avoiding a crash.
> 
> **Overview**
> Prevents app crashes when Google Play Billing’s `BillingClient.showInAppMessages` throws a `RuntimeException` despite lifecycle/window checks, by wrapping the call in a `try/catch` and logging a new `BILLING_INAPP_MESSAGE_SHOW_EXCEPTION` error instead of propagating the crash.
> 
> Adds a regression test that forces `showInAppMessages` to throw (e.g., `NullPointerException`) and asserts the wrapper logs the error and continues without crashing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5cd08333839c2e9b525b8ae8a643bf5e691eb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
