### PR TITLE
Add `close_workflow` button action

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/components/ButtonComponent.kt
@@ -49,6 +49,9 @@ public class ButtonComponent(
         public object WorkflowTrigger : Action
 
         @Serializable
+        public object CloseWorkflow : Action
+
+        @Serializable
         @Immutable
         public data class NavigateTo(@get:JvmSynthetic val destination: Destination) : Action
     }
@@ -149,12 +152,14 @@ private class ActionSurrogate(
             is Action.NavigateTo -> ActionTypeSurrogate.navigate_to
             is Action.RestorePurchases -> ActionTypeSurrogate.restore_purchases
             is Action.WorkflowTrigger -> ActionTypeSurrogate.workflow
+            is Action.CloseWorkflow -> ActionTypeSurrogate.close_workflow
         },
         destination = when (action) {
             is Action.Unknown,
             is Action.NavigateBack,
             is Action.RestorePurchases,
             is Action.WorkflowTrigger,
+            is Action.CloseWorkflow,
             -> null
 
             is Action.NavigateTo -> when (action.destination) {
@@ -171,6 +176,7 @@ private class ActionSurrogate(
             is Action.NavigateBack,
             is Action.RestorePurchases,
             is Action.WorkflowTrigger,
+            is Action.CloseWorkflow,
             -> null
 
             is Action.NavigateTo -> when (action.destination) {
@@ -199,6 +205,7 @@ private class ActionSurrogate(
             is Action.NavigateBack,
             is Action.RestorePurchases,
             is Action.WorkflowTrigger,
+            is Action.CloseWorkflow,
             -> null
 
             is Action.NavigateTo -> when (action.destination) {
@@ -219,6 +226,7 @@ private class ActionSurrogate(
             ActionTypeSurrogate.restore_purchases -> Action.RestorePurchases
             ActionTypeSurrogate.navigate_back -> Action.NavigateBack
             ActionTypeSurrogate.workflow -> Action.WorkflowTrigger
+            ActionTypeSurrogate.close_workflow -> Action.CloseWorkflow
             ActionTypeSurrogate.navigate_to -> Action.NavigateTo(
                 destination = when (destination) {
                     DestinationSurrogate.customer_center -> Destination.CustomerCenter
@@ -266,6 +274,7 @@ private enum class ActionTypeSurrogate {
     navigate_back,
     navigate_to,
     workflow,
+    close_workflow,
     unknown,
 }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/components/ButtonComponentTests.kt
@@ -874,6 +874,17 @@ internal class ButtonComponentTests {
                     ),
                 ),
                 arrayOf(
+                    "close_workflow",
+                    Args(
+                        serialized = """
+                        {
+                          "type": "close_workflow"
+                        }
+                        """.trimIndent(),
+                        deserialized = ButtonComponent.Action.CloseWorkflow,
+                    ),
+                ),
+                arrayOf(
                     "unknown",
                     Args(
                         serialized = """

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/InternalPaywall.kt
@@ -408,6 +408,8 @@ private fun rememberPaywallActionHandler(viewModel: PaywallViewModel): suspend (
                     }
                 }
 
+                is PaywallAction.External.CloseWorkflow -> viewModel.closePaywall()
+
                 is PaywallAction.External.WorkflowTrigger ->
                     viewModel.handleWorkflowAction(action.componentId, action.triggerType)
 

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallAction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallAction.kt
@@ -27,6 +27,7 @@ internal sealed interface PaywallAction {
 
         object RestorePurchases : External
         object NavigateBack : External
+        object CloseWorkflow : External
         data class WorkflowTrigger(val componentId: String, val triggerType: WorkflowTriggerType) : External
         data class PurchasePackage(
             val rcPackage: Package?,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteraction.kt
@@ -16,6 +16,8 @@ internal fun ButtonComponentStyle.Action.componentInteraction(localeUrl: String?
             ButtonComponentInteraction(value = "restore_purchases")
         is ButtonComponentStyle.Action.NavigateBack ->
             ButtonComponentInteraction(value = "navigate_back")
+        is ButtonComponentStyle.Action.CloseWorkflow ->
+            ButtonComponentInteraction(value = "close_workflow")
         is ButtonComponentStyle.Action.NavigateTo -> destination.componentInteraction(localeUrl)
         is ButtonComponentStyle.Action.PurchasePackage,
         is ButtonComponentStyle.Action.WebCheckout,
@@ -51,5 +53,6 @@ internal fun ButtonComponentStyle.Action.isPurchaseRelated(): Boolean =
         is ButtonComponentStyle.Action.NavigateBack,
         is ButtonComponentStyle.Action.NavigateTo,
         is ButtonComponentStyle.Action.WorkflowTrigger,
+        is ButtonComponentStyle.Action.CloseWorkflow,
         -> false
     }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentState.kt
@@ -56,6 +56,7 @@ internal class ButtonComponentState(
     private fun ButtonComponentStyle.Action.toPaywallAction(localeId: LocaleId, componentId: String?): PaywallAction? =
         when (this) {
             is ButtonComponentStyle.Action.NavigateBack -> PaywallAction.External.NavigateBack
+            is ButtonComponentStyle.Action.CloseWorkflow -> PaywallAction.External.CloseWorkflow
             is ButtonComponentStyle.Action.NavigateTo -> toPaywallAction(localeId)
 
             is ButtonComponentStyle.Action.PurchasePackage ->

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/ButtonComponentStyle.kt
@@ -28,6 +28,7 @@ internal data class ButtonComponentStyle(
         object RestorePurchases : Action
         object NavigateBack : Action
         object WorkflowTrigger : Action
+        object CloseWorkflow : Action
 
         @get:JvmSynthetic
         val description: String

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactory.kt
@@ -729,6 +729,7 @@ internal class StyleFactory(
             is ButtonComponent.Action.NavigateTo -> convertDestination(action.destination)
                 .map { destination -> destination?.let { ButtonComponentStyle.Action.NavigateTo(it) } }
             is ButtonComponent.Action.WorkflowTrigger -> Result.Success(ButtonComponentStyle.Action.WorkflowTrigger)
+            is ButtonComponent.Action.CloseWorkflow -> Result.Success(ButtonComponentStyle.Action.CloseWorkflow)
             // Returning null here, which will result in this button being hidden.
             is ButtonComponent.Action.Unknown -> Result.Success(null)
         }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
@@ -162,6 +162,7 @@ class PaywallActionTests {
             is PaywallAction.External.WorkflowTrigger -> error(
                 "Workflow is a runtime workflow navigation action, not a ButtonComponent.Action."
             )
+            is PaywallAction.External.CloseWorkflow -> ButtonComponent.Action.CloseWorkflow
         }
 
     private fun PaywallAction.External.NavigateTo.Destination.toButtonDestination(): ButtonComponent.Destination =

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -195,6 +196,64 @@ class PaywallActionTests {
         componentsLocalizations = localizations,
         defaultLocaleIdentifier = defaultLocale,
     )
+
+    @Test
+    fun `CloseWorkflow inside a sheet propagates to outer handler and dismisses paywall`(): Unit = with(composeTestRule) {
+        // Arrange
+        val textColor = ColorScheme(ColorInfo.Hex(Color.Black.toArgb()))
+        val defaultLocale = LocaleId("en_US")
+        val localizationKeyOpenSheet = LocalizationKey("open_sheet")
+        val localizationKeyCloseWorkflow = LocalizationKey("close_workflow_btn")
+        val localizationDataOpenSheet = LocalizationData.Text("Open Sheet")
+        val localizationDataCloseWorkflow = LocalizationData.Text("Close Workflow")
+
+        val localizations = nonEmptyMapOf(
+            defaultLocale to nonEmptyMapOf(
+                localizationKeyOpenSheet to localizationDataOpenSheet,
+                localizationKeyCloseWorkflow to localizationDataCloseWorkflow,
+            ),
+        )
+        val sheetStack = StackComponent(
+            components = listOf(
+                ButtonComponent(
+                    action = ButtonComponent.Action.CloseWorkflow,
+                    stack = StackComponent(
+                        components = listOf(TextComponent(text = localizationKeyCloseWorkflow, color = textColor)),
+                    ),
+                ),
+            ),
+        )
+        val components = listOf(
+            ButtonComponent(
+                action = ButtonComponent.Action.NavigateTo(
+                    ButtonComponent.Destination.Sheet(
+                        id = "test-sheet",
+                        name = null,
+                        stack = sheetStack,
+                        backgroundBlur = false,
+                        size = null,
+                    ),
+                ),
+                stack = StackComponent(
+                    components = listOf(TextComponent(text = localizationKeyOpenSheet, color = textColor)),
+                ),
+            ),
+        )
+
+        val offering = FakeOffering(components, localizations)
+        val options = PaywallOptions.Builder(dismissRequest = { }).setOffering(offering).build()
+        val viewModel = MockViewModel(offering = offering, allowsPurchases = true)
+
+        // Act — open the sheet, then click CloseWorkflow inside it
+        setContent { InternalPaywall(options, viewModel) }
+        onAllNodesWithText(localizationDataOpenSheet.value).get(0).assertIsDisplayed().performClick()
+        waitForIdle()
+        onNodeWithText(localizationDataCloseWorkflow.value).assertIsDisplayed().performClick()
+        waitForIdle()
+
+        // CloseWorkflow must propagate to the outer handler (not just hide the sheet)
+        assertEquals(1, viewModel.closePaywallCallCount)
+    }
 
     @Suppress("TestFunctionName")
     private fun FakeOffering(data: PaywallComponentsData): Offering =

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/PaywallActionTests.kt
@@ -57,14 +57,17 @@ class PaywallActionTests {
         val localizationKeyRestore = LocalizationKey("restore")
         val localizationKeyBack = LocalizationKey("back")
         val localizationKeyPurchase = LocalizationKey("purchase")
+        val localizationKeyCloseWorkflow = LocalizationKey("close_workflow")
         val localizationDataRestore = LocalizationData.Text("restore")
         val localizationDataBack = LocalizationData.Text("back")
         val localizationDataPurchase = LocalizationData.Text("purchase")
+        val localizationDataCloseWorkflow = LocalizationData.Text("close workflow")
         val localizations = nonEmptyMapOf(
             defaultLocale to nonEmptyMapOf(
                 localizationKeyRestore to localizationDataRestore,
                 localizationKeyBack to localizationDataBack,
                 localizationKeyPurchase to localizationDataPurchase,
+                localizationKeyCloseWorkflow to localizationDataCloseWorkflow,
             )
         )
         // Bit of a convoluted way to create components, to ensure we use an an exhaustive when, forcing ourselves to
@@ -73,11 +76,13 @@ class PaywallActionTests {
             PaywallAction.External.RestorePurchases to localizationKeyRestore,
             PaywallAction.External.NavigateBack to localizationKeyBack,
             PaywallAction.External.PurchasePackage(rcPackage = null) to localizationKeyPurchase,
+            PaywallAction.External.CloseWorkflow to localizationKeyCloseWorkflow,
         ).map { (action: PaywallAction, key) ->
             when (action) {
                 is PaywallAction.External.RestorePurchases,
                 is PaywallAction.External.NavigateBack,
                 is PaywallAction.External.NavigateTo,
+                is PaywallAction.External.CloseWorkflow,
                     -> ButtonComponent(
                     action = action.toButtonAction(),
                     stack = StackComponent(components = listOf(TextComponent(text = key, color = textColor)))
@@ -102,10 +107,12 @@ class PaywallActionTests {
         clickButtonsWithText(localizationDataRestore, expectedCount = 2)
         clickButtonsWithText(localizationDataBack, expectedCount = 2)
         clickButtonsWithText(localizationDataPurchase, expectedCount = 2)
+        clickButtonsWithText(localizationDataCloseWorkflow, expectedCount = 2)
 
         // Assert
         assertEquals(2, viewModel.handleRestorePurchasesCallCount)
-        assertEquals(2, viewModel.closePaywallCallCount)
+        // 2 from NavigateBack + 2 from CloseWorkflow — both route to closePaywall()
+        assertEquals(4, viewModel.closePaywallCallCount)
         assertEquals(2, viewModel.handlePackagePurchaseCount)
     }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteractionTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/button/ButtonComponentInteractionTests.kt
@@ -1,0 +1,117 @@
+package com.revenuecat.purchases.ui.revenuecatui.components.button
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.paywalls.components.ButtonComponent
+import com.revenuecat.purchases.paywalls.components.common.LocaleId
+import com.revenuecat.purchases.ui.revenuecatui.components.style.ButtonComponentStyle
+import com.revenuecat.purchases.ui.revenuecatui.helpers.nonEmptyMapOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ButtonComponentInteractionTests {
+
+    // region componentInteraction
+
+    @Test
+    fun `CloseWorkflow componentInteraction emits close_workflow`() {
+        assertThat(ButtonComponentStyle.Action.CloseWorkflow.componentInteraction(localeUrl = null))
+            .isEqualTo(ButtonComponentInteraction(value = "close_workflow"))
+    }
+
+    @Test
+    fun `NavigateBack componentInteraction emits navigate_back`() {
+        assertThat(ButtonComponentStyle.Action.NavigateBack.componentInteraction(localeUrl = null))
+            .isEqualTo(ButtonComponentInteraction(value = "navigate_back"))
+    }
+
+    @Test
+    fun `RestorePurchases componentInteraction emits restore_purchases`() {
+        assertThat(ButtonComponentStyle.Action.RestorePurchases.componentInteraction(localeUrl = null))
+            .isEqualTo(ButtonComponentInteraction(value = "restore_purchases"))
+    }
+
+    @Test
+    fun `WorkflowTrigger componentInteraction returns null`() {
+        assertThat(ButtonComponentStyle.Action.WorkflowTrigger.componentInteraction(localeUrl = null))
+            .isNull()
+    }
+
+    @Test
+    fun `PurchasePackage componentInteraction returns null`() {
+        assertThat(
+            ButtonComponentStyle.Action.PurchasePackage(rcPackage = null)
+                .componentInteraction(localeUrl = null)
+        ).isNull()
+    }
+
+    @Test
+    fun `NavigateTo CustomerCenter componentInteraction emits navigate_to_customer_center`() {
+        val action = ButtonComponentStyle.Action.NavigateTo(
+            ButtonComponentStyle.Action.NavigateTo.Destination.CustomerCenter
+        )
+        assertThat(action.componentInteraction(localeUrl = null))
+            .isEqualTo(ButtonComponentInteraction(value = "navigate_to_customer_center"))
+    }
+
+    @Test
+    fun `NavigateTo Url componentInteraction emits navigate_to_url with the locale url`() {
+        val action = ButtonComponentStyle.Action.NavigateTo(
+            ButtonComponentStyle.Action.NavigateTo.Destination.Url(
+                urls = nonEmptyMapOf(LocaleId("en_US") to "https://example.com"),
+                method = ButtonComponent.UrlMethod.EXTERNAL_BROWSER,
+            )
+        )
+        assertThat(action.componentInteraction(localeUrl = "https://example.com"))
+            .isEqualTo(ButtonComponentInteraction(value = "navigate_to_url", url = "https://example.com"))
+    }
+
+    // endregion
+
+    // region isPurchaseRelated
+
+    @Test
+    fun `CloseWorkflow is not purchase related`() {
+        assertThat(ButtonComponentStyle.Action.CloseWorkflow.isPurchaseRelated()).isFalse()
+    }
+
+    @Test
+    fun `WorkflowTrigger is not purchase related`() {
+        assertThat(ButtonComponentStyle.Action.WorkflowTrigger.isPurchaseRelated()).isFalse()
+    }
+
+    @Test
+    fun `NavigateBack is not purchase related`() {
+        assertThat(ButtonComponentStyle.Action.NavigateBack.isPurchaseRelated()).isFalse()
+    }
+
+    @Test
+    fun `PurchasePackage is purchase related`() {
+        assertThat(ButtonComponentStyle.Action.PurchasePackage(rcPackage = null).isPurchaseRelated())
+            .isTrue()
+    }
+
+    @Test
+    fun `WebCheckout is purchase related`() {
+        assertThat(
+            ButtonComponentStyle.Action.WebCheckout(
+                rcPackage = null,
+                autoDismiss = false,
+                openMethod = ButtonComponent.UrlMethod.IN_APP_BROWSER,
+            ).isPurchaseRelated()
+        ).isTrue()
+    }
+
+    @Test
+    fun `WebProductSelection is purchase related`() {
+        assertThat(
+            ButtonComponentStyle.Action.WebProductSelection(
+                autoDismiss = false,
+                openMethod = ButtonComponent.UrlMethod.IN_APP_BROWSER,
+            ).isPurchaseRelated()
+        ).isTrue()
+    }
+
+    // endregion
+}

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/style/StyleFactoryTests.kt
@@ -1547,4 +1547,21 @@ class StyleFactoryTests {
         assertThat(style.action).isEqualTo(ButtonComponentStyle.Action.WorkflowTrigger)
         assertThat(style.componentId).isEqualTo("btn-workflow")
     }
+
+    @Test
+    fun `convertAction maps CloseWorkflow to ButtonComponentStyle Action CloseWorkflow`() {
+        // Arrange
+        val component = ButtonComponent(
+            action = ButtonComponent.Action.CloseWorkflow,
+            stack = StackComponent(components = emptyList()),
+        )
+
+        // Act
+        val result = styleFactory.create(component)
+
+        // Assert
+        assertThat(result.isSuccess).isTrue()
+        val style = result.getOrNull()!!.componentStyle as ButtonComponentStyle
+        assertThat(style.action).isEqualTo(ButtonComponentStyle.Action.CloseWorkflow)
+    }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -1277,15 +1277,6 @@ class PaywallViewModelTest {
     }
 
     @Test
-    fun `close_workflow action dismisses paywall`() {
-        val model = create()
-
-        assertThat(dismissInvoked).isFalse
-        model.closePaywall()
-        assertThat(dismissInvoked).isTrue
-    }
-
-    @Test
     fun `handleBackNavigation returns false for regular paywall`() {
         val model = create()
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -1277,6 +1277,15 @@ class PaywallViewModelTest {
     }
 
     @Test
+    fun `close_workflow action dismisses paywall`() {
+        val model = create()
+
+        assertThat(dismissInvoked).isFalse
+        model.closePaywall()
+        assertThat(dismissInvoked).isTrue
+    }
+
+    @Test
     fun `handleBackNavigation returns false for regular paywall`() {
         val model = create()
 


### PR DESCRIPTION
## Summary

- Adds `close_workflow` button action that always dismisses the paywall regardless of workflow step
- Flows through the existing button-action pipeline: `ButtonComponent.Action.CloseWorkflow` → `ButtonComponentStyle.Action.CloseWorkflow` → `PaywallAction.External.CloseWorkflow` → `viewModel.closePaywall()`
- No new ViewModel function or event type needed. `CloseWorkflow` propagates to the outer paywall-level handler via the existing `else -> onClick(action)` path
- The matching `close_workflow` analytics event lands later with the Analytics milestone

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new serialized button action that directly dismisses the paywall, which could change navigation/dismiss behavior in workflow-based paywalls if misconfigured or triggered unexpectedly.
> 
> **Overview**
> Adds a new `close_workflow` button action end-to-end (component model, style conversion, UI action mapping) so dashboard-configured buttons can *always* dismiss the paywall via `viewModel.closePaywall()`.
> 
> Updates serialization/deserialization to recognize the new action type, wires it through `PaywallAction.External`, and adds/extends unit + compose tests (including sheet propagation) plus interaction mapping coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3a0e31fcab98ad9bc0bff9332e2cffe21a01664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->