### PR TITLE
Extract private function `NavigateTo.toPaywallAction`

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
@@ -62,22 +62,7 @@ internal class ButtonComponentState(
     private fun ButtonComponentStyle.Action.toPaywallAction(localeId: LocaleId): PaywallAction =
         when (this) {
             is ButtonComponentStyle.Action.NavigateBack -> PaywallAction.External.NavigateBack
-            is ButtonComponentStyle.Action.NavigateTo -> when (destination) {
-                is ButtonComponentStyle.Action.NavigateTo.Destination.CustomerCenter ->
-                    PaywallAction.External.NavigateTo(PaywallAction.External.NavigateTo.Destination.CustomerCenter)
-
-                is ButtonComponentStyle.Action.NavigateTo.Destination.Url ->
-                    PaywallAction.External.NavigateTo(
-                        PaywallAction.External.NavigateTo.Destination.Url(
-                            // We will use the URL for the default locale if there's no URL for the current locale.
-                            url = destination.urls.run { getOrDefault(localeId, entry.value) },
-                            method = destination.method,
-                        ),
-                    )
-
-                is ButtonComponentStyle.Action.NavigateTo.Destination.Sheet ->
-                    PaywallAction.Internal.NavigateTo(PaywallAction.Internal.NavigateTo.Destination.Sheet(destination))
-            }
+            is ButtonComponentStyle.Action.NavigateTo -> toPaywallAction(localeId)
 
             is ButtonComponentStyle.Action.PurchasePackage ->
                 PaywallAction.External.PurchasePackage(
@@ -122,5 +107,23 @@ internal class ButtonComponentState(
                 Logger.e("ButtonComponentState: reached toPaywallAction for Workflow action — componentId may be null")
                 PaywallAction.External.NavigateBack
             }
+        }
+
+    private fun ButtonComponentStyle.Action.NavigateTo.toPaywallAction(localeId: LocaleId): PaywallAction =
+        when (destination) {
+            is ButtonComponentStyle.Action.NavigateTo.Destination.CustomerCenter ->
+                PaywallAction.External.NavigateTo(PaywallAction.External.NavigateTo.Destination.CustomerCenter)
+
+            is ButtonComponentStyle.Action.NavigateTo.Destination.Url ->
+                PaywallAction.External.NavigateTo(
+                    PaywallAction.External.NavigateTo.Destination.Url(
+                        // We will use the URL for the default locale if there's no URL for the current locale.
+                        url = destination.urls.run { getOrDefault(localeId, entry.value) },
+                        method = destination.method,
+                    ),
+                )
+
+            is ButtonComponentStyle.Action.NavigateTo.Destination.Sheet ->
+                PaywallAction.Internal.NavigateTo(PaywallAction.Internal.NavigateTo.Destination.Sheet(destination))
         }
 }


### PR DESCRIPTION
Groundwork for https://github.com/RevenueCat/purchases-android/pull/3381/ to keep the review simpler.

I am just extracting a private function 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only reorganizes `NavigateTo` action mapping logic without changing behavior. Main risk is accidental regression in `NavigateTo` destination handling, but the moved code remains identical.
> 
> **Overview**
> Refactors `ButtonComponentState` by extracting the `ButtonComponentStyle.Action.NavigateTo` → `PaywallAction` conversion into a dedicated private `NavigateTo.toPaywallAction(localeId)` helper.
> 
> The main `Action.toPaywallAction` mapping now delegates `NavigateTo` handling to this helper, keeping behavior (including locale-specific URL selection) unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d7dbb1c2a38054d56c5720d6c3479350f5b7955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->