### PR TITLE
test: workflow color-scheme refresh regression tests

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -29,8 +29,10 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.request.ImageRequest
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.events.PaywallComponentType
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant.defaultAnimation
@@ -48,6 +50,7 @@ import com.revenuecat.purchases.ui.revenuecatui.data.isInFullScreenMode
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.defaultpaywall.DefaultPaywallView
 import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
+import com.revenuecat.purchases.ui.revenuecatui.extensions.getImageLoaderTyped
 import com.revenuecat.purchases.ui.revenuecatui.fonts.PaywallTheme
 import com.revenuecat.purchases.ui.revenuecatui.helpers.LocalActivity
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
@@ -306,6 +309,7 @@ internal fun getPaywallViewModel(
     shouldDisplayBlock: ((CustomerInfo) -> Boolean)? = null,
 ): PaywallViewModel {
     val applicationContext = LocalContext.current.applicationContext
+    val enqueueImage = rememberImageEnqueuer(applicationContext)
     val viewModel = viewModel<PaywallViewModelImpl>(
         key = options.hashCode().toString(),
         factory = PaywallViewModelFactory(
@@ -315,10 +319,21 @@ internal fun getPaywallViewModel(
             isSystemInDarkTheme(),
             shouldDisplayBlock = shouldDisplayBlock,
             preview = isInPreviewMode(),
+            enqueueImage = enqueueImage,
         ),
     )
     viewModel.updateOptions(options)
     return viewModel
+}
+
+@Composable
+private fun rememberImageEnqueuer(applicationContext: Context): (String) -> Unit {
+    val imageLoader = remember(applicationContext) { Purchases.getImageLoaderTyped(applicationContext) }
+    return remember(applicationContext, imageLoader) {
+        fun(url: String) {
+            imageLoader.enqueue(ImageRequest.Builder(applicationContext).data(url).build())
+        }
+    }
 }
 
 @ReadOnlyComposable

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -35,6 +35,7 @@ import com.revenuecat.purchases.paywalls.components.ButtonComponent
 import com.revenuecat.purchases.paywalls.events.PaywallComponentType
 import com.revenuecat.purchases.ui.revenuecatui.UIConstant.defaultAnimation
 import com.revenuecat.purchases.ui.revenuecatui.components.LoadedPaywallComponents
+import com.revenuecat.purchases.ui.revenuecatui.components.LoadedWorkflowPaywall
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.composables.CloseButton
 import com.revenuecat.purchases.ui.revenuecatui.composables.ErrorDialog
@@ -144,11 +145,21 @@ internal fun InternalPaywall(
                     viewModel.trackPaywallImpressionIfNeeded()
                 }
             }
