### PR TITLE
Cache remote config response in memory with TTL and persist to disk

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -1,0 +1,51 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import android.content.Context
+import com.revenuecat.purchases.common.errorLog
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.io.IOException
+
+/**
+ * Persists the latest successful [RemoteConfigResponse] to disk under
+ * `noBackupFilesDir/RevenueCat/remote_config.json`.
+ *
+ * This is currently write-only. A subsequent PR will read this file at startup to seed the
+ * in-memory cache before the first network refresh.
+ */
+internal class RemoteConfigDiskCache(
+    private val applicationContext: Context,
+    private val json: Json,
+) {
+    fun write(response: RemoteConfigResponse) {
+        val parent = File(applicationContext.noBackupFilesDir, REMOTE_CONFIG_ROOT)
+        try {
+            if (!parent.exists()) {
+                parent.mkdirs()
+            }
+            val target = File(parent, REMOTE_CONFIG_FILE_NAME)
+            val tempFile = File.createTempFile("rc_remote_config_", ".tmp", parent)
+            try {
+                tempFile.writeText(json.encodeToString(response))
+                if (!tempFile.renameTo(target)) {
+                    tempFile.copyTo(target, overwrite = true)
+                }
+            } finally {
+                if (tempFile.exists()) {
+                    tempFile.delete()
+                }
+            }
+        } catch (e: IOException) {
+            errorLog(e) { "Failed to persist remote config to disk." }
+        } catch (e: SerializationException) {
+            errorLog(e) { "Failed to serialize remote config for disk persistence." }
+        }
+    }
+
+    private companion object {
+        const val REMOTE_CONFIG_ROOT = "RevenueCat"
+        const val REMOTE_CONFIG_FILE_NAME = "remote_config.json"
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCache.kt
@@ -19,6 +19,7 @@ internal class RemoteConfigDiskCache(
     private val applicationContext: Context,
     private val json: Json,
 ) {
+    /** Performs blocking disk I/O — call from a background dispatcher (e.g. [kotlinx.coroutines.Dispatchers.IO]). */
     fun write(response: RemoteConfigResponse) {
         val parent = File(applicationContext.noBackupFilesDir, REMOTE_CONFIG_ROOT)
         try {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -1,8 +1,12 @@
 package com.revenuecat.purchases.common.remoteconfig
 
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.safeResume
 import com.revenuecat.purchases.common.safeResumeWithException
@@ -15,18 +19,29 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.Date
 
+@OptIn(InternalRevenueCatAPI::class)
 internal class RemoteConfigManager(
     private val backend: Backend,
     private val topicFetcher: TopicFetcher,
+    private val diskCache: RemoteConfigDiskCache,
+    private val dateProvider: DateProvider = DefaultDateProvider(),
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    @Volatile
+    private var cache: CacheEntry? = null
 
     fun updateRemoteConfigIfNeeded(
         appInBackground: Boolean,
         completion: ((PurchasesError?) -> Unit)? = null,
     ) {
+        if (!cache?.cachedAt.isCacheStale(appInBackground, dateProvider)) {
+            completion?.invoke(null)
+            return
+        }
         scope.launch {
             val error = refresh(appInBackground)
             completion?.invoke(error)
@@ -46,7 +61,7 @@ internal class RemoteConfigManager(
             val entry = entries[DEFAULT_ENTRY_ID] ?: return@mapNotNull null
             TopicTask(topic, DEFAULT_ENTRY_ID, entry)
         }
-        return if (source == null || tasks.isEmpty()) {
+        val firstError: PurchasesError? = if (source == null || tasks.isEmpty()) {
             null
         } else {
             coroutineScope {
@@ -62,6 +77,11 @@ internal class RemoteConfigManager(
                 }.awaitAll().firstNotNullOfOrNull { it }
             }
         }
+        if (firstError == null) {
+            cache = CacheEntry(response, dateProvider.now)
+            diskCache.write(response)
+        }
+        return firstError
     }
 
     private suspend fun getRemoteConfig(appInBackground: Boolean): RemoteConfigResponse =
@@ -74,6 +94,8 @@ internal class RemoteConfigManager(
         }
 
     private data class TopicTask(val topic: Topic, val entryId: String, val entry: TopicEntry)
+
+    private data class CacheEntry(val response: RemoteConfigResponse, val cachedAt: Date)
 
     private companion object {
         const val DEFAULT_ENTRY_ID = "default"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -77,9 +77,14 @@ internal class RemoteConfigManager(
                 }.awaitAll().firstNotNullOfOrNull { it }
             }
         }
-        if (firstError == null) {
+        // Only cache when at least one topic was actually fetched — empty sources, empty topics,
+        // and missing default entryIds are treated as no-op refreshes that don't populate the cache.
+        if (firstError == null && source != null && tasks.isNotEmpty()) {
+            val previousResponse = cache?.response
             cache = CacheEntry(response, dateProvider.now)
-            diskCache.write(response)
+            if (previousResponse != response) {
+                diskCache.write(response)
+            }
         }
         return firstError
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/TopicFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/TopicFetcher.kt
@@ -105,6 +105,6 @@ internal class TopicFetcher(
         const val TOPICS_ROOT = "RevenueCat/topics"
         const val BLOB_REF_PLACEHOLDER = "{blob_ref}"
         const val MAX_PARALLEL_TOPIC_DOWNLOADS = 4
-        val BLOB_REF_PATTERN = Regex("^[a-zA-Z0-9]+$")
+        val BLOB_REF_PATTERN = Regex("^[a-fA-F0-9]{64}$")
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigDiskCacheTest.kt
@@ -1,0 +1,120 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.serialization.json.Json
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+@Config(manifest = Config.NONE)
+class RemoteConfigDiskCacheTest {
+
+    private val testFolder = "temp_remote_config_disk_cache_test_folder"
+
+    private lateinit var rootDir: File
+    private lateinit var applicationContext: Context
+    private lateinit var diskCache: RemoteConfigDiskCache
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Before
+    fun setUp() {
+        rootDir = File(testFolder)
+        if (rootDir.exists()) {
+            error("Temp test folder should not exist before starting tests")
+        }
+        rootDir.mkdirs()
+
+        applicationContext = mockk()
+        every { applicationContext.noBackupFilesDir } returns rootDir
+
+        diskCache = RemoteConfigDiskCache(applicationContext, json)
+    }
+
+    @After
+    fun tearDown() {
+        rootDir.deleteRecursively()
+    }
+
+    @Test
+    fun `write persists JSON file at expected path`() {
+        val response = sampleResponse()
+
+        diskCache.write(response)
+
+        val target = File(File(rootDir, "RevenueCat"), "remote_config.json")
+        assertThat(target.exists()).isTrue
+        val roundTripped = json.decodeFromString<RemoteConfigResponse>(target.readText())
+        assertThat(roundTripped).isEqualTo(response)
+    }
+
+    @Test
+    fun `write creates parent RevenueCat directory if missing`() {
+        val parent = File(rootDir, "RevenueCat")
+        assertThat(parent.exists()).isFalse
+
+        diskCache.write(sampleResponse())
+
+        assertThat(parent.exists()).isTrue
+        assertThat(parent.isDirectory).isTrue
+    }
+
+    @Test
+    fun `subsequent writes overwrite the previous snapshot`() {
+        val first = sampleResponse(blobRef = "blob-1")
+        val second = sampleResponse(blobRef = "blob-2")
+
+        diskCache.write(first)
+        diskCache.write(second)
+
+        val target = File(File(rootDir, "RevenueCat"), "remote_config.json")
+        val roundTripped = json.decodeFromString<RemoteConfigResponse>(target.readText())
+        assertThat(roundTripped).isEqualTo(second)
+    }
+
+    @Test
+    fun `write does not leave temp files behind on success`() {
+        diskCache.write(sampleResponse())
+
+        val parent = File(rootDir, "RevenueCat")
+        val tempFiles = parent.listFiles { _, name -> name.startsWith("rc_remote_config_") }
+        assertThat(tempFiles).isNotNull
+        assertThat(tempFiles!!).isEmpty()
+    }
+
+    @Test
+    fun `write swallows IOException when noBackupFilesDir is not writable`() {
+        // Replace rootDir with a regular file so mkdirs / createTempFile inside it fails.
+        rootDir.deleteRecursively()
+        rootDir.writeText("not a directory")
+
+        // Should not throw.
+        diskCache.write(sampleResponse())
+    }
+
+    private fun sampleResponse(blobRef: String = "blob-default"): RemoteConfigResponse =
+        RemoteConfigResponse(
+            blobSources = listOf(
+                BlobSource(
+                    id = "primary",
+                    urlFormat = "https://assets.example/{blob_ref}",
+                    priority = 0,
+                    weight = 100,
+                ),
+            ),
+            manifest = Manifest(
+                topics = mapOf(
+                    Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf(
+                        "default" to TopicEntry(blobRef = blobRef),
+                    ),
+                ),
+            ),
+        )
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -85,7 +85,7 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `empty sources skips fetcher and completes with null`() = runTest {
+    fun `empty sources skips fetcher, completes with null, and does not cache`() = runTest {
         val manager = newManager(testScheduler)
         val response = response(
             blobSources = emptyList(),
@@ -104,10 +104,18 @@ class RemoteConfigManagerTest {
         assertThat(completionInvoked).isTrue
         assertThat(completionError).isNull()
         coVerify(exactly = 0) { topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any()) }
+        verify(exactly = 0) { diskCache.write(any()) }
+
+        // Cache wasn't populated, so a follow-up call still hits the backend.
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+        verify(exactly = 2) {
+            backend.getRemoteConfig(appInBackground = false, onSuccess = any(), onError = any())
+        }
     }
 
     @Test
-    fun `empty topics map skips fetcher and completes with null`() = runTest {
+    fun `empty topics map skips fetcher, completes with null, and does not cache`() = runTest {
         val manager = newManager(testScheduler)
         val response = response(
             blobSources = listOf(source("primary")),
@@ -126,10 +134,17 @@ class RemoteConfigManagerTest {
         assertThat(completionInvoked).isTrue
         assertThat(completionError).isNull()
         coVerify(exactly = 0) { topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any()) }
+        verify(exactly = 0) { diskCache.write(any()) }
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+        verify(exactly = 2) {
+            backend.getRemoteConfig(appInBackground = false, onSuccess = any(), onError = any())
+        }
     }
 
     @Test
-    fun `topic without default entryId is skipped`() = runTest {
+    fun `topic without default entryId is skipped and not cached`() = runTest {
         val manager = newManager(testScheduler)
         val response = response(
             blobSources = listOf(source("primary")),
@@ -150,6 +165,13 @@ class RemoteConfigManagerTest {
         assertThat(completionInvoked).isTrue
         assertThat(completionError).isNull()
         coVerify(exactly = 0) { topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any()) }
+        verify(exactly = 0) { diskCache.write(any()) }
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+        verify(exactly = 2) {
+            backend.getRemoteConfig(appInBackground = false, onSuccess = any(), onError = any())
+        }
     }
 
     @Test
@@ -315,7 +337,7 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `vacuously successful refresh (no sources) populates cache and writes to disk`() = runTest {
+    fun `vacuously successful refresh (no sources) does not populate cache or write to disk`() = runTest {
         val manager = newManager(testScheduler)
         val response = response(
             blobSources = emptyList(),
@@ -326,7 +348,14 @@ class RemoteConfigManagerTest {
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
 
-        verify(exactly = 1) { diskCache.write(response) }
+        verify(exactly = 0) { diskCache.write(any()) }
+
+        // Cache wasn't populated, so a follow-up call still hits the backend.
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+        verify(exactly = 2) {
+            backend.getRemoteConfig(appInBackground = false, onSuccess = any(), onError = any())
+        }
     }
 
     @Test
@@ -412,11 +441,19 @@ class RemoteConfigManagerTest {
     @Test
     fun `call after foreground TTL expiry refetches and updates cache`() = runTest {
         val manager = newManager(testScheduler)
-        val response = response(
+        val first = response(
             blobSources = listOf(source("primary")),
-            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob-1"))),
         )
-        mockBackendSuccess(response)
+        val second = response(
+            blobSources = listOf(source("primary")),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob-2"))),
+        )
+        val onSuccessSlot = slot<(RemoteConfigResponse) -> Unit>()
+        val responses = ArrayDeque(listOf(first, second))
+        every {
+            backend.getRemoteConfig(any(), capture(onSuccessSlot), any())
+        } answers { onSuccessSlot.captured.invoke(responses.removeFirst()) }
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
         } returns null
@@ -433,7 +470,8 @@ class RemoteConfigManagerTest {
         verify(exactly = 2) {
             backend.getRemoteConfig(appInBackground = false, onSuccess = any(), onError = any())
         }
-        verify(exactly = 2) { diskCache.write(response) }
+        verify(exactly = 1) { diskCache.write(first) }
+        verify(exactly = 1) { diskCache.write(second) }
     }
 
     @Test
@@ -491,6 +529,52 @@ class RemoteConfigManagerTest {
 
         verify(exactly = 2) {
             backend.getRemoteConfig(appInBackground = true, onSuccess = any(), onError = any())
+        }
+    }
+
+    @Test
+    fun `identical responses across TTL gap only write disk once`() = runTest {
+        val manager = newManager(testScheduler)
+        val response = response(
+            blobSources = listOf(source("primary")),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } returns null
+
+        fakeNow = Date(0)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        fakeNow = Date(6.minutes.inWholeMilliseconds)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        verify(exactly = 2) {
+            backend.getRemoteConfig(appInBackground = false, onSuccess = any(), onError = any())
+        }
+        verify(exactly = 1) { diskCache.write(response) }
+    }
+
+    @Test
+    fun `consecutive stale calls each issue a backend request`() = runTest {
+        val manager = newManager(testScheduler)
+        val onErrorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            backend.getRemoteConfig(any(), any(), capture(onErrorSlot))
+        } answers {
+            onErrorSlot.captured.invoke(PurchasesError(PurchasesErrorCode.NetworkError, "boom"))
+        }
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        verify(exactly = 2) {
+            backend.getRemoteConfig(appInBackground = false, onSuccess = any(), onError = any())
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.DateProvider
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -11,6 +12,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -18,6 +20,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.util.Date
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -26,20 +31,23 @@ class RemoteConfigManagerTest {
 
     private lateinit var backend: Backend
     private lateinit var topicFetcher: TopicFetcher
+    private lateinit var diskCache: RemoteConfigDiskCache
+    private lateinit var dateProvider: DateProvider
+    private var fakeNow: Date = Date(0)
 
     @Before
     fun setUp() {
         backend = mockk()
         topicFetcher = mockk()
+        diskCache = mockk(relaxed = true)
+        fakeNow = Date(0)
+        dateProvider = mockk()
+        every { dateProvider.now } answers { fakeNow }
     }
 
     @Test
     fun `single topic with single source delegates to fetcher and completes with null`() = runTest {
-        val manager = RemoteConfigManager(
-            backend = backend,
-            topicFetcher = topicFetcher,
-            dispatcher = UnconfinedTestDispatcher(testScheduler),
-        )
+        val manager = newManager(testScheduler)
         val src = source("primary")
         val entry = topicEntry("blob-default")
         val response = response(
@@ -78,11 +86,7 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `empty sources skips fetcher and completes with null`() = runTest {
-        val manager = RemoteConfigManager(
-            backend = backend,
-            topicFetcher = topicFetcher,
-            dispatcher = UnconfinedTestDispatcher(testScheduler),
-        )
+        val manager = newManager(testScheduler)
         val response = response(
             blobSources = emptyList(),
             topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
@@ -104,11 +108,7 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `empty topics map skips fetcher and completes with null`() = runTest {
-        val manager = RemoteConfigManager(
-            backend = backend,
-            topicFetcher = topicFetcher,
-            dispatcher = UnconfinedTestDispatcher(testScheduler),
-        )
+        val manager = newManager(testScheduler)
         val response = response(
             blobSources = listOf(source("primary")),
             topics = emptyMap(),
@@ -130,11 +130,7 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `topic without default entryId is skipped`() = runTest {
-        val manager = RemoteConfigManager(
-            backend = backend,
-            topicFetcher = topicFetcher,
-            dispatcher = UnconfinedTestDispatcher(testScheduler),
-        )
+        val manager = newManager(testScheduler)
         val response = response(
             blobSources = listOf(source("primary")),
             topics = mapOf(
@@ -158,11 +154,7 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `selects the first source when multiple are available`() = runTest {
-        val manager = RemoteConfigManager(
-            backend = backend,
-            topicFetcher = topicFetcher,
-            dispatcher = UnconfinedTestDispatcher(testScheduler),
-        )
+        val manager = newManager(testScheduler)
         val first = source("first")
         val second = source("second")
         val response = response(
@@ -188,11 +180,7 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `forwards fetcher error to completion`() = runTest {
-        val manager = RemoteConfigManager(
-            backend = backend,
-            topicFetcher = topicFetcher,
-            dispatcher = UnconfinedTestDispatcher(testScheduler),
-        )
+        val manager = newManager(testScheduler)
         val response = response(
             blobSources = listOf(source("primary")),
             topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
@@ -217,11 +205,7 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `backend error short-circuits and never invokes fetcher`() = runTest {
-        val manager = RemoteConfigManager(
-            backend = backend,
-            topicFetcher = topicFetcher,
-            dispatcher = UnconfinedTestDispatcher(testScheduler),
-        )
+        val manager = newManager(testScheduler)
         val backendError = PurchasesError(PurchasesErrorCode.NetworkError, "backend down")
         val onErrorSlot = slot<(PurchasesError) -> Unit>()
         every {
@@ -243,11 +227,7 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `forwards background flag to backend`() = runTest {
-        val manager = RemoteConfigManager(
-            backend = backend,
-            topicFetcher = topicFetcher,
-            dispatcher = UnconfinedTestDispatcher(testScheduler),
-        )
+        val manager = newManager(testScheduler)
         val response = response(
             blobSources = listOf(source("primary")),
             topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
@@ -271,11 +251,7 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `null completion does not crash on success`() = runTest {
-        val manager = RemoteConfigManager(
-            backend = backend,
-            topicFetcher = topicFetcher,
-            dispatcher = UnconfinedTestDispatcher(testScheduler),
-        )
+        val manager = newManager(testScheduler)
         val response = response(
             blobSources = listOf(source("primary")),
             topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
@@ -292,11 +268,7 @@ class RemoteConfigManagerTest {
 
     @Test
     fun `refresh runs even when completion is null`() = runTest {
-        val manager = RemoteConfigManager(
-            backend = backend,
-            topicFetcher = topicFetcher,
-            dispatcher = UnconfinedTestDispatcher(testScheduler),
-        )
+        val manager = newManager(testScheduler)
         val src = source("primary")
         val entry = topicEntry("blob-default")
         val response = response(
@@ -323,6 +295,212 @@ class RemoteConfigManagerTest {
             )
         }
     }
+
+    @Test
+    fun `successful refresh writes response to disk cache`() = runTest {
+        val manager = newManager(testScheduler)
+        val response = response(
+            blobSources = listOf(source("primary")),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } returns null
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        verify(exactly = 1) { diskCache.write(response) }
+    }
+
+    @Test
+    fun `vacuously successful refresh (no sources) populates cache and writes to disk`() = runTest {
+        val manager = newManager(testScheduler)
+        val response = response(
+            blobSources = emptyList(),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        verify(exactly = 1) { diskCache.write(response) }
+    }
+
+    @Test
+    fun `topic fetch error skips disk write and leaves cache unpopulated`() = runTest {
+        val manager = newManager(testScheduler)
+        val response = response(
+            blobSources = listOf(source("primary")),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } returns PurchasesError(PurchasesErrorCode.NetworkError, "boom")
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        verify(exactly = 0) { diskCache.write(any()) }
+
+        // Subsequent call should hit backend again because cache was never populated.
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+        verify(exactly = 2) {
+            backend.getRemoteConfig(appInBackground = false, onSuccess = any(), onError = any())
+        }
+    }
+
+    @Test
+    fun `backend error skips disk write and leaves cache unpopulated`() = runTest {
+        val manager = newManager(testScheduler)
+        val backendError = PurchasesError(PurchasesErrorCode.NetworkError, "backend down")
+        val onErrorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            backend.getRemoteConfig(any(), any(), capture(onErrorSlot))
+        } answers { onErrorSlot.captured.invoke(backendError) }
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        verify(exactly = 0) { diskCache.write(any()) }
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+        verify(exactly = 2) {
+            backend.getRemoteConfig(appInBackground = false, onSuccess = any(), onError = any())
+        }
+    }
+
+    @Test
+    fun `second call within foreground TTL is skipped without hitting backend`() = runTest {
+        val manager = newManager(testScheduler)
+        val response = response(
+            blobSources = listOf(source("primary")),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } returns null
+
+        fakeNow = Date(0)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        // Advance 4 minutes — within 5-minute foreground TTL.
+        fakeNow = Date(4.minutes.inWholeMilliseconds)
+        var completionInvoked = false
+        var completionError: PurchasesError? = PurchasesError(PurchasesErrorCode.UnknownError)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) { error ->
+            completionInvoked = true
+            completionError = error
+        }
+        testScheduler.advanceUntilIdle()
+
+        assertThat(completionInvoked).isTrue
+        assertThat(completionError).isNull()
+        verify(exactly = 1) {
+            backend.getRemoteConfig(appInBackground = false, onSuccess = any(), onError = any())
+        }
+        verify(exactly = 1) { diskCache.write(any()) }
+    }
+
+    @Test
+    fun `call after foreground TTL expiry refetches and updates cache`() = runTest {
+        val manager = newManager(testScheduler)
+        val response = response(
+            blobSources = listOf(source("primary")),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } returns null
+
+        fakeNow = Date(0)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        // Advance just past 5-minute foreground TTL.
+        fakeNow = Date(6.minutes.inWholeMilliseconds)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        verify(exactly = 2) {
+            backend.getRemoteConfig(appInBackground = false, onSuccess = any(), onError = any())
+        }
+        verify(exactly = 2) { diskCache.write(response) }
+    }
+
+    @Test
+    fun `30 minutes after foreground populate, foregrounded call refetches but backgrounded call is skipped`() = runTest {
+        val manager = newManager(testScheduler)
+        val response = response(
+            blobSources = listOf(source("primary")),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } returns null
+
+        fakeNow = Date(0)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        // 30 minutes later: stale under 5 min foreground TTL, fresh under 25 hr background TTL.
+        fakeNow = Date(30.minutes.inWholeMilliseconds)
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = true) {}
+        testScheduler.advanceUntilIdle()
+        verify(exactly = 1) {
+            backend.getRemoteConfig(appInBackground = any(), onSuccess = any(), onError = any())
+        }
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+        verify(exactly = 2) {
+            backend.getRemoteConfig(appInBackground = any(), onSuccess = any(), onError = any())
+        }
+    }
+
+    @Test
+    fun `call past background TTL refetches even when backgrounded`() = runTest {
+        val manager = newManager(testScheduler)
+        val response = response(
+            blobSources = listOf(source("primary")),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } returns null
+
+        fakeNow = Date(0)
+        manager.updateRemoteConfigIfNeeded(appInBackground = true) {}
+        testScheduler.advanceUntilIdle()
+
+        // Just past 25-hour background TTL.
+        fakeNow = Date(26.hours.inWholeMilliseconds)
+        manager.updateRemoteConfigIfNeeded(appInBackground = true) {}
+        testScheduler.advanceUntilIdle()
+
+        verify(exactly = 2) {
+            backend.getRemoteConfig(appInBackground = true, onSuccess = any(), onError = any())
+        }
+    }
+
+    private fun newManager(scheduler: TestCoroutineScheduler) = RemoteConfigManager(
+        backend = backend,
+        topicFetcher = topicFetcher,
+        diskCache = diskCache,
+        dateProvider = dateProvider,
+        dispatcher = UnconfinedTestDispatcher(scheduler),
+    )
 
     private fun mockBackendSuccess(response: RemoteConfigResponse) {
         val onSuccess = slot<(RemoteConfigResponse) -> Unit>()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/TopicFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/TopicFetcherTest.kt
@@ -256,6 +256,50 @@ class TopicFetcherTest {
     }
 
     @Test
+    fun `rejects blobRef shorter than 64 hex chars`() = runTest {
+        val error = fetcher().fetchTopicIfNeeded(
+            topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
+            entryId = "default",
+            topicEntry = topicEntry("abc123"),
+            source = source("https://assets.example/{blob_ref}"),
+        )
+
+        assertThat(error).isNotNull
+        assertThat(error?.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
+        verify(exactly = 0) { urlConnectionFactory.createConnection(any(), any()) }
+    }
+
+    @Test
+    fun `rejects blobRef longer than 64 hex chars`() = runTest {
+        val tooLong = "a".repeat(65)
+        val error = fetcher().fetchTopicIfNeeded(
+            topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
+            entryId = "default",
+            topicEntry = topicEntry(tooLong),
+            source = source("https://assets.example/{blob_ref}"),
+        )
+
+        assertThat(error).isNotNull
+        assertThat(error?.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
+        verify(exactly = 0) { urlConnectionFactory.createConnection(any(), any()) }
+    }
+
+    @Test
+    fun `rejects 64-char blobRef containing non-hex letters`() = runTest {
+        val nonHex = "g".repeat(64)
+        val error = fetcher().fetchTopicIfNeeded(
+            topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
+            entryId = "default",
+            topicEntry = topicEntry(nonHex),
+            source = source("https://assets.example/{blob_ref}"),
+        )
+
+        assertThat(error).isNotNull
+        assertThat(error?.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
+        verify(exactly = 0) { urlConnectionFactory.createConnection(any(), any()) }
+    }
+
+    @Test
     fun `accepts mixed-case 64-char hex blobRef`() = runTest {
         val mixedCaseHex = "ABCDEFabcdef" + "0".repeat(52)
         val url = "https://assets.example/$mixedCaseHex"


### PR DESCRIPTION
### Description
This caches the remote config response both on disk and in memory. Right now the in memory cache is only used to avoid fetching the config multiple times without need. The disk cache is currently unused but will be used in future PRs.

The idea is to use this cache for the api config to be used to perform other SDK requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new caching and disk I/O paths in remote config fetching, which can affect refresh behavior and persistence semantics if TTL logic or write conditions are incorrect.
> 
> **Overview**
> Adds an in-memory TTL cache to `RemoteConfigManager` so repeated `updateRemoteConfigIfNeeded` calls can short-circuit without hitting the backend when the cached response is still fresh (foreground vs background TTL via `isCacheStale`).
> 
> Introduces `RemoteConfigDiskCache` to atomically persist the latest *successful* `RemoteConfigResponse` to `noBackupFilesDir/RevenueCat/remote_config.json`, writing only when at least one topic fetch occurred and the response changed.
> 
> Tightens `TopicFetcher` blob ref validation from “alphanumeric” to a strict 64-char hex SHA-256 format, with expanded tests covering acceptance/rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f91f3d8ebf0d4d8a9f9200218ca9dc4e4909bf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->