### PR TITLE
Wire RemoteConfigManager refresh on first foreground and identity changes (off by default)

### DIFF
--- a/local.properties.example
+++ b/local.properties.example
@@ -68,3 +68,11 @@
 ## Only takes effect in debug builds.
 ## ──────────────────────────────────────────────
 #REMOTE_CONFIG_BASE_URL=http://localhost:8080/
+
+## ──────────────────────────────────────────────
+## Remote Config Refresh (developer flag)
+## When true, the SDK kicks off a remote-config refresh the first time the
+## app is foregrounded after Purchases.configure(...) and on every logIn /
+## logOut / switchUser that changes the app user id. Off by default.
+## ──────────────────────────────────────────────
+#ENABLE_REMOTE_CONFIG=true

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -71,6 +71,12 @@ android {
         )
 
         buildConfigField(
+            type = "boolean",
+            name = "ENABLE_REMOTE_CONFIG",
+            value = (localProperties["ENABLE_REMOTE_CONFIG"] as? String ?: "false"),
+        )
+
+        buildConfigField(
             type = "String",
             name = "SAMSUNG_IAP_SDK_VERSION",
             value = "\"${libs.versions.samsungIap.get()}\"",

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -36,6 +36,9 @@ import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineCustomerInfoCalculator
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.offlineentitlements.PurchasedProductsFetcher
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigDiskCache
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
+import com.revenuecat.purchases.common.remoteconfig.TopicFetcher
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
 import com.revenuecat.purchases.common.warnLog
@@ -54,6 +57,7 @@ import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesPoster
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
 import com.revenuecat.purchases.utils.CoilImageDownloader
+import com.revenuecat.purchases.utils.DefaultUrlConnectionFactory
 import com.revenuecat.purchases.utils.EventsFileHelper
 import com.revenuecat.purchases.utils.IsDebugBuildProvider
 import com.revenuecat.purchases.utils.OfferingImagePreDownloader
@@ -423,6 +427,15 @@ internal class PurchasesFactory(
                 baseURL = AppConfig.adEventsURL,
             )
 
+            val remoteConfigManager = RemoteConfigManager(
+                backend = backend,
+                topicFetcher = TopicFetcher(
+                    applicationContext = application,
+                    urlConnectionFactory = DefaultUrlConnectionFactory(),
+                ),
+                diskCache = RemoteConfigDiskCache(application, Backend.json),
+            )
+
             val purchasesOrchestrator = PurchasesOrchestrator(
                 application,
                 appUserID,
@@ -454,6 +467,7 @@ internal class PurchasesFactory(
                 purchaseParamsValidator = purchaseParamsValidator,
                 workflowManager = workflowManager,
                 fileRepository = fileRepository,
+                remoteConfigManager = remoteConfigManager,
             )
 
             return Purchases(purchasesOrchestrator)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -342,7 +342,7 @@ internal class PurchasesOrchestrator(
                 diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
             }
             if (firstTimeInForeground) {
-                refreshRemoteConfigIfEnabled(identityManager.currentAppUserID)
+                refreshRemoteConfigIfEnabled()
             }
         }
     }
@@ -770,7 +770,7 @@ internal class PurchasesOrchestrator(
                             customerInfoUpdateHandler.notifyListeners(customerInfo)
                         }
                         offeringsManager.fetchAndCacheOfferings(newAppUserID, state.appInBackground)
-                        refreshRemoteConfigIfEnabled(newAppUserID)
+                        refreshRemoteConfigIfEnabled()
                         backupManager.dataChanged()
                     },
                     onError = { error ->
@@ -804,7 +804,7 @@ internal class PurchasesOrchestrator(
                     state = state.copy(purchaseCallbacksByProductId = Collections.emptyMap())
                 }
                 updateAllCaches(identityManager.currentAppUserID, callback)
-                refreshRemoteConfigIfEnabled(identityManager.currentAppUserID)
+                refreshRemoteConfigIfEnabled()
                 backupManager.dataChanged()
             }
         }
