### PR TITLE
Plumb `componentId` through buttons on workflow interactions

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
@@ -46,7 +46,7 @@ public class ButtonComponent(
         public object NavigateBack : Action
 
         @Serializable
-        public object Workflow : Action
+        public object WorkflowTrigger : Action
 
         @Serializable
         @Immutable
@@ -148,13 +148,13 @@ private class ActionSurrogate(
             is Action.NavigateBack -> ActionTypeSurrogate.navigate_back
             is Action.NavigateTo -> ActionTypeSurrogate.navigate_to
             is Action.RestorePurchases -> ActionTypeSurrogate.restore_purchases
-            is Action.Workflow -> ActionTypeSurrogate.workflow
+            is Action.WorkflowTrigger -> ActionTypeSurrogate.workflow
         },
         destination = when (action) {
             is Action.Unknown,
             is Action.NavigateBack,
             is Action.RestorePurchases,
-            is Action.Workflow,
+            is Action.WorkflowTrigger,
             -> null
 
             is Action.NavigateTo -> when (action.destination) {
@@ -170,7 +170,7 @@ private class ActionSurrogate(
             is Action.Unknown,
             is Action.NavigateBack,
             is Action.RestorePurchases,
-            is Action.Workflow,
+            is Action.WorkflowTrigger,
             -> null
 
             is Action.NavigateTo -> when (action.destination) {
@@ -198,7 +198,7 @@ private class ActionSurrogate(
             is Action.Unknown,
             is Action.NavigateBack,
             is Action.RestorePurchases,
-            is Action.Workflow,
+            is Action.WorkflowTrigger,
             -> null
 
             is Action.NavigateTo -> when (action.destination) {
@@ -218,7 +218,7 @@ private class ActionSurrogate(
             ActionTypeSurrogate.unknown -> Action.Unknown
             ActionTypeSurrogate.restore_purchases -> Action.RestorePurchases
             ActionTypeSurrogate.navigate_back -> Action.NavigateBack
-            ActionTypeSurrogate.workflow -> Action.Workflow
+            ActionTypeSurrogate.workflow -> Action.WorkflowTrigger
             ActionTypeSurrogate.navigate_to -> Action.NavigateTo(
                 destination = when (destination) {
                     DestinationSurrogate.customer_center -> Destination.CustomerCenter

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
@@ -870,7 +870,7 @@ internal class ButtonComponentTests {
                           "type": "workflow"
                         }
                         """.trimIndent(),
-                        deserialized = ButtonComponent.Action.Workflow,
+                        deserialized = ButtonComponent.Action.WorkflowTrigger,
                     ),
                 ),
                 arrayOf(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -361,6 +361,8 @@ private fun rememberPaywallActionHandler(viewModel: PaywallViewModel): suspend (
                 }
 
                 is PaywallAction.External.NavigateBack -> viewModel.closePaywall()
+                is PaywallAction.External.Workflow ->
+                    Logger.d("Workflow received for componentId=${action.componentId}")
                 is PaywallAction.External.NavigateTo -> when (val destination = action.destination) {
                     is PaywallAction.External.NavigateTo.Destination.CustomerCenter ->
                         Logger.w("Customer Center is not yet implemented on Android.")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -361,7 +361,7 @@ private fun rememberPaywallActionHandler(viewModel: PaywallViewModel): suspend (
                 }
 
                 is PaywallAction.External.NavigateBack -> viewModel.closePaywall()
-                is PaywallAction.External.Workflow ->
+                is PaywallAction.External.WorkflowTrigger ->
                     Logger.d("Workflow received for componentId=${action.componentId}")
                 is PaywallAction.External.NavigateTo -> when (val destination = action.destination) {
                     is PaywallAction.External.NavigateTo.Destination.CustomerCenter ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallAction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallAction.kt
@@ -26,7 +26,7 @@ internal sealed interface PaywallAction {
 
         object RestorePurchases : External
         object NavigateBack : External
-        data class Workflow(val componentId: String) : External
+        data class WorkflowTrigger(val componentId: String) : External
         data class PurchasePackage(
             val rcPackage: Package?,
             val resolvedOffer: ResolvedOffer? = null,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallAction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallAction.kt
@@ -26,6 +26,7 @@ internal sealed interface PaywallAction {
 
         object RestorePurchases : External
         object NavigateBack : External
+        data class Workflow(val componentId: String) : External
         data class PurchasePackage(
             val rcPackage: Package?,
             val resolvedOffer: ResolvedOffer? = null,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
@@ -1,9 +1,5 @@
-@file:OptIn(InternalRevenueCatAPI::class)
-
 package com.revenuecat.purchases.ui.revenuecatui.components.button
 
-import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
 
 /**
@@ -39,13 +35,6 @@ private fun ButtonComponentStyle.Action.NavigateTo.Destination.componentInteract
             ButtonComponentInteraction(value = componentInteractionValue, url = localeUrl)
         is ButtonComponentStyle.Action.NavigateTo.Destination.Sheet ->
             ButtonComponentInteraction(value = "navigate_to_sheet")
-    }
-
-internal fun PaywallAction.workflowInteraction(): ButtonComponentInteraction? =
-    if (this is PaywallAction.External.WorkflowTrigger) {
-        ButtonComponentInteraction(value = "workflow_trigger")
-    } else {
-        null
     }
 
 /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
@@ -25,7 +25,7 @@ internal fun ButtonComponentStyle.Action.componentInteraction(localeUrl: String?
         is ButtonComponentStyle.Action.WebCheckout,
         is ButtonComponentStyle.Action.WebProductSelection,
         is ButtonComponentStyle.Action.CustomWebCheckout,
-        is ButtonComponentStyle.Action.Workflow,
+        is ButtonComponentStyle.Action.WorkflowTrigger,
         -> null
     }
 
@@ -42,8 +42,8 @@ private fun ButtonComponentStyle.Action.NavigateTo.Destination.componentInteract
     }
 
 internal fun PaywallAction.workflowInteraction(): ButtonComponentInteraction? =
-    if (this is PaywallAction.External.Workflow) {
-        ButtonComponentInteraction(value = "workflow")
+    if (this is PaywallAction.External.WorkflowTrigger) {
+        ButtonComponentInteraction(value = "workflow_trigger")
     } else {
         null
     }
@@ -61,6 +61,6 @@ internal fun ButtonComponentStyle.Action.isPurchaseRelated(): Boolean =
         is ButtonComponentStyle.Action.RestorePurchases,
         is ButtonComponentStyle.Action.NavigateBack,
         is ButtonComponentStyle.Action.NavigateTo,
-        is ButtonComponentStyle.Action.Workflow,
+        is ButtonComponentStyle.Action.WorkflowTrigger,
         -> false
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
@@ -3,6 +3,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.button
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
 
 /**
@@ -38,6 +39,13 @@ private fun ButtonComponentStyle.Action.NavigateTo.Destination.componentInteract
             ButtonComponentInteraction(value = componentInteractionValue, url = localeUrl)
         is ButtonComponentStyle.Action.NavigateTo.Destination.Sheet ->
             ButtonComponentInteraction(value = "navigate_to_sheet")
+    }
+
+internal fun PaywallAction.workflowInteraction(): ButtonComponentInteraction? =
+    if (this is PaywallAction.External.Workflow) {
+        ButtonComponentInteraction(value = "workflow")
+    } else {
+        null
     }
 
 /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
@@ -48,10 +48,10 @@ internal class ButtonComponentState(
 
     @get:JvmSynthetic
     val action by derivedStateOf {
-        if (style.action is ButtonComponentStyle.Action.Workflow) {
+        if (style.action is ButtonComponentStyle.Action.WorkflowTrigger) {
             val componentId = style.componentId
             if (componentId != null) {
-                return@derivedStateOf PaywallAction.External.Workflow(componentId)
+                return@derivedStateOf PaywallAction.External.WorkflowTrigger(componentId)
             }
         }
         val localeId = localeProvider().toLocaleId()
@@ -116,9 +116,9 @@ internal class ButtonComponentState(
                     ),
                 )
             }
-            // Should not reach here: Action.Workflow is handled before calling toPaywallAction.
+            // Should not reach here: Action.WorkflowTrigger is handled before calling toPaywallAction.
             // Reached only if componentId is null (misconfigured button).
-            is ButtonComponentStyle.Action.Workflow -> {
+            is ButtonComponentStyle.Action.WorkflowTrigger -> {
                 Logger.e("ButtonComponentState: reached toPaywallAction for Workflow action — componentId may be null")
                 PaywallAction.External.NavigateBack
             }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
@@ -48,6 +48,12 @@ internal class ButtonComponentState(
 
     @get:JvmSynthetic
     val action by derivedStateOf {
+        if (style.action is ButtonComponentStyle.Action.Workflow) {
+            val componentId = style.componentId
+            if (componentId != null) {
+                return@derivedStateOf PaywallAction.External.Workflow(componentId)
+            }
+        }
         val localeId = localeProvider().toLocaleId()
 
         style.action.toPaywallAction(localeId)
@@ -110,8 +116,8 @@ internal class ButtonComponentState(
                     ),
                 )
             }
-            // Workflow buttons are normally intercepted before toPaywallAction() is called.
-            // Reaching this is unexpected and indicates a misconfigured button (e.g. null componentId).
+            // Should not reach here: Action.Workflow is handled before calling toPaywallAction.
+            // Reached only if componentId is null (misconfigured button).
             is ButtonComponentStyle.Action.Workflow -> {
                 Logger.e("ButtonComponentState: reached toPaywallAction for Workflow action — componentId may be null")
                 PaywallAction.External.NavigateBack

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -164,13 +164,15 @@ internal fun ButtonComponentView(
                     )
                 } else {
                     val urlForEvent = paywallAction.navigationUrlForComponentInteraction()
-                    style.action.componentInteraction(urlForEvent)?.let { interaction ->
+                    val interaction = paywallAction.workflowInteraction()
+                        ?: style.action.componentInteraction(urlForEvent)
+                    interaction?.let {
                         componentInteractionTracker.track(
                             PaywallComponentInteractionData(
                                 componentType = PaywallComponentType.BUTTON,
                                 componentName = style.componentName,
-                                componentValue = interaction.value,
-                                componentUrl = interaction.url,
+                                componentValue = it.value,
+                                componentUrl = it.url,
                             ),
                         )
                     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -287,6 +287,13 @@ private fun PaywallAction.navigationUrlForComponentInteraction(): String? =
         else -> null
     }
 
+private fun PaywallAction.workflowInteraction(): ButtonComponentInteraction? =
+    if (this is PaywallAction.External.WorkflowTrigger) {
+        ButtonComponentInteraction(value = "workflow_trigger")
+    } else {
+        null
+    }
+
 /**
  * Resolves the [Package] used for purchase / web-checkout analytics: explicit package on the button style when
  * present, otherwise the paywall's currently selected package.

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
@@ -3,7 +3,6 @@ package com.revenuecat.purchases.ui.revenuecatui.components.style
 import androidx.compose.runtime.Immutable
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
-import com.revenuecat.purchases.paywalls.components.ButtonComponent.Destination
 import com.revenuecat.purchases.paywalls.components.PaywallTransition
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.paywalls.components.properties.Size
@@ -28,7 +27,7 @@ internal data class ButtonComponentStyle(
     internal sealed interface Action {
         object RestorePurchases : Action
         object NavigateBack : Action
-        object Workflow : Action
+        object WorkflowTrigger : Action
 
         @get:JvmSynthetic
         val description: String

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -722,7 +722,7 @@ internal class StyleFactory(
             is ButtonComponent.Action.RestorePurchases -> Result.Success(ButtonComponentStyle.Action.RestorePurchases)
             is ButtonComponent.Action.NavigateTo -> convertDestination(action.destination)
                 .map { destination -> destination?.let { ButtonComponentStyle.Action.NavigateTo(it) } }
-            is ButtonComponent.Action.Workflow -> Result.Success(ButtonComponentStyle.Action.Workflow)
+            is ButtonComponent.Action.WorkflowTrigger -> Result.Success(ButtonComponentStyle.Action.WorkflowTrigger)
             // Returning null here, which will result in this button being hidden.
             is ButtonComponent.Action.Unknown -> Result.Success(null)
         }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
@@ -159,6 +159,9 @@ class PaywallActionTests {
             is PaywallAction.External.LaunchWebCheckout -> error(
                 "LaunchWebCheckout is not a ButtonComponent.Action. It is handled by PurchaseButtonComponent instead."
             )
+            is PaywallAction.External.Workflow -> error(
+                "Workflow is a runtime workflow navigation action, not a ButtonComponent.Action."
+            )
         }
 
     private fun PaywallAction.External.NavigateTo.Destination.toButtonDestination(): ButtonComponent.Destination =

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
@@ -159,7 +159,7 @@ class PaywallActionTests {
             is PaywallAction.External.LaunchWebCheckout -> error(
                 "LaunchWebCheckout is not a ButtonComponent.Action. It is handled by PurchaseButtonComponent instead."
             )
-            is PaywallAction.External.Workflow -> error(
+            is PaywallAction.External.WorkflowTrigger -> error(
                 "Workflow is a runtime workflow navigation action, not a ButtonComponent.Action."
             )
         }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapperTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowScreenMapperTest.kt
@@ -5,7 +5,6 @@ package com.revenuecat.purchases.ui.revenuecatui.workflow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.UiConfig
 import com.revenuecat.purchases.common.workflows.WorkflowScreen
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.common.Background


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #3377 (`ButtonComponent.id`). Base will update to `main` once that PR merges.

## Summary
- Plumbs `componentId` through `ButtonComponentStyle`, populated from `ButtonComponent.id` in `StyleFactory`.
- Tracks a `"workflow_trigger"` value as the component interaction event.
- `InternalPaywall`'s action handler currently just logs. The actual dispatch to `PaywallViewModel.handleWorkflowAction` lands in the multipage-workflow wiring PR that depends on this one


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall button action mapping and analytics tracking paths; misconfigured buttons (missing `componentId`) now fall back to `NavigateBack`, so behavior changes should be validated on real paywalls.
> 
> **Overview**
> Adds explicit **workflow trigger** support for V2 paywall buttons by renaming the serialized `ButtonComponent.Action.Workflow` to `WorkflowTrigger` while keeping the backend JSON `"type": "workflow"` mapping.
> 
> Plumbs the button `id` into `ButtonComponentStyle.componentId` via `StyleFactory`, emits a new `PaywallAction.External.WorkflowTrigger(componentId)`, and tracks a `component_value` of `"workflow_trigger"` for component-interaction analytics. `InternalPaywall` now recognizes this action (currently logs only), and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 186f654f10b3aefe96f63051c2b24997e233bc62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->