### PR TITLE
Fix `revenuecat.useWorkflowsEndpoint` compiler flag

### DIFF
--- a/ui/revenuecatui/build.gradle.kts
+++ b/ui/revenuecatui/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.io.FileInputStream
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.revenuecat.public.library)
@@ -9,6 +11,10 @@ plugins {
     alias(libs.plugins.paparazzi)
     alias(libs.plugins.poko)
 }
+
+val localProperties = Properties()
+val localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) localProperties.load(FileInputStream(localPropertiesFile))
 
 android {
     namespace = "com.revenuecat.purchases.ui.revenuecatui"
@@ -47,9 +53,9 @@ android {
         // GET /workflows/{id} instead of the offerings cache. Enable with
         // `-Prevenuecat.useWorkflowsEndpoint=true` when building the SDK locally.
         buildConfigField(
-            "boolean",
-            "USE_WORKFLOWS_ENDPOINT",
-            (project.findProperty("revenuecat.useWorkflowsEndpoint") == "true").toString(),
+            type = "boolean",
+            name = "USE_WORKFLOWS_ENDPOINT",
+            value = (localProperties["revenuecat.useWorkflowsEndpoint"] == "true").toString(),
         )
     }
 


### PR DESCRIPTION
The `revenuecat.useWorkflowsEndpoint` wasn't being populated from local.properties correctly