### PR TITLE
[DO NOT MERGE]: Set platform header for galaxy store

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/HTTPClient.kt
@@ -514,6 +514,7 @@ internal class HTTPClient(
 
     private fun getXPlatformHeader() = when (appConfig.store) {
         Store.AMAZON -> "amazon"
+        Store.GALAXY -> "galaxy"
         else -> "android"
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -8,6 +8,7 @@ package com.revenuecat.purchases.common
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.ForceServerErrorStrategy
+import com.revenuecat.purchases.Store
 import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.api.BuildConfig
@@ -1291,6 +1292,46 @@ internal class HTTPClientTest: BaseHTTPClientTest() {
 }
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
+internal class ParameterizedXPlatformHeaderTest(
+    private val store: Store,
+    private val expectedHeader: String,
+) : BaseHTTPClientTest() {
+
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "store={0}")
+        fun parameters(): Collection<Array<Any>> {
+            return listOf(
+                arrayOf(Store.PLAY_STORE, "android"),
+                arrayOf(Store.AMAZON, "amazon"),
+                arrayOf(Store.GALAXY, "galaxy"),
+            )
+        }
+    }
+
+    @Before
+    fun setupClient() {
+        mockSigningManager = mockk()
+        every { mockSigningManager.shouldVerifyEndpoint(any()) } returns false
+        client = createClient(appConfig = createAppConfig(store = store))
+    }
+
+    @Test
+    fun `sends expected platform header for store`() {
+        val endpoint = Endpoint.LogIn
+        enqueue(
+            endpoint.getPath(),
+            HTTPResult.createResult()
+        )
+
+        client.performRequest(baseURL, endpoint, body = null, postFieldsToSign = null, mapOf("" to ""))
+
+        val request = server.takeRequest()
+        assertThat(request.getHeader("X-Platform")).isEqualTo(expectedHeader)
+    }
+}
+
+@RunWith(ParameterizedRobolectricTestRunner::class)
 internal class ParameterizedNonJsonResponseBodyTest(
     private val endpoint: Endpoint,
     private val statusCode: Int,
@@ -1472,4 +1513,5 @@ internal class ParameterizedConnectionFailureFallbackTest(
             fallbackServer.shutdown()
         }
     }
+
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/HTTPClientTest.kt
@@ -1513,5 +1513,4 @@ internal class ParameterizedConnectionFailureFallbackTest(
             fallbackServer.shutdown()
         }
     }
-
 }


### PR DESCRIPTION
### Description
Sets the `X-Platform` header to `galaxy` when the SDK is using the Galaxy store.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small header mapping change plus a targeted parameterized test; impact is limited to request metadata for Galaxy builds.
> 
> **Overview**
> **Adds Galaxy store support for the `X-Platform` header.** `HTTPClient.getXPlatformHeader()` now returns `"galaxy"` when `appConfig.store` is `Store.GALAXY` (existing behavior for Amazon/Android remains).
> 
> **Tests updated.** Introduces a parameterized `HTTPClient` test to assert `X-Platform` is `android`, `amazon`, or `galaxy` depending on the configured `Store`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07496ad02a7a4cdba55ebbe5c80a9c3c730b750f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->