### PR TITLE
Rebuild workflow step states on color scheme change

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -898,6 +898,12 @@ internal class PaywallViewModelImpl(
         workflowStepStateCache.clear()
         _workflowState.value = null
 
+        val stepWithPackagesId = result.workflow.singleStepFallbackId
+        val stepWithPackages = stepWithPackagesId?.let { result.workflow.steps[it] }
+        if (stepWithPackages != null && stepWithPackages.id != currentStep.id) {
+            buildStateFromStep(stepWithPackages, result.workflow, offerings, presentedOfferingContext)
+        }
+
         buildStateFromStep(currentStep, result.workflow, offerings, presentedOfferingContext)
         preWarmWorkflowStepCache(result.workflow, offerings, presentedOfferingContext)
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -281,7 +281,12 @@ internal class PaywallViewModelImpl(
         }
         if (_colorScheme.value != colorScheme) {
             _colorScheme.value = colorScheme
-            updateState()
+            if (workflowNavigator != null) {
+                // Rebuild step states in-place to avoid resetting the user's navigation position.
+                rebuildWorkflowStepStates()
+            } else {
+                updateState()
+            }
         }
     }
 
@@ -873,6 +878,27 @@ internal class PaywallViewModelImpl(
 
         buildStateFromStep(initialStep, workflow, offerings, presentedOfferingContext)
         preWarmWorkflowStepCache(workflow, offerings, presentedOfferingContext)
+    }
+
+    /**
+     * Rebuilds workflow step states with the current color scheme without resetting the
+     * navigator position. Used when colors change while a workflow paywall is active,
+     * so the user is not silently sent back to the first step.
+     */
+    @Suppress("ReturnCount")
+    private fun rebuildWorkflowStepStates() {
+        val result = currentWorkflowResult ?: return
+        val offerings = currentWorkflowOfferings ?: return
+        val presentedOfferingContext = currentWorkflowPresentedOfferingContext
+        val navigator = workflowNavigator ?: return
+        val currentStep = navigator.currentStep ?: return
+
+        preWarmJob?.cancel()
+        workflowStepStateCache.clear()
+        _workflowState.value = null
+
+        buildStateFromStep(currentStep, result.workflow, offerings, presentedOfferingContext)
+        preWarmWorkflowStepCache(result.workflow, offerings, presentedOfferingContext)
     }
 
     private fun buildStateFromStep(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -160,6 +160,7 @@ internal class PaywallViewModelImpl(
     private val shouldDisplayBlock: ((CustomerInfo) -> Boolean)?,
     preview: Boolean = false,
     private val productChangeCalculator: ProductChangeCalculator = ProductChangeCalculator(purchases),
+    private val useWorkflowsEndpoint: Boolean = BuildConfig.USE_WORKFLOWS_ENDPOINT,
 ) : ViewModel(), PaywallViewModel {
     private val variableDataProvider = VariableDataProvider(resourceProvider, preview)
 
@@ -739,7 +740,7 @@ internal class PaywallViewModelImpl(
 
     private suspend fun updateStateFromWorkflowEndpointIfNeeded(offeringSelection: OfferingSelection): Boolean {
         var updatedFromWorkflow = false
-        if (BuildConfig.USE_WORKFLOWS_ENDPOINT) {
+        if (useWorkflowsEndpoint) {
             val workflowParams = when (offeringSelection) {
                 is OfferingSelection.IdAndPresentedOfferingContext ->
                     offeringSelection.offeringId to offeringSelection.presentedOfferingContext

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -822,7 +822,6 @@ internal class PaywallViewModelImpl(
         }
     }
 
-    @Suppress("ReturnCount")
     internal fun updateStateFromWorkflow(
         fetchResult: WorkflowDataResult,
         offerings: Offerings,
@@ -862,23 +861,12 @@ internal class PaywallViewModelImpl(
                 )
             } ?: ExitOfferData.Unavailable(),
         )
-        preWarmJob?.cancel()
-        workflowStepStateCache.clear()
-        _workflowState.value = null
 
-        // Pre-compute the package step so its default package is available in cache
-        // for early packageless steps to use as context.
         val stepWithPackagesId = workflow.singleStepFallbackId
-        val stepWithPackages = stepWithPackagesId?.let { workflow.steps[it] }
-        if (stepWithPackagesId != null && stepWithPackages == null) {
+        if (stepWithPackagesId != null && workflow.steps[stepWithPackagesId] == null) {
             Logger.w("Workflow singleStepFallbackId '$stepWithPackagesId' not found in steps")
         }
-        if (stepWithPackages != null && stepWithPackages.id != initialStep.id) {
-            buildStateFromStep(stepWithPackages, workflow, offerings, presentedOfferingContext)
-        }
-
-        buildStateFromStep(initialStep, workflow, offerings, presentedOfferingContext)
-        preWarmWorkflowStepCache(workflow, offerings, presentedOfferingContext)
+        buildWorkflowStates(workflow, offerings, presentedOfferingContext, currentStep = initialStep)
     }
 
     /**
@@ -890,22 +878,39 @@ internal class PaywallViewModelImpl(
     private fun rebuildWorkflowStepStates() {
         val result = currentWorkflowResult ?: return
         val offerings = currentWorkflowOfferings ?: return
-        val presentedOfferingContext = currentWorkflowPresentedOfferingContext
-        val navigator = workflowNavigator ?: return
-        val currentStep = navigator.currentStep ?: return
+        val currentStep = workflowNavigator?.currentStep ?: return
+        buildWorkflowStates(
+            workflow = result.workflow,
+            offerings = offerings,
+            presentedOfferingContext = currentWorkflowPresentedOfferingContext,
+            anchorStep = currentStep,
+        )
+    }
 
+    /**
+     * Clears any cached workflow step states and builds the state for [currentStep] (plus the
+     * package-bearing step, if different) so the UI can render the paywall. Also kicks off
+     * pre-warming of the remaining steps' caches.
+     */
+    private fun buildWorkflowStates(
+        workflow: PublishedWorkflow,
+        offerings: Offerings,
+        presentedOfferingContext: PresentedOfferingContext?,
+        currentStep: WorkflowStep,
+    ) {
         preWarmJob?.cancel()
         workflowStepStateCache.clear()
         _workflowState.value = null
 
-        val stepWithPackagesId = result.workflow.singleStepFallbackId
-        val stepWithPackages = stepWithPackagesId?.let { result.workflow.steps[it] }
+        // Pre-compute the package step so its default package is available in cache
+        // for early packageless steps to use as context.
+        val stepWithPackages = workflow.singleStepFallbackId?.let { workflow.steps[it] }
         if (stepWithPackages != null && stepWithPackages.id != currentStep.id) {
-            buildStateFromStep(stepWithPackages, result.workflow, offerings, presentedOfferingContext)
+            buildStateFromStep(stepWithPackages, workflow, offerings, presentedOfferingContext)
         }
 
-        buildStateFromStep(currentStep, result.workflow, offerings, presentedOfferingContext)
-        preWarmWorkflowStepCache(result.workflow, offerings, presentedOfferingContext)
+        buildStateFromStep(currentStep, workflow, offerings, presentedOfferingContext)
+        preWarmWorkflowStepCache(workflow, offerings, presentedOfferingContext)
     }
 
     private fun buildStateFromStep(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -883,7 +883,7 @@ internal class PaywallViewModelImpl(
             workflow = result.workflow,
             offerings = offerings,
             presentedOfferingContext = currentWorkflowPresentedOfferingContext,
-            anchorStep = currentStep,
+            currentStep = currentStep,
         )
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -36,6 +36,12 @@ import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConf
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
+import com.revenuecat.purchases.common.workflows.WorkflowDataResult
+import com.revenuecat.purchases.common.workflows.WorkflowScreen
+import com.revenuecat.purchases.common.workflows.WorkflowStep
+import com.revenuecat.purchases.common.workflows.WorkflowTrigger
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.paywalls.events.PaywallComponentType
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
@@ -1325,6 +1331,130 @@ class PaywallViewModelTest {
 
         assertThat(model.state.value).isEqualTo(stateBefore)
         assertThat(dismissInvoked).isFalse()
+    }
+
+    @Test
+    fun `refreshStateIfColorsChanged on workflow preserves current navigation step`() {
+        val workflowScreen = WorkflowScreen(
+            templateName = "template",
+            revision = 0,
+            assetBaseURL = URL("https://assets.pawwalls.com"),
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = StackComponent(components = listOf(TestData.Components.monthlyPackageComponent)),
+                    background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+                    stickyFooter = null,
+                ),
+            ),
+            componentsLocalizations = localizations,
+            defaultLocaleIdentifier = defaultLocaleIdentifier,
+            offeringIdentifier = defaultOffering.identifier,
+        )
+        val stepOne = WorkflowStep(
+            id = "step-1",
+            type = "screen",
+            screenId = "screen-1",
+            triggers = listOf(
+                WorkflowTrigger(
+                    name = "Next",
+                    type = WorkflowTriggerType.ON_PRESS,
+                    actionId = "action-next",
+                    componentId = "btn-next",
+                ),
+            ),
+            triggerActions = mapOf("action-next" to WorkflowTriggerAction.Step(stepId = "step-2")),
+        )
+        val stepTwo = WorkflowStep(id = "step-2", type = "screen", screenId = "screen-1")
+        val workflow = PublishedWorkflow(
+            id = "wfl-test",
+            displayName = "Test Workflow",
+            initialStepId = "step-1",
+            steps = mapOf("step-1" to stepOne, "step-2" to stepTwo),
+            screens = mapOf("screen-1" to workflowScreen),
+            uiConfig = UiConfig(),
+        )
+        coEvery { purchases.awaitGetWorkflow(any()) } returns WorkflowDataResult(workflow, null)
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOfferingSelection(OfferingSelection.IdAndPresentedOfferingContext("wfl-test", null))
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        assertThat(model.workflowState.value?.currentStepId).isEqualTo("step-1")
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+
+        model.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        assertThat(model.workflowState.value?.currentStepId).isEqualTo("step-2")
+
+        model.refreshStateIfColorsChanged(
+            colorScheme = TestData.Constants.currentColorScheme.copy(primary = Color.Black),
+            isDark = true,
+        )
+
+        assertThat(model.workflowState.value?.currentStepId).isEqualTo("step-2")
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+    }
+
+    @Test
+    fun `refreshStateIfColorsChanged on workflow does not trigger updateState`() {
+        // updateState would re-fetch the workflow and reset the navigator; this test verifies
+        // that rebuildWorkflowStepStates is taken instead, leaving awaitGetWorkflow call count at 1.
+        val workflowScreen = WorkflowScreen(
+            templateName = "template",
+            revision = 0,
+            assetBaseURL = URL("https://assets.pawwalls.com"),
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = StackComponent(components = listOf(TestData.Components.monthlyPackageComponent)),
+                    background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+                    stickyFooter = null,
+                ),
+            ),
+            componentsLocalizations = localizations,
+            defaultLocaleIdentifier = defaultLocaleIdentifier,
+            offeringIdentifier = defaultOffering.identifier,
+        )
+        val stepOne = WorkflowStep(id = "step-1", type = "screen", screenId = "screen-1")
+        val workflow = PublishedWorkflow(
+            id = "wfl-test",
+            displayName = "Test Workflow",
+            initialStepId = "step-1",
+            steps = mapOf("step-1" to stepOne),
+            screens = mapOf("screen-1" to workflowScreen),
+            uiConfig = UiConfig(),
+        )
+        coEvery { purchases.awaitGetWorkflow(any()) } returns WorkflowDataResult(workflow, null)
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOfferingSelection(OfferingSelection.IdAndPresentedOfferingContext("wfl-test", null))
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        coVerify(exactly = 1) { purchases.awaitGetWorkflow(any()) }
+
+        model.refreshStateIfColorsChanged(
+            colorScheme = TestData.Constants.currentColorScheme.copy(primary = Color.Black),
+            isDark = true,
+        )
+
+        coVerify(exactly = 1) { purchases.awaitGetWorkflow(any()) }
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
     }
 
     // region events


### PR DESCRIPTION
### Motivation

In a multi-step workflow paywall, toggling dark/light mode while on a non-first step would silently navigate the user back to step 1. The configuration change calls `updateState()`, which re-runs the full workflow setup — including resetting `WorkflowNavigator` to the initial step — instead of just rebuilding the cached step states for the new color scheme.

### Description

Introduces `rebuildWorkflowStepStates()`, called from the configuration-change path instead of `updateState()` when the active paywall is a workflow. It:

- Clears the existing `workflowStepStateCache`.
- Rebuilds the current step's `PaywallState.Loaded.Components` against the new color scheme.
- Leaves `WorkflowNavigator`'s `currentStepId` and `backStack` untouched, so the user stays on the step they were on.
- Re-kicks the off-thread pre-warm so visited and unvisited steps repopulate with the new colors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow paywall refresh behavior to rebuild step UI state in-place instead of reloading the workflow, which could impact navigation/state caching if edge cases exist. Covered by new unit tests that assert navigation position and network call count are preserved.
> 
> **Overview**
> Fixes a workflow-paywall bug where changing the Compose `ColorScheme` (e.g., dark/light toggle) could reset multi-step workflow navigation back to the initial step.
> 
> When a workflow is active, `refreshStateIfColorsChanged` now rebuilds workflow step states via `rebuildWorkflowStepStates`/`buildWorkflowStates` (clearing and repopulating the step cache using the *current* step) instead of calling `updateState()` and re-fetching/resetting the `WorkflowNavigator`. Adds tests ensuring the current workflow step is preserved and that `awaitGetWorkflow` is not called again on color refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 847246366d768b1a1d5af6694724b1a226c5433a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->