### PR TITLE
Replace unauthenticated SDKMAN install with SHA-pinned orb command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ aliases:
 version: 2.1
 orbs:
   android: circleci/android@3.1.0
-  revenuecat: revenuecat/sdks-common-config@3.17.0
+  revenuecat: revenuecat/sdks-common-config@3.20.0
   codecov: codecov/codecov@3.2.4
 
 parameters:
@@ -56,17 +56,9 @@ parameters:
 
 commands:
   install-sdkman:
-    description: Install SDKMAN
+    description: Install SDKMAN and set up Java environment
     steps:
-      - run:
-          name: Installing SDKMAN
-          command: |
-            if curl -s "https://get.sdkman.io?rcupdate=false" | bash; then
-              echo -e '\nsource "/home/circleci/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
-              source $BASH_ENV
-            else
-              echo "Error installing SDKMAN, continuing with default Java" >&2
-            fi
+      - revenuecat/install-sdkman
       - run:
           name: Setup Java environment
           command: |


### PR DESCRIPTION
Bumps `revenuecat/sdks-common-config` to `3.20.0` and replaces the local `install-sdkman` command (which used unauthenticated `curl https://get.sdkman.io | bash`) with the new `revenuecat/install-sdkman` orb command, which pins SDKMAN to a SHA256-verified GitHub release.

Mirrors the pattern from [sdks-circleci-orb#55](https://github.com/RevenueCat/sdks-circleci-orb/pull/55).

The prior soft-fail wrapper around the SDKMAN install ("continuing with default Java") is dropped — the orb command intentionally fails hard on a SHA-256 mismatch, which is the security guarantee. The downstream `sdk env install` Java setup is preserved as its own run-step at each of the 28 invocation sites, with its existing soft-fail kept intact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI bootstrapping for Java/SDKMAN; orb-based install may fail builds if verification or orb behavior differs, but impact is limited to pipeline execution (not runtime product code).
> 
> **Overview**
> Replaces the custom `install-sdkman` implementation in `.circleci/config.yml` (curling `get.sdkman.io`) with the orb-provided `revenuecat/install-sdkman` command, shifting SDKMAN installation to a SHA-verified mechanism.
> 
> Bumps `revenuecat/sdks-common-config` from `3.17.0` to `3.20.0` while keeping the subsequent `sdk env install` Java setup step (still soft-failing to default Java on error).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aefb0d8eeacc480a1ec7c18679db7ec986fb8c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->