### PR TITLE
Workflow state & ViewModel infrastructure

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -35,6 +35,7 @@ import com.revenuecat.purchases.ui.revenuecatui.composables.PlaceholderDefaults
 import com.revenuecat.purchases.ui.revenuecatui.composables.placeholder
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
@@ -191,6 +192,7 @@ private class LoadingViewModel(
     override val actionError: State<PurchasesError?> = mutableStateOf(null)
     override val purchaseCompleted: State<Boolean> = mutableStateOf(false)
     override val preloadedExitOffering: State<Offering?> = mutableStateOf(null)
+    override val workflowState: State<WorkflowPaywallUiState?> = mutableStateOf(null)
 
     override fun trackPaywallImpressionIfNeeded() = Unit
     override fun trackExitOffer(exitOfferType: ExitOfferType, exitOfferingIdentifier: String) = Unit
@@ -236,6 +238,8 @@ private class LoadingViewModel(
     override fun handleWorkflowAction(componentId: String, triggerType: WorkflowTriggerType) = Unit
 
     override fun handleBackNavigation(): Boolean = false
+
+    override fun onTransitionComplete(transitionId: Int) = Unit
 
     override fun clearActionError() = Unit
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -775,11 +775,17 @@ internal class PaywallViewModelImpl(
         }
         // Set workflowState before _state so a recomposition that lands between the two writes
         // sees the workflow branch and the correct step, not the single-page branch.
-        _workflowState.value = WorkflowPaywallUiState(
-            currentStepId = step.id,
-            stepStates = workflowStepStateCache.toMap(),
-            pendingTransition = pendingTransition,
-        )
+        // On error, clear workflowState so the UI falls through to the normal error path rather
+        // than entering workflow mode with a currentStepId absent from stepStates.
+        _workflowState.value = if (newState is PaywallState.Loaded.Components) {
+            WorkflowPaywallUiState(
+                currentStepId = step.id,
+                stepStates = workflowStepStateCache.toMap(),
+                pendingTransition = pendingTransition,
+            )
+        } else {
+            null
+        }
         _state.value = newState
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -833,7 +833,7 @@ internal class PaywallViewModelImpl(
             Logger.e("Cannot navigate to step '${candidate.id}': $error")
             return
         }
-        val fromStepId = navigator.currentStep()?.id
+        val fromStepId = navigator.currentStep?.id
         // triggerAction repeats the same lookup as peekTriggerStep. It should not return null
         // given the peek succeeded, but guard anyway to avoid a hard crash.
         val newStep = navigator.triggerAction(componentId, triggerType) ?: run {
@@ -861,7 +861,7 @@ internal class PaywallViewModelImpl(
             Logger.e("Cannot navigate back to step '${candidate.id}': $error")
             return false
         }
-        val fromStepId = navigator.currentStep()?.id
+        val fromStepId = navigator.currentStep?.id
         // navigateBack should not return null given canNavigateBack is true, but guard to be safe.
         val newStep = navigator.navigateBack() ?: run {
             Logger.e("navigateBack returned null after canNavigateBack was true — this is a bug")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -755,14 +755,14 @@ internal class PaywallViewModelImpl(
         offerings: Offerings,
         presentedOfferingContext: PresentedOfferingContext?,
         fromStepId: String? = null,
-        navigationDirection: NavigationDirection = NavigationDirection.NONE,
+        navigationDirection: NavigationDirection? = null,
     ) {
         val cached = workflowStepStateCache[step.id]
         val newState = cached ?: computeStateForStep(step, workflow, offerings, presentedOfferingContext)
         if (cached == null && newState is PaywallState.Loaded.Components) {
             workflowStepStateCache[step.id] = newState
         }
-        val pendingTransition = if (fromStepId != null && navigationDirection != NavigationDirection.NONE) {
+        val pendingTransition = if (fromStepId != null && navigationDirection != null) {
             WorkflowPendingTransition(
                 fromStepId = fromStepId,
                 direction = navigationDirection,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -63,6 +63,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.toLegacyPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.validatedPaywall
 import com.revenuecat.purchases.ui.revenuecatui.isFullScreen
 import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorStrings
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
 import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowNavigator
 import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowScreenMapper
 import kotlinx.coroutines.async
@@ -110,6 +111,11 @@ internal interface PaywallViewModel {
     }
     fun closePaywall(result: PaywallResult? = null)
 
+    /**
+     * Workflow-related UI state. Non-null when the loaded paywall is a multi-step workflow.
+     */
+    val workflowState: State<WorkflowPaywallUiState?>
+
     fun handleWorkflowAction(componentId: String, triggerType: WorkflowTriggerType)
 
     /**
@@ -117,6 +123,13 @@ internal interface PaywallViewModel {
      * (previous step rendered), false to fall through to dismiss.
      */
     fun handleBackNavigation(): Boolean
+
+    /**
+     * Called by the UI when a slide animation completes. Clears the [WorkflowPendingTransition]
+     * for the given [transitionId] so the outgoing step can be removed from the slot table.
+     * A guard on [transitionId] prevents stale callbacks from clobbering a newer transition.
+     */
+    fun onTransitionComplete(transitionId: Int)
 
     fun getWebCheckoutUrl(launchWebCheckout: PaywallAction.External.LaunchWebCheckout): String?
     fun invalidateCustomerInfoCache()
@@ -158,12 +171,15 @@ internal class PaywallViewModelImpl(
         get() = _purchaseCompleted
     override val preloadedExitOffering: State<Offering?>
         get() = _preloadedExitOffering
+    override val workflowState: State<WorkflowPaywallUiState?>
+        get() = _workflowState
 
     private val _state: MutableStateFlow<PaywallState> = MutableStateFlow(PaywallState.Loading)
     private val _actionInProgress: MutableState<Boolean> = mutableStateOf(false)
     private val _actionError: MutableState<PurchasesError?> = mutableStateOf(null)
     private val _purchaseCompleted: MutableState<Boolean> = mutableStateOf(false)
     private val _preloadedExitOffering: MutableState<Offering?> = mutableStateOf(null)
+    private val _workflowState: MutableState<WorkflowPaywallUiState?> = mutableStateOf(null)
     private val _lastLocaleList = MutableStateFlow(getCurrentLocaleList())
     private val _colorScheme = MutableStateFlow(colorScheme)
 
@@ -182,6 +198,8 @@ internal class PaywallViewModelImpl(
     private var currentWorkflowResult: WorkflowDataResult? = null
     private var currentWorkflowOfferings: Offerings? = null
     private var currentWorkflowPresentedOfferingContext: PresentedOfferingContext? = null
+    private val workflowStepStateCache = mutableMapOf<String, PaywallState.Loaded.Components>()
+    private var transitionIdCounter: Int = 0
 
     private data class PaywallPresentationFingerprint(
         val paywallIdentifier: String?,
@@ -725,51 +743,68 @@ internal class PaywallViewModelImpl(
         currentWorkflowOfferings = offerings
         currentWorkflowPresentedOfferingContext = presentedOfferingContext
         workflowNavigator = WorkflowNavigator(workflow)
+        workflowStepStateCache.clear()
+        _workflowState.value = null
 
         buildStateFromStep(initialStep, workflow, offerings, presentedOfferingContext)
     }
 
-    @Suppress("ReturnCount")
     private fun buildStateFromStep(
         step: WorkflowStep,
         workflow: PublishedWorkflow,
         offerings: Offerings,
         presentedOfferingContext: PresentedOfferingContext?,
+        fromStepId: String? = null,
+        navigationDirection: NavigationDirection = NavigationDirection.NONE,
     ) {
+        val cached = workflowStepStateCache[step.id]
+        val newState = cached ?: computeStateForStep(step, workflow, offerings, presentedOfferingContext)
+        if (cached == null && newState is PaywallState.Loaded.Components) {
+            workflowStepStateCache[step.id] = newState
+        }
+        val pendingTransition = if (fromStepId != null && navigationDirection != NavigationDirection.NONE) {
+            WorkflowPendingTransition(
+                fromStepId = fromStepId,
+                direction = navigationDirection,
+                id = ++transitionIdCounter,
+            )
+        } else {
+            null
+        }
+        // Set workflowState before _state so a recomposition that lands between the two writes
+        // sees the workflow branch and the correct step, not the single-page branch.
+        _workflowState.value = WorkflowPaywallUiState(
+            currentStepId = step.id,
+            stepStates = workflowStepStateCache.toMap(),
+            pendingTransition = pendingTransition,
+        )
+        _state.value = newState
+    }
+
+    override fun onTransitionComplete(transitionId: Int) {
+        val current = _workflowState.value ?: return
+        if (current.pendingTransition?.id == transitionId) {
+            _workflowState.value = current.copy(pendingTransition = null)
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun computeStateForStep(
+        step: WorkflowStep,
+        workflow: PublishedWorkflow,
+        offerings: Offerings,
+        presentedOfferingContext: PresentedOfferingContext?,
+    ): PaywallState {
         val screenId = step.screenId
-        if (screenId == null) {
-            _state.value = PaywallState.Error(
-                "Step '${step.id}' has no screen_id in workflow '${workflow.id}'",
-            )
-            return
-        }
-
+            ?: return PaywallState.Error("Step '${step.id}' has no screen_id in workflow '${workflow.id}'")
         val screen = workflow.screens[screenId]
-        if (screen == null) {
-            _state.value = PaywallState.Error(
-                "Screen '$screenId' not found in workflow '${workflow.id}'",
-            )
-            return
-        }
-
+            ?: return PaywallState.Error("Screen '$screenId' not found in workflow '${workflow.id}'")
         val offeringId = screen.offeringIdentifier
-        if (offeringId == null) {
-            _state.value = PaywallState.Error(
-                "Screen '$screenId' has no offering_id in workflow '${workflow.id}'",
-            )
-            return
-        }
-
+            ?: return PaywallState.Error("Screen '$screenId' has no offering_id in workflow '${workflow.id}'")
         val baseOffering = offerings[offeringId]
-        if (baseOffering == null) {
-            _state.value = PaywallState.Error(
-                "Offering '$offeringId' not found for screen '$screenId'",
-            )
-            return
-        }
+            ?: return PaywallState.Error("Offering '$offeringId' not found for screen '$screenId'")
 
         val paywallComponents = WorkflowScreenMapper.toPaywallComponents(screen, screenId, workflow.uiConfig)
-
         val offering = Offering(
             identifier = baseOffering.identifier,
             serverDescription = baseOffering.serverDescription,
@@ -780,7 +815,7 @@ internal class PaywallViewModelImpl(
         )
         val offeringWithContext = presentedOfferingContext?.let { offering.copy(it) } ?: offering
 
-        _state.value = calculateState(
+        return calculateState(
             offering = offeringWithContext,
             colorScheme = _colorScheme.value,
             storefrontCountryCode = purchases.storefrontCountryCode,
@@ -798,8 +833,21 @@ internal class PaywallViewModelImpl(
             Logger.e("Cannot navigate to step '${candidate.id}': $error")
             return
         }
-        val newStep = navigator.triggerAction(componentId, triggerType) ?: return
-        buildStateFromStep(newStep, result.workflow, offerings, currentWorkflowPresentedOfferingContext)
+        val fromStepId = navigator.currentStep()?.id
+        // triggerAction repeats the same lookup as peekTriggerStep. It should not return null
+        // given the peek succeeded, but guard anyway to avoid a hard crash.
+        val newStep = navigator.triggerAction(componentId, triggerType) ?: run {
+            Logger.e("triggerAction returned null after peekTriggerStep succeeded — this is a bug")
+            return
+        }
+        buildStateFromStep(
+            newStep,
+            result.workflow,
+            offerings,
+            currentWorkflowPresentedOfferingContext,
+            fromStepId = fromStepId,
+            navigationDirection = NavigationDirection.FORWARD,
+        )
     }
 
     @Suppress("ReturnCount")
@@ -813,8 +861,20 @@ internal class PaywallViewModelImpl(
             Logger.e("Cannot navigate back to step '${candidate.id}': $error")
             return false
         }
-        val newStep = navigator.navigateBack() ?: return false
-        buildStateFromStep(newStep, result.workflow, offerings, currentWorkflowPresentedOfferingContext)
+        val fromStepId = navigator.currentStep()?.id
+        // navigateBack should not return null given canNavigateBack is true, but guard to be safe.
+        val newStep = navigator.navigateBack() ?: run {
+            Logger.e("navigateBack returned null after canNavigateBack was true — this is a bug")
+            return false
+        }
+        buildStateFromStep(
+            newStep,
+            result.workflow,
+            offerings,
+            currentWorkflowPresentedOfferingContext,
+            fromStepId = fromStepId,
+            navigationDirection = NavigationDirection.BACKWARD,
+        )
         return true
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -725,7 +725,7 @@ internal class PaywallViewModelImpl(
     }
 
     @Suppress("ReturnCount")
-    private fun updateStateFromWorkflow(
+    internal fun updateStateFromWorkflow(
         fetchResult: WorkflowDataResult,
         offerings: Offerings,
         presentedOfferingContext: PresentedOfferingContext?,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -233,7 +233,9 @@ internal class PaywallViewModelImpl(
             // If we have a Components paywall state, update its locale instead of recreating the entire state
             val currentState = _state.value
             if (currentState is PaywallState.Loaded.Components) {
-                currentState.update(localeList = currentLocaleList.toFrameworkLocaleList())
+                val localeFrameworkList = currentLocaleList.toFrameworkLocaleList()
+                currentState.update(localeList = localeFrameworkList)
+                workflowStepStateCache.values.forEach { it.update(localeList = localeFrameworkList) }
             } else {
                 updateState()
             }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WorkflowPaywallUiState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WorkflowPaywallUiState.kt
@@ -1,0 +1,39 @@
+package com.revenuecat.purchases.ui.revenuecatui.data
+
+import androidx.compose.runtime.Stable
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+
+/**
+ * Snapshot of the workflow-related state the UI needs to render a multi-step paywall.
+ *
+ * Non-null when the loaded paywall is a workflow; null otherwise. Updated atomically when the
+ * user navigates between steps; [stepStates] grows lazily as steps are visited.
+ */
+@Stable
+internal data class WorkflowPaywallUiState(
+    val currentStepId: String,
+    val stepStates: Map<String, PaywallState.Loaded.Components>,
+    /**
+     * Describes a navigation that should be animated. Set atomically with [currentStepId] so
+     * the first recomposition after navigation already knows both surfaces and can position them
+     * correctly — no gap-detection or [androidx.compose.animation.core.Animatable.snapTo] needed.
+     *
+     * Null when idle (no animation in progress or queued).
+     */
+    val pendingTransition: WorkflowPendingTransition? = null,
+)
+
+/**
+ * Describes a navigation transition that is ready to be animated.
+ *
+ * @param fromStepId the step sliding out.
+ * @param direction which way the new step enters.
+ * @param id monotonically-increasing counter used as a [androidx.compose.runtime.key] discriminator.
+ *   A fresh [androidx.compose.animation.core.Animatable] at 0f is created per distinct id, which
+ *   means the first draw of each transition already starts at the correct offscreen position.
+ */
+internal data class WorkflowPendingTransition(
+    val fromStepId: String,
+    val direction: NavigationDirection,
+    val id: Int,
+)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -36,6 +36,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.data.MockPurchasesType
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
 import com.revenuecat.purchases.ui.revenuecatui.data.loadedLegacy
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
@@ -531,6 +532,7 @@ internal class MockViewModel(
         get() = _actionError
     override val purchaseCompleted: State<Boolean> = mutableStateOf(false)
     override val preloadedExitOffering: State<Offering?> = mutableStateOf(null)
+    override val workflowState: State<WorkflowPaywallUiState?> = mutableStateOf(null)
 
     fun loadedLegacyState(): PaywallState.Loaded.Legacy? {
         return state.value.loadedLegacy()
@@ -695,6 +697,12 @@ internal class MockViewModel(
     override fun handleBackNavigation(): Boolean {
         handleBackNavigationCallCount++
         return handleBackNavigationResult
+    }
+
+    var onTransitionCompleteCallCount = 0
+        private set
+    override fun onTransitionComplete(transitionId: Int) {
+        onTransitionCompleteCallCount++
     }
 
     var clearActionErrorCallCount = 0

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/NavigationDirection.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/NavigationDirection.kt
@@ -1,0 +1,7 @@
+package com.revenuecat.purchases.ui.revenuecatui.workflow
+
+internal enum class NavigationDirection {
+    NONE,
+    FORWARD,
+    BACKWARD,
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/NavigationDirection.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/NavigationDirection.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.ui.revenuecatui.workflow
 
 internal enum class NavigationDirection {
-    NONE,
     FORWARD,
     BACKWARD,
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
@@ -9,7 +9,8 @@ internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
 
     private var currentStepId: String = workflow.initialStepId
 
-    val backStack = ArrayDeque<String>()
+    private val backStack = ArrayDeque<String>()
+    val backStackSnapshot: List<String> get() = backStack
 
     fun currentStep(): WorkflowStep? = workflow.steps[currentStepId]
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
@@ -5,18 +5,13 @@ import com.revenuecat.purchases.common.workflows.WorkflowStep
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-
 internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
 
-    private val _currentStepId = MutableStateFlow(workflow.initialStepId)
-    val currentStepId: StateFlow<String> = _currentStepId.asStateFlow()
+    private var currentStepId: String = workflow.initialStepId
 
-    private val backStack = ArrayDeque<String>()
+    val backStack = ArrayDeque<String>()
 
-    fun currentStep(): WorkflowStep? = workflow.steps[_currentStepId.value]
+    fun currentStep(): WorkflowStep? = workflow.steps[currentStepId]
 
     @Suppress("ReturnCount")
     fun peekTriggerStep(componentId: String, triggerType: WorkflowTriggerType): WorkflowStep? {
@@ -51,15 +46,15 @@ internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
             Logger.w("Step '$stepId' not found in workflow '${workflow.id}'")
             return null
         }
-        backStack.addLast(_currentStepId.value)
-        _currentStepId.value = stepId
+        backStack.addLast(currentStepId)
+        currentStepId = stepId
         return nextStep
     }
 
     fun navigateBack(): WorkflowStep? {
         if (backStack.isEmpty()) return null
         val prevStepId = backStack.removeLast()
-        _currentStepId.value = prevStepId
+        currentStepId = prevStepId
         return workflow.steps[prevStepId]
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
@@ -12,11 +12,11 @@ internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
     private val backStack = ArrayDeque<String>()
     val backStackSnapshot: List<String> get() = backStack
 
-    fun currentStep(): WorkflowStep? = workflow.steps[currentStepId]
+    val currentStep: WorkflowStep? get() = workflow.steps[currentStepId]
 
     @Suppress("ReturnCount")
     fun peekTriggerStep(componentId: String, triggerType: WorkflowTriggerType): WorkflowStep? {
-        val step = currentStep() ?: return null
+        val step = currentStep ?: return null
         val trigger = step.triggers.firstOrNull { it.componentId == componentId && it.type == triggerType }
             ?: return null
         val action = step.triggerActions[trigger.actionId] ?: return null
@@ -29,7 +29,7 @@ internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
 
     @Suppress("ReturnCount")
     fun triggerAction(componentId: String, triggerType: WorkflowTriggerType): WorkflowStep? {
-        val step = currentStep() ?: return null
+        val step = currentStep ?: return null
         val trigger = step.triggers.firstOrNull { it.componentId == componentId && it.type == triggerType } ?: run {
             Logger.w("No trigger found for componentId '$componentId' and type '$triggerType' in step '${step.id}'")
             return null

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -1,0 +1,270 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.data
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.PurchasesAreCompletedBy
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
+import com.revenuecat.purchases.common.workflows.WorkflowDataResult
+import com.revenuecat.purchases.common.workflows.WorkflowScreen
+import com.revenuecat.purchases.common.workflows.WorkflowStep
+import com.revenuecat.purchases.common.workflows.WorkflowTrigger
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.common.Background
+import com.revenuecat.purchases.paywalls.components.common.ComponentsConfig
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.paywalls.components.common.LocalizationData
+import com.revenuecat.purchases.paywalls.components.common.LocalizationKey
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
+import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
+import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.MockResourceProvider
+import com.revenuecat.purchases.ui.revenuecatui.data.testdata.TestData
+import com.revenuecat.purchases.ui.revenuecatui.helpers.UiConfig
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.URL
+
+@RunWith(AndroidJUnit4::class)
+class PaywallViewModelWorkflowTest {
+
+    @get:Rule
+    var instantExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var purchases: PurchasesType
+
+    // Both steps share one offering; screen1 and screen2 differ only by ID.
+    private val offeringId = "test_offering"
+    private val screenId1 = "screen-1"
+    private val screenId2 = "screen-2"
+
+    private val defaultLocaleId = LocaleId("en_US")
+    private val localizations = mapOf(
+        defaultLocaleId to mapOf(
+            LocalizationKey("dummy_text") to LocalizationData.Text("dummy"),
+        ),
+    )
+    private val componentsConfig = ComponentsConfig(
+        base = PaywallComponentsConfig(
+            // At least one PackageComponent is required for calculateState to produce
+            // PaywallState.Loaded.Components instead of PaywallState.Error.
+            stack = StackComponent(components = listOf(TestData.Components.monthlyPackageComponent)),
+            background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+            stickyFooter = null,
+        ),
+    )
+
+    private fun makeScreen(screenId: String) = WorkflowScreen(
+        name = screenId,
+        templateName = "template_v2",
+        revision = 1,
+        assetBaseURL = URL("https://assets.pawwalls.com"),
+        componentsConfig = componentsConfig,
+        componentsLocalizations = localizations,
+        defaultLocaleIdentifier = defaultLocaleId,
+        offeringIdentifier = offeringId,
+    )
+
+    private val step1 = WorkflowStep(
+        id = "step-1",
+        type = "screen",
+        screenId = screenId1,
+        triggers = listOf(
+            WorkflowTrigger(
+                name = "Next",
+                type = WorkflowTriggerType.ON_PRESS,
+                actionId = "action-next",
+                componentId = "btn-next",
+            ),
+        ),
+        triggerActions = mapOf("action-next" to WorkflowTriggerAction.Step(stepId = "step-2")),
+    )
+    private val step2 = WorkflowStep(
+        id = "step-2",
+        type = "screen",
+        screenId = screenId2,
+        triggers = emptyList(),
+        triggerActions = emptyMap(),
+    )
+
+    private val workflow = PublishedWorkflow(
+        id = "wfl-test",
+        displayName = "Test",
+        initialStepId = "step-1",
+        steps = mapOf("step-1" to step1, "step-2" to step2),
+        screens = mapOf(screenId1 to makeScreen(screenId1), screenId2 to makeScreen(screenId2)),
+        uiConfig = UiConfig(),
+        metadata = emptyMap(),
+    )
+    private val fetchResult = WorkflowDataResult(workflow = workflow, enrolledVariants = null)
+
+    private val testOffering = Offering(
+        identifier = offeringId,
+        serverDescription = "",
+        metadata = emptyMap(),
+        availablePackages = listOf(TestData.Packages.monthly),
+        paywallComponents = null,
+        webCheckoutURL = null,
+    )
+    private val testOfferings = Offerings(testOffering, mapOf(offeringId to testOffering))
+
+    @Before
+    fun setUp() {
+        purchases = mockk {
+            every { storefrontCountryCode } returns "US"
+            every { preferredUILocaleOverride } returns null
+            every { purchasesAreCompletedBy } returns PurchasesAreCompletedBy.REVENUECAT
+            every { track(any()) } just Runs
+            coEvery { awaitOfferings() } returns testOfferings
+            coEvery { awaitCustomerInfo(any()) } returns mockk {
+                every { activeSubscriptions } returns setOf()
+                every { nonSubscriptionTransactions } returns listOf()
+            }
+        }
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    private fun createVm(): PaywallViewModelImpl = PaywallViewModelImpl(
+        resourceProvider = MockResourceProvider(),
+        purchases = purchases,
+        options = PaywallOptions.Builder(dismissRequest = {}).build(),
+        colorScheme = TestData.Constants.currentColorScheme,
+        isDarkMode = false,
+        shouldDisplayBlock = null,
+    )
+
+    // region forward navigation
+
+    @Test
+    fun `forward navigation sets FORWARD on pendingTransition`() {
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResult, testOfferings, null)
+
+        vm.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+
+        assertThat(vm.workflowState.value?.pendingTransition?.direction)
+            .isEqualTo(NavigationDirection.FORWARD)
+    }
+
+    @Test
+    fun `forward navigation sets fromStepId to the step navigated away from`() {
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResult, testOfferings, null)
+
+        vm.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+
+        assertThat(vm.workflowState.value?.pendingTransition?.fromStepId).isEqualTo("step-1")
+    }
+
+    // endregion
+
+    // region back navigation
+
+    @Test
+    fun `back navigation sets BACKWARD on pendingTransition`() {
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResult, testOfferings, null)
+        vm.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        vm.onTransitionComplete(vm.workflowState.value!!.pendingTransition!!.id)
+
+        vm.handleBackNavigation()
+
+        assertThat(vm.workflowState.value?.pendingTransition?.direction)
+            .isEqualTo(NavigationDirection.BACKWARD)
+    }
+
+    @Test
+    fun `back navigation sets fromStepId to the step navigated away from`() {
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResult, testOfferings, null)
+        vm.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        vm.onTransitionComplete(vm.workflowState.value!!.pendingTransition!!.id)
+
+        vm.handleBackNavigation()
+
+        assertThat(vm.workflowState.value?.pendingTransition?.fromStepId).isEqualTo("step-2")
+    }
+
+    // endregion
+
+    // region cache
+
+    @Test
+    fun `second visit to a step returns the cached state instance`() {
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResult, testOfferings, null)
+
+        // First visit to step-2: state is computed and cached.
+        vm.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        val firstState = vm.workflowState.value?.stepStates?.get("step-2")
+        assertThat(firstState).isNotNull()
+
+        // Navigate back to step-1, then forward to step-2 again.
+        vm.onTransitionComplete(vm.workflowState.value!!.pendingTransition!!.id)
+        vm.handleBackNavigation()
+        vm.onTransitionComplete(vm.workflowState.value!!.pendingTransition!!.id)
+        vm.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+
+        assertThat(vm.workflowState.value?.stepStates?.get("step-2")).isSameAs(firstState)
+    }
+
+    // endregion
+
+    // region onTransitionComplete
+
+    @Test
+    fun `onTransitionComplete clears pendingTransition for the matching id`() {
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResult, testOfferings, null)
+        vm.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        val id = vm.workflowState.value!!.pendingTransition!!.id
+
+        vm.onTransitionComplete(id)
+
+        assertThat(vm.workflowState.value?.pendingTransition).isNull()
+    }
+
+    @Test
+    fun `onTransitionComplete with stale id does not clear a newer transition`() {
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResult, testOfferings, null)
+        vm.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        val staleId = vm.workflowState.value!!.pendingTransition!!.id
+        vm.onTransitionComplete(staleId)
+
+        // A new transition starts (back navigation).
+        vm.handleBackNavigation()
+        val currentId = vm.workflowState.value!!.pendingTransition!!.id
+        assertThat(currentId).isNotEqualTo(staleId)
+
+        vm.onTransitionComplete(staleId)
+
+        assertThat(vm.workflowState.value?.pendingTransition?.id).isEqualTo(currentId)
+    }
+
+    // endregion
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
@@ -71,7 +71,7 @@ class WorkflowNavigatorTest {
     @Test
     fun `currentStep returns initial step`() {
         val navigator = WorkflowNavigator(workflow)
-        assertThat(navigator.currentStep()).isEqualTo(step1)
+        assertThat(navigator.currentStep).isEqualTo(step1)
     }
 
     @Test
@@ -79,8 +79,8 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(workflow)
         val result = navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isEqualTo(step2)
-        assertThat(navigator.currentStep()).isEqualTo(step2)
-        assertThat(navigator.currentStep()?.id).isEqualTo("step-2")
+        assertThat(navigator.currentStep).isEqualTo(step2)
+        assertThat(navigator.currentStep?.id).isEqualTo("step-2")
     }
 
     @Test
@@ -89,7 +89,7 @@ class WorkflowNavigatorTest {
         navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         val result = navigator.triggerAction("btn-finish", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isEqualTo(step3)
-        assertThat(navigator.currentStep()).isEqualTo(step3)
+        assertThat(navigator.currentStep).isEqualTo(step3)
     }
 
     @Test
@@ -97,7 +97,7 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(workflow)
         val result = navigator.triggerAction("btn-unknown", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isNull()
-        assertThat(navigator.currentStep()).isEqualTo(step1)
+        assertThat(navigator.currentStep).isEqualTo(step1)
     }
 
     @Test
@@ -119,7 +119,7 @@ class WorkflowNavigatorTest {
         navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         val result = navigator.navigateBack()
         assertThat(result).isEqualTo(step1)
-        assertThat(navigator.currentStep()).isEqualTo(step1)
+        assertThat(navigator.currentStep).isEqualTo(step1)
     }
 
     @Test
@@ -142,16 +142,16 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(workflow)
         navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         navigator.triggerAction("btn-finish", WorkflowTriggerType.ON_PRESS)
-        assertThat(navigator.currentStep()).isEqualTo(step3)
+        assertThat(navigator.currentStep).isEqualTo(step3)
 
         val back1 = navigator.navigateBack()
         assertThat(back1).isEqualTo(step2)
-        assertThat(navigator.currentStep()).isEqualTo(step2)
+        assertThat(navigator.currentStep).isEqualTo(step2)
         assertThat(navigator.canNavigateBack).isTrue()
 
         val back2 = navigator.navigateBack()
         assertThat(back2).isEqualTo(step1)
-        assertThat(navigator.currentStep()).isEqualTo(step1)
+        assertThat(navigator.currentStep).isEqualTo(step1)
         assertThat(navigator.canNavigateBack).isFalse()
     }
 
@@ -180,7 +180,7 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(wfl)
         val result = navigator.triggerAction("btn-x", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isNull()
-        assertThat(navigator.currentStep()).isEqualTo(stepWithUnknownAction)
+        assertThat(navigator.currentStep).isEqualTo(stepWithUnknownAction)
     }
 
     // region backStack
@@ -280,7 +280,7 @@ class WorkflowNavigatorTest {
     fun `peekTriggerStep does not mutate navigator state`() {
         val navigator = WorkflowNavigator(workflow)
         navigator.peekTriggerStep("btn-next", WorkflowTriggerType.ON_PRESS)
-        assertThat(navigator.currentStep()).isEqualTo(step1)
+        assertThat(navigator.currentStep).isEqualTo(step1)
         assertThat(navigator.backStackSnapshot).isEmpty()
     }
 
@@ -309,7 +309,7 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(wfl)
         val result = navigator.triggerAction("btn-x", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isNull()
-        assertThat(navigator.currentStep()).isEqualTo(stepWithMissingAction)
+        assertThat(navigator.currentStep).isEqualTo(stepWithMissingAction)
     }
 
     @Test
@@ -337,6 +337,6 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(wfl)
         val result = navigator.triggerAction("btn-x", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isNull()
-        assertThat(navigator.currentStep()).isEqualTo(stepWithMissingTarget)
+        assertThat(navigator.currentStep).isEqualTo(stepWithMissingTarget)
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
@@ -80,7 +80,7 @@ class WorkflowNavigatorTest {
         val result = navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isEqualTo(step2)
         assertThat(navigator.currentStep()).isEqualTo(step2)
-        assertThat(navigator.currentStepId.value).isEqualTo("step-2")
+        assertThat(navigator.currentStep()?.id).isEqualTo("step-2")
     }
 
     @Test
@@ -182,6 +182,109 @@ class WorkflowNavigatorTest {
         assertThat(result).isNull()
         assertThat(navigator.currentStep()).isEqualTo(stepWithUnknownAction)
     }
+
+    // region backStack
+
+    @Test
+    fun `backStack is empty initially`() {
+        val navigator = WorkflowNavigator(workflow)
+        assertThat(navigator.backStack).isEmpty()
+    }
+
+    @Test
+    fun `backStack contains visited step IDs in order after forward navigation`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        navigator.triggerAction("btn-finish", WorkflowTriggerType.ON_PRESS)
+        assertThat(navigator.backStack).containsExactly("step-1", "step-2")
+    }
+
+    @Test
+    fun `backStack shrinks on navigateBack`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        navigator.triggerAction("btn-finish", WorkflowTriggerType.ON_PRESS)
+        navigator.navigateBack()
+        assertThat(navigator.backStack).containsExactly("step-1")
+    }
+
+    // endregion
+
+    // region peekBackStep
+
+    @Test
+    fun `peekBackStep is null on initial step`() {
+        val navigator = WorkflowNavigator(workflow)
+        assertThat(navigator.peekBackStep).isNull()
+    }
+
+    @Test
+    fun `peekBackStep returns previous step after forward navigation`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        assertThat(navigator.peekBackStep).isEqualTo(step1)
+    }
+
+    @Test
+    fun `peekBackStep does not modify backStack`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        navigator.peekBackStep
+        navigator.peekBackStep
+        assertThat(navigator.backStack).containsExactly("step-1")
+    }
+
+    // endregion
+
+    // region peekTriggerStep
+
+    @Test
+    fun `peekTriggerStep returns target step for valid trigger`() {
+        val navigator = WorkflowNavigator(workflow)
+        val result = navigator.peekTriggerStep("btn-next", WorkflowTriggerType.ON_PRESS)
+        assertThat(result).isEqualTo(step2)
+    }
+
+    @Test
+    fun `peekTriggerStep returns null for unknown componentId`() {
+        val navigator = WorkflowNavigator(workflow)
+        val result = navigator.peekTriggerStep("btn-unknown", WorkflowTriggerType.ON_PRESS)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `peekTriggerStep returns null for non-Step trigger action`() {
+        val stepWithUnknownAction = WorkflowStep(
+            id = "step-x",
+            type = "screen",
+            screenId = "screen-x",
+            triggers = listOf(
+                WorkflowTrigger(
+                    name = "X",
+                    type = WorkflowTriggerType.ON_PRESS,
+                    actionId = "ax",
+                    componentId = "btn-x",
+                ),
+            ),
+            triggerActions = mapOf("ax" to WorkflowTriggerAction.Unknown),
+        )
+        val wfl = workflow.copy(
+            initialStepId = "step-x",
+            steps = mapOf("step-x" to stepWithUnknownAction),
+        )
+        val navigator = WorkflowNavigator(wfl)
+        assertThat(navigator.peekTriggerStep("btn-x", WorkflowTriggerType.ON_PRESS)).isNull()
+    }
+
+    @Test
+    fun `peekTriggerStep does not mutate navigator state`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.peekTriggerStep("btn-next", WorkflowTriggerType.ON_PRESS)
+        assertThat(navigator.currentStep()).isEqualTo(step1)
+        assertThat(navigator.backStack).isEmpty()
+    }
+
+    // endregion
 
     @Test
     fun `triggerAction with actionId not in triggerActions returns null and does not navigate`() {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
@@ -188,7 +188,7 @@ class WorkflowNavigatorTest {
     @Test
     fun `backStack is empty initially`() {
         val navigator = WorkflowNavigator(workflow)
-        assertThat(navigator.backStack).isEmpty()
+        assertThat(navigator.backStackSnapshot).isEmpty()
     }
 
     @Test
@@ -196,7 +196,7 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(workflow)
         navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         navigator.triggerAction("btn-finish", WorkflowTriggerType.ON_PRESS)
-        assertThat(navigator.backStack).containsExactly("step-1", "step-2")
+        assertThat(navigator.backStackSnapshot).containsExactly("step-1", "step-2")
     }
 
     @Test
@@ -205,7 +205,7 @@ class WorkflowNavigatorTest {
         navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         navigator.triggerAction("btn-finish", WorkflowTriggerType.ON_PRESS)
         navigator.navigateBack()
-        assertThat(navigator.backStack).containsExactly("step-1")
+        assertThat(navigator.backStackSnapshot).containsExactly("step-1")
     }
 
     // endregion
@@ -231,7 +231,7 @@ class WorkflowNavigatorTest {
         navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         navigator.peekBackStep
         navigator.peekBackStep
-        assertThat(navigator.backStack).containsExactly("step-1")
+        assertThat(navigator.backStackSnapshot).containsExactly("step-1")
     }
 
     // endregion
@@ -281,7 +281,7 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(workflow)
         navigator.peekTriggerStep("btn-next", WorkflowTriggerType.ON_PRESS)
         assertThat(navigator.currentStep()).isEqualTo(step1)
-        assertThat(navigator.backStack).isEmpty()
+        assertThat(navigator.backStackSnapshot).isEmpty()
     }
 
     // endregion


### PR DESCRIPTION
### Motivation

Multi-step workflow paywalls need the UI to know which step is active, what the neighboring steps look like, and which direction a navigation is going, all before the first recomposition after a tap. Without this, the slide animation can't start from the correct offscreen position and the outgoing step can't be cleaned up safely.

### Description

Introduces the ViewModel-side infrastructure that drives animated, multi-step workflow paywalls:

**`WorkflowPaywallUiState`** — a new `@Stable` data class exposed from `PaywallViewModel` as `workflowState: State<WorkflowPaywallUiState?>`. It is non-null when the active paywall is a workflow, and carries:
- `currentStepId` — the step currently on screen.
- `stepStates` — a map of computed `PaywallState.Loaded.Components` keyed by step id. Populated lazily as the user navigates so any visited step is cheap to revisit. (Eager pre-warm is added on top in #3420.)
- `pendingTransition` — a `WorkflowPendingTransition` (from-step, direction, monotonic id) set atomically alongside `currentStepId` so the first recomposition after a navigation already has both surfaces and their target positions.

**`NavigationDirection`** — a simple `FORWARD` / `BACKWARD` enum used by `WorkflowPendingTransition` so the UI knows which way to slide.

**Step state caching** — `buildStateFromStep` checks `workflowStepStateCache` before doing the heavy `calculateState` work and stores the result on first visit, so back-navigation never recomputes.

**`onTransitionComplete(transitionId: Int)`** — called by the UI when a slide animation ends. Clears `pendingTransition` for the matching id (guarded against stale callbacks), letting the outgoing step be removed from the Compose slot table.

**`WorkflowNavigator` cleanup** — replaces the internal `MutableStateFlow<String>` with a plain `var` (the ViewModel already owns the single source of truth) and drops `StateFlow`-related imports. The `backStack` field is exposed directly so the new tests can assert on its contents (the class is `internal`, so visibility is naturally scoped).

### Checklist

- [x] Unit tests added
- [ ] If applicable, create follow-up issues for \`purchases-ios\` and hybrids

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall state management and workflow navigation paths, which could affect paywall rendering and step transitions; changes are scoped and backed by new unit tests.
> 
> **Overview**
> Adds **ViewModel-driven workflow UI state** to support animated, multi-step paywall workflows. `PaywallViewModel` now exposes `workflowState` (`WorkflowPaywallUiState`) plus `onTransitionComplete(transitionId)` so the UI can render the current step, cache visited step `PaywallState.Loaded.Components`, and coordinate slide transitions via a monotonic transition id and `NavigationDirection`.
> 
> Refactors workflow navigation to be less reactive (removes `StateFlow` from `WorkflowNavigator`), updates locale-refresh to also update cached step states, and adds unit tests covering forward/back navigation, transition cleanup, and step-state caching; mocks/previews are updated to implement the new interface members.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb4093fb6ee557ffd85ae6cd09e8ec75d993f561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->