### PR TITLE
Add slide transition to workflow paywalls

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -36,6 +36,7 @@ import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.events.PaywallComponentType
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant.defaultAnimation
 import com.revenuecat.purchases.ui.revenuecatui.components.LoadedPaywallComponents
+import com.revenuecat.purchases.ui.revenuecatui.components.LoadedWorkflowPaywall
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.composables.CloseButton
 import com.revenuecat.purchases.ui.revenuecatui.composables.ErrorDialog
@@ -146,11 +147,21 @@ internal fun InternalPaywall(
                     viewModel.trackPaywallImpressionIfNeeded()
                 }
             }
-            LoadedPaywallComponents(
-                state = state,
-                clickHandler = rememberPaywallActionHandler(viewModel),
-                componentInteractionTracker = componentInteractionTracker,
-            )
+            val workflowState = viewModel.workflowState.value
+            if (workflowState != null) {
+                LoadedWorkflowPaywall(
+                    workflowState = workflowState,
+                    onTransitionComplete = viewModel::onTransitionComplete,
+                    clickHandler = rememberPaywallActionHandler(viewModel),
+                    componentInteractionTracker = componentInteractionTracker,
+                )
+            } else {
+                LoadedPaywallComponents(
+                    state = state,
+                    clickHandler = rememberPaywallActionHandler(viewModel),
+                    componentInteractionTracker = componentInteractionTracker,
+                )
+            }
         } else {
             Logger.e(
                 "State is not loaded while transitioning animation. This may happen if state changes " +

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -238,7 +238,6 @@ internal fun Modifier.headerTopPadding(state: PaywallState.Loaded.Components): M
  * Returns `false` when the root stack already scrolls vertically (overflow = SCROLL on a vertical
  * dimension), because two vertical scroll modifiers on the same axis crash at runtime.
  */
-@JvmSynthetic
 internal fun shouldWrapMainContentInVerticalScroll(rootStack: ComponentStyle): Boolean =
     (rootStack as? StackComponentStyle)?.scrollOrientation != Orientation.Vertical
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -171,7 +171,7 @@ internal fun PaywallComponentsScaffold(
                     state = state,
                     modifier = Modifier.weight(1f),
                 ) {
-                    // Child 0: caller-supplied main content (scrollable body).
+                    // Child 0: caller-supplied main content.
                     mainContent()
                     // Child 1 (optional): fixed header overlay.
                     headerContent?.invoke()

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -1,5 +1,6 @@
 @file:JvmSynthetic
 @file:OptIn(InternalRevenueCatAPI::class)
+@file:Suppress("MatchingDeclarationName")
 
 package com.revenuecat.purchases.ui.revenuecatui.components
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -1,0 +1,240 @@
+@file:JvmSynthetic
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.rememberBackgroundStyle
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPendingTransition
+import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+
+internal data class WorkflowHeaderTransitionState(
+    val pendingTransition: WorkflowPendingTransition?,
+)
+
+internal data class WorkflowHeaderStepInfo(
+    val hasHeroImage: Boolean,
+    val hasHeader: Boolean,
+)
+
+@Composable
+internal fun LoadedWorkflowPaywall(
+    workflowState: WorkflowPaywallUiState,
+    onTransitionComplete: (transitionId: Int) -> Unit,
+    clickHandler: suspend (PaywallAction.External) -> Unit,
+    componentInteractionTracker: PaywallComponentInteractionTracker,
+    modifier: Modifier = Modifier,
+) {
+    val currentStepId = workflowState.currentStepId
+    val stepStates = workflowState.stepStates
+    val currentState = stepStates[currentStepId] ?: run {
+        Logger.e("Workflow step '$currentStepId' not found in stepStates — rendering nothing")
+        return
+    }
+
+    val configuration = LocalConfiguration.current
+    currentState.update(localeList = configuration.locales)
+
+    val slideState = rememberWorkflowSlideState(
+        workflowState = workflowState,
+        onTransitionComplete = onTransitionComplete,
+    )
+
+    val headerState = workflowHeaderState(
+        currentStepId = currentStepId,
+        currentState = currentState,
+        stepStates = stepStates,
+        slideState = slideState,
+    )
+    val onClick: suspend (PaywallAction) -> Unit = { action ->
+        handleClick(action, currentState, clickHandler, componentInteractionTracker)
+    }
+    PaywallComponentsScaffold(
+        state = currentState,
+        modifier = modifier,
+        background = null,
+        headerContent = headerState.header?.let { headerStyle ->
+            {
+                ComponentView(
+                    style = headerStyle,
+                    state = headerState,
+                    onClick = onClick,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+    ) {
+        WorkflowStepsContent(
+            currentStepId = currentStepId,
+            stepStates = stepStates,
+            slideState = slideState,
+            clickHandler = clickHandler,
+            componentInteractionTracker = componentInteractionTracker,
+        )
+    }
+}
+
+private fun workflowHeaderState(
+    currentStepId: String,
+    currentState: PaywallState.Loaded.Components,
+    stepStates: Map<String, PaywallState.Loaded.Components>,
+    slideState: WorkflowSlideState,
+): PaywallState.Loaded.Components {
+    val headerStepInfo = stepStates.mapValues { (_, stepState) ->
+        WorkflowHeaderStepInfo(
+            hasHeroImage = stepState.mainStackHasHeroImage,
+            hasHeader = stepState.header != null,
+        )
+    }
+    val headerStepId = selectWorkflowHeaderStepId(
+        currentStepId = currentStepId,
+        stepInfoByStepId = headerStepInfo,
+        transitionState = WorkflowHeaderTransitionState(
+            pendingTransition = slideState.animatingFromStepId?.let { fromId ->
+                WorkflowPendingTransition(
+                    fromStepId = fromId,
+                    direction = slideState.animatingDirection,
+                    id = 0, // id not needed for header selection
+                )
+            },
+        ),
+    )
+
+    return stepStates[headerStepId] ?: currentState
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun WorkflowStepsContent(
+    currentStepId: String,
+    stepStates: Map<String, PaywallState.Loaded.Components>,
+    slideState: WorkflowSlideState,
+    clickHandler: suspend (PaywallAction.External) -> Unit,
+    componentInteractionTracker: PaywallComponentInteractionTracker,
+) {
+    // Multi-step slide container: the current and outgoing steps are stacked and translated by workflowSlide.
+    // No clipToBounds here — horizontal overflow is bounded by the window/dialog, and adding
+    // a top clip causes the hero image (which renders behind the status bar) to get cropped
+    // during the slide transition.
+    Box(modifier = Modifier.fillMaxSize()) {
+        for (stepId in slideState.visibleStepIds) {
+            val stepState = stepStates[stepId] ?: continue
+            key(stepId) {
+                WorkflowStepContent(
+                    stepId = stepId,
+                    stepState = stepState,
+                    isCurrent = stepId == currentStepId,
+                    currentStepId = currentStepId,
+                    slideState = slideState,
+                    clickHandler = clickHandler,
+                    componentInteractionTracker = componentInteractionTracker,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Renders one workflow step's body and footer as a self-contained sliding surface.
+ * Header is rendered at scaffold level and stays fixed.
+ * Off-screen (parked) steps still receive a click handler, but it short-circuits because they are
+ * translated off-screen and can't receive touches.
+ */
+@Suppress("LongParameterList")
+@Composable
+private fun WorkflowStepContent(
+    stepId: String,
+    stepState: PaywallState.Loaded.Components,
+    isCurrent: Boolean,
+    currentStepId: String,
+    slideState: WorkflowSlideState,
+    clickHandler: suspend (PaywallAction.External) -> Unit,
+    componentInteractionTracker: PaywallComponentInteractionTracker,
+) {
+    val onClick: suspend (PaywallAction) -> Unit = { action ->
+        if (isCurrent) {
+            handleClick(action, stepState, clickHandler, componentInteractionTracker)
+        }
+    }
+    val tracker = if (isCurrent) componentInteractionTracker else PaywallComponentInteractionTracker { _ -> }
+    val background = rememberBackgroundStyle(stepState.background)
+    val shouldWrapMainContentInVerticalScroll = shouldWrapMainContentInVerticalScroll(stepState.stack)
+    val mainScrollState = rememberScrollState()
+
+    WithOptionalBackgroundOverlay(
+        state = stepState,
+        background = background,
+        modifier = Modifier
+            .fillMaxSize()
+            .workflowSlide(slideState, stepId, currentStepId)
+            .background(background),
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            ComponentView(
+                style = stepState.stack,
+                state = stepState,
+                onClick = onClick,
+                componentInteractionTracker = tracker,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .conditional(shouldWrapMainContentInVerticalScroll) {
+                        verticalScroll(mainScrollState)
+                    }
+                    .conditional(stepState.header != null && !stepState.mainStackHasHeroImage) {
+                        headerTopPadding(stepState)
+                    },
+            )
+            stepState.stickyFooter?.let { footerStyle ->
+                ComponentView(
+                    style = footerStyle,
+                    state = stepState,
+                    onClick = onClick,
+                    componentInteractionTracker = tracker,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+internal fun selectWorkflowHeaderStepId(
+    currentStepId: String,
+    stepInfoByStepId: Map<String, WorkflowHeaderStepInfo>,
+    transitionState: WorkflowHeaderTransitionState,
+): String {
+    val fromStepId = transitionState.pendingTransition?.fromStepId
+    val direction = transitionState.pendingTransition?.direction ?: NavigationDirection.NONE
+    val fromStepInfo = fromStepId?.let(stepInfoByStepId::get)
+    val toStepInfo = stepInfoByStepId[currentStepId]
+    val useOutgoingHeader = transitionState.pendingTransition != null &&
+        fromStepInfo != null &&
+        toStepInfo != null &&
+        shouldUseOutgoingHeader(direction, fromStepInfo, toStepInfo)
+
+    return if (useOutgoingHeader) fromStepId ?: currentStepId else currentStepId
+}
+
+private fun shouldUseOutgoingHeader(
+    direction: NavigationDirection,
+    fromStepInfo: WorkflowHeaderStepInfo,
+    toStepInfo: WorkflowHeaderStepInfo,
+): Boolean = fromStepInfo.hasHeader &&
+    !toStepInfo.hasHeroImage &&
+    (direction == NavigationDirection.BACKWARD || fromStepInfo.hasHeroImage)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -24,10 +24,6 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
 import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
 import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
 
-internal data class WorkflowHeaderTransitionState(
-    val pendingTransition: WorkflowPendingTransition?,
-)
-
 internal data class WorkflowHeaderStepInfo(
     val hasHeroImage: Boolean,
     val hasHeader: Boolean,
@@ -105,17 +101,15 @@ private fun workflowHeaderState(
     val headerStepId = selectWorkflowHeaderStepId(
         currentStepId = currentStepId,
         stepInfoByStepId = headerStepInfo,
-        transitionState = WorkflowHeaderTransitionState(
-            pendingTransition = if (slideState.animatingFromStepId != null && slideState.animatingDirection != null) {
-                WorkflowPendingTransition(
-                    fromStepId = slideState.animatingFromStepId,
-                    direction = slideState.animatingDirection,
-                    id = 0, // id not needed for header selection
-                )
-            } else {
-                null
-            },
-        ),
+        pendingTransition = if (slideState.animatingFromStepId != null && slideState.animatingDirection != null) {
+            WorkflowPendingTransition(
+                fromStepId = slideState.animatingFromStepId,
+                direction = slideState.animatingDirection,
+                id = 0, // id not needed for header selection
+            )
+        } else {
+            null
+        },
     )
 
     return stepStates[headerStepId] ?: currentState
@@ -141,7 +135,6 @@ private fun WorkflowStepsContent(
                 WorkflowStepContent(
                     stepId = stepId,
                     stepState = stepState,
-                    isCurrent = stepId == currentStepId,
                     currentStepId = currentStepId,
                     slideState = slideState,
                     clickHandler = clickHandler,
@@ -163,12 +156,12 @@ private fun WorkflowStepsContent(
 private fun WorkflowStepContent(
     stepId: String,
     stepState: PaywallState.Loaded.Components,
-    isCurrent: Boolean,
     currentStepId: String,
     slideState: WorkflowSlideState,
     clickHandler: suspend (PaywallAction.External) -> Unit,
     componentInteractionTracker: PaywallComponentInteractionTracker,
 ) {
+    val isCurrent = stepId == currentStepId
     val onClick: suspend (PaywallAction) -> Unit = { action ->
         if (isCurrent) {
             handleClick(action, stepState, clickHandler, componentInteractionTracker)
@@ -223,18 +216,18 @@ private fun WorkflowStepContent(
 internal fun selectWorkflowHeaderStepId(
     currentStepId: String,
     stepInfoByStepId: Map<String, WorkflowHeaderStepInfo>,
-    transitionState: WorkflowHeaderTransitionState,
+    pendingTransition: WorkflowPendingTransition?,
 ): String {
-    val fromStepId = transitionState.pendingTransition?.fromStepId
-    val direction = transitionState.pendingTransition?.direction
+    val fromStepId = pendingTransition?.fromStepId
+    val direction = pendingTransition?.direction
     val fromStepInfo = fromStepId?.let(stepInfoByStepId::get)
     val toStepInfo = stepInfoByStepId[currentStepId]
-    val useOutgoingHeader = transitionState.pendingTransition != null &&
+    val useOutgoingHeader = pendingTransition != null &&
         fromStepInfo != null &&
         toStepInfo != null &&
         shouldUseOutgoingHeader(direction, fromStepInfo, toStepInfo)
 
-    return if (useOutgoingHeader) fromStepId ?: currentStepId else currentStepId
+    return if (useOutgoingHeader) fromStepId!! else currentStepId
 }
 
 private fun shouldUseOutgoingHeader(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -179,38 +179,42 @@ private fun WorkflowStepContent(
     val shouldWrapMainContentInVerticalScroll = shouldWrapMainContentInVerticalScroll(stepState.stack)
     val mainScrollState = rememberScrollState()
 
-    WithOptionalBackgroundOverlay(
-        state = stepState,
-        background = background,
+    Box(
         modifier = Modifier
             .fillMaxSize()
             .workflowSlide(slideState, stepId, currentStepId)
             .background(background),
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            ComponentView(
-                style = stepState.stack,
-                state = stepState,
-                onClick = onClick,
-                componentInteractionTracker = tracker,
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .conditional(shouldWrapMainContentInVerticalScroll) {
-                        verticalScroll(mainScrollState)
-                    }
-                    .conditional(stepState.header != null && !stepState.mainStackHasHeroImage) {
-                        headerTopPadding(stepState)
-                    },
-            )
-            stepState.stickyFooter?.let { footerStyle ->
+        WithOptionalBackgroundOverlay(
+            state = stepState,
+            background = background,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
                 ComponentView(
-                    style = footerStyle,
+                    style = stepState.stack,
                     state = stepState,
                     onClick = onClick,
                     componentInteractionTracker = tracker,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .conditional(shouldWrapMainContentInVerticalScroll) {
+                            verticalScroll(mainScrollState)
+                        }
+                        .conditional(stepState.header != null && !stepState.mainStackHasHeroImage) {
+                            headerTopPadding(stepState)
+                        },
                 )
+                stepState.stickyFooter?.let { footerStyle ->
+                    ComponentView(
+                        style = footerStyle,
+                        state = stepState,
+                        onClick = onClick,
+                        componentInteractionTracker = tracker,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
         }
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -106,12 +106,14 @@ private fun workflowHeaderState(
         currentStepId = currentStepId,
         stepInfoByStepId = headerStepInfo,
         transitionState = WorkflowHeaderTransitionState(
-            pendingTransition = slideState.animatingFromStepId?.let { fromId ->
+            pendingTransition = if (slideState.animatingFromStepId != null && slideState.animatingDirection != null) {
                 WorkflowPendingTransition(
-                    fromStepId = fromId,
+                    fromStepId = slideState.animatingFromStepId,
                     direction = slideState.animatingDirection,
                     id = 0, // id not needed for header selection
                 )
+            } else {
+                null
             },
         ),
     )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -220,7 +220,7 @@ internal fun selectWorkflowHeaderStepId(
     transitionState: WorkflowHeaderTransitionState,
 ): String {
     val fromStepId = transitionState.pendingTransition?.fromStepId
-    val direction = transitionState.pendingTransition?.direction ?: NavigationDirection.NONE
+    val direction = transitionState.pendingTransition?.direction
     val fromStepInfo = fromStepId?.let(stepInfoByStepId::get)
     val toStepInfo = stepInfoByStepId[currentStepId]
     val useOutgoingHeader = transitionState.pendingTransition != null &&
@@ -232,7 +232,7 @@ internal fun selectWorkflowHeaderStepId(
 }
 
 private fun shouldUseOutgoingHeader(
-    direction: NavigationDirection,
+    direction: NavigationDirection?,
     fromStepInfo: WorkflowHeaderStepInfo,
     toStepInfo: WorkflowHeaderStepInfo,
 ): Boolean = fromStepInfo.hasHeader &&

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideState.kt
@@ -30,14 +30,14 @@ private const val SLIDE_DURATION_MS = 350
  *
  * @param visibleStepIds step IDs currently held in the Compose slot table.
  * @param animatingFromStepId step ID sliding out; null when idle.
- * @param animatingDirection direction of the active slide; [NavigationDirection.NONE] when idle.
+ * @param animatingDirection direction of the active slide; null when idle.
  * @param animatable drives progress 0f→1f. Created fresh via [key] for each new
  *   [WorkflowPaywallUiState.pendingTransition] so it always starts at 0f.
  */
 internal class WorkflowSlideState(
     val visibleStepIds: Set<String>,
     val animatingFromStepId: String?,
-    val animatingDirection: NavigationDirection,
+    val animatingDirection: NavigationDirection?,
     val animatable: Animatable<Float, AnimationVector1D>,
 )
 
@@ -89,7 +89,7 @@ internal fun rememberWorkflowSlideState(
             setOf(currentStepId)
         },
         animatingFromStepId = pendingTransition?.fromStepId,
-        animatingDirection = pendingTransition?.direction ?: NavigationDirection.NONE,
+        animatingDirection = pendingTransition?.direction,
         animatable = animatable,
     )
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideState.kt
@@ -1,0 +1,120 @@
+@file:JvmSynthetic
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+
+private const val SLIDE_DURATION_MS = 350
+
+/**
+ * Snapshot of the data needed to render and animate the two-surface workflow paywall slide.
+ *
+ * Built during composition from [WorkflowPaywallUiState.pendingTransition], so the first frame
+ * after navigation already has both surfaces positioned correctly — no gap-detection, no
+ * [Animatable.snapTo], no [androidx.compose.runtime.withFrameNanos] required.
+ *
+ * @param visibleStepIds step IDs currently held in the Compose slot table.
+ * @param animatingFromStepId step ID sliding out; null when idle.
+ * @param animatingDirection direction of the active slide; [NavigationDirection.NONE] when idle.
+ * @param animatable drives progress 0f→1f. Created fresh via [key] for each new
+ *   [WorkflowPaywallUiState.pendingTransition] so it always starts at 0f.
+ */
+internal class WorkflowSlideState(
+    val visibleStepIds: Set<String>,
+    val animatingFromStepId: String?,
+    val animatingDirection: NavigationDirection,
+    val animatable: Animatable<Float, AnimationVector1D>,
+)
+
+/**
+ * Builds a [WorkflowSlideState] from [workflowState].
+ *
+ * When [WorkflowPaywallUiState.pendingTransition] is non-null:
+ * - [key] on the transition id creates a fresh [Animatable] **at 0f during composition**, so
+ *   the draw phase of Frame N (the first frame after navigation) already reads 0f. The incoming
+ *   step is positioned offscreen and the outgoing step stays at 0 — all without a
+ *   [Animatable.snapTo] call.
+ * - [LaunchedEffect] only drives `animateTo(1f)`; it no longer sets up animation state.
+ * - [onTransitionComplete] is called with the transition id when the animation finishes so
+ *   the ViewModel can clear [WorkflowPaywallUiState.pendingTransition].
+ */
+@Composable
+internal fun rememberWorkflowSlideState(
+    workflowState: WorkflowPaywallUiState,
+    onTransitionComplete: (transitionId: Int) -> Unit,
+): WorkflowSlideState {
+    val currentStepId = workflowState.currentStepId
+    val pendingTransition = workflowState.pendingTransition
+
+    // key() on the transition id causes a new Animatable to be created in composition
+    // when a transition starts. The new Animatable starts at 0f (incoming step offscreen)
+    // so Frame N's draw is already correct — no snapTo() needed.
+    val animatable: Animatable<Float, AnimationVector1D> = key(pendingTransition?.id) {
+        remember { Animatable(if (pendingTransition != null) 0f else 1f) }
+    }
+
+    // rememberUpdatedState ensures the effect always calls the latest lambda without
+    // restarting the LaunchedEffect (which is keyed on transition id, not the lambda).
+    val latestOnTransitionComplete by rememberUpdatedState(onTransitionComplete)
+
+    LaunchedEffect(pendingTransition?.id) {
+        if (pendingTransition != null) {
+            animatable.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(SLIDE_DURATION_MS, easing = FastOutSlowInEasing),
+            )
+            latestOnTransitionComplete(pendingTransition.id)
+        }
+    }
+
+    return WorkflowSlideState(
+        visibleStepIds = if (pendingTransition != null) {
+            setOf(pendingTransition.fromStepId, currentStepId)
+        } else {
+            setOf(currentStepId)
+        },
+        animatingFromStepId = pendingTransition?.fromStepId,
+        animatingDirection = pendingTransition?.direction ?: NavigationDirection.NONE,
+        animatable = animatable,
+    )
+}
+
+/**
+ * Translates a step's content horizontally based on its role in the current slide animation:
+ *
+ * - **Current step**: slides from `±width` to `0` as progress goes 0→1.
+ * - **Outgoing step**: slides from `0` to `∓width` as progress goes 0→1.
+ * - **Other (parked) steps**: positioned far off-screen so the GraphicsLayer skips drawing.
+ *
+ * State reads happen inside the layer block so animation frames invalidate the layer without
+ * triggering recomposition.
+ */
+internal fun Modifier.workflowSlide(
+    state: WorkflowSlideState,
+    stepId: String,
+    currentStepId: String,
+): Modifier = graphicsLayer {
+    val progress = state.animatable.value
+    val directionFactor = if (state.animatingDirection == NavigationDirection.FORWARD) 1f else -1f
+
+    translationX = when (stepId) {
+        currentStepId -> (1f - progress) * directionFactor * size.width
+        state.animatingFromStepId -> -progress * directionFactor * size.width
+        else -> 2f * size.width
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
@@ -15,9 +15,7 @@ internal class LoadedWorkflowPaywallHeaderSelectionTest {
                 "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
                 "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
             ),
-            transitionState = WorkflowHeaderTransitionState(
-                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
-            ),
+            pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
         )
 
         assertThat(selected).isEqualTo("from")
@@ -31,7 +29,7 @@ internal class LoadedWorkflowPaywallHeaderSelectionTest {
                 "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
                 "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
             ),
-            transitionState = WorkflowHeaderTransitionState(pendingTransition = null),
+            pendingTransition = null,
         )
 
         assertThat(selected).isEqualTo("target")
@@ -45,9 +43,7 @@ internal class LoadedWorkflowPaywallHeaderSelectionTest {
                 "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
                 "target" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
             ),
-            transitionState = WorkflowHeaderTransitionState(
-                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
-            ),
+            pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
         )
 
         assertThat(selected).isEqualTo("target")
@@ -61,9 +57,7 @@ internal class LoadedWorkflowPaywallHeaderSelectionTest {
                 "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
                 "target" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
             ),
-            transitionState = WorkflowHeaderTransitionState(
-                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.BACKWARD, 1),
-            ),
+            pendingTransition = WorkflowPendingTransition("from", NavigationDirection.BACKWARD, 1),
         )
 
         assertThat(selected).isEqualTo("target")
@@ -77,9 +71,7 @@ internal class LoadedWorkflowPaywallHeaderSelectionTest {
                 "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
                 "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
             ),
-            transitionState = WorkflowHeaderTransitionState(
-                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.BACKWARD, 1),
-            ),
+            pendingTransition = WorkflowPendingTransition("from", NavigationDirection.BACKWARD, 1),
         )
 
         assertThat(selected).isEqualTo("from")
@@ -93,9 +85,7 @@ internal class LoadedWorkflowPaywallHeaderSelectionTest {
                 "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
                 "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
             ),
-            transitionState = WorkflowHeaderTransitionState(
-                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
-            ),
+            pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
         )
 
         assertThat(selected).isEqualTo("target")
@@ -109,9 +99,7 @@ internal class LoadedWorkflowPaywallHeaderSelectionTest {
                 "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = false),
                 "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
             ),
-            transitionState = WorkflowHeaderTransitionState(
-                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
-            ),
+            pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
         )
 
         assertThat(selected).isEqualTo("target")
@@ -124,7 +112,7 @@ internal class LoadedWorkflowPaywallHeaderSelectionTest {
             stepInfoByStepId = mapOf(
                 "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
             ),
-            transitionState = WorkflowHeaderTransitionState(pendingTransition = null),
+            pendingTransition = null,
         )
 
         assertThat(selected).isEqualTo("target")

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
@@ -1,0 +1,132 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPendingTransition
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class LoadedWorkflowPaywallHeaderSelectionTest {
+
+    @Test
+    fun `hero to non-hero keeps outgoing hero header while animating`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
+            ),
+        )
+
+        assertThat(selected).isEqualTo("from")
+    }
+
+    @Test
+    fun `hero to non-hero switches to target header after animation`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(pendingTransition = null),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `non-hero to hero uses incoming header immediately`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
+            ),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `non-hero to hero backward transition uses incoming header while animating`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.BACKWARD, 1),
+            ),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `non-hero to non-hero backward transition keeps outgoing header while animating`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.BACKWARD, 1),
+            ),
+        )
+
+        assertThat(selected).isEqualTo("from")
+    }
+
+    @Test
+    fun `non-hero to non-hero forward transition uses incoming header while animating`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
+            ),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `missing outgoing hero header falls back to target header`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = false),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
+            ),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `idle state always uses current step header`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(pendingTransition = null),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+}


### PR DESCRIPTION
### Motivation

A workflow paywall pre-rendering approach was retired in favor of a two-surface slide model. Holding every step in the slot table at once was wasteful (most are off-screen) and the prior animation needed `snapTo()` + `withFrameNanos()` workarounds to avoid first-frame flashes.

### Description

Only the current step and the outgoing/incoming step are held in the slot table during a transition; all other steps are dropped.

Key design:

- `WorkflowPaywallUiState` carries a `pendingTransition` (`fromStepId`, `direction`, monotonic `id`) set atomically with `currentStepId` in the ViewModel. The first recomposition after navigation already knows both surfaces and their initial positions.
- `key(pendingTransition.id)` creates a fresh `Animatable(0f)` during the composition phase, so frame N's draw immediately sees the correct offscreen position — no `snapTo()` or `withFrameNanos()` needed.
- `LaunchedEffect` only drives `animateTo(1f)`; it no longer sets up state.
- `onTransitionComplete(id)` runs after the animation finishes so the ViewModel can clear `pendingTransition`; a guard on `id` prevents stale callbacks from clobbering a newer transition.
- Header pinning logic (hero/non-hero, backward) is simplified by removing the `seenStepId` gap-detection; `pendingTransition` covers both the "before animation starts" and "animating" cases with the same branch.
- `navigationDirection` removed from the `PaywallViewModel` interface; direction lives exclusively in `WorkflowPendingTransition`.

Image cache pre-warming for the off-screen steps is split into a follow-up PR (#3421) so this PR stays focused on the surface model and animation.

### Checklist

- [x] Unit tests added (`LoadedWorkflowPaywallHeaderSelectionTest`)
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new workflow-specific rendering and animation state for Components paywalls, which can affect navigation, touch handling, and header/hero layout during transitions. Risk is mostly UI/UX regressions (flashes, clipping, wrong header selection) rather than data/security concerns.
> 
> **Overview**
> Adds a dedicated workflow paywall renderer that uses a two-surface slide transition: `InternalPaywall` now renders `LoadedWorkflowPaywall` when `workflowState` is present, otherwise it falls back to `LoadedPaywallComponents`.
> 
> Implements `WorkflowSlideState` to drive horizontal slide animations keyed by `pendingTransition.id` (keeping only the current + outgoing/incoming steps in composition) and adds header-selection logic to keep the correct header visible during hero/non-hero and backward transitions, covered by new unit tests (`LoadedWorkflowPaywallHeaderSelectionTest`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88595b3feee1921f3418a4ece7e58ca49d668a69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->