### PR TITLE
Fix `WorkflowTriggerAction.stepId` JSON field name

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -21,7 +21,7 @@ import java.net.URL
 @Serializable
 public data class WorkflowTriggerAction(
     val type: String,
-    @SerialName("step_id") val stepId: String? = null,
+    @SerialName("value") val stepId: String? = null,
 )
 
 @InternalRevenueCatAPI


### PR DESCRIPTION
## Summary
- The backend serializes the target step id for a workflow trigger action under the `value` key, not `step_id`.
- Deserialization was silently failing and leaving `stepId` null, which blocks any multipage workflow navigation.

## Test plan
- [ ] Unit tests pass: `./gradlew :purchases:testDefaultsBc8DebugUnitTest`
- [ ] Manually verified a workflow response parses with a non-null `stepId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)