### PR TITLE
test: cover singleStepFallbackId == initialStepId edge case

### DIFF
--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -640,5 +640,25 @@ class PaywallViewModelWorkflowTest {
         assertThat(step1State!!.selectedPackageInfo).isNull()
     }
 
+    @Test
+    fun `singleStepFallbackId equal to initialStepId does not crash and own selection is used`() {
+        // Edge case: the fallback step IS the initial step — no earlier packageless steps exist,
+        // so the pre-computation guard skips re-building the step. The step's own selection
+        // (ownSelection) must still win over the self-referential defaultPackageInfo.
+        val (twoPackageResult, twoPackageOfferings) = makeTwoPackageWorkflow()
+        val singleFallbackResult = twoPackageResult.copy(
+            workflow = twoPackageResult.workflow.copy(singleStepFallbackId = "step-1"),
+        )
+        val vm = createVm()
+
+        vm.updateStateFromWorkflow(singleFallbackResult, twoPackageOfferings, null)
+
+        val step1State = vm.workflowState.value?.stepStates?.get("step-1")
+        assertThat(step1State).isNotNull()
+        // monthlyPackageComponentDefault has isSelectedByDefault = true → MONTHLY wins.
+        assertThat(step1State!!.selectedPackageInfo?.rcPackage?.identifier)
+            .isEqualTo(PackageType.MONTHLY.identifier)
+    }
+
     // endregion
 }


### PR DESCRIPTION
## Summary

Follow-up to #3431.

During review of #3431 I noticed that when `singleStepFallbackId` points to the same step as `initialStepId`, the pre-computation guard (`stepWithPackages.id != initialStep.id`) correctly skips re-building the step, but there was no test covering this path.

In this edge case `setDefaultPackage` is effectively called on the step with its own `selectedPackageInfo` as input (a self-referential read from the cache). The test verifies that:
- No crash occurs
- `ownSelection` takes precedence — MONTHLY (the default-by-config package) is still returned correctly

## Test plan
- [x] New test passes locally: `singleStepFallbackId equal to initialStepId does not crash and own selection is used`
- [x] Full `PaywallViewModelWorkflowTest` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a unit test only, with no production code changes; the main impact is tighter regression coverage around workflow default package selection.
> 
> **Overview**
> Adds a new `PaywallViewModelWorkflowTest` case covering the edge scenario where `workflow.singleStepFallbackId` equals `initialStepId`.
> 
> The test asserts `updateStateFromWorkflow` doesn’t crash and that the initial step’s *own* default package selection still wins (e.g. MONTHLY) rather than being overridden by a self-referential fallback/default package lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd9659d32bbd59c88e252f74061be4c88a8a761c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->