### PR TITLE
perf: pre-warm workflow paywall step states off-thread

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -854,6 +854,7 @@ internal class PaywallViewModelImpl(
                 }
                 if (computed is PaywallState.Loaded.Components && stepId !in workflowStepStateCache) {
                     workflowStepStateCache[stepId] = computed
+                    computed.update(localeList = _lastLocaleList.value.toFrameworkLocaleList())
                 }
             }
             _workflowState.value = _workflowState.value?.copy(stepStates = workflowStepStateCache.toMap())

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -854,9 +854,9 @@ internal class PaywallViewModelImpl(
                 }
                 if (computed is PaywallState.Loaded.Components && stepId !in workflowStepStateCache) {
                     workflowStepStateCache[stepId] = computed
-                    _workflowState.value = _workflowState.value?.copy(stepStates = workflowStepStateCache.toMap())
                 }
             }
+            _workflowState.value = _workflowState.value?.copy(stepStates = workflowStepStateCache.toMap())
         }
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -846,7 +846,6 @@ internal class PaywallViewModelImpl(
         offerings: Offerings,
         presentedOfferingContext: PresentedOfferingContext?,
     ) {
-        preWarmJob?.cancel()
         preWarmJob = viewModelScope.launch {
             for ((stepId, step) in workflow.steps) {
                 if (stepId in workflowStepStateCache) continue

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -66,6 +66,8 @@ import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorSt
 import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
 import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowNavigator
 import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowScreenMapper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -73,6 +75,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import java.util.Date
 import java.util.Locale
 import java.util.UUID
@@ -199,6 +202,7 @@ internal class PaywallViewModelImpl(
     private var currentWorkflowOfferings: Offerings? = null
     private var currentWorkflowPresentedOfferingContext: PresentedOfferingContext? = null
     private val workflowStepStateCache = mutableMapOf<String, PaywallState.Loaded.Components>()
+    private var preWarmJob: Job? = null
     private var transitionIdCounter: Int = 0
 
     private data class PaywallPresentationFingerprint(
@@ -745,10 +749,12 @@ internal class PaywallViewModelImpl(
         currentWorkflowOfferings = offerings
         currentWorkflowPresentedOfferingContext = presentedOfferingContext
         workflowNavigator = WorkflowNavigator(workflow)
+        preWarmJob?.cancel()
         workflowStepStateCache.clear()
         _workflowState.value = null
 
         buildStateFromStep(initialStep, workflow, offerings, presentedOfferingContext)
+        preWarmWorkflowStepCache(workflow, offerings, presentedOfferingContext)
     }
 
     private fun buildStateFromStep(
@@ -829,6 +835,30 @@ internal class PaywallViewModelImpl(
             storefrontCountryCode = purchases.storefrontCountryCode,
             mode = options.mode,
         )
+    }
+
+    /**
+     * Eagerly computes and caches states for the remaining workflow steps off the main thread,
+     * so that navigating to them doesn't block on the heavy [calculateState] work.
+     */
+    private fun preWarmWorkflowStepCache(
+        workflow: PublishedWorkflow,
+        offerings: Offerings,
+        presentedOfferingContext: PresentedOfferingContext?,
+    ) {
+        preWarmJob?.cancel()
+        preWarmJob = viewModelScope.launch {
+            for ((stepId, step) in workflow.steps) {
+                if (stepId in workflowStepStateCache) continue
+                val computed = withContext(Dispatchers.Default) {
+                    computeStateForStep(step, workflow, offerings, presentedOfferingContext)
+                }
+                if (computed is PaywallState.Loaded.Components && stepId !in workflowStepStateCache) {
+                    workflowStepStateCache[stepId] = computed
+                    _workflowState.value = _workflowState.value?.copy(stepStates = workflowStepStateCache.toMap())
+                }
+            }
+        }
     }
 
     @Suppress("ReturnCount")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WorkflowPaywallUiState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WorkflowPaywallUiState.kt
@@ -7,7 +7,8 @@ import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
  * Snapshot of the workflow-related state the UI needs to render a multi-step paywall.
  *
  * Non-null when the loaded paywall is a workflow; null otherwise. Updated atomically when the
- * user navigates between steps; [stepStates] grows lazily as steps are visited.
+ * user navigates between steps and when the background pre-warm finishes computing additional
+ * step states.
  */
 @Stable
 internal data class WorkflowPaywallUiState(


### PR DESCRIPTION
### Motivation

The lazy step-state cache from #3416 already keeps back-navigation instant (each step is memoized on first visit). But the *first* forward navigation to a never-visited step still pays the full `calculateState` cost on the main thread, which can drop frames on a slide animation.

### Description

Adds `preWarmWorkflowStepCache(...)`, a coroutine launched on `viewModelScope` immediately after the initial step is built. It iterates every step in the workflow, computes its state on `Dispatchers.Default`, and stores the result in `workflowStepStateCache`. Once all steps finish computing, `_workflowState.stepStates` is updated in a single batch write.

The job is cancelled and the cache cleared whenever a new workflow loads, so a workflow swap doesn't leak stale states or compute work.

Pure perf optimization — `buildStateFromStep` already handles a missing cache entry by computing on demand, so behavior is identical with or without the pre-warm. The only observable difference is that forward navigation to a never-visited step is no longer blocking on the main thread once the pre-warm has had a chance to finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds background coroutine work and shared cache mutation in `PaywallViewModelImpl`, which could introduce race conditions or extra CPU usage if cancellation/timing isn’t handled as expected. Functional behavior should remain the same, but workflow navigation state updates now occur asynchronously.
> 
> **Overview**
> Reduces jank when navigating forward in multi-step workflow paywalls by **precomputing and caching** each step’s `PaywallState` in the background.
> 
> `PaywallViewModelImpl` now launches a `viewModelScope` job that computes missing step states on `Dispatchers.Default`, updates locale on computed states, and then batch-updates `workflowState.stepStates`; the job is cancelled and the cache cleared when a new workflow is loaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a661ac390bb2debf4b7a44546cc26796944bc674. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->