### PR TITLE
refactor: convert WorkflowNavigator.currentStep() to a property

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
@@ -16,11 +16,12 @@ internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
 
     private val backStack = ArrayDeque<String>()
 
-    fun currentStep(): WorkflowStep? = workflow.steps[_currentStepId.value]
+    val currentStep: WorkflowStep?
+        get() = workflow.steps[_currentStepId.value]
 
     @Suppress("ReturnCount")
     fun peekTriggerStep(componentId: String, triggerType: WorkflowTriggerType): WorkflowStep? {
-        val step = currentStep() ?: return null
+        val step = currentStep ?: return null
         val trigger = step.triggers.firstOrNull { it.componentId == componentId && it.type == triggerType }
             ?: return null
         val action = step.triggerActions[trigger.actionId] ?: return null
@@ -33,7 +34,7 @@ internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
 
     @Suppress("ReturnCount")
     fun triggerAction(componentId: String, triggerType: WorkflowTriggerType): WorkflowStep? {
-        val step = currentStep() ?: return null
+        val step = currentStep ?: return null
         val trigger = step.triggers.firstOrNull { it.componentId == componentId && it.type == triggerType } ?: run {
             Logger.w("No trigger found for componentId '$componentId' and type '$triggerType' in step '${step.id}'")
             return null

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
@@ -71,7 +71,7 @@ class WorkflowNavigatorTest {
     @Test
     fun `currentStep returns initial step`() {
         val navigator = WorkflowNavigator(workflow)
-        assertThat(navigator.currentStep()).isEqualTo(step1)
+        assertThat(navigator.currentStep).isEqualTo(step1)
     }
 
     @Test
@@ -79,7 +79,7 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(workflow)
         val result = navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isEqualTo(step2)
-        assertThat(navigator.currentStep()).isEqualTo(step2)
+        assertThat(navigator.currentStep).isEqualTo(step2)
         assertThat(navigator.currentStepId.value).isEqualTo("step-2")
     }
 
@@ -89,7 +89,7 @@ class WorkflowNavigatorTest {
         navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         val result = navigator.triggerAction("btn-finish", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isEqualTo(step3)
-        assertThat(navigator.currentStep()).isEqualTo(step3)
+        assertThat(navigator.currentStep).isEqualTo(step3)
     }
 
     @Test
@@ -97,7 +97,7 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(workflow)
         val result = navigator.triggerAction("btn-unknown", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isNull()
-        assertThat(navigator.currentStep()).isEqualTo(step1)
+        assertThat(navigator.currentStep).isEqualTo(step1)
     }
 
     @Test
@@ -119,7 +119,7 @@ class WorkflowNavigatorTest {
         navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         val result = navigator.navigateBack()
         assertThat(result).isEqualTo(step1)
-        assertThat(navigator.currentStep()).isEqualTo(step1)
+        assertThat(navigator.currentStep).isEqualTo(step1)
     }
 
     @Test
@@ -142,16 +142,16 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(workflow)
         navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         navigator.triggerAction("btn-finish", WorkflowTriggerType.ON_PRESS)
-        assertThat(navigator.currentStep()).isEqualTo(step3)
+        assertThat(navigator.currentStep).isEqualTo(step3)
 
         val back1 = navigator.navigateBack()
         assertThat(back1).isEqualTo(step2)
-        assertThat(navigator.currentStep()).isEqualTo(step2)
+        assertThat(navigator.currentStep).isEqualTo(step2)
         assertThat(navigator.canNavigateBack).isTrue()
 
         val back2 = navigator.navigateBack()
         assertThat(back2).isEqualTo(step1)
-        assertThat(navigator.currentStep()).isEqualTo(step1)
+        assertThat(navigator.currentStep).isEqualTo(step1)
         assertThat(navigator.canNavigateBack).isFalse()
     }
 
@@ -180,7 +180,7 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(wfl)
         val result = navigator.triggerAction("btn-x", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isNull()
-        assertThat(navigator.currentStep()).isEqualTo(stepWithUnknownAction)
+        assertThat(navigator.currentStep).isEqualTo(stepWithUnknownAction)
     }
 
     @Test
@@ -206,7 +206,7 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(wfl)
         val result = navigator.triggerAction("btn-x", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isNull()
-        assertThat(navigator.currentStep()).isEqualTo(stepWithMissingAction)
+        assertThat(navigator.currentStep).isEqualTo(stepWithMissingAction)
     }
 
     @Test
@@ -234,6 +234,6 @@ class WorkflowNavigatorTest {
         val navigator = WorkflowNavigator(wfl)
         val result = navigator.triggerAction("btn-x", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isNull()
-        assertThat(navigator.currentStep()).isEqualTo(stepWithMissingTarget)
+        assertThat(navigator.currentStep).isEqualTo(stepWithMissingTarget)
     }
 }


### PR DESCRIPTION
## Summary

- Converts `fun currentStep(): WorkflowStep?` to `val currentStep: WorkflowStep?` in `WorkflowNavigator` — it's a side-effect-free derived state query with no mutation or computation, making it semantically a property
- Updates all internal call sites (`peekTriggerStep`, `triggerAction`) and test assertions accordingly

## Test plan

- [ ] Existing `WorkflowNavigatorTest` suite covers all navigation paths — no logic changed, only declaration form