### PR TITLE
refactor: extract shared PaywallComponentsScaffold for reuse across paywall variants

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -72,7 +72,6 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.toComponentsPaywallState
 import java.net.URL
 import java.util.Date
 
-@Suppress("LongMethod")
 @Composable
 internal fun LoadedPaywallComponents(
     state: PaywallState.Loaded.Components,
@@ -83,15 +82,53 @@ internal fun LoadedPaywallComponents(
     val configuration = LocalConfiguration.current
     state.update(localeList = configuration.locales)
 
-    val style = state.stack
-    val headerComponentStyle = state.header
-    val footerComponentStyle = state.stickyFooter
-    val background = rememberBackgroundStyle(state.background)
-    val mainScrollState = rememberScrollState()
+    val onClick: suspend (PaywallAction) -> Unit = { action: PaywallAction ->
+        handleClick(action, state, clickHandler, componentInteractionTracker)
+    }
+
     // If the root stack already scrolls vertically (overflow = SCROLL on a vertical dimension),
     // skip the outer verticalScroll — two vertical scroll modifiers on the same axis crashes.
     val shouldWrapMainContentInVerticalScroll =
-        (style as? StackComponentStyle)?.scrollOrientation != Orientation.Vertical
+        (state.stack as? StackComponentStyle)?.scrollOrientation != Orientation.Vertical
+    val mainScrollState = rememberScrollState()
+
+    PaywallComponentsScaffold(
+        state = state,
+        clickHandler = clickHandler,
+        componentInteractionTracker = componentInteractionTracker,
+        modifier = modifier,
+    ) {
+        ComponentView(
+            style = state.stack,
+            state = state,
+            onClick = onClick,
+            componentInteractionTracker = componentInteractionTracker,
+            modifier = Modifier
+                .fillMaxSize()
+                .conditional(shouldWrapMainContentInVerticalScroll) {
+                    verticalScroll(mainScrollState)
+                }
+                .conditional(state.header != null && !state.mainStackHasHeroImage) {
+                    headerTopPadding(state)
+                },
+        )
+    }
+}
+
+/**
+ * Shared scaffold for all Components-based paywall variants. Handles the background, bottom-sheet,
+ * overlay, fixed-header overlay, and sticky footer. Callers supply the main scrollable content as
+ * [mainContent] and decide for themselves whether to apply [headerTopPadding] based on [state].
+ */
+@Composable
+internal fun PaywallComponentsScaffold(
+    state: PaywallState.Loaded.Components,
+    clickHandler: suspend (PaywallAction.External) -> Unit,
+    componentInteractionTracker: PaywallComponentInteractionTracker,
+    modifier: Modifier = Modifier,
+    mainContent: @Composable () -> Unit,
+) {
+    val background = rememberBackgroundStyle(state.background)
     val onClick: suspend (PaywallAction) -> Unit = { action: PaywallAction ->
         handleClick(action, state, clickHandler, componentInteractionTracker)
     }
@@ -106,25 +143,10 @@ internal fun LoadedPaywallComponents(
                     state = state,
                     modifier = Modifier.weight(1f),
                 ) {
-                    // Child 0: main scrollable content.
-                    ComponentView(
-                        style = style,
-                        state = state,
-                        onClick = onClick,
-                        componentInteractionTracker = componentInteractionTracker,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .conditional(shouldWrapMainContentInVerticalScroll) {
-                                verticalScroll(mainScrollState)
-                            }
-                            .conditional(
-                                headerComponentStyle != null && !state.mainStackHasHeroImage,
-                            ) {
-                                headerTopPadding(state)
-                            },
-                    )
-                    // Child 1 (optional): header overlay.
-                    headerComponentStyle?.let { headerStyle ->
+                    // Child 0: caller-supplied main content (scrollable body or slide container).
+                    mainContent()
+                    // Child 1 (optional): fixed header overlay.
+                    state.header?.let { headerStyle ->
                         ComponentView(
                             style = headerStyle,
                             state = state,
@@ -133,7 +155,7 @@ internal fun LoadedPaywallComponents(
                         )
                     }
                 }
-                footerComponentStyle?.let {
+                state.stickyFooter?.let {
                     ComponentView(
                         style = it,
                         state = state,
@@ -156,7 +178,7 @@ internal fun LoadedPaywallComponents(
  * Children: index 0 = main scrollable content, index 1 (optional) = header overlay.
  */
 @Composable
-private fun HeaderOverlayLayout(
+internal fun HeaderOverlayLayout(
     state: PaywallState.Loaded.Components,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
@@ -191,7 +213,7 @@ private fun HeaderOverlayLayout(
  * layout phase from [state.headerHeightPx][PaywallState.Loaded.Components.headerHeightPx], which
  * is set by [HeaderOverlayLayout] earlier in the same layout pass.
  */
-private fun Modifier.headerTopPadding(state: PaywallState.Loaded.Components): Modifier =
+internal fun Modifier.headerTopPadding(state: PaywallState.Loaded.Components): Modifier =
     this.layout { measurable, constraints ->
         val topPad = state.headerHeightPx
         val placeable = measurable.measure(constraints.offset(vertical = -topPad))
@@ -200,7 +222,7 @@ private fun Modifier.headerTopPadding(state: PaywallState.Loaded.Components): Mo
         }
     }
 
-private suspend fun handleClick(
+internal suspend fun handleClick(
     action: PaywallAction,
     state: PaywallState.Loaded.Components,
     externalClickHandler: suspend (PaywallAction.External) -> Unit,
@@ -234,7 +256,7 @@ private suspend fun handleClick(
 /**
  * Shows the provided [sheet] as this [SimpleSheetState]'s sheet content.
  */
-private fun SimpleSheetState.show(
+internal fun SimpleSheetState.show(
     sheet: ButtonComponentStyle.Action.NavigateTo.Destination.Sheet,
     state: PaywallState.Loaded.Components,
     componentInteractionTracker: PaywallComponentInteractionTracker,


### PR DESCRIPTION
Little refactor in preparation for animation work on workflows

---

> [!NOTE]
> **Medium Risk**
> Primarily a UI refactor, but it reshapes the composable/layout structure for paywalls (header overlay, padding, sticky footer), which could cause subtle rendering or interaction regressions across variants.
>
> **Overview**
> Extracts the background, bottom-sheet, overlay, fixed-header overlay, and sticky footer composition out of `LoadedPaywallComponents` into a new reusable `PaywallComponentsScaffold` composable. `LoadedPaywallComponents` now simply calls the scaffold and supplies the main scrollable content as a slot, keeping the header top-padding logic local to the caller.
>
> Promotes `HeaderOverlayLayout`, `headerTopPadding`, `handleClick`, and `SimpleSheetState.show` from `private` to `internal` so they can be reused by other components-based paywall variants without duplicating the layout and click-handling logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI-only refactor, but it changes the composition/layout structure around header measurement/padding, overlays, and sticky footer placement, which could cause subtle rendering or interaction regressions across paywall variants.
> 
> **Overview**
> `LoadedPaywallComponents` is restructured to delegate background, optional overlay, fixed header overlay, sticky footer, and bottom-sheet wiring to a new reusable `PaywallComponentsScaffold`, with the main body provided via a `mainContent` slot.
> 
> Several layout/click helpers are promoted from `private` to `internal` (`HeaderOverlayLayout`, `headerTopPadding`, `handleClick`, `SimpleSheetState.show`) to enable reuse across other components-based paywall variants without duplicating this composition logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e1eb7e34e7bd278b621e49a0e57a08512efba48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->