### PR TITLE
Update codelabs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ Or view / build our Android sample app:
 
 ## Codelab
 
-1. [RevenueCat Google Play Integration](https://revenuecat.github.io/codelab/google-play/codelab-1-google-play-integration/index.html#0): In this codelab, you'll learn how to:
+1. [RevenueCat Google Play Integration](https://revenuecat.github.io/codelabs/google-play.html#0): In this codelab, you'll learn how to:
 
    - Properly configure products on Google Play.
    - Set up the RevenueCat dashboard and connect it to your Google Play products.
    - Understanding Product, Offering, Package, and Entitlement.
    - Create paywalls using the [Paywall Editor](https://www.revenuecat.com/docs/tools/paywalls/creating-paywalls#using-the-editor).
 
-2. [Android In-App Purchases & Paywalls](https://revenuecat.github.io/codelab/android/codelab-2-android-sdk/index.html#0): In this codelab, you will:
+2. [Android In-App Purchases & Paywalls](https://revenuecat.github.io/codelabs/android.html#0): In this codelab, you will:
 
    - Integrate the Android RevenueCat SDK into your project
    - Implement in-app purchases in your Android application


### PR DESCRIPTION
Update codelabs links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; the only impact is whether the new external URLs are correct and remain stable.
> 
> **Overview**
> Updates the `README.md` **Codelab** section to point both codelab entries at the new `https://revenuecat.github.io/codelabs/...` pages instead of the older per-codelab `.../codelab/.../index.html` URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13f4bd9563c69e4794acbdee50de40b513132038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->