### PR TITLE
Add `triggerType` to `WorkflowTrigger`

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -362,7 +362,7 @@ private fun rememberPaywallActionHandler(viewModel: PaywallViewModel): suspend (
 
                 is PaywallAction.External.NavigateBack -> viewModel.closePaywall()
                 is PaywallAction.External.WorkflowTrigger ->
-                    Logger.d("Workflow received for componentId=${action.componentId}")
+                    Logger.d("Workflow received for componentId=${action.componentId} trigger=${action.triggerType}")
                 is PaywallAction.External.NavigateTo -> when (val destination = action.destination) {
                     is PaywallAction.External.NavigateTo.Destination.CustomerCenter ->
                         Logger.w("Customer Center is not yet implemented on Android.")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallAction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallAction.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.ui.revenuecatui.components
 
 import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ResolvedOffer
@@ -26,7 +27,7 @@ internal sealed interface PaywallAction {
 
         object RestorePurchases : External
         object NavigateBack : External
-        data class WorkflowTrigger(val componentId: String) : External
+        data class WorkflowTrigger(val componentId: String, val triggerType: WorkflowTriggerType) : External
         data class PurchasePackage(
             val rcPackage: Package?,
             val resolvedOffer: ResolvedOffer? = null,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.text.intl.Locale
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.paywalls.components.common.LocaleId
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toLocaleId
@@ -51,7 +52,10 @@ internal class ButtonComponentState(
         if (style.action is ButtonComponentStyle.Action.WorkflowTrigger) {
             val componentId = style.componentId
             if (componentId != null) {
-                return@derivedStateOf PaywallAction.External.WorkflowTrigger(componentId)
+                return@derivedStateOf PaywallAction.External.WorkflowTrigger(
+                    componentId,
+                    WorkflowTriggerType.ON_PRESS,
+                )
             }
         }
         val localeId = localeProvider().toLocaleId()


### PR DESCRIPTION
Groundwork for https://github.com/RevenueCat/purchases-android/pull/3381/

Passing `triggerType` to `WorkflowTrigger`, which for now it's always `ON_PRESS`, but could be different in the future. The idea is that the button (or other component) is the one that indicates the workflow trigger type.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, internal data-shape change that currently only affects workflow-trigger action construction and logging.
> 
> **Overview**
> Adds a `triggerType` field to `PaywallAction.External.WorkflowTrigger` and introduces `WorkflowTriggerType` to represent how the workflow was triggered.
> 
> Updates button action creation to emit `WorkflowTrigger(componentId, WorkflowTriggerType.ON_PRESS)` and updates the paywall action handler logging to include the new trigger type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e0e0f5a5a3c8f29df18b8ee4d927036a78f67f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->