### PR TITLE
Wire multipage workflow navigation into PaywallViewModel

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -73,7 +73,9 @@ internal fun InternalPaywall(
     viewModel: PaywallViewModel = getPaywallViewModel(options),
 ) {
     BackHandler {
-        viewModel.closePaywall()
+        if (!viewModel.handleBackNavigation()) {
+            viewModel.closePaywall()
+        }
     }
 
     val colorScheme = MaterialTheme.colorScheme
@@ -360,9 +362,15 @@ private fun rememberPaywallActionHandler(viewModel: PaywallViewModel): suspend (
                     }
                 }
 
-                is PaywallAction.External.NavigateBack -> viewModel.closePaywall()
+                is PaywallAction.External.NavigateBack -> {
+                    if (!viewModel.handleBackNavigation()) {
+                        viewModel.closePaywall()
+                    }
+                }
+
                 is PaywallAction.External.WorkflowTrigger ->
-                    Logger.d("Workflow received for componentId=${action.componentId} trigger=${action.triggerType}")
+                    viewModel.handleWorkflowAction(action.componentId, action.triggerType)
+
                 is PaywallAction.External.NavigateTo -> when (val destination = action.destination) {
                     is PaywallAction.External.NavigateTo.Destination.CustomerCenter ->
                         Logger.w("Customer Center is not yet implemented on Android.")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.TestStoreProduct
@@ -231,6 +232,10 @@ private class LoadingViewModel(
     override suspend fun handleRestorePurchases() {
         // no-op
     }
+
+    override fun handleWorkflowAction(componentId: String, triggerType: WorkflowTriggerType) = Unit
+
+    override fun handleBackNavigation(): Boolean = false
 
     override fun clearActionError() = Unit
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.button
 
-import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
 
 /**
@@ -36,13 +35,6 @@ private fun ButtonComponentStyle.Action.NavigateTo.Destination.componentInteract
             ButtonComponentInteraction(value = componentInteractionValue, url = localeUrl)
         is ButtonComponentStyle.Action.NavigateTo.Destination.Sheet ->
             ButtonComponentInteraction(value = "navigate_to_sheet")
-    }
-
-internal fun PaywallAction.workflowInteraction(): ButtonComponentInteraction? =
-    if (this is PaywallAction.External.WorkflowTrigger) {
-        ButtonComponentInteraction(value = "workflow_trigger")
-    } else {
-        null
     }
 
 /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
@@ -40,7 +40,7 @@ private fun ButtonComponentStyle.Action.NavigateTo.Destination.componentInteract
 
 internal fun PaywallAction.workflowInteraction(): ButtonComponentInteraction? =
     if (this is PaywallAction.External.WorkflowTrigger) {
-        ButtonComponentInteraction(value = "workflow")
+        ButtonComponentInteraction(value = "workflow_trigger")
     } else {
         null
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.button
 
+import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
 
 /**
@@ -35,6 +36,13 @@ private fun ButtonComponentStyle.Action.NavigateTo.Destination.componentInteract
             ButtonComponentInteraction(value = componentInteractionValue, url = localeUrl)
         is ButtonComponentStyle.Action.NavigateTo.Destination.Sheet ->
             ButtonComponentInteraction(value = "navigate_to_sheet")
+    }
+
+internal fun PaywallAction.workflowInteraction(): ButtonComponentInteraction? =
+    if (this is PaywallAction.External.WorkflowTrigger) {
+        ButtonComponentInteraction(value = "workflow")
+    } else {
+        null
     }
 
 /**

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
@@ -1,4 +1,5 @@
 @file:JvmSynthetic
+@file:OptIn(InternalRevenueCatAPI::class)
 
 package com.revenuecat.purchases.ui.revenuecatui.components.button
 
@@ -8,6 +9,8 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.text.intl.Locale
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toLocaleId
@@ -47,15 +50,10 @@ internal class ButtonComponentState(
 
     @get:JvmSynthetic
     val action: PaywallAction? by derivedStateOf {
-        style.action.toPaywallAction(localeProvider().toLocaleId())
+        style.action.toPaywallAction(localeProvider().toLocaleId(), style.componentId)
     }
 
-    @get:JvmSynthetic
-    val workflowComponentId: String? by derivedStateOf {
-        if (style.action is ButtonComponentStyle.Action.WorkflowTrigger) style.componentId else null
-    }
-
-    private fun ButtonComponentStyle.Action.toPaywallAction(localeId: LocaleId): PaywallAction? =
+    private fun ButtonComponentStyle.Action.toPaywallAction(localeId: LocaleId, componentId: String?): PaywallAction? =
         when (this) {
             is ButtonComponentStyle.Action.NavigateBack -> PaywallAction.External.NavigateBack
             is ButtonComponentStyle.Action.NavigateTo -> toPaywallAction(localeId)
@@ -98,7 +96,9 @@ internal class ButtonComponentState(
                 )
             }
 
-            is ButtonComponentStyle.Action.WorkflowTrigger -> null
+            is ButtonComponentStyle.Action.WorkflowTrigger -> componentId?.let {
+                PaywallAction.External.WorkflowTrigger(it, WorkflowTriggerType.ON_PRESS)
+            }
         }
 
     private fun ButtonComponentStyle.Action.NavigateTo.toPaywallAction(localeId: LocaleId): PaywallAction =

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
@@ -8,13 +8,11 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.text.intl.Locale
-import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toLocaleId
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
-import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 @Stable
 @JvmSynthetic
@@ -48,22 +46,16 @@ internal class ButtonComponentState(
 ) {
 
     @get:JvmSynthetic
-    val action by derivedStateOf {
-        if (style.action is ButtonComponentStyle.Action.WorkflowTrigger) {
-            val componentId = style.componentId
-            if (componentId != null) {
-                return@derivedStateOf PaywallAction.External.WorkflowTrigger(
-                    componentId,
-                    WorkflowTriggerType.ON_PRESS,
-                )
-            }
-        }
-        val localeId = localeProvider().toLocaleId()
-
-        style.action.toPaywallAction(localeId)
+    val action: PaywallAction? by derivedStateOf {
+        style.action.toPaywallAction(localeProvider().toLocaleId())
     }
 
-    private fun ButtonComponentStyle.Action.toPaywallAction(localeId: LocaleId): PaywallAction =
+    @get:JvmSynthetic
+    val workflowComponentId: String? by derivedStateOf {
+        if (style.action is ButtonComponentStyle.Action.WorkflowTrigger) style.componentId else null
+    }
+
+    private fun ButtonComponentStyle.Action.toPaywallAction(localeId: LocaleId): PaywallAction? =
         when (this) {
             is ButtonComponentStyle.Action.NavigateBack -> PaywallAction.External.NavigateBack
             is ButtonComponentStyle.Action.NavigateTo -> toPaywallAction(localeId)
@@ -105,12 +97,8 @@ internal class ButtonComponentState(
                     ),
                 )
             }
-            // Should not reach here: Action.WorkflowTrigger is handled before calling toPaywallAction.
-            // Reached only if componentId is null (misconfigured button).
-            is ButtonComponentStyle.Action.WorkflowTrigger -> {
-                Logger.e("ButtonComponentState: reached toPaywallAction for Workflow action — componentId may be null")
-                PaywallAction.External.NavigateBack
-            }
+
+            is ButtonComponentStyle.Action.WorkflowTrigger -> null
         }
 
     private fun ButtonComponentStyle.Action.NavigateTo.toPaywallAction(localeId: LocaleId): PaywallAction =

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.unit.coerceIn
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Package
-import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.paywalls.components.CountdownComponent
 import com.revenuecat.purchases.paywalls.components.properties.CornerRadiuses
 import com.revenuecat.purchases.paywalls.components.properties.Dimension
@@ -145,10 +144,7 @@ internal fun ButtonComponentView(
                 )
             },
             modifier = modifier.clickable(enabled = !anyActionInProgress) {
-                val paywallAction = buttonState.workflowComponentId
-                    ?.let { PaywallAction.External.WorkflowTrigger(it, WorkflowTriggerType.ON_PRESS) }
-                    ?: buttonState.action
-                    ?: return@clickable
+                val paywallAction = buttonState.action ?: return@clickable
                 myActionInProgress = true
                 state.update(actionInProgress = true)
                 if (style.action.isPurchaseRelated()) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentView.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.coerceIn
 import androidx.compose.ui.unit.dp
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.paywalls.components.CountdownComponent
 import com.revenuecat.purchases.paywalls.components.properties.CornerRadiuses
 import com.revenuecat.purchases.paywalls.components.properties.Dimension
@@ -144,7 +145,10 @@ internal fun ButtonComponentView(
                 )
             },
             modifier = modifier.clickable(enabled = !anyActionInProgress) {
-                val paywallAction = buttonState.action
+                val paywallAction = buttonState.workflowComponentId
+                    ?.let { PaywallAction.External.WorkflowTrigger(it, WorkflowTriggerType.ON_PRESS) }
+                    ?: buttonState.action
+                    ?: return@clickable
                 myActionInProgress = true
                 state.update(actionInProgress = true)
                 if (style.action.isPurchaseRelated()) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -634,6 +634,12 @@ internal class StyleFactory(
                 componentId = component.id,
             )
         }
+    }.flatMap { style ->
+        if (style?.action is ButtonComponentStyle.Action.WorkflowTrigger && style.componentId == null) {
+            Result.Error(nonEmptyListOf(PaywallValidationError.WorkflowButtonMissingComponentId(component.name)))
+        } else {
+            Result.Success(style)
+        }
     }
 
     private fun StyleFactoryScope.createPackageComponentStyle(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -808,7 +808,7 @@ internal class PaywallViewModelImpl(
         if (!navigator.canNavigateBack) return false
         val result = currentWorkflowResult ?: return false
         val offerings = currentWorkflowOfferings ?: return false
-        val candidate = navigator.peekBackStep() ?: return false
+        val candidate = navigator.peekBackStep ?: return false
         validateStep(candidate, result.workflow, offerings)?.let { error ->
             Logger.e("Cannot navigate back to step '${candidate.id}': $error")
             return false

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -22,7 +22,10 @@ import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.common.workflows.WorkflowDataResult
+import com.revenuecat.purchases.common.workflows.WorkflowStep
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.paywalls.components.common.ProductChangeConfig
 import com.revenuecat.purchases.paywalls.events.ExitOfferType
@@ -60,6 +63,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.toLegacyPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.validatedPaywall
 import com.revenuecat.purchases.ui.revenuecatui.isFullScreen
 import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorStrings
+import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowNavigator
 import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowScreenMapper
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -105,6 +109,14 @@ internal interface PaywallViewModel {
         )
     }
     fun closePaywall(result: PaywallResult? = null)
+
+    fun handleWorkflowAction(componentId: String, triggerType: WorkflowTriggerType)
+
+    /**
+     * Handles back navigation within a workflow. Returns true if consumed by the workflow
+     * (previous step rendered), false to fall through to dismiss.
+     */
+    fun handleBackNavigation(): Boolean
 
     fun getWebCheckoutUrl(launchWebCheckout: PaywallAction.External.LaunchWebCheckout): String?
     fun invalidateCustomerInfoCache()
@@ -165,6 +177,11 @@ internal class PaywallViewModelImpl(
         get() = options.purchaseLogic
 
     private var paywallPresentationData: PaywallEvent.Data? = null
+
+    private var workflowNavigator: WorkflowNavigator? = null
+    private var currentWorkflowResult: WorkflowDataResult? = null
+    private var currentWorkflowOfferings: Offerings? = null
+    private var currentWorkflowPresentedOfferingContext: PresentedOfferingContext? = null
 
     private data class PaywallPresentationFingerprint(
         val paywallIdentifier: String?,
@@ -696,19 +713,33 @@ internal class PaywallViewModelImpl(
         presentedOfferingContext: PresentedOfferingContext?,
     ) {
         val workflow = fetchResult.workflow
-
-        val step = workflow.steps[workflow.initialStepId]
-        if (step == null) {
+        val initialStep = workflow.steps[workflow.initialStepId]
+        if (initialStep == null) {
             _state.value = PaywallState.Error(
                 "Initial step '${workflow.initialStepId}' not found in workflow '${workflow.id}'",
             )
             return
         }
 
+        currentWorkflowResult = fetchResult
+        currentWorkflowOfferings = offerings
+        currentWorkflowPresentedOfferingContext = presentedOfferingContext
+        workflowNavigator = WorkflowNavigator(workflow)
+
+        buildStateFromStep(initialStep, workflow, offerings, presentedOfferingContext)
+    }
+
+    @Suppress("ReturnCount")
+    private fun buildStateFromStep(
+        step: WorkflowStep,
+        workflow: PublishedWorkflow,
+        offerings: Offerings,
+        presentedOfferingContext: PresentedOfferingContext?,
+    ) {
         val screenId = step.screenId
         if (screenId == null) {
             _state.value = PaywallState.Error(
-                "Initial step '${step.id}' has no screen_id in workflow '${workflow.id}'",
+                "Step '${step.id}' has no screen_id in workflow '${workflow.id}'",
             )
             return
         }
@@ -750,11 +781,31 @@ internal class PaywallViewModelImpl(
         val offeringWithContext = presentedOfferingContext?.let { offering.copy(it) } ?: offering
 
         _state.value = calculateState(
-            offeringWithContext,
-            _colorScheme.value,
-            purchases.storefrontCountryCode,
-            options.mode,
+            offering = offeringWithContext,
+            colorScheme = _colorScheme.value,
+            storefrontCountryCode = purchases.storefrontCountryCode,
+            mode = options.mode,
         )
+    }
+
+    @Suppress("ReturnCount")
+    override fun handleWorkflowAction(componentId: String, triggerType: WorkflowTriggerType) {
+        val navigator = workflowNavigator ?: return
+        val result = currentWorkflowResult ?: return
+        val offerings = currentWorkflowOfferings ?: return
+        val newStep = navigator.triggerAction(componentId, triggerType) ?: return
+        buildStateFromStep(newStep, result.workflow, offerings, currentWorkflowPresentedOfferingContext)
+    }
+
+    @Suppress("ReturnCount")
+    override fun handleBackNavigation(): Boolean {
+        val navigator = workflowNavigator ?: return false
+        if (!navigator.canNavigateBack) return false
+        val newStep = navigator.navigateBack() ?: return false
+        val result = currentWorkflowResult ?: return false
+        val offerings = currentWorkflowOfferings ?: return false
+        buildStateFromStep(newStep, result.workflow, offerings, currentWorkflowPresentedOfferingContext)
+        return true
     }
 
     private fun getCurrentLocaleList(): LocaleListCompat {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -793,6 +793,11 @@ internal class PaywallViewModelImpl(
         val navigator = workflowNavigator ?: return
         val result = currentWorkflowResult ?: return
         val offerings = currentWorkflowOfferings ?: return
+        val candidate = navigator.peekTriggerStep(componentId, triggerType) ?: return
+        validateStep(candidate, result.workflow, offerings)?.let { error ->
+            Logger.e("Cannot navigate to step '${candidate.id}': $error")
+            return
+        }
         val newStep = navigator.triggerAction(componentId, triggerType) ?: return
         buildStateFromStep(newStep, result.workflow, offerings, currentWorkflowPresentedOfferingContext)
     }
@@ -803,9 +808,27 @@ internal class PaywallViewModelImpl(
         if (!navigator.canNavigateBack) return false
         val result = currentWorkflowResult ?: return false
         val offerings = currentWorkflowOfferings ?: return false
+        val candidate = navigator.peekBackStep() ?: return false
+        validateStep(candidate, result.workflow, offerings)?.let { error ->
+            Logger.e("Cannot navigate back to step '${candidate.id}': $error")
+            return false
+        }
         val newStep = navigator.navigateBack() ?: return false
         buildStateFromStep(newStep, result.workflow, offerings, currentWorkflowPresentedOfferingContext)
         return true
+    }
+
+    @Suppress("ReturnCount")
+    private fun validateStep(step: WorkflowStep, workflow: PublishedWorkflow, offerings: Offerings): String? {
+        val screenId = step.screenId
+            ?: return "Step '${step.id}' has no screen_id in workflow '${workflow.id}'"
+        val screen = workflow.screens[screenId]
+            ?: return "Screen '$screenId' not found in workflow '${workflow.id}'"
+        val offeringId = screen.offeringIdentifier
+            ?: return "Screen '$screenId' has no offering_id in workflow '${workflow.id}'"
+        offerings[offeringId]
+            ?: return "Offering '$offeringId' not found for screen '$screenId'"
+        return null
     }
 
     private fun getCurrentLocaleList(): LocaleListCompat {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -801,9 +801,9 @@ internal class PaywallViewModelImpl(
     override fun handleBackNavigation(): Boolean {
         val navigator = workflowNavigator ?: return false
         if (!navigator.canNavigateBack) return false
-        val newStep = navigator.navigateBack() ?: return false
         val result = currentWorkflowResult ?: return false
         val offerings = currentWorkflowOfferings ?: return false
+        val newStep = navigator.navigateBack() ?: return false
         buildStateFromStep(newStep, result.workflow, offerings, currentWorkflowPresentedOfferingContext)
         return true
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -18,6 +18,7 @@ import com.revenuecat.purchases.PackageType
 import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.UiConfig
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.models.Period
 import com.revenuecat.purchases.models.Price
 import com.revenuecat.purchases.models.TestStoreProduct
@@ -677,6 +678,23 @@ internal class MockViewModel(
         } else {
             unsupportedMethod("Can't restore purchases")
         }
+    }
+
+    var handleWorkflowActionCallCount = 0
+        private set
+    var handleWorkflowActionParams = mutableListOf<Pair<String, WorkflowTriggerType>>()
+        private set
+    override fun handleWorkflowAction(componentId: String, triggerType: WorkflowTriggerType) {
+        handleWorkflowActionCallCount++
+        handleWorkflowActionParams.add(componentId to triggerType)
+    }
+
+    var handleBackNavigationCallCount = 0
+        private set
+    var handleBackNavigationResult = false
+    override fun handleBackNavigation(): Boolean {
+        handleBackNavigationCallCount++
+        return handleBackNavigationResult
     }
 
     var clearActionErrorCallCount = 0

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/errors/PaywallValidationError.kt
@@ -47,6 +47,7 @@ internal sealed class PaywallValidationError : Throwable() {
             is TabControlNotInTab -> message
             is UnsupportedBackgroundType -> message
             is RootComponentUnsupportedProperties -> message
+            is WorkflowButtonMissingComponentId -> message
         }
     }
 
@@ -136,5 +137,11 @@ internal sealed class PaywallValidationError : Throwable() {
     ) : PaywallValidationError() {
         override val message: String = PaywallValidationErrorStrings.ROOT_COMPONENT_UNSUPPORTED_PROPERTIES
             .format(component::class.java.simpleName)
+    }
+    data class WorkflowButtonMissingComponentId(
+        val componentName: String?,
+    ) : PaywallValidationError() {
+        override val message: String = PaywallValidationErrorStrings.WORKFLOW_BUTTON_MISSING_COMPONENT_ID
+            .format(componentName ?: "<unnamed>")
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/strings/PaywallValidationErrorStrings.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/strings/PaywallValidationErrorStrings.kt
@@ -37,4 +37,6 @@ internal object PaywallValidationErrorStrings {
     const val UNSUPPORTED_BACKGROUND_TYPE = "This SDK version does not support this background type: %s"
     const val ROOT_COMPONENT_UNSUPPORTED_PROPERTIES =
         "This paywall's root component is hidden because it contains unsupported properties: %s"
+    const val WORKFLOW_BUTTON_MISSING_COMPONENT_ID =
+        "Workflow button '%s' has no component id and will not respond to taps."
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
@@ -28,7 +28,8 @@ internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
         return workflow.steps[action.stepId]
     }
 
-    fun peekBackStep(): WorkflowStep? = backStack.lastOrNull()?.let { workflow.steps[it] }
+    val peekBackStep: WorkflowStep?
+        get() = backStack.lastOrNull()?.let { workflow.steps[it] }
 
     @Suppress("ReturnCount")
     fun triggerAction(componentId: String, triggerType: WorkflowTriggerType): WorkflowStep? {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
@@ -19,6 +19,18 @@ internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
     fun currentStep(): WorkflowStep? = workflow.steps[_currentStepId.value]
 
     @Suppress("ReturnCount")
+    fun peekTriggerStep(componentId: String, triggerType: WorkflowTriggerType): WorkflowStep? {
+        val step = currentStep() ?: return null
+        val trigger = step.triggers.firstOrNull { it.componentId == componentId && it.type == triggerType }
+            ?: return null
+        val action = step.triggerActions[trigger.actionId] ?: return null
+        if (action !is WorkflowTriggerAction.Step) return null
+        return workflow.steps[action.stepId]
+    }
+
+    fun peekBackStep(): WorkflowStep? = backStack.lastOrNull()?.let { workflow.steps[it] }
+
+    @Suppress("ReturnCount")
     fun triggerAction(componentId: String, triggerType: WorkflowTriggerType): WorkflowStep? {
         val step = currentStep() ?: return null
         val trigger = step.triggers.firstOrNull { it.componentId == componentId && it.type == triggerType } ?: run {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentViewTests.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -822,5 +823,48 @@ class ButtonComponentViewTests {
                 .assertHasClickAction()
                 .performClick()
         }
+
+    @Test
+    fun `onClick does not fire when action is null (WorkflowTrigger with no componentId)`() {
+        var actionHandleCalledCount = 0
+
+        composeTestRule.setContent {
+            // WorkflowTrigger with componentId = null produces a null action in ButtonComponentState,
+            // so the clickable guard `buttonState.action ?: return@clickable` short-circuits.
+            val style = ButtonComponentStyle(
+                stackComponentStyle = StackComponentStyle(
+                    children = emptyList(),
+                    dimension = Dimension.Vertical(alignment = CENTER, distribution = START),
+                    visible = true,
+                    size = Size(width = Fill, height = Fill),
+                    spacing = 0.dp,
+                    background = BackgroundStyles.Color(ColorStyles(ColorStyle.Solid(Color.Transparent))),
+                    padding = PaddingValues(all = 0.dp),
+                    margin = PaddingValues(all = 0.dp),
+                    shape = Shape.Rectangle(CornerRadiuses.Dp(all = 0.0)),
+                    border = null,
+                    shadow = null,
+                    badge = null,
+                    scrollOrientation = null,
+                    rcPackage = null,
+                    tabIndex = null,
+                    countdownDate = null,
+                    countFrom = CountdownComponent.CountFrom.DAYS,
+                    overrides = emptyList(),
+                ),
+                action = ButtonComponentStyle.Action.WorkflowTrigger,
+                componentId = null,
+            )
+            ButtonComponentView(
+                style = style,
+                state = FakePaywallState(TestData.Packages.annual),
+                onClick = { actionHandleCalledCount++ },
+            )
+        }
+
+        composeTestRule.onRoot().performClick()
+
+        assertThat(actionHandleCalledCount).isEqualTo(0)
+    }
 
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -1509,4 +1509,42 @@ class StyleFactoryTests {
         val heroImage = zLayerStack.children[0] as ImageComponentStyle
         assertThat(heroImage.ignoreTopWindowInsets).isTrue()
     }
+
+    @Test
+    fun `Should fail when a WorkflowTrigger button has no component id`() {
+        // Arrange
+        val component = ButtonComponent(
+            action = ButtonComponent.Action.WorkflowTrigger,
+            id = null,
+            stack = StackComponent(components = emptyList()),
+        )
+
+        // Act
+        val result = styleFactory.create(component)
+
+        // Assert
+        assertThat(result.isError).isTrue()
+        val errors = result.errorOrNull()!!
+        assertThat(errors.size).isEqualTo(1)
+        assertThat(errors[0]).isInstanceOf(PaywallValidationError.WorkflowButtonMissingComponentId::class.java)
+    }
+
+    @Test
+    fun `Should succeed when a WorkflowTrigger button has a component id`() {
+        // Arrange
+        val component = ButtonComponent(
+            action = ButtonComponent.Action.WorkflowTrigger,
+            id = "btn-workflow",
+            stack = StackComponent(components = emptyList()),
+        )
+
+        // Act
+        val result = styleFactory.create(component)
+
+        // Assert
+        assertThat(result.isSuccess).isTrue()
+        val style = result.getOrNull()!!.componentStyle as ButtonComponentStyle
+        assertThat(style.action).isEqualTo(ButtonComponentStyle.Action.WorkflowTrigger)
+        assertThat(style.componentId).isEqualTo("btn-workflow")
+    }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -1283,19 +1283,6 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `back press on regular paywall closes paywall exactly once`() {
-        val model = create()
-
-        // Simulate the BackHandler block in InternalPaywall:
-        // if (!viewModel.handleBackNavigation()) { viewModel.closePaywall() }
-        if (!model.handleBackNavigation()) {
-            model.closePaywall()
-        }
-
-        assertThat(dismissInvoked).isTrue()
-    }
-
-    @Test
     fun `handleWorkflowAction does nothing when no workflow is loaded`() {
         val model = create()
         val stateBefore = model.state.value

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -1295,6 +1295,26 @@ class PaywallViewModelTest {
         assertThat(dismissInvoked).isTrue()
     }
 
+    @Test
+    fun `handleWorkflowAction does nothing when no workflow is loaded`() {
+        val model = create()
+        val stateBefore = model.state.value
+
+        model.handleWorkflowAction("btn-next", com.revenuecat.purchases.common.workflows.WorkflowTriggerType.ON_PRESS)
+
+        assertThat(model.state.value).isEqualTo(stateBefore)
+        assertThat(dismissInvoked).isFalse()
+    }
+
+    @Test
+    fun `handleWorkflowAction does not dismiss paywall when no workflow is loaded`() {
+        val model = create()
+
+        model.handleWorkflowAction("btn-next", com.revenuecat.purchases.common.workflows.WorkflowTriggerType.ON_PRESS)
+
+        assertThat(dismissInvoked).isFalse()
+    }
+
     // region events
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -34,6 +34,7 @@ import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConf
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.paywalls.events.PaywallComponentType
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventType
@@ -1287,7 +1288,7 @@ class PaywallViewModelTest {
         val model = create()
         val stateBefore = model.state.value
 
-        model.handleWorkflowAction("btn-next", com.revenuecat.purchases.common.workflows.WorkflowTriggerType.ON_PRESS)
+        model.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
 
         assertThat(model.state.value).isEqualTo(stateBefore)
         assertThat(dismissInvoked).isFalse()

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -1293,15 +1293,6 @@ class PaywallViewModelTest {
         assertThat(dismissInvoked).isFalse()
     }
 
-    @Test
-    fun `handleWorkflowAction does not dismiss paywall when no workflow is loaded`() {
-        val model = create()
-
-        model.handleWorkflowAction("btn-next", com.revenuecat.purchases.common.workflows.WorkflowTriggerType.ON_PRESS)
-
-        assertThat(dismissInvoked).isFalse()
-    }
-
     // region events
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -1275,6 +1275,26 @@ class PaywallViewModelTest {
         assertThat(dismissInvoked).isTrue
     }
 
+    @Test
+    fun `handleBackNavigation returns false for regular paywall`() {
+        val model = create()
+
+        assertThat(model.handleBackNavigation()).isFalse()
+    }
+
+    @Test
+    fun `back press on regular paywall closes paywall exactly once`() {
+        val model = create()
+
+        // Simulate the BackHandler block in InternalPaywall:
+        // if (!viewModel.handleBackNavigation()) { viewModel.closePaywall() }
+        if (!model.handleBackNavigation()) {
+            model.closePaywall()
+        }
+
+        assertThat(dismissInvoked).isTrue()
+    }
+
     // region events
 
     @Test


### PR DESCRIPTION
## Summary
- `PaywallViewModel` fetches the workflow result and creates a `WorkflowNavigator` to manage step traversal
- Adds an `isWorkflowActive` flag to `PaywallState.Loaded.Components` (defaults to `false`). No caller sets it to `true` yet, a follow-up PR will.
- `handleWorkflowAction(componentId)` advances the navigator to the next step and re-builds paywall state with `isWorkflowActive = true`
- `handleBackNavigation()` pops the back stack via the navigator; `BackHandler` and `NavigateBack` calls in `InternalPaywall` use this before closing the paywall
- `LoadingPaywall` gains no-op stubs for both new interface methods

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new navigation/state transitions for workflow-driven paywalls and changes back-button behavior, which could affect dismissal and screen rendering flow. Purchase/restore logic is untouched, but workflow step validation and action nullability may surface new configuration errors.
> 
> **Overview**
> Adds workflow step navigation to paywalls by having `PaywallViewModelImpl` keep a `WorkflowNavigator`, rebuild paywall state from the active workflow step on `handleWorkflowAction`, and consume back presses via `handleBackNavigation` before dismissing.
> 
> Tightens workflow button handling by making `WorkflowTrigger` actions nullable when `componentId` is missing (guarding clicks), and by validating/erroing during style creation with a new `PaywallValidationError.WorkflowButtonMissingComponentId` to prevent misconfigured workflow buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0f8ad7b395eebdf4f194b1654b66214e863fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->