### PR TITLE
Extract `PaywallComponentsImagePreDownloader`

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -201,6 +201,10 @@ internal class PurchasesFactory(
                 httpClient,
                 backendHelper,
             )
+            val coilImageDownloader = CoilImageDownloader(application)
+            val paywallComponentsImagePreDownloader = PaywallComponentsImagePreDownloader(
+                coilImageDownloader = coilImageDownloader,
+            )
 
             val workflowManager = WorkflowManager(
                 backend = backend,
@@ -359,7 +363,10 @@ internal class PurchasesFactory(
                 offeringsCache,
                 backend,
                 OfferingsFactory(billing, offeringParser, dispatcher, appConfig),
-                OfferingImagePreDownloader(coilImageDownloader = CoilImageDownloader(application)),
+                OfferingImagePreDownloader(
+                    coilImageDownloader = coilImageDownloader,
+                    paywallComponentsImagePreDownloader = paywallComponentsImagePreDownloader,
+                ),
                 diagnosticsTracker,
                 offeringFontPreDownloader = offeringFontPreDownloader,
                 uiPreviewMode = appConfig.uiPreviewMode,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -57,6 +57,7 @@ import com.revenuecat.purchases.utils.CoilImageDownloader
 import com.revenuecat.purchases.utils.EventsFileHelper
 import com.revenuecat.purchases.utils.IsDebugBuildProvider
 import com.revenuecat.purchases.utils.OfferingImagePreDownloader
+import com.revenuecat.purchases.utils.PaywallComponentsImagePreDownloader
 import com.revenuecat.purchases.utils.PurchaseParamsValidator
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencyManager

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/OfferingImagePreDownloader.kt
@@ -8,15 +8,6 @@ import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.common.canUsePaywallUI
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.verboseLog
-import com.revenuecat.purchases.paywalls.components.CarouselComponent
-import com.revenuecat.purchases.paywalls.components.CountdownComponent
-import com.revenuecat.purchases.paywalls.components.IconComponent
-import com.revenuecat.purchases.paywalls.components.ImageComponent
-import com.revenuecat.purchases.paywalls.components.StackComponent
-import com.revenuecat.purchases.paywalls.components.TabsComponent
-import com.revenuecat.purchases.paywalls.components.VideoComponent
-import com.revenuecat.purchases.paywalls.components.common.Background
-import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
 
 internal class OfferingImagePreDownloader(
     /**
@@ -25,6 +16,8 @@ internal class OfferingImagePreDownloader(
      */
     private val shouldPredownloadImages: Boolean = canUsePaywallUI,
     private val coilImageDownloader: CoilImageDownloader,
+    private val paywallComponentsImagePreDownloader: PaywallComponentsImagePreDownloader =
+        PaywallComponentsImagePreDownloader(shouldPredownloadImages, coilImageDownloader),
 ) {
     fun preDownloadOfferingImages(offering: Offering) {
         if (!shouldPredownloadImages) {
@@ -52,89 +45,7 @@ internal class OfferingImagePreDownloader(
 
     private fun downloadV2Images(offering: Offering) {
         offering.paywallComponents?.let { paywallComponents ->
-            val imageUrls = findImageUrisToDownload(paywallComponents)
-            imageUrls.forEach {
-                debugLog { "Pre-downloading Paywall V2 image: $it" }
-                coilImageDownloader.downloadImage(it)
-            }
+            paywallComponentsImagePreDownloader.preDownloadImages(paywallComponents.data.componentsConfig.base)
         }
-    }
-
-    private fun findImageUrisToDownload(paywallComponents: Offering.PaywallComponents): Set<Uri> {
-        val paywallComponentsConfig = paywallComponents.data.componentsConfig.base
-
-        return paywallComponentsConfig.stack.findImageUrisToDownload() +
-            (paywallComponentsConfig.stickyFooter?.stack?.findImageUrisToDownload().orEmpty()) +
-            paywallComponentsConfig.background.findImageUrisToDownload()
-    }
-
-    private fun StackComponent.findImageUrisToDownload(): Set<Uri> {
-        return filter {
-            it is StackComponent ||
-                it is IconComponent ||
-                it is CarouselComponent ||
-                it is TabsComponent ||
-                it is ImageComponent ||
-                it is CountdownComponent
-        }.flatMapTo(mutableSetOf()) { component ->
-            when (component) {
-                is StackComponent -> {
-                    component.background.findImageUrisToDownload() + component.overrides.flatMapTo(mutableSetOf()) {
-                        it.properties.background.findImageUrisToDownload()
-                    }
-                }
-                is IconComponent -> {
-                    setOf(Uri.parse(component.baseUrl).buildUpon().path(component.formats.webp).build())
-                }
-                is CarouselComponent -> {
-                    component.background.findImageUrisToDownload() + component.overrides.flatMapTo(mutableSetOf()) {
-                        it.properties.background.findImageUrisToDownload()
-                    }
-                }
-                is TabsComponent -> {
-                    component.background.findImageUrisToDownload() + component.overrides.flatMapTo(mutableSetOf()) {
-                        it.properties.background.findImageUrisToDownload()
-                    }
-                }
-                is ImageComponent -> {
-                    component.source.findImageUrisToDownload() + component.overrides.flatMapTo(mutableSetOf()) {
-                        it.properties.source?.findImageUrisToDownload().orEmpty()
-                    }
-                }
-                is VideoComponent -> {
-                    component.fallbackSource?.findImageUrisToDownload().orEmpty()
-                }
-                is CountdownComponent -> {
-                    component.countdownStack.findImageUrisToDownload() +
-                        (component.endStack?.findImageUrisToDownload().orEmpty()) +
-                        (component.fallback?.findImageUrisToDownload().orEmpty())
-                }
-                else -> emptySet()
-            }
-        }
-    }
-
-    private fun Background?.findImageUrisToDownload(): Set<Uri> {
-        return when (this) {
-            is Background.Image -> setOfNotNull(
-                Uri.parse(value.light.webpLowRes.toString()),
-                value.dark?.webpLowRes?.toString()?.let { Uri.parse(it) },
-            )
-            is Background.Video -> setOfNotNull(
-                Uri.parse(fallbackImage.light.webpLowRes.toString()),
-                fallbackImage.dark?.webpLowRes?.toString()?.let { Uri.parse(it) },
-            )
-            is Background.Color,
-            is Background.Unknown,
-            null,
-            -> emptySet()
-        }
-    }
-
-    private fun ThemeImageUrls.findImageUrisToDownload(): Set<Uri> {
-        return setOfNotNull(
-            light.webpLowRes.toString().let { Uri.parse(it) },
-            dark?.webpLowRes?.toString()?.let { Uri.parse(it) },
-        )
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentsImagePreDownloader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/utils/PaywallComponentsImagePreDownloader.kt
@@ -1,0 +1,119 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.utils
+
+import android.net.Uri
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.canUsePaywallUI
+import com.revenuecat.purchases.common.debugLog
+import com.revenuecat.purchases.common.verboseLog
+import com.revenuecat.purchases.paywalls.components.CarouselComponent
+import com.revenuecat.purchases.paywalls.components.CountdownComponent
+import com.revenuecat.purchases.paywalls.components.IconComponent
+import com.revenuecat.purchases.paywalls.components.ImageComponent
+import com.revenuecat.purchases.paywalls.components.StackComponent
+import com.revenuecat.purchases.paywalls.components.TabsComponent
+import com.revenuecat.purchases.paywalls.components.VideoComponent
+import com.revenuecat.purchases.paywalls.components.common.Background
+import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConfig
+import com.revenuecat.purchases.paywalls.components.properties.ThemeImageUrls
+
+internal class PaywallComponentsImagePreDownloader(
+    /**
+     * We check for the existence of the paywalls SDK. If so, the Coil SDK should be available to
+     * pre-download the images.
+     */
+    private val shouldPredownloadImages: Boolean = canUsePaywallUI,
+    private val coilImageDownloader: CoilImageDownloader,
+) {
+
+    fun preDownloadImages(paywallComponentsConfig: PaywallComponentsConfig) {
+        if (!shouldPredownloadImages) {
+            verboseLog { "PaywallComponentsImagePreDownloader won't pre-download images" }
+            return
+        }
+
+        val imageUrls = findImageUrisToDownload(paywallComponentsConfig)
+        imageUrls.forEach {
+            debugLog { "Pre-downloading Paywall V2 image: $it" }
+            coilImageDownloader.downloadImage(it)
+        }
+    }
+
+    private fun findImageUrisToDownload(paywallComponentsConfig: PaywallComponentsConfig): Set<Uri> {
+        return paywallComponentsConfig.stack.findImageUrisToDownload() +
+            (paywallComponentsConfig.header?.stack?.findImageUrisToDownload().orEmpty()) +
+            (paywallComponentsConfig.stickyFooter?.stack?.findImageUrisToDownload().orEmpty()) +
+            paywallComponentsConfig.background.findImageUrisToDownload()
+    }
+
+    private fun StackComponent.findImageUrisToDownload(): Set<Uri> {
+        return filter {
+            it is StackComponent ||
+                it is IconComponent ||
+                it is CarouselComponent ||
+                it is TabsComponent ||
+                it is ImageComponent ||
+                it is CountdownComponent
+        }.flatMapTo(mutableSetOf()) { component ->
+            when (component) {
+                is StackComponent -> {
+                    component.background.findImageUrisToDownload() + component.overrides.flatMapTo(mutableSetOf()) {
+                        it.properties.background.findImageUrisToDownload()
+                    }
+                }
+                is IconComponent -> {
+                    setOf(Uri.parse(component.baseUrl).buildUpon().path(component.formats.webp).build())
+                }
+                is CarouselComponent -> {
+                    component.background.findImageUrisToDownload() + component.overrides.flatMapTo(mutableSetOf()) {
+                        it.properties.background.findImageUrisToDownload()
+                    }
+                }
+                is TabsComponent -> {
+                    component.background.findImageUrisToDownload() + component.overrides.flatMapTo(mutableSetOf()) {
+                        it.properties.background.findImageUrisToDownload()
+                    }
+                }
+                is ImageComponent -> {
+                    component.source.findImageUrisToDownload() + component.overrides.flatMapTo(mutableSetOf()) {
+                        it.properties.source?.findImageUrisToDownload().orEmpty()
+                    }
+                }
+                is VideoComponent -> {
+                    component.fallbackSource?.findImageUrisToDownload().orEmpty()
+                }
+                is CountdownComponent -> {
+                    component.countdownStack.findImageUrisToDownload() +
+                        (component.endStack?.findImageUrisToDownload().orEmpty()) +
+                        (component.fallback?.findImageUrisToDownload().orEmpty())
+                }
+                else -> emptySet()
+            }
+        }
+    }
+
+    private fun Background?.findImageUrisToDownload(): Set<Uri> {
+        return when (this) {
+            is Background.Image -> setOfNotNull(
+                Uri.parse(value.light.webpLowRes.toString()),
+                value.dark?.webpLowRes?.toString()?.let { Uri.parse(it) },
+            )
+            is Background.Video -> setOfNotNull(
+                Uri.parse(fallbackImage.light.webpLowRes.toString()),
+                fallbackImage.dark?.webpLowRes?.toString()?.let { Uri.parse(it) },
+            )
+            is Background.Color,
+            is Background.Unknown,
+            null,
+            -> emptySet()
+        }
+    }
+
+    private fun ThemeImageUrls.findImageUrisToDownload(): Set<Uri> {
+        return setOfNotNull(
+            light.webpLowRes.toString().let { Uri.parse(it) },
+            dark?.webpLowRes?.toString()?.let { Uri.parse(it) },
+        )
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/utils/OfferingImagePreDownloaderTest.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.ColorAlias
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.paywalls.PaywallData
 import com.revenuecat.purchases.paywalls.components.CarouselComponent
+import com.revenuecat.purchases.paywalls.components.HeaderComponent
 import com.revenuecat.purchases.paywalls.components.IconComponent
 import com.revenuecat.purchases.paywalls.components.ImageComponent
 import com.revenuecat.purchases.paywalls.components.PartialImageComponent
@@ -136,6 +137,8 @@ class OfferingImagePreDownloaderTest {
             "https://pawwalls.com/test_sticky_footer_override_2_light_low_res.webp",
             "https://pawwalls.com/test_sticky_footer_override_2_dark_low_res.webp",
             "https://pawwalls.com/test_icon_2.webp",
+            "https://pawwalls.com/test_header_low_res.webp",
+            "https://pawwalls.com/test_icon_5.webp",
             "https://pawwalls.com/test_icon_3.webp",
             "https://pawwalls.com/test_icon_4.webp",
         )
@@ -284,6 +287,26 @@ class OfferingImagePreDownloaderTest {
                                             dark = createMockImageUrls(webpLowRes = "https://pawwalls.com/test_sticky_footer_override_2_dark_low_res.webp"),
                                         ),
                                     ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                header = HeaderComponent(
+                    stack = StackComponent(
+                        components = listOf(
+                            IconComponent(
+                                baseUrl = "https://pawwalls.com",
+                                iconName = "test_icon",
+                                formats = IconComponent.Formats(
+                                    webp = "test_icon_5.webp",
+                                ),
+                            ),
+                        ),
+                        background = Background.Image(
+                            value = ThemeImageUrls(
+                                light = createMockImageUrls(
+                                    webpLowRes = "https://pawwalls.com/test_header_low_res.webp",
                                 ),
                             ),
                         ),


### PR DESCRIPTION
Extracted from https://github.com/RevenueCat/purchases-android/pull/3447/

Little refactor extracting PaywallComponentsImagePreDownloader

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall image predownload behavior and wiring, which could increase/alter network/cache usage for paywall assets (notably header images) and affect startup/background work.
> 
> **Overview**
> Extracts Paywall V2 image predownload logic from `OfferingImagePreDownloader` into a new `PaywallComponentsImagePreDownloader`, and updates `PurchasesFactory` to create/reuse a single `CoilImageDownloader` and pass the new predownloader through.
> 
> Updates the image selection for Paywall V2 to include `header` stack assets (in addition to stack/sticky footer/background), and adjusts tests to cover the new header image/icon downloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb8a6ed9cf3eec25a6dc6920652d50bc1630d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->