### PR TITLE
feat: pre-render workflow paywall pages with smooth slide animation

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -35,6 +35,7 @@ import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.events.PaywallComponentType
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant.defaultAnimation
 import com.revenuecat.purchases.ui.revenuecatui.components.LoadedPaywallComponents
+import com.revenuecat.purchases.ui.revenuecatui.components.LoadedWorkflowPaywall
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.composables.CloseButton
 import com.revenuecat.purchases.ui.revenuecatui.composables.ErrorDialog
@@ -144,11 +145,21 @@ internal fun InternalPaywall(
                     viewModel.trackPaywallImpressionIfNeeded()
                 }
             }
-            LoadedPaywallComponents(
-                state = state,
-                clickHandler = rememberPaywallActionHandler(viewModel),
-                componentInteractionTracker = componentInteractionTracker,
-            )
+            val workflowState = viewModel.workflowState.value
+            if (workflowState != null) {
+                LoadedWorkflowPaywall(
+                    workflowState = workflowState,
+                    navigationDirection = viewModel.navigationDirection.value,
+                    clickHandler = rememberPaywallActionHandler(viewModel),
+                    componentInteractionTracker = componentInteractionTracker,
+                )
+            } else {
+                LoadedPaywallComponents(
+                    state = state,
+                    clickHandler = rememberPaywallActionHandler(viewModel),
+                    componentInteractionTracker = componentInteractionTracker,
+                )
+            }
         } else {
             Logger.e(
                 "State is not loaded while transitioning animation. This may happen if state changes " +

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -35,6 +35,7 @@ import com.revenuecat.purchases.ui.revenuecatui.composables.PlaceholderDefaults
 import com.revenuecat.purchases.ui.revenuecatui.composables.placeholder
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
@@ -45,6 +46,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toLegacyPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toResourceProvider
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template2
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -191,6 +193,8 @@ private class LoadingViewModel(
     override val actionError: State<PurchasesError?> = mutableStateOf(null)
     override val purchaseCompleted: State<Boolean> = mutableStateOf(false)
     override val preloadedExitOffering: State<Offering?> = mutableStateOf(null)
+    override val navigationDirection: State<NavigationDirection> = mutableStateOf(NavigationDirection.NONE)
+    override val workflowState: State<WorkflowPaywallUiState?> = mutableStateOf(null)
 
     override fun trackPaywallImpressionIfNeeded() = Unit
     override fun trackExitOffer(exitOfferType: ExitOfferType, exitOfferingIdentifier: String) = Unit

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -1,0 +1,129 @@
+@file:JvmSynthetic
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.platform.LocalConfiguration
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
+import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+
+@Composable
+internal fun LoadedWorkflowPaywall(
+    workflowState: WorkflowPaywallUiState,
+    navigationDirection: NavigationDirection,
+    clickHandler: suspend (PaywallAction.External) -> Unit,
+    componentInteractionTracker: PaywallComponentInteractionTracker,
+    modifier: Modifier = Modifier,
+) {
+    val currentStepId = workflowState.currentStepId
+    val stepStates = workflowState.stepStates
+    val currentState = stepStates[currentStepId] ?: run {
+        Logger.e("Workflow step '$currentStepId' not found in stepStates — rendering nothing")
+        return
+    }
+
+    val configuration = LocalConfiguration.current
+    currentState.update(localeList = configuration.locales)
+
+    val slideState = rememberWorkflowSlideState(
+        workflowState = workflowState,
+        navigationDirection = navigationDirection,
+    )
+
+    PaywallComponentsScaffold(
+        state = currentState,
+        clickHandler = clickHandler,
+        componentInteractionTracker = componentInteractionTracker,
+        modifier = modifier,
+    ) {
+        // Multi-step slide container: all composed steps are stacked and translated by workflowSlide.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clipToBounds(),
+        ) {
+            for (stepId in slideState.composedStepIds) {
+                val stepState = stepStates[stepId] ?: continue
+                key(stepId) {
+                    WorkflowStepBody(
+                        stepId = stepId,
+                        stepState = stepState,
+                        isCurrent = stepId == currentStepId,
+                        currentStepId = currentStepId,
+                        headerOffsetState = currentState,
+                        navigationDirection = navigationDirection,
+                        slideState = slideState,
+                        clickHandler = clickHandler,
+                        componentInteractionTracker = componentInteractionTracker,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Renders one step's main scrollable content with the slide-animation modifier applied.
+ * Off-screen (parked) steps still receive a click handler, but it short-circuits since they
+ * are translated far off-screen and can't receive touches.
+ *
+ * [headerOffsetState] is the *current* step's state — used so the header-top-padding modifier
+ * stays in sync with the visible header during navigation, regardless of which step is being
+ * laid out.
+ */
+@Suppress("LongParameterList")
+@Composable
+private fun WorkflowStepBody(
+    stepId: String,
+    stepState: PaywallState.Loaded.Components,
+    isCurrent: Boolean,
+    currentStepId: String,
+    headerOffsetState: PaywallState.Loaded.Components,
+    navigationDirection: NavigationDirection,
+    slideState: WorkflowSlideState,
+    clickHandler: suspend (PaywallAction.External) -> Unit,
+    componentInteractionTracker: PaywallComponentInteractionTracker,
+) {
+    val onClick: suspend (PaywallAction) -> Unit = { action ->
+        if (isCurrent) {
+            handleClick(action, stepState, clickHandler, componentInteractionTracker)
+        }
+    }
+    val tracker = if (isCurrent) componentInteractionTracker else PaywallComponentInteractionTracker { _ -> }
+    // Skip the outer verticalScroll if the step's root stack already scrolls vertically — see
+    // LoadedPaywallComponents for the rationale.
+    val shouldWrapInVerticalScroll =
+        (stepState.stack as? StackComponentStyle)?.scrollOrientation != Orientation.Vertical
+    val scrollState = rememberScrollState()
+
+    ComponentView(
+        style = stepState.stack,
+        state = stepState,
+        onClick = onClick,
+        componentInteractionTracker = tracker,
+        modifier = Modifier
+            .fillMaxSize()
+            .workflowSlide(slideState, stepId, currentStepId, navigationDirection)
+            .conditional(shouldWrapInVerticalScroll) {
+                verticalScroll(scrollState)
+            }
+            .conditional(headerOffsetState.header != null && !stepState.mainStackHasHeroImage) {
+                headerTopPadding(headerOffsetState)
+            },
+    )
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideState.kt
@@ -1,0 +1,173 @@
+@file:JvmSynthetic
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+
+private const val SLIDE_DURATION_MS = 350
+
+// Keeps this many recent back-stack entries pre-composed so backward swipes feel instant.
+// 3 covers typical A→B→C funnels without unbounded memory growth.
+private const val BACK_STACK_WINDOW = 3
+
+/**
+ * Drives the cross-step slide animation for a workflow paywall.
+ *
+ * Owns:
+ * - the set of step IDs currently composed in the slot table,
+ * - the animation values used by [Modifier.workflowSlide] to position each step's content.
+ *
+ * Use [rememberWorkflowSlideState] to obtain an instance bound to the current workflow inputs.
+ */
+@Stable
+internal class WorkflowSlideState(initialStepId: String) {
+
+    /** Step IDs whose ComponentView is currently in the Compose slot table. */
+    var composedStepIds: Set<String> by mutableStateOf(setOf(initialStepId))
+        private set
+
+    /**
+     * Last step ID the [LaunchedEffect] has fully bound to its animation state.
+     *
+     * While `currentStepId != seenStepId`, we're in the recomposition triggered by the new
+     * currentStepId, but the LaunchedEffect's `snapTo(0f)` hasn't run yet. We use this gap
+     * to render with `progress = 0f` so the new step starts off-screen and the previous step
+     * stays at position 0 — preventing the flash where the new step would otherwise appear
+     * at its final position before the slide begins.
+     */
+    internal var seenStepId by mutableStateOf(initialStepId)
+        private set
+
+    internal var animatingFromStepId by mutableStateOf<String?>(null)
+        private set
+
+    internal var animatingDirection by mutableStateOf(NavigationDirection.NONE)
+        private set
+
+    // 1f = "fully arrived"; animation runs from 0f (off-screen) to 1f (on-screen).
+    internal val animatable = Animatable(1f)
+
+    internal suspend fun runTransition(
+        toStepId: String,
+        navigationDirection: NavigationDirection,
+        backStack: List<String>,
+        reachableStepIds: Set<String>,
+        stepStates: Map<String, PaywallState.Loaded.Components>,
+    ) {
+        // Always include the target step (handles the synchronous fallback edge case).
+        composedStepIds = composedStepIds + toStepId
+
+        if (seenStepId != toStepId) {
+            val fromId = seenStepId
+            // Closing the gap before snapTo would cause the flash; we close it as part of
+            // setting up the animation values below.
+            seenStepId = toStepId
+
+            if (navigationDirection != NavigationDirection.NONE) {
+                animatingFromStepId = fromId
+                animatingDirection = navigationDirection
+                animatable.snapTo(0f)
+                animatable.animateTo(
+                    targetValue = 1f,
+                    animationSpec = tween(SLIDE_DURATION_MS, easing = FastOutSlowInEasing),
+                )
+                animatingFromStepId = null
+                animatingDirection = NavigationDirection.NONE
+            }
+        }
+
+        evictAndPreWarm(
+            currentStepId = toStepId,
+            backStack = backStack,
+            reachableStepIds = reachableStepIds,
+            stepStates = stepStates,
+        )
+    }
+
+    private suspend fun evictAndPreWarm(
+        currentStepId: String,
+        backStack: List<String>,
+        reachableStepIds: Set<String>,
+        stepStates: Map<String, PaywallState.Loaded.Components>,
+    ) {
+        val backStackWindow = backStack.takeLast(BACK_STACK_WINDOW).toSet()
+        val targetIds = setOf(currentStepId) + reachableStepIds + backStackWindow
+        composedStepIds = composedStepIds.intersect(targetIds)
+
+        // Tier-2: stagger pre-warm of reachable/recent steps one per frame so each composition
+        // pass stays small enough to avoid a visible hitch.
+        val toPrewarm = (reachableStepIds + backStackWindow)
+            .filter { it in stepStates && it !in composedStepIds }
+        for (stepId in toPrewarm) {
+            withFrameNanos {}
+            composedStepIds = composedStepIds + stepId
+        }
+    }
+}
+
+@Composable
+internal fun rememberWorkflowSlideState(
+    workflowState: WorkflowPaywallUiState,
+    navigationDirection: NavigationDirection,
+): WorkflowSlideState {
+    val state = remember { WorkflowSlideState(workflowState.currentStepId) }
+
+    LaunchedEffect(workflowState.currentStepId) {
+        state.runTransition(
+            toStepId = workflowState.currentStepId,
+            navigationDirection = navigationDirection,
+            backStack = workflowState.backStack,
+            reachableStepIds = workflowState.reachableStepIds,
+            stepStates = workflowState.stepStates,
+        )
+    }
+
+    return state
+}
+
+/**
+ * Translates a step's content horizontally based on its role in the current slide animation:
+ *
+ * - **Current step**: slides from `±width` to `0` as the animation progresses.
+ * - **Step being animated out**: slides from `0` to `∓width`.
+ * - **All other (parked) steps**: positioned far off-screen so the GraphicsLayer skips drawing.
+ *
+ * State reads happen inside the layer block so animation frames invalidate the layer without
+ * triggering recomposition. During the [WorkflowSlideState.seenStepId] / `currentStepId` gap,
+ * progress is forced to 0 to keep the new step off-screen until the animation actually starts.
+ */
+internal fun Modifier.workflowSlide(
+    state: WorkflowSlideState,
+    stepId: String,
+    currentStepId: String,
+    navigationDirection: NavigationDirection,
+): Modifier = graphicsLayer {
+    val inGap = state.seenStepId != currentStepId
+    val animatingFrom = if (inGap) state.seenStepId else state.animatingFromStepId
+    val direction = if (inGap) navigationDirection else state.animatingDirection
+    val progress = if (inGap) 0f else state.animatable.value
+    val directionFactor = if (direction == NavigationDirection.FORWARD) 1f else -1f
+
+    translationX = when (stepId) {
+        currentStepId -> (1f - progress) * directionFactor * size.width
+        animatingFrom -> -progress * directionFactor * size.width
+        else -> 2f * size.width
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -63,8 +63,11 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.toLegacyPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.validatedPaywall
 import com.revenuecat.purchases.ui.revenuecatui.isFullScreen
 import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorStrings
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
 import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowNavigator
 import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowScreenMapper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -72,6 +75,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import java.util.Date
 import java.util.Locale
 import java.util.UUID
@@ -109,6 +113,13 @@ internal interface PaywallViewModel {
         )
     }
     fun closePaywall(result: PaywallResult? = null)
+
+    val navigationDirection: State<NavigationDirection>
+
+    /**
+     * Workflow-related UI state. Non-null when the loaded paywall is a multi-step workflow.
+     */
+    val workflowState: State<WorkflowPaywallUiState?>
 
     fun handleWorkflowAction(componentId: String, triggerType: WorkflowTriggerType)
 
@@ -158,12 +169,18 @@ internal class PaywallViewModelImpl(
         get() = _purchaseCompleted
     override val preloadedExitOffering: State<Offering?>
         get() = _preloadedExitOffering
+    override val navigationDirection: State<NavigationDirection>
+        get() = _navigationDirection
+    override val workflowState: State<WorkflowPaywallUiState?>
+        get() = _workflowState
 
     private val _state: MutableStateFlow<PaywallState> = MutableStateFlow(PaywallState.Loading)
     private val _actionInProgress: MutableState<Boolean> = mutableStateOf(false)
     private val _actionError: MutableState<PurchasesError?> = mutableStateOf(null)
     private val _purchaseCompleted: MutableState<Boolean> = mutableStateOf(false)
     private val _preloadedExitOffering: MutableState<Offering?> = mutableStateOf(null)
+    private val _navigationDirection: MutableState<NavigationDirection> = mutableStateOf(NavigationDirection.NONE)
+    private val _workflowState: MutableState<WorkflowPaywallUiState?> = mutableStateOf(null)
     private val _lastLocaleList = MutableStateFlow(getCurrentLocaleList())
     private val _colorScheme = MutableStateFlow(colorScheme)
 
@@ -182,6 +199,8 @@ internal class PaywallViewModelImpl(
     private var currentWorkflowResult: WorkflowDataResult? = null
     private var currentWorkflowOfferings: Offerings? = null
     private var currentWorkflowPresentedOfferingContext: PresentedOfferingContext? = null
+    private val workflowStepStateCache = mutableMapOf<String, PaywallState.Loaded.Components>()
+    private var preWarmJob: Job? = null
 
     private data class PaywallPresentationFingerprint(
         val paywallIdentifier: String?,
@@ -229,7 +248,12 @@ internal class PaywallViewModelImpl(
         }
         if (_colorScheme.value != colorScheme) {
             _colorScheme.value = colorScheme
-            updateState()
+            if (workflowNavigator != null) {
+                // Rebuild step states in-place to avoid resetting the user's navigation position.
+                rebuildWorkflowStepStates()
+            } else {
+                updateState()
+            }
         }
     }
 
@@ -640,6 +664,7 @@ internal class PaywallViewModelImpl(
         }
     }
     private fun updateState() {
+        _navigationDirection.value = NavigationDirection.NONE
         viewModelScope.launch {
             try {
                 updateStateFromOffering(options.offeringSelection)
@@ -725,51 +750,75 @@ internal class PaywallViewModelImpl(
         currentWorkflowOfferings = offerings
         currentWorkflowPresentedOfferingContext = presentedOfferingContext
         workflowNavigator = WorkflowNavigator(workflow)
+        preWarmJob?.cancel()
+        workflowStepStateCache.clear()
+        _workflowState.value = null
 
         buildStateFromStep(initialStep, workflow, offerings, presentedOfferingContext)
+        preWarmWorkflowStepCache(workflow, offerings, presentedOfferingContext)
     }
 
+    /**
+     * Rebuilds workflow step states with the current color scheme without resetting the
+     * navigator position. Used when colors change while a workflow paywall is active,
+     * so the user is not silently sent back to the first step.
+     */
     @Suppress("ReturnCount")
+    private fun rebuildWorkflowStepStates() {
+        val result = currentWorkflowResult ?: return
+        val offerings = currentWorkflowOfferings ?: return
+        val presentedOfferingContext = currentWorkflowPresentedOfferingContext
+        val navigator = workflowNavigator ?: return
+        val currentStep = navigator.currentStep() ?: return
+
+        preWarmJob?.cancel()
+        workflowStepStateCache.clear()
+        _workflowState.value = null
+
+        buildStateFromStep(currentStep, result.workflow, offerings, presentedOfferingContext)
+        preWarmWorkflowStepCache(result.workflow, offerings, presentedOfferingContext)
+    }
+
     private fun buildStateFromStep(
         step: WorkflowStep,
         workflow: PublishedWorkflow,
         offerings: Offerings,
         presentedOfferingContext: PresentedOfferingContext?,
     ) {
+        val navigator = workflowNavigator ?: return
+        val cached = workflowStepStateCache[step.id]
+        val newState = cached ?: computeStateForStep(step, workflow, offerings, presentedOfferingContext)
+        if (cached == null && newState is PaywallState.Loaded.Components) {
+            workflowStepStateCache[step.id] = newState
+        }
+        // Set workflowState before _state so a recomposition that lands between the two writes
+        // sees the workflow branch and the correct step, not the single-page branch.
+        _workflowState.value = WorkflowPaywallUiState(
+            currentStepId = step.id,
+            stepStates = workflowStepStateCache.toMap(),
+            backStack = navigator.backStack,
+            reachableStepIds = navigator.reachableSteps(),
+        )
+        _state.value = newState
+    }
+
+    @Suppress("ReturnCount")
+    private fun computeStateForStep(
+        step: WorkflowStep,
+        workflow: PublishedWorkflow,
+        offerings: Offerings,
+        presentedOfferingContext: PresentedOfferingContext?,
+    ): PaywallState {
         val screenId = step.screenId
-        if (screenId == null) {
-            _state.value = PaywallState.Error(
-                "Step '${step.id}' has no screen_id in workflow '${workflow.id}'",
-            )
-            return
-        }
-
+            ?: return PaywallState.Error("Step '${step.id}' has no screen_id in workflow '${workflow.id}'")
         val screen = workflow.screens[screenId]
-        if (screen == null) {
-            _state.value = PaywallState.Error(
-                "Screen '$screenId' not found in workflow '${workflow.id}'",
-            )
-            return
-        }
-
+            ?: return PaywallState.Error("Screen '$screenId' not found in workflow '${workflow.id}'")
         val offeringId = screen.offeringIdentifier
-        if (offeringId == null) {
-            _state.value = PaywallState.Error(
-                "Screen '$screenId' has no offering_id in workflow '${workflow.id}'",
-            )
-            return
-        }
-
+            ?: return PaywallState.Error("Screen '$screenId' has no offering_id in workflow '${workflow.id}'")
         val baseOffering = offerings[offeringId]
-        if (baseOffering == null) {
-            _state.value = PaywallState.Error(
-                "Offering '$offeringId' not found for screen '$screenId'",
-            )
-            return
-        }
+            ?: return PaywallState.Error("Offering '$offeringId' not found for screen '$screenId'")
 
         val paywallComponents = WorkflowScreenMapper.toPaywallComponents(screen, screenId, workflow.uiConfig)
-
         val offering = Offering(
             identifier = baseOffering.identifier,
             serverDescription = baseOffering.serverDescription,
@@ -780,12 +829,36 @@ internal class PaywallViewModelImpl(
         )
         val offeringWithContext = presentedOfferingContext?.let { offering.copy(it) } ?: offering
 
-        _state.value = calculateState(
+        return calculateState(
             offering = offeringWithContext,
             colorScheme = _colorScheme.value,
             storefrontCountryCode = purchases.storefrontCountryCode,
             mode = options.mode,
         )
+    }
+
+    /**
+     * Eagerly computes and caches states for the remaining workflow steps off the main thread,
+     * so that navigating to them doesn't block on the heavy [calculateState] work.
+     */
+    private fun preWarmWorkflowStepCache(
+        workflow: PublishedWorkflow,
+        offerings: Offerings,
+        presentedOfferingContext: PresentedOfferingContext?,
+    ) {
+        preWarmJob?.cancel()
+        preWarmJob = viewModelScope.launch {
+            for ((stepId, step) in workflow.steps) {
+                if (stepId in workflowStepStateCache) continue
+                val computed = withContext(Dispatchers.Default) {
+                    computeStateForStep(step, workflow, offerings, presentedOfferingContext)
+                }
+                if (computed is PaywallState.Loaded.Components && stepId !in workflowStepStateCache) {
+                    workflowStepStateCache[stepId] = computed
+                    _workflowState.value = _workflowState.value?.copy(stepStates = workflowStepStateCache.toMap())
+                }
+            }
+        }
     }
 
     @Suppress("ReturnCount")
@@ -798,7 +871,16 @@ internal class PaywallViewModelImpl(
             Logger.e("Cannot navigate to step '${candidate.id}': $error")
             return
         }
-        val newStep = navigator.triggerAction(componentId, triggerType) ?: return
+        // triggerAction repeats the same lookup as peekTriggerStep. It should not return null
+        // given the peek succeeded, but guard anyway to avoid a hard crash.
+        val newStep = navigator.triggerAction(componentId, triggerType) ?: run {
+            Logger.e("triggerAction returned null after peekTriggerStep succeeded — this is a bug")
+            return
+        }
+        // _navigationDirection is intentionally left set until consumed by the next recomposition
+        // (read inside the LaunchedEffect key in rememberWorkflowSlideState) and reset on the
+        // next navigation or full reload.
+        _navigationDirection.value = NavigationDirection.FORWARD
         buildStateFromStep(newStep, result.workflow, offerings, currentWorkflowPresentedOfferingContext)
     }
 
@@ -813,7 +895,12 @@ internal class PaywallViewModelImpl(
             Logger.e("Cannot navigate back to step '${candidate.id}': $error")
             return false
         }
-        val newStep = navigator.navigateBack() ?: return false
+        // navigateBack should not return null given canNavigateBack is true, but guard to be safe.
+        val newStep = navigator.navigateBack() ?: run {
+            Logger.e("navigateBack returned null after canNavigateBack was true — this is a bug")
+            return false
+        }
+        _navigationDirection.value = NavigationDirection.BACKWARD
         buildStateFromStep(newStep, result.workflow, offerings, currentWorkflowPresentedOfferingContext)
         return true
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WorkflowPaywallUiState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WorkflowPaywallUiState.kt
@@ -1,0 +1,18 @@
+package com.revenuecat.purchases.ui.revenuecatui.data
+
+import androidx.compose.runtime.Stable
+
+/**
+ * Snapshot of the workflow-related state the UI needs to render a multi-step paywall.
+ *
+ * Non-null when the loaded paywall is a workflow; null otherwise. Updated atomically when the
+ * user navigates between steps and when the background pre-warm finishes computing additional
+ * step states.
+ */
+@Stable
+internal data class WorkflowPaywallUiState(
+    val currentStepId: String,
+    val stepStates: Map<String, PaywallState.Loaded.Components>,
+    val backStack: List<String>,
+    val reachableStepIds: Set<String>,
+)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -36,6 +36,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.data.MockPurchasesType
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
 import com.revenuecat.purchases.ui.revenuecatui.data.loadedLegacy
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
@@ -53,6 +54,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.ResourceProvider
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toComponentsPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toLegacyPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.validatedPaywall
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -531,6 +533,8 @@ internal class MockViewModel(
         get() = _actionError
     override val purchaseCompleted: State<Boolean> = mutableStateOf(false)
     override val preloadedExitOffering: State<Offering?> = mutableStateOf(null)
+    override val navigationDirection: State<NavigationDirection> = mutableStateOf(NavigationDirection.NONE)
+    override val workflowState: State<WorkflowPaywallUiState?> = mutableStateOf(null)
 
     fun loadedLegacyState(): PaywallState.Loaded.Legacy? {
         return state.value.loadedLegacy()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/NavigationDirection.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/NavigationDirection.kt
@@ -1,0 +1,7 @@
+package com.revenuecat.purchases.ui.revenuecatui.workflow
+
+internal enum class NavigationDirection {
+    NONE,
+    FORWARD,
+    BACKWARD,
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
@@ -5,18 +5,22 @@ import com.revenuecat.purchases.common.workflows.WorkflowStep
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-
 internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
 
-    private val _currentStepId = MutableStateFlow(workflow.initialStepId)
-    val currentStepId: StateFlow<String> = _currentStepId.asStateFlow()
+    private var currentStepId: String = workflow.initialStepId
 
-    private val backStack = ArrayDeque<String>()
+    private val _backStack = ArrayDeque<String>()
+    val backStack: List<String> get() = _backStack.toList()
 
-    fun currentStep(): WorkflowStep? = workflow.steps[_currentStepId.value]
+    fun currentStep(): WorkflowStep? = workflow.steps[currentStepId]
+
+    fun reachableSteps(): Set<String> {
+        val step = currentStep() ?: return emptySet()
+        return step.triggerActions.values
+            .filterIsInstance<WorkflowTriggerAction.Step>()
+            .map { it.stepId }
+            .toSet()
+    }
 
     @Suppress("ReturnCount")
     fun peekTriggerStep(componentId: String, triggerType: WorkflowTriggerType): WorkflowStep? {
@@ -29,7 +33,7 @@ internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
     }
 
     val peekBackStep: WorkflowStep?
-        get() = backStack.lastOrNull()?.let { workflow.steps[it] }
+        get() = _backStack.lastOrNull()?.let { workflow.steps[it] }
 
     @Suppress("ReturnCount")
     fun triggerAction(componentId: String, triggerType: WorkflowTriggerType): WorkflowStep? {
@@ -51,18 +55,18 @@ internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
             Logger.w("Step '$stepId' not found in workflow '${workflow.id}'")
             return null
         }
-        backStack.addLast(_currentStepId.value)
-        _currentStepId.value = stepId
+        _backStack.addLast(currentStepId)
+        currentStepId = stepId
         return nextStep
     }
 
     fun navigateBack(): WorkflowStep? {
-        if (backStack.isEmpty()) return null
-        val prevStepId = backStack.removeLast()
-        _currentStepId.value = prevStepId
+        if (_backStack.isEmpty()) return null
+        val prevStepId = _backStack.removeLast()
+        currentStepId = prevStepId
         return workflow.steps[prevStepId]
     }
 
     val canNavigateBack: Boolean
-        get() = backStack.isNotEmpty()
+        get() = _backStack.isNotEmpty()
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
@@ -80,7 +80,7 @@ class WorkflowNavigatorTest {
         val result = navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isEqualTo(step2)
         assertThat(navigator.currentStep()).isEqualTo(step2)
-        assertThat(navigator.currentStepId.value).isEqualTo("step-2")
+        assertThat(navigator.currentStep()?.id).isEqualTo("step-2")
     }
 
     @Test
@@ -182,6 +182,163 @@ class WorkflowNavigatorTest {
         assertThat(result).isNull()
         assertThat(navigator.currentStep()).isEqualTo(stepWithUnknownAction)
     }
+
+    // region backStack
+
+    @Test
+    fun `backStack is empty initially`() {
+        val navigator = WorkflowNavigator(workflow)
+        assertThat(navigator.backStack).isEmpty()
+    }
+
+    @Test
+    fun `backStack contains visited step IDs in order after forward navigation`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        navigator.triggerAction("btn-finish", WorkflowTriggerType.ON_PRESS)
+        assertThat(navigator.backStack).containsExactly("step-1", "step-2")
+    }
+
+    @Test
+    fun `backStack shrinks on navigateBack`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        navigator.triggerAction("btn-finish", WorkflowTriggerType.ON_PRESS)
+        navigator.navigateBack()
+        assertThat(navigator.backStack).containsExactly("step-1")
+    }
+
+    // endregion
+
+    // region peekBackStep
+
+    @Test
+    fun `peekBackStep is null on initial step`() {
+        val navigator = WorkflowNavigator(workflow)
+        assertThat(navigator.peekBackStep).isNull()
+    }
+
+    @Test
+    fun `peekBackStep returns previous step after forward navigation`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        assertThat(navigator.peekBackStep).isEqualTo(step1)
+    }
+
+    @Test
+    fun `peekBackStep does not modify backStack`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        navigator.peekBackStep
+        navigator.peekBackStep
+        assertThat(navigator.backStack).containsExactly("step-1")
+    }
+
+    // endregion
+
+    // region peekTriggerStep
+
+    @Test
+    fun `peekTriggerStep returns target step for valid trigger`() {
+        val navigator = WorkflowNavigator(workflow)
+        val result = navigator.peekTriggerStep("btn-next", WorkflowTriggerType.ON_PRESS)
+        assertThat(result).isEqualTo(step2)
+    }
+
+    @Test
+    fun `peekTriggerStep returns null for unknown componentId`() {
+        val navigator = WorkflowNavigator(workflow)
+        val result = navigator.peekTriggerStep("btn-unknown", WorkflowTriggerType.ON_PRESS)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `peekTriggerStep returns null for non-Step trigger action`() {
+        val stepWithUnknownAction = WorkflowStep(
+            id = "step-x",
+            type = "screen",
+            screenId = "screen-x",
+            triggers = listOf(
+                WorkflowTrigger(
+                    name = "X",
+                    type = WorkflowTriggerType.ON_PRESS,
+                    actionId = "ax",
+                    componentId = "btn-x",
+                ),
+            ),
+            triggerActions = mapOf("ax" to WorkflowTriggerAction.Unknown),
+        )
+        val wfl = workflow.copy(
+            initialStepId = "step-x",
+            steps = mapOf("step-x" to stepWithUnknownAction),
+        )
+        val navigator = WorkflowNavigator(wfl)
+        assertThat(navigator.peekTriggerStep("btn-x", WorkflowTriggerType.ON_PRESS)).isNull()
+    }
+
+    @Test
+    fun `peekTriggerStep does not mutate navigator state`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.peekTriggerStep("btn-next", WorkflowTriggerType.ON_PRESS)
+        assertThat(navigator.currentStep()).isEqualTo(step1)
+        assertThat(navigator.backStack).isEmpty()
+    }
+
+    // endregion
+
+    // region reachableSteps
+
+    @Test
+    fun `reachableSteps returns IDs of all steps reachable via triggers`() {
+        val navigator = WorkflowNavigator(workflow)
+        assertThat(navigator.reachableSteps()).containsExactly("step-2")
+    }
+
+    @Test
+    fun `reachableSteps is empty for a step with no triggers`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        navigator.triggerAction("btn-finish", WorkflowTriggerType.ON_PRESS)
+        assertThat(navigator.reachableSteps()).isEmpty()
+    }
+
+    @Test
+    fun `reachableSteps excludes non-Step trigger actions`() {
+        val stepWithMixedActions = WorkflowStep(
+            id = "step-mixed",
+            type = "screen",
+            screenId = "screen-mixed",
+            triggers = listOf(
+                WorkflowTrigger(
+                    name = "Next",
+                    type = WorkflowTriggerType.ON_PRESS,
+                    actionId = "action-step",
+                    componentId = "btn-step",
+                ),
+                WorkflowTrigger(
+                    name = "Unknown",
+                    type = WorkflowTriggerType.ON_PRESS,
+                    actionId = "action-unknown",
+                    componentId = "btn-unknown",
+                ),
+            ),
+            triggerActions = mapOf(
+                "action-step" to WorkflowTriggerAction.Step(stepId = "step-2"),
+                "action-unknown" to WorkflowTriggerAction.Unknown,
+            ),
+        )
+        val wfl = workflow.copy(
+            initialStepId = "step-mixed",
+            steps = mapOf(
+                "step-mixed" to stepWithMixedActions,
+                "step-2" to step2,
+            ),
+        )
+        val navigator = WorkflowNavigator(wfl)
+        assertThat(navigator.reachableSteps()).containsExactly("step-2")
+    }
+
+    // endregion
 
     @Test
     fun `triggerAction with actionId not in triggerActions returns null and does not navigate`() {


### PR DESCRIPTION
### Motivation

Multi-step workflow paywalls previously replaced the entire paywall content on each navigation step, causing an abrupt jump with no visual transition. This change introduces animated slide transitions between workflow steps and pre-warms step states in the background to keep navigation feeling instant.

### Description

Introduces `WorkflowPaywallUiState`, a snapshot of all the data the UI needs to render a multi-step workflow paywall, including the current step ID, a map of pre-computed step states, the back stack, and the set of reachable step IDs. When a loaded paywall is a workflow, `InternalPaywall` renders `LoadedWorkflowPaywall` instead of `LoadedPaywallComponents`.

`LoadedWorkflowPaywall` keeps all relevant steps composed simultaneously inside a `Box` and uses `WorkflowSlideState` to position them via `graphicsLayer` translations. The current step slides in from the edge while the previous step slides out, driven by an `Animatable` running a 350ms `FastOutSlowIn` tween. A `seenStepId` / `currentStepId` gap is tracked to prevent a flash where the incoming step would appear at its final position before the animation begins. Off-screen (parked) steps are translated two screen-widths away so the graphics layer skips drawing them entirely.

`WorkflowSlideState` also manages which steps are kept in the Compose slot table. After each navigation it evicts steps that are no longer the current step, reachable, or within a three-entry back-stack window, then stagger-pre-warms the remaining reachable and recent steps one per frame to avoid composition hitches.

`PaywallViewModelImpl` now eagerly computes and caches `PaywallState.Loaded.Components` for all workflow steps off the main thread via a `preWarmWorkflowStepCache` coroutine. `buildStateFromStep` reads from this cache before calling `computeStateForStep`, and updates `_workflowState` before `_state` to ensure recompositions always land in the workflow branch with the correct step visible. Color-scheme changes rebuild step states in-place via `rebuildWorkflowStepStates` rather than resetting the navigator, so the user's position in the funnel is preserved.

`WorkflowNavigator` was simplified by replacing the `MutableStateFlow<String>` for `currentStepId` with a plain `var`, and a `reachableSteps()` method was added to expose the step IDs reachable from the current step via `Step` trigger actions. Comprehensive unit tests were added covering `backStack`, `peekBackStep`, `peekTriggerStep`, and `reachableSteps` behaviors.