### PR TITLE
Fall back across blob sources when topic downloads fail

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -62,6 +62,10 @@ internal class RemoteConfigManager(
             errorLog { "Failed to fetch remote config: ${e.error}" }
             return e.error
         }
+        val previouslyCachedResponse = cache?.response
+        if (previouslyCachedResponse != null && previouslyCachedResponse != response) {
+            cachedSourceId = null
+        }
         val referenced = buildReferenceSet(response.manifest)
         val tasks = response.manifest.topics.mapNotNull { (topic, entries) ->
             val entry = entries[DEFAULT_ENTRY_ID] ?: return@mapNotNull null
@@ -109,7 +113,7 @@ internal class RemoteConfigManager(
             triedIds += source.id
 
             val attempt = attemptDownloads(source, remaining)
-            lastError = lastError ?: attempt.firstError
+            lastError = attempt.firstError ?: lastError
             if (attempt.invalidating && source.id == previouslyCachedSourceId) {
                 cachedSourceFailedInvalidating = true
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManager.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.common.remoteconfig
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
@@ -37,6 +38,9 @@ internal class RemoteConfigManager(
     @Volatile
     private var cache: CacheEntry? = null
 
+    @Volatile
+    private var cachedSourceId: String? = null
+
     fun updateRemoteConfigIfNeeded(
         appInBackground: Boolean,
         completion: ((PurchasesError?) -> Unit)? = null,
@@ -58,41 +62,118 @@ internal class RemoteConfigManager(
             errorLog { "Failed to fetch remote config: ${e.error}" }
             return e.error
         }
-        val source = response.blobSources.selectWeighted(random)
         val referenced = buildReferenceSet(response.manifest)
         val tasks = response.manifest.topics.mapNotNull { (topic, entries) ->
             val entry = entries[DEFAULT_ENTRY_ID] ?: return@mapNotNull null
             TopicTask(topic, DEFAULT_ENTRY_ID, entry)
         }
-        val firstError: PurchasesError? = if (source == null || tasks.isEmpty()) {
-            null
+        val outcome = if (response.blobSources.isEmpty() || tasks.isEmpty()) {
+            RefreshOutcome.VacuousSuccess
         } else {
-            coroutineScope {
-                tasks.map { task ->
-                    async {
-                        topicFetcher.fetchTopicIfNeeded(
-                            topic = task.topic,
-                            entryId = task.entryId,
-                            topicEntry = task.entry,
-                            source = source,
-                        )
-                    }
-                }.awaitAll().firstNotNullOfOrNull { it }
-            }
+            downloadTopicsWithFallback(response.blobSources, tasks)
         }
-        if (firstError == null) {
-            // Only cache when at least one topic was actually fetched — empty sources, empty topics,
-            // and missing default entryIds are treated as no-op refreshes that don't populate the cache.
-            if (source != null && tasks.isNotEmpty()) {
+
+        return when (outcome) {
+            is RefreshOutcome.Success -> {
+                cachedSourceId = outcome.source.id
                 val previousResponse = cache?.response
                 topicFetcher.cleanupUnreferencedTopics(referenced)
                 cache = CacheEntry(response, dateProvider.now)
                 if (previousResponse != response) {
                     diskCache.write(response)
                 }
+                null
+            }
+            RefreshOutcome.VacuousSuccess -> null
+            is RefreshOutcome.Failure -> {
+                if (outcome.clearCachedSource) {
+                    cachedSourceId = null
+                }
+                outcome.error
             }
         }
-        return firstError
+    }
+
+    private suspend fun downloadTopicsWithFallback(
+        blobSources: List<BlobSource>,
+        tasks: List<TopicTask>,
+    ): RefreshOutcome {
+        val triedIds = mutableSetOf<String>()
+        var remaining = tasks
+        var lastError: PurchasesError? = null
+        var cachedSourceFailedInvalidating = false
+        val previouslyCachedSourceId = cachedSourceId
+
+        while (remaining.isNotEmpty()) {
+            val source = pickNextSource(blobSources, triedIds, previouslyCachedSourceId) ?: break
+            triedIds += source.id
+
+            val attempt = attemptDownloads(source, remaining)
+            lastError = lastError ?: attempt.firstError
+            if (attempt.invalidating && source.id == previouslyCachedSourceId) {
+                cachedSourceFailedInvalidating = true
+            }
+            if (attempt.stillFailing.isEmpty()) {
+                return RefreshOutcome.Success(source)
+            }
+            remaining = attempt.stillFailing
+        }
+
+        return RefreshOutcome.Failure(
+            error = lastError ?: PurchasesError(
+                PurchasesErrorCode.NetworkError,
+                "All blob sources exhausted while downloading topics.",
+            ),
+            clearCachedSource = cachedSourceFailedInvalidating,
+        )
+    }
+
+    private suspend fun attemptDownloads(
+        source: BlobSource,
+        tasks: List<TopicTask>,
+    ): SourceAttempt {
+        val results = coroutineScope {
+            tasks.map { task ->
+                async {
+                    task to topicFetcher.fetchTopicIfNeeded(
+                        topic = task.topic,
+                        entryId = task.entryId,
+                        topicEntry = task.entry,
+                        source = source,
+                    )
+                }
+            }.awaitAll()
+        }
+        val stillFailing = mutableListOf<TopicTask>()
+        var firstError: PurchasesError? = null
+        var invalidating = false
+        for ((task, result) in results) {
+            when (result) {
+                is TopicFetchResult.Success -> Unit
+                is TopicFetchResult.TransientFailure -> {
+                    stillFailing += task
+                    firstError = firstError ?: result.error
+                }
+                is TopicFetchResult.InvalidatingFailure -> {
+                    stillFailing += task
+                    firstError = firstError ?: result.error
+                    invalidating = true
+                }
+            }
+        }
+        return SourceAttempt(stillFailing, firstError, invalidating)
+    }
+
+    private fun pickNextSource(
+        blobSources: List<BlobSource>,
+        triedIds: Set<String>,
+        previouslyCachedSourceId: String?,
+    ): BlobSource? {
+        if (triedIds.isEmpty() && previouslyCachedSourceId != null) {
+            val cachedSource = blobSources.firstOrNull { it.id == previouslyCachedSourceId }
+            if (cachedSource != null) return cachedSource
+        }
+        return blobSources.selectWeightedExcluding(triedIds, BlobSource::id, random)
     }
 
     private suspend fun getRemoteConfig(appInBackground: Boolean): RemoteConfigResponse =
@@ -111,7 +192,19 @@ internal class RemoteConfigManager(
 
     private data class TopicTask(val topic: Topic, val entryId: String, val entry: TopicEntry)
 
+    private data class SourceAttempt(
+        val stillFailing: List<TopicTask>,
+        val firstError: PurchasesError?,
+        val invalidating: Boolean,
+    )
+
     private data class CacheEntry(val response: RemoteConfigResponse, val cachedAt: Date)
+
+    private sealed class RefreshOutcome {
+        data class Success(val source: BlobSource) : RefreshOutcome()
+        object VacuousSuccess : RefreshOutcome()
+        data class Failure(val error: PurchasesError, val clearCachedSource: Boolean) : RefreshOutcome()
+    }
 
     private companion object {
         const val DEFAULT_ENTRY_ID = "default"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/TopicFetcher.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/TopicFetcher.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.networking.ConnectionErrorReason
 import com.revenuecat.purchases.common.toPurchasesError
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.models.Checksum
@@ -17,6 +18,12 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.IOException
+
+internal sealed class TopicFetchResult {
+    object Success : TopicFetchResult()
+    data class TransientFailure(val error: PurchasesError) : TopicFetchResult()
+    data class InvalidatingFailure(val error: PurchasesError) : TopicFetchResult()
+}
 
 @OptIn(InternalRevenueCatAPI::class, ExperimentalCoroutinesApi::class)
 internal class TopicFetcher(
@@ -30,11 +37,13 @@ internal class TopicFetcher(
         entryId: String,
         topicEntry: TopicEntry,
         source: BlobSource,
-    ): PurchasesError? {
+    ): TopicFetchResult {
         if (!topicEntry.blobRef.matches(BLOB_REF_PATTERN)) {
             val message = "Topic $topic ($entryId) has a malformed blob_ref; refusing to fetch."
             errorLog { message }
-            return PurchasesError(PurchasesErrorCode.UnexpectedBackendResponseError, message)
+            return TopicFetchResult.InvalidatingFailure(
+                PurchasesError(PurchasesErrorCode.UnexpectedBackendResponseError, message),
+            )
         }
         return withContext(downloadDispatcher) { fetchOnDispatcher(topic, entryId, topicEntry, source) }
     }
@@ -44,25 +53,33 @@ internal class TopicFetcher(
         entryId: String,
         topicEntry: TopicEntry,
         source: BlobSource,
-    ): PurchasesError? {
+    ): TopicFetchResult {
         val targetFile = topicFile(topic, topicEntry.blobRef)
         if (targetFile.exists()) {
             verboseLog { "Topic $topic ($entryId) already cached at ${targetFile.absolutePath}" }
-            return null
+            return TopicFetchResult.Success
         }
         return try {
             val url = source.urlFormat.replace(BLOB_REF_PLACEHOLDER, topicEntry.blobRef)
             downloadVerifyAndStore(url, topicEntry.blobRef, targetFile)
             debugLog { "Topic $topic ($entryId) downloaded to ${targetFile.absolutePath}" }
-            null
+            TopicFetchResult.Success
         } catch (e: Checksum.ChecksumValidationException) {
             errorLog(e) { "Downloaded topic $topic ($entryId) failed SHA-256 verification." }
-            PurchasesError(
-                PurchasesErrorCode.NetworkError,
-                "Downloaded topic $topic ($entryId) failed SHA-256 verification.",
+            TopicFetchResult.InvalidatingFailure(
+                PurchasesError(
+                    PurchasesErrorCode.NetworkError,
+                    "Downloaded topic $topic ($entryId) failed SHA-256 verification.",
+                ),
             )
         } catch (e: IOException) {
-            e.toPurchasesError().also { errorLog(it) }
+            val error = e.toPurchasesError().also { errorLog(it) }
+            when (ConnectionErrorReason.fromIOException(e)) {
+                ConnectionErrorReason.TIMEOUT,
+                ConnectionErrorReason.NO_NETWORK,
+                -> TopicFetchResult.TransientFailure(error)
+                ConnectionErrorReason.OTHER -> TopicFetchResult.InvalidatingFailure(error)
+            }
         }
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/WeightedSource.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/remoteconfig/WeightedSource.kt
@@ -29,3 +29,9 @@ internal fun <T : WeightedSource> List<T>.selectWeighted(random: Random = Random
         }
     }
 }
+
+internal fun <T : WeightedSource> List<T>.selectWeightedExcluding(
+    excludedIds: Set<String>,
+    idOf: (T) -> String,
+    random: Random = Random.Default,
+): T? = filter { idOf(it) !in excludedIds }.selectWeighted(random)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -68,7 +68,7 @@ class RemoteConfigManagerTest {
                 topicEntry = capture(capturedEntry),
                 source = capture(capturedSource),
             )
-        } returns null
+        } returns TopicFetchResult.Success
 
         var completionInvoked = false
         var completionError: PurchasesError? = null
@@ -199,7 +199,7 @@ class RemoteConfigManagerTest {
                 topicEntry = any(),
                 source = capture(capturedSource),
             )
-        } returns null
+        } returns TopicFetchResult.Success
 
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
@@ -225,7 +225,7 @@ class RemoteConfigManagerTest {
                 topicEntry = any(),
                 source = capture(capturedSource),
             )
-        } returns null
+        } returns TopicFetchResult.Success
 
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
@@ -244,7 +244,7 @@ class RemoteConfigManagerTest {
         val fetcherError = PurchasesError(PurchasesErrorCode.NetworkError, "fetcher failed")
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns fetcherError
+        } returns TopicFetchResult.InvalidatingFailure(fetcherError)
 
         var completionInvoked = false
         var completionError: PurchasesError? = null
@@ -290,7 +290,7 @@ class RemoteConfigManagerTest {
         mockBackendSuccess(response)
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns null
+        } returns TopicFetchResult.Success
 
         manager.updateRemoteConfigIfNeeded(appInBackground = true) {}
         testScheduler.advanceUntilIdle()
@@ -314,7 +314,7 @@ class RemoteConfigManagerTest {
         mockBackendSuccess(response)
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns null
+        } returns TopicFetchResult.Success
 
         manager.updateRemoteConfigIfNeeded(appInBackground = false)
         testScheduler.advanceUntilIdle()
@@ -333,7 +333,7 @@ class RemoteConfigManagerTest {
         mockBackendSuccess(response)
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns null
+        } returns TopicFetchResult.Success
 
         manager.updateRemoteConfigIfNeeded(appInBackground = false, completion = null)
         testScheduler.advanceUntilIdle()
@@ -368,7 +368,7 @@ class RemoteConfigManagerTest {
         mockBackendSuccess(response)
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns null
+        } returns TopicFetchResult.Success
         val capturedReferenced = slot<Map<Topic, Set<String>>>()
         coEvery { topicFetcher.cleanupUnreferencedTopics(capture(capturedReferenced)) } returns Unit
 
@@ -391,7 +391,7 @@ class RemoteConfigManagerTest {
         val fetcherError = PurchasesError(PurchasesErrorCode.NetworkError, "fetcher failed")
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns fetcherError
+        } returns TopicFetchResult.InvalidatingFailure(fetcherError)
 
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
@@ -439,7 +439,7 @@ class RemoteConfigManagerTest {
         mockBackendSuccess(response)
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns null
+        } returns TopicFetchResult.Success
 
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
@@ -457,7 +457,9 @@ class RemoteConfigManagerTest {
         mockBackendSuccess(response)
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns PurchasesError(PurchasesErrorCode.NetworkError, "boom")
+        } returns TopicFetchResult.InvalidatingFailure(
+            PurchasesError(PurchasesErrorCode.NetworkError, "boom"),
+        )
 
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
@@ -503,7 +505,7 @@ class RemoteConfigManagerTest {
         mockBackendSuccess(response)
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns null
+        } returns TopicFetchResult.Success
 
         fakeNow = Date(0)
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
@@ -545,7 +547,7 @@ class RemoteConfigManagerTest {
         } answers { onSuccessSlot.captured.invoke(responses.removeFirst()) }
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns null
+        } returns TopicFetchResult.Success
 
         fakeNow = Date(0)
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
@@ -573,7 +575,7 @@ class RemoteConfigManagerTest {
         mockBackendSuccess(response)
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns null
+        } returns TopicFetchResult.Success
 
         fakeNow = Date(0)
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
@@ -605,7 +607,7 @@ class RemoteConfigManagerTest {
         mockBackendSuccess(response)
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns null
+        } returns TopicFetchResult.Success
 
         fakeNow = Date(0)
         manager.updateRemoteConfigIfNeeded(appInBackground = true) {}
@@ -631,7 +633,7 @@ class RemoteConfigManagerTest {
         mockBackendSuccess(response)
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns null
+        } returns TopicFetchResult.Success
 
         fakeNow = Date(0)
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
@@ -665,6 +667,353 @@ class RemoteConfigManagerTest {
         verify(exactly = 2) {
             backend.getRemoteConfig(appInBackground = false, onSuccess = any(), onError = any())
         }
+    }
+
+    @Test
+    fun `falls back to a same-priority alternate when first source returns InvalidatingFailure`() = runTest {
+        val manager = newManager(testScheduler)
+        val first = source("first", priority = 5, weight = 50)
+        val second = source("second", priority = 5, weight = 50)
+        val response = response(
+            blobSources = listOf(first, second),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        val attempts = mutableListOf<BlobSource>()
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } answers {
+            val src = arg<BlobSource>(3)
+            attempts += src
+            if (attempts.size == 1) {
+                TopicFetchResult.InvalidatingFailure(
+                    PurchasesError(PurchasesErrorCode.NetworkError, "first-failed"),
+                )
+            } else {
+                TopicFetchResult.Success
+            }
+        }
+
+        var completionError: PurchasesError? = PurchasesError(PurchasesErrorCode.UnknownError)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) { error ->
+            completionError = error
+        }
+        testScheduler.advanceUntilIdle()
+
+        assertThat(completionError).isNull()
+        assertThat(attempts).hasSize(2)
+        assertThat(attempts[0]).isNotEqualTo(attempts[1])
+    }
+
+    @Test
+    fun `falls back to a lower priority source only after top tier is exhausted`() = runTest {
+        val manager = newManager(testScheduler)
+        val high = source("high", priority = 5, weight = 100)
+        val low = source("low", priority = 1, weight = 100)
+        val response = response(
+            blobSources = listOf(high, low),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        val attempts = mutableListOf<BlobSource>()
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } answers {
+            val src = arg<BlobSource>(3)
+            attempts += src
+            if (src.id == "high") {
+                TopicFetchResult.InvalidatingFailure(
+                    PurchasesError(PurchasesErrorCode.NetworkError, "high-failed"),
+                )
+            } else {
+                TopicFetchResult.Success
+            }
+        }
+
+        var completionError: PurchasesError? = PurchasesError(PurchasesErrorCode.UnknownError)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) { error ->
+            completionError = error
+        }
+        testScheduler.advanceUntilIdle()
+
+        assertThat(completionError).isNull()
+        assertThat(attempts).containsExactly(high, low)
+    }
+
+    @Test
+    fun `returns last error after every source is exhausted`() = runTest {
+        val manager = newManager(testScheduler)
+        val first = source("first", priority = 5, weight = 50)
+        val second = source("second", priority = 5, weight = 50)
+        val response = response(
+            blobSources = listOf(first, second),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        val attempts = mutableListOf<BlobSource>()
+        val lastError = PurchasesError(PurchasesErrorCode.NetworkError, "first-fail")
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } answers {
+            val src = arg<BlobSource>(3)
+            attempts += src
+            TopicFetchResult.InvalidatingFailure(lastError)
+        }
+
+        var completionError: PurchasesError? = null
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) { error ->
+            completionError = error
+        }
+        testScheduler.advanceUntilIdle()
+
+        assertThat(attempts).hasSize(2)
+        assertThat(completionError).isSameAs(lastError)
+        verify(exactly = 0) { diskCache.write(any()) }
+    }
+
+    @Test
+    fun `cached source is preferred on the next refresh after a successful download`() = runTest {
+        val manager = newManager(testScheduler, random = Random(42L))
+        val first = source("first", priority = 5, weight = 50)
+        val second = source("second", priority = 5, weight = 50)
+        val response = response(
+            blobSources = listOf(first, second),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        val attempts = mutableListOf<BlobSource>()
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } answers {
+            attempts += arg<BlobSource>(3)
+            TopicFetchResult.Success
+        }
+
+        fakeNow = Date(0)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+        val firstAttempt = attempts.single()
+
+        // Past TTL: second refresh.
+        fakeNow = Date(6.minutes.inWholeMilliseconds)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        assertThat(attempts).hasSize(2)
+        assertThat(attempts[1]).isEqualTo(firstAttempt)
+    }
+
+    @Test
+    fun `cached source missing from new response is ignored`() = runTest {
+        val manager = newManager(testScheduler)
+        val original = source("first", priority = 5, weight = 100)
+        val replacement = source("replacement", priority = 5, weight = 100)
+        val firstResponse = response(
+            blobSources = listOf(original),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        val secondResponse = response(
+            blobSources = listOf(replacement),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob-2"))),
+        )
+        val onSuccess = slot<(RemoteConfigResponse) -> Unit>()
+        val responses = ArrayDeque(listOf(firstResponse, secondResponse))
+        every {
+            backend.getRemoteConfig(any(), capture(onSuccess), any())
+        } answers { onSuccess.captured.invoke(responses.removeFirst()) }
+        val attempts = mutableListOf<BlobSource>()
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } answers {
+            attempts += arg<BlobSource>(3)
+            TopicFetchResult.Success
+        }
+
+        fakeNow = Date(0)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+        fakeNow = Date(6.minutes.inWholeMilliseconds)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        assertThat(attempts).containsExactly(original, replacement)
+    }
+
+    @Test
+    fun `TransientFailure on cached source preserves the cached source id`() = runTest {
+        val manager = newManager(testScheduler)
+        val src = source("primary", priority = 5, weight = 100)
+        val response = response(
+            blobSources = listOf(src),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        // First refresh: success, populates cachedSourceId.
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } returns TopicFetchResult.Success
+        fakeNow = Date(0)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        // Second refresh: cached source fails transiently and no other source exists.
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } returns TopicFetchResult.TransientFailure(
+            PurchasesError(PurchasesErrorCode.NetworkError, "no network"),
+        )
+        fakeNow = Date(6.minutes.inWholeMilliseconds)
+        var secondError: PurchasesError? = null
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) { error -> secondError = error }
+        testScheduler.advanceUntilIdle()
+        assertThat(secondError).isNotNull
+
+        // Third refresh: cached source should still be tried first, success again.
+        val attempts = mutableListOf<BlobSource>()
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } answers {
+            attempts += arg<BlobSource>(3)
+            TopicFetchResult.Success
+        }
+        fakeNow = Date(12.minutes.inWholeMilliseconds)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        assertThat(attempts).containsExactly(src)
+    }
+
+    @Test
+    fun `InvalidatingFailure on cached source clears cachedSourceId when refresh fails`() = runTest {
+        val manager = newManager(testScheduler)
+        val src = source("primary", priority = 5, weight = 100)
+        val response = response(
+            blobSources = listOf(src),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } returns TopicFetchResult.Success
+        fakeNow = Date(0)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } returns TopicFetchResult.InvalidatingFailure(
+            PurchasesError(PurchasesErrorCode.NetworkError, "http 500"),
+        )
+        fakeNow = Date(6.minutes.inWholeMilliseconds)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        // Add an alternate source for the third refresh — selectWeighted should pick it freely
+        // because cachedSourceId was cleared.
+        val alternate = source("alternate", priority = 5, weight = 100)
+        val responseWithAlternate = response(
+            blobSources = listOf(src, alternate),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        val onSuccess = slot<(RemoteConfigResponse) -> Unit>()
+        every {
+            backend.getRemoteConfig(any(), capture(onSuccess), any())
+        } answers { onSuccess.captured.invoke(responseWithAlternate) }
+        val attempts = mutableListOf<BlobSource>()
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } answers {
+            attempts += arg<BlobSource>(3)
+            TopicFetchResult.Success
+        }
+        fakeNow = Date(12.minutes.inWholeMilliseconds)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        // A fixed seed makes selection deterministic; the assertion below confirms either source could be
+        // picked (since cachedSourceId was cleared the picker doesn't lock in src).
+        assertThat(attempts.single()).isIn(src, alternate)
+    }
+
+    @Test
+    fun `fallback success updates cachedSourceId to the winning source`() = runTest {
+        val manager = newManager(testScheduler)
+        val first = source("first", priority = 5, weight = 50)
+        val second = source("second", priority = 5, weight = 50)
+        val response = response(
+            blobSources = listOf(first, second),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        mockBackendSuccess(response)
+        // First refresh: "first" wins on the initial weighted pick (with seed 0L it picks first).
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } answers {
+            val src = arg<BlobSource>(3)
+            if (src.id == "first") {
+                TopicFetchResult.InvalidatingFailure(
+                    PurchasesError(PurchasesErrorCode.NetworkError, "first failed"),
+                )
+            } else {
+                TopicFetchResult.Success
+            }
+        }
+        fakeNow = Date(0)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        // Second refresh: cached source should now be "second"; it should be tried first.
+        val attempts = mutableListOf<BlobSource>()
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } answers {
+            attempts += arg<BlobSource>(3)
+            TopicFetchResult.Success
+        }
+        fakeNow = Date(6.minutes.inWholeMilliseconds)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        assertThat(attempts).containsExactly(second)
+    }
+
+    @Test
+    fun `topics that succeed on one source are not re-requested on the next source`() = runTest {
+        val manager = newManager(testScheduler)
+        val first = source("first", priority = 5, weight = 50)
+        val second = source("second", priority = 5, weight = 50)
+        val entryA = topicEntry("blob-a".padEnd(64, '0'))
+        val response = response(
+            blobSources = listOf(first, second),
+            topics = mapOf(
+                Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to entryA),
+            ),
+        )
+        mockBackendSuccess(response)
+        val attempts = mutableListOf<Pair<BlobSource, TopicEntry>>()
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } answers {
+            val src = arg<BlobSource>(3)
+            val entry = arg<TopicEntry>(2)
+            attempts += src to entry
+            if (src.id == "first") {
+                TopicFetchResult.InvalidatingFailure(
+                    PurchasesError(PurchasesErrorCode.NetworkError, "first failed"),
+                )
+            } else {
+                TopicFetchResult.Success
+            }
+        }
+
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        // The entry was attempted once on each source — once with first (failed), once with second (success).
+        val firstAttempts = attempts.filter { it.first.id == "first" }
+        val secondAttempts = attempts.filter { it.first.id == "second" }
+        assertThat(firstAttempts).hasSize(1)
+        assertThat(secondAttempts).hasSize(1)
     }
 
     private fun newManager(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/RemoteConfigManagerTest.kt
@@ -741,7 +741,7 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `returns last error after every source is exhausted`() = runTest {
+    fun `returns the most recent error after every source is exhausted`() = runTest {
         val manager = newManager(testScheduler)
         val first = source("first", priority = 5, weight = 50)
         val second = source("second", priority = 5, weight = 50)
@@ -751,13 +751,16 @@ class RemoteConfigManagerTest {
         )
         mockBackendSuccess(response)
         val attempts = mutableListOf<BlobSource>()
-        val lastError = PurchasesError(PurchasesErrorCode.NetworkError, "first-fail")
+        val errorsBySource = mapOf(
+            "first" to PurchasesError(PurchasesErrorCode.NetworkError, "first-fail"),
+            "second" to PurchasesError(PurchasesErrorCode.NetworkError, "second-fail"),
+        )
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
         } answers {
             val src = arg<BlobSource>(3)
             attempts += src
-            TopicFetchResult.InvalidatingFailure(lastError)
+            TopicFetchResult.InvalidatingFailure(errorsBySource.getValue(src.id))
         }
 
         var completionError: PurchasesError? = null
@@ -767,7 +770,7 @@ class RemoteConfigManagerTest {
         testScheduler.advanceUntilIdle()
 
         assertThat(attempts).hasSize(2)
-        assertThat(completionError).isSameAs(lastError)
+        assertThat(completionError).isSameAs(errorsBySource.getValue(attempts.last().id))
         verify(exactly = 0) { diskCache.write(any()) }
     }
 
@@ -884,41 +887,53 @@ class RemoteConfigManagerTest {
     }
 
     @Test
-    fun `InvalidatingFailure on cached source clears cachedSourceId when refresh fails`() = runTest {
-        val manager = newManager(testScheduler)
-        val src = source("primary", priority = 5, weight = 100)
+    fun `InvalidatingFailure on cached source clears cachedSourceId so next refresh re-rolls`() = runTest {
+        // QueuedRandom sequence:
+        //   [0]  refresh 1 picks src    (nextInt(100)=0 -> src wins via cumulative<50 check)
+        //   [1]  refresh 2 picks alternate from the remaining tier after src fails (only candidate)
+        //   [99] refresh 3 picks alternate via re-rolled selectWeighted (nextInt(100)=99 -> alternate)
+        //
+        // If cachedSourceId were not cleared after refresh 2's InvalidatingFailure, refresh 3 would
+        // pin to "src" and consume no random — the final assertion would see src instead of alternate.
+        val random = QueuedRandom(listOf(0, 0, 99))
+        val manager = newManager(testScheduler, random = random)
+        val src = source("src", priority = 5, weight = 50)
+        val alternate = source("alternate", priority = 5, weight = 50)
         val response = response(
-            blobSources = listOf(src),
+            blobSources = listOf(src, alternate),
             topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
         )
         mockBackendSuccess(response)
+
+        // Refresh 1: src wins the weighted pick and succeeds.
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
-        } returns TopicFetchResult.Success
+        } answers {
+            if (arg<BlobSource>(3).id == "src") {
+                TopicFetchResult.Success
+            } else {
+                TopicFetchResult.InvalidatingFailure(
+                    PurchasesError(PurchasesErrorCode.NetworkError, "unexpected alt call"),
+                )
+            }
+        }
         fakeNow = Date(0)
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
 
+        // Refresh 2: cached source src is tried first (pinned), then alternate — both fail with
+        // InvalidatingFailure so the overall refresh fails and clearCachedSource fires.
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
         } returns TopicFetchResult.InvalidatingFailure(
-            PurchasesError(PurchasesErrorCode.NetworkError, "http 500"),
+            PurchasesError(PurchasesErrorCode.NetworkError, "both-failed"),
         )
         fakeNow = Date(6.minutes.inWholeMilliseconds)
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
 
-        // Add an alternate source for the third refresh — selectWeighted should pick it freely
-        // because cachedSourceId was cleared.
-        val alternate = source("alternate", priority = 5, weight = 100)
-        val responseWithAlternate = response(
-            blobSources = listOf(src, alternate),
-            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
-        )
-        val onSuccess = slot<(RemoteConfigResponse) -> Unit>()
-        every {
-            backend.getRemoteConfig(any(), capture(onSuccess), any())
-        } answers { onSuccess.captured.invoke(responseWithAlternate) }
+        // Refresh 3: both succeed. With cachedSourceId cleared the picker rolls selectWeighted and
+        // the queued 99 lands in alternate's bucket. A surviving pin would pick src.
         val attempts = mutableListOf<BlobSource>()
         coEvery {
             topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
@@ -930,9 +945,45 @@ class RemoteConfigManagerTest {
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
 
-        // A fixed seed makes selection deterministic; the assertion below confirms either source could be
-        // picked (since cachedSourceId was cleared the picker doesn't lock in src).
-        assertThat(attempts.single()).isIn(src, alternate)
+        assertThat(attempts).containsExactly(alternate)
+    }
+
+    @Test
+    fun `new response from backend clears cachedSourceId so picker restarts from top priority`() = runTest {
+        val manager = newManager(testScheduler)
+        val src = source("src", priority = 1, weight = 100)
+        val top = source("top", priority = 5, weight = 100)
+        val firstResponse = response(
+            blobSources = listOf(src),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob"))),
+        )
+        val secondResponse = response(
+            blobSources = listOf(src, top),
+            topics = mapOf(Topic.PRODUCT_ENTITLEMENT_MAPPING to mapOf("default" to topicEntry("blob-2"))),
+        )
+        val onSuccess = slot<(RemoteConfigResponse) -> Unit>()
+        val responses = ArrayDeque(listOf(firstResponse, secondResponse))
+        every {
+            backend.getRemoteConfig(any(), capture(onSuccess), any())
+        } answers { onSuccess.captured.invoke(responses.removeFirst()) }
+        val attempts = mutableListOf<BlobSource>()
+        coEvery {
+            topicFetcher.fetchTopicIfNeeded(any(), any(), any(), any())
+        } answers {
+            attempts += arg<BlobSource>(3)
+            TopicFetchResult.Success
+        }
+
+        fakeNow = Date(0)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+        fakeNow = Date(6.minutes.inWholeMilliseconds)
+        manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
+        testScheduler.advanceUntilIdle()
+
+        // Refresh 1 pins src (only candidate). The second response is different, so the pin is
+        // cleared and selectWeighted runs against the new top-priority tier — picking top, not src.
+        assertThat(attempts).containsExactly(src, top)
     }
 
     @Test
@@ -977,8 +1028,12 @@ class RemoteConfigManagerTest {
         assertThat(attempts).containsExactly(second)
     }
 
+    // Only one Topic enum value (PRODUCT_ENTITLEMENT_MAPPING) currently exists, so a refresh always
+    // produces at most one TopicTask. The broader "topics that succeed on one source aren't
+    // re-requested on the next source" property isn't testable through updateRemoteConfigIfNeeded
+    // until another Topic value is added; this test covers the single-topic shape only.
     @Test
-    fun `topics that succeed on one source are not re-requested on the next source`() = runTest {
+    fun `failing topic is retried at most once per source during fallback`() = runTest {
         val manager = newManager(testScheduler)
         val first = source("first", priority = 5, weight = 50)
         val second = source("second", priority = 5, weight = 50)
@@ -1009,11 +1064,7 @@ class RemoteConfigManagerTest {
         manager.updateRemoteConfigIfNeeded(appInBackground = false) {}
         testScheduler.advanceUntilIdle()
 
-        // The entry was attempted once on each source — once with first (failed), once with second (success).
-        val firstAttempts = attempts.filter { it.first.id == "first" }
-        val secondAttempts = attempts.filter { it.first.id == "second" }
-        assertThat(firstAttempts).hasSize(1)
-        assertThat(secondAttempts).hasSize(1)
+        assertThat(attempts).containsExactly(first to entryA, second to entryA)
     }
 
     private fun newManager(
@@ -1055,4 +1106,10 @@ class RemoteConfigManagerTest {
     )
 
     private fun topicEntry(blobRef: String) = TopicEntry(blobRef = blobRef)
+
+    private class QueuedRandom(values: List<Int>) : Random() {
+        private val queue = ArrayDeque(values)
+        override fun nextBits(bitCount: Int): Int = error("nextBits should not be used")
+        override fun nextInt(until: Int): Int = queue.removeFirst()
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/TopicFetcherTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/TopicFetcherTest.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases.common.remoteconfig
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.utils.UrlConnection
 import com.revenuecat.purchases.utils.UrlConnectionFactory
@@ -23,7 +22,10 @@ import org.robolectric.annotation.Config
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.IOException
+import java.net.ConnectException
 import java.net.HttpURLConnection
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 import java.security.MessageDigest
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -70,14 +72,14 @@ class TopicFetcherTest {
         target.parentFile?.mkdirs()
         target.writeBytes(payload)
 
-        val error = fetcher().fetchTopicIfNeeded(
+        val result = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "default",
             topicEntry = topicEntry(blobRef),
             source = source("https://assets.example/{blob_ref}"),
         )
 
-        assertThat(error).isNull()
+        assertThat(result).isEqualTo(TopicFetchResult.Success)
         verify(exactly = 0) { urlConnectionFactory.createConnection(any(), any()) }
     }
 
@@ -87,14 +89,14 @@ class TopicFetcherTest {
         val blobRef = sha256Hex(payload)
         mockSuccessfulDownload("https://assets.example/$blobRef", payload)
 
-        val error = fetcher().fetchTopicIfNeeded(
+        val result = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "default",
             topicEntry = topicEntry(blobRef),
             source = source("https://assets.example/{blob_ref}"),
         )
 
-        assertThat(error).isNull()
+        assertThat(result).isEqualTo(TopicFetchResult.Success)
         val target = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, blobRef)
         assertThat(target).exists()
         assertThat(target.readBytes()).isEqualTo(payload)
@@ -108,19 +110,19 @@ class TopicFetcherTest {
         val expectedUrl = "https://cdn.example/topics/$blobRef"
         mockSuccessfulDownload(expectedUrl, payload)
 
-        val error = fetcher().fetchTopicIfNeeded(
+        val result = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "default",
             topicEntry = topicEntry(blobRef),
             source = source("https://cdn.example/topics/{blob_ref}"),
         )
 
-        if (error != null) fail<Unit>("Expected success, got error: $error")
+        if (result !is TopicFetchResult.Success) fail<Unit>("Expected success, got: $result")
         verify(exactly = 1) { urlConnectionFactory.createConnection(expectedUrl, any()) }
     }
 
     @Test
-    fun `surfaces error and writes no target file when HTTP response is non-200`() = runTest {
+    fun `HTTP non-200 is classified as InvalidatingFailure`() = runTest {
         val payload = """{}""".toByteArray()
         val blobRef = sha256Hex(payload)
         val url = "https://assets.example/$blobRef"
@@ -129,20 +131,20 @@ class TopicFetcherTest {
         }
         every { urlConnectionFactory.createConnection(url, any()) } returns connection
 
-        val error = fetcher().fetchTopicIfNeeded(
+        val result = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "default",
             topicEntry = topicEntry(blobRef),
             source = source("https://assets.example/{blob_ref}"),
         )
 
-        assertThat(error).isNotNull
+        assertThat(result).isInstanceOf(TopicFetchResult.InvalidatingFailure::class.java)
         assertThat(topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, blobRef)).doesNotExist()
         verify { connection.disconnect() }
     }
 
     @Test
-    fun `surfaces error and leaves no temp files when reading the input stream throws`() = runTest {
+    fun `generic IOException while reading the input stream is InvalidatingFailure`() = runTest {
         val payload = """{}""".toByteArray()
         val blobRef = sha256Hex(payload)
         val url = "https://assets.example/$blobRef"
@@ -155,35 +157,81 @@ class TopicFetcherTest {
         }
         every { urlConnectionFactory.createConnection(url, any()) } returns connection
 
-        val error: PurchasesError? = fetcher().fetchTopicIfNeeded(
+        val result = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "default",
             topicEntry = topicEntry(blobRef),
             source = source("https://assets.example/{blob_ref}"),
         )
 
-        assertThat(error).isNotNull
+        assertThat(result).isInstanceOf(TopicFetchResult.InvalidatingFailure::class.java)
         val target = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, blobRef)
         assertThat(target).doesNotExist()
         assertThat(leftoverTempFiles(target.parentFile)).isEmpty()
     }
 
     @Test
-    fun `surfaces error when downloaded bytes don't match the expected SHA-256`() = runTest {
+    fun `UnknownHostException is classified as TransientFailure`() = runTest {
+        val blobRef = "a".repeat(64)
+        every { urlConnectionFactory.createConnection(any(), any()) } throws UnknownHostException("no dns")
+
+        val result = fetcher().fetchTopicIfNeeded(
+            topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
+            entryId = "default",
+            topicEntry = topicEntry(blobRef),
+            source = source("https://assets.example/{blob_ref}"),
+        )
+
+        assertThat(result).isInstanceOf(TopicFetchResult.TransientFailure::class.java)
+    }
+
+    @Test
+    fun `SocketTimeoutException is classified as TransientFailure`() = runTest {
+        val blobRef = "a".repeat(64)
+        every { urlConnectionFactory.createConnection(any(), any()) } throws SocketTimeoutException("timeout")
+
+        val result = fetcher().fetchTopicIfNeeded(
+            topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
+            entryId = "default",
+            topicEntry = topicEntry(blobRef),
+            source = source("https://assets.example/{blob_ref}"),
+        )
+
+        assertThat(result).isInstanceOf(TopicFetchResult.TransientFailure::class.java)
+    }
+
+    @Test
+    fun `ConnectException is classified as TransientFailure`() = runTest {
+        val blobRef = "a".repeat(64)
+        every { urlConnectionFactory.createConnection(any(), any()) } throws ConnectException("refused")
+
+        val result = fetcher().fetchTopicIfNeeded(
+            topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
+            entryId = "default",
+            topicEntry = topicEntry(blobRef),
+            source = source("https://assets.example/{blob_ref}"),
+        )
+
+        assertThat(result).isInstanceOf(TopicFetchResult.TransientFailure::class.java)
+    }
+
+    @Test
+    fun `checksum mismatch is classified as InvalidatingFailure`() = runTest {
         val payload = """{"actual":"contents"}""".toByteArray()
         val wrongBlobRef = "0".repeat(64)
         val url = "https://assets.example/$wrongBlobRef"
         mockSuccessfulDownload(url, payload)
 
-        val error = fetcher().fetchTopicIfNeeded(
+        val result = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "default",
             topicEntry = topicEntry(wrongBlobRef),
             source = source("https://assets.example/{blob_ref}"),
         )
 
-        assertThat(error).isNotNull
-        assertThat(error?.code).isEqualTo(PurchasesErrorCode.NetworkError)
+        assertThat(result).isInstanceOf(TopicFetchResult.InvalidatingFailure::class.java)
+        val failure = result as TopicFetchResult.InvalidatingFailure
+        assertThat(failure.error.code).isEqualTo(PurchasesErrorCode.NetworkError)
         val target = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, wrongBlobRef)
         assertThat(target).doesNotExist()
         assertThat(leftoverTempFiles(target.parentFile)).isEmpty()
@@ -198,20 +246,20 @@ class TopicFetcherTest {
         mockSuccessfulDownload("https://assets.example/$blobRefA", payloadA)
         mockSuccessfulDownload("https://assets.example/$blobRefB", payloadB)
 
-        val errorA = fetcher().fetchTopicIfNeeded(
+        val resultA = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "default",
             topicEntry = topicEntry(blobRefA),
             source = source("https://assets.example/{blob_ref}"),
         )
-        if (errorA != null) fail<Unit>("Expected success, got error: $errorA")
-        val errorB = fetcher().fetchTopicIfNeeded(
+        if (resultA !is TopicFetchResult.Success) fail<Unit>("Expected success, got: $resultA")
+        val resultB = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "EXPERIMENT_A",
             topicEntry = topicEntry(blobRefB),
             source = source("https://assets.example/{blob_ref}"),
         )
-        if (errorB != null) fail<Unit>("Expected success, got error: $errorB")
+        if (resultB !is TopicFetchResult.Success) fail<Unit>("Expected success, got: $resultB")
 
         val targetA = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, blobRefA)
         val targetB = topicFile(Topic.PRODUCT_ENTITLEMENT_MAPPING, blobRefB)
@@ -224,15 +272,16 @@ class TopicFetcherTest {
 
     @Test
     fun `rejects malformed blobRef before any IO`() = runTest {
-        val error = fetcher().fetchTopicIfNeeded(
+        val result = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "default",
             topicEntry = topicEntry("not-hex"),
             source = source("https://assets.example/{blob_ref}"),
         )
 
-        assertThat(error).isNotNull
-        assertThat(error?.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
+        assertThat(result).isInstanceOf(TopicFetchResult.InvalidatingFailure::class.java)
+        val failure = result as TopicFetchResult.InvalidatingFailure
+        assertThat(failure.error.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
         verify(exactly = 0) { urlConnectionFactory.createConnection(any(), any()) }
         val topicDir = File(File(rootDir, "RevenueCat/topics"), Topic.PRODUCT_ENTITLEMENT_MAPPING.key)
         assertThat(topicDir.exists() && topicDir.listFiles()?.isNotEmpty() == true).isFalse
@@ -241,15 +290,16 @@ class TopicFetcherTest {
     @Test
     fun `rejects blobRef containing path separators`() = runTest {
         val malicious = "../../escape"
-        val error = fetcher().fetchTopicIfNeeded(
+        val result = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "default",
             topicEntry = topicEntry(malicious),
             source = source("https://assets.example/{blob_ref}"),
         )
 
-        assertThat(error).isNotNull
-        assertThat(error?.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
+        assertThat(result).isInstanceOf(TopicFetchResult.InvalidatingFailure::class.java)
+        val failure = result as TopicFetchResult.InvalidatingFailure
+        assertThat(failure.error.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
         verify(exactly = 0) { urlConnectionFactory.createConnection(any(), any()) }
         val outsideTarget = File(rootDir.parentFile, "escape")
         assertThat(outsideTarget).doesNotExist()
@@ -257,45 +307,48 @@ class TopicFetcherTest {
 
     @Test
     fun `rejects blobRef shorter than 64 hex chars`() = runTest {
-        val error = fetcher().fetchTopicIfNeeded(
+        val result = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "default",
             topicEntry = topicEntry("abc123"),
             source = source("https://assets.example/{blob_ref}"),
         )
 
-        assertThat(error).isNotNull
-        assertThat(error?.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
+        assertThat(result).isInstanceOf(TopicFetchResult.InvalidatingFailure::class.java)
+        val failure = result as TopicFetchResult.InvalidatingFailure
+        assertThat(failure.error.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
         verify(exactly = 0) { urlConnectionFactory.createConnection(any(), any()) }
     }
 
     @Test
     fun `rejects blobRef longer than 64 hex chars`() = runTest {
         val tooLong = "a".repeat(65)
-        val error = fetcher().fetchTopicIfNeeded(
+        val result = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "default",
             topicEntry = topicEntry(tooLong),
             source = source("https://assets.example/{blob_ref}"),
         )
 
-        assertThat(error).isNotNull
-        assertThat(error?.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
+        assertThat(result).isInstanceOf(TopicFetchResult.InvalidatingFailure::class.java)
+        val failure = result as TopicFetchResult.InvalidatingFailure
+        assertThat(failure.error.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
         verify(exactly = 0) { urlConnectionFactory.createConnection(any(), any()) }
     }
 
     @Test
     fun `rejects 64-char blobRef containing non-hex letters`() = runTest {
         val nonHex = "g".repeat(64)
-        val error = fetcher().fetchTopicIfNeeded(
+        val result = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "default",
             topicEntry = topicEntry(nonHex),
             source = source("https://assets.example/{blob_ref}"),
         )
 
-        assertThat(error).isNotNull
-        assertThat(error?.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
+        assertThat(result).isInstanceOf(TopicFetchResult.InvalidatingFailure::class.java)
+        val failure = result as TopicFetchResult.InvalidatingFailure
+        assertThat(failure.error.code).isEqualTo(PurchasesErrorCode.UnexpectedBackendResponseError)
         verify(exactly = 0) { urlConnectionFactory.createConnection(any(), any()) }
     }
 
@@ -305,7 +358,7 @@ class TopicFetcherTest {
         val url = "https://assets.example/$mixedCaseHex"
         mockSuccessfulDownload(url, "ignored".toByteArray())
 
-        val error = fetcher().fetchTopicIfNeeded(
+        val result = fetcher().fetchTopicIfNeeded(
             topic = Topic.PRODUCT_ENTITLEMENT_MAPPING,
             entryId = "default",
             topicEntry = topicEntry(mixedCaseHex),
@@ -314,8 +367,9 @@ class TopicFetcherTest {
 
         // Validation passes; download is attempted (checksum fails because mixedCaseHex is not the real SHA-256
         // of "ignored", which is expected — the point is that the request was made).
-        assertThat(error).isNotNull
-        assertThat(error?.code).isEqualTo(PurchasesErrorCode.NetworkError)
+        assertThat(result).isInstanceOf(TopicFetchResult.InvalidatingFailure::class.java)
+        val failure = result as TopicFetchResult.InvalidatingFailure
+        assertThat(failure.error.code).isEqualTo(PurchasesErrorCode.NetworkError)
         verify(exactly = 1) { urlConnectionFactory.createConnection(url, any()) }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/WeightedSourceSelectionTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/WeightedSourceSelectionTest.kt
@@ -80,16 +80,6 @@ class WeightedSourceSelectionTest {
     }
 
     @Test
-    fun `negative total weight falls back to uniform random`() {
-        val a = TestSource(priority = 0, weight = -10)
-        val b = TestSource(priority = 0, weight = 5)
-        val sources = listOf(a, b)
-
-        assertThat(sources.selectWeighted(FakeRandom(0))).isSameAs(a)
-        assertThat(sources.selectWeighted(FakeRandom(1))).isSameAs(b)
-    }
-
-    @Test
     fun `any negative weight falls back to uniform random even when total is positive`() {
         val a = TestSource(priority = 0, weight = -10)
         val b = TestSource(priority = 0, weight = 30)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/WeightedSourceSelectionTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/remoteconfig/WeightedSourceSelectionTest.kt
@@ -99,7 +99,56 @@ class WeightedSourceSelectionTest {
         assertThat(sources.selectWeighted(FakeRandom(1))).isSameAs(b)
     }
 
+    @Test
+    fun `selectWeightedExcluding skips excluded id within the top priority tier`() {
+        val a = TestSource(id = "a", priority = 5, weight = 30)
+        val b = TestSource(id = "b", priority = 5, weight = 70)
+        val sources = listOf(a, b)
+
+        val picked = sources.selectWeightedExcluding(
+            excludedIds = setOf("a"),
+            idOf = TestSource::id,
+            random = FakeRandom(0),
+        )
+
+        assertThat(picked).isSameAs(b)
+    }
+
+    @Test
+    fun `selectWeightedExcluding drops to the next priority tier when top tier is fully excluded`() {
+        val high = TestSource(id = "high", priority = 5, weight = 50)
+        val midA = TestSource(id = "midA", priority = 3, weight = 10)
+        val midB = TestSource(id = "midB", priority = 3, weight = 90)
+        val low = TestSource(id = "low", priority = 1, weight = 99)
+        val sources = listOf(high, midA, midB, low)
+
+        val picked = sources.selectWeightedExcluding(
+            excludedIds = setOf("high"),
+            idOf = TestSource::id,
+            random = FakeRandom(9),
+        )
+
+        assertThat(picked).isSameAs(midA)
+    }
+
+    @Test
+    fun `selectWeightedExcluding returns null when every id is excluded`() {
+        val sources = listOf(
+            TestSource(id = "a", priority = 5, weight = 10),
+            TestSource(id = "b", priority = 5, weight = 10),
+        )
+
+        val picked = sources.selectWeightedExcluding(
+            excludedIds = setOf("a", "b"),
+            idOf = TestSource::id,
+            random = FakeRandom(0),
+        )
+
+        assertThat(picked).isNull()
+    }
+
     private data class TestSource(
+        val id: String = "",
         override val priority: Int,
         override val weight: Int,
     ) : WeightedSource


### PR DESCRIPTION
### Motivation

`RemoteConfigManager` previously picked a single blob source per refresh and gave up if any topic failed to download from it. With weighted multi-source distribution in place (#previous stack PR), we want to gracefully fall back to other sources when one is degraded so a refresh can still succeed.

### Description

- **Classify topic-fetch outcomes** (`TopicFetcher.kt`): `fetchTopicIfNeeded` now returns a `TopicFetchResult` sealed type — `Success`, `TransientFailure` (timeouts / no network — worth retrying against a different source), or `InvalidatingFailure` (malformed blob ref, checksum mismatch, other IO). Transient/invalidating is decided via `ConnectionErrorReason.fromIOException`.
- **Fallback loop in `RemoteConfigManager.kt`**: introduces `downloadTopicsWithFallback`, which repeatedly picks the next weighted source, attempts the still-failing tasks against it, and stops as soon as everything succeeds or sources are exhausted. The most recent source's error is preserved for the completion callback so callers see the freshest failure reason rather than the first one encountered.
- **Sticky source selection**: tracks the source that produced the last successful refresh in `cachedSourceId`. On the next refresh, that source is tried first (bypassing weighted selection) to keep clients on a known-good source. If the sticky source returns an invalidating failure, the cached id is cleared so a fresh weighted draw can take over next time.
- **Pin reset on response change**: when the backend returns a `RemoteConfigResponse` different from the one currently cached (e.g. an updated source list, new priorities, or new weights), `cachedSourceId` is cleared before the fallback loop runs. This guarantees a new top-priority source can take over instead of the client staying pinned to a now-lower-priority cached source.
- **`selectWeightedExcluding` helper** (`WeightedSource.kt`): weighted selection filtered to sources not already tried in the current refresh. Negative weights are clamped to zero so a single misconfigured entry can't poison the picker.
- **Refactored refresh result** into a `RefreshOutcome` sealed class (`Success` / `VacuousSuccess` / `Failure`) so caching, cleanup, and cached-source clearing are driven by a single decision rather than nested null checks.

### Tests

- `RemoteConfigManagerTest`: new coverage for cross-source fallback on transient failures, exhaustion behavior, invalidating-failure short-circuit per task, sticky-source preference on subsequent refreshes, `cachedSourceId` invalidation when the sticky source fails with an invalidating error (rewritten with a staged `QueuedRandom` so the test actually distinguishes cleared/not-cleared paths), and `cachedSourceId` reset when the backend returns a new response.
- `TopicFetcherTest`: updated for the new `TopicFetchResult` return type, including timeout/no-network → `TransientFailure` and checksum/malformed/other-IO → `InvalidatingFailure` classification.
- `WeightedSourceSelectionTest`: new tests for `selectWeightedExcluding` and for negative-weight clamping behavior.

### Checklist
- [x] Unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the remote-config refresh path to retry topic downloads across multiple blob sources with sticky source selection, which can affect config update reliability and caching behavior under network failures.
> 
> **Overview**
> Remote config refresh now **falls back across blob sources** when topic downloads fail, retrying only the still-failing topics until one source succeeds or all sources are exhausted; the completion error now reflects the latest failure.
> 
> `TopicFetcher.fetchTopicIfNeeded` now returns a `TopicFetchResult` (`Success`, `TransientFailure`, `InvalidatingFailure`) with error classification driven by `ConnectionErrorReason`, and `RemoteConfigManager` tracks a **sticky** `cachedSourceId` (prefer last-good source, clear it on invalidating failures or when the backend response changes). `WeightedSource` adds `selectWeightedExcluding` to avoid re-trying sources within a refresh, and tests are expanded/updated to cover fallback, stickiness/reset, and new result classifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4650c7119398cce612b29f4d18e69fd130fe7b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->