### PR TITLE
Add `componentId` to `ButtonCoomponentStyle`

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
@@ -21,6 +21,8 @@ internal data class ButtonComponentStyle(
     val transition: PaywallTransition? = null,
     @get:JvmSynthetic
     val componentName: String? = null,
+    @get:JvmSynthetic
+    val componentId: String? = null,
 ) : ComponentStyle {
 
     internal sealed interface Action {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -631,6 +631,7 @@ internal class StyleFactory(
                 action = action,
                 transition = component.transition,
                 componentName = component.name,
+                componentId = component.id,
             )
         }
     }


### PR DESCRIPTION
This is required by workflows since it's the link between the button in the paywall layout and the corresponding trigger node in the workflow graph. When the button is tapped, its componentId will be used to look up which workflow transition is associated with that button and advance to the next step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional ID field to an internal style model and wires it through the style factory; behavior is unchanged unless downstream code starts consuming the new value.
> 
> **Overview**
> Adds an optional `componentId` to `ButtonComponentStyle` so button styles can carry the originating paywall component identifier.
> 
> Updates `StyleFactory.createButtonComponentStyleOrNull` to populate `componentId` from `ButtonComponent.id` when building button styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfe2c125d581e8b490b84e752daf72c25d040c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->