### PR TITLE
fix: url encode query prameters

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URIExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URIExtensions.kt
@@ -2,6 +2,7 @@
 
 package com.revenuecat.purchases.ui.revenuecatui.utils
 
+import android.net.Uri
 import java.net.URI
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -18,5 +19,4 @@ internal fun URI.appendQueryParameter(name: String, value: String): URI {
     return URI("$uriWithoutFragment$separator$encodedParameter$fragment")
 }
 
-private fun String.encodeQueryParameterComponent(): String =
-    URLEncoder.encode(this, StandardCharsets.UTF_8.name()).replace("+", "%20")
+private fun String.encodeQueryParameterComponent(): String = Uri.encode(this)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URIExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URIExtensions.kt
@@ -3,9 +3,20 @@
 package com.revenuecat.purchases.ui.revenuecatui.utils
 
 import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 @JvmSynthetic
 internal fun URI.appendQueryParameter(name: String, value: String): URI {
-    val separator = if (this.query == null) "?" else "&"
-    return URI("$this$separator$name=$value")
+    val encodedParameter = "${name.encodeQueryParameterComponent()}=${value.encodeQueryParameterComponent()}"
+    val uriString = toString()
+    val fragmentIndex = uriString.indexOf('#')
+    val uriWithoutFragment = if (fragmentIndex == -1) uriString else uriString.substring(0, fragmentIndex)
+    val fragment = if (fragmentIndex == -1) "" else uriString.substring(fragmentIndex)
+    val separator = if (this.rawQuery == null) "?" else "&"
+
+    return URI("$uriWithoutFragment$separator$encodedParameter$fragment")
 }
