### PR TITLE
Add presented offering context to custom paywall events

### DIFF
--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -38,6 +38,7 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -144,7 +145,7 @@ final class PurchasesAPI {
                 "my-offering",
                 "",
                 new HashMap<>(),
-                new java.util.ArrayList<>()
+                new ArrayList<>()
         );
         CustomPaywallImpressionParams paramsWithOfferingObject =
                 new CustomPaywallImpressionParams("my-paywall", offering);

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -10,6 +10,7 @@ import com.revenuecat.purchases.AmazonLWAConsentStatus;
 import com.revenuecat.purchases.CacheFetchPolicy;
 import com.revenuecat.purchases.CustomerInfo;
 import com.revenuecat.purchases.EntitlementVerificationMode;
+import com.revenuecat.purchases.Offering;
 import com.revenuecat.purchases.Offerings;
 import com.revenuecat.purchases.Purchases;
 import com.revenuecat.purchases.PurchasesAreCompletedBy;
@@ -139,10 +140,21 @@ final class PurchasesAPI {
         VirtualCurrencies cachedVirtualCurrencies = purchases.getCachedVirtualCurrencies();
 
         // trackCustomPaywallImpression API
+        Offering offering = new Offering(
+                "my-offering",
+                "",
+                new HashMap<>(),
+                new java.util.ArrayList<>()
+        );
+        CustomPaywallImpressionParams paramsWithOfferingObject =
+                new CustomPaywallImpressionParams("my-paywall", offering);
+        Offering offeringObject = paramsWithOfferingObject.getOffering();
         purchases.trackCustomPaywallImpression();
         purchases.trackCustomPaywallImpression(new CustomPaywallImpressionParams());
         purchases.trackCustomPaywallImpression(new CustomPaywallImpressionParams("my-paywall"));
         purchases.trackCustomPaywallImpression(new CustomPaywallImpressionParams("my-paywall", "my-offering"));
+        purchases.trackCustomPaywallImpression(paramsWithOfferingObject);
+        purchases.trackCustomPaywallImpression(new CustomPaywallImpressionParams(offering));
     }
 
     static void checkSyncAmazonPurchase(final Purchases purchases,

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.CustomerInfo;
 import com.revenuecat.purchases.EntitlementVerificationMode;
 import com.revenuecat.purchases.Offering;
 import com.revenuecat.purchases.Offerings;
+import com.revenuecat.purchases.PresentedOfferingContext;
 import com.revenuecat.purchases.Purchases;
 import com.revenuecat.purchases.PurchasesAreCompletedBy;
 import com.revenuecat.purchases.PurchasesConfiguration;
@@ -43,7 +44,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-@SuppressWarnings({"unused"})
+@SuppressWarnings({"unused", "deprecation"})
 final class PurchasesAPI {
     @OptIn(markerClass = ExperimentalPreviewRevenueCatPurchasesAPI.class)
     static void check(
@@ -149,7 +150,7 @@ final class PurchasesAPI {
         );
         CustomPaywallImpressionParams paramsWithOfferingObject =
                 new CustomPaywallImpressionParams("my-paywall", offering);
-        Offering offeringObject = paramsWithOfferingObject.getOffering();
+        PresentedOfferingContext presentedOfferingContext = paramsWithOfferingObject.getPresentedOfferingContext();
         purchases.trackCustomPaywallImpression();
         purchases.trackCustomPaywallImpression(new CustomPaywallImpressionParams());
         purchases.trackCustomPaywallImpression(new CustomPaywallImpressionParams("my-paywall"));

--- a/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
+++ b/api-tester/src/defaults/java/com/revenuecat/apitester/java/PurchasesAPI.java
@@ -39,7 +39,6 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -51,7 +50,8 @@ final class PurchasesAPI {
             final Purchases purchases,
             final WebPurchaseRedemption webPurchaseRedemption,
             final RedeemWebPurchaseListener redeemWebPurchaseListener,
-            final Intent intent
+            final Intent intent,
+            final Offering offering
             ) {
         final ReceiveCustomerInfoCallback receiveCustomerInfoListener = new ReceiveCustomerInfoCallback() {
             @Override
@@ -142,12 +142,6 @@ final class PurchasesAPI {
         VirtualCurrencies cachedVirtualCurrencies = purchases.getCachedVirtualCurrencies();
 
         // trackCustomPaywallImpression API
-        Offering offering = new Offering(
-                "my-offering",
-                "",
-                new HashMap<>(),
-                new ArrayList<>()
-        );
         CustomPaywallImpressionParams paramsWithOfferingObject =
                 new CustomPaywallImpressionParams("my-paywall", offering);
         PresentedOfferingContext presentedOfferingContext = paramsWithOfferingObject.getPresentedOfferingContext();

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.EntitlementVerificationMode
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.Purchases.Companion.sharedInstance
@@ -141,10 +142,21 @@ private class PurchasesAPI {
         val defaultParams = CustomPaywallImpressionParams()
         val paramsWithId = CustomPaywallImpressionParams(paywallId = "my-paywall")
         val paramsWithOffering = CustomPaywallImpressionParams(paywallId = "my-paywall", offeringId = "my-offering")
+        val offering = Offering(
+            identifier = "my-offering",
+            serverDescription = "",
+            metadata = emptyMap(),
+            availablePackages = emptyList(),
+        )
+        val paramsWithOfferingObject = CustomPaywallImpressionParams(paywallId = "my-paywall", offering = offering)
+        val paramsOfferingObjectOnly = CustomPaywallImpressionParams(offering = offering)
+        val offeringObject: Offering? = paramsWithOfferingObject.offering
         purchases.trackCustomPaywallImpression()
         purchases.trackCustomPaywallImpression(defaultParams)
         purchases.trackCustomPaywallImpression(paramsWithId)
         purchases.trackCustomPaywallImpression(paramsWithOffering)
+        purchases.trackCustomPaywallImpression(paramsWithOfferingObject)
+        purchases.trackCustomPaywallImpression(paramsOfferingObjectOnly)
     }
 
     @Suppress("LongParameterList")

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.Purchases.Companion.sharedInstance
 import com.revenuecat.purchases.PurchasesAreCompletedBy
@@ -150,7 +151,7 @@ private class PurchasesAPI {
         )
         val paramsWithOfferingObject = CustomPaywallImpressionParams(paywallId = "my-paywall", offering = offering)
         val paramsOfferingObjectOnly = CustomPaywallImpressionParams(offering = offering)
-        val offeringObject: Offering? = paramsWithOfferingObject.offering
+        val presentedOfferingContext: PresentedOfferingContext? = paramsWithOfferingObject.presentedOfferingContext
         purchases.trackCustomPaywallImpression()
         purchases.trackCustomPaywallImpression(defaultParams)
         purchases.trackCustomPaywallImpression(paramsWithId)

--- a/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
+++ b/api-tester/src/defaults/kotlin/com/revenuecat/apitester/kotlin/PurchasesAPI.kt
@@ -69,6 +69,7 @@ private class PurchasesAPI {
         webPurchaseRedemption: WebPurchaseRedemption,
         redeemWebPurchaseListener: RedeemWebPurchaseListener,
         intent: Intent,
+        offering: Offering,
     ) {
         val receiveCustomerInfoCallback = object : ReceiveCustomerInfoCallback {
             override fun onReceived(customerInfo: CustomerInfo) {}
@@ -143,12 +144,6 @@ private class PurchasesAPI {
         val defaultParams = CustomPaywallImpressionParams()
         val paramsWithId = CustomPaywallImpressionParams(paywallId = "my-paywall")
         val paramsWithOffering = CustomPaywallImpressionParams(paywallId = "my-paywall", offeringId = "my-offering")
-        val offering = Offering(
-            identifier = "my-offering",
-            serverDescription = "",
-            metadata = emptyMap(),
-            availablePackages = emptyList(),
-        )
         val paramsWithOfferingObject = CustomPaywallImpressionParams(paywallId = "my-paywall", offering = offering)
         val paramsOfferingObjectOnly = CustomPaywallImpressionParams(offering = offering)
         val presentedOfferingContext: PresentedOfferingContext? = paramsWithOfferingObject.presentedOfferingContext

--- a/purchases/api-defaults-bc7.txt
+++ b/purchases/api-defaults-bc7.txt
@@ -1634,10 +1634,15 @@ package com.revenuecat.purchases.paywalls.events {
 
   @dev.drewhamilton.poko.Poko public final class CustomPaywallImpressionParams {
     ctor public CustomPaywallImpressionParams();
+    ctor public CustomPaywallImpressionParams(com.revenuecat.purchases.Offering offering);
     ctor public CustomPaywallImpressionParams(optional String? paywallId);
+    ctor public CustomPaywallImpressionParams(optional String? paywallId, com.revenuecat.purchases.Offering offering);
     ctor public CustomPaywallImpressionParams(optional String? paywallId, optional String? offeringId);
+    ctor public CustomPaywallImpressionParams(optional String? paywallId, optional String? offeringId, optional com.revenuecat.purchases.Offering? offering);
+    method public com.revenuecat.purchases.Offering? getOffering();
     method public String? getOfferingId();
     method public String? getPaywallId();
+    property public final com.revenuecat.purchases.Offering? offering;
     property public final String? offeringId;
     property public final String? paywallId;
   }

--- a/purchases/api-defaults-bc7.txt
+++ b/purchases/api-defaults-bc7.txt
@@ -1637,14 +1637,13 @@ package com.revenuecat.purchases.paywalls.events {
     ctor public CustomPaywallImpressionParams(com.revenuecat.purchases.Offering offering);
     ctor public CustomPaywallImpressionParams(optional String? paywallId);
     ctor public CustomPaywallImpressionParams(optional String? paywallId, com.revenuecat.purchases.Offering offering);
-    ctor public CustomPaywallImpressionParams(optional String? paywallId, optional String? offeringId);
-    ctor public CustomPaywallImpressionParams(optional String? paywallId, optional String? offeringId, optional com.revenuecat.purchases.Offering? offering);
-    method public com.revenuecat.purchases.Offering? getOffering();
+    ctor @Deprecated public CustomPaywallImpressionParams(optional String? paywallId, String? offeringId);
     method public String? getOfferingId();
     method public String? getPaywallId();
-    property public final com.revenuecat.purchases.Offering? offering;
+    method public com.revenuecat.purchases.PresentedOfferingContext? getPresentedOfferingContext();
     property public final String? offeringId;
     property public final String? paywallId;
+    property public final com.revenuecat.purchases.PresentedOfferingContext? presentedOfferingContext;
   }
 
 }

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -1634,10 +1634,15 @@ package com.revenuecat.purchases.paywalls.events {
 
   @dev.drewhamilton.poko.Poko public final class CustomPaywallImpressionParams {
     ctor public CustomPaywallImpressionParams();
+    ctor public CustomPaywallImpressionParams(com.revenuecat.purchases.Offering offering);
     ctor public CustomPaywallImpressionParams(optional String? paywallId);
+    ctor public CustomPaywallImpressionParams(optional String? paywallId, com.revenuecat.purchases.Offering offering);
     ctor public CustomPaywallImpressionParams(optional String? paywallId, optional String? offeringId);
+    ctor public CustomPaywallImpressionParams(optional String? paywallId, optional String? offeringId, optional com.revenuecat.purchases.Offering? offering);
+    method public com.revenuecat.purchases.Offering? getOffering();
     method public String? getOfferingId();
     method public String? getPaywallId();
+    property public final com.revenuecat.purchases.Offering? offering;
     property public final String? offeringId;
     property public final String? paywallId;
   }

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -1637,14 +1637,13 @@ package com.revenuecat.purchases.paywalls.events {
     ctor public CustomPaywallImpressionParams(com.revenuecat.purchases.Offering offering);
     ctor public CustomPaywallImpressionParams(optional String? paywallId);
     ctor public CustomPaywallImpressionParams(optional String? paywallId, com.revenuecat.purchases.Offering offering);
-    ctor public CustomPaywallImpressionParams(optional String? paywallId, optional String? offeringId);
-    ctor public CustomPaywallImpressionParams(optional String? paywallId, optional String? offeringId, optional com.revenuecat.purchases.Offering? offering);
-    method public com.revenuecat.purchases.Offering? getOffering();
+    ctor @Deprecated public CustomPaywallImpressionParams(optional String? paywallId, String? offeringId);
     method public String? getOfferingId();
     method public String? getPaywallId();
-    property public final com.revenuecat.purchases.Offering? offering;
+    method public com.revenuecat.purchases.PresentedOfferingContext? getPresentedOfferingContext();
     property public final String? offeringId;
     property public final String? paywallId;
+    property public final com.revenuecat.purchases.PresentedOfferingContext? presentedOfferingContext;
   }
 
 }

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -1515,14 +1515,13 @@ package com.revenuecat.purchases.paywalls.events {
     ctor public CustomPaywallImpressionParams(com.revenuecat.purchases.Offering offering);
     ctor public CustomPaywallImpressionParams(optional String? paywallId);
     ctor public CustomPaywallImpressionParams(optional String? paywallId, com.revenuecat.purchases.Offering offering);
-    ctor public CustomPaywallImpressionParams(optional String? paywallId, optional String? offeringId);
-    ctor public CustomPaywallImpressionParams(optional String? paywallId, optional String? offeringId, optional com.revenuecat.purchases.Offering? offering);
-    method public com.revenuecat.purchases.Offering? getOffering();
+    ctor @Deprecated public CustomPaywallImpressionParams(optional String? paywallId, String? offeringId);
     method public String? getOfferingId();
     method public String? getPaywallId();
-    property public final com.revenuecat.purchases.Offering? offering;
+    method public com.revenuecat.purchases.PresentedOfferingContext? getPresentedOfferingContext();
     property public final String? offeringId;
     property public final String? paywallId;
+    property public final com.revenuecat.purchases.PresentedOfferingContext? presentedOfferingContext;
   }
 
 }

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -1512,10 +1512,15 @@ package com.revenuecat.purchases.paywalls.events {
 
   @dev.drewhamilton.poko.Poko public final class CustomPaywallImpressionParams {
     ctor public CustomPaywallImpressionParams();
+    ctor public CustomPaywallImpressionParams(com.revenuecat.purchases.Offering offering);
     ctor public CustomPaywallImpressionParams(optional String? paywallId);
+    ctor public CustomPaywallImpressionParams(optional String? paywallId, com.revenuecat.purchases.Offering offering);
     ctor public CustomPaywallImpressionParams(optional String? paywallId, optional String? offeringId);
+    ctor public CustomPaywallImpressionParams(optional String? paywallId, optional String? offeringId, optional com.revenuecat.purchases.Offering? offering);
+    method public com.revenuecat.purchases.Offering? getOffering();
     method public String? getOfferingId();
     method public String? getPaywallId();
+    property public final com.revenuecat.purchases.Offering? offering;
     property public final String? offeringId;
     property public final String? paywallId;
   }

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -677,11 +677,21 @@ public class Purchases internal constructor(
     @OptIn(InternalRevenueCatAPI::class)
     @JvmOverloads
     public fun trackCustomPaywallImpression(params: CustomPaywallImpressionParams = CustomPaywallImpressionParams()) {
+        val cachedOfferings = purchasesOrchestrator.cachedOfferings
+        val resolvedOffering = params.offering
+            ?: params.offeringId?.let { cachedOfferings?.get(it) }
+            ?: if (params.offeringId == null) cachedOfferings?.current else null
+        val presentedOfferingContext = resolvedOffering?.availablePackages?.firstOrNull()?.presentedOfferingContext
+        val offeringId = params.offeringId ?: resolvedOffering?.identifier
+
         purchasesOrchestrator.track(
             CustomPaywallEvent.Impression(
                 data = CustomPaywallEvent.Impression.Data(
                     paywallId = params.paywallId,
-                    offeringId = params.offeringId ?: purchasesOrchestrator.cachedCurrentOfferingIdentifier,
+                    offeringId = offeringId,
+                    placementIdentifier = presentedOfferingContext?.placementIdentifier,
+                    targetingRevision = presentedOfferingContext?.targetingContext?.revision,
+                    targetingRuleId = presentedOfferingContext?.targetingContext?.ruleId,
                 ),
             ),
         )

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -689,12 +689,18 @@ public class Purchases internal constructor(
             params.offeringId != null -> {
                 val resolvedOffering = cachedOfferings?.get(params.offeringId)
                 resolvedOfferingId = params.offeringId
-                resolvedPresentedOfferingContext = resolvedOffering?.availablePackages?.firstOrNull()?.presentedOfferingContext
+                resolvedPresentedOfferingContext = resolvedOffering
+                    ?.availablePackages
+                    ?.firstOrNull()
+                    ?.presentedOfferingContext
             }
             else -> {
                 val resolvedOffering = cachedOfferings?.current
                 resolvedOfferingId = resolvedOffering?.identifier
-                resolvedPresentedOfferingContext = resolvedOffering?.availablePackages?.firstOrNull()?.presentedOfferingContext
+                resolvedPresentedOfferingContext = resolvedOffering
+                    ?.availablePackages
+                    ?.firstOrNull()
+                    ?.presentedOfferingContext
             }
         }
 

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/Purchases.kt
@@ -678,20 +678,34 @@ public class Purchases internal constructor(
     @JvmOverloads
     public fun trackCustomPaywallImpression(params: CustomPaywallImpressionParams = CustomPaywallImpressionParams()) {
         val cachedOfferings = purchasesOrchestrator.cachedOfferings
-        val resolvedOffering = params.offering
-            ?: params.offeringId?.let { cachedOfferings?.get(it) }
-            ?: if (params.offeringId == null) cachedOfferings?.current else null
-        val presentedOfferingContext = resolvedOffering?.availablePackages?.firstOrNull()?.presentedOfferingContext
-        val offeringId = params.offeringId ?: resolvedOffering?.identifier
+        val resolvedOfferingId: String?
+        val resolvedPresentedOfferingContext: PresentedOfferingContext?
+
+        when {
+            params.presentedOfferingContext != null -> {
+                resolvedOfferingId = params.offeringId
+                resolvedPresentedOfferingContext = params.presentedOfferingContext
+            }
+            params.offeringId != null -> {
+                val resolvedOffering = cachedOfferings?.get(params.offeringId)
+                resolvedOfferingId = params.offeringId
+                resolvedPresentedOfferingContext = resolvedOffering?.availablePackages?.firstOrNull()?.presentedOfferingContext
+            }
+            else -> {
+                val resolvedOffering = cachedOfferings?.current
+                resolvedOfferingId = resolvedOffering?.identifier
+                resolvedPresentedOfferingContext = resolvedOffering?.availablePackages?.firstOrNull()?.presentedOfferingContext
+            }
+        }
 
         purchasesOrchestrator.track(
             CustomPaywallEvent.Impression(
                 data = CustomPaywallEvent.Impression.Data(
                     paywallId = params.paywallId,
-                    offeringId = offeringId,
-                    placementIdentifier = presentedOfferingContext?.placementIdentifier,
-                    targetingRevision = presentedOfferingContext?.targetingContext?.revision,
-                    targetingRuleId = presentedOfferingContext?.targetingContext?.ruleId,
+                    offeringId = resolvedOfferingId,
+                    placementIdentifier = resolvedPresentedOfferingContext?.placementIdentifier,
+                    targetingRevision = resolvedPresentedOfferingContext?.targetingContext?.revision,
+                    targetingRuleId = resolvedPresentedOfferingContext?.targetingContext?.ruleId,
                 ),
             ),
         )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -172,6 +172,9 @@ internal class PurchasesOrchestrator(
     val cachedCurrentOfferingIdentifier: String?
         get() = offeringsManager.cachedCurrentOfferingIdentifier
 
+    val cachedOfferings: Offerings?
+        get() = offeringsManager.cachedOfferings
+
     val currentConfiguration: PurchasesConfiguration
         get() = if (initialConfiguration.appUserID == null) {
             initialConfiguration

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
@@ -189,6 +189,8 @@ internal sealed class BackendEvent : Event {
      * @property appSessionID The session ID of the app session when this event occurred.
      * @property timestamp Unix timestamp representing when the event occurred.
      * @property paywallID The identifier of the custom paywall.
+     * @property offeringID The offering ID related to this custom paywall event.
+     * @property presentedOfferingContext The placement and targeting context for the offering, if any.
      */
     @Serializable
     @SerialName("custom_paywall_event")
@@ -205,6 +207,8 @@ internal sealed class BackendEvent : Event {
         val paywallID: String? = null,
         @SerialName("offering_id")
         val offeringID: String? = null,
+        @SerialName("presented_offering_context")
+        val presentedOfferingContext: CustomPaywallPresentedOfferingContextData? = null,
     ) : BackendEvent()
 
     /**
@@ -256,6 +260,33 @@ internal sealed class BackendEvent : Event {
             @SerialName("is_last_variant_step")
             val isLastVariantStep: Boolean? = null,
         )
+    }
+
+    @Serializable
+    data class CustomPaywallPresentedOfferingContextData(
+        @SerialName("placement_identifier")
+        val placementIdentifier: String? = null,
+        @SerialName("targeting_revision")
+        val targetingRevision: Int? = null,
+        @SerialName("targeting_rule_id")
+        val targetingRuleId: String? = null,
+    ) {
+        companion object {
+            fun from(
+                placementIdentifier: String?,
+                targetingRevision: Int?,
+                targetingRuleId: String?,
+            ): CustomPaywallPresentedOfferingContextData? {
+                if (placementIdentifier == null && targetingRevision == null && targetingRuleId == null) {
+                    return null
+                }
+                return CustomPaywallPresentedOfferingContextData(
+                    placementIdentifier = placementIdentifier,
+                    targetingRevision = targetingRevision,
+                    targetingRuleId = targetingRuleId,
+                )
+            }
+        }
     }
 
     @Serializable

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -338,6 +338,7 @@ internal fun AdEvent.FailedToLoad.toBackendStoredEvent(
  * @param appSessionID The session ID of the app session when this event occurred.
  * @return A `BackendStoredEvent.CustomPaywall` containing a `BackendEvent.CustomPaywall`.
  */
+@OptIn(InternalRevenueCatAPI::class)
 @JvmSynthetic
 internal fun CustomPaywallEvent.Impression.toBackendStoredEvent(
     appUserID: String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -353,6 +353,11 @@ internal fun CustomPaywallEvent.Impression.toBackendStoredEvent(
             timestamp = creationData.date.time,
             paywallID = data.paywallId,
             offeringID = data.offeringId,
+            presentedOfferingContext = BackendEvent.CustomPaywallPresentedOfferingContextData.from(
+                placementIdentifier = data.placementIdentifier,
+                targetingRevision = data.targetingRevision,
+                targetingRuleId = data.targetingRuleId,
+            ),
         ),
     )
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -47,6 +47,9 @@ internal class OfferingsManager(
     val cachedCurrentOfferingIdentifier: String?
         get() = offeringsCache.cachedOfferings?.current?.identifier
 
+    val cachedOfferings: Offerings?
+        get() = offeringsCache.cachedOfferings
+
     fun getOfferings(
         appUserID: String,
         appInBackground: Boolean,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/CustomPaywallEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/CustomPaywallEvent.kt
@@ -32,6 +32,9 @@ internal sealed class CustomPaywallEvent : FeatureEvent {
         internal class Data(
             val paywallId: String?,
             val offeringId: String? = null,
+            val placementIdentifier: String? = null,
+            val targetingRevision: Int? = null,
+            val targetingRuleId: String? = null,
         )
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/CustomPaywallEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/CustomPaywallEvent.kt
@@ -9,8 +9,8 @@ import java.util.UUID
 /**
  * Sealed class representing custom paywall events. Each subtype represents a specific event type.
  */
-@OptIn(InternalRevenueCatAPI::class)
-internal sealed class CustomPaywallEvent : FeatureEvent {
+@InternalRevenueCatAPI
+public sealed class CustomPaywallEvent : FeatureEvent {
 
     override val isPriorityEvent: Boolean get() = true
 
@@ -18,23 +18,23 @@ internal sealed class CustomPaywallEvent : FeatureEvent {
      * Type representing a custom paywall impression event. Meant for tracking custom paywall views.
      */
     @Poko
-    internal class Impression(
-        val creationData: CreationData = CreationData(),
-        val data: Data,
+    public class Impression(
+        public val creationData: CreationData = CreationData(),
+        public val data: Data,
     ) : CustomPaywallEvent() {
         @Poko
-        internal class CreationData(
-            val id: UUID = UUID.randomUUID(),
-            val date: Date = Date(),
+        public class CreationData(
+            public val id: UUID = UUID.randomUUID(),
+            public val date: Date = Date(),
         )
 
         @Poko
-        internal class Data(
-            val paywallId: String?,
-            val offeringId: String? = null,
-            val placementIdentifier: String? = null,
-            val targetingRevision: Int? = null,
-            val targetingRuleId: String? = null,
+        public class Data(
+            public val paywallId: String?,
+            public val offeringId: String? = null,
+            public val placementIdentifier: String? = null,
+            public val targetingRevision: Int? = null,
+            public val targetingRuleId: String? = null,
         )
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/CustomPaywallImpressionParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/CustomPaywallImpressionParams.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.paywalls.events
 
+import com.revenuecat.purchases.Offering
 import dev.drewhamilton.poko.Poko
 
 /**
@@ -7,10 +8,33 @@ import dev.drewhamilton.poko.Poko
  *
  * @property paywallId An optional identifier for the custom paywall being shown.
  * @property offeringId An optional identifier for the offering associated with the custom paywall.
- * If not provided, the SDK will use the current offering identifier from the cache.
+ * If neither [offeringId] nor [offering] is provided, the SDK will use the current offering
+ * identifier from the cache.
+ * @property offering An optional [Offering] associated with the custom paywall. When provided, the
+ * SDK will derive both the offering identifier and the presented offering context (placement and
+ * targeting information) from this offering.
  */
 @Poko
 public class CustomPaywallImpressionParams @JvmOverloads constructor(
     public val paywallId: String? = null,
     public val offeringId: String? = null,
-)
+    public val offering: Offering? = null,
+) {
+    /**
+     * Creates parameters for a custom paywall impression from the offering it was obtained from.
+     *
+     * Use this constructor when presenting a paywall for an offering that is not the current
+     * offering (for example, a placement-resolved offering). The SDK will derive both the offering
+     * identifier and the presented offering context (placement and targeting information) from
+     * the provided offering.
+     *
+     * @param paywallId An optional identifier for the custom paywall being shown.
+     * @param offering The [Offering] associated with the custom paywall.
+     */
+    @JvmOverloads
+    public constructor(paywallId: String? = null, offering: Offering) : this(
+        paywallId = paywallId,
+        offeringId = offering.identifier,
+        offering = offering,
+    )
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/CustomPaywallImpressionParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/CustomPaywallImpressionParams.kt
@@ -1,6 +1,8 @@
 package com.revenuecat.purchases.paywalls.events
 
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.PresentedOfferingContext
 import dev.drewhamilton.poko.Poko
 
 /**
@@ -8,20 +10,53 @@ import dev.drewhamilton.poko.Poko
  *
  * @property paywallId An optional identifier for the custom paywall being shown.
  * @property offeringId An optional identifier for the offering associated with the custom paywall.
- * If neither [offeringId] nor [offering] is provided, the SDK will use the current offering
+ * If neither [offeringId] nor an [Offering] is provided, the SDK will use the current offering
  * identifier from the cache.
- * @property offering An optional [Offering] associated with the custom paywall. When provided, the
- * SDK will derive both the offering identifier and the presented offering context (placement and
- * targeting information) from this offering.
+ * @property presentedOfferingContext The presented offering context (placement and targeting
+ * information) derived from the offering, if available.
  */
 @Poko
-public class CustomPaywallImpressionParams @JvmOverloads constructor(
-    public val paywallId: String? = null,
-    public val offeringId: String? = null,
-    public val offering: Offering? = null,
+public class CustomPaywallImpressionParams @InternalRevenueCatAPI constructor(
+    public val paywallId: String?,
+    public val offeringId: String?,
+    public val presentedOfferingContext: PresentedOfferingContext?,
 ) {
     /**
-     * Creates parameters for a custom paywall impression from the offering it was obtained from.
+     * Creates parameters with no offering information. The SDK will use the current offering
+     * identifier and context from the cache.
+     *
+     * @param paywallId An optional identifier for the custom paywall being shown.
+     */
+    @JvmOverloads
+    @OptIn(InternalRevenueCatAPI::class)
+    public constructor(paywallId: String? = null) : this(
+        paywallId = paywallId,
+        offeringId = null,
+        presentedOfferingContext = null,
+    )
+
+    /**
+     * Creates parameters with an offering identifier string.
+     *
+     * @param paywallId An optional identifier for the custom paywall being shown.
+     * @param offeringId The identifier for the offering associated with the custom paywall.
+     * @deprecated Pass an [Offering] object instead. Using an offering identifier string prevents
+     * the SDK from deriving placement and targeting context automatically.
+     */
+    @Deprecated(
+        message = "Pass an Offering object instead. Using an offering identifier string prevents " +
+            "the SDK from deriving placement and targeting context automatically.",
+        replaceWith = ReplaceWith("CustomPaywallImpressionParams(paywallId, offering)"),
+    )
+    @OptIn(InternalRevenueCatAPI::class)
+    public constructor(paywallId: String? = null, offeringId: String?) : this(
+        paywallId = paywallId,
+        offeringId = offeringId,
+        presentedOfferingContext = null,
+    )
+
+    /**
+     * Creates parameters from the offering the paywall was obtained from.
      *
      * Use this constructor when presenting a paywall for an offering that is not the current
      * offering (for example, a placement-resolved offering). The SDK will derive both the offering
@@ -32,9 +67,10 @@ public class CustomPaywallImpressionParams @JvmOverloads constructor(
      * @param offering The [Offering] associated with the custom paywall.
      */
     @JvmOverloads
+    @OptIn(InternalRevenueCatAPI::class)
     public constructor(paywallId: String? = null, offering: Offering) : this(
         paywallId = paywallId,
         offeringId = offering.identifier,
-        offering = offering,
+        presentedOfferingContext = offering.availablePackages.firstOrNull()?.presentedOfferingContext,
     )
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/CustomPaywallEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/CustomPaywallEventTest.kt
@@ -1,8 +1,13 @@
 package com.revenuecat.purchases.paywalls.events
 
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Package
+import com.revenuecat.purchases.PackageType
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.common.events.BackendEvent
 import com.revenuecat.purchases.common.events.BackendStoredEvent
 import com.revenuecat.purchases.common.events.toBackendStoredEvent
+import com.revenuecat.purchases.utils.stubStoreProduct
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
@@ -353,5 +358,241 @@ class CustomPaywallEventTest {
         val jsonString = json.encodeToString(BackendStoredEvent.serializer(), storedEvent)
 
         assertThat(jsonString).contains("\"app_session_id\":\"$appSessionID\"")
+    }
+
+    // region Params: Offering-based init
+
+    @Test
+    fun `CustomPaywallImpressionParams default has null offering`() {
+        val params = CustomPaywallImpressionParams()
+        assertThat(params.offering).isNull()
+    }
+
+    @Test
+    fun `CustomPaywallImpressionParams string-id init does not store offering`() {
+        val params = CustomPaywallImpressionParams(paywallId = "pw", offeringId = "my-offering")
+        assertThat(params.offering).isNull()
+    }
+
+    @Test
+    fun `CustomPaywallImpressionParams Offering-based init populates offeringId from offering`() {
+        val offering = makeOffering(identifier = "my-offering")
+        val params = CustomPaywallImpressionParams(paywallId = "pw", offering = offering)
+
+        assertThat(params.paywallId).isEqualTo("pw")
+        assertThat(params.offeringId).isEqualTo("my-offering")
+    }
+
+    @Test
+    fun `CustomPaywallImpressionParams Offering-based init stores offering`() {
+        val offering = makeOffering(identifier = "my-offering")
+        val params = CustomPaywallImpressionParams(paywallId = "pw", offering = offering)
+
+        assertThat(params.offering).isSameAs(offering)
+    }
+
+    @Test
+    fun `CustomPaywallImpressionParams Offering-only init defaults paywallId to null`() {
+        val offering = makeOffering(identifier = "offering_1")
+        val params = CustomPaywallImpressionParams(offering = offering)
+
+        assertThat(params.paywallId).isNull()
+        assertThat(params.offeringId).isEqualTo("offering_1")
+        assertThat(params.offering).isSameAs(offering)
+    }
+
+    // endregion
+
+    // region Data: placement and targeting fields
+
+    @Test
+    fun `CustomPaywallEvent Data placement and targeting default to null`() {
+        val data = CustomPaywallEvent.Impression.Data(paywallId = "pw", offeringId = "off")
+
+        assertThat(data.placementIdentifier).isNull()
+        assertThat(data.targetingRevision).isNull()
+        assertThat(data.targetingRuleId).isNull()
+    }
+
+    @Test
+    fun `CustomPaywallEvent Data preserves placement and targeting`() {
+        val data = CustomPaywallEvent.Impression.Data(
+            paywallId = "pw",
+            offeringId = "off",
+            placementIdentifier = "home_banner",
+            targetingRevision = 3,
+            targetingRuleId = "rule_abc123",
+        )
+
+        assertThat(data.placementIdentifier).isEqualTo("home_banner")
+        assertThat(data.targetingRevision).isEqualTo(3)
+        assertThat(data.targetingRuleId).isEqualTo("rule_abc123")
+    }
+
+    // endregion
+
+    // region toBackendStoredEvent: presented offering context
+
+    @Test
+    fun `toBackendStoredEvent populates presentedOfferingContext when all fields set`() {
+        val event = CustomPaywallEvent.Impression(
+            creationData = CustomPaywallEvent.Impression.CreationData(id = fixedId, date = fixedDate),
+            data = CustomPaywallEvent.Impression.Data(
+                paywallId = "pw",
+                offeringId = "off",
+                placementIdentifier = "home_banner",
+                targetingRevision = 3,
+                targetingRuleId = "rule_abc123",
+            ),
+        )
+
+        val storedEvent = event.toBackendStoredEvent(appUserID, appSessionID) as BackendStoredEvent.CustomPaywall
+
+        assertThat(storedEvent.event.presentedOfferingContext).isEqualTo(
+            BackendEvent.CustomPaywallPresentedOfferingContextData(
+                placementIdentifier = "home_banner",
+                targetingRevision = 3,
+                targetingRuleId = "rule_abc123",
+            ),
+        )
+    }
+
+    @Test
+    fun `toBackendStoredEvent populates presentedOfferingContext with placement only`() {
+        val event = CustomPaywallEvent.Impression(
+            creationData = CustomPaywallEvent.Impression.CreationData(id = fixedId, date = fixedDate),
+            data = CustomPaywallEvent.Impression.Data(
+                paywallId = "pw",
+                offeringId = "off",
+                placementIdentifier = "home_banner",
+            ),
+        )
+
+        val storedEvent = event.toBackendStoredEvent(appUserID, appSessionID) as BackendStoredEvent.CustomPaywall
+
+        assertThat(storedEvent.event.presentedOfferingContext).isEqualTo(
+            BackendEvent.CustomPaywallPresentedOfferingContextData(placementIdentifier = "home_banner"),
+        )
+    }
+
+    @Test
+    fun `toBackendStoredEvent leaves presentedOfferingContext null when all fields null`() {
+        val event = CustomPaywallEvent.Impression(
+            creationData = CustomPaywallEvent.Impression.CreationData(id = fixedId, date = fixedDate),
+            data = CustomPaywallEvent.Impression.Data(paywallId = "pw", offeringId = "off"),
+        )
+
+        val storedEvent = event.toBackendStoredEvent(appUserID, appSessionID) as BackendStoredEvent.CustomPaywall
+
+        assertThat(storedEvent.event.presentedOfferingContext).isNull()
+    }
+
+    // endregion
+
+    // region Wire encoding: presented_offering_context
+
+    @Test
+    fun `BackendStoredEvent CustomPaywall JSON nests presented_offering_context with all fields`() {
+        val event = CustomPaywallEvent.Impression(
+            creationData = CustomPaywallEvent.Impression.CreationData(id = fixedId, date = fixedDate),
+            data = CustomPaywallEvent.Impression.Data(
+                paywallId = "pw",
+                offeringId = "off",
+                placementIdentifier = "home_banner",
+                targetingRevision = 3,
+                targetingRuleId = "rule_abc123",
+            ),
+        )
+        val storedEvent = event.toBackendStoredEvent(appUserID, appSessionID)
+
+        val jsonString = json.encodeToString(BackendStoredEvent.serializer(), storedEvent)
+
+        assertThat(jsonString).contains(
+            "\"presented_offering_context\":{" +
+                "\"placement_identifier\":\"home_banner\"," +
+                "\"targeting_revision\":3," +
+                "\"targeting_rule_id\":\"rule_abc123\"" +
+                "}",
+        )
+    }
+
+    @Test
+    fun `BackendStoredEvent CustomPaywall JSON nests presented_offering_context with placement only`() {
+        val event = CustomPaywallEvent.Impression(
+            creationData = CustomPaywallEvent.Impression.CreationData(id = fixedId, date = fixedDate),
+            data = CustomPaywallEvent.Impression.Data(
+                paywallId = "pw",
+                offeringId = "off",
+                placementIdentifier = "home_banner",
+            ),
+        )
+        val storedEvent = event.toBackendStoredEvent(appUserID, appSessionID)
+
+        val jsonString = json.encodeToString(BackendStoredEvent.serializer(), storedEvent)
+
+        assertThat(jsonString).contains("\"presented_offering_context\":{\"placement_identifier\":\"home_banner\"}")
+        assertThat(jsonString).doesNotContain("\"targeting_revision\"")
+        assertThat(jsonString).doesNotContain("\"targeting_rule_id\"")
+    }
+
+    @Test
+    fun `BackendStoredEvent CustomPaywall JSON omits presented_offering_context when null`() {
+        val event = CustomPaywallEvent.Impression(
+            creationData = CustomPaywallEvent.Impression.CreationData(id = fixedId, date = fixedDate),
+            data = CustomPaywallEvent.Impression.Data(paywallId = "pw", offeringId = "off"),
+        )
+        val storedEvent = event.toBackendStoredEvent(appUserID, appSessionID)
+
+        val jsonString = json.encodeToString(BackendStoredEvent.serializer(), storedEvent)
+
+        assertThat(jsonString).doesNotContain("presented_offering_context")
+    }
+
+    @Test
+    fun `BackendStoredEvent CustomPaywall JSON roundtrip preserves presented_offering_context`() {
+        val event = CustomPaywallEvent.Impression(
+            creationData = CustomPaywallEvent.Impression.CreationData(id = fixedId, date = fixedDate),
+            data = CustomPaywallEvent.Impression.Data(
+                paywallId = "pw",
+                offeringId = "off",
+                placementIdentifier = "home_banner",
+                targetingRevision = 3,
+                targetingRuleId = "rule_abc123",
+            ),
+        )
+        val storedEvent = event.toBackendStoredEvent(appUserID, appSessionID)
+
+        val jsonString = json.encodeToString(BackendStoredEvent.serializer(), storedEvent)
+        val decoded = json.decodeFromString(BackendStoredEvent.serializer(), jsonString)
+
+        val decodedEvent = (decoded as BackendStoredEvent.CustomPaywall).event
+        assertThat(decodedEvent.presentedOfferingContext).isEqualTo(
+            BackendEvent.CustomPaywallPresentedOfferingContextData(
+                placementIdentifier = "home_banner",
+                targetingRevision = 3,
+                targetingRuleId = "rule_abc123",
+            ),
+        )
+    }
+
+    // endregion
+
+    private fun makeOffering(
+        identifier: String,
+        presentedOfferingContext: PresentedOfferingContext = PresentedOfferingContext(identifier),
+    ): Offering {
+        val storeProduct = stubStoreProduct("monthly_product")
+        val packageObject = Package(
+            identifier = "\$rc_monthly",
+            packageType = PackageType.MONTHLY,
+            product = storeProduct,
+            presentedOfferingContext = presentedOfferingContext,
+        )
+        return Offering(
+            identifier = identifier,
+            serverDescription = "",
+            metadata = emptyMap(),
+            availablePackages = listOf(packageObject),
+        )
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/CustomPaywallEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/CustomPaywallEventTest.kt
@@ -363,15 +363,16 @@ class CustomPaywallEventTest {
     // region Params: Offering-based init
 
     @Test
-    fun `CustomPaywallImpressionParams default has null offering`() {
+    fun `CustomPaywallImpressionParams default has null presentedOfferingContext`() {
         val params = CustomPaywallImpressionParams()
-        assertThat(params.offering).isNull()
+        assertThat(params.presentedOfferingContext).isNull()
     }
 
     @Test
-    fun `CustomPaywallImpressionParams string-id init does not store offering`() {
+    @Suppress("DEPRECATION")
+    fun `CustomPaywallImpressionParams string-id init has null presentedOfferingContext`() {
         val params = CustomPaywallImpressionParams(paywallId = "pw", offeringId = "my-offering")
-        assertThat(params.offering).isNull()
+        assertThat(params.presentedOfferingContext).isNull()
     }
 
     @Test
@@ -384,11 +385,12 @@ class CustomPaywallEventTest {
     }
 
     @Test
-    fun `CustomPaywallImpressionParams Offering-based init stores offering`() {
+    fun `CustomPaywallImpressionParams Offering-based init stores presentedOfferingContext`() {
         val offering = makeOffering(identifier = "my-offering")
         val params = CustomPaywallImpressionParams(paywallId = "pw", offering = offering)
 
-        assertThat(params.offering).isSameAs(offering)
+        val expectedContext = offering.availablePackages.first().presentedOfferingContext
+        assertThat(params.presentedOfferingContext).isEqualTo(expectedContext)
     }
 
     @Test
@@ -396,9 +398,10 @@ class CustomPaywallEventTest {
         val offering = makeOffering(identifier = "offering_1")
         val params = CustomPaywallImpressionParams(offering = offering)
 
+        val expectedContext = offering.availablePackages.first().presentedOfferingContext
         assertThat(params.paywallId).isNull()
         assertThat(params.offeringId).isEqualTo("offering_1")
-        assertThat(params.offering).isSameAs(offering)
+        assertThat(params.presentedOfferingContext).isEqualTo(expectedContext)
     }
 
     // endregion

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -32,6 +32,8 @@ import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreReplacementMode
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.paywalls.DownloadedFontFamily
+import com.revenuecat.purchases.paywalls.events.CustomPaywallEvent
+import com.revenuecat.purchases.paywalls.events.CustomPaywallImpressionParams
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventType
 import com.revenuecat.purchases.utils.Responses
@@ -1543,6 +1545,174 @@ internal class PurchasesTest : BasePurchasesTest() {
     }
 
     // endregion track events
+
+    // region trackCustomPaywallImpression presented offering context resolution
+
+    @OptIn(InternalRevenueCatAPI::class)
+    @Test
+    fun `trackCustomPaywallImpression derives context from cached current offering`() {
+        val context = PresentedOfferingContext(
+            offeringIdentifier = "current_offering",
+            placementIdentifier = "home_banner",
+            targetingContext = PresentedOfferingContext.TargetingContext(revision = 3, ruleId = "rule_abc123"),
+        )
+        val offering = makeOfferingWithContext(identifier = "current_offering", context = context)
+        every { mockOfferingsManager.cachedOfferings } returns Offerings(
+            current = offering,
+            all = mapOf(offering.identifier to offering),
+        )
+        val capturedEvent = slot<CustomPaywallEvent>()
+        every { mockEventsManager.track(capture(capturedEvent)) } just Runs
+
+        purchases.trackCustomPaywallImpression(CustomPaywallImpressionParams(paywallId = "pw"))
+
+        val data = (capturedEvent.captured as CustomPaywallEvent.Impression).data
+        assertThat(data.offeringId).isEqualTo("current_offering")
+        assertThat(data.placementIdentifier).isEqualTo("home_banner")
+        assertThat(data.targetingRevision).isEqualTo(3)
+        assertThat(data.targetingRuleId).isEqualTo("rule_abc123")
+    }
+
+    @OptIn(InternalRevenueCatAPI::class)
+    @Test
+    fun `trackCustomPaywallImpression derives context from cached offering matching passed id`() {
+        val currentContext = PresentedOfferingContext(
+            offeringIdentifier = "current_offering",
+            placementIdentifier = "current_placement",
+            targetingContext = PresentedOfferingContext.TargetingContext(revision = 1, ruleId = "current_rule"),
+        )
+        val otherContext = PresentedOfferingContext(
+            offeringIdentifier = "other_offering",
+            placementIdentifier = "other_placement",
+            targetingContext = PresentedOfferingContext.TargetingContext(revision = 5, ruleId = "other_rule"),
+        )
+        val currentOffering = makeOfferingWithContext("current_offering", currentContext)
+        val otherOffering = makeOfferingWithContext("other_offering", otherContext)
+        every { mockOfferingsManager.cachedOfferings } returns Offerings(
+            current = currentOffering,
+            all = mapOf(
+                currentOffering.identifier to currentOffering,
+                otherOffering.identifier to otherOffering,
+            ),
+        )
+        val capturedEvent = slot<CustomPaywallEvent>()
+        every { mockEventsManager.track(capture(capturedEvent)) } just Runs
+
+        purchases.trackCustomPaywallImpression(
+            CustomPaywallImpressionParams(paywallId = "pw", offeringId = "other_offering"),
+        )
+
+        val data = (capturedEvent.captured as CustomPaywallEvent.Impression).data
+        assertThat(data.offeringId).isEqualTo("other_offering")
+        assertThat(data.placementIdentifier).isEqualTo("other_placement")
+        assertThat(data.targetingRevision).isEqualTo(5)
+        assertThat(data.targetingRuleId).isEqualTo("other_rule")
+    }
+
+    @OptIn(InternalRevenueCatAPI::class)
+    @Test
+    fun `trackCustomPaywallImpression leaves context null when passed id not in cache`() {
+        val currentContext = PresentedOfferingContext(
+            offeringIdentifier = "current_offering",
+            placementIdentifier = "current_placement",
+            targetingContext = PresentedOfferingContext.TargetingContext(revision = 1, ruleId = "current_rule"),
+        )
+        val currentOffering = makeOfferingWithContext("current_offering", currentContext)
+        every { mockOfferingsManager.cachedOfferings } returns Offerings(
+            current = currentOffering,
+            all = mapOf(currentOffering.identifier to currentOffering),
+        )
+        val capturedEvent = slot<CustomPaywallEvent>()
+        every { mockEventsManager.track(capture(capturedEvent)) } just Runs
+
+        purchases.trackCustomPaywallImpression(
+            CustomPaywallImpressionParams(paywallId = "pw", offeringId = "unknown_offering"),
+        )
+
+        val data = (capturedEvent.captured as CustomPaywallEvent.Impression).data
+        assertThat(data.offeringId).isEqualTo("unknown_offering")
+        assertThat(data.placementIdentifier).isNull()
+        assertThat(data.targetingRevision).isNull()
+        assertThat(data.targetingRuleId).isNull()
+    }
+
+    @OptIn(InternalRevenueCatAPI::class)
+    @Test
+    fun `trackCustomPaywallImpression uses passed offering context`() {
+        val cachedContext = PresentedOfferingContext(
+            offeringIdentifier = "current_offering",
+            placementIdentifier = "cached_placement",
+            targetingContext = PresentedOfferingContext.TargetingContext(revision = 1, ruleId = "cached_rule"),
+        )
+        val cachedOffering = makeOfferingWithContext("current_offering", cachedContext)
+        every { mockOfferingsManager.cachedOfferings } returns Offerings(
+            current = cachedOffering,
+            all = mapOf(cachedOffering.identifier to cachedOffering),
+        )
+
+        val passedContext = PresentedOfferingContext(
+            offeringIdentifier = "passed_offering",
+            placementIdentifier = "passed_placement",
+            targetingContext = PresentedOfferingContext.TargetingContext(revision = 7, ruleId = "passed_rule"),
+        )
+        val passedOffering = makeOfferingWithContext("passed_offering", passedContext)
+        val capturedEvent = slot<CustomPaywallEvent>()
+        every { mockEventsManager.track(capture(capturedEvent)) } just Runs
+
+        purchases.trackCustomPaywallImpression(
+            CustomPaywallImpressionParams(paywallId = "pw", offering = passedOffering),
+        )
+
+        val data = (capturedEvent.captured as CustomPaywallEvent.Impression).data
+        assertThat(data.offeringId).isEqualTo("passed_offering")
+        assertThat(data.placementIdentifier).isEqualTo("passed_placement")
+        assertThat(data.targetingRevision).isEqualTo(7)
+        assertThat(data.targetingRuleId).isEqualTo("passed_rule")
+    }
+
+    @OptIn(InternalRevenueCatAPI::class)
+    @Test
+    fun `trackCustomPaywallImpression leaves context null when cached offering has no context`() {
+        val offering = makeOfferingWithContext(
+            identifier = "current_offering",
+            context = PresentedOfferingContext("current_offering"),
+        )
+        every { mockOfferingsManager.cachedOfferings } returns Offerings(
+            current = offering,
+            all = mapOf(offering.identifier to offering),
+        )
+        val capturedEvent = slot<CustomPaywallEvent>()
+        every { mockEventsManager.track(capture(capturedEvent)) } just Runs
+
+        purchases.trackCustomPaywallImpression(CustomPaywallImpressionParams(paywallId = "pw"))
+
+        val data = (capturedEvent.captured as CustomPaywallEvent.Impression).data
+        assertThat(data.offeringId).isEqualTo("current_offering")
+        assertThat(data.placementIdentifier).isNull()
+        assertThat(data.targetingRevision).isNull()
+        assertThat(data.targetingRuleId).isNull()
+    }
+
+    private fun makeOfferingWithContext(
+        identifier: String,
+        context: PresentedOfferingContext,
+    ): Offering {
+        val storeProduct = stubStoreProduct("monthly_$identifier")
+        val packageObject = Package(
+            identifier = "\$rc_monthly",
+            packageType = PackageType.MONTHLY,
+            product = storeProduct,
+            presentedOfferingContext = context,
+        )
+        return Offering(
+            identifier = identifier,
+            serverDescription = "",
+            metadata = emptyMap(),
+            availablePackages = listOf(packageObject),
+        )
+    }
+
+    // endregion trackCustomPaywallImpression presented offering context resolution
 
     @Test
     fun `Setting platform info sets it in the AppConfig when configuring the SDK`() {

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -1574,6 +1574,7 @@ internal class PurchasesTest : BasePurchasesTest() {
     }
 
     @OptIn(InternalRevenueCatAPI::class)
+    @Suppress("DEPRECATION")
     @Test
     fun `trackCustomPaywallImpression derives context from cached offering matching passed id`() {
         val currentContext = PresentedOfferingContext(
@@ -1609,6 +1610,7 @@ internal class PurchasesTest : BasePurchasesTest() {
         assertThat(data.targetingRuleId).isEqualTo("other_rule")
     }
 
+    @Suppress("DEPRECATION")
     @OptIn(InternalRevenueCatAPI::class)
     @Test
     fun `trackCustomPaywallImpression leaves context null when passed id not in cache`() {


### PR DESCRIPTION
### Description

Adds `placement_identifier`, `targeting_revision`, and `targeting_rule_id` to the custom paywall impression event.

Mirrors the event payload work in iOS PR https://github.com/RevenueCat/purchases-ios/pull/6707 for Android. The internal paywall events already received this context via #3253; this PR brings the same placement/targeting attribution to custom paywall events.

### What's new

- `CustomPaywallImpressionParams` gains an `Offering`-based constructor. Passing an `Offering` lets the SDK derive the offering identifier and `PresentedOfferingContext` from the offering's first available package.
- The params object stores `paywallId`, `offeringId`, and `presentedOfferingContext`; it does not store or expose the `Offering` object. This keeps the public params surface focused on the values needed for event tracking.
- The string `offeringId` constructor is deprecated in favor of passing an `Offering`, because an offering identifier alone cannot reliably carry placement and targeting context.
- An `@InternalRevenueCatAPI` constructor accepts `paywallId`, `offeringId`, and `presentedOfferingContext` directly, so hybrid SDKs can pass the context through PHC to native without exposing `Offering` on the public params API.
- `Purchases.trackCustomPaywallImpression(params)` resolves event data with this fallback chain:

  | Developer passes | `offering_id` sent | context sent |
  | --- | --- | --- |
  | Nothing (or only `paywallId`) | from `cachedOfferings.current` | from current offering |
  | Deprecated `offeringId` matching cache | passed string | from cached match |
  | Deprecated `offeringId` not in cache | passed string | nil |
  | `Offering` object | from offering | derived from offering |
  | Internal `presentedOfferingContext` | passed `offeringId` | passed context |

- `CustomPaywallEvent.Impression.Data` carries flat `placementIdentifier` / `targetingRevision` / `targetingRuleId` fields, mirroring the existing internal `PaywallEvent` Android shape.
- The wire payload nests these under `presented_offering_context`. The custom paywall event has its own `BackendEvent.CustomPaywallPresentedOfferingContextData` rather than reusing the internal paywall event's struct, matching the iOS approach where each event owns its own.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API surface changes (new constructors, deprecation) and analytics event schema updates; behavior is localized to custom paywall tracking rather than purchases or auth.
> 
> **Overview**
> Custom paywall impression tracking now sends **placement and targeting context** (placement identifier, targeting revision, rule id) on the backend event, nested as `presented_offering_context`, aligning custom paywalls with internal paywall analytics.
> 
> **`CustomPaywallImpressionParams`** adds constructors that take an **`Offering`** (or offering-only) so the SDK can set `offeringId` and `presentedOfferingContext` from the offering’s first package. The **`offeringId` string constructor is deprecated** in favor of `Offering`. Params expose `presentedOfferingContext` but not the offering object itself.
> 
> **`Purchases.trackCustomPaywallImpression`** resolves what gets tracked: explicit context from params, lookup from **cached offerings** when only an offering id or nothing is passed, or values taken directly from a passed **`Offering`**.
> 
> Wire and storage paths extend **`CustomPaywallEvent.Impression.Data`** and **`BackendEvent.CustomPaywall`** with the new fields; **`cachedOfferings`** is exposed on the orchestrator/offerings manager to support resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3369c13d4aa1fa9b1904c4ca8d272c0c57c73d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->