### PR TITLE
Abstract workflow page transition animation behind sealed class 

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -103,16 +103,14 @@ private fun workflowHeaderState(
         )
     }
     val pendingTransition = when (transitionState) {
-        is WorkflowTransitionState.SlideInOut -> {
-            val fromStepId = transitionState.animatingFromStepId
-            val direction = transitionState.animatingDirection
-            if (fromStepId != null && direction != null) {
+        is WorkflowTransitionState.SlideInOut -> transitionState.animatingFromStepId?.let { fromStepId ->
+            transitionState.animatingDirection?.let { direction ->
                 WorkflowPendingTransition(
                     fromStepId = fromStepId,
                     direction = direction,
                     id = 0, // id not needed for header selection
                 )
-            } else null
+            }
         }
     }
     val headerStepId = selectWorkflowHeaderStepId(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -38,7 +38,7 @@ internal fun LoadedWorkflowPaywall(
     clickHandler: suspend (PaywallAction.External) -> Unit,
     componentInteractionTracker: PaywallComponentInteractionTracker,
     modifier: Modifier = Modifier,
-    transition: WorkflowTransitionAnimation = WorkflowTransitionAnimation.Slide(),
+    transition: WorkflowTransitionAnimation = WorkflowTransitionAnimation.SlideInOut(),
 ) {
     val currentStepId = workflowState.currentStepId
     val stepStates = workflowState.stepStates
@@ -50,7 +50,7 @@ internal fun LoadedWorkflowPaywall(
     val configuration = LocalConfiguration.current
     currentState.update(localeList = configuration.locales)
 
-    val slideState = rememberWorkflowSlideState(
+    val transitionState = rememberWorkflowTransitionState(
         workflowState = workflowState,
         onTransitionComplete = onTransitionComplete,
         transition = transition,
@@ -60,7 +60,7 @@ internal fun LoadedWorkflowPaywall(
         currentStepId = currentStepId,
         currentState = currentState,
         stepStates = stepStates,
-        slideState = slideState,
+        transitionState = transitionState,
     )
     val onClick: suspend (PaywallAction) -> Unit = { action ->
         handleClick(action, currentState, clickHandler, componentInteractionTracker)
@@ -83,7 +83,7 @@ internal fun LoadedWorkflowPaywall(
         WorkflowStepsContent(
             currentStepId = currentStepId,
             stepStates = stepStates,
-            slideState = slideState,
+            transitionState = transitionState,
             clickHandler = clickHandler,
             componentInteractionTracker = componentInteractionTracker,
         )
@@ -94,7 +94,7 @@ private fun workflowHeaderState(
     currentStepId: String,
     currentState: PaywallState.Loaded.Components,
     stepStates: Map<String, PaywallState.Loaded.Components>,
-    slideState: WorkflowSlideState,
+    transitionState: WorkflowTransitionState,
 ): PaywallState.Loaded.Components {
     val headerStepInfo = stepStates.mapValues { (_, stepState) ->
         WorkflowHeaderStepInfo(
@@ -102,18 +102,23 @@ private fun workflowHeaderState(
             hasHeader = stepState.header != null,
         )
     }
+    val pendingTransition = when (transitionState) {
+        is WorkflowTransitionState.SlideInOut -> {
+            val fromStepId = transitionState.animatingFromStepId
+            val direction = transitionState.animatingDirection
+            if (fromStepId != null && direction != null) {
+                WorkflowPendingTransition(
+                    fromStepId = fromStepId,
+                    direction = direction,
+                    id = 0, // id not needed for header selection
+                )
+            } else null
+        }
+    }
     val headerStepId = selectWorkflowHeaderStepId(
         currentStepId = currentStepId,
         stepInfoByStepId = headerStepInfo,
-        pendingTransition = if (slideState.animatingFromStepId != null && slideState.animatingDirection != null) {
-            WorkflowPendingTransition(
-                fromStepId = slideState.animatingFromStepId,
-                direction = slideState.animatingDirection,
-                id = 0, // id not needed for header selection
-            )
-        } else {
-            null
-        },
+        pendingTransition = pendingTransition,
     )
 
     return stepStates[headerStepId] ?: currentState
@@ -124,23 +129,23 @@ private fun workflowHeaderState(
 private fun WorkflowStepsContent(
     currentStepId: String,
     stepStates: Map<String, PaywallState.Loaded.Components>,
-    slideState: WorkflowSlideState,
+    transitionState: WorkflowTransitionState,
     clickHandler: suspend (PaywallAction.External) -> Unit,
     componentInteractionTracker: PaywallComponentInteractionTracker,
 ) {
-    // Multi-step slide container: the current and outgoing steps are stacked and translated by workflowSlide.
+    // Multi-step container: the current and outgoing steps are stacked and translated by workflowTransition.
     // No clipToBounds here — horizontal overflow is bounded by the window/dialog, and adding
     // a top clip causes the hero image (which renders behind the status bar) to get cropped
     // during the slide transition.
     Box(modifier = Modifier.fillMaxSize()) {
-        for (stepId in slideState.visibleStepIds) {
+        for (stepId in transitionState.visibleStepIds) {
             val stepState = stepStates[stepId] ?: continue
             key(stepId) {
                 WorkflowStepContent(
                     stepId = stepId,
                     stepState = stepState,
                     currentStepId = currentStepId,
-                    slideState = slideState,
+                    transitionState = transitionState,
                     clickHandler = clickHandler,
                     componentInteractionTracker = componentInteractionTracker,
                 )
@@ -161,7 +166,7 @@ private fun WorkflowStepContent(
     stepId: String,
     stepState: PaywallState.Loaded.Components,
     currentStepId: String,
-    slideState: WorkflowSlideState,
+    transitionState: WorkflowTransitionState,
     clickHandler: suspend (PaywallAction.External) -> Unit,
     componentInteractionTracker: PaywallComponentInteractionTracker,
 ) {
@@ -179,7 +184,7 @@ private fun WorkflowStepContent(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .workflowSlide(slideState, stepId, currentStepId)
+            .workflowTransition(transitionState, stepId, currentStepId)
             .background(background),
     ) {
         WithOptionalBackgroundOverlay(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -30,6 +30,7 @@ internal data class WorkflowHeaderStepInfo(
     val hasHeader: Boolean,
 )
 
+@Suppress("LongParameterList")
 @Composable
 internal fun LoadedWorkflowPaywall(
     workflowState: WorkflowPaywallUiState,
@@ -37,6 +38,7 @@ internal fun LoadedWorkflowPaywall(
     clickHandler: suspend (PaywallAction.External) -> Unit,
     componentInteractionTracker: PaywallComponentInteractionTracker,
     modifier: Modifier = Modifier,
+    transition: WorkflowTransitionAnimation = WorkflowTransitionAnimation.Slide(),
 ) {
     val currentStepId = workflowState.currentStepId
     val stepStates = workflowState.stepStates
@@ -51,6 +53,7 @@ internal fun LoadedWorkflowPaywall(
     val slideState = rememberWorkflowSlideState(
         workflowState = workflowState,
         onTransitionComplete = onTransitionComplete,
+        transition = transition,
     )
 
     val headerState = workflowHeaderState(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideState.kt
@@ -4,8 +4,8 @@
 package com.revenuecat.purchases.ui.revenuecatui.components
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.AnimationVector1D
-import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -19,27 +19,32 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
 import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
 
-private const val SLIDE_DURATION_MS = 350
-
 /**
- * Snapshot of the data needed to render and animate the two-surface workflow paywall slide.
+ * Snapshot of the data needed to render and animate the two-surface workflow paywall transition.
  *
  * Built during composition from [WorkflowPaywallUiState.pendingTransition], so the first frame
  * after navigation already has both surfaces positioned correctly — no gap-detection, no
  * [Animatable.snapTo], no [androidx.compose.runtime.withFrameNanos] required.
  *
  * @param visibleStepIds step IDs currently held in the Compose slot table.
- * @param animatingFromStepId step ID sliding out; null when idle.
- * @param animatingDirection direction of the active slide; null when idle.
+ * @param animatingFromStepId step ID transitioning out; null when idle.
+ * @param animatingDirection direction of the active transition; null when idle.
  * @param animatable drives progress 0f→1f. Created fresh via [key] for each new
  *   [WorkflowPaywallUiState.pendingTransition] so it always starts at 0f.
+ * @param transition animation type that determines the visual transform applied by
+ *   [Modifier.workflowSlide] and the animation spec used to drive [animatable].
  */
 internal class WorkflowSlideState(
     val visibleStepIds: Set<String>,
     val animatingFromStepId: String?,
     val animatingDirection: NavigationDirection?,
     val animatable: Animatable<Float, AnimationVector1D>,
-)
+    val transition: WorkflowTransitionAnimation,
+) {
+    companion object {
+        const val SLIDE_DURATION_MS = 350
+    }
+}
 
 /**
  * Builds a [WorkflowSlideState] from [workflowState].
@@ -52,11 +57,15 @@ internal class WorkflowSlideState(
  * - [LaunchedEffect] only drives `animateTo(1f)`; it no longer sets up animation state.
  * - [onTransitionComplete] is called with the transition id when the animation finishes so
  *   the ViewModel can clear [WorkflowPaywallUiState.pendingTransition].
+ *
+ * @param transition animation type used for the transition. Defaults to
+ *   [WorkflowTransitionAnimation.Slide] for the existing horizontal slide behavior.
  */
 @Composable
 internal fun rememberWorkflowSlideState(
     workflowState: WorkflowPaywallUiState,
     onTransitionComplete: (transitionId: Int) -> Unit,
+    transition: WorkflowTransitionAnimation = WorkflowTransitionAnimation.Slide(),
 ): WorkflowSlideState {
     val currentStepId = workflowState.currentStepId
     val pendingTransition = workflowState.pendingTransition
@@ -76,7 +85,7 @@ internal fun rememberWorkflowSlideState(
         if (pendingTransition != null) {
             animatable.animateTo(
                 targetValue = 1f,
-                animationSpec = tween(SLIDE_DURATION_MS, easing = FastOutSlowInEasing),
+                animationSpec = transition.toAnimationSpec(),
             )
             latestOnTransitionComplete(pendingTransition.id)
         }
@@ -91,12 +100,14 @@ internal fun rememberWorkflowSlideState(
         animatingFromStepId = pendingTransition?.fromStepId,
         animatingDirection = pendingTransition?.direction,
         animatable = animatable,
+        transition = transition,
     )
 }
 
 /**
- * Translates a step's content horizontally based on its role in the current slide animation:
+ * Applies the visual transform for the active [WorkflowSlideState.transition] to a step's content.
  *
+ * For [WorkflowTransitionAnimation.Slide], translates horizontally:
  * - **Current step**: slides from `±width` to `0` as progress goes 0→1.
  * - **Outgoing step**: slides from `0` to `∓width` as progress goes 0→1.
  * - **Other (parked) steps**: positioned far off-screen so the GraphicsLayer skips drawing.
@@ -110,11 +121,18 @@ internal fun Modifier.workflowSlide(
     currentStepId: String,
 ): Modifier = graphicsLayer {
     val progress = state.animatable.value
-    val directionFactor = if (state.animatingDirection == NavigationDirection.FORWARD) 1f else -1f
-
-    translationX = when (stepId) {
-        currentStepId -> (1f - progress) * directionFactor * size.width
-        state.animatingFromStepId -> -progress * directionFactor * size.width
-        else -> 2f * size.width
+    when (state.transition) {
+        is WorkflowTransitionAnimation.Slide -> {
+            val directionFactor = if (state.animatingDirection == NavigationDirection.FORWARD) 1f else -1f
+            translationX = when (stepId) {
+                currentStepId -> (1f - progress) * directionFactor * size.width
+                state.animatingFromStepId -> -progress * directionFactor * size.width
+                else -> 2f * size.width
+            }
+        }
     }
+}
+
+private fun WorkflowTransitionAnimation.toAnimationSpec(): AnimationSpec<Float> = when (this) {
+    is WorkflowTransitionAnimation.Slide -> tween(durationMs, easing = easing)
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowTransitionAnimation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowTransitionAnimation.kt
@@ -8,15 +8,16 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 /**
  * Describes the animation used to transition between workflow paywall steps.
  *
- * The visual transform for each subclass lives in [Modifier.workflowSlide]; the animation
- * timing lives in [rememberWorkflowSlideState]. Adding a new transition type requires:
+ * The visual transform for each subclass lives in [Modifier.workflowTransition]; the animation
+ * timing lives in [rememberWorkflowTransitionState]. Adding a new transition type requires:
  *  1. Adding a new subclass here.
- *  2. Adding a `when` branch in [Modifier.workflowSlide] for the visual transform.
- *  3. Adding a `when` branch in [rememberWorkflowSlideState] for the animation spec.
+ *  2. Adding a matching [WorkflowTransitionState] subclass with its animation-specific properties.
+ *  3. Adding a `when` branch in [rememberWorkflowTransitionState] to build the state subclass.
+ *  4. Adding a `when` branch in [Modifier.workflowTransition] for the visual transform.
  */
 internal sealed class WorkflowTransitionAnimation {
-    data class Slide(
-        val durationMs: Int = WorkflowSlideState.SLIDE_DURATION_MS,
+    data class SlideInOut(
+        val durationMs: Int = WorkflowTransitionState.SLIDE_DURATION_MS,
         val easing: Easing = FastOutSlowInEasing,
     ) : WorkflowTransitionAnimation()
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowTransitionAnimation.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowTransitionAnimation.kt
@@ -1,0 +1,22 @@
+@file:JvmSynthetic
+
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.FastOutSlowInEasing
+
+/**
+ * Describes the animation used to transition between workflow paywall steps.
+ *
+ * The visual transform for each subclass lives in [Modifier.workflowSlide]; the animation
+ * timing lives in [rememberWorkflowSlideState]. Adding a new transition type requires:
+ *  1. Adding a new subclass here.
+ *  2. Adding a `when` branch in [Modifier.workflowSlide] for the visual transform.
+ *  3. Adding a `when` branch in [rememberWorkflowSlideState] for the animation spec.
+ */
+internal sealed class WorkflowTransitionAnimation {
+    data class Slide(
+        val durationMs: Int = WorkflowSlideState.SLIDE_DURATION_MS,
+        val easing: Easing = FastOutSlowInEasing,
+    ) : WorkflowTransitionAnimation()
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowTransitionState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowTransitionState.kt
@@ -26,28 +26,39 @@ import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
  * after navigation already has both surfaces positioned correctly — no gap-detection, no
  * [Animatable.snapTo], no [androidx.compose.runtime.withFrameNanos] required.
  *
- * @param visibleStepIds step IDs currently held in the Compose slot table.
- * @param animatingFromStepId step ID transitioning out; null when idle.
- * @param animatingDirection direction of the active transition; null when idle.
- * @param animatable drives progress 0f→1f. Created fresh via [key] for each new
+ * Each subclass carries only the properties that are meaningful for its animation type, so callers
+ * pattern-match rather than interrogating nullable fields that don't apply.
+ *
+ * @property visibleStepIds step IDs currently held in the Compose slot table.
+ * @property animatingFromStepId step ID transitioning out; null when idle.
+ * @property animatable drives progress 0f→1f. Created fresh via [key] for each new
  *   [WorkflowPaywallUiState.pendingTransition] so it always starts at 0f.
- * @param transition animation type that determines the visual transform applied by
- *   [Modifier.workflowSlide] and the animation spec used to drive [animatable].
  */
-internal class WorkflowSlideState(
-    val visibleStepIds: Set<String>,
-    val animatingFromStepId: String?,
-    val animatingDirection: NavigationDirection?,
-    val animatable: Animatable<Float, AnimationVector1D>,
-    val transition: WorkflowTransitionAnimation,
-) {
+internal sealed class WorkflowTransitionState {
+    abstract val visibleStepIds: Set<String>
+    abstract val animatingFromStepId: String?
+    abstract val animatable: Animatable<Float, AnimationVector1D>
+
+    /**
+     * Both surfaces slide simultaneously: the incoming step translates in from one side while
+     * the outgoing step translates out to the other. [animatingDirection] determines which sides.
+     *
+     * @property animatingDirection direction of the active transition; null when idle.
+     */
+    class SlideInOut(
+        override val visibleStepIds: Set<String>,
+        override val animatingFromStepId: String?,
+        val animatingDirection: NavigationDirection?,
+        override val animatable: Animatable<Float, AnimationVector1D>,
+    ) : WorkflowTransitionState()
+
     companion object {
         const val SLIDE_DURATION_MS = 350
     }
 }
 
 /**
- * Builds a [WorkflowSlideState] from [workflowState].
+ * Builds a [WorkflowTransitionState] from [workflowState].
  *
  * When [WorkflowPaywallUiState.pendingTransition] is non-null:
  * - [key] on the transition id creates a fresh [Animatable] **at 0f during composition**, so
@@ -59,14 +70,14 @@ internal class WorkflowSlideState(
  *   the ViewModel can clear [WorkflowPaywallUiState.pendingTransition].
  *
  * @param transition animation type used for the transition. Defaults to
- *   [WorkflowTransitionAnimation.Slide] for the existing horizontal slide behavior.
+ *   [WorkflowTransitionAnimation.SlideInOut] for the existing horizontal slide behavior.
  */
 @Composable
-internal fun rememberWorkflowSlideState(
+internal fun rememberWorkflowTransitionState(
     workflowState: WorkflowPaywallUiState,
     onTransitionComplete: (transitionId: Int) -> Unit,
-    transition: WorkflowTransitionAnimation = WorkflowTransitionAnimation.Slide(),
-): WorkflowSlideState {
+    transition: WorkflowTransitionAnimation = WorkflowTransitionAnimation.SlideInOut(),
+): WorkflowTransitionState {
     val currentStepId = workflowState.currentStepId
     val pendingTransition = workflowState.pendingTransition
 
@@ -91,23 +102,26 @@ internal fun rememberWorkflowSlideState(
         }
     }
 
-    return WorkflowSlideState(
-        visibleStepIds = if (pendingTransition != null) {
-            setOf(pendingTransition.fromStepId, currentStepId)
-        } else {
-            setOf(currentStepId)
-        },
-        animatingFromStepId = pendingTransition?.fromStepId,
-        animatingDirection = pendingTransition?.direction,
-        animatable = animatable,
-        transition = transition,
-    )
+    val visibleStepIds = if (pendingTransition != null) {
+        setOf(pendingTransition.fromStepId, currentStepId)
+    } else {
+        setOf(currentStepId)
+    }
+
+    return when (transition) {
+        is WorkflowTransitionAnimation.SlideInOut -> WorkflowTransitionState.SlideInOut(
+            visibleStepIds = visibleStepIds,
+            animatingFromStepId = pendingTransition?.fromStepId,
+            animatingDirection = pendingTransition?.direction,
+            animatable = animatable,
+        )
+    }
 }
 
 /**
- * Applies the visual transform for the active [WorkflowSlideState.transition] to a step's content.
+ * Applies the visual transform for the active [WorkflowTransitionState] to a step's content.
  *
- * For [WorkflowTransitionAnimation.Slide], translates horizontally:
+ * For [WorkflowTransitionState.SlideInOut], translates horizontally:
  * - **Current step**: slides from `±width` to `0` as progress goes 0→1.
  * - **Outgoing step**: slides from `0` to `∓width` as progress goes 0→1.
  * - **Other (parked) steps**: positioned far off-screen so the GraphicsLayer skips drawing.
@@ -115,14 +129,14 @@ internal fun rememberWorkflowSlideState(
  * State reads happen inside the layer block so animation frames invalidate the layer without
  * triggering recomposition.
  */
-internal fun Modifier.workflowSlide(
-    state: WorkflowSlideState,
+internal fun Modifier.workflowTransition(
+    state: WorkflowTransitionState,
     stepId: String,
     currentStepId: String,
 ): Modifier = graphicsLayer {
     val progress = state.animatable.value
-    when (state.transition) {
-        is WorkflowTransitionAnimation.Slide -> {
+    when (state) {
+        is WorkflowTransitionState.SlideInOut -> {
             val directionFactor = if (state.animatingDirection == NavigationDirection.FORWARD) 1f else -1f
             translationX = when (stepId) {
                 currentStepId -> (1f - progress) * directionFactor * size.width
@@ -134,5 +148,5 @@ internal fun Modifier.workflowSlide(
 }
 
 private fun WorkflowTransitionAnimation.toAnimationSpec(): AnimationSpec<Float> = when (this) {
-    is WorkflowTransitionAnimation.Slide -> tween(durationMs, easing = easing)
+    is WorkflowTransitionAnimation.SlideInOut -> tween(durationMs, easing = easing)
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowTransitionState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowTransitionState.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.GraphicsLayerScope
 import androidx.compose.ui.graphics.graphicsLayer
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
@@ -134,15 +135,21 @@ internal fun Modifier.workflowTransition(
     stepId: String,
     currentStepId: String,
 ): Modifier = graphicsLayer {
-    val progress = state.animatable.value
-    when (state) {
-        is WorkflowTransitionState.SlideInOut -> {
-            val directionFactor = if (state.animatingDirection == NavigationDirection.FORWARD) 1f else -1f
-            translationX = when (stepId) {
-                currentStepId -> (1f - progress) * directionFactor * size.width
-                state.animatingFromStepId -> -progress * directionFactor * size.width
-                else -> 2f * size.width
-            }
+    applyWorkflowTransition(state, stepId, currentStepId, progress = state.animatable.value)
+}
+
+private fun GraphicsLayerScope.applyWorkflowTransition(
+    state: WorkflowTransitionState,
+    stepId: String,
+    currentStepId: String,
+    progress: Float,
+): Unit = when (state) {
+    is WorkflowTransitionState.SlideInOut -> {
+        val directionFactor = if (state.animatingDirection == NavigationDirection.FORWARD) 1f else -1f
+        translationX = when (stepId) {
+            currentStepId -> (1f - progress) * directionFactor * size.width
+            state.animatingFromStepId -> -progress * directionFactor * size.width
+            else -> 2f * size.width
         }
     }
 }


### PR DESCRIPTION
Refactor creating a `WorkflowTransitionAnimation` that can be easily extended in the future. This PR doesn't change any behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that preserves existing slide behavior but rewires workflow-step transition plumbing; main risk is subtle regressions in step/header selection or animation timing.
> 
> **Overview**
> Refactors workflow paywall step transitions to be driven by a new `WorkflowTransitionAnimation`/`WorkflowTransitionState` sealed-class abstraction, keeping the current Slide-In/Out behavior as the default.
> 
> `LoadedWorkflowPaywall` and related composables now use `rememberWorkflowTransitionState` and `Modifier.workflowTransition` (instead of the slide-specific state/modifier), and header selection logic is updated to derive any pending transition from the active transition-state subtype.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27b67503cb1b25ddd5a580ca0b01fe713870b745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->