### PR TITLE
Use product_entitlement_mapping topic blob for offline entitlements when remote config enabled

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.UserManagerCompat
+import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BackendHelper
@@ -33,11 +34,16 @@ import com.revenuecat.purchases.common.networking.ETagManager
 import com.revenuecat.purchases.common.offerings.OfferingsCache
 import com.revenuecat.purchases.common.offerings.OfferingsFactory
 import com.revenuecat.purchases.common.offerings.OfferingsManager
+import com.revenuecat.purchases.common.offlineentitlements.DeviceCacheProductEntitlementMappingSource
 import com.revenuecat.purchases.common.offlineentitlements.OfflineCustomerInfoCalculator
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
+import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMappingSource
+import com.revenuecat.purchases.common.offlineentitlements.ProductEntitlementMappingTopicReader
 import com.revenuecat.purchases.common.offlineentitlements.PurchasedProductsFetcher
+import com.revenuecat.purchases.common.offlineentitlements.RemoteConfigProductEntitlementMappingSource
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigDiskCache
 import com.revenuecat.purchases.common.remoteconfig.RemoteConfigManager
+import com.revenuecat.purchases.common.remoteconfig.Topic
 import com.revenuecat.purchases.common.remoteconfig.TopicFetcher
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.verification.SigningManager
@@ -243,8 +249,31 @@ internal class PurchasesFactory(
                 automaticDeviceIdentifierCollectionEnabled,
             )
 
+            val useRemoteConfigForProductEntitlementMapping = BuildConfig.ENABLE_REMOTE_CONFIG
+
+            val productEntitlementMappingTopicReader = ProductEntitlementMappingTopicReader(
+                applicationContext = application,
+            )
+
+            val topicFetcher = TopicFetcher(
+                applicationContext = application,
+                urlConnectionFactory = DefaultUrlConnectionFactory(),
+                topicUpdatedListener = { topic ->
+                    if (topic == Topic.PRODUCT_ENTITLEMENT_MAPPING) {
+                        productEntitlementMappingTopicReader.invalidate()
+                    }
+                },
+            )
+
+            val productEntitlementMappingSource: ProductEntitlementMappingSource =
+                if (useRemoteConfigForProductEntitlementMapping) {
+                    RemoteConfigProductEntitlementMappingSource(productEntitlementMappingTopicReader, cache)
+                } else {
+                    DeviceCacheProductEntitlementMappingSource(cache)
+                }
+
             val offlineCustomerInfoCalculator = OfflineCustomerInfoCalculator(
-                PurchasedProductsFetcher(cache, billing),
+                PurchasedProductsFetcher(productEntitlementMappingSource, billing),
                 appConfig,
                 diagnosticsTracker,
             )
