### PR TITLE
Generalize `PaywallComponentsScaffold` for workflow reuse

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -55,11 +55,13 @@ import com.revenuecat.purchases.paywalls.components.properties.TwoDimensionalAli
 import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toJavaLocale
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.rememberBackgroundStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.composables.SimpleBottomSheetScaffold
 import com.revenuecat.purchases.ui.revenuecatui.composables.SimpleSheetState
@@ -87,14 +89,11 @@ internal fun LoadedPaywallComponents(
     val configuration = LocalConfiguration.current
     state.update(localeList = configuration.locales)
 
-    val onClick: suspend (PaywallAction) -> Unit = { action: PaywallAction ->
+    val onClick: suspend (PaywallAction) -> Unit = { action ->
         handleClick(action, state, clickHandler, componentInteractionTracker)
     }
 
-    // If the root stack already scrolls vertically (overflow = SCROLL on a vertical dimension),
-    // skip the outer verticalScroll — two vertical scroll modifiers on the same axis crashes.
-    val shouldWrapMainContentInVerticalScroll =
-        (state.stack as? StackComponentStyle)?.scrollOrientation != Orientation.Vertical
+    val shouldWrapMainContentInVerticalScroll = shouldWrapMainContentInVerticalScroll(state.stack)
     val mainScrollState = rememberScrollState()
     val layoutDirection = remember(state.locale) {
         state.locale.toJavaLocale().toLayoutDirection()
@@ -103,9 +102,28 @@ internal fun LoadedPaywallComponents(
     CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
         PaywallComponentsScaffold(
             state = state,
-            clickHandler = clickHandler,
-            componentInteractionTracker = componentInteractionTracker,
             modifier = modifier,
+            headerContent = state.header?.let { headerStyle ->
+                {
+                    ComponentView(
+                        style = headerStyle,
+                        state = state,
+                        onClick = onClick,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            },
+            footerContent = state.stickyFooter?.let { footerStyle ->
+                {
+                    ComponentView(
+                        style = footerStyle,
+                        state = state,
+                        onClick = onClick,
+                        componentInteractionTracker = componentInteractionTracker,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            },
         ) {
             ComponentView(
                 style = state.stack,
@@ -127,25 +145,25 @@ internal fun LoadedPaywallComponents(
 
 /**
  * Shared scaffold for all Components-based paywall variants. Handles the background, bottom-sheet,
- * overlay, fixed-header overlay, and sticky footer. Callers supply the main scrollable content as
- * [mainContent] and decide for themselves whether to apply [headerTopPadding] based on [state].
+ * and fixed-header overlay layout. Callers supply [mainContent] (the scrollable body) plus optional
+ * [headerContent] and [footerContent] composables.
+ *
+ * Pass [background] = null to skip background painting (e.g. workflow paywalls render per-step
+ * backgrounds inside their sliding surfaces).
  */
+@Suppress("LongParameterList")
 @Composable
 internal fun PaywallComponentsScaffold(
     state: PaywallState.Loaded.Components,
-    clickHandler: suspend (PaywallAction.External) -> Unit,
-    componentInteractionTracker: PaywallComponentInteractionTracker,
     modifier: Modifier = Modifier,
+    background: BackgroundStyle? = rememberBackgroundStyle(state.background),
+    headerContent: (@Composable () -> Unit)? = null,
+    footerContent: (@Composable () -> Unit)? = null,
     mainContent: @Composable () -> Unit,
 ) {
-    val background = rememberBackgroundStyle(state.background)
-    val onClick: suspend (PaywallAction) -> Unit = { action: PaywallAction ->
-        handleClick(action, state, clickHandler, componentInteractionTracker)
-    }
-
     SimpleBottomSheetScaffold(
         sheetState = state.sheet,
-        modifier = modifier.background(background),
+        modifier = background?.let { modifier.background(it) } ?: modifier,
     ) {
         WithOptionalBackgroundOverlay(state, background = background) {
             Column {
@@ -153,37 +171,20 @@ internal fun PaywallComponentsScaffold(
                     state = state,
                     modifier = Modifier.weight(1f),
                 ) {
-                    // Child 0: caller-supplied main content (scrollable body or slide container).
+                    // Child 0: caller-supplied main content (scrollable body).
                     mainContent()
                     // Child 1 (optional): fixed header overlay.
-                    state.header?.let { headerStyle ->
-                        ComponentView(
-                            style = headerStyle,
-                            state = state,
-                            onClick = onClick,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    }
+                    headerContent?.invoke()
                 }
-                state.stickyFooter?.let {
-                    ComponentView(
-                        style = it,
-                        state = state,
-                        onClick = onClick,
-                        componentInteractionTracker = componentInteractionTracker,
-                        modifier = Modifier
-                            .fillMaxWidth(),
-                    )
-                }
+                footerContent?.invoke()
             }
         }
     }
 }
 
 /**
- * Custom Layout that measures the header overlay first, stores its pixel height in [state],
- * then measures the main content. This ensures the header height is available during the main
- * content's layout phase without requiring a second composition pass.
+ * Custom Layout that measures the fixed header overlay first, stores its pixel height in [state],
+ * then measures the main content.
  *
  * Children: index 0 = main scrollable content, index 1 (optional) = header overlay.
  */
@@ -231,6 +232,15 @@ internal fun Modifier.headerTopPadding(state: PaywallState.Loaded.Components): M
             placeable.place(0, topPad)
         }
     }
+
+/**
+ * Returns whether the caller should wrap [rootStack] in an outer `verticalScroll` modifier.
+ * Returns `false` when the root stack already scrolls vertically (overflow = SCROLL on a vertical
+ * dimension), because two vertical scroll modifiers on the same axis crash at runtime.
+ */
+@JvmSynthetic
+internal fun shouldWrapMainContentInVerticalScroll(rootStack: ComponentStyle): Boolean =
+    (rootStack as? StackComponentStyle)?.scrollOrientation != Orientation.Vertical
 
 internal suspend fun handleClick(
     action: PaywallAction,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
@@ -10,7 +10,7 @@ internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
     private var currentStepId: String = workflow.initialStepId
 
     private val backStack = ArrayDeque<String>()
-    val backStackSnapshot: List<String> get() = backStack
+    val backStackSnapshot: List<String> get() = backStack.toList()
 
     val currentStep: WorkflowStep? get() = workflow.steps[currentStepId]
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ShouldWrapMainContentInVerticalScrollTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ShouldWrapMainContentInVerticalScrollTest.kt
@@ -1,0 +1,45 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.compose.foundation.gestures.Orientation
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class ShouldWrapMainContentInVerticalScrollTest {
+
+    @Test
+    fun `vertically scrolling root stack is not wrapped`() {
+        val stack = previewStackComponentStyle(
+            children = emptyList(),
+            scrollOrientation = Orientation.Vertical,
+        )
+
+        assertThat(shouldWrapMainContentInVerticalScroll(stack)).isFalse()
+    }
+
+    @Test
+    fun `horizontally scrolling root stack is wrapped`() {
+        val stack = previewStackComponentStyle(
+            children = emptyList(),
+            scrollOrientation = Orientation.Horizontal,
+        )
+
+        assertThat(shouldWrapMainContentInVerticalScroll(stack)).isTrue()
+    }
+
+    @Test
+    fun `non-scrolling root stack is wrapped`() {
+        val stack = previewStackComponentStyle(
+            children = emptyList(),
+            scrollOrientation = null,
+        )
+
+        assertThat(shouldWrapMainContentInVerticalScroll(stack)).isTrue()
+    }
+
+    @Test
+    fun `non-stack root component is wrapped`() {
+        val text = previewTextComponentStyle(text = "non-stack root")
+
+        assertThat(shouldWrapMainContentInVerticalScroll(text)).isTrue()
+    }
+}


### PR DESCRIPTION
### Motivation

Workflow paywalls (multi-step) and single-page component paywalls share the same chrome — background, bottom sheet, fixed header overlay, and sticky footer — but differ in how the body is rendered (a single column vs. two sliding columns). Today `LoadedPaywallComponents` owns all of that scaffolding inline, so a workflow renderer would have to either duplicate it or wrap it awkwardly.

### Description

Refactors `PaywallComponentsScaffold` into a pure layout primitive with three composable slots and a narrow value type for the painted background:

```kotlin
@Composable
internal fun PaywallComponentsScaffold(
    state: PaywallState.Loaded.Components,
    modifier: Modifier = Modifier,
    background: BackgroundStyle? = rememberBackgroundStyle(state.background),
    headerContent: (@Composable () -> Unit)? = null,
    footerContent: (@Composable () -> Unit)? = null,
    mainContent: @Composable () -> Unit,
)
```

- **`state`** — primary state, used for the bottom sheet, locale, and the layout pass that measures the header overlay's height.
- **`background`** — narrow `BackgroundStyle?` instead of a whole `PaywallState.Loaded.Components`. Defaults to `rememberBackgroundStyle(state.background)`. Pass `null` to skip background painting (workflow paints per-step backgrounds inside its sliding surfaces).
- **`headerContent`** — composable slot for the fixed header overlay. Standard caller derives it from `state.header`; workflow caller derives it from a workflow-selected step state to keep the from-step's header visible during a backward swipe. The slot is rendered as child 1 of `HeaderOverlayLayout`, which still measures it first to set `state.headerHeightPx` for body padding.
- **`footerContent`** — composable slot for the sticky footer. Standard caller derives it from `state.stickyFooter`; workflow caller passes nothing because each step renders its own footer that slides with the body.
- **`mainContent`** — the scrollable body.

Click handling and component-interaction tracking are no longer scaffold concerns — the scaffold has nothing to dispatch from once header/footer rendering moves to caller-owned slots, so `clickHandler` / `componentInteractionTracker` parameters are dropped. Each caller constructs its own `onClick` and threads it through the slot lambdas.

Pure refactor — single-page behavior is unchanged. Workflow PRs downstream consume the slots.

### Checklist

- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for \`purchases-ios\` and hybrids

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors paywall Compose scaffolding and background application, which could subtly affect layout/scrolling behavior across paywalls despite being intended as behavior-preserving. Adds a small workflow navigation snapshot change that reduces mutation risk.
> 
> **Overview**
> Refactors `PaywallComponentsScaffold` into a reusable layout primitive with explicit `mainContent`, optional `headerContent`/`footerContent` slots, and an optional `BackgroundStyle?` so workflow paywalls can reuse the same chrome while controlling header/footer rendering and background painting.
> 
> Moves click handling/interaction tracking out of the scaffold into `LoadedPaywallComponents`, adds `shouldWrapMainContentInVerticalScroll(...)` helper (with new unit tests) to avoid double-`verticalScroll` crashes, and makes `WorkflowNavigator.backStackSnapshot` return an immutable list copy (`toList()`) instead of exposing the deque.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cd2187ac2e76cd4f1fb27de9fa93de3d53783f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->