### PR TITLE
Select blob source by priority and weighted random

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -20,13 +20,16 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.util.Date
+import kotlin.random.Random
 
 @OptIn(InternalRevenueCatAPI::class)
+@Suppress("LongParameterList")
 internal class RemoteConfigManager(
     private val backend: Backend,
     private val topicFetcher: TopicFetcher,
     private val diskCache: RemoteConfigDiskCache,
     private val dateProvider: DateProvider = DefaultDateProvider(),
+    private val random: Random = Random.Default,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
@@ -55,8 +58,7 @@ internal class RemoteConfigManager(
             errorLog { "Failed to fetch remote config: ${e.error}" }
             return e.error
         }
-        // WIP: We should have some logic to pick the correct source for this. Right now, hardcoded to the first source.
-        val source = response.blobSources.firstOrNull()
+        val source = response.blobSources.selectWeighted(random)
         val referenced = buildReferenceSet(response.manifest)
         val tasks = response.manifest.topics.mapNotNull { (topic, entries) ->
             val entry = entries[DEFAULT_ENTRY_ID] ?: return@mapNotNull null

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigResponse.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigResponse.kt
@@ -20,17 +20,17 @@ internal data class RemoteConfigResponse(
 internal data class ApiSource(
     val id: String,
     val url: String,
-    val priority: Int,
-    val weight: Int,
-)
+    override val priority: Int,
+    override val weight: Int,
+) : WeightedSource
 
 @Serializable
 internal data class BlobSource(
     val id: String,
     @SerialName("url_format") val urlFormat: String,
-    val priority: Int,
-    val weight: Int,
-)
+    override val priority: Int,
+    override val weight: Int,
+) : WeightedSource
 
 @Serializable
 internal data class Manifest(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/WeightedSource.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/WeightedSource.kt
@@ -1,0 +1,31 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import kotlin.random.Random
+
+internal interface WeightedSource {
+    val priority: Int
+    val weight: Int
+}
+
+/**
+ * Helper function to select a source from a list of [WeightedSource]s
+ * - Highest priority
+ * - Tied priority uses weights to choose randomly.
+ * - If weights add up to 0 or any negative weight, uniform random selection.
+ */
+internal fun <T : WeightedSource> List<T>.selectWeighted(random: Random = Random.Default): T? {
+    val highestPriority = maxOfOrNull { it.priority } ?: return null
+    val candidates = filter { it.priority == highestPriority }
+    val totalWeight = candidates.sumOf { it.weight }
+    val anyNegativeWeights = candidates.any { it.weight < 0 }
+    return if (totalWeight <= 0 || anyNegativeWeights) {
+        candidates[random.nextInt(candidates.size)]
+    } else {
+        val r = random.nextInt(totalWeight)
+        var cumulative = 0
+        candidates.first { candidate ->
+            cumulative += candidate.weight
+            r < cumulative
+        }
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -21,6 +21,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.util.Date
+import kotlin.random.Random
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
@@ -179,12 +180,14 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `selects the first source when multiple are available`() = runTest {
+    fun `selects one of the top priority sources and ignores lower priority ones`() = runTest {
         val manager = newManager(testScheduler)
-        val first = source("first")
-        val second = source("second")
+        val highA = source("highA", priority = 1)
+        val highB = source("highB", priority = 1)
+        val lowA = source("lowA", priority = 0)
+        val lowB = source("lowB", priority = 0)
         val response = response(
-            blobSources = listOf(first, second),
+            blobSources = listOf(lowA, highA, lowB, highB),
             topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
         )
         mockBackendSuccess(response)
@@ -201,7 +204,33 @@ class RemoteConfigManagerTest {
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
 
-        assertThat(capturedSource.captured).isEqualTo(first)
+        assertThat(capturedSource.captured).isIn(highA, highB)
+    }
+
+    @Test
+    fun `selects the highest priority source even with lower weight`() = runTest {
+        val manager = newManager(testScheduler)
+        val low = source("low", priority = 0, weight = 999)
+        val high = source("high", priority = 5, weight = 1)
+        val response = response(
+            blobSources = listOf(low, high),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        val capturedSource = slot<BlobSource>()
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(
+                topic = any(),
+                entryId = any(),
+                topicEntry = any(),
+                source = capture(capturedSource),
+            )
+        } returns null
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        assertThat(capturedSource.captured).isEqualTo(high)
     }
 
     @Test
@@ -638,11 +667,15 @@ class RemoteConfigManagerTest {
         }
     }
 
-    private fun newManager(scheduler: TestCoroutineScheduler) = RemoteConfigManager(
+    private fun newManager(
+        scheduler: TestCoroutineScheduler,
+        random: Random = Random(0L),
+    ) = RemoteConfigManager(
         backend = backend,
         topicFetcher = topicFetcher,
         diskCache = diskCache,
         dateProvider = dateProvider,
+        random = random,
         dispatcher = UnconfinedTestDispatcher(scheduler),
     )
 
@@ -661,11 +694,15 @@ class RemoteConfigManagerTest {
         manifest = Manifest(topics = topics),
     )
 
-    private fun source(id: String) = BlobSource(
+    private fun source(
+        id: String,
+        priority: Int = 0,
+        weight: Int = 100,
+    ) = BlobSource(
         id = id,
         urlFormat = "https://assets.example/{blob_ref}",
-        priority = 0,
-        weight = 100,
+        priority = priority,
+        weight = weight,
     )
 
     private fun topicEntry(blobRef: String) = TopicEntry(blobRef = blobRef)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/WeightedSourceSelectionTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/WeightedSourceSelectionTest.kt
@@ -1,0 +1,111 @@
+package com.revenuecat.purchases.common.remoteconfig
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import kotlin.random.Random
+
+class WeightedSourceSelectionTest {
+
+    @Test
+    fun `empty list returns null`() {
+        val sources: List<TestSource> = emptyList()
+        assertThat(sources.selectWeighted(Random.Default)).isNull()
+    }
+
+    @Test
+    fun `single source with positive weight is selected`() {
+        val only = TestSource(priority = 0, weight = 10)
+        assertThat(listOf(only).selectWeighted(FakeRandom(0))).isSameAs(only)
+        assertThat(listOf(only).selectWeighted(FakeRandom(1))).isSameAs(only)
+    }
+
+    @Test
+    fun `single source with zero weight is still selected`() {
+        val only = TestSource(priority = 0, weight = 0)
+        assertThat(listOf(only).selectWeighted(FakeRandom(0))).isSameAs(only)
+    }
+
+    @Test
+    fun `highest priority wins regardless of weight`() {
+        val low = TestSource(priority = 1, weight = 999)
+        val high = TestSource(priority = 5, weight = 1)
+        assertThat(listOf(low, high).selectWeighted(FakeRandom(0))).isSameAs(high)
+    }
+
+    @Test
+    fun `weighted pick lands in the first bucket at lower boundary`() {
+        val a = TestSource(priority = 0, weight = 30)
+        val b = TestSource(priority = 0, weight = 70)
+        assertThat(listOf(a, b).selectWeighted(FakeRandom(0))).isSameAs(a)
+    }
+
+    @Test
+    fun `weighted pick lands in the first bucket just below its upper boundary`() {
+        val a = TestSource(priority = 0, weight = 30)
+        val b = TestSource(priority = 0, weight = 70)
+        assertThat(listOf(a, b).selectWeighted(FakeRandom(29))).isSameAs(a)
+    }
+
+    @Test
+    fun `weighted pick crosses into the second bucket exactly at boundary`() {
+        val a = TestSource(priority = 0, weight = 30)
+        val b = TestSource(priority = 0, weight = 70)
+        assertThat(listOf(a, b).selectWeighted(FakeRandom(30))).isSameAs(b)
+    }
+
+    @Test
+    fun `weighted pick lands in the second bucket near upper end`() {
+        val a = TestSource(priority = 0, weight = 30)
+        val b = TestSource(priority = 0, weight = 70)
+        assertThat(listOf(a, b).selectWeighted(FakeRandom(99))).isSameAs(b)
+    }
+
+    @Test
+    fun `falls back to uniform random when all top priority weights are zero`() {
+        val topA = TestSource(priority = 5, weight = 0)
+        val topB = TestSource(priority = 5, weight = 0)
+        val low = TestSource(priority = 1, weight = 100)
+        val sources = listOf(topA, topB, low)
+
+        assertThat(sources.selectWeighted(FakeRandom(0))).isSameAs(topA)
+        assertThat(sources.selectWeighted(FakeRandom(1))).isSameAs(topB)
+    }
+
+    @Test
+    fun `ignores lower priority sources even when their combined weight dominates`() {
+        val high = TestSource(priority = 10, weight = 1)
+        val low1 = TestSource(priority = 0, weight = 100)
+        val low2 = TestSource(priority = 0, weight = 100)
+        assertThat(listOf(low1, high, low2).selectWeighted(FakeRandom(0))).isSameAs(high)
+    }
+
+    @Test
+    fun `negative total weight falls back to uniform random`() {
+        val a = TestSource(priority = 0, weight = -10)
+        val b = TestSource(priority = 0, weight = 5)
+        val sources = listOf(a, b)
+
+        assertThat(sources.selectWeighted(FakeRandom(0))).isSameAs(a)
+        assertThat(sources.selectWeighted(FakeRandom(1))).isSameAs(b)
+    }
+
+    @Test
+    fun `any negative weight falls back to uniform random even when total is positive`() {
+        val a = TestSource(priority = 0, weight = -10)
+        val b = TestSource(priority = 0, weight = 30)
+        val sources = listOf(a, b)
+
+        assertThat(sources.selectWeighted(FakeRandom(0))).isSameAs(a)
+        assertThat(sources.selectWeighted(FakeRandom(1))).isSameAs(b)
+    }
+
+    private data class TestSource(
+        override val priority: Int,
+        override val weight: Int,
+    ) : WeightedSource
+
+    private class FakeRandom(private val value: Int) : Random() {
+        override fun nextBits(bitCount: Int): Int = error("nextBits should not be used")
+        override fun nextInt(until: Int): Int = value
+    }
+}


### PR DESCRIPTION
### Motivation
`RemoteConfigManager.refresh` was hardcoded to pick `blobSources.firstOrNull()` with a `WIP:` comment. The backend already returns `priority` and `weight` on each source, so this PR wires up the real selection logic.

### Description
- Highest `priority` value wins.
- Among sources tied at the top priority, pick one with weighted random using `weight`:
  ```
  total = sum(weights)
  r = random(0, total)
  cumulative = 0
  for source in candidates:
      cumulative += source.weight
      if r < cumulative: return source
  ```
- Fallback to uniform random when all top-priority weights are zero (or any of them are negative, defensively).
- Selection extracted into a `WeightedSource` interface + `List<T>.selectWeighted(Random)` extension so the same algorithm can later be reused for `ApiSource` (which has the same `priority`/`weight` shape).
- `RemoteConfigManager` now takes an injectable `Random` (defaulted to `Random.Default`) for deterministic unit tests.

### Test plan
- [x] New `WeightedSourceSelectionTest` covers: empty list, single source with zero weight, priority dominance, weighted-pick boundary cases (`r=0`, `r=29`, `r=30`, `r=99` for weights `[30, 70]`), zero-weight uniform fallback, negative-weight uniform fallback.
- [x] `RemoteConfigManagerTest` updated: existing multi-source test relaxed to assert delegation; new test asserts the highest-priority source is selected through the manager.
- [x] `./gradlew :purchases:testDefaultsBc8DebugUnitTest --tests "com.revenuecat.purchases.common.remoteconfig.*"` passes.
- [x] `./gradlew detektAll` passes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote-config blob source selection from deterministic first-item to priority/weight-based randomness, which can affect which CDN/source is used in production. Risk is moderate but bounded to remote config fetching and covered by new unit tests and injectable RNG for determinism.
> 
> **Overview**
> Remote config blob fetching now selects a `BlobSource` by **highest `priority`**, and breaks ties with **weighted random** using `weight` (with a uniform-random fallback for zero/negative weights) rather than always using `blobSources.firstOrNull()`.
> 
> This extracts the algorithm into a reusable `WeightedSource` + `selectWeighted(...)` helper, updates `ApiSource`/`BlobSource` to implement it, injects `Random` into `RemoteConfigManager` for deterministic tests, and expands unit coverage for priority/weight edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98ba25479bee1cd7355d70dedb90274c77c9a7ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->