@@ -255,6 +284,7 @@ internal class PurchasesFactory(
                 cache,
                 appConfig,
                 diagnosticsTracker,
+                useRemoteConfigForProductEntitlementMapping,
             )
 
             val offeringsCache = OfferingsCache(
@@ -429,10 +459,7 @@ internal class PurchasesFactory(
 
             val remoteConfigManager = RemoteConfigManager(
                 backend = backend,
-                topicFetcher = TopicFetcher(
-                    applicationContext = application,
-                    urlConnectionFactory = DefaultUrlConnectionFactory(),
-                ),
+                topicFetcher = topicFetcher,
                 diskCache = RemoteConfigDiskCache(application, Backend.json),
             )
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManager.kt
@@ -21,6 +21,7 @@ internal class OfflineEntitlementsManager(
     private val deviceCache: DeviceCache,
     private val appConfig: AppConfig,
     private val diagnosticsTracker: DiagnosticsTracker?,
+    private val useRemoteConfigForProductEntitlementMapping: Boolean,
 ) {
     // We cache the offline customer info in memory, so it's not persisted.
     val offlineCustomerInfo: CustomerInfo?
@@ -99,6 +100,10 @@ internal class OfflineEntitlementsManager(
     }
 
     fun updateProductEntitlementMappingCacheIfStale(completion: ((PurchasesError?) -> Unit)? = null) {
+        if (useRemoteConfigForProductEntitlementMapping) {
+            completion?.invoke(null)
+            return
+        }
         if (isOfflineEntitlementsEnabled() && deviceCache.isProductEntitlementMappingCacheStale()) {
             debugLog { OfflineEntitlementsStrings.UPDATING_PRODUCT_ENTITLEMENT_MAPPING }
             backend.getProductEntitlementMapping(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingSource.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingSource.kt
@@ -1,0 +1,39 @@
+package com.revenuecat.purchases.common.offlineentitlements
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.caching.DeviceCache
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+@OptIn(InternalRevenueCatAPI::class)
+internal fun interface ProductEntitlementMappingSource {
+    fun getProductEntitlementMapping(completion: (ProductEntitlementMapping?) -> Unit)
+}
+
+@OptIn(InternalRevenueCatAPI::class)
+internal class DeviceCacheProductEntitlementMappingSource(
+    private val deviceCache: DeviceCache,
+) : ProductEntitlementMappingSource {
+    override fun getProductEntitlementMapping(completion: (ProductEntitlementMapping?) -> Unit) {
+        completion(deviceCache.getProductEntitlementMapping())
+    }
+}
+
+@OptIn(InternalRevenueCatAPI::class)
+internal class RemoteConfigProductEntitlementMappingSource(
+    private val reader: ProductEntitlementMappingTopicReader,
+    private val deviceCache: DeviceCache,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ProductEntitlementMappingSource {
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    override fun getProductEntitlementMapping(completion: (ProductEntitlementMapping?) -> Unit) {
+        scope.launch {
+            val topicMapping = reader.read()
+            completion(topicMapping ?: deviceCache.getProductEntitlementMapping())
+        }
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingTopicReader.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingTopicReader.kt
@@ -1,0 +1,77 @@
+package com.revenuecat.purchases.common.offlineentitlements
+
+import android.content.Context
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.remoteconfig.Topic
+import com.revenuecat.purchases.common.remoteconfig.TopicFetcher
+import com.revenuecat.purchases.common.verboseLog
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import org.json.JSONObject
+import java.io.File
+
+@OptIn(InternalRevenueCatAPI::class)
+internal class ProductEntitlementMappingTopicReader(
+    private val applicationContext: Context,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+    private val lock = Any()
+
+    @Volatile
+    private var cached: ProductEntitlementMapping? = null
+    private var inFlight: Deferred<ProductEntitlementMapping?>? = null
+
+    suspend fun read(): ProductEntitlementMapping? {
+        // Lazy start: assigning `inFlight` must happen before the body runs, otherwise an eager
+        // dispatcher would let the body's `inFlight = null` execute and then `.also` would
+        // overwrite it back with the (already-completed) deferred, leaking it into the next read.
+        val deferred: Deferred<ProductEntitlementMapping?>? = synchronized(lock) {
+            if (cached != null) {
+                null
+            } else {
+                inFlight ?: scope.async(start = CoroutineStart.LAZY) {
+                    val result = readMappingFromTopicFile()
+                    synchronized(lock) {
+                        cached = result
+                        inFlight = null
+                    }
+                    result
+                }.also { inFlight = it }
+            }
+        }
+        return deferred?.await() ?: cached
+    }
+
+    fun invalidate() {
+        synchronized(lock) {
+            cached = null
+        }
+    }
+
+    private fun readMappingFromTopicFile(): ProductEntitlementMapping? {
+        val dir = File(
+            File(applicationContext.noBackupFilesDir, TopicFetcher.TOPICS_ROOT),
+            Topic.PRODUCT_ENTITLEMENT_MAPPING.key,
+        )
+        val blobFile = dir.takeIf { it.isDirectory }
+            ?.listFiles()
+            ?.firstOrNull { !it.name.startsWith(TopicFetcher.TEMP_PREFIX) }
+        if (blobFile == null) {
+            verboseLog { "No product entitlement mapping topic blob found at ${dir.absolutePath}" }
+            return null
+        }
+        return runCatching {
+            val json = JSONObject(blobFile.readBytes().decodeToString())
+            ProductEntitlementMapping.fromJson(json, loadedFromCache = true)
+        }.onFailure { e ->
+            errorLog(e) { "Failed to parse product entitlement mapping topic file at ${blobFile.absolutePath}" }
+        }.getOrNull()
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcher.kt
@@ -7,7 +7,6 @@ import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
-import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.strings.OfflineEntitlementsStrings
 import java.util.Date
@@ -15,7 +14,7 @@ import java.util.concurrent.TimeUnit
 
 @OptIn(InternalRevenueCatAPI::class)
 internal class PurchasedProductsFetcher(
-    private val deviceCache: DeviceCache,
+    private val productEntitlementMappingSource: ProductEntitlementMappingSource,
     private val billing: BillingAbstract,
     private val dateProvider: DateProvider = DefaultDateProvider(),
 ) {
@@ -25,27 +24,29 @@ internal class PurchasedProductsFetcher(
         onSuccess: (List<PurchasedProduct>) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
-        val productEntitlementMapping = deviceCache.getProductEntitlementMapping() ?: run {
-            onError(
-                PurchasesError(
-                    PurchasesErrorCode.CustomerInfoError,
-                    OfflineEntitlementsStrings.PRODUCT_ENTITLEMENT_MAPPING_REQUIRED,
-                ),
-            )
-            return
-        }
+        productEntitlementMappingSource.getProductEntitlementMapping { productEntitlementMapping ->
+            if (productEntitlementMapping == null) {
+                onError(
+                    PurchasesError(
+                        PurchasesErrorCode.CustomerInfoError,
+                        OfflineEntitlementsStrings.PRODUCT_ENTITLEMENT_MAPPING_REQUIRED,
+                    ),
+                )
+                return@getProductEntitlementMapping
+            }
 
-        billing.queryPurchases(
-            appUserID,
-            onSuccess = { activePurchasesByHashedToken ->
-                val activePurchases = activePurchasesByHashedToken.values
-                val purchasedProducts = activePurchases.flatMap {
-                    createPurchasedProducts(it, productEntitlementMapping)
-                }
-                onSuccess(purchasedProducts)
-            },
-            onError,
-        )
+            billing.queryPurchases(
+                appUserID,
+                onSuccess = { activePurchasesByHashedToken ->
+                    val activePurchases = activePurchasesByHashedToken.values
+                    val purchasedProducts = activePurchases.flatMap {
+                        createPurchasedProducts(it, productEntitlementMapping)
+                    }
+                    onSuccess(purchasedProducts)
+                },
+                onError,
+            )
+        }
     }
 
     private fun createPurchasedProducts(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/TopicFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/TopicFetcher.kt
@@ -29,6 +29,7 @@ internal sealed class TopicFetchResult {
 internal class TopicFetcher(
     private val applicationContext: Context,
     private val urlConnectionFactory: UrlConnectionFactory,
+    private val topicUpdatedListener: ((Topic) -> Unit)? = null,
     private val downloadDispatcher: CoroutineDispatcher =
         Dispatchers.IO.limitedParallelism(MAX_PARALLEL_TOPIC_DOWNLOADS),
 ) {
@@ -63,6 +64,7 @@ internal class TopicFetcher(
             val url = source.urlFormat.replace(BLOB_REF_PLACEHOLDER, topicEntry.blobRef)
             downloadVerifyAndStore(url, topicEntry.blobRef, targetFile)
             debugLog { "Topic $topic ($entryId) downloaded to ${targetFile.absolutePath}" }
+            topicUpdatedListener?.invoke(topic)
             TopicFetchResult.Success
         } catch (e: Checksum.ChecksumValidationException) {
             errorLog(e) { "Downloaded topic $topic ($entryId) failed SHA-256 verification." }
@@ -146,11 +148,11 @@ internal class TopicFetcher(
         }
     }
 
-    private companion object {
-        const val TOPICS_ROOT = "RevenueCat/topics"
-        const val BLOB_REF_PLACEHOLDER = "{blob_ref}"
-        const val MAX_PARALLEL_TOPIC_DOWNLOADS = 4
-        const val TEMP_PREFIX = "rc_topic_"
-        val BLOB_REF_PATTERN = Regex("^[a-fA-F0-9]{64}$")
+    internal companion object {
+        internal const val TOPICS_ROOT = "RevenueCat/topics"
+        internal const val TEMP_PREFIX = "rc_topic_"
+        private const val BLOB_REF_PLACEHOLDER = "{blob_ref}"
+        private const val MAX_PARALLEL_TOPIC_DOWNLOADS = 4
+        private val BLOB_REF_PATTERN = Regex("^[a-fA-F0-9]{64}$")
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/OfflineEntitlementsManagerTest.kt
@@ -82,6 +82,7 @@ class OfflineEntitlementsManagerTest {
             deviceCache,
             appConfig,
             diagnosticsTracker,
+            useRemoteConfigForProductEntitlementMapping = false,
         )
     }
 
@@ -489,6 +490,27 @@ class OfflineEntitlementsManagerTest {
         every { appConfig.customEntitlementComputation } returns true
         offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale()
         verify(exactly = 0) { backend.getProductEntitlementMapping(any(), any()) }
+    }
+
+    @Test
+    fun `updateProductEntitlementMappingCacheIfStale skips backend fetch when useRemoteConfigForProductEntitlementMapping is true`() {
+        offlineEntitlementsManager = OfflineEntitlementsManager(
+            backend,
+            offlineEntitlementsCalculator,
+            deviceCache,
+            appConfig,
+            diagnosticsTracker,
+            useRemoteConfigForProductEntitlementMapping = true,
+        )
+        every { deviceCache.isProductEntitlementMappingCacheStale() } returns true
+        var completionCallCount = 0
+        offlineEntitlementsManager.updateProductEntitlementMappingCacheIfStale {
+            assertThat(it).isNull()
+            completionCallCount++
+        }
+        assertThat(completionCallCount).isEqualTo(1)
+        verify(exactly = 0) { backend.getProductEntitlementMapping(any(), any()) }
+        verify(exactly = 0) { deviceCache.isProductEntitlementMappingCacheStale() }
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingTopicReaderTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/ProductEntitlementMappingTopicReaderTest.kt
@@ -1,0 +1,170 @@
+package com.revenuecat.purchases.common.offlineentitlements
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.remoteconfig.Topic
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class ProductEntitlementMappingTopicReaderTest {
+
+    private val testFolder = "temp_topic_reader_test_folder"
+    private val topicDirRelative = "RevenueCat/topics/${Topic.PRODUCT_ENTITLEMENT_MAPPING.key}"
+
+    private lateinit var rootDir: File
+    private lateinit var topicDir: File
+    private lateinit var applicationContext: Context
+    private var dirAccessCount: Int = 0
+
+    @Before
+    fun setUp() {
+        rootDir = File(testFolder)
+        if (rootDir.exists()) {
+            error("Temp test folder should not exist before starting tests")
+        }
+        rootDir.mkdirs()
+        topicDir = File(rootDir, topicDirRelative)
+
+        applicationContext = mockk()
+        dirAccessCount = 0
+        every { applicationContext.noBackupFilesDir } answers {
+            dirAccessCount++
+            rootDir
+        }
+    }
+
+    @After
+    fun tearDown() {
+        rootDir.deleteRecursively()
+    }
+
+    @Test
+    fun `read returns null when the topic directory does not exist`() = runTest {
+        val reader = ProductEntitlementMappingTopicReader(applicationContext, UnconfinedTestDispatcher(testScheduler))
+        val mapping = reader.read()
+        assertThat(mapping).isNull()
+    }
+
+    @Test
+    fun `read returns null when the topic directory is empty`() = runTest {
+        topicDir.mkdirs()
+        val reader = ProductEntitlementMappingTopicReader(applicationContext, UnconfinedTestDispatcher(testScheduler))
+        val mapping = reader.read()
+        assertThat(mapping).isNull()
+    }
+
+    @Test
+    fun `read parses the blob and exposes the mapping`() = runTest {
+        writeBlob("abc", validMappingJson("monthly", "pro"))
+        val reader = ProductEntitlementMappingTopicReader(applicationContext, UnconfinedTestDispatcher(testScheduler))
+
+        val mapping = reader.read()!!
+
+        assertThat(mapping.mappings).containsKey("monthly")
+        assertThat(mapping.mappings["monthly"]?.entitlements).containsExactly("pro")
+        assertThat(mapping.loadedFromCache).isTrue
+    }
+
+    @Test
+    fun `second read after a successful load returns the cached mapping without re-reading from disk`() = runTest {
+        writeBlob("abc", validMappingJson("monthly", "pro"))
+        val reader = ProductEntitlementMappingTopicReader(applicationContext, UnconfinedTestDispatcher(testScheduler))
+
+        val firstMapping = reader.read()!!
+        val accessesAfterFirst = dirAccessCount
+
+        // Replace the on-disk blob: cached read should return the original, not the new contents.
+        topicDir.listFiles()?.forEach { it.delete() }
+        writeBlob("def", validMappingJson("annual", "premium"))
+
+        val second = reader.read()
+        assertThat(second).isSameAs(firstMapping)
+        assertThat(dirAccessCount).isEqualTo(accessesAfterFirst)
+    }
+
+    @Test
+    fun `read ignores files starting with the rc_topic_ temp prefix`() = runTest {
+        topicDir.mkdirs()
+        File(topicDir, "rc_topic_inflight.tmp").writeText("not a real blob")
+        val reader = ProductEntitlementMappingTopicReader(applicationContext, UnconfinedTestDispatcher(testScheduler))
+
+        val mapping = reader.read()
+        assertThat(mapping).isNull()
+    }
+
+    @Test
+    fun `read returns null when the blob payload is not valid JSON`() = runTest {
+        writeBlob("abc", "not-json")
+        val reader = ProductEntitlementMappingTopicReader(applicationContext, UnconfinedTestDispatcher(testScheduler))
+
+        val mapping = reader.read()
+        assertThat(mapping).isNull()
+    }
+
+    @Test
+    fun `invalidate clears the in-memory cache so the next read re-loads from disk`() = runTest {
+        writeBlob("abc", validMappingJson("monthly", "pro"))
+        val reader = ProductEntitlementMappingTopicReader(applicationContext, UnconfinedTestDispatcher(testScheduler))
+
+        val firstMapping = reader.read()!!
+        assertThat(firstMapping.mappings).containsKey("monthly")
+
+        topicDir.listFiles()?.forEach { it.delete() }
+        writeBlob("def", validMappingJson("annual", "premium"))
+
+        reader.invalidate()
+        val mapping = reader.read()!!
+        assertThat(mapping.mappings).containsKey("annual")
+        assertThat(mapping.mappings).doesNotContainKey("monthly")
+    }
+
+    @Test
+    fun `concurrent reads coalesce into a single disk access`() = runTest {
+        writeBlob("abc", validMappingJson("monthly", "pro"))
+        // StandardTestDispatcher: scheduled work waits for advanceUntilIdle, so we can interleave callers.
+        val reader = ProductEntitlementMappingTopicReader(applicationContext, StandardTestDispatcher(testScheduler))
+
+        val first = async { reader.read() }
+        val second = async { reader.read() }
+
+        testScheduler.advanceUntilIdle()
+
+        assertThat(first.await()?.mappings).containsKey("monthly")
+        assertThat(second.await()?.mappings).containsKey("monthly")
+        assertThat(first.await()).isSameAs(second.await())
+        // Disk read happens once even though two callers raced.
+        assertThat(dirAccessCount).isEqualTo(1)
+    }
+
+    private fun writeBlob(blobRef: String, json: String) {
+        topicDir.mkdirs()
+        File(topicDir, blobRef).writeText(json)
+    }
+
+    private fun validMappingJson(productId: String, entitlement: String): String =
+        """
+        {
+          "product_entitlement_mapping": {
+            "$productId": {
+              "product_identifier": "$productId",
+              "entitlements": ["$entitlement"]
+            }
+          }
+        }
+        """.trimIndent()
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offlineentitlements/PurchasedProductsFetcherTest.kt
@@ -6,7 +6,6 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.BillingAbstract
 import com.revenuecat.purchases.common.DateProvider
-import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.sha1
 import com.revenuecat.purchases.google.toStoreTransaction
 import com.revenuecat.purchases.models.StoreTransaction
@@ -28,7 +27,7 @@ import java.util.Date
 class PurchasedProductsFetcherTest {
     private lateinit var fetcher: PurchasedProductsFetcher
 
-    private lateinit var deviceCache: DeviceCache
+    private lateinit var productEntitlementMappingSource: ProductEntitlementMappingSource
     private lateinit var billing: BillingAbstract
     private lateinit var dateProvider: DateProvider
 
@@ -43,20 +42,18 @@ class PurchasedProductsFetcherTest {
 
     @Before
     fun setUp() {
-        deviceCache = mockk()
+        productEntitlementMappingSource = mockk()
         billing = mockk()
         dateProvider = object : DateProvider {
             override val now: Date
                 get() = testDate
         }
-        fetcher = PurchasedProductsFetcher(deviceCache, billing, dateProvider)
+        fetcher = PurchasedProductsFetcher(productEntitlementMappingSource, billing, dateProvider)
     }
 
     @Test
     fun `checks onError callback is called`() {
-        every {
-            deviceCache.getProductEntitlementMapping()
-        } returns null
+        mockEntitlementMappingSource(null)
         var error: PurchasesError? = null
 
         fetcher.queryActiveProducts(
@@ -70,9 +67,7 @@ class PurchasedProductsFetcherTest {
 
     @Test
     fun `fails fetching products if product entitlement mappings not available`() {
-        every {
-            deviceCache.getProductEntitlementMapping()
-        } returns null
+        mockEntitlementMappingSource(null)
         var error: PurchasesError? = null
 
         fetcher.queryActiveProducts(
@@ -456,10 +451,15 @@ class PurchasedProductsFetcherTest {
         val mappings = productIdentifierToEntitlements.mapValues { (identifier, entitlements) ->
             ProductEntitlementMapping.Mapping(identifier, null, entitlements)
         }
-        val productEntitlementMapping = ProductEntitlementMapping(mappings)
+        mockEntitlementMappingSource(ProductEntitlementMapping(mappings))
+    }
+
+    private fun mockEntitlementMappingSource(mapping: ProductEntitlementMapping?) {
         every {
-            deviceCache.getProductEntitlementMapping()
-        } returns productEntitlementMapping
+            productEntitlementMappingSource.getProductEntitlementMapping(captureLambda())
+        } answers {
+            lambda<(ProductEntitlementMapping?) -> Unit>().captured.invoke(mapping)
+        }
     }
     // endregion
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/TopicFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/TopicFetcherTest.kt
@@ -466,6 +466,78 @@ class TopicFetcherTest {
         assertThat(stale2).doesNotExist()
     }
 
+    @Test
+    fun `topicUpdatedListener fires when a new blob is successfully downloaded`() = runTest {
+        val updatedTopics = mutableListOf<Topic>()
+        val fetcher = TopicFetcher(
+            applicationContext = applicationContext,
+            urlConnectionFactory = urlConnectionFactory,
+            topicUpdatedListener = { topic -> updatedTopics += topic },
+            downloadDispatcher = UnconfinedTestDispatcher(testScheduler),
+        )
+        val payload = """{"hello":"world"}""".toByteArray()
+        val blobRef = sha256Hex(payload)
+        mockSuccessfulDownload("https://assets.example/$blobRef", payload)
+
+        val result = fetcher.fetchTopicIfNeeded(
+            topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
+            entryId = "default",
+            topicEntry = topicEntry(blobRef),
+            source = source("https://assets.example/{blob_ref}"),
+        )
+        if (result !is TopicFetchResult.Success) fail<Unit>("Expected success, got: $result")
+
+        assertThat(updatedTopics).containsExactly(Topic.PRODUCT_ENTITLEMENT_MAPPING)
+    }
+
+    @Test
+    fun `topicUpdatedListener does not fire when target file already exists`() = runTest {
+        val updatedTopics = mutableListOf<Topic>()
+        val fetcher = TopicFetcher(
+            applicationContext = applicationContext,
+            urlConnectionFactory = urlConnectionFactory,
+            topicUpdatedListener = { topic -> updatedTopics += topic },
+            downloadDispatcher = UnconfinedTestDispatcher(testScheduler),
+        )
+        val payload = """{"cached":true}""".toByteArray()
+        val blobRef = sha256Hex(payload)
+        val target = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, blobRef)
+        target.parentFile?.mkdirs()
+        target.writeBytes(payload)
+
+        val result = fetcher.fetchTopicIfNeeded(
+            topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
+            entryId = "default",
+            topicEntry = topicEntry(blobRef),
+            source = source("https://assets.example/{blob_ref}"),
+        )
+        if (result !is TopicFetchResult.Success) fail<Unit>("Expected success, got: $result")
+
+        assertThat(updatedTopics).isEmpty()
+    }
+
+    @Test
+    fun `topicUpdatedListener does not fire when download errors out`() = runTest {
+        val updatedTopics = mutableListOf<Topic>()
+        val fetcher = TopicFetcher(
+            applicationContext = applicationContext,
+            urlConnectionFactory = urlConnectionFactory,
+            topicUpdatedListener = { topic -> updatedTopics += topic },
+            downloadDispatcher = UnconfinedTestDispatcher(testScheduler),
+        )
+        val blobRef = "a".repeat(64)
+        every { urlConnectionFactory.createConnection(any(), any()) } throws IOException("network down")
+
+        fetcher.fetchTopicIfNeeded(
+            topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
+            entryId = "default",
+            topicEntry = topicEntry(blobRef),
+            source = source("https://assets.example/{blob_ref}"),
+        )
+
+        assertThat(updatedTopics).isEmpty()
+    }
+
     private fun mockSuccessfulDownload(url: String, payload: ByteArray) {
         val connection = mockk<UrlConnection>(relaxed = true).also {
             every { it.responseCode } returns HttpURLConnection.HTTP_OK


### PR DESCRIPTION
### Motivation

When `BuildConfig.ENABLE_REMOTE_CONFIG` is on, the remote-config pipeline (#3435/#3437/#3439/#3450) downloads the `product_entitlement_mapping` topic blob to disk. The SDK should consume that file as the source-of-truth for offline entitlements instead of issuing the legacy `GET /v1/product_entitlement_mapping` call. When the flag is off, behavior must be unchanged.

### Description

Behavior gated on `BuildConfig.ENABLE_REMOTE_CONFIG`, surfaced into the SDK via a single `useRemoteConfigForProductEntitlementMapping` value computed once in `PurchasesFactory`:

- **Stop the direct backend fetch.** `OfflineEntitlementsManager.updateProductEntitlementMappingCacheIfStale` becomes a no-op (`completion?.invoke(null)` and return) when the flag is on, so `Backend.getProductEntitlementMapping` is never issued.
- **Read the topic file at consumer-call time, off-main, with in-memory caching.** New `ProductEntitlementMappingTopicReader`:
  - `suspend fun read(): ProductEntitlementMapping?` — reads the single non-`rc_topic_` file in `noBackupFilesDir/RevenueCat/topics/product_entitlement_mapping/` and parses it via `ProductEntitlementMapping.fromJson(JSONObject(...), loadedFromCache = true)`.
  - Coalesces concurrent callers via a shared `Deferred<ProductEntitlementMapping?>` held in `inFlight`, guarded by `synchronized(lock)`. Started with `CoroutineStart.LAZY` so `inFlight` is assigned **before** the body runs (otherwise an eager dispatcher would let the body's `inFlight = null` execute and `.also { inFlight = it }` would overwrite it back with a completed deferred, leaking it into the next read).
  - Owns its own `CoroutineScope(SupervisorJob() + dispatcher)` (`dispatcher: CoroutineDispatcher = Dispatchers.IO`, overridable for tests) so cancellation of one caller doesn't cancel the load others are awaiting.
  - `fun invalidate()` is non-suspend (it's called from a synchronous topic-update listener); just clears `cached` under the lock.
- **Fall back to the existing `SharedPreferences` cache** if the topic file is absent (first launch, download in-flight). New `ProductEntitlementMappingSource` interface (kept callback-shaped because its consumer `PurchasedProductsFetcher.queryActiveProducts` is pre-existing callback API):
  - `DeviceCacheProductEntitlementMappingSource` — synchronous, used when the flag is off.
  - `RemoteConfigProductEntitlementMappingSource` — owns a small `CoroutineScope`, launches `reader.read()` (suspend) and forwards `topicMapping ?: deviceCache.getProductEntitlementMapping()` to the callback.
- **Invalidate the in-memory cache when a fresh blob is downloaded.** `TopicFetcher` gains a `topicUpdatedListener: ((Topic) -> Unit)? = null` parameter, invoked after a successful `downloadVerifyAndStore`. `PurchasesFactory` registers a listener that calls `productEntitlementMappingTopicReader.invalidate()` when the `PRODUCT_ENTITLEMENT_MAPPING` topic is rewritten, so a new manifest takes effect within the same session.
- **Wiring (`PurchasesFactory`).** Hoists `TopicFetcher` out of `RemoteConfigManager`'s inline construction so the same instance is shared between the manager and the reader's invalidation hook. The flag funnels in at one place, matching the existing `PurchasesOrchestrator.refreshRemoteConfigIfEnabled` gating style.

### Tests

`runTest` for everything; `UnconfinedTestDispatcher` for the simple paths and `StandardTestDispatcher` for the coalescing test (so two callers can interleave before the body runs):

- `ProductEntitlementMappingTopicReaderTest` (new) — missing dir, empty dir, valid blob parsed, second read returns same instance with no extra disk access (counted via `noBackupFilesDir` mock answer), ignores `rc_topic_` prefix files, corrupt JSON returns null, `invalidate()` clears the cache, concurrent reads coalesce into a single disk access.
- `OfflineEntitlementsManagerTest` — adds a "skips backend fetch when `useRemoteConfigForProductEntitlementMapping = true`" case and confirms the existing 25h staleness logic still runs when the flag is off.
- `PurchasedProductsFetcherTest` — already callback-shaped via `ProductEntitlementMappingSource`; reused unchanged.
- `TopicFetcherTest` — adds three listener cases (fires after successful download, doesn't fire on cache hit, doesn't fire on download error).

### Trade-offs

- The topic blob is read into a `ByteArray` and decoded as UTF-8 JSON. Realistic mapping size is well under 1 MB; revisit if it grows materially.
- We do not bridge a topic-file mapping into `SharedPreferences`. The two stores stay independent — SharedPreferences exists only as a fallback. With the flag on and the topic system healthy, the SharedPreferences cache will go stale; that's intentional.
- `Backend.getProductEntitlementMapping` stays callback-based — it's the legacy network path.

All changes are `internal`; no public API surface change.

### Stack

- ⬇ `Add network scaffolding for remote config endpoint`: #3435
- ⬇ `Add RemoteConfigManager and TopicFetcher`: #3437
- ⬇ `Clean up unreferenced topic files after successful remote-config refresh`: #3439
- ⬇ `Wire RemoteConfigManager refresh on first foreground and identity changes`: #3450
- This PR: #3455

### Checklist

- [x] Unit tests
- [ ] Follow-up issues for `purchases-ios` / hybrids (deferred — feature is not yet wired to any consumer)
