### PR TITLE
Add `id` field to `ButtonComponent`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
@@ -27,6 +27,7 @@ public class ButtonComponent(
     @get:JvmSynthetic public val stack: StackComponent,
     @get:JvmSynthetic public val transition: PaywallTransition? = null,
     @get:JvmSynthetic public val name: String? = null,
+    @get:JvmSynthetic @SerialName("id") public val id: String? = null,
 ) : PaywallComponent {
 
     @InternalRevenueCatAPI

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
@@ -27,7 +27,7 @@ public class ButtonComponent(
     @get:JvmSynthetic public val stack: StackComponent,
     @get:JvmSynthetic public val transition: PaywallTransition? = null,
     @get:JvmSynthetic public val name: String? = null,
-    @get:JvmSynthetic @SerialName("id") public val id: String? = null,
+    @get:JvmSynthetic public val id: String? = null,
 ) : PaywallComponent {
 
     @InternalRevenueCatAPI

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
@@ -574,6 +574,51 @@ internal class ButtonComponentTests {
                         )
                     ),
                 ),
+                arrayOf(
+                    "with id",
+                    Args(
+                        json = """
+                        {
+                          "type": "button",
+                          "action": {
+                            "type": "navigate_back"
+                          },
+                          "id": "btn-next-step",
+                          "stack": {
+                            "type": "stack",
+                            "components": [
+                              {
+                                "color": {
+                                  "light": {
+                                    "type": "alias",
+                                    "value": "primary"
+                                  }
+                                },
+                                "components": [],
+                                "id": "xmpgCrN9Rb",
+                                "name": "Text",
+                                "text_lid": "7bkohQjzIE",
+                                "type": "text"
+                              }
+                            ]
+                          }
+                        }
+                        """.trimIndent(),
+                        expected = ButtonComponent(
+                            action = ButtonComponent.Action.NavigateBack,
+                            stack = StackComponent(
+                                components = listOf(
+                                    TextComponent(
+                                        text = LocalizationKey("7bkohQjzIE"),
+                                        color = ColorScheme(light = ColorInfo.Alias(ColorAlias("primary"))),
+                                        name = "Text",
+                                    )
+                                ),
+                            ),
+                            id = "btn-next-step",
+                        )
+                    ),
+                ),
             )
         }
 


### PR DESCRIPTION
## Summary
- Adds an optional `id` field to `ButtonComponent` that mirrors the `id` key the backend serializes for button components in `components_config` ([khepri `Button.id`](https://github.com/RevenueCat/khepri/blob/main/khepri/services/paywalls/domain/template_schemas/v2/components/button.py)).
- This id is how a paywall button is referenced from a workflow step's `triggers[*].component_id`, and will be used in follow-up PRs to dispatch multipage workflow navigation when a button is pressed.
- No behavior change — the field is parsed but not consumed yet.

## Test plan
- [x] New deserialization test covers `ButtonComponent` JSON with an `id` field
- [x] `./gradlew :purchases:testDefaultsBc8DebugUnitTest --tests "com.revenuecat.purchases.paywalls.components.ButtonComponentTests"`
- [x] `./scripts/api-check.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new nullable field to `ButtonComponent` and a deserialization test, with no behavior changes beyond capturing additional backend JSON.
> 
> **Overview**
> Paywall `ButtonComponent` now includes an optional `id` field so backend-provided button identifiers are preserved during serialization/deserialization.
> 
> Tests add coverage to ensure `ButtonComponent` JSON containing `id` is decoded correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d277380e09b91defb1dd246b8195f75a1a219e00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->