### PR TITLE
Launch Customer Center from paywall navigation destination

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -3,7 +3,9 @@
 package com.revenuecat.purchases.ui.revenuecatui
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.Intent
 import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
@@ -42,6 +44,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelFactory
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModelImpl
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenterActivity
 import com.revenuecat.purchases.ui.revenuecatui.data.currentColors
 import com.revenuecat.purchases.ui.revenuecatui.data.isInFullScreenMode
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
@@ -363,7 +366,7 @@ private fun rememberPaywallActionHandler(viewModel: PaywallViewModel): suspend (
                 is PaywallAction.External.NavigateBack -> viewModel.closePaywall()
                 is PaywallAction.External.NavigateTo -> when (val destination = action.destination) {
                     is PaywallAction.External.NavigateTo.Destination.CustomerCenter ->
-                        Logger.w("Customer Center is not yet implemented on Android.")
+                        context.launchCustomerCenter()
 
                     is PaywallAction.External.NavigateTo.Destination.Url -> context.handleUrlDestination(
                         url = destination.url,
@@ -388,6 +391,23 @@ private fun Context.handleUrlDestination(url: String, method: ButtonComponent.Ur
     }
 
     URLOpener.openURL(this, url, openingMethod)
+}
+
+internal fun Context.launchCustomerCenter() {
+    try {
+        val intent = CustomerCenterActivity.createIntent(this)
+        // LocalContext can sometimes be backed by Application context.
+        if (getActivity() == null) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        startActivity(intent)
+    } catch (e: ActivityNotFoundException) {
+        Logger.e("Customer Center activity was not found when launched from paywall", e)
+    } catch (e: SecurityException) {
+        Logger.e("Unable to launch Customer Center from paywall due to security restrictions", e)
+    } catch (e: IllegalArgumentException) {
+        Logger.e("Failed to launch Customer Center from paywall", e)
+    }
 }
 
 private fun Modifier.screenModeBackground(isInFullScreenMode: Boolean, backgroundColor: Color): Modifier = this

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallDestinationHandlerTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywallDestinationHandlerTest.kt
@@ -1,0 +1,49 @@
+package com.revenuecat.purchases.ui.revenuecatui
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenterActivity
+import com.revenuecat.purchases.ui.revenuecatui.helpers.getActivity
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.Runs
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class InternalPaywallDestinationHandlerTest {
+
+    @Test
+    fun `launchCustomerCenter adds NEW_TASK flag without Activity context`() {
+        val context = mockk<Context>(relaxed = true)
+        val intentSlot = slot<Intent>()
+        every { context.startActivity(capture(intentSlot)) } just Runs
+
+        context.launchCustomerCenter()
+
+        verify(exactly = 1) { context.startActivity(any()) }
+        assertThat(intentSlot.captured.component?.className).isEqualTo(CustomerCenterActivity::class.java.name)
+        assertThat(intentSlot.captured.flags and Intent.FLAG_ACTIVITY_NEW_TASK)
+            .isEqualTo(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+
+    @Test
+    fun `launchCustomerCenter does not add NEW_TASK flag with Activity context`() {
+        val context = mockk<Activity>(relaxed = true)
+        val intentSlot = slot<Intent>()
+        every { context.startActivity(capture(intentSlot)) } just Runs
+
+        context.launchCustomerCenter()
+
+        verify(exactly = 1) { context.startActivity(any()) }
+        assertThat(intentSlot.captured.component?.className).isEqualTo(CustomerCenterActivity::class.java.name)
+        assertThat(intentSlot.captured.flags and Intent.FLAG_ACTIVITY_NEW_TASK).isEqualTo(0)
+        assertThat(context.getActivity()).isNotNull()
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Motivation
Resolves CC-651.

The paywall button action `NavigateTo(CustomerCenter)` incorrectly logged `Customer Center is not yet implemented on Android.` despite Android Customer Center support existing in RevenueCatUI.

### Description
- Replaced the stale warning path in `InternalPaywall` with actual navigation to Customer Center.
- Added `Context.launchCustomerCenter()` helper that:
  - builds `CustomerCenterActivity` intent,
  - adds `FLAG_ACTIVITY_NEW_TASK` when no `Activity` is available from the context,
  - safely handles launch failures with scoped logging (`ActivityNotFoundException`, `SecurityException`, `IllegalArgumentException`).
- Added `InternalPaywallDestinationHandlerTest` to verify:
  - Customer Center intent is launched,
  - `FLAG_ACTIVITY_NEW_TASK` is set for non-`Activity` contexts,
  - the flag is not set for `Activity` contexts.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CC-651](https://linear.app/revenuecat/issue/CC-651/android-log-wrongly-says-customer-center-isnt-implemented)

<div><a href="https://cursor.com/agents/bc-97803676-ddcb-4a00-86b7-08890e1cabdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97803676-ddcb-4a00-86b7-08890e1cabdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

