### PR TITLE
Simplify `WorkflowTransitionState` with explicit from/to step fields

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -136,19 +136,20 @@ private fun WorkflowStepsContent(
     // a top clip causes the hero image (which renders behind the status bar) to get cropped
     // during the slide transition.
     Box(modifier = Modifier.fillMaxSize()) {
-        for (stepId in transitionState.visibleStepIds) {
-            val stepState = stepStates[stepId] ?: continue
-            key(stepId) {
-                WorkflowStepContent(
-                    stepId = stepId,
-                    stepState = stepState,
-                    currentStepId = currentStepId,
-                    transitionState = transitionState,
-                    clickHandler = clickHandler,
-                    componentInteractionTracker = componentInteractionTracker,
-                )
+        listOfNotNull(transitionState.animatingFromStepId, transitionState.animatingToStepId)
+            .forEach { stepId ->
+                val stepState = stepStates[stepId] ?: return@forEach
+                key(stepId) {
+                    WorkflowStepContent(
+                        stepId = stepId,
+                        stepState = stepState,
+                        currentStepId = currentStepId,
+                        transitionState = transitionState,
+                        clickHandler = clickHandler,
+                        componentInteractionTracker = componentInteractionTracker,
+                    )
+                }
             }
-        }
     }
 }
 
@@ -182,7 +183,7 @@ private fun WorkflowStepContent(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .workflowTransition(transitionState, stepId, currentStepId)
+            .workflowTransition(transitionState, stepId)
             .background(background),
     ) {
         WithOptionalBackgroundOverlay(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowTransitionState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowTransitionState.kt
@@ -30,14 +30,14 @@ import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
  * Each subclass carries only the properties that are meaningful for its animation type, so callers
  * pattern-match rather than interrogating nullable fields that don't apply.
  *
- * @property visibleStepIds step IDs currently held in the Compose slot table.
  * @property animatingFromStepId step ID transitioning out; null when idle.
+ * @property animatingToStepId step ID transitioning in (the current step).
  * @property animatable drives progress 0f→1f. Created fresh via [key] for each new
  *   [WorkflowPaywallUiState.pendingTransition] so it always starts at 0f.
  */
 internal sealed class WorkflowTransitionState {
-    abstract val visibleStepIds: Set<String>
     abstract val animatingFromStepId: String?
+    abstract val animatingToStepId: String
     abstract val animatable: Animatable<Float, AnimationVector1D>
 
     /**
@@ -47,8 +47,8 @@ internal sealed class WorkflowTransitionState {
      * @property animatingDirection direction of the active transition; null when idle.
      */
     class SlideInOut(
-        override val visibleStepIds: Set<String>,
         override val animatingFromStepId: String?,
+        override val animatingToStepId: String,
         val animatingDirection: NavigationDirection?,
         override val animatable: Animatable<Float, AnimationVector1D>,
     ) : WorkflowTransitionState()
@@ -103,16 +103,10 @@ internal fun rememberWorkflowTransitionState(
         }
     }
 
-    val visibleStepIds = if (pendingTransition != null) {
-        setOf(pendingTransition.fromStepId, currentStepId)
-    } else {
-        setOf(currentStepId)
-    }
-
     return when (transition) {
         is WorkflowTransitionAnimation.SlideInOut -> WorkflowTransitionState.SlideInOut(
-            visibleStepIds = visibleStepIds,
             animatingFromStepId = pendingTransition?.fromStepId,
+            animatingToStepId = currentStepId,
             animatingDirection = pendingTransition?.direction,
             animatable = animatable,
         )
@@ -123,9 +117,8 @@ internal fun rememberWorkflowTransitionState(
  * Applies the visual transform for the active [WorkflowTransitionState] to a step's content.
  *
  * For [WorkflowTransitionState.SlideInOut], translates horizontally:
- * - **Current step**: slides from `±width` to `0` as progress goes 0→1.
+ * - **Incoming step**: slides from `±width` to `0` as progress goes 0→1.
  * - **Outgoing step**: slides from `0` to `∓width` as progress goes 0→1.
- * - **Other (parked) steps**: positioned far off-screen so the GraphicsLayer skips drawing.
  *
  * State reads happen inside the layer block so animation frames invalidate the layer without
  * triggering recomposition.
@@ -133,23 +126,21 @@ internal fun rememberWorkflowTransitionState(
 internal fun Modifier.workflowTransition(
     state: WorkflowTransitionState,
     stepId: String,
-    currentStepId: String,
 ): Modifier = graphicsLayer {
-    applyWorkflowTransition(state, stepId, currentStepId, progress = state.animatable.value)
+    applyWorkflowTransition(state, stepId, progress = state.animatable.value)
 }
 
 private fun GraphicsLayerScope.applyWorkflowTransition(
     state: WorkflowTransitionState,
     stepId: String,
-    currentStepId: String,
     progress: Float,
 ): Unit = when (state) {
     is WorkflowTransitionState.SlideInOut -> {
         val directionFactor = if (state.animatingDirection == NavigationDirection.FORWARD) 1f else -1f
         translationX = when (stepId) {
-            currentStepId -> (1f - progress) * directionFactor * size.width
+            state.animatingToStepId -> (1f - progress) * directionFactor * size.width
             state.animatingFromStepId -> -progress * directionFactor * size.width
-            else -> 2f * size.width
+            else -> 0f
         }
     }
 }


### PR DESCRIPTION
Cleanup from a review comment on #3430.

`visibleStepIds: Set` was redundant with `animatingFromStepId: String?`: the set was always either `{from, to}` or `{to}`, derivable from the from/to pair. Replaced both with explicit `animatingFromStepId` + `animatingToStepId`. This was there becuase I was attempting some performance improvements in other branch that used a set, but we are going with just from and to for now.

Also dropped some dead code:
- the unreachable parked-step branch in `applyWorkflowTransition` (vestige of an old "render all steps" design)
- the `currentStepId` param of `workflowTransition`, now read off `state.animatingToStepId`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes which workflow steps are kept in composition and how slide translations are computed, which could cause visual/animation regressions if edge cases exist.
> 
> **Overview**
> Simplifies workflow paywall transitions by removing `visibleStepIds` and making `WorkflowTransitionState` explicitly track `animatingFromStepId` and `animatingToStepId`.
> 
> Rendering now only composes the outgoing + incoming steps during a transition (via `listOfNotNull(from,to)`), and `workflowTransition` no longer requires `currentStepId`, instead deriving positioning from `state.animatingToStepId`. Dead/unused “parked step” translation logic is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67fadd3be53f6361148cb5613f411f981c9aef34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->