### PR TITLE
Add `WorkflowNavigator` for multipage workflow step navigation

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
@@ -1,8 +1,5 @@
-@file:OptIn(InternalRevenueCatAPI::class)
-
 package com.revenuecat.purchases.ui.revenuecatui.workflow
 
-import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.common.workflows.WorkflowStep
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
@@ -51,5 +51,6 @@ internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
         return workflow.steps[prevStepId]
     }
 
-    fun canNavigateBack(): Boolean = backStack.isNotEmpty()
+    val canNavigateBack: Boolean
+        get() = backStack.isNotEmpty()
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
@@ -1,0 +1,58 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.workflow
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
+import com.revenuecat.purchases.common.workflows.WorkflowStep
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
+
+    private val _currentStepId = MutableStateFlow(workflow.initialStepId)
+    val currentStepId: StateFlow<String> = _currentStepId.asStateFlow()
+
+    private val backStack = ArrayDeque<String>()
+
+    fun currentStep(): WorkflowStep? = workflow.steps[_currentStepId.value]
+
+    @Suppress("ReturnCount")
+    fun triggerAction(componentId: String): WorkflowStep? {
+        val step = currentStep() ?: return null
+        val trigger = step.triggers.firstOrNull { it.componentId == componentId } ?: run {
+            Logger.w("No trigger found for componentId '$componentId' in step '${step.id}'")
+            return null
+        }
+        val action = step.triggerActions[trigger.actionId] ?: run {
+            Logger.w("No trigger action found for actionId '${trigger.actionId}' in step '${step.id}'")
+            return null
+        }
+        if (action.type != "step") {
+            Logger.w("Unknown workflow trigger action type '${action.type}' — ignoring")
+            return null
+        }
+        val stepId = action.stepId ?: run {
+            Logger.w("Trigger action '${trigger.actionId}' has no step_id")
+            return null
+        }
+        val nextStep = workflow.steps[stepId] ?: run {
+            Logger.w("Step '$stepId' not found in workflow '${workflow.id}'")
+            return null
+        }
+        backStack.addLast(_currentStepId.value)
+        _currentStepId.value = stepId
+        return nextStep
+    }
+
+    fun navigateBack(): WorkflowStep? {
+        if (backStack.isEmpty()) return null
+        val prevStepId = backStack.removeLast()
+        _currentStepId.value = prevStepId
+        return workflow.steps[prevStepId]
+    }
+
+    fun canNavigateBack(): Boolean = backStack.isNotEmpty()
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
@@ -125,14 +125,14 @@ class WorkflowNavigatorTest {
     @Test
     fun `canNavigateBack is false on initial step`() {
         val navigator = WorkflowNavigator(workflow)
-        assertThat(navigator.canNavigateBack()).isFalse()
+        assertThat(navigator.canNavigateBack).isFalse()
     }
 
     @Test
     fun `canNavigateBack is true after forward navigation`() {
         val navigator = WorkflowNavigator(workflow)
         navigator.triggerAction("btn-next")
-        assertThat(navigator.canNavigateBack()).isTrue()
+        assertThat(navigator.canNavigateBack).isTrue()
     }
 
     @Test
@@ -156,6 +156,68 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(workflow)
         navigator.triggerAction("btn-next")
         navigator.navigateBack()
-        assertThat(navigator.canNavigateBack()).isFalse()
+        assertThat(navigator.canNavigateBack).isFalse()
+    }
+
+    @Test
+    fun `multiple forward and back navigations work correctly`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next")
+        navigator.triggerAction("btn-finish")
+        assertThat(navigator.currentStep()).isEqualTo(step3)
+
+        val back1 = navigator.navigateBack()
+        assertThat(back1).isEqualTo(step2)
+        assertThat(navigator.currentStep()).isEqualTo(step2)
+        assertThat(navigator.canNavigateBack).isTrue()
+
+        val back2 = navigator.navigateBack()
+        assertThat(back2).isEqualTo(step1)
+        assertThat(navigator.currentStep()).isEqualTo(step1)
+        assertThat(navigator.canNavigateBack).isFalse()
+    }
+
+    @Test
+    fun `triggerAction with actionId not in triggerActions returns null and does not navigate`() {
+        val stepWithMissingAction = WorkflowStep(
+            id = "step-x",
+            type = "screen",
+            screenId = "screen-x",
+            triggers = listOf(
+                WorkflowTrigger(name = "X", type = "on_press", actionId = "action-missing", componentId = "btn-x"),
+            ),
+            triggerActions = emptyMap(),
+        )
+        val wfl = workflow.copy(
+            initialStepId = "step-x",
+            steps = mapOf("step-x" to stepWithMissingAction),
+        )
+        val navigator = WorkflowNavigator(wfl)
+        val result = navigator.triggerAction("btn-x")
+        assertThat(result).isNull()
+        assertThat(navigator.currentStep()).isEqualTo(stepWithMissingAction)
+    }
+
+    @Test
+    fun `triggerAction with target step not in workflow returns null and does not navigate`() {
+        val stepWithMissingTarget = WorkflowStep(
+            id = "step-x",
+            type = "screen",
+            screenId = "screen-x",
+            triggers = listOf(
+                WorkflowTrigger(name = "X", type = "on_press", actionId = "ax", componentId = "btn-x"),
+            ),
+            triggerActions = mapOf(
+                "ax" to WorkflowTriggerAction(type = "step", stepId = "step-nonexistent"),
+            ),
+        )
+        val wfl = workflow.copy(
+            initialStepId = "step-x",
+            steps = mapOf("step-x" to stepWithMissingTarget),
+        )
+        val navigator = WorkflowNavigator(wfl)
+        val result = navigator.triggerAction("btn-x")
+        assertThat(result).isNull()
+        assertThat(navigator.currentStep()).isEqualTo(stepWithMissingTarget)
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
@@ -1,0 +1,161 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.workflow
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
+import com.revenuecat.purchases.common.workflows.WorkflowStep
+import com.revenuecat.purchases.common.workflows.WorkflowTrigger
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
+import com.revenuecat.purchases.ui.revenuecatui.helpers.UiConfig
+import org.assertj.core.api.Assertions.assertThat
+
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WorkflowNavigatorTest {
+
+    private val step1 = WorkflowStep(
+        id = "step-1",
+        type = "screen",
+        screenId = "screen-1",
+        triggers = listOf(
+            WorkflowTrigger(
+                name = "Next",
+                type = "on_press",
+                actionId = "action-next",
+                componentId = "btn-next",
+            ),
+        ),
+        triggerActions = mapOf(
+            "action-next" to WorkflowTriggerAction(type = "step", stepId = "step-2"),
+        ),
+    )
+
+    private val step2 = WorkflowStep(
+        id = "step-2",
+        type = "screen",
+        screenId = "screen-2",
+        triggers = listOf(
+            WorkflowTrigger(
+                name = "Finish",
+                type = "on_press",
+                actionId = "action-finish",
+                componentId = "btn-finish",
+            ),
+        ),
+        triggerActions = mapOf(
+            "action-finish" to WorkflowTriggerAction(type = "step", stepId = "step-3"),
+        ),
+    )
+
+    private val step3 = WorkflowStep(
+        id = "step-3",
+        type = "screen",
+        screenId = "screen-3",
+    )
+
+    private val workflow = PublishedWorkflow(
+        id = "wfl-test",
+        displayName = "Test Workflow",
+        initialStepId = "step-1",
+        steps = mapOf("step-1" to step1, "step-2" to step2, "step-3" to step3),
+        screens = emptyMap(),
+        uiConfig = UiConfig(),
+        metadata = emptyMap(),
+    )
+
+    @Test
+    fun `currentStep returns initial step`() {
+        val navigator = WorkflowNavigator(workflow)
+        assertThat(navigator.currentStep()).isEqualTo(step1)
+    }
+
+    @Test
+    fun `triggerAction navigates to next step`() {
+        val navigator = WorkflowNavigator(workflow)
+        val result = navigator.triggerAction("btn-next")
+        assertThat(result).isEqualTo(step2)
+        assertThat(navigator.currentStep()).isEqualTo(step2)
+        assertThat(navigator.currentStepId.value).isEqualTo("step-2")
+    }
+
+    @Test
+    fun `triggerAction supports step type on second step`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next")
+        val result = navigator.triggerAction("btn-finish")
+        assertThat(result).isEqualTo(step3)
+        assertThat(navigator.currentStep()).isEqualTo(step3)
+    }
+
+    @Test
+    fun `triggerAction with unknown componentId returns null and does not navigate`() {
+        val navigator = WorkflowNavigator(workflow)
+        val result = navigator.triggerAction("btn-unknown")
+        assertThat(result).isNull()
+        assertThat(navigator.currentStep()).isEqualTo(step1)
+    }
+
+    @Test
+    fun `triggerAction with unknown action type returns null and does not navigate`() {
+        val stepWithUnknownAction = WorkflowStep(
+            id = "step-x",
+            type = "screen",
+            screenId = "screen-x",
+            triggers = listOf(
+                WorkflowTrigger(name = "X", type = "on_press", actionId = "ax", componentId = "btn-x"),
+            ),
+            triggerActions = mapOf(
+                "ax" to WorkflowTriggerAction(type = "some_unknown_type", stepId = "step-1"),
+            ),
+        )
+        val wfl = workflow.copy(
+            initialStepId = "step-x",
+            steps = mapOf("step-x" to stepWithUnknownAction),
+        )
+        val navigator = WorkflowNavigator(wfl)
+        val result = navigator.triggerAction("btn-x")
+        assertThat(result).isNull()
+        assertThat(navigator.currentStep()).isEqualTo(stepWithUnknownAction)
+    }
+
+    @Test
+    fun `canNavigateBack is false on initial step`() {
+        val navigator = WorkflowNavigator(workflow)
+        assertThat(navigator.canNavigateBack()).isFalse()
+    }
+
+    @Test
+    fun `canNavigateBack is true after forward navigation`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next")
+        assertThat(navigator.canNavigateBack()).isTrue()
+    }
+
+    @Test
+    fun `navigateBack returns to previous step`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next")
+        val result = navigator.navigateBack()
+        assertThat(result).isEqualTo(step1)
+        assertThat(navigator.currentStep()).isEqualTo(step1)
+    }
+
+    @Test
+    fun `navigateBack returns null when backStack is empty`() {
+        val navigator = WorkflowNavigator(workflow)
+        val result = navigator.navigateBack()
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `navigateBack restores canNavigateBack to false after popping last entry`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next")
+        navigator.navigateBack()
+        assertThat(navigator.canNavigateBack()).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces a standalone `WorkflowNavigator` class that tracks the current step in a `PublishedWorkflow` and supports forward navigation via component triggers + back navigation via a back stack.
- Not wired into any UI. A follow-up PR will consume this from `PaywallViewModel` to drive multipage paywall navigation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: new, internal navigation helper and tests only; no existing UI flow is modified, though future integration will rely on correct trigger/step ID handling.
> 
> **Overview**
> Introduces `WorkflowNavigator`, an internal helper that tracks the current `PublishedWorkflow` step via a `StateFlow`, advances to the next step when a component trigger maps to a `step` action, and maintains a back stack for `navigateBack`/`canNavigateBack`.
> 
> Adds comprehensive tests validating forward navigation, back navigation behavior, and non-navigation on invalid component/action/step references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22c1559d2ee3a89a3587ad8dcef5a003107c6751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->