### PR TITLE
Add `ButtonComponent.Action.Workflow`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
@@ -46,6 +46,9 @@ public class ButtonComponent(
         public object NavigateBack : Action
 
         @Serializable
+        public object Workflow : Action
+
+        @Serializable
         @Immutable
         public data class NavigateTo(@get:JvmSynthetic val destination: Destination) : Action
     }
@@ -145,11 +148,13 @@ private class ActionSurrogate(
             is Action.NavigateBack -> ActionTypeSurrogate.navigate_back
             is Action.NavigateTo -> ActionTypeSurrogate.navigate_to
             is Action.RestorePurchases -> ActionTypeSurrogate.restore_purchases
+            is Action.Workflow -> ActionTypeSurrogate.workflow
         },
         destination = when (action) {
             is Action.Unknown,
             is Action.NavigateBack,
             is Action.RestorePurchases,
+            is Action.Workflow,
             -> null
 
             is Action.NavigateTo -> when (action.destination) {
@@ -165,6 +170,7 @@ private class ActionSurrogate(
             is Action.Unknown,
             is Action.NavigateBack,
             is Action.RestorePurchases,
+            is Action.Workflow,
             -> null
 
             is Action.NavigateTo -> when (action.destination) {
@@ -192,6 +198,7 @@ private class ActionSurrogate(
             is Action.Unknown,
             is Action.NavigateBack,
             is Action.RestorePurchases,
+            is Action.Workflow,
             -> null
 
             is Action.NavigateTo -> when (action.destination) {
@@ -211,6 +218,7 @@ private class ActionSurrogate(
             ActionTypeSurrogate.unknown -> Action.Unknown
             ActionTypeSurrogate.restore_purchases -> Action.RestorePurchases
             ActionTypeSurrogate.navigate_back -> Action.NavigateBack
+            ActionTypeSurrogate.workflow -> Action.Workflow
             ActionTypeSurrogate.navigate_to -> Action.NavigateTo(
                 destination = when (destination) {
                     DestinationSurrogate.customer_center -> Destination.CustomerCenter
@@ -257,6 +265,7 @@ private enum class ActionTypeSurrogate {
     restore_purchases,
     navigate_back,
     navigate_to,
+    workflow,
     unknown,
 }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
@@ -863,6 +863,17 @@ internal class ButtonComponentTests {
                     ),
                 ),
                 arrayOf(
+                    "workflow",
+                    Args(
+                        serialized = """
+                        {
+                          "type": "workflow"
+                        }
+                        """.trimIndent(),
+                        deserialized = ButtonComponent.Action.Workflow,
+                    ),
+                ),
+                arrayOf(
                     "unknown",
                     Args(
                         serialized = """

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
@@ -24,6 +24,7 @@ internal fun ButtonComponentStyle.Action.componentInteraction(localeUrl: String?
         is ButtonComponentStyle.Action.WebCheckout,
         is ButtonComponentStyle.Action.WebProductSelection,
         is ButtonComponentStyle.Action.CustomWebCheckout,
+        is ButtonComponentStyle.Action.Workflow,
         -> null
     }
 
@@ -52,5 +53,6 @@ internal fun ButtonComponentStyle.Action.isPurchaseRelated(): Boolean =
         is ButtonComponentStyle.Action.RestorePurchases,
         is ButtonComponentStyle.Action.NavigateBack,
         is ButtonComponentStyle.Action.NavigateTo,
+        is ButtonComponentStyle.Action.Workflow,
         -> false
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
@@ -109,5 +109,8 @@ internal class ButtonComponentState(
                     ),
                 )
             }
+            // Should not reach here: Action.Workflow will be handled before calling toPaywallAction.
+            // Reached only if componentId is null (misconfigured button).
+            is ButtonComponentStyle.Action.Workflow -> PaywallAction.External.NavigateBack
         }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toLocaleId
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 
 @Stable
 @JvmSynthetic
@@ -109,8 +110,11 @@ internal class ButtonComponentState(
                     ),
                 )
             }
-            // Should not reach here: Action.Workflow will be handled before calling toPaywallAction.
-            // Reached only if componentId is null (misconfigured button).
-            is ButtonComponentStyle.Action.Workflow -> PaywallAction.External.NavigateBack
+            // Workflow buttons are normally intercepted before toPaywallAction() is called.
+            // Reaching this is unexpected and indicates a misconfigured button (e.g. null componentId).
+            is ButtonComponentStyle.Action.Workflow -> {
+                Logger.e("ButtonComponentState: reached toPaywallAction for Workflow action — componentId may be null")
+                PaywallAction.External.NavigateBack
+            }
         }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
@@ -28,6 +28,7 @@ internal data class ButtonComponentStyle(
     internal sealed interface Action {
         object RestorePurchases : Action
         object NavigateBack : Action
+        object Workflow : Action
 
         @get:JvmSynthetic
         val description: String

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
@@ -21,6 +21,8 @@ internal data class ButtonComponentStyle(
     val transition: PaywallTransition? = null,
     @get:JvmSynthetic
     val componentName: String? = null,
+    @get:JvmSynthetic
+    val componentId: String? = null,
 ) : ComponentStyle {
 
     internal sealed interface Action {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -722,6 +722,7 @@ internal class StyleFactory(
             is ButtonComponent.Action.RestorePurchases -> Result.Success(ButtonComponentStyle.Action.RestorePurchases)
             is ButtonComponent.Action.NavigateTo -> convertDestination(action.destination)
                 .map { destination -> destination?.let { ButtonComponentStyle.Action.NavigateTo(it) } }
+            is ButtonComponent.Action.Workflow -> Result.Success(ButtonComponentStyle.Action.Workflow)
             // Returning null here, which will result in this button being hidden.
             is ButtonComponent.Action.Unknown -> Result.Success(null)
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -631,6 +631,7 @@ internal class StyleFactory(
                 action = action,
                 transition = component.transition,
                 componentName = component.name,
+                componentId = component.id,
             )
         }
     }


### PR DESCRIPTION
Add new type of action for the `ButtonComponent`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it extends the paywall action serialization/deserialization contract and alters UI action mapping; misconfiguration could change runtime behavior for affected buttons.
> 
> **Overview**
> Introduces a new `ButtonComponent.Action.Workflow` action and supports it in the surrogate serializer/deserializer (including `ActionTypeSurrogate.workflow`) with a matching unit test for JSON round-trip.
> 
> Propagates this action into RevenueCatUI by adding `ButtonComponentStyle.Action.Workflow`, passing `componentId` through `StyleFactory`, excluding it from interaction/purchase-related analytics mapping, and adding a defensive fallback in `ButtonComponentState` that logs an error and navigates back if `Workflow` reaches `toPaywallAction()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d15edb2f36466d3879cdea54998d02df271e331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->