@@ -1265,7 +1265,7 @@ internal class PurchasesOrchestrator(
         identityManager.switchUser(newAppUserID)
 
         offeringsManager.fetchAndCacheOfferings(newAppUserID, state.appInBackground)
-        refreshRemoteConfigIfEnabled(newAppUserID)
+        refreshRemoteConfigIfEnabled()
     }
     //endregion
 
@@ -1287,10 +1287,9 @@ internal class PurchasesOrchestrator(
         dispatcher.enqueue({ command() }, Delay.NONE)
     }
 
-    private fun refreshRemoteConfigIfEnabled(appUserID: String) {
+    private fun refreshRemoteConfigIfEnabled() {
         if (!BuildConfig.ENABLE_REMOTE_CONFIG) return
         remoteConfigManager.updateRemoteConfigIfNeeded(
-            appUserID = appUserID,
             appInBackground = state.appInBackground,
         )
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -19,6 +19,7 @@ import com.android.billingclient.api.BillingClientStateListener
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.PendingPurchasesParams
 import com.revenuecat.purchases.ads.events.AdTracker
+import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.blockstore.BlockstoreHelper
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
@@ -47,6 +48,7 @@ import com.revenuecat.purchases.common.events.FeatureEvent
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.offerings.OfferingsManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
+import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.common.subscriberattributes.SubscriberAttributeKey
 import com.revenuecat.purchases.common.verboseLog
@@ -155,6 +157,7 @@ internal class PurchasesOrchestrator(
     private val purchaseParamsValidator: PurchaseParamsValidator,
 
     private val workflowManager: WorkflowManager,
+    private val remoteConfigManager: RemoteConfigManager,
     val processLifecycleOwnerProvider: () -> LifecycleOwner = { ProcessLifecycleOwner.get() },
     private val blockstoreHelper: BlockstoreHelper = BlockstoreHelper(application, identityManager),
     private val backupManager: BackupManager = BackupManager(application),
@@ -337,6 +340,9 @@ internal class PurchasesOrchestrator(
             flushEvents(Delay.DEFAULT)
             if (firstTimeInForeground && isAndroidNOrNewer()) {
                 diagnosticsSynchronizer?.syncDiagnosticsFileIfNeeded()
+            }
+            if (firstTimeInForeground) {
+                refreshRemoteConfigIfEnabled(identityManager.currentAppUserID)
             }
         }
     }
@@ -764,6 +770,7 @@ internal class PurchasesOrchestrator(
                             customerInfoUpdateHandler.notifyListeners(customerInfo)
                         }
                         offeringsManager.fetchAndCacheOfferings(newAppUserID, state.appInBackground)
+                        refreshRemoteConfigIfEnabled(newAppUserID)
                         backupManager.dataChanged()
                     },
                     onError = { error ->
@@ -797,6 +804,7 @@ internal class PurchasesOrchestrator(
                     state = state.copy(purchaseCallbacksByProductId = Collections.emptyMap())
                 }
                 updateAllCaches(identityManager.currentAppUserID, callback)
+                refreshRemoteConfigIfEnabled(identityManager.currentAppUserID)
                 backupManager.dataChanged()
             }
         }
@@ -1257,6 +1265,7 @@ internal class PurchasesOrchestrator(
         identityManager.switchUser(newAppUserID)
 
         offeringsManager.fetchAndCacheOfferings(newAppUserID, state.appInBackground)
+        refreshRemoteConfigIfEnabled(newAppUserID)
     }
     //endregion
 
