### PR TITLE
Bump revenucatui-tests gradle cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -848,14 +848,25 @@ jobs:
           avd_name: test-revenuecat-ui
           system_image: system-images;android-32;google_apis;x86_64
           install: true
+      # Use a dedicated cache prefix so this job is isolated from the shared
+      # default gradle cache, which became corrupted (truncated
+      # module-metadata.bin entry for androidx.annotation:annotation-experimental).
+      # Bump the suffix to force a fresh cache if this job's cache ever goes bad.
+      - android/restore_gradle_cache:
+          cache_prefix: ui-tests-v1
+      - android/restore_build_cache:
+          cache_prefix: ui-tests-v1
       - android/start_emulator:
           avd_name: test-revenuecat-ui
           post_emulator_launch_assemble_command: ./gradlew ui:revenuecatui:assembleBc8DebugAndroidTest
-      - android/restore_gradle_cache
       - run:
           name: Run RevenueCatUI UI tests for Android in CircleCI
           command: |
             ./gradlew ui:revenuecatui:connectedBc8DebugAndroidTest
+      - android/save_gradle_cache:
+          cache_prefix: ui-tests-v1
+      - android/save_build_cache:
+          cache_prefix: ui-tests-v1
 
   run-maestro-e2e-tests:
     description: "Run Maestro tests for Paywall Tester app"


### PR DESCRIPTION
### Description
This bumps the revenuecatui tests gradle cache key to try to solve some CI issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that updates cache keys for a single job; main risk is slower builds or reduced cache hits if the new cache prefix is misconfigured.
> 
> **Overview**
> Updates the `run-revenuecatui-ui-tests` CircleCI job to use a dedicated Gradle and build cache prefix (`ui-tests-v1`) instead of the shared default cache, and adds corresponding save steps.
> 
> This is intended to avoid cache corruption impacting the RevenueCatUI UI test job by isolating its caches and making future cache busting explicit via the prefix suffix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6935ff965b81ce104c83fdec6ffe6f462340870c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->