### PR TITLE
Fix paywall layout direction for RTL locale overrides (PWENG-39)

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.revenuecat.purchases.CustomerInfo
@@ -56,6 +57,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.getActivity
 import com.revenuecat.purchases.ui.revenuecatui.helpers.isInPreviewMode
 import com.revenuecat.purchases.ui.revenuecatui.helpers.paywallProductIdentifier
 import com.revenuecat.purchases.ui.revenuecatui.helpers.paywallPurchaseButtonAction
+import com.revenuecat.purchases.ui.revenuecatui.helpers.toLayoutDirection
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toResourceProvider
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template1
 import com.revenuecat.purchases.ui.revenuecatui.templates.Template2
@@ -264,6 +266,7 @@ private fun LoadedPaywall(
             LocalActivity provides activity,
             LocalContext provides state.contextWithConfiguration(configuration),
             LocalConfiguration provides configuration,
+            LocalLayoutDirection provides state.templateConfiguration.locale.toLayoutDirection(),
         ) {
             TemplatePaywall(state = state, viewModel = viewModel)
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -261,12 +261,15 @@ private fun LoadedPaywall(
         modifier = Modifier.screenModeBackground(state.isInFullScreenMode, backgroundColor),
     ) {
         val configuration = state.configurationWithOverriddenLocale()
+        val layoutDirection = remember(state.templateConfiguration.locale) {
+            state.templateConfiguration.locale.toLayoutDirection()
+        }
 
         CompositionLocalProvider(
             LocalActivity provides activity,
             LocalContext provides state.contextWithConfiguration(configuration),
             LocalConfiguration provides configuration,
-            LocalLayoutDirection provides state.templateConfiguration.locale.toLayoutDirection(),
+            LocalLayoutDirection provides layoutDirection,
         ) {
             TemplatePaywall(state = state, viewModel = viewModel)
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -11,12 +11,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.offset
 import com.revenuecat.purchases.InternalRevenueCatAPI
@@ -49,6 +51,7 @@ import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fi
 import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fit
 import com.revenuecat.purchases.paywalls.components.properties.TwoDimensionalAlignment
 import com.revenuecat.purchases.paywalls.components.properties.TwoDimensionalAlignment.BOTTOM
+import com.revenuecat.purchases.ui.revenuecatui.components.ktx.toJavaLocale
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
@@ -69,6 +72,7 @@ import com.revenuecat.purchases.ui.revenuecatui.helpers.getOrThrow
 import com.revenuecat.purchases.ui.revenuecatui.helpers.paywallPackageSelectionSheetClose
 import com.revenuecat.purchases.ui.revenuecatui.helpers.paywallPackageSelectionSheetOpen
 import com.revenuecat.purchases.ui.revenuecatui.helpers.toComponentsPaywallState
+import com.revenuecat.purchases.ui.revenuecatui.helpers.toLayoutDirection
 import java.net.URL
 import java.util.Date
 
@@ -92,26 +96,28 @@ internal fun LoadedPaywallComponents(
         (state.stack as? StackComponentStyle)?.scrollOrientation != Orientation.Vertical
     val mainScrollState = rememberScrollState()
 
-    PaywallComponentsScaffold(
-        state = state,
-        clickHandler = clickHandler,
-        componentInteractionTracker = componentInteractionTracker,
-        modifier = modifier,
-    ) {
-        ComponentView(
-            style = state.stack,
+    CompositionLocalProvider(LocalLayoutDirection provides state.locale.toJavaLocale().toLayoutDirection()) {
+        PaywallComponentsScaffold(
             state = state,
-            onClick = onClick,
+            clickHandler = clickHandler,
             componentInteractionTracker = componentInteractionTracker,
-            modifier = Modifier
-                .fillMaxSize()
-                .conditional(shouldWrapMainContentInVerticalScroll) {
-                    verticalScroll(mainScrollState)
-                }
-                .conditional(state.header != null && !state.mainStackHasHeroImage) {
-                    headerTopPadding(state)
-                },
-        )
+            modifier = modifier,
+        ) {
+            ComponentView(
+                style = state.stack,
+                state = state,
+                onClick = onClick,
+                componentInteractionTracker = componentInteractionTracker,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .conditional(shouldWrapMainContentInVerticalScroll) {
+                        verticalScroll(mainScrollState)
+                    }
+                    .conditional(state.header != null && !state.mainStackHasHeroImage) {
+                        headerTopPadding(state)
+                    },
+            )
+        }
     }
 }
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedPaywallComponents.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -95,8 +96,11 @@ internal fun LoadedPaywallComponents(
     val shouldWrapMainContentInVerticalScroll =
         (state.stack as? StackComponentStyle)?.scrollOrientation != Orientation.Vertical
     val mainScrollState = rememberScrollState()
+    val layoutDirection = remember(state.locale) {
+        state.locale.toJavaLocale().toLayoutDirection()
+    }
 
-    CompositionLocalProvider(LocalLayoutDirection provides state.locale.toJavaLocale().toLayoutDirection()) {
+    CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
         PaywallComponentsScaffold(
             state = state,
             clickHandler = clickHandler,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/LocaleHelpers.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/LocaleHelpers.kt
@@ -1,5 +1,8 @@
 package com.revenuecat.purchases.ui.revenuecatui.helpers
 
+import android.content.res.Configuration
+import android.view.View
+import androidx.compose.ui.unit.LayoutDirection
 import java.util.Locale
 
 /**
@@ -22,5 +25,18 @@ internal fun createLocaleFromString(localeString: String): Locale {
         }
     } else {
         Locale(localeString)
+    }
+}
+
+/**
+ * Returns the Compose [LayoutDirection] matching this locale's character direction.
+ */
+internal fun Locale.toLayoutDirection(): LayoutDirection {
+    val configuration = Configuration().apply { setLocale(this@toLayoutDirection) }
+
+    return if (configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL) {
+        LayoutDirection.Rtl
+    } else {
+        LayoutDirection.Ltr
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/LocaleHelpersTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/helpers/LocaleHelpersTest.kt
@@ -1,0 +1,37 @@
+package com.revenuecat.purchases.ui.revenuecatui.helpers
+
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+
+@RunWith(AndroidJUnit4::class)
+internal class LocaleHelpersTest {
+
+    @Test
+    fun `toLayoutDirection returns RTL for Hebrew`() {
+        assertThat(Locale.forLanguageTag("he-IL").toLayoutDirection()).isEqualTo(LayoutDirection.Rtl)
+    }
+
+    @Test
+    fun `toLayoutDirection returns RTL for Arabic`() {
+        assertThat(Locale.forLanguageTag("ar").toLayoutDirection()).isEqualTo(LayoutDirection.Rtl)
+    }
+
+    @Test
+    fun `toLayoutDirection returns RTL for Farsi`() {
+        assertThat(Locale.forLanguageTag("fa").toLayoutDirection()).isEqualTo(LayoutDirection.Rtl)
+    }
+
+    @Test
+    fun `toLayoutDirection returns LTR for English`() {
+        assertThat(Locale.US.toLayoutDirection()).isEqualTo(LayoutDirection.Ltr)
+    }
+
+    @Test
+    fun `toLayoutDirection returns LTR for unknown locale`() {
+        assertThat(Locale.ROOT.toLayoutDirection()).isEqualTo(LayoutDirection.Ltr)
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-ios` and hybrids [PR](https://github.com/RevenueCat/purchases-ios/pull/6723)

### Motivation
Fixes paywall layout direction when `preferredUILocaleOverride` resolves to an RTL locale while the device/system locale is LTR.
Previously, Android paywalls could use the overridden locale for localized strings while still inheriting the system Compose `LocalLayoutDirection`, so RTL languages like Hebrew and Arabic could render translated text but keep LTR layout behavior.

Resolves:  PWENG-39

### Changes
- Adds a locale-to-Compose-layout-direction helper backed by Android `Configuration.layoutDirection`.
- Applies the resolved locale layout direction to legacy paywalls.
- Applies the resolved locale layout direction to V2/components paywalls.
- Adds unit coverage for RTL and LTR locale direction resolution.

[Screen_recording_20260501_134422.webm](https://github.com/user-attachments/assets/b19c2be7-9bdd-4daa-8954-e119e8f8d01d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall composition locals to force `LocalLayoutDirection` based on the resolved/overridden locale, which could subtly affect layout/alignment across both legacy and components paywalls. Risk is limited to UI rendering (no purchase/auth logic), but may introduce visual regressions in LTR/RTL edge cases.
> 
> **Overview**
> Fixes paywall rendering when a `preferredUILocaleOverride` resolves to an RTL language by deriving a Compose `LayoutDirection` from the resolved locale and providing it via `LocalLayoutDirection`.
> 
> Applies this override in both legacy template paywalls (`InternalPaywall`) and V2/components paywalls (`LoadedPaywallComponents`), and adds a new `Locale.toLayoutDirection()` helper with Android instrumentation tests covering RTL (Hebrew/Arabic/Farsi) and LTR locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fc33523de416be6e7ce624a8f8699025611a132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->