### PR TITLE
Pre-warm image cache for workflow step states

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -30,8 +30,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.request.ImageRequest
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.events.PaywallComponentType
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant.defaultAnimation
@@ -49,6 +51,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.isInFullScreenMode
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.defaultpaywall.DefaultPaywallView
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
+import com.revenuecat.purchases.ui.revenuecatui.extensions.getImageLoaderTyped
 import com.revenuecat.purchases.ui.revenuecatui.fonts.PaywallTheme
 import com.revenuecat.purchases.ui.revenuecatui.helpers.LocalActivity
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
@@ -312,6 +315,7 @@ internal fun getPaywallViewModel(
     shouldDisplayBlock: ((CustomerInfo) -> Boolean)? = null,
 ): PaywallViewModel {
     val applicationContext = LocalContext.current.applicationContext
+    val enqueueImage = rememberImageEnqueuer(applicationContext)
     val viewModel = viewModel<PaywallViewModelImpl>(
         key = options.hashCode().toString(),
         factory = PaywallViewModelFactory(
@@ -321,10 +325,21 @@ internal fun getPaywallViewModel(
             isSystemInDarkTheme(),
             shouldDisplayBlock = shouldDisplayBlock,
             preview = isInPreviewMode(),
+            enqueueImage = enqueueImage,
         ),
     )
     viewModel.updateOptions(options)
     return viewModel
+}
+
+@Composable
+private fun rememberImageEnqueuer(applicationContext: Context): (String) -> Unit {
+    val imageLoader = remember(applicationContext) { Purchases.getImageLoaderTyped(applicationContext) }
+    return remember(applicationContext, imageLoader) {
+        fun(url: String) {
+            imageLoader.enqueue(ImageRequest.Builder(applicationContext).data(url).build())
+        }
+    }
 }
 
 @ReadOnlyComposable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowImageUrls.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowImageUrls.kt
@@ -1,0 +1,120 @@
+@file:JvmSynthetic
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.CarouselComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.CountdownComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.HeaderComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.IconComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ImageComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.PackageComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StickyFooterComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TabControlButtonComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TabControlStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TabControlToggleComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TabsComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TextComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TimelineComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.VideoComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+
+/**
+ * Walks every image-bearing node in the components tree (background, stack, header, sticky footer,
+ * plus buttons/carousels/tabs/timelines/etc.) and yields each image URL — light, dark, and
+ * low-resolution variants — so the caller can enqueue them into Coil's image cache up front.
+ */
+@JvmSynthetic
+internal fun PaywallState.Loaded.Components.preloadImageUrls(): Sequence<String> = sequence {
+    yieldAll(background.preloadImageUrls())
+    yieldAll(stack.preloadImageUrls())
+    header?.let { yieldAll(it.preloadImageUrls()) }
+    stickyFooter?.let { yieldAll(it.preloadImageUrls()) }
+}
+
+@Suppress("CyclomaticComplexMethod")
+private fun ComponentStyle.preloadImageUrls(): Sequence<String> = when (this) {
+    is ButtonComponentStyle -> preloadButtonImageUrls()
+    is CarouselComponentStyle -> preloadCarouselImageUrls()
+    is CountdownComponentStyle -> sequence {
+        yieldAll(countdownStackComponentStyle.preloadImageUrls())
+        endStackComponentStyle?.let { yieldAll(it.preloadImageUrls()) }
+        fallbackStackComponentStyle?.let { yieldAll(it.preloadImageUrls()) }
+    }
+    is HeaderComponentStyle -> stackComponentStyle.preloadImageUrls()
+    is IconComponentStyle -> sequenceOf("$baseUrl/${formats.webp}")
+    is ImageComponentStyle -> sources.values.asSequence().flatMap { it.preloadImageUrls() }
+    is PackageComponentStyle -> stackComponentStyle.preloadImageUrls()
+    is StackComponentStyle -> preloadStackImageUrls()
+    is StickyFooterComponentStyle -> stackComponentStyle.preloadImageUrls()
+    is TabControlButtonComponentStyle -> stack.preloadImageUrls()
+    is TabControlToggleComponentStyle -> emptySequence()
+    is TabControlStyle.Buttons -> stack.preloadImageUrls()
+    is TabControlStyle.Toggle -> stack.preloadImageUrls()
+    is TabsComponentStyle -> preloadTabsImageUrls()
+    is TextComponentStyle -> emptySequence()
+    is TimelineComponentStyle -> preloadTimelineImageUrls()
+    is VideoComponentStyle -> {
+        fallbackSources
+            ?.values
+            ?.asSequence()
+            ?.flatMap { it.preloadImageUrls() }
+            .orEmpty()
+    }
+}
+
+private fun ButtonComponentStyle.preloadButtonImageUrls(): Sequence<String> = sequence {
+    yieldAll(stackComponentStyle.preloadImageUrls())
+    val sheet = (action as? ButtonComponentStyle.Action.NavigateTo)
+        ?.destination as? ButtonComponentStyle.Action.NavigateTo.Destination.Sheet
+    sheet?.let { yieldAll(it.stack.preloadImageUrls()) }
+}
+
+private fun CarouselComponentStyle.preloadCarouselImageUrls(): Sequence<String> = sequence {
+    yieldAll(background.preloadImageUrls())
+    pages.forEach { yieldAll(it.preloadImageUrls()) }
+}
+
+private fun StackComponentStyle.preloadStackImageUrls(): Sequence<String> = sequence {
+    yieldAll(background.preloadImageUrls())
+    badge?.let { yieldAll(it.stackStyle.preloadImageUrls()) }
+    children.forEach { yieldAll(it.preloadImageUrls()) }
+}
+
+private fun TabsComponentStyle.preloadTabsImageUrls(): Sequence<String> = sequence {
+    yieldAll(background.preloadImageUrls())
+    yieldAll(control.preloadImageUrls())
+    tabs.forEach { yieldAll(it.stack.preloadImageUrls()) }
+}
+
+private fun TimelineComponentStyle.preloadTimelineImageUrls(): Sequence<String> =
+    items.asSequence().flatMap { item ->
+        sequence {
+            yieldAll(item.title.preloadImageUrls())
+            item.description?.let { yieldAll(it.preloadImageUrls()) }
+            yieldAll(item.icon.preloadImageUrls())
+        }
+    }
+
+private fun BackgroundStyles?.preloadImageUrls(): Sequence<String> = when (this) {
+    is BackgroundStyles.Image -> sources.preloadImageUrls()
+    is BackgroundStyles.Video -> fallbackImage.preloadImageUrls()
+    is BackgroundStyles.Color,
+    null,
+    -> emptySequence()
+}
+
+private fun ThemeImageUrls.preloadImageUrls(): Sequence<String> = sequence {
+    yield(light.webpLowRes.toString())
+    yield(light.webp.toString())
+    dark?.let {
+        yield(it.webpLowRes.toString())
+        yield(it.webp.toString())
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -45,6 +45,7 @@ import com.revenuecat.purchases.ui.revenuecatui.ProductChange
 import com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
+import com.revenuecat.purchases.ui.revenuecatui.components.preloadImageUrls
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
 import com.revenuecat.purchases.ui.revenuecatui.errors.PaywallValidationError
@@ -161,6 +162,7 @@ internal class PaywallViewModelImpl(
     private val shouldDisplayBlock: ((CustomerInfo) -> Boolean)?,
     preview: Boolean = false,
     private val productChangeCalculator: ProductChangeCalculator = ProductChangeCalculator(purchases),
+    private val enqueueImage: (url: String) -> Unit = { },
 ) : ViewModel(), PaywallViewModel {
     private val variableDataProvider = VariableDataProvider(resourceProvider, preview)
 
@@ -202,6 +204,7 @@ internal class PaywallViewModelImpl(
     private var currentWorkflowOfferings: Offerings? = null
     private var currentWorkflowPresentedOfferingContext: PresentedOfferingContext? = null
     private val workflowStepStateCache = mutableMapOf<String, PaywallState.Loaded.Components>()
+    private val enqueuedImageUrls = mutableSetOf<String>()
     private var preWarmJob: Job? = null
     private var transitionIdCounter: Int = 0
 
@@ -751,6 +754,7 @@ internal class PaywallViewModelImpl(
         workflowNavigator = WorkflowNavigator(workflow)
         preWarmJob?.cancel()
         workflowStepStateCache.clear()
+        enqueuedImageUrls.clear()
         _workflowState.value = null
 
         buildStateFromStep(initialStep, workflow, offerings, presentedOfferingContext)
@@ -768,7 +772,7 @@ internal class PaywallViewModelImpl(
         val cached = workflowStepStateCache[step.id]
         val newState = cached ?: computeStateForStep(step, workflow, offerings, presentedOfferingContext)
         if (cached == null && newState is PaywallState.Loaded.Components) {
-            workflowStepStateCache[step.id] = newState
+            cacheStepState(step.id, newState)
         }
         val pendingTransition = if (fromStepId != null && navigationDirection != null) {
             WorkflowPendingTransition(
@@ -838,6 +842,18 @@ internal class PaywallViewModelImpl(
     }
 
     /**
+     * Stores a computed step state in the cache and pre-warms Coil's image cache with that step's
+     * image URLs (light, dark, and low-resolution variants), deduplicated across the workflow's
+     * lifetime.
+     */
+    private fun cacheStepState(stepId: String, state: PaywallState.Loaded.Components) {
+        workflowStepStateCache[stepId] = state
+        state.preloadImageUrls()
+            .filter(enqueuedImageUrls::add)
+            .forEach { url -> enqueueImage(url) }
+    }
+
+    /**
      * Eagerly computes and caches states for the remaining workflow steps off the main thread,
      * so that navigating to them doesn't block on the heavy [calculateState] work.
      */
@@ -853,7 +869,7 @@ internal class PaywallViewModelImpl(
                     computeStateForStep(step, workflow, offerings, presentedOfferingContext)
                 }
                 if (computed is PaywallState.Loaded.Components && stepId !in workflowStepStateCache) {
-                    workflowStepStateCache[stepId] = computed
+                    cacheStepState(stepId, computed)
                     computed.update(localeList = _lastLocaleList.value.toFrameworkLocaleList())
                 }
             }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ResourceProvider
 
+@Suppress("LongParameterList")
 internal class PaywallViewModelFactory(
     private val resourceProvider: ResourceProvider,
     private val options: PaywallOptions,
@@ -14,6 +15,7 @@ internal class PaywallViewModelFactory(
     private val isDarkMode: Boolean,
     private val shouldDisplayBlock: ((CustomerInfo) -> Boolean)?,
     private val preview: Boolean = false,
+    private val enqueueImage: (url: String) -> Unit = { },
 ) : ViewModelProvider.NewInstanceFactory() {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -24,6 +26,7 @@ internal class PaywallViewModelFactory(
             isDarkMode = isDarkMode,
             preview = preview,
             shouldDisplayBlock = shouldDisplayBlock,
+            enqueueImage = enqueueImage,
         ) as T
     }
 }


### PR DESCRIPTION
### Motivation

When the two-surface workflow slide animation (#3418) starts a transition, the incoming step's images may not yet be in Coil's cache, causing a visible pop-in mid-slide. Pre-warming images for every workflow step at composition time lets transitions start with warm caches.

### Description

`WorkflowImagePreloader` walks each step's component tree (background, stack, header, sticky footer — plus buttons, carousels, tabs, timelines, countdowns, icons, images, and video fallback frames) and enqueues every unique image URL into Coil's image loader. Light, dark, and low-resolution variants are all submitted up front. A remembered set guards against duplicate enqueues across recompositions.

The composable is invoked from `LoadedWorkflowPaywall` once the step states are ready; it returns no UI, only side-effecting cache warming.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: this adds background image preloading across workflow steps, which can increase network/memory usage and affect performance if URL enumeration or enqueueing is incorrect.
> 
> **Overview**
> Preloads workflow paywall images into Coil ahead of time to prevent image pop-in during step-to-step slide transitions.
> 
> This introduces `WorkflowImageUrls.preloadImageUrls()` to walk a components paywall tree (backgrounds, stacks, headers/footers, and nested component styles) and extract light/dark/low-res image URLs, then updates `PaywallViewModelImpl` to cache step states via a new `cacheStepState` that deduplicates and enqueues those URLs. `InternalPaywall` now supplies an `enqueueImage` function (backed by `Purchases.getImageLoaderTyped` + `ImageRequest`) through `PaywallViewModelFactory` into the view model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10681c4eb11ec559ec81fd8d4550a194345b33d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->