@@ -1276,6 +1285,14 @@ internal class PurchasesOrchestrator(
     // region Private Methods
     private fun enqueue(command: () -> Unit) {
         dispatcher.enqueue({ command() }, Delay.NONE)
+    }
+
+    private fun refreshRemoteConfigIfEnabled(appUserID: String) {
+        if (!BuildConfig.ENABLE_REMOTE_CONFIG) return
+        remoteConfigManager.updateRemoteConfigIfNeeded(
+            appUserID = appUserID,
+            appInBackground = state.appInBackground,
+        )
     }
 
     private fun shouldRefreshCustomerInfo(firstTimeInForeground: Boolean): Boolean {

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -508,6 +508,7 @@ internal open class BasePurchasesTest {
             backupManager = mockBackupManager,
             purchaseParamsValidator = mockPurchaseParamsValidator,
             workflowManager = mockk(relaxed = true),
+            remoteConfigManager = mockk(relaxed = true),
         )
 
         purchases = Purchases(

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/attributes/SubscriberAttributesPurchasesTests.kt
@@ -133,6 +133,7 @@ class SubscriberAttributesPurchasesTests {
             virtualCurrencyManager = virtualCurrencyManagerMock,
             purchaseParamsValidator = purchaseParamsValidator,
             workflowManager = mockk(relaxed = true),
+            remoteConfigManager = mockk(relaxed = true),
         )
 
         underTest = Purchases(purchasesOrchestrator)


### PR DESCRIPTION
### Motivation

Final piece of the initial remote-config wiring: hook `RemoteConfigManager` into the SDK's actual lifecycle so the topic-fetch pipeline runs on real devices. The earlier PRs in the stack added the network scaffolding (#3435), the manager + topic fetcher (#3437), and the unreferenced-topic cleanup (#3439). None of them invoke the manager — this PR does, behind a developer-only build flag so production traffic is unaffected.

### Description

- Constructs `RemoteConfigManager` (with a `TopicFetcher`) inside `PurchasesFactory` and passes it into `PurchasesOrchestrator`.
- Adds a private `refreshRemoteConfigIfEnabled(appUserID)` helper on `PurchasesOrchestrator` that calls `remoteConfigManager.updateRemoteConfigIfNeeded(...)`. The helper is invoked from four places, each of which already runs only when something meaningful changed:
  - `onAppForegrounded()` — only when `state.firstTimeInForeground` is true (i.e. first foreground after `Purchases.configure(...)`, exactly once per `Purchases` instance).
  - `logIn(...)` `onSuccess` — only reached when the new `appUserID` differs from the current one.
  - `logOut(...)` success branch — the `appUserID` has just been replaced with a fresh anonymous id.
  - `switchUser(...)` — the early-return on the same-id path filters out no-ops before we get here.
- Every call site is gated on the new compile-time flag `BuildConfig.ENABLE_REMOTE_CONFIG`, fed from `local.properties` (`ENABLE_REMOTE_CONFIG=true`). Default: `false`, so disabling the flag is a no-op at every call site. Mirrors the existing `ENABLE_EXTRA_REQUEST_LOGGING` pattern.
- Existing orchestrator tests are updated to pass a relaxed mock for the new constructor parameter. No tests are added for the flag-on path: `BuildConfig.ENABLE_REMOTE_CONFIG` is `false` in CI unit-test builds, so that branch is unreachable from JUnit. Same precedent as `ENABLE_EXTRA_REQUEST_LOGGING`. The on-path is exercised manually via `purchase-tester` against a localhost backend (combine with `REMOTE_CONFIG_BASE_URL` from #3435).

All new types remain `internal`. No public API surface change.

### Stack

- ⬇ `Add remote-config network scaffolding`: #3435
- ⬇ `Add RemoteConfigManager and TopicFetcher`: #3437
- ⬇ `Clean up unreferenced topic files after successful remote-config refresh`: #3439
- This PR

### Checklist

- [x] Existing unit tests pass (orchestrator tests pick up the new relaxed mock; flag-on path is dev-only, tested manually).
- [ ] Follow-up issues for `purchases-ios` / hybrids (deferred — feature is not yet wired to any consumer).
