### PR TITLE
Auto load paywall in paywall tester via local.properties

### DIFF
--- a/examples/paywall-tester/build.gradle.kts
+++ b/examples/paywall-tester/build.gradle.kts
@@ -66,6 +66,11 @@ android {
             "PAYWALL_TESTER_API_KEY_B_LABEL",
             "\"${resolveProperty("PAYWALL_TESTER_API_KEY_B_LABEL")}\"",
         )
+        buildConfigField(
+            "String",
+            "PAYWALL_TESTER_AUTO_OPEN_OFFERING_ID",
+            "\"${resolveProperty("PAYWALL_TESTER_AUTO_OPEN_OFFERING_ID")}\"",
+        )
     }
 
     signingConfigs {

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
@@ -13,6 +13,9 @@ object Constants {
     val GOOGLE_API_KEY_A_LABEL: String = BuildConfig.PAYWALL_TESTER_API_KEY_A_LABEL.ifEmpty { "API_KEY_A_LABEL" }
     val GOOGLE_API_KEY_B_LABEL: String = BuildConfig.PAYWALL_TESTER_API_KEY_B_LABEL.ifEmpty { "API_KEY_B_LABEL" }
 
+    // Optional: Set `paywallTesterAutoOpenOfferingId` to open an offering directly on app launch.
+    val AUTO_OPEN_OFFERING_ID: String = BuildConfig.PAYWALL_TESTER_AUTO_OPEN_OFFERING_ID
+
     // Optional: Set a preferred UI locale override (e.g., "en-US", "es-ES", "fr-FR")
     // Leave as empty string to use system default locale
     const val PREFERRED_UI_LOCALE_OVERRIDE: String = ""

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/Constants.kt
@@ -13,7 +13,7 @@ object Constants {
     val GOOGLE_API_KEY_A_LABEL: String = BuildConfig.PAYWALL_TESTER_API_KEY_A_LABEL.ifEmpty { "API_KEY_A_LABEL" }
     val GOOGLE_API_KEY_B_LABEL: String = BuildConfig.PAYWALL_TESTER_API_KEY_B_LABEL.ifEmpty { "API_KEY_B_LABEL" }
 
-    // Optional: Set `paywallTesterAutoOpenOfferingId` to open an offering directly on app launch.
+    // Optional: Set `PAYWALL_TESTER_AUTO_OPEN_OFFERING_ID` to open an offering directly on app launch.
     val AUTO_OPEN_OFFERING_ID: String = BuildConfig.PAYWALL_TESTER_AUTO_OPEN_OFFERING_ID
 
     // Optional: Set a preferred UI locale override (e.g., "en-US", "es-ES", "fr-FR")

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallTesterApp.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallTesterApp.kt
@@ -1,11 +1,31 @@
 package com.revenuecat.paywallstester
 
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.revenuecat.paywallstester.ui.screens.AppScreen
@@ -14,6 +34,8 @@ import com.revenuecat.paywallstester.ui.screens.main.MainScreen
 import com.revenuecat.paywallstester.ui.screens.paywall.PaywallScreen
 import com.revenuecat.paywallstester.ui.screens.paywall.PaywallScreenViewModel
 import com.revenuecat.paywallstester.ui.screens.paywallfooter.PaywallFooterScreen
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.awaitOfferings
 import com.revenuecat.purchases.ui.revenuecatui.customercenter.CustomerCenter
 
 @Composable
@@ -29,69 +51,122 @@ private fun AppNavHost(
     navController: NavHostController,
     modifier: Modifier = Modifier,
 ) {
-    NavHost(
-        navController,
-        startDestination = AppScreen.Main.route,
-        modifier = modifier,
-    ) {
-        composable(AppScreen.Main.route) {
-            MainScreen(
-                navigateToPaywallScreen = { offering ->
-                    navController.navigate(AppScreen.Paywall.route.plus("/${offering?.identifier}"))
-                },
-                navigateToPaywallFooterScreen = { offering ->
-                    navController.navigate(AppScreen.PaywallFooter.route.plus("/${offering?.identifier}"))
-                },
-                navigateToPaywallCondensedFooterScreen = { offering ->
-                    navController.navigate(
-                        AppScreen.PaywallFooter.route
-                            .plus("/${offering?.identifier}")
-                            .plus("?${PaywallScreenViewModel.FOOTER_CONDENSED_KEY}=true"),
-                    )
-                },
-                navigateToPaywallByPlacementScreen = { placementId ->
-                    navController.navigate(
-                        AppScreen.PaywallByPlacement.route
-                            .plus("/$placementId"),
-                    )
-                },
-                navigateToCustomerCenterScreen = {
-                    navController.navigate(AppScreen.CustomerCenter.route)
-                },
-            )
-        }
-        composable(
-            route = AppScreen.Paywall.route.plus("/{${PaywallScreenViewModel.OFFERING_ID_KEY}}"),
-            arguments = listOf(navArgument(PaywallScreenViewModel.OFFERING_ID_KEY) { type = NavType.StringType }),
+    var autoLoadingDone by remember { mutableStateOf(false) }
+    AutoOpenOffering(navController, onLoadingComplete = { autoLoadingDone = true })
+
+    val currentEntry by navController.currentBackStackEntryAsState()
+    val isOnMainScreen = currentEntry?.destination?.route == AppScreen.Main.route
+    val showLoadingOverlay = Constants.AUTO_OPEN_OFFERING_ID.isNotEmpty() &&
+        !autoLoadingDone &&
+        isOnMainScreen
+
+    Box(modifier = modifier.fillMaxSize()) {
+        NavHost(
+            navController,
+            startDestination = AppScreen.Main.route,
         ) {
-            PaywallScreen(dismissRequest = navController::popBackStack)
-        }
-        composable(
-            route = AppScreen.PaywallByPlacement.route.plus("/{${PaywallScreenViewModel.PLACEMENT_ID_KEY}}"),
-            arguments = listOf(navArgument(PaywallScreenViewModel.PLACEMENT_ID_KEY) { type = NavType.StringType }),
-        ) {
-            PaywallScreen(dismissRequest = navController::popBackStack)
-        }
-        composable(
-            route = AppScreen.PaywallFooter.route
-                .plus("/{${PaywallScreenViewModel.OFFERING_ID_KEY}}")
-                .plus(
-                    "?${PaywallScreenViewModel.FOOTER_CONDENSED_KEY}={${PaywallScreenViewModel.FOOTER_CONDENSED_KEY}}",
+            composable(AppScreen.Main.route) {
+                MainScreen(
+                    navigateToPaywallScreen = { offering ->
+                        navController.navigate(AppScreen.Paywall.route.plus("/${offering?.identifier}"))
+                    },
+                    navigateToPaywallFooterScreen = { offering ->
+                        navController.navigate(AppScreen.PaywallFooter.route.plus("/${offering?.identifier}"))
+                    },
+                    navigateToPaywallCondensedFooterScreen = { offering ->
+                        navController.navigate(
+                            AppScreen.PaywallFooter.route
+                                .plus("/${offering?.identifier}")
+                                .plus("?${PaywallScreenViewModel.FOOTER_CONDENSED_KEY}=true"),
+                        )
+                    },
+                    navigateToPaywallByPlacementScreen = { placementId ->
+                        navController.navigate(
+                            AppScreen.PaywallByPlacement.route
+                                .plus("/$placementId"),
+                        )
+                    },
+                    navigateToCustomerCenterScreen = {
+                        navController.navigate(AppScreen.CustomerCenter.route)
+                    },
+                )
+            }
+            composable(
+                route = AppScreen.Paywall.route.plus("/{${PaywallScreenViewModel.OFFERING_ID_KEY}}"),
+                arguments = listOf(navArgument(PaywallScreenViewModel.OFFERING_ID_KEY) { type = NavType.StringType }),
+            ) {
+                PaywallScreen(dismissRequest = navController::popBackStack)
+            }
+            composable(
+                route = AppScreen.PaywallByPlacement.route.plus("/{${PaywallScreenViewModel.PLACEMENT_ID_KEY}}"),
+                arguments = listOf(navArgument(PaywallScreenViewModel.PLACEMENT_ID_KEY) { type = NavType.StringType }),
+            ) {
+                PaywallScreen(dismissRequest = navController::popBackStack)
+            }
+            composable(
+                route = AppScreen.PaywallFooter.route
+                    .plus("/{${PaywallScreenViewModel.OFFERING_ID_KEY}}")
+                    .plus(
+                        "?${PaywallScreenViewModel.FOOTER_CONDENSED_KEY}" +
+                            "={${PaywallScreenViewModel.FOOTER_CONDENSED_KEY}}",
+                    ),
+                arguments = listOf(
+                    navArgument(PaywallScreenViewModel.OFFERING_ID_KEY) { type = NavType.StringType },
+                    navArgument(PaywallScreenViewModel.FOOTER_CONDENSED_KEY) {
+                        type = NavType.BoolType
+                        defaultValue = false
+                    },
                 ),
-            arguments = listOf(
-                navArgument(PaywallScreenViewModel.OFFERING_ID_KEY) { type = NavType.StringType },
-                navArgument(PaywallScreenViewModel.FOOTER_CONDENSED_KEY) {
-                    type = NavType.BoolType
-                    defaultValue = false
-                },
-            ),
-        ) {
-            PaywallFooterScreen(
-                dismissRequest = navController::popBackStack,
-            )
+            ) {
+                PaywallFooterScreen(
+                    dismissRequest = navController::popBackStack,
+                )
+            }
+            composable(route = AppScreen.CustomerCenter.route) {
+                CustomerCenterScreen(dismissRequest = navController::popBackStack)
+            }
         }
-        composable(route = AppScreen.CustomerCenter.route) {
-            CustomerCenterScreen(dismissRequest = navController::popBackStack)
+
+        if (showLoadingOverlay) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                CircularProgressIndicator()
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = "Loading offering ${Constants.AUTO_OPEN_OFFERING_ID}…",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+            }
         }
     }
 }
+
+@Composable
+private fun AutoOpenOffering(navController: NavHostController, onLoadingComplete: () -> Unit) {
+    val currentOnLoadingComplete by rememberUpdatedState(onLoadingComplete)
+    LaunchedEffect(Unit) {
+        val offeringId = Constants.AUTO_OPEN_OFFERING_ID
+        if (offeringId.isEmpty()) return@LaunchedEffect
+
+        runCatching {
+            Purchases.sharedInstance.awaitOfferings()
+        }.onSuccess { offerings ->
+            if (offerings.all.containsKey(offeringId)) {
+                navController.navigate(AppScreen.Paywall.route.plus("/$offeringId"))
+            } else {
+                Log.w(TAG, "Configured auto-open offering '$offeringId' was not found.")
+            }
+        }.onFailure { error ->
+            Log.w(TAG, "Could not auto-open offering '$offeringId'.", error)
+        }
+        currentOnLoadingComplete()
+    }
+}
+
+private const val TAG = "PaywallTesterApp"

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallTesterApp.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/PaywallTesterApp.kt
@@ -15,8 +15,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -51,7 +51,7 @@ private fun AppNavHost(
     navController: NavHostController,
     modifier: Modifier = Modifier,
 ) {
-    var autoLoadingDone by remember { mutableStateOf(false) }
+    var autoLoadingDone by rememberSaveable { mutableStateOf(false) }
     AutoOpenOffering(navController, onLoadingComplete = { autoLoadingDone = true })
 
     val currentEntry by navController.currentBackStackEntryAsState()

--- a/local.properties.example
+++ b/local.properties.example
@@ -11,6 +11,7 @@
 #PAYWALL_TESTER_API_KEY_B=your_key
 #PAYWALL_TESTER_API_KEY_A_LABEL=Key A
 #PAYWALL_TESTER_API_KEY_B_LABEL=Key B
+#PAYWALL_TESTER_AUTO_OPEN_OFFERING_ID=your_offering_id
 
 ## ──────────────────────────────────────────────
 ## Purchase Tester (pre-fills the API key field)


### PR DESCRIPTION
Add a `PAYWALL_TESTER_AUTO_OPEN_OFFERING_ID` Gradle property that will auto load an offering when set. Very useful when testing the same paywall over and over.

[Screen_recording_20260429_144038.webm](https://github.com/user-attachments/assets/9d288c23-9579-4c03-8dc4-94435e393ce0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the Paywall Tester example app; changes are limited to startup navigation/loading UI and a new BuildConfig field.
> 
> **Overview**
> Adds an optional `PAYWALL_TESTER_AUTO_OPEN_OFFERING_ID` build-time property to the Paywall Tester example that, when set, fetches offerings on app launch and automatically navigates to the matching paywall.
> 
> Updates the app’s navigation host to run this auto-open flow and show a blocking loading overlay while the offering lookup is in progress, and documents the new property in `local.properties.example`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2af8013d362bfa45de6000a70f71f81276bd5a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->