### PR TITLE
Reorganize AdMob tracking unit tests

### DIFF
--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/tracking/AdMobPrecisionMappingTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/tracking/AdMobPrecisionMappingTest.kt
@@ -1,10 +1,9 @@
 @file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 
-package com.revenuecat.purchases.admob
+package com.revenuecat.purchases.admob.tracking
 
 import com.google.android.gms.ads.AdValue
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
-import com.revenuecat.purchases.admob.tracking.toAdRevenuePrecision
 import com.revenuecat.purchases.ads.events.types.AdRevenuePrecision
 import org.junit.Assert.assertEquals
 import org.junit.Test

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/tracking/PaidEventTrackingTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/tracking/PaidEventTrackingTest.kt
@@ -1,14 +1,12 @@
 @file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 
-package com.revenuecat.purchases.admob
+package com.revenuecat.purchases.admob.tracking
 
 import com.google.android.gms.ads.AdValue
 import com.google.android.gms.ads.OnPaidEventListener
 import com.google.android.gms.ads.ResponseInfo
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Purchases
-import com.revenuecat.purchases.admob.tracking.TrackingOnPaidEventListener
-import com.revenuecat.purchases.admob.tracking.setUpPaidEventTracking
 import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdFormat
 import com.revenuecat.purchases.ads.events.types.AdMediatorName

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/tracking/TrackIfConfiguredTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/tracking/TrackIfConfiguredTest.kt
@@ -1,10 +1,9 @@
 @file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 
-package com.revenuecat.purchases.admob
+package com.revenuecat.purchases.admob.tracking
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Purchases
-import com.revenuecat.purchases.admob.tracking.trackIfConfigured
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.After

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/tracking/TrackingAdListenerBehaviorTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/tracking/TrackingAdListenerBehaviorTest.kt
@@ -1,13 +1,12 @@
 @file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 
-package com.revenuecat.purchases.admob
+package com.revenuecat.purchases.admob.tracking
 
 import com.google.android.gms.ads.AdListener
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.ResponseInfo
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Purchases
-import com.revenuecat.purchases.admob.tracking.TrackingAdListener
 import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdDisplayedData
 import com.revenuecat.purchases.ads.events.types.AdFailedToLoadData

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/tracking/TrackingFullScreenContentCallbackBehaviorTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/tracking/TrackingFullScreenContentCallbackBehaviorTest.kt
@@ -1,6 +1,6 @@
 @file:OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
 
-package com.revenuecat.purchases.admob
+package com.revenuecat.purchases.admob.tracking
 
 import com.google.android.gms.ads.AdError
 import com.google.android.gms.ads.FullScreenContentCallback
@@ -9,7 +9,6 @@ import com.google.android.gms.ads.interstitial.InterstitialAd
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.setTrackingFullScreenContentCallback
-import com.revenuecat.purchases.admob.tracking.TrackingFullScreenContentCallback
 import com.revenuecat.purchases.ads.events.AdTracker
 import com.revenuecat.purchases.ads.events.types.AdDisplayedData
 import com.revenuecat.purchases.ads.events.types.AdFormat


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Tracking internals in `feature/admob` are organized under `tracking/*`, but tracking-focused unit tests were still in the root `unit/` package.

### Description
- moves existing tracking-focused unit tests into `unit/tracking`
- updates test packages/imports accordingly
- keeps test behavior and assertions unchanged

### Testing
- tests were reorganized only; no production code changes
- `ReadLints` reports no issues for moved test files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only changes test package declarations/imports; no production code or behavior is modified.
> 
> **Overview**
> Reorganizes AdMob tracking-focused unit tests by moving them under the `com.revenuecat.purchases.admob.tracking` test package (updating package declarations and removing now-unneeded imports).
> 
> Test logic and assertions remain the same; this is a structural/namespace cleanup to match the `tracking/*` production organization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 254b57bb5b68aca7ec4f987d0c21971100e12f74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->