### PR TITLE
feat: pin outgoing header during workflow hero↔non-hero transitions

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -119,51 +119,60 @@ internal fun LoadedPaywallComponents(
  * Shared scaffold for all Components-based paywall variants. Handles the background, bottom-sheet,
  * overlay, fixed-header overlay, and sticky footer. Callers supply the main scrollable content as
  * [mainContent] and decide for themselves whether to apply [headerTopPadding] based on [state].
+ * [headerState] can differ from [state] during workflow transitions to keep header visuals stable.
  */
+@Suppress("LongParameterList")
 @Composable
 internal fun PaywallComponentsScaffold(
     state: PaywallState.Loaded.Components,
     clickHandler: suspend (PaywallAction.External) -> Unit,
     componentInteractionTracker: PaywallComponentInteractionTracker,
     modifier: Modifier = Modifier,
+    headerState: PaywallState.Loaded.Components = state,
+    backgroundState: PaywallState.Loaded.Components? = state,
+    statesForHeaderHeight: Iterable<PaywallState.Loaded.Components> = listOf(state),
+    renderStickyFooter: Boolean = true,
     mainContent: @Composable () -> Unit,
 ) {
-    val background = rememberBackgroundStyle(state.background)
+    val background = backgroundState?.let { rememberBackgroundStyle(it.background) }
     val onClick: suspend (PaywallAction) -> Unit = { action: PaywallAction ->
         handleClick(action, state, clickHandler, componentInteractionTracker)
     }
 
     SimpleBottomSheetScaffold(
         sheetState = state.sheet,
-        modifier = modifier.background(background),
+        modifier = background?.let { modifier.background(it) } ?: modifier,
     ) {
-        WithOptionalBackgroundOverlay(state, background = background) {
+        WithOptionalBackgroundOverlay(backgroundState ?: state, background = background) {
             Column {
                 HeaderOverlayLayout(
                     state = state,
                     modifier = Modifier.weight(1f),
+                    statesForHeaderHeight = statesForHeaderHeight,
                 ) {
                     // Child 0: caller-supplied main content (scrollable body or slide container).
                     mainContent()
                     // Child 1 (optional): fixed header overlay.
-                    state.header?.let { headerStyle ->
+                    headerState.header?.let { headerStyle ->
                         ComponentView(
                             style = headerStyle,
-                            state = state,
+                            state = headerState,
                             onClick = onClick,
                             modifier = Modifier.fillMaxWidth(),
                         )
                     }
                 }
-                state.stickyFooter?.let {
-                    ComponentView(
-                        style = it,
-                        state = state,
-                        onClick = onClick,
-                        componentInteractionTracker = componentInteractionTracker,
-                        modifier = Modifier
-                            .fillMaxWidth(),
-                    )
+                if (renderStickyFooter) {
+                    state.stickyFooter?.let {
+                        ComponentView(
+                            style = it,
+                            state = state,
+                            onClick = onClick,
+                            componentInteractionTracker = componentInteractionTracker,
+                            modifier = Modifier
+                                .fillMaxWidth(),
+                        )
+                    }
                 }
             }
         }
@@ -171,9 +180,8 @@ internal fun PaywallComponentsScaffold(
 }
 
 /**
- * Custom Layout that measures the header overlay first, stores its pixel height in [state],
- * then measures the main content. This ensures the header height is available during the main
- * content's layout phase without requiring a second composition pass.
+ * Custom Layout that measures the fixed header overlay first, stores its pixel height in each
+ * state from [statesForHeaderHeight], then measures the main content.
  *
  * Children: index 0 = main scrollable content, index 1 (optional) = header overlay.
  */
@@ -181,6 +189,7 @@ internal fun PaywallComponentsScaffold(
 internal fun HeaderOverlayLayout(
     state: PaywallState.Loaded.Components,
     modifier: Modifier = Modifier,
+    statesForHeaderHeight: Iterable<PaywallState.Loaded.Components> = listOf(state),
     content: @Composable () -> Unit,
 ) {
     Layout(
@@ -196,9 +205,10 @@ internal fun HeaderOverlayLayout(
 
         // Store header height so child Modifier.layout blocks can read it in this same pass.
         // Both hero (ZLayer reads it) and non-hero (headerTopPadding reads it) cases need this.
-        state.headerHeightPx = headerPlaceable?.height ?: 0
+        val headerHeight = headerPlaceable?.height ?: 0
+        statesForHeaderHeight.forEach { it.headerHeightPx = headerHeight }
 
-        // Measure main content. Its inner Modifier.layout blocks can now read state.headerHeightPx.
+        // Measure main content. Its inner Modifier.layout blocks can now read headerHeightPx.
         val mainPlaceable = measurables[0].measure(constraints)
 
         layout(constraints.maxWidth, constraints.maxHeight) {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -5,15 +5,18 @@ package com.revenuecat.purchases.ui.revenuecatui.components
 
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.platform.LocalConfiguration
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.rememberBackgroundStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
@@ -21,6 +24,18 @@ import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
 import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+
+internal data class WorkflowHeaderTransitionState(
+    val seenStepId: String,
+    val animatingFromStepId: String?,
+    val animatingDirection: NavigationDirection,
+    val navigationDirection: NavigationDirection,
+)
+
+internal data class WorkflowHeaderStepInfo(
+    val hasHeroImage: Boolean,
+    val hasHeader: Boolean,
+)
 
 @Composable
 internal fun LoadedWorkflowPaywall(
@@ -45,55 +60,128 @@ internal fun LoadedWorkflowPaywall(
         navigationDirection = navigationDirection,
     )
 
+    val headerState = workflowHeaderState(
+        currentStepId = currentStepId,
+        currentState = currentState,
+        stepStates = stepStates,
+        navigationDirection = navigationDirection,
+        slideState = slideState,
+    )
+    val statesForHeaderHeight = workflowStatesForHeaderHeight(
+        currentStepId = currentStepId,
+        stepStates = stepStates,
+        slideState = slideState,
+    )
+
     PaywallComponentsScaffold(
         state = currentState,
+        headerState = headerState,
+        backgroundState = null,
+        statesForHeaderHeight = statesForHeaderHeight,
+        renderStickyFooter = false,
         clickHandler = clickHandler,
         componentInteractionTracker = componentInteractionTracker,
         modifier = modifier,
     ) {
-        // Multi-step slide container: all composed steps are stacked and translated by workflowSlide.
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .clipToBounds(),
-        ) {
-            for (stepId in slideState.composedStepIds) {
-                val stepState = stepStates[stepId] ?: continue
-                key(stepId) {
-                    WorkflowStepBody(
-                        stepId = stepId,
-                        stepState = stepState,
-                        isCurrent = stepId == currentStepId,
-                        currentStepId = currentStepId,
-                        headerOffsetState = currentState,
-                        navigationDirection = navigationDirection,
-                        slideState = slideState,
-                        clickHandler = clickHandler,
-                        componentInteractionTracker = componentInteractionTracker,
-                    )
-                }
+        WorkflowStepsContent(
+            currentStepId = currentStepId,
+            stepStates = stepStates,
+            navigationDirection = navigationDirection,
+            slideState = slideState,
+            clickHandler = clickHandler,
+            componentInteractionTracker = componentInteractionTracker,
+        )
+    }
+}
+
+private fun workflowHeaderState(
+    currentStepId: String,
+    currentState: PaywallState.Loaded.Components,
+    stepStates: Map<String, PaywallState.Loaded.Components>,
+    navigationDirection: NavigationDirection,
+    slideState: WorkflowSlideState,
+): PaywallState.Loaded.Components {
+    val headerStepInfo = stepStates.mapValues { (_, stepState) ->
+        WorkflowHeaderStepInfo(
+            hasHeroImage = stepState.mainStackHasHeroImage,
+            hasHeader = stepState.header != null,
+        )
+    }
+    val headerStepId = selectWorkflowHeaderStepId(
+        currentStepId = currentStepId,
+        stepInfoByStepId = headerStepInfo,
+        transitionState = WorkflowHeaderTransitionState(
+            seenStepId = slideState.seenStepId,
+            animatingFromStepId = slideState.animatingFromStepId,
+            animatingDirection = slideState.animatingDirection,
+            navigationDirection = navigationDirection,
+        ),
+    )
+
+    return stepStates[headerStepId] ?: currentState
+}
+
+private fun workflowStatesForHeaderHeight(
+    currentStepId: String,
+    stepStates: Map<String, PaywallState.Loaded.Components>,
+    slideState: WorkflowSlideState,
+): List<PaywallState.Loaded.Components> {
+    val statesForHeaderHeightIds = buildSet {
+        addAll(slideState.composedStepIds)
+        add(currentStepId)
+        add(slideState.seenStepId)
+        slideState.animatingFromStepId?.let(::add)
+    }
+
+    return statesForHeaderHeightIds.mapNotNull(stepStates::get)
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun WorkflowStepsContent(
+    currentStepId: String,
+    stepStates: Map<String, PaywallState.Loaded.Components>,
+    navigationDirection: NavigationDirection,
+    slideState: WorkflowSlideState,
+    clickHandler: suspend (PaywallAction.External) -> Unit,
+    componentInteractionTracker: PaywallComponentInteractionTracker,
+) {
+    // Multi-step slide container: all composed steps are stacked and translated by workflowSlide.
+    // No clipToBounds here — horizontal overflow is bounded by the window/dialog, and adding
+    // a top clip causes the hero image (which renders behind the status bar) to get cropped
+    // during the slide transition.
+    Box(modifier = Modifier.fillMaxSize()) {
+        for (stepId in slideState.composedStepIds) {
+            val stepState = stepStates[stepId] ?: continue
+            key(stepId) {
+                WorkflowStepContent(
+                    stepId = stepId,
+                    stepState = stepState,
+                    isCurrent = stepId == currentStepId,
+                    currentStepId = currentStepId,
+                    navigationDirection = navigationDirection,
+                    slideState = slideState,
+                    clickHandler = clickHandler,
+                    componentInteractionTracker = componentInteractionTracker,
+                )
             }
         }
     }
 }
 
 /**
- * Renders one step's main scrollable content with the slide-animation modifier applied.
- * Off-screen (parked) steps still receive a click handler, but it short-circuits since they
- * are translated far off-screen and can't receive touches.
- *
- * [headerOffsetState] is the *current* step's state — used so the header-top-padding modifier
- * stays in sync with the visible header during navigation, regardless of which step is being
- * laid out.
+ * Renders one workflow step's body and footer as a self-contained sliding surface.
+ * Header is rendered at scaffold level and stays fixed.
+ * Off-screen (parked) steps still receive a click handler, but it short-circuits because they are
+ * translated off-screen and can't receive touches.
  */
 @Suppress("LongParameterList")
 @Composable
-private fun WorkflowStepBody(
+private fun WorkflowStepContent(
     stepId: String,
     stepState: PaywallState.Loaded.Components,
     isCurrent: Boolean,
     currentStepId: String,
-    headerOffsetState: PaywallState.Loaded.Components,
     navigationDirection: NavigationDirection,
     slideState: WorkflowSlideState,
     clickHandler: suspend (PaywallAction.External) -> Unit,
@@ -105,25 +193,96 @@ private fun WorkflowStepBody(
         }
     }
     val tracker = if (isCurrent) componentInteractionTracker else PaywallComponentInteractionTracker { _ -> }
+    val background = rememberBackgroundStyle(stepState.background)
     // Skip the outer verticalScroll if the step's root stack already scrolls vertically — see
     // LoadedPaywallComponents for the rationale.
     val shouldWrapInVerticalScroll =
         (stepState.stack as? StackComponentStyle)?.scrollOrientation != Orientation.Vertical
     val scrollState = rememberScrollState()
 
-    ComponentView(
-        style = stepState.stack,
+    WithOptionalBackgroundOverlay(
         state = stepState,
-        onClick = onClick,
-        componentInteractionTracker = tracker,
+        background = background,
         modifier = Modifier
             .fillMaxSize()
             .workflowSlide(slideState, stepId, currentStepId, navigationDirection)
-            .conditional(shouldWrapInVerticalScroll) {
-                verticalScroll(scrollState)
+            .background(background),
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            ComponentView(
+                style = stepState.stack,
+                state = stepState,
+                onClick = onClick,
+                componentInteractionTracker = tracker,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .conditional(shouldWrapInVerticalScroll) {
+                        verticalScroll(scrollState)
+                    }
+                    .conditional(stepState.header != null && !stepState.mainStackHasHeroImage) {
+                        headerTopPadding(stepState)
+                    },
+            )
+            stepState.stickyFooter?.let { footerStyle ->
+                ComponentView(
+                    style = footerStyle,
+                    state = stepState,
+                    onClick = onClick,
+                    componentInteractionTracker = tracker,
+                    modifier = Modifier.fillMaxWidth(),
+                )
             }
-            .conditional(headerOffsetState.header != null && !stepState.mainStackHasHeroImage) {
-                headerTopPadding(headerOffsetState)
-            },
-    )
+        }
+    }
+}
+
+/**
+ * Picks which step's header should be rendered at the scaffold level during a workflow transition.
+ *
+ * The visual goal: avoid header "flashes" mid-animation. Two cases need the outgoing step's header
+ * to stay visible while the body slides:
+ *  - **Hero → non-hero (any direction):** the outgoing hero header would otherwise pop off before
+ *    the body finishes sliding, briefly exposing the new step's plain background under the old hero.
+ *  - **Backward navigation with an outgoing header:** users expect the previous screen's header to
+ *    remain "the surface they're returning toward", so we keep it until the slide completes.
+ *
+ * Otherwise we use the incoming step's header (or none).
+ *
+ * [currentStepId] is the step we're navigating to. The "from" step is taken from
+ * [WorkflowHeaderTransitionState.animatingFromStepId] once the animation has bound, or from
+ * [WorkflowHeaderTransitionState.seenStepId] during the brief gap between recomposition and the
+ * `LaunchedEffect` running.
+ */
+internal fun selectWorkflowHeaderStepId(
+    currentStepId: String,
+    stepInfoByStepId: Map<String, WorkflowHeaderStepInfo>,
+    transitionState: WorkflowHeaderTransitionState,
+): String {
+    val inGap = transitionState.seenStepId != currentStepId
+    val fromStepId = if (inGap) transitionState.seenStepId else transitionState.animatingFromStepId
+    val direction = if (inGap) transitionState.navigationDirection else transitionState.animatingDirection
+    val fromStepInfo = fromStepId?.let { stepInfoByStepId[it] }
+    val toStepInfo = stepInfoByStepId[currentStepId]
+
+    val outgoing = fromStepId.takeIf {
+        fromStepInfo != null &&
+            toStepInfo != null &&
+            direction != NavigationDirection.NONE &&
+            shouldKeepOutgoingHeader(inGap, direction, fromStepInfo, toStepInfo)
+    }
+    return outgoing ?: currentStepId
+}
+
+private fun shouldKeepOutgoingHeader(
+    inGap: Boolean,
+    direction: NavigationDirection,
+    fromStepInfo: WorkflowHeaderStepInfo,
+    toStepInfo: WorkflowHeaderStepInfo,
+): Boolean = if (inGap) {
+    fromStepInfo.hasHeader
+} else {
+    fromStepInfo.hasHeader &&
+        !toStepInfo.hasHeroImage &&
+        (direction == NavigationDirection.BACKWARD || fromStepInfo.hasHeroImage)
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WithOptionalBackgroundOverlay.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WithOptionalBackgroundOverlay.kt
@@ -43,7 +43,9 @@ internal fun WithOptionalBackgroundOverlay(
             }
         }
         else -> {
-            content()
+            Box(modifier = modifier) {
+                content()
+            }
         }
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideState.kt
@@ -76,20 +76,24 @@ internal class WorkflowSlideState(initialStepId: String) {
 
         if (seenStepId != toStepId) {
             val fromId = seenStepId
-            // Closing the gap before snapTo would cause the flash; we close it as part of
-            // setting up the animation values below.
-            seenStepId = toStepId
 
             if (navigationDirection != NavigationDirection.NONE) {
                 animatingFromStepId = fromId
                 animatingDirection = navigationDirection
                 animatable.snapTo(0f)
+                // Keep the outgoing step/header visible for one frame after binding animation
+                // state. Without this, already-composed targets can show their header before
+                // the first translated frame, creating a header flash over the old background.
+                withFrameNanos {}
+                seenStepId = toStepId
                 animatable.animateTo(
                     targetValue = 1f,
                     animationSpec = tween(SLIDE_DURATION_MS, easing = FastOutSlowInEasing),
                 )
                 animatingFromStepId = null
                 animatingDirection = NavigationDirection.NONE
+            } else {
+                seenStepId = toStepId
             }
         }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
@@ -1,0 +1,160 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class LoadedWorkflowPaywallHeaderSelectionTest {
+
+    @Test
+    fun `hero to non-hero keeps outgoing hero header while animating`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                seenStepId = "target",
+                animatingFromStepId = "from",
+                animatingDirection = NavigationDirection.FORWARD,
+                navigationDirection = NavigationDirection.FORWARD,
+            ),
+        )
+
+        assertThat(selected).isEqualTo("from")
+    }
+
+    @Test
+    fun `hero to non-hero switches to target header after animation`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                seenStepId = "target",
+                animatingFromStepId = null,
+                animatingDirection = NavigationDirection.NONE,
+                navigationDirection = NavigationDirection.FORWARD,
+            ),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `non-hero to hero uses incoming header immediately`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                seenStepId = "target",
+                animatingFromStepId = "from",
+                animatingDirection = NavigationDirection.FORWARD,
+                navigationDirection = NavigationDirection.FORWARD,
+            ),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `current step gap keeps outgoing header before animation state is bound`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                seenStepId = "from",
+                animatingFromStepId = null,
+                animatingDirection = NavigationDirection.NONE,
+                navigationDirection = NavigationDirection.BACKWARD,
+            ),
+        )
+
+        assertThat(selected).isEqualTo("from")
+    }
+
+    @Test
+    fun `non-hero to hero backward transition uses incoming header while animating`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                seenStepId = "target",
+                animatingFromStepId = "from",
+                animatingDirection = NavigationDirection.BACKWARD,
+                navigationDirection = NavigationDirection.BACKWARD,
+            ),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `non-hero to non-hero backward transition keeps outgoing header while animating`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                seenStepId = "target",
+                animatingFromStepId = "from",
+                animatingDirection = NavigationDirection.BACKWARD,
+                navigationDirection = NavigationDirection.BACKWARD,
+            ),
+        )
+
+        assertThat(selected).isEqualTo("from")
+    }
+
+    @Test
+    fun `non-hero to non-hero forward transition uses incoming header while animating`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                seenStepId = "target",
+                animatingFromStepId = "from",
+                animatingDirection = NavigationDirection.FORWARD,
+                navigationDirection = NavigationDirection.FORWARD,
+            ),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `missing outgoing hero header falls back to target header`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = false),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                seenStepId = "target",
+                animatingFromStepId = "from",
+                animatingDirection = NavigationDirection.FORWARD,
+                navigationDirection = NavigationDirection.FORWARD,
+            ),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
