### PR TITLE
In-memory cache for workflows

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -42,6 +42,7 @@ import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.common.workflows.FileCachedWorkflowCdnFetcher
 import com.revenuecat.purchases.common.workflows.WorkflowDetailResolver
 import com.revenuecat.purchases.common.workflows.WorkflowManager
+import com.revenuecat.purchases.common.workflows.WorkflowsCache
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.paywalls.FontLoader
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
@@ -209,6 +210,8 @@ internal class PurchasesFactory(
                 coilImageDownloader = coilImageDownloader,
             )
 
+            val workflowsCache = WorkflowsCache()
+
             val purchasesStateProvider = PurchasesStateCache(PurchasesState())
 
             // Override used for integration tests.
@@ -263,6 +266,7 @@ internal class PurchasesFactory(
                 subscriberAttributesCache,
                 subscriberAttributesManager,
                 offeringsCache,
+                workflowsCache,
                 backend,
                 offlineEntitlementsManager,
                 dispatcher,
@@ -364,6 +368,7 @@ internal class PurchasesFactory(
                     paywallComponentsImagePreDownloader = paywallComponentsImagePreDownloader,
                     offeringFontPreDownloader = offeringFontPreDownloader,
                 ),
+                workflowsCache = workflowsCache,
             )
 
             val offeringsManager = OfferingsManager(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -22,6 +22,7 @@ internal class WorkflowManager(
     private val backend: Backend,
     private val workflowDetailResolver: WorkflowDetailResolver,
     private val workflowAssetPreDownloader: WorkflowAssetPreDownloader,
+    private val workflowsCache: WorkflowsCache,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {
 
@@ -36,6 +37,11 @@ internal class WorkflowManager(
         onSuccess: (WorkflowDataResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
+        val cached = workflowsCache.cachedWorkflow(workflowId)
+        if (cached != null && !workflowsCache.isWorkflowCacheStale(workflowId, appInBackground)) {
+            onSuccess(cached)
+            return
+        }
         backend.getWorkflow(
             appUserID = appUserID,
             workflowId = workflowId,
@@ -44,6 +50,7 @@ internal class WorkflowManager(
                 scope.launch {
                     try {
                         val result = workflowDetailResolver.resolve(response)
+                        workflowsCache.cacheWorkflow(workflowId, result)
                         scope.launch {
                             runCatching { workflowAssetPreDownloader.preDownloadWorkflowAssets(result.workflow) }
                                 .onFailure { errorLog(it) { "Failed to pre-download workflow assets" } }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -1,0 +1,33 @@
+package com.revenuecat.purchases.common.workflows
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.caching.InMemoryCachedObject
+import com.revenuecat.purchases.common.caching.isCacheStale
+
+@OptIn(InternalRevenueCatAPI::class)
+internal class WorkflowsCache(
+    private val dateProvider: DateProvider = DefaultDateProvider(),
+) {
+    private val cachedWorkflows = mutableMapOf<String, InMemoryCachedObject<WorkflowDataResult>>()
+
+    @Synchronized
+    fun cachedWorkflow(workflowId: String): WorkflowDataResult? =
+        cachedWorkflows[workflowId]?.cachedInstance
+
+    @Synchronized
+    fun isWorkflowCacheStale(workflowId: String, appInBackground: Boolean): Boolean =
+        cachedWorkflows[workflowId]?.lastUpdatedAt?.isCacheStale(appInBackground, dateProvider) ?: true
+
+    @Synchronized
+    fun cacheWorkflow(workflowId: String, result: WorkflowDataResult) {
+        val cached = cachedWorkflows.getOrPut(workflowId) { InMemoryCachedObject(dateProvider = dateProvider) }
+        cached.cacheInstance(result)
+    }
+
+    @Synchronized
+    fun clearCache() {
+        cachedWorkflows.clear()
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsMa
 import com.revenuecat.purchases.common.safeResume
 import com.revenuecat.purchases.common.safeResumeWithException
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
+import com.revenuecat.purchases.common.workflows.WorkflowsCache
 import com.revenuecat.purchases.strings.IdentityStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
@@ -34,6 +35,7 @@ internal class IdentityManager(
     private val subscriberAttributesCache: SubscriberAttributesCache,
     private val subscriberAttributesManager: SubscriberAttributesManager,
     private val offeringsCache: OfferingsCache,
+    private val workflowsCache: WorkflowsCache,
     private val backend: Backend,
     private val offlineEntitlementsManager: OfflineEntitlementsManager,
     private val dispatcher: Dispatcher,
@@ -102,6 +104,7 @@ internal class IdentityManager(
                             IdentityStrings.ALIAS_OLD_USER_ID_TO_CURRENT_SUCCESSFUL.format(oldAppUserID, newAppUserID)
                         }
                         offeringsCache.clearCache()
+                        workflowsCache.clearCache()
                         deviceCache.clearCustomerInfoCache(newAppUserID)
                         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
                     }
@@ -154,6 +157,7 @@ internal class IdentityManager(
                         }
                         deviceCache.clearCachesForAppUserID(oldAppUserID)
                         offeringsCache.clearCache()
+                        workflowsCache.clearCache()
                         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
 
                         deviceCache.cacheAppUserID(newAppUserID)
@@ -256,6 +260,7 @@ internal class IdentityManager(
     private fun resetAndSaveUserID(newUserID: String) {
         deviceCache.clearCachesForAppUserID(currentAppUserID)
         offeringsCache.clearCache()
+        workflowsCache.clearCache()
         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(currentAppUserID)
         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
         deviceCache.cacheAppUserID(newUserID)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -1,12 +1,16 @@
 package com.revenuecat.purchases.common.workflows
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.LogHandler
 import com.revenuecat.purchases.NoOpLogHandler
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
+import com.revenuecat.purchases.utils.add
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -19,13 +23,25 @@ import org.assertj.core.api.Assertions.fail
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 import java.io.IOException
+import java.util.Date
+import kotlin.time.Duration.Companion.minutes
 
+@OptIn(InternalRevenueCatAPI::class)
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
 class WorkflowManagerTest {
+
+    private val initialDate = Date(1685098228L)
+    private lateinit var currentDate: Date
+    private lateinit var dateProvider: DateProvider
 
     private val mockBackend: Backend = mockk(relaxed = true)
     private val mockResolver: WorkflowDetailResolver = mockk()
     private val mockAssetPreDownloader: WorkflowAssetPreDownloader = mockk(relaxed = true)
+    private lateinit var workflowsCache: WorkflowsCache
     private lateinit var workflowManager: WorkflowManager
     private lateinit var originalLogHandler: LogHandler
 
@@ -33,10 +49,17 @@ class WorkflowManagerTest {
     fun setUp() {
         originalLogHandler = currentLogHandler
         currentLogHandler = NoOpLogHandler
+        currentDate = initialDate
+        dateProvider = object : DateProvider {
+            override val now: Date
+                get() = currentDate
+        }
+        workflowsCache = WorkflowsCache(dateProvider = dateProvider)
         workflowManager = WorkflowManager(
             backend = mockBackend,
             workflowDetailResolver = mockResolver,
             workflowAssetPreDownloader = mockAssetPreDownloader,
+            workflowsCache = workflowsCache,
             scope = CoroutineScope(UnconfinedTestDispatcher()),
         )
     }
@@ -213,5 +236,210 @@ class WorkflowManagerTest {
         )
         assertThat(error).isNotNull
         assertThat(error!!.code).isEqualTo(PurchasesErrorCode.NetworkError)
+    }
+
+    @Test
+    fun `getWorkflow caches result on success`() {
+        val response = WorkflowDetailResponse(
+            action = WorkflowResponseAction.INLINE,
+            data = mockk(),
+        )
+        val expectedResult = WorkflowDataResult(
+            workflow = response.data!!,
+            enrolledVariants = null,
+        )
+        coEvery { mockResolver.resolve(response) } returns expectedResult
+
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = any(),
+            )
+        } answers {
+            successSlot.captured(response)
+        }
+
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(expectedResult)
+    }
+
+    @Test
+    fun `getWorkflow returns cached result without calling backend when cache is fresh`() {
+        val response = WorkflowDetailResponse(
+            action = WorkflowResponseAction.INLINE,
+            data = mockk(),
+        )
+        val expectedResult = WorkflowDataResult(
+            workflow = response.data!!,
+            enrolledVariants = null,
+        )
+        coEvery { mockResolver.resolve(response) } returns expectedResult
+
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = any(),
+            )
+        } answers {
+            successSlot.captured(response)
+        }
+
+        // First call populates the cache.
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        // Second call should hit the cache.
+        var secondResult: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { secondResult = it },
+            onError = { fail("unexpected error $it") },
+        )
+
+        assertThat(secondResult).isSameAs(expectedResult)
+        verify(exactly = 1) {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `getWorkflow re-fetches when cache is stale`() {
+        val response = WorkflowDetailResponse(
+            action = WorkflowResponseAction.INLINE,
+            data = mockk(),
+        )
+        val expectedResult = WorkflowDataResult(
+            workflow = response.data!!,
+            enrolledVariants = null,
+        )
+        coEvery { mockResolver.resolve(response) } returns expectedResult
+
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = any(),
+            )
+        } answers {
+            successSlot.captured(response)
+        }
+
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        currentDate = currentDate.add(6.minutes)
+
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        verify(exactly = 2) {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `getWorkflow does not cache on backend error`() {
+        val expectedError = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = capture(errorSlot),
+            )
+        } answers {
+            errorSlot.captured(expectedError)
+        }
+
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { fail("expected error") },
+            onError = {},
+        )
+
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isNull()
+    }
+
+    @Test
+    fun `getWorkflow does not cache when resolver throws`() {
+        val response = WorkflowDetailResponse(
+            action = WorkflowResponseAction.INLINE,
+            data = null,
+        )
+        coEvery { mockResolver.resolve(response) } throws IllegalStateException("missing data")
+
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = any(),
+            )
+        } answers {
+            successSlot.captured(response)
+        }
+
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { fail("expected error") },
+            onError = {},
+        )
+
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isNull()
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -1,0 +1,116 @@
+package com.revenuecat.purchases.common.workflows
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.utils.add
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Date
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+@OptIn(InternalRevenueCatAPI::class)
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class WorkflowsCacheTest {
+
+    private val initialDate = Date(1685098228L) // Friday, May 26, 2023 10:50:28 AM GMT
+    private lateinit var currentDate: Date
+    private lateinit var dateProvider: DateProvider
+
+    private lateinit var workflowsCache: WorkflowsCache
+
+    @Before
+    fun setUp() {
+        currentDate = initialDate
+        dateProvider = object : DateProvider {
+            override val now: Date
+                get() = currentDate
+        }
+        workflowsCache = WorkflowsCache(dateProvider = dateProvider)
+    }
+
+    @Test
+    fun `cachedWorkflow returns null when nothing cached`() {
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isNull()
+    }
+
+    @Test
+    fun `cachedWorkflow returns cached value after cacheWorkflow`() {
+        val result = mockk<WorkflowDataResult>()
+        workflowsCache.cacheWorkflow("wf_1", result)
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(result)
+    }
+
+    @Test
+    fun `isWorkflowCacheStale is true when nothing cached`() {
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = true)).isTrue
+    }
+
+    @Test
+    fun `isWorkflowCacheStale is false right after caching in foreground`() {
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isFalse
+    }
+
+    @Test
+    fun `isWorkflowCacheStale is true after foreground TTL expires`() {
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        currentDate = currentDate.add(6.minutes)
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
+    }
+
+    @Test
+    fun `isWorkflowCacheStale is false after foreground TTL expires when in background`() {
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        currentDate = currentDate.add(6.minutes)
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = true)).isFalse
+    }
+
+    @Test
+    fun `isWorkflowCacheStale is true after background TTL expires`() {
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        currentDate = currentDate.add(26.hours)
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = true)).isTrue
+    }
+
+    @Test
+    fun `clearCache removes all cached workflows`() {
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        workflowsCache.cacheWorkflow("wf_2", mockk())
+        workflowsCache.clearCache()
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isNull()
+        assertThat(workflowsCache.cachedWorkflow("wf_2")).isNull()
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_2", appInBackground = false)).isTrue
+    }
+
+    @Test
+    fun `different workflowIds are cached independently`() {
+        val first = mockk<WorkflowDataResult>()
+        val second = mockk<WorkflowDataResult>()
+        workflowsCache.cacheWorkflow("wf_1", first)
+        currentDate = currentDate.add(6.minutes)
+        workflowsCache.cacheWorkflow("wf_2", second)
+
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(first)
+        assertThat(workflowsCache.cachedWorkflow("wf_2")).isSameAs(second)
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_2", appInBackground = false)).isFalse
+    }
+
+    @Test
+    fun `re-caching same workflowId refreshes timestamp`() {
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        currentDate = currentDate.add(6.minutes)
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isFalse
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.offerings.OfferingsCache
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
+import com.revenuecat.purchases.common.workflows.WorkflowsCache
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
@@ -41,6 +42,7 @@ class IdentityManagerTests {
     private lateinit var mockSubscriberAttributesCache: SubscriberAttributesCache
     private lateinit var mockSubscriberAttributesManager: SubscriberAttributesManager
     private lateinit var mockOfferingsCache: OfferingsCache
+    private lateinit var mockWorkflowsCache: WorkflowsCache
     private lateinit var mockBackend: Backend
     private lateinit var mockOfflineEntitlementsManager: OfflineEntitlementsManager
     private lateinit var identityManager: IdentityManager
@@ -72,6 +74,9 @@ class IdentityManagerTests {
         }
         mockSubscriberAttributesManager = mockk()
         mockOfferingsCache = mockk<OfferingsCache>().apply {
+            every { clearCache() } just Runs
+        }
+        mockWorkflowsCache = mockk<WorkflowsCache>().apply {
             every { clearCache() } just Runs
         }
 
@@ -245,6 +250,7 @@ class IdentityManagerTests {
             mockSubscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
+        verify(exactly = 1) { mockWorkflowsCache.clearCache() }
     }
 
     @Test
@@ -399,6 +405,7 @@ class IdentityManagerTests {
             )
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
+        verify(exactly = 1) { mockWorkflowsCache.clearCache() }
     }
 
     @Test
@@ -623,6 +630,7 @@ class IdentityManagerTests {
 
         verify(exactly = 1) { mockDeviceCache.clearCachesForAppUserID(oldAppUserID) }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
+        verify(exactly = 1) { mockWorkflowsCache.clearCache() }
         verify(exactly = 1) {
             mockSubscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
         }
@@ -754,6 +762,7 @@ class IdentityManagerTests {
             )
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
+        verify(exactly = 1) { mockWorkflowsCache.clearCache() }
         verify(exactly = 1) { mockDeviceCache.clearCustomerInfoCache(newAppUserId) }
         verify(exactly = 1) { mockOfflineEntitlementsManager.resetOfflineCustomerInfoCache() }
     }
@@ -792,6 +801,7 @@ class IdentityManagerTests {
             )
         }
         verify(exactly = 0) { mockOfferingsCache.clearCache() }
+        verify(exactly = 0) { mockWorkflowsCache.clearCache() }
         verify(exactly = 0) { mockDeviceCache.clearCustomerInfoCache(newAppUserId) }
         verify(exactly = 0) { mockOfflineEntitlementsManager.resetOfflineCustomerInfoCache() }
     }
@@ -885,6 +895,7 @@ class IdentityManagerTests {
         subscriberAttributesCache: SubscriberAttributesCache = mockSubscriberAttributesCache,
         subscriberAttributesManager: SubscriberAttributesManager = mockSubscriberAttributesManager,
         offeringsCache: OfferingsCache = mockOfferingsCache,
+        workflowsCache: WorkflowsCache = mockWorkflowsCache,
         backend: Backend = mockBackend,
         offlineEntitlementsManager: OfflineEntitlementsManager = mockOfflineEntitlementsManager,
         uiPreviewMode: Boolean = false,
@@ -894,6 +905,7 @@ class IdentityManagerTests {
             subscriberAttributesCache,
             subscriberAttributesManager,
             offeringsCache,
+            workflowsCache,
             backend,
             offlineEntitlementsManager,
             SyncDispatcher(),


### PR DESCRIPTION
 Workflows currently hit the network on every `WorkflowManager.getWorkflow()` call. `Backend` already de-duplicates concurrent in-flight requests via `workflowDetailCallbacks`, and `FileCachedWorkflowCdnFetcher` caches the CDN file on disk by checksum, but the resolved `WorkflowDataResult` itself is not retained — so the next call re-runs the backend round trip and CDN fetch.
 
 This PR adds an in-memory layer on top of the resolver that caches `WorkflowDataResult` per `workflowId`, mirroring the offerings caching pattern.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an in-memory cache in the workflow fetch path, which can change when/if the app re-fetches workflow definitions and could surface staleness/invalidations issues across app-user switches if incorrect.
> 
> **Overview**
> Adds an **in-memory `WorkflowsCache`** that stores resolved `WorkflowDataResult` per `workflowId` with the existing foreground/background TTL semantics, avoiding repeated backend/CDN round-trips for subsequent `WorkflowManager.getWorkflow()` calls.
> 
> Wires this cache through `PurchasesFactory` and `WorkflowManager`, and clears it during identity transitions (`logIn`, `logOut`, `switchUser`, `aliasCurrentUserIdTo`) to prevent cross-user reuse. Includes new/updated unit tests covering caching, staleness, and non-caching on errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 831e10a484e2ac8c4a3895fd0ebe0d65ccdfb4a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->