+
+private fun String.encodeQueryParameterComponent(): String =
+    URLEncoder.encode(this, StandardCharsets.UTF_8.name()).replace("+", "%20")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URIExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URIExtensions.kt
@@ -4,8 +4,6 @@ package com.revenuecat.purchases.ui.revenuecatui.utils
 
 import android.net.Uri
 import java.net.URI
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 
 @JvmSynthetic
 internal fun URI.appendQueryParameter(name: String, value: String): URI {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URLExtensions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URLExtensions.kt
@@ -5,7 +5,5 @@ package com.revenuecat.purchases.ui.revenuecatui.utils
 import java.net.URL
 
 @JvmSynthetic
-internal fun URL.appendQueryParameter(name: String, value: String): URL {
-    val separator = if (this.query == null) "?" else "&"
-    return URL("$this$separator$name=$value")
-}
+internal fun URL.appendQueryParameter(name: String, value: String): URL =
+    toURI().appendQueryParameter(name, value).toURL()

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -2006,7 +2006,7 @@ class PaywallViewModelTest {
         val model = create(offering = offeringWithWPL)
         assertThat(
             model.getWebCheckoutUrl(launchWebCheckoutWithCustomUrlAndPackage),
-        ).isEqualTo("https://revenuecat.com?rc_package=\$rc_monthly")
+        ).isEqualTo("https://revenuecat.com?rc_package=%24rc_monthly")
 
         assertThat(
             model.getWebCheckoutUrl(launchWebCheckoutWithCustomUrlNoPackage),
@@ -2040,12 +2040,12 @@ class PaywallViewModelTest {
         // Uses given package
         assertThat(
             model.getWebCheckoutUrl(launchWebCheckoutWithCustomUrlAndPackage),
-        ).isEqualTo("https://revenuecat.com?rc_package=\$rc_monthly")
+        ).isEqualTo("https://revenuecat.com?rc_package=%24rc_monthly")
 
         // Uses selected package when no package specified in action
         assertThat(
             model.getWebCheckoutUrl(launchWebCheckoutWithCustomUrlNoPackage),
-        ).isEqualTo("https://revenuecat.com?rc_package=\$rc_monthly")
+        ).isEqualTo("https://revenuecat.com?rc_package=%24rc_monthly")
 
         assertThat(
             model.getWebCheckoutUrl(launchWebCheckoutWithCustomUrlNoPackageParam),
@@ -2062,6 +2062,30 @@ class PaywallViewModelTest {
         assertThat(
             model.getWebCheckoutUrl(launchWebCheckoutWithoutAppendingPackage),
         ).isEqualTo("https://test-web-billing.revenuecat.com")
+    }
+
+    @Test
+    fun `getWebCheckoutUrl encodes package parameter when package identifier has whitespace`(): Unit = runBlocking {
+        val packageWithWhitespace = Package(
+            identifier = "Annual Trial",
+            packageType = TestData.Packages.annual.packageType,
+            product = TestData.Packages.annual.product,
+            presentedOfferingContext = PresentedOfferingContext(offeringIdentifier = "offering"),
+        )
+        val action = PaywallAction.External.LaunchWebCheckout(
+            customUrl = "https://revenuecat.com",
+            autoDismiss = true,
+            openMethod = ButtonComponent.UrlMethod.EXTERNAL_BROWSER,
+            packageParamBehavior = PaywallAction.External.LaunchWebCheckout.PackageParamBehavior.Append(
+                rcPackage = packageWithWhitespace,
+                packageParam = "rc_package",
+            ),
+        )
+        val model = create(offering = offeringWithWPL)
+
+        assertThat(
+            model.getWebCheckoutUrl(action),
+        ).isEqualTo("https://revenuecat.com?rc_package=Annual%20Trial")
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URIExtensionsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URIExtensionsTest.kt
@@ -14,6 +14,13 @@ class URIExtensionsTest {
     }
 
     @Test
+    fun `appendQueryParameter encodes query parameter name and value`() {
+        val uri = URI("https://example.com/path")
+        val updatedUri = uri.appendQueryParameter("package name", "Annual Trial & Intro")
+        assertEquals(updatedUri.toString(), "https://example.com/path?package%20name=Annual%20Trial%20%26%20Intro")
+    }
+
+    @Test
     fun `appendQueryParameter appends parameter correctly to URI with existing query`() {
         val uri = URI("https://example.com/path?existing=param")
         val updatedUri = uri.appendQueryParameter("key", "value")
@@ -32,5 +39,12 @@ class URIExtensionsTest {
         val uri = URI("revenuecatbilling://test?rc_source=app")
         val updatedUri = uri.appendQueryParameter("key", "value")
         assertEquals(updatedUri.toString(), "revenuecatbilling://test?rc_source=app&key=value")
+    }
+
+    @Test
+    fun `appendQueryParameter appends parameter before fragment`() {
+        val uri = URI("https://example.com/path?existing=param#section")
+        val updatedUri = uri.appendQueryParameter("key", "value")
+        assertEquals(updatedUri.toString(), "https://example.com/path?existing=param&key=value#section")
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URLExtensionsTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/utils/URLExtensionsTest.kt
@@ -1,19 +1,20 @@
 package com.revenuecat.purchases.ui.revenuecatui.utils
 
 import org.junit.Test
+import java.net.URL
 
 class URLExtensionsTest {
 
     @Test
     fun `appendQueryParameter appends parameter correctly to URL without existing query`() {
-        val url = java.net.URL("https://example.com/path")
+        val url = URL("https://example.com/path")
         val updatedUrl = url.appendQueryParameter("key", "value")
         assert(updatedUrl.toString() == "https://example.com/path?key=value")
     }
 
     @Test
     fun `appendQueryParameter appends parameter correctly to URL with existing query`() {
-        val url = java.net.URL("https://example.com/path?existing=param")
+        val url = URL("https://example.com/path?existing=param")
         val updatedUrl = url.appendQueryParameter("key", "value")
         assert(updatedUrl.toString() == "https://example.com/path?existing=param&key=value")
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

URL query parameters with spaces caused crashes

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->


url encode query parameters to prevent crashes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how web checkout/custom URLs are constructed by encoding query components and inserting parameters before fragments, which could subtly affect downstream URL parsing and expectations in integrations.
> 
> **Overview**
> Fixes URL construction when appending query params by **URL-encoding parameter names/values** and ensuring new params are inserted *before* any `#fragment` in `URI.appendQueryParameter`.
> 
> `URL.appendQueryParameter` is simplified to delegate through the `URI` implementation, and tests are updated/added to assert encoding behavior (including whitespace) and fragment handling; web-checkout URL expectations now reflect encoded values (e.g. `%24rc_monthly`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4a604b8063ebba8b6a2f57e5ba85d019ce09452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->