### PR TITLE
[DO NOT MERGE] Use revenuecat/install-sdkman orb command instead of inline install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ parameters:
 
 commands:
   install-sdkman:
-    description: Install SDKMAN (via revenuecat orb) and run `sdk env install` to set up Java
+    description: Install SDKMAN and set up Java
     steps:
       - revenuecat/install-sdkman
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ aliases:
 version: 2.1
 orbs:
   android: circleci/android@3.1.0
-  revenuecat: revenuecat/sdks-common-config@3.17.0
+  revenuecat: revenuecat/sdks-common-config@dev:8aa259ac8067ba610fc70b399bacc2f552bf17bb
   codecov: codecov/codecov@3.2.4
 
 parameters:
@@ -56,23 +56,12 @@ parameters:
 
 commands:
   install-sdkman:
-    description: Install SDKMAN
+    description: Install SDKMAN (via revenuecat orb) and run `sdk env install` to set up Java
     steps:
-      - run:
-          name: Installing SDKMAN
-          command: |
-            if curl -s "https://get.sdkman.io?rcupdate=false" | bash; then
-              echo -e '\nsource "/home/circleci/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
-              source $BASH_ENV
-            else
-              echo "Error installing SDKMAN, continuing with default Java" >&2
-            fi
+      - revenuecat/install-sdkman
       - run:
           name: Setup Java environment
-          command: |
-            if ! sdk env install; then
-              echo "Error installing Java SDK through SDKMAN, continuing with default Java" >&2
-            fi
+          command: sdk env install
 
   android-dependencies:
     steps:


### PR DESCRIPTION
**Do not merge.** Test PR to validate consuming the new `revenuecat/install-sdkman` orb command on CI before the orb release lands.

Depends on RevenueCat/sdks-circleci-orb#55. Pinned to its dev-published version (`dev:8aa259ac8067ba610fc70b399bacc2f552bf17bb`) — bump back to a tagged release version once #55 merges.