-            LoadedPaywallComponents(
-                state = state,
-                clickHandler = rememberPaywallActionHandler(viewModel),
-                componentInteractionTracker = componentInteractionTracker,
-            )
+            val workflowState = viewModel.workflowState.value
+            if (workflowState != null) {
+                LoadedWorkflowPaywall(
+                    workflowState = workflowState,
+                    onTransitionComplete = viewModel::onTransitionComplete,
+                    clickHandler = rememberPaywallActionHandler(viewModel),
+                    componentInteractionTracker = componentInteractionTracker,
+                )
+            } else {
+                LoadedPaywallComponents(
+                    state = state,
+                    clickHandler = rememberPaywallActionHandler(viewModel),
+                    componentInteractionTracker = componentInteractionTracker,
+                )
+            }
         } else {
             Logger.e(
                 "State is not loaded while transitioning animation. This may happen if state changes " +

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/LoadingPaywall.kt
@@ -35,6 +35,7 @@ import com.revenuecat.purchases.ui.revenuecatui.composables.PlaceholderDefaults
 import com.revenuecat.purchases.ui.revenuecatui.composables.placeholder
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.PaywallTemplate
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
@@ -191,6 +192,7 @@ private class LoadingViewModel(
     override val actionError: State<PurchasesError?> = mutableStateOf(null)
     override val purchaseCompleted: State<Boolean> = mutableStateOf(false)
     override val preloadedExitOffering: State<Offering?> = mutableStateOf(null)
+    override val workflowState: State<WorkflowPaywallUiState?> = mutableStateOf(null)
 
     override fun trackPaywallImpressionIfNeeded() = Unit
     override fun trackExitOffer(exitOfferType: ExitOfferType, exitOfferingIdentifier: String) = Unit
@@ -236,6 +238,8 @@ private class LoadingViewModel(
     override fun handleWorkflowAction(componentId: String, triggerType: WorkflowTriggerType) = Unit
 
     override fun handleBackNavigation(): Boolean = false
+
+    override fun onTransitionComplete(transitionId: Int) = Unit
 
     override fun clearActionError() = Unit
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -51,11 +51,13 @@ import com.revenuecat.purchases.paywalls.components.properties.TwoDimensionalAli
 import com.revenuecat.purchases.paywalls.components.properties.TwoDimensionalAlignment.BOTTOM
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.ColorStyles
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.rememberBackgroundStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.composables.SimpleBottomSheetScaffold
 import com.revenuecat.purchases.ui.revenuecatui.composables.SimpleSheetState
@@ -82,21 +84,37 @@ internal fun LoadedPaywallComponents(
     val configuration = LocalConfiguration.current
     state.update(localeList = configuration.locales)
 
-    val onClick: suspend (PaywallAction) -> Unit = { action: PaywallAction ->
+    val onClick: suspend (PaywallAction) -> Unit = { action ->
         handleClick(action, state, clickHandler, componentInteractionTracker)
     }
 
-    // If the root stack already scrolls vertically (overflow = SCROLL on a vertical dimension),
-    // skip the outer verticalScroll — two vertical scroll modifiers on the same axis crashes.
-    val shouldWrapMainContentInVerticalScroll =
-        (state.stack as? StackComponentStyle)?.scrollOrientation != Orientation.Vertical
+    val shouldWrapMainContentInVerticalScroll = shouldWrapMainContentInVerticalScroll(state.stack)
     val mainScrollState = rememberScrollState()
 
     PaywallComponentsScaffold(
         state = state,
-        clickHandler = clickHandler,
-        componentInteractionTracker = componentInteractionTracker,
         modifier = modifier,
+        headerContent = state.header?.let { headerStyle ->
+            {
+                ComponentView(
+                    style = headerStyle,
+                    state = state,
+                    onClick = onClick,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        footerContent = state.stickyFooter?.let { footerStyle ->
+            {
+                ComponentView(
+                    style = footerStyle,
+                    state = state,
+                    onClick = onClick,
+                    componentInteractionTracker = componentInteractionTracker,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
     ) {
         ComponentView(
             style = state.stack,
@@ -117,25 +135,25 @@ internal fun LoadedPaywallComponents(
 
 /**
  * Shared scaffold for all Components-based paywall variants. Handles the background, bottom-sheet,
- * overlay, fixed-header overlay, and sticky footer. Callers supply the main scrollable content as
- * [mainContent] and decide for themselves whether to apply [headerTopPadding] based on [state].
+ * and fixed-header overlay layout. Callers supply [mainContent] (the scrollable body) plus optional
+ * [headerContent] and [footerContent] composables.
+ *
+ * Pass [background] = null to skip background painting (e.g. workflow paywalls render per-step
+ * backgrounds inside their sliding surfaces).
  */
+@Suppress("LongParameterList")
 @Composable
 internal fun PaywallComponentsScaffold(
     state: PaywallState.Loaded.Components,
-    clickHandler: suspend (PaywallAction.External) -> Unit,
-    componentInteractionTracker: PaywallComponentInteractionTracker,
     modifier: Modifier = Modifier,
+    background: BackgroundStyle? = rememberBackgroundStyle(state.background),
+    headerContent: (@Composable () -> Unit)? = null,
+    footerContent: (@Composable () -> Unit)? = null,
     mainContent: @Composable () -> Unit,
 ) {
-    val background = rememberBackgroundStyle(state.background)
-    val onClick: suspend (PaywallAction) -> Unit = { action: PaywallAction ->
-        handleClick(action, state, clickHandler, componentInteractionTracker)
-    }
-
     SimpleBottomSheetScaffold(
         sheetState = state.sheet,
-        modifier = modifier.background(background),
+        modifier = background?.let { modifier.background(it) } ?: modifier,
     ) {
         WithOptionalBackgroundOverlay(state, background = background) {
             Column {
@@ -143,37 +161,20 @@ internal fun PaywallComponentsScaffold(
                     state = state,
                     modifier = Modifier.weight(1f),
                 ) {
-                    // Child 0: caller-supplied main content (scrollable body or slide container).
+                    // Child 0: caller-supplied main content (scrollable body).
                     mainContent()
                     // Child 1 (optional): fixed header overlay.
-                    state.header?.let { headerStyle ->
-                        ComponentView(
-                            style = headerStyle,
-                            state = state,
-                            onClick = onClick,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    }
+                    headerContent?.invoke()
                 }
-                state.stickyFooter?.let {
-                    ComponentView(
-                        style = it,
-                        state = state,
-                        onClick = onClick,
-                        componentInteractionTracker = componentInteractionTracker,
-                        modifier = Modifier
-                            .fillMaxWidth(),
-                    )
-                }
+                footerContent?.invoke()
             }
         }
     }
 }
 
 /**
- * Custom Layout that measures the header overlay first, stores its pixel height in [state],
- * then measures the main content. This ensures the header height is available during the main
- * content's layout phase without requiring a second composition pass.
+ * Custom Layout that measures the fixed header overlay first, stores its pixel height in [state],
+ * then measures the main content.
  *
  * Children: index 0 = main scrollable content, index 1 (optional) = header overlay.
  */
@@ -221,6 +222,15 @@ internal fun Modifier.headerTopPadding(state: PaywallState.Loaded.Components): M
             placeable.place(0, topPad)
         }
     }
+
+/**
+ * Returns whether the caller should wrap [rootStack] in an outer `verticalScroll` modifier.
+ * Returns `false` when the root stack already scrolls vertically (overflow = SCROLL on a vertical
+ * dimension), because two vertical scroll modifiers on the same axis crash at runtime.
+ */
+@JvmSynthetic
+internal fun shouldWrapMainContentInVerticalScroll(rootStack: ComponentStyle): Boolean =
+    (rootStack as? StackComponentStyle)?.scrollOrientation != Orientation.Vertical
 
 internal suspend fun handleClick(
     action: PaywallAction,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -1,0 +1,240 @@
+@file:JvmSynthetic
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.rememberBackgroundStyle
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPendingTransition
+import com.revenuecat.purchases.ui.revenuecatui.extensions.conditional
+import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
+import com.revenuecat.purchases.ui.revenuecatui.helpers.PaywallComponentInteractionTracker
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+
+internal data class WorkflowHeaderTransitionState(
+    val pendingTransition: WorkflowPendingTransition?,
+)
+
+internal data class WorkflowHeaderStepInfo(
+    val hasHeroImage: Boolean,
+    val hasHeader: Boolean,
+)
+
+@Composable
+internal fun LoadedWorkflowPaywall(
+    workflowState: WorkflowPaywallUiState,
+    onTransitionComplete: (transitionId: Int) -> Unit,
+    clickHandler: suspend (PaywallAction.External) -> Unit,
+    componentInteractionTracker: PaywallComponentInteractionTracker,
+    modifier: Modifier = Modifier,
+) {
+    val currentStepId = workflowState.currentStepId
+    val stepStates = workflowState.stepStates
+    val currentState = stepStates[currentStepId] ?: run {
+        Logger.e("Workflow step '$currentStepId' not found in stepStates — rendering nothing")
+        return
+    }
+
+    val configuration = LocalConfiguration.current
+    currentState.update(localeList = configuration.locales)
+
+    val slideState = rememberWorkflowSlideState(
+        workflowState = workflowState,
+        onTransitionComplete = onTransitionComplete,
+    )
+
+    val headerState = workflowHeaderState(
+        currentStepId = currentStepId,
+        currentState = currentState,
+        stepStates = stepStates,
+        slideState = slideState,
+    )
+    val onClick: suspend (PaywallAction) -> Unit = { action ->
+        handleClick(action, currentState, clickHandler, componentInteractionTracker)
+    }
+    PaywallComponentsScaffold(
+        state = currentState,
+        modifier = modifier,
+        background = null,
+        headerContent = headerState.header?.let { headerStyle ->
+            {
+                ComponentView(
+                    style = headerStyle,
+                    state = headerState,
+                    onClick = onClick,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+    ) {
+        WorkflowStepsContent(
+            currentStepId = currentStepId,
+            stepStates = stepStates,
+            slideState = slideState,
+            clickHandler = clickHandler,
+            componentInteractionTracker = componentInteractionTracker,
+        )
+    }
+}
+
+private fun workflowHeaderState(
+    currentStepId: String,
+    currentState: PaywallState.Loaded.Components,
+    stepStates: Map<String, PaywallState.Loaded.Components>,
+    slideState: WorkflowSlideState,
+): PaywallState.Loaded.Components {
+    val headerStepInfo = stepStates.mapValues { (_, stepState) ->
+        WorkflowHeaderStepInfo(
+            hasHeroImage = stepState.mainStackHasHeroImage,
+            hasHeader = stepState.header != null,
+        )
+    }
+    val headerStepId = selectWorkflowHeaderStepId(
+        currentStepId = currentStepId,
+        stepInfoByStepId = headerStepInfo,
+        transitionState = WorkflowHeaderTransitionState(
+            pendingTransition = slideState.animatingFromStepId?.let { fromId ->
+                WorkflowPendingTransition(
+                    fromStepId = fromId,
+                    direction = slideState.animatingDirection,
+                    id = 0, // id not needed for header selection
+                )
+            },
+        ),
+    )
+
+    return stepStates[headerStepId] ?: currentState
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun WorkflowStepsContent(
+    currentStepId: String,
+    stepStates: Map<String, PaywallState.Loaded.Components>,
+    slideState: WorkflowSlideState,
+    clickHandler: suspend (PaywallAction.External) -> Unit,
+    componentInteractionTracker: PaywallComponentInteractionTracker,
+) {
+    // Multi-step slide container: the current and outgoing steps are stacked and translated by workflowSlide.
+    // No clipToBounds here — horizontal overflow is bounded by the window/dialog, and adding
+    // a top clip causes the hero image (which renders behind the status bar) to get cropped
+    // during the slide transition.
+    Box(modifier = Modifier.fillMaxSize()) {
+        for (stepId in slideState.visibleStepIds) {
+            val stepState = stepStates[stepId] ?: continue
+            key(stepId) {
+                WorkflowStepContent(
+                    stepId = stepId,
+                    stepState = stepState,
+                    isCurrent = stepId == currentStepId,
+                    currentStepId = currentStepId,
+                    slideState = slideState,
+                    clickHandler = clickHandler,
+                    componentInteractionTracker = componentInteractionTracker,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Renders one workflow step's body and footer as a self-contained sliding surface.
+ * Header is rendered at scaffold level and stays fixed.
+ * Off-screen (parked) steps still receive a click handler, but it short-circuits because they are
+ * translated off-screen and can't receive touches.
+ */
+@Suppress("LongParameterList")
+@Composable
+private fun WorkflowStepContent(
+    stepId: String,
+    stepState: PaywallState.Loaded.Components,
+    isCurrent: Boolean,
+    currentStepId: String,
+    slideState: WorkflowSlideState,
+    clickHandler: suspend (PaywallAction.External) -> Unit,
+    componentInteractionTracker: PaywallComponentInteractionTracker,
+) {
+    val onClick: suspend (PaywallAction) -> Unit = { action ->
+        if (isCurrent) {
+            handleClick(action, stepState, clickHandler, componentInteractionTracker)
+        }
+    }
+    val tracker = if (isCurrent) componentInteractionTracker else PaywallComponentInteractionTracker { _ -> }
+    val background = rememberBackgroundStyle(stepState.background)
+    val shouldWrapMainContentInVerticalScroll = shouldWrapMainContentInVerticalScroll(stepState.stack)
+    val mainScrollState = rememberScrollState()
+
+    WithOptionalBackgroundOverlay(
+        state = stepState,
+        background = background,
+        modifier = Modifier
+            .fillMaxSize()
+            .workflowSlide(slideState, stepId, currentStepId)
+            .background(background),
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            ComponentView(
+                style = stepState.stack,
+                state = stepState,
+                onClick = onClick,
+                componentInteractionTracker = tracker,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .conditional(shouldWrapMainContentInVerticalScroll) {
+                        verticalScroll(mainScrollState)
+                    }
+                    .conditional(stepState.header != null && !stepState.mainStackHasHeroImage) {
+                        headerTopPadding(stepState)
+                    },
+            )
+            stepState.stickyFooter?.let { footerStyle ->
+                ComponentView(
+                    style = footerStyle,
+                    state = stepState,
+                    onClick = onClick,
+                    componentInteractionTracker = tracker,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+internal fun selectWorkflowHeaderStepId(
+    currentStepId: String,
+    stepInfoByStepId: Map<String, WorkflowHeaderStepInfo>,
+    transitionState: WorkflowHeaderTransitionState,
+): String {
+    val fromStepId = transitionState.pendingTransition?.fromStepId
+    val direction = transitionState.pendingTransition?.direction ?: NavigationDirection.NONE
+    val fromStepInfo = fromStepId?.let(stepInfoByStepId::get)
+    val toStepInfo = stepInfoByStepId[currentStepId]
+    val useOutgoingHeader = transitionState.pendingTransition != null &&
+        fromStepInfo != null &&
+        toStepInfo != null &&
+        shouldUseOutgoingHeader(direction, fromStepInfo, toStepInfo)
+
+    return if (useOutgoingHeader) fromStepId ?: currentStepId else currentStepId
+}
+
+private fun shouldUseOutgoingHeader(
+    direction: NavigationDirection,
+    fromStepInfo: WorkflowHeaderStepInfo,
+    toStepInfo: WorkflowHeaderStepInfo,
+): Boolean = fromStepInfo.hasHeader &&
+    !toStepInfo.hasHeroImage &&
+    (direction == NavigationDirection.BACKWARD || fromStepInfo.hasHeroImage)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowImageUrls.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowImageUrls.kt
@@ -1,0 +1,120 @@
+@file:JvmSynthetic
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
+import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.CarouselComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.CountdownComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.HeaderComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.IconComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ImageComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.PackageComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.StickyFooterComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TabControlButtonComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TabControlStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TabControlToggleComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TabsComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TextComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.TimelineComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.components.style.VideoComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
+
+/**
+ * Walks every image-bearing node in the components tree (background, stack, header, sticky footer,
+ * plus buttons/carousels/tabs/timelines/etc.) and yields each image URL — light, dark, and
+ * low-resolution variants — so the caller can enqueue them into Coil's image cache up front.
+ */
+@JvmSynthetic
+internal fun PaywallState.Loaded.Components.preloadImageUrls(): Sequence<String> = sequence {
+    yieldAll(background.preloadImageUrls())
+    yieldAll(stack.preloadImageUrls())
+    header?.let { yieldAll(it.preloadImageUrls()) }
+    stickyFooter?.let { yieldAll(it.preloadImageUrls()) }
+}
+
+@Suppress("CyclomaticComplexMethod")
+private fun ComponentStyle.preloadImageUrls(): Sequence<String> = when (this) {
+    is ButtonComponentStyle -> preloadButtonImageUrls()
+    is CarouselComponentStyle -> preloadCarouselImageUrls()
+    is CountdownComponentStyle -> sequence {
+        yieldAll(countdownStackComponentStyle.preloadImageUrls())
+        endStackComponentStyle?.let { yieldAll(it.preloadImageUrls()) }
+        fallbackStackComponentStyle?.let { yieldAll(it.preloadImageUrls()) }
+    }
+    is HeaderComponentStyle -> stackComponentStyle.preloadImageUrls()
+    is IconComponentStyle -> sequenceOf("$baseUrl/${formats.webp}")
+    is ImageComponentStyle -> sources.values.asSequence().flatMap { it.preloadImageUrls() }
+    is PackageComponentStyle -> stackComponentStyle.preloadImageUrls()
+    is StackComponentStyle -> preloadStackImageUrls()
+    is StickyFooterComponentStyle -> stackComponentStyle.preloadImageUrls()
+    is TabControlButtonComponentStyle -> stack.preloadImageUrls()
+    is TabControlToggleComponentStyle -> emptySequence()
+    is TabControlStyle.Buttons -> stack.preloadImageUrls()
+    is TabControlStyle.Toggle -> stack.preloadImageUrls()
+    is TabsComponentStyle -> preloadTabsImageUrls()
+    is TextComponentStyle -> emptySequence()
+    is TimelineComponentStyle -> preloadTimelineImageUrls()
+    is VideoComponentStyle -> {
+        fallbackSources
+            ?.values
+            ?.asSequence()
+            ?.flatMap { it.preloadImageUrls() }
+            .orEmpty()
+    }
+}
+
+private fun ButtonComponentStyle.preloadButtonImageUrls(): Sequence<String> = sequence {
+    yieldAll(stackComponentStyle.preloadImageUrls())
+    val sheet = (action as? ButtonComponentStyle.Action.NavigateTo)
+        ?.destination as? ButtonComponentStyle.Action.NavigateTo.Destination.Sheet
+    sheet?.let { yieldAll(it.stack.preloadImageUrls()) }
+}
+
+private fun CarouselComponentStyle.preloadCarouselImageUrls(): Sequence<String> = sequence {
+    yieldAll(background.preloadImageUrls())
+    pages.forEach { yieldAll(it.preloadImageUrls()) }
+}
+
+private fun StackComponentStyle.preloadStackImageUrls(): Sequence<String> = sequence {
+    yieldAll(background.preloadImageUrls())
+    badge?.let { yieldAll(it.stackStyle.preloadImageUrls()) }
+    children.forEach { yieldAll(it.preloadImageUrls()) }
+}
+
+private fun TabsComponentStyle.preloadTabsImageUrls(): Sequence<String> = sequence {
+    yieldAll(background.preloadImageUrls())
+    yieldAll(control.preloadImageUrls())
+    tabs.forEach { yieldAll(it.stack.preloadImageUrls()) }
+}
+
+private fun TimelineComponentStyle.preloadTimelineImageUrls(): Sequence<String> =
+    items.asSequence().flatMap { item ->
+        sequence {
+            yieldAll(item.title.preloadImageUrls())
+            item.description?.let { yieldAll(it.preloadImageUrls()) }
+            yieldAll(item.icon.preloadImageUrls())
+        }
+    }
+
+private fun BackgroundStyles?.preloadImageUrls(): Sequence<String> = when (this) {
+    is BackgroundStyles.Image -> sources.preloadImageUrls()
+    is BackgroundStyles.Video -> fallbackImage.preloadImageUrls()
+    is BackgroundStyles.Color,
+    null,
+    -> emptySequence()
+}
+
+private fun ThemeImageUrls.preloadImageUrls(): Sequence<String> = sequence {
+    yield(light.webpLowRes.toString())
+    yield(light.webp.toString())
+    dark?.let {
+        yield(it.webpLowRes.toString())
+        yield(it.webp.toString())
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideState.kt
@@ -1,0 +1,120 @@
+@file:JvmSynthetic
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+
+private const val SLIDE_DURATION_MS = 350
+
+/**
+ * Snapshot of the data needed to render and animate the two-surface workflow paywall slide.
+ *
+ * Built during composition from [WorkflowPaywallUiState.pendingTransition], so the first frame
+ * after navigation already has both surfaces positioned correctly — no gap-detection, no
+ * [Animatable.snapTo], no [androidx.compose.runtime.withFrameNanos] required.
+ *
+ * @param visibleStepIds step IDs currently held in the Compose slot table.
+ * @param animatingFromStepId step ID sliding out; null when idle.
+ * @param animatingDirection direction of the active slide; [NavigationDirection.NONE] when idle.
+ * @param animatable drives progress 0f→1f. Created fresh via [key] for each new
+ *   [WorkflowPaywallUiState.pendingTransition] so it always starts at 0f.
+ */
+internal class WorkflowSlideState(
+    val visibleStepIds: Set<String>,
+    val animatingFromStepId: String?,
+    val animatingDirection: NavigationDirection,
+    val animatable: Animatable<Float, AnimationVector1D>,
+)
+
+/**
+ * Builds a [WorkflowSlideState] from [workflowState].
+ *
+ * When [WorkflowPaywallUiState.pendingTransition] is non-null:
+ * - [key] on the transition id creates a fresh [Animatable] **at 0f during composition**, so
+ *   the draw phase of Frame N (the first frame after navigation) already reads 0f. The incoming
+ *   step is positioned offscreen and the outgoing step stays at 0 — all without a
+ *   [Animatable.snapTo] call.
+ * - [LaunchedEffect] only drives `animateTo(1f)`; it no longer sets up animation state.
+ * - [onTransitionComplete] is called with the transition id when the animation finishes so
+ *   the ViewModel can clear [WorkflowPaywallUiState.pendingTransition].
+ */
+@Composable
+internal fun rememberWorkflowSlideState(
+    workflowState: WorkflowPaywallUiState,
+    onTransitionComplete: (transitionId: Int) -> Unit,
+): WorkflowSlideState {
+    val currentStepId = workflowState.currentStepId
+    val pendingTransition = workflowState.pendingTransition
+
+    // key() on the transition id causes a new Animatable to be created in composition
+    // when a transition starts. The new Animatable starts at 0f (incoming step offscreen)
+    // so Frame N's draw is already correct — no snapTo() needed.
+    val animatable: Animatable<Float, AnimationVector1D> = key(pendingTransition?.id) {
+        remember { Animatable(if (pendingTransition != null) 0f else 1f) }
+    }
+
+    // rememberUpdatedState ensures the effect always calls the latest lambda without
+    // restarting the LaunchedEffect (which is keyed on transition id, not the lambda).
+    val latestOnTransitionComplete by rememberUpdatedState(onTransitionComplete)
+
+    LaunchedEffect(pendingTransition?.id) {
+        if (pendingTransition != null) {
+            animatable.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(SLIDE_DURATION_MS, easing = FastOutSlowInEasing),
+            )
+            latestOnTransitionComplete(pendingTransition.id)
+        }
+    }
+
+    return WorkflowSlideState(
+        visibleStepIds = if (pendingTransition != null) {
+            setOf(pendingTransition.fromStepId, currentStepId)
+        } else {
+            setOf(currentStepId)
+        },
+        animatingFromStepId = pendingTransition?.fromStepId,
+        animatingDirection = pendingTransition?.direction ?: NavigationDirection.NONE,
+        animatable = animatable,
+    )
+}
+
+/**
+ * Translates a step's content horizontally based on its role in the current slide animation:
+ *
+ * - **Current step**: slides from `±width` to `0` as progress goes 0→1.
+ * - **Outgoing step**: slides from `0` to `∓width` as progress goes 0→1.
+ * - **Other (parked) steps**: positioned far off-screen so the GraphicsLayer skips drawing.
+ *
+ * State reads happen inside the layer block so animation frames invalidate the layer without
+ * triggering recomposition.
+ */
+internal fun Modifier.workflowSlide(
+    state: WorkflowSlideState,
+    stepId: String,
+    currentStepId: String,
+): Modifier = graphicsLayer {
+    val progress = state.animatable.value
+    val directionFactor = if (state.animatingDirection == NavigationDirection.FORWARD) 1f else -1f
+
+    translationX = when (stepId) {
+        currentStepId -> (1f - progress) * directionFactor * size.width
+        state.animatingFromStepId -> -progress * directionFactor * size.width
+        else -> 2f * size.width
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -45,6 +45,7 @@ import com.revenuecat.purchases.ui.revenuecatui.ProductChange
 import com.revenuecat.purchases.ui.revenuecatui.PurchaseLogicResult
 import com.revenuecat.purchases.ui.revenuecatui.activity.PaywallResult
 import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
+import com.revenuecat.purchases.ui.revenuecatui.components.preloadImageUrls
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
 import com.revenuecat.purchases.ui.revenuecatui.errors.PaywallValidationError
@@ -161,6 +162,7 @@ internal class PaywallViewModelImpl(
     private val shouldDisplayBlock: ((CustomerInfo) -> Boolean)?,
     preview: Boolean = false,
     private val productChangeCalculator: ProductChangeCalculator = ProductChangeCalculator(purchases),
+    private val enqueueImage: (url: String) -> Unit = { },
 ) : ViewModel(), PaywallViewModel {
     private val variableDataProvider = VariableDataProvider(resourceProvider, preview)
 
@@ -202,6 +204,7 @@ internal class PaywallViewModelImpl(
     private var currentWorkflowOfferings: Offerings? = null
     private var currentWorkflowPresentedOfferingContext: PresentedOfferingContext? = null
     private val workflowStepStateCache = mutableMapOf<String, PaywallState.Loaded.Components>()
+    private val enqueuedImageUrls = mutableSetOf<String>()
     private var preWarmJob: Job? = null
     private var transitionIdCounter: Int = 0
 
@@ -749,6 +752,7 @@ internal class PaywallViewModelImpl(
         workflowNavigator = WorkflowNavigator(workflow)
         preWarmJob?.cancel()
         workflowStepStateCache.clear()
+        enqueuedImageUrls.clear()
         _workflowState.value = null
 
         buildStateFromStep(initialStep, workflow, offerings, presentedOfferingContext)
@@ -766,7 +770,7 @@ internal class PaywallViewModelImpl(
         val cached = workflowStepStateCache[step.id]
         val newState = cached ?: computeStateForStep(step, workflow, offerings, presentedOfferingContext)
         if (cached == null && newState is PaywallState.Loaded.Components) {
-            workflowStepStateCache[step.id] = newState
+            cacheStepState(step.id, newState)
         }
         val pendingTransition = if (fromStepId != null && navigationDirection != NavigationDirection.NONE) {
             WorkflowPendingTransition(
@@ -830,6 +834,18 @@ internal class PaywallViewModelImpl(
     }
 
     /**
+     * Stores a computed step state in the cache and pre-warms Coil's image cache with that step's
+     * image URLs (light, dark, and low-resolution variants), deduplicated across the workflow's
+     * lifetime.
+     */
+    private fun cacheStepState(stepId: String, state: PaywallState.Loaded.Components) {
+        workflowStepStateCache[stepId] = state
+        state.preloadImageUrls()
+            .filter(enqueuedImageUrls::add)
+            .forEach { url -> enqueueImage(url) }
+    }
+
+    /**
      * Eagerly computes and caches states for the remaining workflow steps off the main thread,
      * so that navigating to them doesn't block on the heavy [calculateState] work.
      */
@@ -846,7 +862,7 @@ internal class PaywallViewModelImpl(
                     computeStateForStep(step, workflow, offerings, presentedOfferingContext)
                 }
                 if (computed is PaywallState.Loaded.Components && stepId !in workflowStepStateCache) {
-                    workflowStepStateCache[stepId] = computed
+                    cacheStepState(stepId, computed)
                     _workflowState.value = _workflowState.value?.copy(stepStates = workflowStepStateCache.toMap())
                 }
             }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -163,6 +163,7 @@ internal class PaywallViewModelImpl(
     preview: Boolean = false,
     private val productChangeCalculator: ProductChangeCalculator = ProductChangeCalculator(purchases),
     private val enqueueImage: (url: String) -> Unit = { },
+    private val useWorkflowsEndpoint: Boolean = BuildConfig.USE_WORKFLOWS_ENDPOINT,
 ) : ViewModel(), PaywallViewModel {
     private val variableDataProvider = VariableDataProvider(resourceProvider, preview)
 
@@ -682,7 +683,7 @@ internal class PaywallViewModelImpl(
     }
 
     private suspend fun updateStateFromOffering(offeringSelection: OfferingSelection) {
-        if (BuildConfig.USE_WORKFLOWS_ENDPOINT) {
+        if (useWorkflowsEndpoint) {
             val workflowParams: Pair<String, PresentedOfferingContext?>? = when (offeringSelection) {
                 is OfferingSelection.IdAndPresentedOfferingContext ->
                     offeringSelection.offeringId to offeringSelection.presentedOfferingContext

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -63,6 +63,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.toLegacyPaywallState
 import com.revenuecat.purchases.ui.revenuecatui.helpers.validatedPaywall
 import com.revenuecat.purchases.ui.revenuecatui.isFullScreen
 import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorStrings
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
 import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowNavigator
 import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowScreenMapper
 import kotlinx.coroutines.async
@@ -110,6 +111,11 @@ internal interface PaywallViewModel {
     }
     fun closePaywall(result: PaywallResult? = null)
 
+    /**
+     * Workflow-related UI state. Non-null when the loaded paywall is a multi-step workflow.
+     */
+    val workflowState: State<WorkflowPaywallUiState?>
+
     fun handleWorkflowAction(componentId: String, triggerType: WorkflowTriggerType)
 
     /**
@@ -117,6 +123,13 @@ internal interface PaywallViewModel {
      * (previous step rendered), false to fall through to dismiss.
      */
     fun handleBackNavigation(): Boolean
+
+    /**
+     * Called by the UI when a slide animation completes. Clears the [WorkflowPendingTransition]
+     * for the given [transitionId] so the outgoing step can be removed from the slot table.
+     * A guard on [transitionId] prevents stale callbacks from clobbering a newer transition.
+     */
+    fun onTransitionComplete(transitionId: Int)
 
     fun getWebCheckoutUrl(launchWebCheckout: PaywallAction.External.LaunchWebCheckout): String?
     fun invalidateCustomerInfoCache()
@@ -158,12 +171,15 @@ internal class PaywallViewModelImpl(
         get() = _purchaseCompleted
     override val preloadedExitOffering: State<Offering?>
         get() = _preloadedExitOffering
+    override val workflowState: State<WorkflowPaywallUiState?>
+        get() = _workflowState
 
     private val _state: MutableStateFlow<PaywallState> = MutableStateFlow(PaywallState.Loading)
     private val _actionInProgress: MutableState<Boolean> = mutableStateOf(false)
     private val _actionError: MutableState<PurchasesError?> = mutableStateOf(null)
     private val _purchaseCompleted: MutableState<Boolean> = mutableStateOf(false)
     private val _preloadedExitOffering: MutableState<Offering?> = mutableStateOf(null)
+    private val _workflowState: MutableState<WorkflowPaywallUiState?> = mutableStateOf(null)
     private val _lastLocaleList = MutableStateFlow(getCurrentLocaleList())
     private val _colorScheme = MutableStateFlow(colorScheme)
 
@@ -182,6 +198,8 @@ internal class PaywallViewModelImpl(
     private var currentWorkflowResult: WorkflowDataResult? = null
     private var currentWorkflowOfferings: Offerings? = null
     private var currentWorkflowPresentedOfferingContext: PresentedOfferingContext? = null
+    private val workflowStepStateCache = mutableMapOf<String, PaywallState.Loaded.Components>()
+    private var transitionIdCounter: Int = 0
 
     private data class PaywallPresentationFingerprint(
         val paywallIdentifier: String?,
@@ -725,51 +743,68 @@ internal class PaywallViewModelImpl(
         currentWorkflowOfferings = offerings
         currentWorkflowPresentedOfferingContext = presentedOfferingContext
         workflowNavigator = WorkflowNavigator(workflow)
+        workflowStepStateCache.clear()
+        _workflowState.value = null
 
         buildStateFromStep(initialStep, workflow, offerings, presentedOfferingContext)
     }
 
-    @Suppress("ReturnCount")
     private fun buildStateFromStep(
         step: WorkflowStep,
         workflow: PublishedWorkflow,
         offerings: Offerings,
         presentedOfferingContext: PresentedOfferingContext?,
+        fromStepId: String? = null,
+        navigationDirection: NavigationDirection = NavigationDirection.NONE,
     ) {
+        val cached = workflowStepStateCache[step.id]
+        val newState = cached ?: computeStateForStep(step, workflow, offerings, presentedOfferingContext)
+        if (cached == null && newState is PaywallState.Loaded.Components) {
+            workflowStepStateCache[step.id] = newState
+        }
+        val pendingTransition = if (fromStepId != null && navigationDirection != NavigationDirection.NONE) {
+            WorkflowPendingTransition(
+                fromStepId = fromStepId,
+                direction = navigationDirection,
+                id = ++transitionIdCounter,
+            )
+        } else {
+            null
+        }
+        // Set workflowState before _state so a recomposition that lands between the two writes
+        // sees the workflow branch and the correct step, not the single-page branch.
+        _workflowState.value = WorkflowPaywallUiState(
+            currentStepId = step.id,
+            stepStates = workflowStepStateCache.toMap(),
+            pendingTransition = pendingTransition,
+        )
+        _state.value = newState
+    }
+
+    override fun onTransitionComplete(transitionId: Int) {
+        val current = _workflowState.value ?: return
+        if (current.pendingTransition?.id == transitionId) {
+            _workflowState.value = current.copy(pendingTransition = null)
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun computeStateForStep(
+        step: WorkflowStep,
+        workflow: PublishedWorkflow,
+        offerings: Offerings,
+        presentedOfferingContext: PresentedOfferingContext?,
+    ): PaywallState {
         val screenId = step.screenId
-        if (screenId == null) {
-            _state.value = PaywallState.Error(
-                "Step '${step.id}' has no screen_id in workflow '${workflow.id}'",
-            )
-            return
-        }
-
+            ?: return PaywallState.Error("Step '${step.id}' has no screen_id in workflow '${workflow.id}'")
         val screen = workflow.screens[screenId]
-        if (screen == null) {
-            _state.value = PaywallState.Error(
-                "Screen '$screenId' not found in workflow '${workflow.id}'",
-            )
-            return
-        }
-
+            ?: return PaywallState.Error("Screen '$screenId' not found in workflow '${workflow.id}'")
         val offeringId = screen.offeringIdentifier
-        if (offeringId == null) {
-            _state.value = PaywallState.Error(
-                "Screen '$screenId' has no offering_id in workflow '${workflow.id}'",
-            )
-            return
-        }
-
+            ?: return PaywallState.Error("Screen '$screenId' has no offering_id in workflow '${workflow.id}'")
         val baseOffering = offerings[offeringId]
-        if (baseOffering == null) {
-            _state.value = PaywallState.Error(
-                "Offering '$offeringId' not found for screen '$screenId'",
-            )
-            return
-        }
+            ?: return PaywallState.Error("Offering '$offeringId' not found for screen '$screenId'")
 
         val paywallComponents = WorkflowScreenMapper.toPaywallComponents(screen, screenId, workflow.uiConfig)
-
         val offering = Offering(
             identifier = baseOffering.identifier,
             serverDescription = baseOffering.serverDescription,
@@ -780,7 +815,7 @@ internal class PaywallViewModelImpl(
         )
         val offeringWithContext = presentedOfferingContext?.let { offering.copy(it) } ?: offering
 
-        _state.value = calculateState(
+        return calculateState(
             offering = offeringWithContext,
             colorScheme = _colorScheme.value,
             storefrontCountryCode = purchases.storefrontCountryCode,
@@ -798,8 +833,21 @@ internal class PaywallViewModelImpl(
             Logger.e("Cannot navigate to step '${candidate.id}': $error")
             return
         }
-        val newStep = navigator.triggerAction(componentId, triggerType) ?: return
-        buildStateFromStep(newStep, result.workflow, offerings, currentWorkflowPresentedOfferingContext)
+        val fromStepId = navigator.currentStep()?.id
+        // triggerAction repeats the same lookup as peekTriggerStep. It should not return null
+        // given the peek succeeded, but guard anyway to avoid a hard crash.
+        val newStep = navigator.triggerAction(componentId, triggerType) ?: run {
+            Logger.e("triggerAction returned null after peekTriggerStep succeeded — this is a bug")
+            return
+        }
+        buildStateFromStep(
+            newStep,
+            result.workflow,
+            offerings,
+            currentWorkflowPresentedOfferingContext,
+            fromStepId = fromStepId,
+            navigationDirection = NavigationDirection.FORWARD,
+        )
     }
 
     @Suppress("ReturnCount")
@@ -813,8 +861,20 @@ internal class PaywallViewModelImpl(
             Logger.e("Cannot navigate back to step '${candidate.id}': $error")
             return false
         }
-        val newStep = navigator.navigateBack() ?: return false
-        buildStateFromStep(newStep, result.workflow, offerings, currentWorkflowPresentedOfferingContext)
+        val fromStepId = navigator.currentStep()?.id
+        // navigateBack should not return null given canNavigateBack is true, but guard to be safe.
+        val newStep = navigator.navigateBack() ?: run {
+            Logger.e("navigateBack returned null after canNavigateBack was true — this is a bug")
+            return false
+        }
+        buildStateFromStep(
+            newStep,
+            result.workflow,
+            offerings,
+            currentWorkflowPresentedOfferingContext,
+            fromStepId = fromStepId,
+            navigationDirection = NavigationDirection.BACKWARD,
+        )
         return true
     }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -66,6 +66,8 @@ import com.revenuecat.purchases.ui.revenuecatui.strings.PaywallValidationErrorSt
 import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
 import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowNavigator
 import com.revenuecat.purchases.ui.revenuecatui.workflow.WorkflowScreenMapper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -73,6 +75,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import java.util.Date
 import java.util.Locale
 import java.util.UUID
@@ -199,6 +202,7 @@ internal class PaywallViewModelImpl(
     private var currentWorkflowOfferings: Offerings? = null
     private var currentWorkflowPresentedOfferingContext: PresentedOfferingContext? = null
     private val workflowStepStateCache = mutableMapOf<String, PaywallState.Loaded.Components>()
+    private var preWarmJob: Job? = null
     private var transitionIdCounter: Int = 0
 
     private data class PaywallPresentationFingerprint(
@@ -743,10 +747,12 @@ internal class PaywallViewModelImpl(
         currentWorkflowOfferings = offerings
         currentWorkflowPresentedOfferingContext = presentedOfferingContext
         workflowNavigator = WorkflowNavigator(workflow)
+        preWarmJob?.cancel()
         workflowStepStateCache.clear()
         _workflowState.value = null
 
         buildStateFromStep(initialStep, workflow, offerings, presentedOfferingContext)
+        preWarmWorkflowStepCache(workflow, offerings, presentedOfferingContext)
     }
 
     private fun buildStateFromStep(
@@ -821,6 +827,30 @@ internal class PaywallViewModelImpl(
             storefrontCountryCode = purchases.storefrontCountryCode,
             mode = options.mode,
         )
+    }
+
+    /**
+     * Eagerly computes and caches states for the remaining workflow steps off the main thread,
+     * so that navigating to them doesn't block on the heavy [calculateState] work.
+     */
+    private fun preWarmWorkflowStepCache(
+        workflow: PublishedWorkflow,
+        offerings: Offerings,
+        presentedOfferingContext: PresentedOfferingContext?,
+    ) {
+        preWarmJob?.cancel()
+        preWarmJob = viewModelScope.launch {
+            for ((stepId, step) in workflow.steps) {
+                if (stepId in workflowStepStateCache) continue
+                val computed = withContext(Dispatchers.Default) {
+                    computeStateForStep(step, workflow, offerings, presentedOfferingContext)
+                }
+                if (computed is PaywallState.Loaded.Components && stepId !in workflowStepStateCache) {
+                    workflowStepStateCache[stepId] = computed
+                    _workflowState.value = _workflowState.value?.copy(stepStates = workflowStepStateCache.toMap())
+                }
+            }
+        }
     }
 
     @Suppress("ReturnCount")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -254,7 +254,12 @@ internal class PaywallViewModelImpl(
         }
         if (_colorScheme.value != colorScheme) {
             _colorScheme.value = colorScheme
-            updateState()
+            if (workflowNavigator != null) {
+                // Rebuild step states in-place to avoid resetting the user's navigation position.
+                rebuildWorkflowStepStates()
+            } else {
+                updateState()
+            }
         }
     }
 
@@ -757,6 +762,27 @@ internal class PaywallViewModelImpl(
 
         buildStateFromStep(initialStep, workflow, offerings, presentedOfferingContext)
         preWarmWorkflowStepCache(workflow, offerings, presentedOfferingContext)
+    }
+
+    /**
+     * Rebuilds workflow step states with the current color scheme without resetting the
+     * navigator position. Used when colors change while a workflow paywall is active,
+     * so the user is not silently sent back to the first step.
+     */
+    @Suppress("ReturnCount")
+    private fun rebuildWorkflowStepStates() {
+        val result = currentWorkflowResult ?: return
+        val offerings = currentWorkflowOfferings ?: return
+        val presentedOfferingContext = currentWorkflowPresentedOfferingContext
+        val navigator = workflowNavigator ?: return
+        val currentStep = navigator.currentStep() ?: return
+
+        preWarmJob?.cancel()
+        workflowStepStateCache.clear()
+        _workflowState.value = null
+
+        buildStateFromStep(currentStep, result.workflow, offerings, presentedOfferingContext)
+        preWarmWorkflowStepCache(result.workflow, offerings, presentedOfferingContext)
     }
 
     private fun buildStateFromStep(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelFactory.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.ui.revenuecatui.PaywallOptions
 import com.revenuecat.purchases.ui.revenuecatui.helpers.ResourceProvider
 
+@Suppress("LongParameterList")
 internal class PaywallViewModelFactory(
     private val resourceProvider: ResourceProvider,
     private val options: PaywallOptions,
@@ -14,6 +15,7 @@ internal class PaywallViewModelFactory(
     private val isDarkMode: Boolean,
     private val shouldDisplayBlock: ((CustomerInfo) -> Boolean)?,
     private val preview: Boolean = false,
+    private val enqueueImage: (url: String) -> Unit = { },
 ) : ViewModelProvider.NewInstanceFactory() {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -24,6 +26,7 @@ internal class PaywallViewModelFactory(
             isDarkMode = isDarkMode,
             preview = preview,
             shouldDisplayBlock = shouldDisplayBlock,
+            enqueueImage = enqueueImage,
         ) as T
     }
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WorkflowPaywallUiState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WorkflowPaywallUiState.kt
@@ -1,0 +1,39 @@
+package com.revenuecat.purchases.ui.revenuecatui.data
+
+import androidx.compose.runtime.Stable
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+
+/**
+ * Snapshot of the workflow-related state the UI needs to render a multi-step paywall.
+ *
+ * Non-null when the loaded paywall is a workflow; null otherwise. Updated atomically when the
+ * user navigates between steps; [stepStates] grows lazily as steps are visited.
+ */
+@Stable
+internal data class WorkflowPaywallUiState(
+    val currentStepId: String,
+    val stepStates: Map<String, PaywallState.Loaded.Components>,
+    /**
+     * Describes a navigation that should be animated. Set atomically with [currentStepId] so
+     * the first recomposition after navigation already knows both surfaces and can position them
+     * correctly — no gap-detection or [androidx.compose.animation.core.Animatable.snapTo] needed.
+     *
+     * Null when idle (no animation in progress or queued).
+     */
+    val pendingTransition: WorkflowPendingTransition? = null,
+)
+
+/**
+ * Describes a navigation transition that is ready to be animated.
+ *
+ * @param fromStepId the step sliding out.
+ * @param direction which way the new step enters.
+ * @param id monotonically-increasing counter used as a [androidx.compose.runtime.key] discriminator.
+ *   A fresh [androidx.compose.animation.core.Animatable] at 0f is created per distinct id, which
+ *   means the first draw of each transition already starts at the correct offscreen position.
+ */
+internal data class WorkflowPendingTransition(
+    val fromStepId: String,
+    val direction: NavigationDirection,
+    val id: Int,
+)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WorkflowPaywallUiState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/WorkflowPaywallUiState.kt
@@ -7,7 +7,8 @@ import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
  * Snapshot of the workflow-related state the UI needs to render a multi-step paywall.
  *
  * Non-null when the loaded paywall is a workflow; null otherwise. Updated atomically when the
- * user navigates between steps; [stepStates] grows lazily as steps are visited.
+ * user navigates between steps and when the background pre-warm finishes computing additional
+ * step states.
  */
 @Stable
 internal data class WorkflowPaywallUiState(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/testdata/TestData.kt
@@ -36,6 +36,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.PaywallAction
 import com.revenuecat.purchases.ui.revenuecatui.data.MockPurchasesType
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallState
 import com.revenuecat.purchases.ui.revenuecatui.data.PaywallViewModel
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
 import com.revenuecat.purchases.ui.revenuecatui.data.loadedLegacy
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.TemplateConfiguration
 import com.revenuecat.purchases.ui.revenuecatui.data.processed.VariableDataProvider
@@ -531,6 +532,7 @@ internal class MockViewModel(
         get() = _actionError
     override val purchaseCompleted: State<Boolean> = mutableStateOf(false)
     override val preloadedExitOffering: State<Offering?> = mutableStateOf(null)
+    override val workflowState: State<WorkflowPaywallUiState?> = mutableStateOf(null)
 
     fun loadedLegacyState(): PaywallState.Loaded.Legacy? {
         return state.value.loadedLegacy()
@@ -695,6 +697,12 @@ internal class MockViewModel(
     override fun handleBackNavigation(): Boolean {
         handleBackNavigationCallCount++
         return handleBackNavigationResult
+    }
+
+    var onTransitionCompleteCallCount = 0
+        private set
+    override fun onTransitionComplete(transitionId: Int) {
+        onTransitionCompleteCallCount++
     }
 
     var clearActionErrorCallCount = 0

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/NavigationDirection.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/NavigationDirection.kt
@@ -1,0 +1,7 @@
+package com.revenuecat.purchases.ui.revenuecatui.workflow
+
+internal enum class NavigationDirection {
+    NONE,
+    FORWARD,
+    BACKWARD,
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigator.kt
@@ -5,18 +5,13 @@ import com.revenuecat.purchases.common.workflows.WorkflowStep
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.ui.revenuecatui.helpers.Logger
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-
 internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
 
-    private val _currentStepId = MutableStateFlow(workflow.initialStepId)
-    val currentStepId: StateFlow<String> = _currentStepId.asStateFlow()
+    private var currentStepId: String = workflow.initialStepId
 
-    private val backStack = ArrayDeque<String>()
+    val backStack = ArrayDeque<String>()
 
-    fun currentStep(): WorkflowStep? = workflow.steps[_currentStepId.value]
+    fun currentStep(): WorkflowStep? = workflow.steps[currentStepId]
 
     @Suppress("ReturnCount")
     fun peekTriggerStep(componentId: String, triggerType: WorkflowTriggerType): WorkflowStep? {
@@ -51,15 +46,15 @@ internal class WorkflowNavigator(private val workflow: PublishedWorkflow) {
             Logger.w("Step '$stepId' not found in workflow '${workflow.id}'")
             return null
         }
-        backStack.addLast(_currentStepId.value)
-        _currentStepId.value = stepId
+        backStack.addLast(currentStepId)
+        currentStepId = stepId
         return nextStep
     }
 
     fun navigateBack(): WorkflowStep? {
         if (backStack.isEmpty()) return null
         val prevStepId = backStack.removeLast()
-        _currentStepId.value = prevStepId
+        currentStepId = prevStepId
         return workflow.steps[prevStepId]
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
@@ -1,0 +1,132 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPendingTransition
+import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class LoadedWorkflowPaywallHeaderSelectionTest {
+
+    @Test
+    fun `hero to non-hero keeps outgoing hero header while animating`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
+            ),
+        )
+
+        assertThat(selected).isEqualTo("from")
+    }
+
+    @Test
+    fun `hero to non-hero switches to target header after animation`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(pendingTransition = null),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `non-hero to hero uses incoming header immediately`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
+            ),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `non-hero to hero backward transition uses incoming header while animating`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.BACKWARD, 1),
+            ),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `non-hero to non-hero backward transition keeps outgoing header while animating`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.BACKWARD, 1),
+            ),
+        )
+
+        assertThat(selected).isEqualTo("from")
+    }
+
+    @Test
+    fun `non-hero to non-hero forward transition uses incoming header while animating`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
+            ),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `missing outgoing hero header falls back to target header`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = false),
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(
+                pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
+            ),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+
+    @Test
+    fun `idle state always uses current step header`() {
+        val selected = selectWorkflowHeaderStepId(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+            ),
+            transitionState = WorkflowHeaderTransitionState(pendingTransition = null),
+        )
+
+        assertThat(selected).isEqualTo("target")
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ShouldWrapMainContentInVerticalScrollTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/ShouldWrapMainContentInVerticalScrollTest.kt
@@ -1,0 +1,45 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.compose.foundation.gestures.Orientation
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class ShouldWrapMainContentInVerticalScrollTest {
+
+    @Test
+    fun `vertically scrolling root stack is not wrapped`() {
+        val stack = previewStackComponentStyle(
+            children = emptyList(),
+            scrollOrientation = Orientation.Vertical,
+        )
+
+        assertThat(shouldWrapMainContentInVerticalScroll(stack)).isFalse()
+    }
+
+    @Test
+    fun `horizontally scrolling root stack is wrapped`() {
+        val stack = previewStackComponentStyle(
+            children = emptyList(),
+            scrollOrientation = Orientation.Horizontal,
+        )
+
+        assertThat(shouldWrapMainContentInVerticalScroll(stack)).isTrue()
+    }
+
+    @Test
+    fun `non-scrolling root stack is wrapped`() {
+        val stack = previewStackComponentStyle(
+            children = emptyList(),
+            scrollOrientation = null,
+        )
+
+        assertThat(shouldWrapMainContentInVerticalScroll(stack)).isTrue()
+    }
+
+    @Test
+    fun `non-stack root component is wrapped`() {
+        val text = previewTextComponentStyle(text = "non-stack root")
+
+        assertThat(shouldWrapMainContentInVerticalScroll(text)).isTrue()
+    }
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -34,6 +34,12 @@ import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConf
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.common.workflows.PublishedWorkflow
+import com.revenuecat.purchases.common.workflows.WorkflowDataResult
+import com.revenuecat.purchases.common.workflows.WorkflowScreen
+import com.revenuecat.purchases.common.workflows.WorkflowStep
+import com.revenuecat.purchases.common.workflows.WorkflowTrigger
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
 import com.revenuecat.purchases.paywalls.events.PaywallComponentType
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
@@ -1292,6 +1298,130 @@ class PaywallViewModelTest {
 
         assertThat(model.state.value).isEqualTo(stateBefore)
         assertThat(dismissInvoked).isFalse()
+    }
+
+    @Test
+    fun `refreshStateIfColorsChanged on workflow preserves current navigation step`() {
+        val workflowScreen = WorkflowScreen(
+            templateName = "template",
+            revision = 0,
+            assetBaseURL = URL("https://assets.pawwalls.com"),
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = StackComponent(components = listOf(TestData.Components.monthlyPackageComponent)),
+                    background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+                    stickyFooter = null,
+                ),
+            ),
+            componentsLocalizations = localizations,
+            defaultLocaleIdentifier = defaultLocaleIdentifier,
+            offeringIdentifier = defaultOffering.identifier,
+        )
+        val stepOne = WorkflowStep(
+            id = "step-1",
+            type = "screen",
+            screenId = "screen-1",
+            triggers = listOf(
+                WorkflowTrigger(
+                    name = "Next",
+                    type = WorkflowTriggerType.ON_PRESS,
+                    actionId = "action-next",
+                    componentId = "btn-next",
+                ),
+            ),
+            triggerActions = mapOf("action-next" to WorkflowTriggerAction.Step(stepId = "step-2")),
+        )
+        val stepTwo = WorkflowStep(id = "step-2", type = "screen", screenId = "screen-1")
+        val workflow = PublishedWorkflow(
+            id = "wfl-test",
+            displayName = "Test Workflow",
+            initialStepId = "step-1",
+            steps = mapOf("step-1" to stepOne, "step-2" to stepTwo),
+            screens = mapOf("screen-1" to workflowScreen),
+            uiConfig = UiConfig(),
+        )
+        coEvery { purchases.awaitGetWorkflow(any()) } returns WorkflowDataResult(workflow, null)
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOfferingSelection(OfferingSelection.IdAndPresentedOfferingContext("wfl-test", null))
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        assertThat(model.workflowState.value?.currentStepId).isEqualTo("step-1")
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+
+        model.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        assertThat(model.workflowState.value?.currentStepId).isEqualTo("step-2")
+
+        model.refreshStateIfColorsChanged(
+            colorScheme = TestData.Constants.currentColorScheme.copy(primary = Color.Black),
+            isDark = true,
+        )
+
+        assertThat(model.workflowState.value?.currentStepId).isEqualTo("step-2")
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
+    }
+
+    @Test
+    fun `refreshStateIfColorsChanged on workflow does not trigger updateState`() {
+        // updateState would re-fetch the workflow and reset the navigator; this test verifies
+        // that rebuildWorkflowStepStates is taken instead, leaving awaitGetWorkflow call count at 1.
+        val workflowScreen = WorkflowScreen(
+            templateName = "template",
+            revision = 0,
+            assetBaseURL = URL("https://assets.pawwalls.com"),
+            componentsConfig = ComponentsConfig(
+                base = PaywallComponentsConfig(
+                    stack = StackComponent(components = listOf(TestData.Components.monthlyPackageComponent)),
+                    background = Background.Color(ColorScheme(light = ColorInfo.Hex(Color.White.toArgb()))),
+                    stickyFooter = null,
+                ),
+            ),
+            componentsLocalizations = localizations,
+            defaultLocaleIdentifier = defaultLocaleIdentifier,
+            offeringIdentifier = defaultOffering.identifier,
+        )
+        val stepOne = WorkflowStep(id = "step-1", type = "screen", screenId = "screen-1")
+        val workflow = PublishedWorkflow(
+            id = "wfl-test",
+            displayName = "Test Workflow",
+            initialStepId = "step-1",
+            steps = mapOf("step-1" to stepOne),
+            screens = mapOf("screen-1" to workflowScreen),
+            uiConfig = UiConfig(),
+        )
+        coEvery { purchases.awaitGetWorkflow(any()) } returns WorkflowDataResult(workflow, null)
+
+        val model = PaywallViewModelImpl(
+            MockResourceProvider(),
+            purchases,
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setOfferingSelection(OfferingSelection.IdAndPresentedOfferingContext("wfl-test", null))
+                .build(),
+            TestData.Constants.currentColorScheme,
+            isDarkMode = false,
+            shouldDisplayBlock = null,
+            useWorkflowsEndpoint = true,
+        )
+
+        coVerify(exactly = 1) { purchases.awaitGetWorkflow(any()) }
+
+        model.refreshStateIfColorsChanged(
+            colorScheme = TestData.Constants.currentColorScheme.copy(primary = Color.Black),
+            isDark = true,
+        )
+
+        coVerify(exactly = 1) { purchases.awaitGetWorkflow(any()) }
+        assertThat(model.state.value).isInstanceOf(PaywallState.Loaded.Components::class.java)
     }
 
     // region events

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/workflow/WorkflowNavigatorTest.kt
@@ -80,7 +80,7 @@ class WorkflowNavigatorTest {
         val result = navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
         assertThat(result).isEqualTo(step2)
         assertThat(navigator.currentStep()).isEqualTo(step2)
-        assertThat(navigator.currentStepId.value).isEqualTo("step-2")
+        assertThat(navigator.currentStep()?.id).isEqualTo("step-2")
     }
 
     @Test
@@ -182,6 +182,109 @@ class WorkflowNavigatorTest {
         assertThat(result).isNull()
         assertThat(navigator.currentStep()).isEqualTo(stepWithUnknownAction)
     }
+
+    // region backStack
+
+    @Test
+    fun `backStack is empty initially`() {
+        val navigator = WorkflowNavigator(workflow)
+        assertThat(navigator.backStack).isEmpty()
+    }
+
+    @Test
+    fun `backStack contains visited step IDs in order after forward navigation`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        navigator.triggerAction("btn-finish", WorkflowTriggerType.ON_PRESS)
+        assertThat(navigator.backStack).containsExactly("step-1", "step-2")
+    }
+
+    @Test
+    fun `backStack shrinks on navigateBack`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        navigator.triggerAction("btn-finish", WorkflowTriggerType.ON_PRESS)
+        navigator.navigateBack()
+        assertThat(navigator.backStack).containsExactly("step-1")
+    }
+
+    // endregion
+
+    // region peekBackStep
+
+    @Test
+    fun `peekBackStep is null on initial step`() {
+        val navigator = WorkflowNavigator(workflow)
+        assertThat(navigator.peekBackStep).isNull()
+    }
+
+    @Test
+    fun `peekBackStep returns previous step after forward navigation`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        assertThat(navigator.peekBackStep).isEqualTo(step1)
+    }
+
+    @Test
+    fun `peekBackStep does not modify backStack`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.triggerAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        navigator.peekBackStep
+        navigator.peekBackStep
+        assertThat(navigator.backStack).containsExactly("step-1")
+    }
+
+    // endregion
+
+    // region peekTriggerStep
+
+    @Test
+    fun `peekTriggerStep returns target step for valid trigger`() {
+        val navigator = WorkflowNavigator(workflow)
+        val result = navigator.peekTriggerStep("btn-next", WorkflowTriggerType.ON_PRESS)
+        assertThat(result).isEqualTo(step2)
+    }
+
+    @Test
+    fun `peekTriggerStep returns null for unknown componentId`() {
+        val navigator = WorkflowNavigator(workflow)
+        val result = navigator.peekTriggerStep("btn-unknown", WorkflowTriggerType.ON_PRESS)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `peekTriggerStep returns null for non-Step trigger action`() {
+        val stepWithUnknownAction = WorkflowStep(
+            id = "step-x",
+            type = "screen",
+            screenId = "screen-x",
+            triggers = listOf(
+                WorkflowTrigger(
+                    name = "X",
+                    type = WorkflowTriggerType.ON_PRESS,
+                    actionId = "ax",
+                    componentId = "btn-x",
+                ),
+            ),
+            triggerActions = mapOf("ax" to WorkflowTriggerAction.Unknown),
+        )
+        val wfl = workflow.copy(
+            initialStepId = "step-x",
+            steps = mapOf("step-x" to stepWithUnknownAction),
+        )
+        val navigator = WorkflowNavigator(wfl)
+        assertThat(navigator.peekTriggerStep("btn-x", WorkflowTriggerType.ON_PRESS)).isNull()
+    }
+
+    @Test
+    fun `peekTriggerStep does not mutate navigator state`() {
+        val navigator = WorkflowNavigator(workflow)
+        navigator.peekTriggerStep("btn-next", WorkflowTriggerType.ON_PRESS)
+        assertThat(navigator.currentStep()).isEqualTo(step1)
+        assertThat(navigator.backStack).isEmpty()
+    }
+
+    // endregion
 
     @Test
     fun `triggerAction with actionId not in triggerActions returns null and does not navigate`() {


### PR DESCRIPTION
## Summary

- Injects `useWorkflowsEndpoint: Boolean = BuildConfig.USE_WORKFLOWS_ENDPOINT` into `PaywallViewModelImpl` so tests can exercise the workflow code path without changing the compile-time flag.
- Adds two unit tests for the fix in #3419:
  1. **`refreshStateIfColorsChanged on workflow preserves current navigation step`** — navigates to step 2, toggles dark mode, asserts the user stays on step 2.
  2. **`refreshStateIfColorsChanged on workflow does not trigger updateState`** — guards against the old bug by asserting `awaitGetWorkflow` is only called once (a second call would mean `updateState()` was invoked, resetting the navigator).

## Test plan

- [ ] `./gradlew :ui:revenuecatui:testDefaultsBc8DebugUnitTest --tests "*.PaywallViewModelTest*"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new multi-step workflow rendering and background step precomputation/image preloading, which can affect paywall UI behavior, animation timing, and memory/network usage. Also changes how color-scheme refresh behaves for workflow paywalls, so regressions could impact navigation state.
> 
> **Overview**
> Adds a new workflow paywall UI path: `InternalPaywall` now renders `LoadedWorkflowPaywall` when `workflowState` is present, enabling multi-step screens with horizontal slide transitions and fixed header behavior.
> 
> Refactors the components scaffold to accept optional `headerContent`/`footerContent` and an optional `background` (nullable), and extracts `shouldWrapMainContentInVerticalScroll` to avoid double vertical-scroll crashes.
> 
> Enhances `PaywallViewModelImpl` workflow handling by injecting `useWorkflowsEndpoint`, preserving the current step on color-scheme changes via `rebuildWorkflowStepStates()`, and pre-warming workflow steps off the main thread while preloading/deduplicating all image URLs into Coil via an injected `enqueueImage` from `InternalPaywall`.
> 
> Adds unit coverage for workflow header selection during transitions, scroll-wrapping behavior, and the workflow color-scheme refresh regression (ensuring navigation isn’t reset and workflows aren’t re-fetched).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 425b66d43d5dfe4cab6c72e456c664a2cecf3693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->