### PR TITLE
Clean up unreferenced topic files after successful remote-config refresh

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -79,11 +79,11 @@ internal class RemoteConfigManager(
             }
         }
         if (firstError == null) {
-            topicFetcher.cleanupUnreferencedTopics(referenced)
             // Only cache when at least one topic was actually fetched — empty sources, empty topics,
             // and missing default entryIds are treated as no-op refreshes that don't populate the cache.
             if (source != null && tasks.isNotEmpty()) {
                 val previousResponse = cache?.response
+                topicFetcher.cleanupUnreferencedTopics(referenced)
                 cache = CacheEntry(response, dateProvider.now)
                 if (previousResponse != response) {
                     diskCache.write(response)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -57,6 +57,7 @@ internal class RemoteConfigManager(
         }
         // WIP: We should have some logic to pick the correct source for this. Right now, hardcoded to the first source.
         val source = response.blobSources.firstOrNull()
+        val referenced = buildReferenceSet(response.manifest)
         val tasks = response.manifest.topics.mapNotNull { (topic, entries) ->
             val entry = entries[DEFAULT_ENTRY_ID] ?: return@mapNotNull null
             TopicTask(topic, DEFAULT_ENTRY_ID, entry)
@@ -77,13 +78,16 @@ internal class RemoteConfigManager(
                 }.awaitAll().firstNotNullOfOrNull { it }
             }
         }
-        // Only cache when at least one topic was actually fetched — empty sources, empty topics,
-        // and missing default entryIds are treated as no-op refreshes that don't populate the cache.
-        if (firstError == null && source != null && tasks.isNotEmpty()) {
-            val previousResponse = cache?.response
-            cache = CacheEntry(response, dateProvider.now)
-            if (previousResponse != response) {
-                diskCache.write(response)
+        if (firstError == null) {
+            topicFetcher.cleanupUnreferencedTopics(referenced)
+            // Only cache when at least one topic was actually fetched — empty sources, empty topics,
+            // and missing default entryIds are treated as no-op refreshes that don't populate the cache.
+            if (source != null && tasks.isNotEmpty()) {
+                val previousResponse = cache?.response
+                cache = CacheEntry(response, dateProvider.now)
+                if (previousResponse != response) {
+                    diskCache.write(response)
+                }
             }
         }
         return firstError
@@ -96,6 +100,11 @@ internal class RemoteConfigManager(
                 onSuccess = { cont.safeResume(it) },
                 onError = { cont.safeResumeWithException(PurchasesException(it)) },
             )
+        }
+
+    private fun buildReferenceSet(manifest: Manifest): Map<Topic, Set<String>> =
+        manifest.topics.mapValues { (_, entries) ->
+            entries.values.map { it.blobRef }.toSet()
         }
 
     private data class TopicTask(val topic: Topic, val entryId: String, val entry: TopicEntry)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/TopicFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/TopicFetcher.kt
@@ -66,6 +66,34 @@ internal class TopicFetcher(
         }
     }
 
+    suspend fun cleanupUnreferencedTopics(referenced: Map<Topic, Set<String>>) {
+        withContext(Dispatchers.IO) {
+            runCatching { deleteUnreferencedTopicFiles(referenced) }
+                .onFailure { e ->
+                    errorLog(e) { "Failed to clean up unreferenced topic files." }
+                }
+        }
+    }
+
+    private fun deleteUnreferencedTopicFiles(referenced: Map<Topic, Set<String>>) {
+        val topicsRoot = File(applicationContext.noBackupFilesDir, TOPICS_ROOT)
+        if (!topicsRoot.exists()) return
+        Topic.values().forEach topics@{ topic ->
+            val topicDir = File(topicsRoot, topic.key)
+            if (!topicDir.isDirectory) return@topics
+            val keep = referenced[topic].orEmpty()
+            topicDir.listFiles()?.forEach files@{ file ->
+                if (file.name.startsWith(TEMP_PREFIX)) return@files
+                if (file.name in keep) return@files
+                if (file.delete()) {
+                    verboseLog { "Deleted unreferenced topic file at ${file.absolutePath}" }
+                } else {
+                    errorLog { "Failed to delete unreferenced topic file at ${file.absolutePath}" }
+                }
+            }
+        }
+    }
+
     private fun topicFile(topic: Topic, blobRef: String): File {
         val dir = File(File(applicationContext.noBackupFilesDir, TOPICS_ROOT), topic.key)
         if (!dir.exists()) {
@@ -77,7 +105,7 @@ internal class TopicFetcher(
     @Throws(IOException::class, Checksum.ChecksumValidationException::class)
     private fun downloadVerifyAndStore(url: String, expectedSha256: String, target: File) {
         val parent = target.parentFile ?: throw IOException("Topic target file has no parent: $target")
-        val tempFile = File.createTempFile("rc_topic_", ".tmp", parent)
+        val tempFile = File.createTempFile(TEMP_PREFIX, ".tmp", parent)
         try {
             urlConnectionFactory.downloadToFileAndVerifyChecksum(
                 url = url,
@@ -105,6 +133,7 @@ internal class TopicFetcher(
         const val TOPICS_ROOT = "RevenueCat/topics"
         const val BLOB_REF_PLACEHOLDER = "{blob_ref}"
         const val MAX_PARALLEL_TOPIC_DOWNLOADS = 4
+        const val TEMP_PREFIX = "rc_topic_"
         val BLOB_REF_PATTERN = Regex("^[a-fA-F0-9]{64}$")
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -39,6 +39,7 @@ class RemoteConfigManagerTest {
     fun setUp() {
         backend = mockk()
         topicFetcher = mockk()
+        coEvery { topicFetcher.cleanupUnreferencedTopics(any()) } returns Unit
         diskCache = mockk(relaxed = true)
         fakeNow = Date(0)
         dateProvider = mockk()
@@ -105,6 +106,7 @@ class RemoteConfigManagerTest {
         assertThat(completionError).isNull()
         coVerify(exactly = 0) { topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any()) }
         verify(exactly = 0) { diskCache.write(any()) }
+        coVerify(exactly = 1) { topicFetcher.cleanupUnreferencedTopics(any()) }
 
         // Cache wasn't populated, so a follow-up call still hits the backend.
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
@@ -135,6 +137,7 @@ class RemoteConfigManagerTest {
         assertThat(completionError).isNull()
         coVerify(exactly = 0) { topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any()) }
         verify(exactly = 0) { diskCache.write(any()) }
+        coVerify(exactly = 1) { topicFetcher.cleanupUnreferencedTopics(emptyMap()) }
 
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
@@ -166,6 +169,12 @@ class RemoteConfigManagerTest {
         assertThat(completionError).isNull()
         coVerify(exactly = 0) { topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any()) }
         verify(exactly = 0) { diskCache.write(any()) }
+        // Cleanup still runs and includes the experiment-only topic's blob ref in the reference set.
+        coVerify(exactly = 1) {
+            topicFetcher.cleanupUnreferencedTopics(
+                mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to setOf("blob")),
+            )
+        }
 
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
@@ -316,6 +325,69 @@ class RemoteConfigManagerTest {
                 source = src,
             )
         }
+    }
+
+    @Test
+    fun `triggers cleanup with all entryId blob refs after successful download`() = runTest {
+        val manager = newManager(testScheduler)
+        val defaultEntry = topicEntry("blob-default")
+        val experimentEntry = topicEntry("blob-experiment")
+        val response = response(
+            blobSources = listOf(source("primary")),
+            topics = mapOf(
+                Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf(
+                    "default" to defaultEntry,
+                    "EXPERIMENT_A" to experimentEntry,
+                ),
+            ),
+        )
+        mockBackendSuccess(response)
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } returns null
+        val capturedReferenced = slot<Map<Topic, Set<String>>>()
+        coEvery { topicFetcher.cleanupUnreferencedTopics(capture(capturedReferenced)) } returns Unit
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        assertThat(capturedReferenced.captured).isEqualTo(
+            mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to setOf("blob-default", "blob-experiment")),
+        )
+    }
+
+    @Test
+    fun `does not trigger cleanup when a fetcher download fails`() = runTest {
+        val manager = newManager(testScheduler)
+        val response = response(
+            blobSources = listOf(source("primary")),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        val fetcherError = PurchasesError(PurchasesErrorCode.NetworkError, "fetcher failed")
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } returns fetcherError
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        coVerify(exactly = 0) { topicFetcher.cleanupUnreferencedTopics(any()) }
+    }
+
+    @Test
+    fun `does not trigger cleanup when backend errors`() = runTest {
+        val manager = newManager(testScheduler)
+        val backendError = PurchasesError(PurchasesErrorCode.NetworkError, "backend down")
+        val onErrorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            backend.getRemoteConfig(any(), any(), capture(onErrorSlot))
+        } answers { onErrorSlot.captured.invoke(backendError) }
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        coVerify(exactly = 0) { topicFetcher.cleanupUnreferencedTopics(any()) }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -106,7 +106,7 @@ class RemoteConfigManagerTest {
         assertThat(completionError).isNull()
         coVerify(exactly = 0) { topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any()) }
         verify(exactly = 0) { diskCache.write(any()) }
-        coVerify(exactly = 1) { topicFetcher.cleanupUnreferencedTopics(any()) }
+        coVerify(exactly = 0) { topicFetcher.cleanupUnreferencedTopics(any()) }
 
         // Cache wasn't populated, so a follow-up call still hits the backend.
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
@@ -137,7 +137,7 @@ class RemoteConfigManagerTest {
         assertThat(completionError).isNull()
         coVerify(exactly = 0) { topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any()) }
         verify(exactly = 0) { diskCache.write(any()) }
-        coVerify(exactly = 1) { topicFetcher.cleanupUnreferencedTopics(emptyMap()) }
+        coVerify(exactly = 0) { topicFetcher.cleanupUnreferencedTopics(any()) }
 
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
@@ -169,12 +169,7 @@ class RemoteConfigManagerTest {
         assertThat(completionError).isNull()
         coVerify(exactly = 0) { topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any()) }
         verify(exactly = 0) { diskCache.write(any()) }
-        // Cleanup still runs and includes the experiment-only topic's blob ref in the reference set.
-        coVerify(exactly = 1) {
-            topicFetcher.cleanupUnreferencedTopics(
-                mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to setOf("blob")),
-            )
-        }
+        coVerify(exactly = 0) { topicFetcher.cleanupUnreferencedTopics(any()) }
 
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
@@ -391,6 +386,21 @@ class RemoteConfigManagerTest {
     }
 
     @Test
+    fun `does not trigger cleanup when manifest has no topics`() = runTest {
+        val manager = newManager(testScheduler)
+        val response = response(
+            blobSources = listOf(source("primary")),
+            topics = emptyMap(),
+        )
+        mockBackendSuccess(response)
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        coVerify(exactly = 0) { topicFetcher.cleanupUnreferencedTopics(any()) }
+    }
+
+    @Test
     fun `successful refresh writes response to disk cache`() = runTest {
         val manager = newManager(testScheduler)
         val response = response(
@@ -406,28 +416,6 @@ class RemoteConfigManagerTest {
         testScheduler.advanceUntilIdle()
 
         verify(exactly = 1) { diskCache.write(response) }
-    }
-
-    @Test
-    fun `vacuously successful refresh (no sources) does not populate cache or write to disk`() = runTest {
-        val manager = newManager(testScheduler)
-        val response = response(
-            blobSources = emptyList(),
-            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
-        )
-        mockBackendSuccess(response)
-
-        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
-        testScheduler.advanceUntilIdle()
-
-        verify(exactly = 0) { diskCache.write(any()) }
-
-        // Cache wasn't populated, so a follow-up call still hits the backend.
-        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
-        testScheduler.advanceUntilIdle()
-        verify(exactly = 2) {
-            backend.getRemoteConfig(appInBackground = false, onSuccess = any(), onError = any())
-        }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/TopicFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/TopicFetcherTest.kt
@@ -319,6 +319,99 @@ class TopicFetcherTest {
         verify(exactly = 1) { urlConnectionFactory.createConnection(url, any()) }
     }
 
+    @Test
+    fun `cleanupUnreferencedTopics deletes files whose blobRef is not in the reference set`() = runTest {
+        val keptBlob = "a".repeat(64)
+        val staleBlob = "b".repeat(64)
+        val keptFile = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, keptBlob).also {
+            it.parentFile?.mkdirs()
+            it.writeBytes(byteArrayOf(1))
+        }
+        val staleFile = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, staleBlob).also {
+            it.parentFile?.mkdirs()
+            it.writeBytes(byteArrayOf(2))
+        }
+
+        fetcher().cleanupUnreferencedTopics(
+            mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to setOf(keptBlob)),
+        )
+
+        assertThat(keptFile).exists()
+        assertThat(staleFile).doesNotExist()
+    }
+
+    @Test
+    fun `cleanupUnreferencedTopics deletes every file for a topic absent from the reference set`() = runTest {
+        val blobA = "a".repeat(64)
+        val blobB = "b".repeat(64)
+        val fileA = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, blobA).also {
+            it.parentFile?.mkdirs()
+            it.writeBytes(byteArrayOf(1))
+        }
+        val fileB = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, blobB).also {
+            it.parentFile?.mkdirs()
+            it.writeBytes(byteArrayOf(2))
+        }
+
+        fetcher().cleanupUnreferencedTopics(emptyMap())
+
+        assertThat(fileA).doesNotExist()
+        assertThat(fileB).doesNotExist()
+    }
+
+    @Test
+    fun `cleanupUnreferencedTopics is a no-op when topics root does not exist`() = runTest {
+        // Sanity: nothing pre-created beyond the empty rootDir.
+        fetcher().cleanupUnreferencedTopics(
+            mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to setOf("a".repeat(64))),
+        )
+        // Reaching here without exception is the assertion.
+    }
+
+    @Test
+    fun `cleanupUnreferencedTopics keeps temp files (rc_topic_ prefix) untouched`() = runTest {
+        val staleBlob = "a".repeat(64)
+        val staleFile = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, staleBlob).also {
+            it.parentFile?.mkdirs()
+            it.writeBytes(byteArrayOf(1))
+        }
+        val tempFile = File(staleFile.parentFile, "rc_topic_inflight.tmp").also {
+            it.writeBytes(byteArrayOf(2))
+        }
+
+        fetcher().cleanupUnreferencedTopics(emptyMap())
+
+        assertThat(staleFile).doesNotExist()
+        assertThat(tempFile).exists()
+    }
+
+    @Test
+    fun `cleanupUnreferencedTopics keeps a referenced file when other files in the same dir are deleted`() = runTest {
+        val keptBlob = "c".repeat(64)
+        val staleBlob1 = "d".repeat(64)
+        val staleBlob2 = "e".repeat(64)
+        val kept = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, keptBlob).also {
+            it.parentFile?.mkdirs()
+            it.writeBytes(byteArrayOf(0))
+        }
+        val stale1 = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, staleBlob1).also {
+            it.parentFile?.mkdirs()
+            it.writeBytes(byteArrayOf(1))
+        }
+        val stale2 = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, staleBlob2).also {
+            it.parentFile?.mkdirs()
+            it.writeBytes(byteArrayOf(2))
+        }
+
+        fetcher().cleanupUnreferencedTopics(
+            mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to setOf(keptBlob)),
+        )
+
+        assertThat(kept).exists()
+        assertThat(stale1).doesNotExist()
+        assertThat(stale2).doesNotExist()
+    }
+
     private fun mockSuccessfulDownload(url: String, payload: ByteArray) {
         val connection = mockk<UrlConnection>(relaxed = true).also {
             every { it.responseCode } returns HttpURLConnection.HTTP_OK


### PR DESCRIPTION
### Motivation

`TopicFetcher` writes a new file every time the manifest's `blob_ref` rotates, but never deletes the previous one. Without cleanup, the on-disk cache at `noBackupFilesDir/RevenueCat/topics/...` grows unboundedly across backend rotations. This PR adds a one-shot disk-hygiene pass that runs at the end of each fully successful remote-config refresh.

### Description

- **`suspend fun TopicFetcher.cleanupUnreferencedTopics(referenced: Map<Topic, Set<String>>)`** — wraps the disk walk in `withContext(Dispatchers.IO)`, iterates `Topic.values()`, lists each topic's directory, and deletes files whose name isn't in the keep-set for that topic. Skips files prefixed with `rc_topic_` (the `createTempFile` prefix, now extracted as a `TEMP_PREFIX` constant) so a concurrent in-flight download isn't clobbered.
- **`RemoteConfigManager.refresh`** — builds the reference set as the union of every blob ref in the new manifest (across all variants, not just `DEFAULT`) and triggers cleanup at the right moment, all within the existing suspend coroutine flow:
  - When `sources` is empty or no DEFAULT-variant tasks remain → cleanup runs immediately (`fetchError = null` short-circuit).
  - When downloads dispatch → after the `async`/`awaitAll` fan-out, cleanup is awaited only if every fetch returned `null` (no error). Partial-failure refreshes leave the cache untouched.

Confirmed semantics:
- Reference set spans **all** variants in the new manifest (forward-compatible if non-DEFAULT variants ever start being cached).
- Topics in the SDK's `Topic` enum but absent from the new manifest get **all** their cached files wiped (reference-set = ∅).
- Cleanup runs **only** when every download in the refresh succeeded.

### Tests

`runTest` for both:

- 5 new `TopicFetcherTest` cases: delete unreferenced / wipe topic absent from set / no-op when root missing / preserve `rc_topic_*.tmp` / mixed keep+delete.
- 5 new `RemoteConfigManagerTest` cases (with `coEvery { topicFetcher.cleanupUnreferencedTopics(any()) } returns Unit` + `coVerify`): cleanup with all-variant refs / cleanup on empty sources & empty topics / no cleanup on fetcher error / no cleanup on backend error.

All changes are `internal`; no public API surface change.

### Stack

- ⬇ `Add network scaffolding for remote config endpoint`: #3435
- ⬇ `Add RemoteConfigManager and TopicFetcher`: #3437
- This PR: #3439

### Checklist

- [x] Unit tests
- [ ] Follow-up issues for `purchases-ios` / hybrids (deferred)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automatic deletion of on-disk topic files after successful remote-config refresh; mistakes in reference calculation or deletion logic could remove still-needed cached data, though it is guarded to run only on fully successful refreshes and has test coverage.
> 
> **Overview**
> After a fully successful remote-config refresh, the SDK now performs a one-shot cleanup pass to delete **unreferenced cached topic blob files** under `noBackupFilesDir/RevenueCat/topics`, preventing unbounded growth when `blob_ref`s rotate.
> 
> `RemoteConfigManager` builds a per-topic keep-set from *all* manifest entryIds’ `blob_ref`s and calls `TopicFetcher.cleanupUnreferencedTopics()` only when refresh completes with no errors (and caching conditions are met). `TopicFetcher` implements the disk walk/deletion, skips in-flight temp files via a shared `rc_topic_` prefix constant, and adds unit tests covering the new cleanup behavior and its failure/no-op cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9503c3688c647908aa63f955c52f75ecd12db710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->