### PR TITLE
Workflow events

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/JsonProvider.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/JsonProvider.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.common.events.BackendEvent
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
 
 internal sealed class JsonProvider {
     companion object {
@@ -12,6 +13,7 @@ internal sealed class JsonProvider {
                 polymorphic(BackendEvent::class) {
                     subclass(BackendEvent.CustomerCenter::class, BackendEvent.CustomerCenter.serializer())
                     subclass(BackendEvent.Paywalls::class, BackendEvent.Paywalls.serializer())
+                    subclass(BackendEvent.Workflows::class, BackendEvent.Workflows.serializer())
                 }
             }
             classDiscriminator = "discriminator"

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
@@ -207,6 +207,57 @@ internal sealed class BackendEvent : Event {
         val offeringID: String? = null,
     ) : BackendEvent()
 
+    /**
+     * Wire shape for workflow lifecycle events. Matches khepri's WorkflowsEvent schema.
+     */
+    @Serializable
+    @SerialName("workflows")
+    data class Workflows(
+        val id: String,
+        val version: Int = WORKFLOW_EVENT_SCHEMA_VERSION,
+        val type: String = WORKFLOW_EVENT_TYPE,
+        @SerialName("event_name")
+        val eventName: String,
+        @SerialName("timestamp_ms")
+        val timestampMs: Long,
+        @SerialName("app_user_id")
+        val appUserID: String,
+        val context: Context = Context(),
+        val properties: Properties,
+    ) : BackendEvent() {
+
+        @Serializable
+        data class Context(
+            val locale: String? = null,
+        )
+
+        @Serializable
+        data class Properties(
+            @SerialName("workflow_id")
+            val workflowId: String,
+            @SerialName("step_id")
+            val stepId: String,
+            @SerialName("trace_id")
+            val traceId: String,
+            @SerialName("from_step_id")
+            val fromStepId: String? = null,
+            @SerialName("to_step_id")
+            val toStepId: String? = null,
+            @SerialName("entry_reason")
+            val entryReason: String? = null,
+            @SerialName("is_first_step")
+            val isFirstStep: Boolean? = null,
+            @SerialName("is_last_step")
+            val isLastStep: Boolean? = null,
+            @SerialName("experiment_id")
+            val experimentId: String? = null,
+            @SerialName("experiment_variant")
+            val experimentVariant: String? = null,
+            @SerialName("is_last_variant_step")
+            val isLastVariantStep: Boolean? = null,
+        )
+    }
+
     @Serializable
     @SerialName("ad")
     data class Ad(
@@ -265,5 +316,15 @@ internal sealed class BackendEvent : Event {
          * Defines the version number of the custom paywall event schema.
          */
         const val CUSTOM_PAYWALL_EVENT_SCHEMA_VERSION = 1
+
+        /**
+         * Defines the version number of the workflow event schema.
+         */
+        const val WORKFLOW_EVENT_SCHEMA_VERSION = 1
+
+        /**
+         * Defines the type identifier for workflow events.
+         */
+        const val WORKFLOW_EVENT_TYPE = "workflows"
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendEvent.kt
@@ -237,8 +237,12 @@ internal sealed class BackendEvent : Event {
             val workflowId: String,
             @SerialName("step_id")
             val stepId: String,
-            @SerialName("trace_id")
-            val traceId: String,
+            @SerialName("workflow_type")
+            val workflowType: String? = null,
+            @SerialName("step_type")
+            val stepType: String? = null,
+            @SerialName("screen_type")
+            val screenType: List<String> = emptyList(),
             @SerialName("from_step_id")
             val fromStepId: String? = null,
             @SerialName("to_step_id")

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -370,7 +370,9 @@ internal fun WorkflowEvent.toBackendStoredEvent(
         is WorkflowEvent.StepStarted -> BackendEvent.Workflows.Properties(
             workflowId = workflowId,
             stepId = stepId,
-            traceId = traceId,
+            workflowType = workflowType,
+            stepType = stepType,
+            screenType = screenType,
             fromStepId = fromStepId,
             entryReason = entryReason,
             isFirstStep = isFirstStep,
@@ -379,7 +381,9 @@ internal fun WorkflowEvent.toBackendStoredEvent(
         is WorkflowEvent.StepCompleted -> BackendEvent.Workflows.Properties(
             workflowId = workflowId,
             stepId = stepId,
-            traceId = traceId,
+            workflowType = workflowType,
+            stepType = stepType,
+            screenType = screenType,
             toStepId = toStepId,
             isFirstStep = isFirstStep,
             isLastStep = isLastStep,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/BackendStoredEvent.kt
@@ -1,8 +1,11 @@
+@file:Suppress("TooManyFunctions")
+
 package com.revenuecat.purchases.common.events
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ads.events.AdEvent
+import com.revenuecat.purchases.common.workflows.events.WorkflowEvent
 import com.revenuecat.purchases.customercenter.events.CustomerCenterImpressionEvent
 import com.revenuecat.purchases.customercenter.events.CustomerCenterSurveyOptionChosenEvent
 import com.revenuecat.purchases.paywalls.events.CustomPaywallEvent
@@ -54,6 +57,13 @@ internal sealed class BackendStoredEvent : Event {
     @Serializable
     @SerialName("custom_paywall_event")
     data class CustomPaywall(val event: BackendEvent.CustomPaywall) : BackendStoredEvent()
+
+    /**
+     * Represents a stored event related to Workflows.
+     */
+    @Serializable
+    @SerialName("workflows")
+    data class Workflows(val event: BackendEvent.Workflows) : BackendStoredEvent()
 }
 
 /**
@@ -68,6 +78,7 @@ internal fun BackendStoredEvent.toBackendEvent(): BackendEvent {
         is BackendStoredEvent.CustomerCenter -> { this.event }
         is BackendStoredEvent.Ad -> { this.event }
         is BackendStoredEvent.CustomPaywall -> { this.event }
+        is BackendStoredEvent.Workflows -> { this.event }
     }
 }
 
@@ -342,6 +353,45 @@ internal fun CustomPaywallEvent.Impression.toBackendStoredEvent(
             timestamp = creationData.date.time,
             paywallID = data.paywallId,
             offeringID = data.offeringId,
+        ),
+    )
+}
+
+@OptIn(InternalRevenueCatAPI::class)
+@JvmSynthetic
+internal fun WorkflowEvent.toBackendStoredEvent(
+    appUserID: String,
+): BackendStoredEvent {
+    val eventName = when (this) {
+        is WorkflowEvent.StepStarted -> "workflows_step_started"
+        is WorkflowEvent.StepCompleted -> "workflows_step_completed"
+    }
+    val properties = when (this) {
+        is WorkflowEvent.StepStarted -> BackendEvent.Workflows.Properties(
+            workflowId = workflowId,
+            stepId = stepId,
+            traceId = traceId,
+            fromStepId = fromStepId,
+            entryReason = entryReason,
+            isFirstStep = isFirstStep,
+            isLastStep = isLastStep,
+        )
+        is WorkflowEvent.StepCompleted -> BackendEvent.Workflows.Properties(
+            workflowId = workflowId,
+            stepId = stepId,
+            traceId = traceId,
+            toStepId = toStepId,
+            isFirstStep = isFirstStep,
+            isLastStep = isLastStep,
+        )
+    }
+    return BackendStoredEvent.Workflows(
+        BackendEvent.Workflows(
+            id = creationData.id.toString(),
+            eventName = eventName,
+            timestampMs = creationData.date.time,
+            appUserID = appUserID,
+            properties = properties,
         ),
     )
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/EventsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/events/EventsManager.kt
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.common.debugLog
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.verboseLog
 import com.revenuecat.purchases.common.warnLog
+import com.revenuecat.purchases.common.workflows.events.WorkflowEvent
 import com.revenuecat.purchases.customercenter.events.CustomerCenterImpressionEvent
 import com.revenuecat.purchases.customercenter.events.CustomerCenterSurveyOptionChosenEvent
 import com.revenuecat.purchases.identity.IdentityManager
@@ -85,6 +86,10 @@ internal class EventsManager(
                     subclass(
                         BackendStoredEvent.CustomPaywall::class,
                         BackendStoredEvent.CustomPaywall.serializer(),
+                    )
+                    subclass(
+                        BackendStoredEvent.Workflows::class,
+                        BackendStoredEvent.Workflows.serializer(),
                     )
                 }
             }
@@ -221,6 +226,9 @@ internal class EventsManager(
                 is CustomPaywallEvent.Impression -> event.toBackendStoredEvent(
                     identityManager.currentAppUserID,
                     appSessionID.toString(),
+                )
+                is WorkflowEvent -> event.toBackendStoredEvent(
+                    identityManager.currentAppUserID,
                 )
                 else -> null
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -65,6 +65,7 @@ public data class WorkflowStep(
     val id: String,
     val type: String,
     @SerialName("screen_id") val screenId: String? = null,
+    @SerialName("screen_type") val screenType: List<String> = emptyList(),
     @SerialName("param_values") val paramValues: Map<String, JsonElement> = emptyMap(),
     val triggers: List<WorkflowTrigger> = emptyList(),
     val outputs: Map<String, JsonElement> = emptyMap(),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/events/WorkflowEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/events/WorkflowEvent.kt
@@ -19,7 +19,9 @@ public sealed class WorkflowEvent : FeatureEvent {
     public abstract val creationData: CreationData
     public abstract val workflowId: String
     public abstract val stepId: String
-    public abstract val traceId: String
+    public abstract val workflowType: String?
+    public abstract val stepType: String?
+    public abstract val screenType: List<String>
 
     override val isPriorityEvent: Boolean get() = false
 
@@ -35,7 +37,9 @@ public sealed class WorkflowEvent : FeatureEvent {
         override val creationData: CreationData,
         override val workflowId: String,
         override val stepId: String,
-        override val traceId: String,
+        override val workflowType: String? = null,
+        override val stepType: String? = null,
+        override val screenType: List<String> = emptyList(),
         public val fromStepId: String? = null,
         public val entryReason: String? = null,
         public val isFirstStep: Boolean? = null,
@@ -48,7 +52,9 @@ public sealed class WorkflowEvent : FeatureEvent {
         override val creationData: CreationData,
         override val workflowId: String,
         override val stepId: String,
-        override val traceId: String,
+        override val workflowType: String? = null,
+        override val stepType: String? = null,
+        override val screenType: List<String> = emptyList(),
         public val toStepId: String? = null,
         public val isFirstStep: Boolean? = null,
         public val isLastStep: Boolean? = null,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/events/WorkflowEvent.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/events/WorkflowEvent.kt
@@ -1,0 +1,56 @@
+package com.revenuecat.purchases.common.workflows.events
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.events.FeatureEvent
+import com.revenuecat.purchases.utils.serializers.DateSerializer
+import com.revenuecat.purchases.utils.serializers.UUIDSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.util.Date
+import java.util.UUID
+
+/**
+ * Workflow lifecycle events. Sibling to PaywallEvent. Internal-only.
+ */
+@InternalRevenueCatAPI
+@Serializable
+public sealed class WorkflowEvent : FeatureEvent {
+
+    public abstract val creationData: CreationData
+    public abstract val workflowId: String
+    public abstract val stepId: String
+    public abstract val traceId: String
+
+    override val isPriorityEvent: Boolean get() = false
+
+    @Serializable
+    public data class CreationData(
+        @Serializable(with = UUIDSerializer::class) public val id: UUID,
+        @Serializable(with = DateSerializer::class) public val date: Date,
+    )
+
+    @Serializable
+    @SerialName("workflow_step_started")
+    public data class StepStarted(
+        override val creationData: CreationData,
+        override val workflowId: String,
+        override val stepId: String,
+        override val traceId: String,
+        public val fromStepId: String? = null,
+        public val entryReason: String? = null,
+        public val isFirstStep: Boolean? = null,
+        public val isLastStep: Boolean? = null,
+    ) : WorkflowEvent()
+
+    @Serializable
+    @SerialName("workflow_step_completed")
+    public data class StepCompleted(
+        override val creationData: CreationData,
+        override val workflowId: String,
+        override val stepId: String,
+        override val traceId: String,
+        public val toStepId: String? = null,
+        public val isFirstStep: Boolean? = null,
+        public val isLastStep: Boolean? = null,
+    ) : WorkflowEvent()
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/events/EventsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/events/EventsManagerTest.kt
@@ -25,6 +25,7 @@ import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.events.CustomerCenterImpressionEvent
 import com.revenuecat.purchases.customercenter.events.CustomerCenterSurveyOptionChosenEvent
 import com.revenuecat.purchases.identity.IdentityManager
+import com.revenuecat.purchases.common.workflows.events.WorkflowEvent
 import com.revenuecat.purchases.paywalls.events.CustomPaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEvent
 import com.revenuecat.purchases.paywalls.events.PaywallEventType
@@ -411,6 +412,11 @@ class EventsManagerTest {
         assertThat(file.readText()).isEqualTo(expectedContents)
     }
 
+    private fun checkFileContentsAndReturn(): String {
+        val file = File(testFolder, EventsManager.EVENTS_FILE_PATH_NEW)
+        return file.readText()
+    }
+
     private fun checkFileExists(shouldExist: Boolean) {
         val file = File(testFolder, EventsManager.EVENTS_FILE_PATH_NEW)
         assertThat(file.exists()).isEqualTo(shouldExist)
@@ -455,6 +461,25 @@ class EventsManagerTest {
     private fun appendToFile(contents: String) {
         val file = File(testFolder, EventsManager.EVENTS_FILE_PATH_NEW)
         file.appendText(contents)
+    }
+
+    @Test
+    fun `tracking a WorkflowEvent stores BackendStoredEvent_Workflows`() {
+        val event = WorkflowEvent.StepStarted(
+            creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
+            workflowId = "wfl_abc",
+            stepId = "step-1",
+            traceId = "trace-1",
+            entryReason = "start",
+            isFirstStep = true,
+        )
+
+        eventsManager.track(event)
+
+        val storedContent = checkFileContentsAndReturn()
+        assertThat(storedContent).contains("\"type\":\"workflows\"")
+        assertThat(storedContent).contains("\"workflow_id\":\"wfl_abc\"")
+        assertThat(storedContent).contains("workflows_step_started")
     }
 
     // Ad Events Tests

--- a/purchases/src/test/java/com/revenuecat/purchases/common/events/EventsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/events/EventsManagerTest.kt
@@ -469,7 +469,8 @@ class EventsManagerTest {
             creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
             workflowId = "wfl_abc",
             stepId = "step-1",
-            traceId = "trace-1",
+            workflowType = "paywall",
+            stepType = "screen",
             entryReason = "start",
             isFirstStep = true,
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/events/WorkflowEventsRequestSerializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/events/WorkflowEventsRequestSerializationTest.kt
@@ -79,4 +79,33 @@ class WorkflowEventsRequestSerializationTest {
         val requestString = JsonProvider.defaultJson.encodeToString(request)
         assertThat(requestString).doesNotContain("trace_id")
     }
+
+    @Test
+    fun `screen_type included in JSON when non-empty`() {
+        val requestWithScreenType = EventsRequest(
+            listOf(
+                BackendEvent.Workflows(
+                    id = "evt_id",
+                    eventName = "workflows_step_started",
+                    timestampMs = 123456789L,
+                    appUserID = "appUserID",
+                    context = BackendEvent.Workflows.Context(locale = "en_US"),
+                    properties = BackendEvent.Workflows.Properties(
+                        workflowId = "wfl_abc",
+                        stepId = "step-1",
+                        workflowType = "paywall",
+                        stepType = "screen",
+                        entryReason = "start",
+                        isFirstStep = true,
+                        isLastStep = false,
+                        screenType = listOf("initial", "paywall"),
+                    ),
+                ),
+            ),
+        )
+
+        val requestString = JsonProvider.defaultJson.encodeToString(requestWithScreenType)
+
+        assertThat(requestString).contains("\"screen_type\":[\"initial\",\"paywall\"]")
+    }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/events/WorkflowEventsRequestSerializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/events/WorkflowEventsRequestSerializationTest.kt
@@ -23,7 +23,8 @@ class WorkflowEventsRequestSerializationTest {
                 properties = BackendEvent.Workflows.Properties(
                     workflowId = "wfl_abc",
                     stepId = "step-1",
-                    traceId = "trace-1",
+                    workflowType = "paywall",
+                    stepType = "screen",
                     entryReason = "start",
                     isFirstStep = true,
                     isLastStep = false,
@@ -48,7 +49,8 @@ class WorkflowEventsRequestSerializationTest {
                         "\"properties\":{" +
                             "\"workflow_id\":\"wfl_abc\"," +
                             "\"step_id\":\"step-1\"," +
-                            "\"trace_id\":\"trace-1\"," +
+                            "\"workflow_type\":\"paywall\"," +
+                            "\"step_type\":\"screen\"," +
                             "\"entry_reason\":\"start\"," +
                             "\"is_first_step\":true," +
                             "\"is_last_step\":false" +
@@ -64,5 +66,17 @@ class WorkflowEventsRequestSerializationTest {
         val requestString = JsonProvider.defaultJson.encodeToString(request)
         val decoded = JsonProvider.defaultJson.decodeFromString<EventsRequest>(requestString)
         assertThat(decoded).isEqualTo(request)
+    }
+
+    @Test
+    fun `screen_type omitted from JSON when empty`() {
+        val requestString = JsonProvider.defaultJson.encodeToString(request)
+        assertThat(requestString).doesNotContain("screen_type")
+    }
+
+    @Test
+    fun `trace_id absent from JSON output`() {
+        val requestString = JsonProvider.defaultJson.encodeToString(request)
+        assertThat(requestString).doesNotContain("trace_id")
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/events/WorkflowEventsRequestSerializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/events/WorkflowEventsRequestSerializationTest.kt
@@ -1,0 +1,68 @@
+package com.revenuecat.purchases.common.events
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.JsonProvider
+import kotlinx.serialization.encodeToString
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34], manifest = Config.NONE)
+class WorkflowEventsRequestSerializationTest {
+
+    private val request = EventsRequest(
+        listOf(
+            BackendEvent.Workflows(
+                id = "evt_id",
+                eventName = "workflows_step_started",
+                timestampMs = 123456789L,
+                appUserID = "appUserID",
+                context = BackendEvent.Workflows.Context(locale = "en_US"),
+                properties = BackendEvent.Workflows.Properties(
+                    workflowId = "wfl_abc",
+                    stepId = "step-1",
+                    traceId = "trace-1",
+                    entryReason = "start",
+                    isFirstStep = true,
+                    isLastStep = false,
+                ),
+            ),
+        ),
+    )
+
+    @Test
+    fun `encodes workflows event to khepri-compatible shape`() {
+        val requestString = JsonProvider.defaultJson.encodeToString(request)
+        assertThat(requestString).isEqualTo(
+            "{" +
+                "\"events\":[" +
+                    "{" +
+                        "\"discriminator\":\"workflows\"," +
+                        "\"id\":\"evt_id\"," +
+                        "\"event_name\":\"workflows_step_started\"," +
+                        "\"timestamp_ms\":123456789," +
+                        "\"app_user_id\":\"appUserID\"," +
+                        "\"context\":{\"locale\":\"en_US\"}," +
+                        "\"properties\":{" +
+                            "\"workflow_id\":\"wfl_abc\"," +
+                            "\"step_id\":\"step-1\"," +
+                            "\"trace_id\":\"trace-1\"," +
+                            "\"entry_reason\":\"start\"," +
+                            "\"is_first_step\":true," +
+                            "\"is_last_step\":false" +
+                        "}" +
+                    "}" +
+                "]" +
+            "}"
+        )
+    }
+
+    @Test
+    fun `round-trips encode and decode`() {
+        val requestString = JsonProvider.defaultJson.encodeToString(request)
+        val decoded = JsonProvider.defaultJson.decodeFromString<EventsRequest>(requestString)
+        assertThat(decoded).isEqualTo(request)
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/events/WorkflowEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/events/WorkflowEventTest.kt
@@ -20,14 +20,16 @@ import java.util.UUID
 class WorkflowEventTest {
 
     @Test
-    fun `StepStarted carries workflow, step, trace, and optional metadata`() {
+    fun `StepStarted carries workflow, step, and optional metadata`() {
         val id = UUID.randomUUID()
         val date = Date()
         val event = WorkflowEvent.StepStarted(
             creationData = WorkflowEvent.CreationData(id = id, date = date),
             workflowId = "wfl_abc",
             stepId = "step-1",
-            traceId = "trace-1",
+            workflowType = "paywall",
+            stepType = "screen",
+            screenType = emptyList(),
             fromStepId = null,
             entryReason = "start",
             isFirstStep = true,
@@ -36,7 +38,9 @@ class WorkflowEventTest {
 
         assertThat(event.workflowId).isEqualTo("wfl_abc")
         assertThat(event.stepId).isEqualTo("step-1")
-        assertThat(event.traceId).isEqualTo("trace-1")
+        assertThat(event.workflowType).isEqualTo("paywall")
+        assertThat(event.stepType).isEqualTo("screen")
+        assertThat(event.screenType).isEmpty()
         assertThat(event.entryReason).isEqualTo("start")
         assertThat(event.isFirstStep).isTrue
         assertThat(event.isPriorityEvent).isFalse
@@ -48,7 +52,8 @@ class WorkflowEventTest {
             creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
             workflowId = "wfl_abc",
             stepId = "step-1",
-            traceId = "trace-1",
+            workflowType = "paywall",
+            stepType = "screen",
             toStepId = "step-2",
             isFirstStep = true,
             isLastStep = false,
@@ -67,7 +72,9 @@ class WorkflowEventTest {
             creationData = WorkflowEvent.CreationData(id, date),
             workflowId = "wfl_abc",
             stepId = "step-1",
-            traceId = "trace-1",
+            workflowType = "paywall",
+            stepType = "screen",
+            screenType = emptyList(),
             fromStepId = null,
             entryReason = "start",
             isFirstStep = true,
@@ -83,7 +90,9 @@ class WorkflowEventTest {
         assertThat(backend.appUserID).isEqualTo("user_42")
         assertThat(backend.properties.workflowId).isEqualTo("wfl_abc")
         assertThat(backend.properties.stepId).isEqualTo("step-1")
-        assertThat(backend.properties.traceId).isEqualTo("trace-1")
+        assertThat(backend.properties.workflowType).isEqualTo("paywall")
+        assertThat(backend.properties.stepType).isEqualTo("screen")
+        assertThat(backend.properties.screenType).isEmpty()
         assertThat(backend.properties.entryReason).isEqualTo("start")
         assertThat(backend.properties.isFirstStep).isTrue
     }
@@ -94,7 +103,8 @@ class WorkflowEventTest {
             creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
             workflowId = "wfl_abc",
             stepId = "step-1",
-            traceId = "trace-1",
+            workflowType = "paywall",
+            stepType = "screen",
             toStepId = "step-2",
             isFirstStep = true,
             isLastStep = false,
@@ -104,6 +114,8 @@ class WorkflowEventTest {
         assertThat(stored.event.eventName).isEqualTo("workflows_step_completed")
         assertThat(stored.event.properties.toStepId).isEqualTo("step-2")
         assertThat(stored.event.properties.fromStepId).isNull()
+        assertThat(stored.event.properties.workflowType).isEqualTo("paywall")
+        assertThat(stored.event.properties.stepType).isEqualTo("screen")
     }
 
     @OptIn(ExperimentalSerializationApi::class)
@@ -126,7 +138,8 @@ class WorkflowEventTest {
                 properties = BackendEvent.Workflows.Properties(
                     workflowId = "wfl",
                     stepId = "s1",
-                    traceId = "t",
+                    workflowType = "paywall",
+                    stepType = "screen",
                 ),
             ),
         )

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/events/WorkflowEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/events/WorkflowEventTest.kt
@@ -1,0 +1,138 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
+package com.revenuecat.purchases.common.workflows.events
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.events.BackendEvent
+import com.revenuecat.purchases.common.events.BackendStoredEvent
+import com.revenuecat.purchases.common.events.toBackendStoredEvent
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.util.Date
+import java.util.UUID
+
+class WorkflowEventTest {
+
+    @Test
+    fun `StepStarted carries workflow, step, trace, and optional metadata`() {
+        val id = UUID.randomUUID()
+        val date = Date()
+        val event = WorkflowEvent.StepStarted(
+            creationData = WorkflowEvent.CreationData(id = id, date = date),
+            workflowId = "wfl_abc",
+            stepId = "step-1",
+            traceId = "trace-1",
+            fromStepId = null,
+            entryReason = "start",
+            isFirstStep = true,
+            isLastStep = false,
+        )
+
+        assertThat(event.workflowId).isEqualTo("wfl_abc")
+        assertThat(event.stepId).isEqualTo("step-1")
+        assertThat(event.traceId).isEqualTo("trace-1")
+        assertThat(event.entryReason).isEqualTo("start")
+        assertThat(event.isFirstStep).isTrue
+        assertThat(event.isPriorityEvent).isFalse
+    }
+
+    @Test
+    fun `StepCompleted carries toStepId for forward nav and null for dismiss`() {
+        val forward = WorkflowEvent.StepCompleted(
+            creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
+            workflowId = "wfl_abc",
+            stepId = "step-1",
+            traceId = "trace-1",
+            toStepId = "step-2",
+            isFirstStep = true,
+            isLastStep = false,
+        )
+        val dismiss = forward.copy(toStepId = null)
+
+        assertThat(forward.toStepId).isEqualTo("step-2")
+        assertThat(dismiss.toStepId).isNull()
+    }
+
+    @Test
+    fun `StepStarted converts to BackendStoredEvent_Workflows with matching properties`() {
+        val id = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val date = Date(1717000000000L)
+        val event = WorkflowEvent.StepStarted(
+            creationData = WorkflowEvent.CreationData(id, date),
+            workflowId = "wfl_abc",
+            stepId = "step-1",
+            traceId = "trace-1",
+            fromStepId = null,
+            entryReason = "start",
+            isFirstStep = true,
+            isLastStep = false,
+        )
+
+        val stored = event.toBackendStoredEvent("user_42")
+        assertThat(stored).isInstanceOf(BackendStoredEvent.Workflows::class.java)
+        val backend = (stored as BackendStoredEvent.Workflows).event
+        assertThat(backend.id).isEqualTo(id.toString())
+        assertThat(backend.eventName).isEqualTo("workflows_step_started")
+        assertThat(backend.timestampMs).isEqualTo(date.time)
+        assertThat(backend.appUserID).isEqualTo("user_42")
+        assertThat(backend.properties.workflowId).isEqualTo("wfl_abc")
+        assertThat(backend.properties.stepId).isEqualTo("step-1")
+        assertThat(backend.properties.traceId).isEqualTo("trace-1")
+        assertThat(backend.properties.entryReason).isEqualTo("start")
+        assertThat(backend.properties.isFirstStep).isTrue
+    }
+
+    @Test
+    fun `StepCompleted converts with toStepId in properties`() {
+        val event = WorkflowEvent.StepCompleted(
+            creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
+            workflowId = "wfl_abc",
+            stepId = "step-1",
+            traceId = "trace-1",
+            toStepId = "step-2",
+            isFirstStep = true,
+            isLastStep = false,
+        )
+
+        val stored = event.toBackendStoredEvent("user_42") as BackendStoredEvent.Workflows
+        assertThat(stored.event.eventName).isEqualTo("workflows_step_completed")
+        assertThat(stored.event.properties.toStepId).isEqualTo("step-2")
+        assertThat(stored.event.properties.fromStepId).isNull()
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    @Test
+    fun `BackendStoredEvent_Workflows round-trips through EventsManager file storage JSON`() {
+        val json = Json {
+            serializersModule = SerializersModule {
+                polymorphic(BackendStoredEvent::class) {
+                    subclass(BackendStoredEvent.Workflows::class, BackendStoredEvent.Workflows.serializer())
+                }
+            }
+            explicitNulls = false
+        }
+        val original = BackendStoredEvent.Workflows(
+            BackendEvent.Workflows(
+                id = "evt_id",
+                eventName = "workflows_step_started",
+                timestampMs = 1L,
+                appUserID = "u",
+                properties = BackendEvent.Workflows.Properties(
+                    workflowId = "wfl",
+                    stepId = "s1",
+                    traceId = "t",
+                ),
+            ),
+        )
+        val encoded = json.encodeToString(BackendStoredEvent.serializer(), original as BackendStoredEvent)
+        val decoded = json.decodeFromString(BackendStoredEvent.serializer(), encoded)
+
+        assertThat(decoded).isEqualTo(original)
+    }
+}

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -25,7 +25,9 @@ import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.common.workflows.PublishedWorkflow
 import com.revenuecat.purchases.common.workflows.WorkflowDataResult
 import com.revenuecat.purchases.common.workflows.WorkflowStep
+import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
+import com.revenuecat.purchases.common.workflows.events.WorkflowEvent
 import com.revenuecat.purchases.models.SubscriptionOption
 import com.revenuecat.purchases.paywalls.components.common.ProductChangeConfig
 import com.revenuecat.purchases.paywalls.events.ExitOfferType
@@ -203,6 +205,7 @@ internal class PaywallViewModelImpl(
     private val workflowStepStateCache = mutableMapOf<String, PaywallState.Loaded.Components>()
     private var preWarmJob: Job? = null
     private var transitionIdCounter: Int = 0
+    private var workflowTraceId: UUID? = null
 
     private sealed interface ExitOfferData {
         val preloadRequested: Boolean
@@ -299,6 +302,9 @@ internal class PaywallViewModelImpl(
 
     override fun closePaywall(result: PaywallResult?) {
         Logger.d("Paywalls: Close paywall initiated")
+        currentWorkflowStepId()?.let { stepId ->
+            trackWorkflowStepCompleted(stepId = stepId, toStepId = null)
+        }
         trackPaywallClose()
         val exitOffering = if (!_purchaseCompleted.value && shouldTriggerExitOfferForCurrentStep) {
             preloadedExitOffering
@@ -309,6 +315,7 @@ internal class PaywallViewModelImpl(
             trackExitOffer(ExitOfferType.DISMISS, exitOffering.identifier)
         }
         paywallPresentationData = null
+        workflowTraceId = null
         val dismissWithExitOffering = options.dismissRequestWithExitOffering
         if (dismissWithExitOffering != null) {
             dismissWithExitOffering(exitOffering, result)
@@ -872,6 +879,14 @@ internal class PaywallViewModelImpl(
         }
 
         buildStateFromStep(initialStep, workflow, offerings, presentedOfferingContext)
+        if (_workflowState.value != null) {
+            workflowTraceId = UUID.randomUUID()
+            trackWorkflowStepStarted(
+                stepId = workflow.initialStepId,
+                fromStepId = null,
+                entryReason = "start",
+            )
+        }
         preWarmWorkflowStepCache(workflow, offerings, presentedOfferingContext)
     }
 
@@ -911,6 +926,12 @@ internal class PaywallViewModelImpl(
         // sees the workflow branch and the correct step, not the single-page branch.
         // On error, clear workflowState so the UI falls through to the normal error path rather
         // than entering workflow mode with a currentStepId absent from stepStates.
+        if (newState !is PaywallState.Loaded.Components) {
+            currentWorkflowStepId()?.let { stepId ->
+                trackWorkflowStepCompleted(stepId = stepId, toStepId = null)
+            }
+            workflowTraceId = null
+        }
         _workflowState.value = if (newState is PaywallState.Loaded.Components) {
             WorkflowPaywallUiState(
                 currentStepId = step.id,
@@ -1017,6 +1038,14 @@ internal class PaywallViewModelImpl(
             fromStepId = fromStepId,
             navigationDirection = NavigationDirection.FORWARD,
         )
+        fromStepId?.let { from ->
+            trackWorkflowStepCompleted(stepId = from, toStepId = newStep.id)
+        }
+        trackWorkflowStepStarted(
+            stepId = newStep.id,
+            fromStepId = fromStepId,
+            entryReason = "forward",
+        )
     }
 
     @Suppress("ReturnCount")
@@ -1044,8 +1073,63 @@ internal class PaywallViewModelImpl(
             fromStepId = fromStepId,
             navigationDirection = NavigationDirection.BACKWARD,
         )
+        fromStepId?.let { from ->
+            trackWorkflowStepCompleted(stepId = from, toStepId = newStep.id)
+        }
+        trackWorkflowStepStarted(
+            stepId = newStep.id,
+            fromStepId = fromStepId,
+            entryReason = "back",
+        )
         return true
     }
+
+    private fun trackWorkflowStepStarted(
+        stepId: String,
+        fromStepId: String?,
+        entryReason: String,
+    ) {
+        val workflowResult = currentWorkflowResult ?: return
+        val traceId = workflowTraceId ?: return
+        val workflow = workflowResult.workflow
+        purchases.track(
+            WorkflowEvent.StepStarted(
+                creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
+                workflowId = workflow.id,
+                stepId = stepId,
+                traceId = traceId.toString(),
+                fromStepId = fromStepId,
+                entryReason = entryReason,
+                isFirstStep = stepId == workflow.initialStepId,
+                isLastStep = isTerminalStep(workflow, stepId),
+            ),
+        )
+    }
+
+    private fun trackWorkflowStepCompleted(stepId: String, toStepId: String?) {
+        val workflowResult = currentWorkflowResult ?: return
+        val traceId = workflowTraceId ?: return
+        val workflow = workflowResult.workflow
+        purchases.track(
+            WorkflowEvent.StepCompleted(
+                creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
+                workflowId = workflow.id,
+                stepId = stepId,
+                traceId = traceId.toString(),
+                toStepId = toStepId,
+                isFirstStep = stepId == workflow.initialStepId,
+                isLastStep = isTerminalStep(workflow, stepId),
+            ),
+        )
+    }
+
+    private fun isTerminalStep(workflow: PublishedWorkflow, stepId: String): Boolean {
+        val step = workflow.steps[stepId] ?: return false
+        return step.triggerActions.values.none { it is WorkflowTriggerAction.Step }
+    }
+
+    private fun currentWorkflowStepId(): String? =
+        _workflowState.value?.currentStepId
 
     @Suppress("ReturnCount")
     private fun validateStep(step: WorkflowStep, workflow: PublishedWorkflow, offerings: Offerings): String? {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -205,7 +205,6 @@ internal class PaywallViewModelImpl(
     private val workflowStepStateCache = mutableMapOf<String, PaywallState.Loaded.Components>()
     private var preWarmJob: Job? = null
     private var transitionIdCounter: Int = 0
-    private var workflowTraceId: UUID? = null
 
     private sealed interface ExitOfferData {
         val preloadRequested: Boolean
@@ -302,8 +301,8 @@ internal class PaywallViewModelImpl(
 
     override fun closePaywall(result: PaywallResult?) {
         Logger.d("Paywalls: Close paywall initiated")
-        currentWorkflowStepId()?.let { stepId ->
-            trackWorkflowStepCompleted(stepId = stepId, toStepId = null)
+        currentWorkflowStep()?.let { step ->
+            trackWorkflowStepCompleted(step = step, toStepId = null)
         }
         trackPaywallClose()
         val exitOffering = if (!_purchaseCompleted.value && shouldTriggerExitOfferForCurrentStep) {
@@ -315,7 +314,6 @@ internal class PaywallViewModelImpl(
             trackExitOffer(ExitOfferType.DISMISS, exitOffering.identifier)
         }
         paywallPresentationData = null
-        workflowTraceId = null
         val dismissWithExitOffering = options.dismissRequestWithExitOffering
         if (dismissWithExitOffering != null) {
             dismissWithExitOffering(exitOffering, result)
@@ -880,9 +878,8 @@ internal class PaywallViewModelImpl(
 
         buildStateFromStep(initialStep, workflow, offerings, presentedOfferingContext)
         if (_workflowState.value != null) {
-            workflowTraceId = UUID.randomUUID()
             trackWorkflowStepStarted(
-                stepId = workflow.initialStepId,
+                step = initialStep,
                 fromStepId = null,
                 entryReason = "start",
             )
@@ -927,10 +924,9 @@ internal class PaywallViewModelImpl(
         // On error, clear workflowState so the UI falls through to the normal error path rather
         // than entering workflow mode with a currentStepId absent from stepStates.
         if (newState !is PaywallState.Loaded.Components) {
-            currentWorkflowStepId()?.let { stepId ->
-                trackWorkflowStepCompleted(stepId = stepId, toStepId = null)
+            currentWorkflowStep()?.let { currentStep ->
+                trackWorkflowStepCompleted(step = currentStep, toStepId = null)
             }
-            workflowTraceId = null
         }
         _workflowState.value = if (newState is PaywallState.Loaded.Components) {
             WorkflowPaywallUiState(
@@ -1030,6 +1026,7 @@ internal class PaywallViewModelImpl(
             Logger.e("triggerAction returned null after peekTriggerStep succeeded — this is a bug")
             return
         }
+        val fromStep = fromStepId?.let { result.workflow.steps[it] }
         buildStateFromStep(
             newStep,
             result.workflow,
@@ -1038,14 +1035,18 @@ internal class PaywallViewModelImpl(
             fromStepId = fromStepId,
             navigationDirection = NavigationDirection.FORWARD,
         )
-        fromStepId?.let { from ->
-            trackWorkflowStepCompleted(stepId = from, toStepId = newStep.id)
+        // If _workflowState is null after buildStateFromStep, an error occurred and
+        // StepCompleted was already fired inside buildStateFromStep.
+        if (_workflowState.value != null) {
+            fromStep?.let { from ->
+                trackWorkflowStepCompleted(step = from, toStepId = newStep.id)
+            }
+            trackWorkflowStepStarted(
+                step = newStep,
+                fromStepId = fromStepId,
+                entryReason = "forward",
+            )
         }
-        trackWorkflowStepStarted(
-            stepId = newStep.id,
-            fromStepId = fromStepId,
-            entryReason = "forward",
-        )
     }
 
     @Suppress("ReturnCount")
@@ -1065,6 +1066,7 @@ internal class PaywallViewModelImpl(
             Logger.e("navigateBack returned null after canNavigateBack was true — this is a bug")
             return false
         }
+        val fromStep = fromStepId?.let { result.workflow.steps[it] }
         buildStateFromStep(
             newStep,
             result.workflow,
@@ -1073,52 +1075,58 @@ internal class PaywallViewModelImpl(
             fromStepId = fromStepId,
             navigationDirection = NavigationDirection.BACKWARD,
         )
-        fromStepId?.let { from ->
-            trackWorkflowStepCompleted(stepId = from, toStepId = newStep.id)
+        // If _workflowState is null after buildStateFromStep, an error occurred and
+        // StepCompleted was already fired inside buildStateFromStep.
+        if (_workflowState.value != null) {
+            fromStep?.let { from ->
+                trackWorkflowStepCompleted(step = from, toStepId = newStep.id)
+            }
+            trackWorkflowStepStarted(
+                step = newStep,
+                fromStepId = fromStepId,
+                entryReason = "back",
+            )
         }
-        trackWorkflowStepStarted(
-            stepId = newStep.id,
-            fromStepId = fromStepId,
-            entryReason = "back",
-        )
         return true
     }
 
     private fun trackWorkflowStepStarted(
-        stepId: String,
+        step: WorkflowStep,
         fromStepId: String?,
         entryReason: String,
     ) {
         val workflowResult = currentWorkflowResult ?: return
-        val traceId = workflowTraceId ?: return
         val workflow = workflowResult.workflow
         purchases.track(
             WorkflowEvent.StepStarted(
                 creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
                 workflowId = workflow.id,
-                stepId = stepId,
-                traceId = traceId.toString(),
+                stepId = step.id,
+                workflowType = "paywall",
+                stepType = step.type,
+                screenType = step.screenType,
                 fromStepId = fromStepId,
                 entryReason = entryReason,
-                isFirstStep = stepId == workflow.initialStepId,
-                isLastStep = isTerminalStep(workflow, stepId),
+                isFirstStep = step.id == workflow.initialStepId,
+                isLastStep = isTerminalStep(workflow, step.id),
             ),
         )
     }
 
-    private fun trackWorkflowStepCompleted(stepId: String, toStepId: String?) {
+    private fun trackWorkflowStepCompleted(step: WorkflowStep, toStepId: String?) {
         val workflowResult = currentWorkflowResult ?: return
-        val traceId = workflowTraceId ?: return
         val workflow = workflowResult.workflow
         purchases.track(
             WorkflowEvent.StepCompleted(
                 creationData = WorkflowEvent.CreationData(UUID.randomUUID(), Date()),
                 workflowId = workflow.id,
-                stepId = stepId,
-                traceId = traceId.toString(),
+                stepId = step.id,
+                workflowType = "paywall",
+                stepType = step.type,
+                screenType = step.screenType,
                 toStepId = toStepId,
-                isFirstStep = stepId == workflow.initialStepId,
-                isLastStep = isTerminalStep(workflow, stepId),
+                isFirstStep = step.id == workflow.initialStepId,
+                isLastStep = isTerminalStep(workflow, step.id),
             ),
         )
     }
@@ -1128,8 +1136,10 @@ internal class PaywallViewModelImpl(
         return step.triggerActions.values.none { it is WorkflowTriggerAction.Step }
     }
 
-    private fun currentWorkflowStepId(): String? =
-        _workflowState.value?.currentStepId
+    private fun currentWorkflowStep(): WorkflowStep? {
+        val stepId = _workflowState.value?.currentStepId ?: return null
+        return currentWorkflowResult?.workflow?.steps?.get(stepId)
+    }
 
     @Suppress("ReturnCount")
     private fun validateStep(step: WorkflowStep, workflow: PublishedWorkflow, offerings: Offerings): String? {

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -1044,7 +1044,9 @@ class PaywallViewModelWorkflowTest {
         assertThat(started.first().entryReason).isEqualTo("start")
         assertThat(started.first().fromStepId).isNull()
         assertThat(started.first().isFirstStep).isTrue
-        assertThat(started.first().traceId).isNotEmpty()
+        assertThat(started.first().workflowType).isEqualTo("paywall")
+        assertThat(started.first().stepType).isEqualTo("screen")
+        assertThat(started.first().screenType).isEmpty()
     }
 
     @Test

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -1147,5 +1147,42 @@ class PaywallViewModelWorkflowTest {
         assertThat(completed[0].toStepId).isNull()
     }
 
+    @Test
+    fun `StepStarted event carries non-empty screenType when step has screenType set`() {
+        val stepWithScreenType = WorkflowStep(
+            id = "step-1",
+            type = "screen",
+            screenId = screenId1,
+            screenType = listOf("initial", "paywall"),
+            triggers = listOf(
+                WorkflowTrigger(
+                    name = "Next",
+                    type = WorkflowTriggerType.ON_PRESS,
+                    actionId = "action-next",
+                    componentId = "btn-next",
+                ),
+            ),
+            triggerActions = mapOf("action-next" to WorkflowTriggerAction.Step(stepId = "step-2")),
+        )
+        val workflowWithScreenType = workflow.copy(
+            steps = mapOf("step-1" to stepWithScreenType, "step-2" to step2),
+        )
+        val fetchResultWithScreenType = WorkflowDataResult(
+            workflow = workflowWithScreenType,
+            enrolledVariants = null,
+        )
+
+        val captured = mutableListOf<FeatureEvent>()
+        every { purchases.track(any()) } answers { captured.add(firstArg()) }
+
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResultWithScreenType, testOfferings, null)
+
+        val started = captured.filterIsInstance<WorkflowEvent.StepStarted>()
+        assertThat(started).hasSize(1)
+        assertThat(started.first().stepId).isEqualTo("step-1")
+        assertThat(started.first().screenType).isEqualTo(listOf("initial", "paywall"))
+    }
+
     // endregion
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelWorkflowTest.kt
@@ -20,6 +20,8 @@ import com.revenuecat.purchases.common.workflows.WorkflowStep
 import com.revenuecat.purchases.common.workflows.WorkflowTrigger
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerAction
 import com.revenuecat.purchases.common.workflows.WorkflowTriggerType
+import com.revenuecat.purchases.common.events.FeatureEvent
+import com.revenuecat.purchases.common.workflows.events.WorkflowEvent
 import com.revenuecat.purchases.paywalls.components.StackComponent
 import com.revenuecat.purchases.paywalls.components.common.Background
 import com.revenuecat.purchases.paywalls.components.common.ComponentsConfig
@@ -323,6 +325,98 @@ class PaywallViewModelWorkflowTest {
         workflow = workflowWithFallbackPointingToFirstStep,
         enrolledVariants = null,
     )
+
+    // An offering with no packages — validateStep passes but calculateState returns PaywallState.Error.
+    private val emptyOfferingId = "empty_offering"
+    private val emptyOffering = Offering(
+        identifier = emptyOfferingId,
+        serverDescription = "",
+        metadata = emptyMap(),
+        availablePackages = emptyList(),
+        paywallComponents = null,
+        webCheckoutURL = null,
+    )
+    private val testOfferingsWithEmpty = Offerings(
+        testOffering,
+        mapOf(offeringId to testOffering, emptyOfferingId to emptyOffering),
+    )
+
+    private val screenEmptyId = "screen-empty"
+    private val screenWithEmptyOffering = WorkflowScreen(
+        name = "screen-empty",
+        templateName = "template_v2",
+        revision = 1,
+        assetBaseURL = URL("https://assets.pawwalls.com"),
+        componentsConfig = componentsConfig,
+        componentsLocalizations = localizations,
+        defaultLocaleIdentifier = defaultLocaleId,
+        offeringIdentifier = emptyOfferingId,
+    )
+
+    private val step3EmptyOffering = WorkflowStep(
+        id = "step-3",
+        type = "screen",
+        screenId = screenEmptyId,
+        triggers = emptyList(),
+        triggerActions = emptyMap(),
+    )
+
+    private val step1ToStep3 = WorkflowStep(
+        id = "step-1",
+        type = "screen",
+        screenId = screenId1,
+        triggers = listOf(
+            WorkflowTrigger(
+                name = "Next",
+                type = WorkflowTriggerType.ON_PRESS,
+                actionId = "action-next",
+                componentId = "btn-next",
+            ),
+        ),
+        triggerActions = mapOf("action-next" to WorkflowTriggerAction.Step(stepId = "step-3")),
+    )
+
+    private val screenWithEmptyOffering2 = WorkflowScreen(
+        name = "screen-empty-initial",
+        templateName = "template_v2",
+        revision = 1,
+        assetBaseURL = URL("https://assets.pawwalls.com"),
+        componentsConfig = componentsConfig,
+        componentsLocalizations = localizations,
+        defaultLocaleIdentifier = defaultLocaleId,
+        offeringIdentifier = emptyOfferingId,
+    )
+
+    private val step1WithEmptyOffering = WorkflowStep(
+        id = "step-1",
+        type = "screen",
+        screenId = "screen-empty-initial",
+        triggers = emptyList(),
+        triggerActions = emptyMap(),
+    )
+
+    private val workflowFailingInitial = PublishedWorkflow(
+        id = "wfl-failing",
+        displayName = "Failing",
+        initialStepId = "step-1",
+        steps = mapOf("step-1" to step1WithEmptyOffering),
+        screens = mapOf("screen-empty-initial" to screenWithEmptyOffering2),
+        uiConfig = UiConfig(),
+        metadata = emptyMap(),
+    )
+    private val fetchResultFailingInitial = WorkflowDataResult(workflow = workflowFailingInitial, enrolledVariants = null)
+
+    private val workflowToError = PublishedWorkflow(
+        id = "wfl-test",
+        displayName = "Test",
+        initialStepId = "step-1",
+        steps = mapOf("step-1" to step1ToStep3, "step-3" to step3EmptyOffering),
+        screens = mapOf(screenId1 to makeScreen(screenId1), screenEmptyId to screenWithEmptyOffering),
+        uiConfig = UiConfig(),
+        metadata = emptyMap(),
+    )
+    private val fetchResultToError = WorkflowDataResult(workflow = workflowToError, enrolledVariants = null)
+
 
     @Before
     fun setUp() {
@@ -930,4 +1024,126 @@ class PaywallViewModelWorkflowTest {
     }
 
     // endregion exit offers
+
+    // region event tracking
+
+    @Test
+    fun `workflow load tracks StepStarted with start entryReason`() {
+        val captured = mutableListOf<FeatureEvent>()
+        every { purchases.track(any()) } answers {
+            captured.add(firstArg())
+        }
+
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResult, testOfferings, null)
+
+        val started = captured.filterIsInstance<WorkflowEvent.StepStarted>()
+        assertThat(started).hasSize(1)
+        assertThat(started.first().workflowId).isEqualTo("wfl-test")
+        assertThat(started.first().stepId).isEqualTo("step-1")
+        assertThat(started.first().entryReason).isEqualTo("start")
+        assertThat(started.first().fromStepId).isNull()
+        assertThat(started.first().isFirstStep).isTrue
+        assertThat(started.first().traceId).isNotEmpty()
+    }
+
+    @Test
+    fun `forward navigation fires StepCompleted for current step and StepStarted for next`() {
+        val captured = mutableListOf<FeatureEvent>()
+        every { purchases.track(any()) } answers { captured.add(firstArg()) }
+
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResult, testOfferings, null)
+        // Clear load events (already tested in Task 7)
+        captured.clear()
+
+        vm.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+
+        val workflowEvents = captured.filterIsInstance<WorkflowEvent>()
+        // Expect: StepCompleted(step-1, to=step-2), StepStarted(step-2, forward)
+        assertThat(workflowEvents).hasSize(2)
+        val completed = workflowEvents[0] as WorkflowEvent.StepCompleted
+        assertThat(completed.stepId).isEqualTo("step-1")
+        assertThat(completed.toStepId).isEqualTo("step-2")
+        val nextStarted = workflowEvents[1] as WorkflowEvent.StepStarted
+        assertThat(nextStarted.stepId).isEqualTo("step-2")
+        assertThat(nextStarted.entryReason).isEqualTo("forward")
+        assertThat(nextStarted.fromStepId).isEqualTo("step-1")
+    }
+
+    @Test
+    fun `back navigation fires StepCompleted for current step and StepStarted for previous with back reason`() {
+        val captured = mutableListOf<FeatureEvent>()
+        every { purchases.track(any()) } answers { captured.add(firstArg()) }
+
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResult, testOfferings, null)
+        vm.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+        vm.onTransitionComplete(vm.workflowState.value!!.pendingTransition!!.id)
+        captured.clear() // clear load + forward nav events
+
+        vm.handleBackNavigation()
+
+        val workflowEvents = captured.filterIsInstance<WorkflowEvent>()
+        assertThat(workflowEvents).hasSize(2)
+        val completed = workflowEvents[0] as WorkflowEvent.StepCompleted
+        assertThat(completed.stepId).isEqualTo("step-2")
+        assertThat(completed.toStepId).isEqualTo("step-1")
+        val started = workflowEvents[1] as WorkflowEvent.StepStarted
+        assertThat(started.stepId).isEqualTo("step-1")
+        assertThat(started.entryReason).isEqualTo("back")
+        assertThat(started.fromStepId).isEqualTo("step-2")
+    }
+
+    @Test
+    fun `closePaywall during workflow fires StepCompleted with null toStepId`() {
+        val captured = mutableListOf<FeatureEvent>()
+        every { purchases.track(any()) } answers { captured.add(firstArg()) }
+
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResult, testOfferings, null)
+        captured.clear() // clear load event
+
+        vm.closePaywall(result = null)
+
+        val workflowEvents = captured.filterIsInstance<WorkflowEvent>()
+        assertThat(workflowEvents).hasSize(1)
+        val completed = workflowEvents[0] as WorkflowEvent.StepCompleted
+        assertThat(completed.stepId).isEqualTo("step-1")
+        assertThat(completed.toStepId).isNull()
+    }
+
+    @Test
+    fun `failed initial workflow load does not fire StepStarted`() {
+        val captured = mutableListOf<FeatureEvent>()
+        every { purchases.track(any()) } answers { captured.add(firstArg()) }
+
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResultFailingInitial, testOfferingsWithEmpty, null)
+
+        val started = captured.filterIsInstance<WorkflowEvent.StepStarted>()
+        assertThat(started).isEmpty()
+    }
+
+    @Test
+    fun `error during navigation clears workflow state and fires StepCompleted with null toStepId`() {
+        val captured = mutableListOf<FeatureEvent>()
+        every { purchases.track(any()) } answers { captured.add(firstArg()) }
+
+        val vm = createVm()
+        vm.updateStateFromWorkflow(fetchResultToError, testOfferingsWithEmpty, null)
+        captured.clear() // clear load event
+
+        // Navigate to step-3 — computeStateForStep returns Error since its offering has no packages
+        vm.handleWorkflowAction("btn-next", WorkflowTriggerType.ON_PRESS)
+
+        val workflowEvents = captured.filterIsInstance<WorkflowEvent>()
+        // StepCompleted for step-1 must be fired when _workflowState is cleared due to error
+        val completed = workflowEvents.filterIsInstance<WorkflowEvent.StepCompleted>()
+        assertThat(completed).hasSize(1)
+        assertThat(completed[0].stepId).isEqualTo("step-1")
+        assertThat(completed[0].toStepId).isNull()
+    }
+
+    // endregion
 }


### PR DESCRIPTION
### Checklist
- [x] Unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation

Implements the `workflows_step_started` and `workflows_step_completed` event pipeline, routing workflow lifecycle events from `PaywallViewModel` through `EventsManager` → `/v1/events`.

Aligned with [Dan Pannasch's Monetization Event Naming Spec (March 2026)](https://www.notion.so/Monetization-Event-Naming-Spec-32ccb1a108b0816d9a3efcf8f26813e4).

### Description

**New domain model — `WorkflowEvent`**

Sealed class with two subtypes (`StepStarted`, `StepCompleted`) implementing `FeatureEvent`. Carries the canonical event properties from the spec.

**Event pipeline**

`WorkflowEvent` → `BackendStoredEvent.Workflows` → `BackendEvent.Workflows` → `/v1/events`

Registered in both `JsonProvider` and `EventsManager`'s polymorphic JSON module.

**Event properties (per spec)**

| Property | Value |
|---|---|
| `workflow_id` | `PublishedWorkflow.id` |
| `workflow_type` | `"paywall"` (hardcoded — Android only handles paywall workflows) |
| `step_id` | `WorkflowStep.id` |
| `step_type` | `WorkflowStep.type` (always `"screen"` for paywall steps) |
| `screen_type` | `WorkflowStep.screenType` (`List<String>`, e.g. `["initial", "paywall"]`) |
| `from_step_id` | Previous step ID (on `step_started`) |
| `to_step_id` | Next step ID (on `step_completed`) |
| `entry_reason` | `"start"` / `"forward"` / `"back"` |
| `is_first_step` / `is_last_step` | Position in workflow |

**Tracking in `PaywallViewModel`**

- `step_started` fires on successful initial workflow load
- `step_completed` + `step_started` fire on forward and back navigation
- `step_completed` (with `to_step_id = null`) fires on paywall close
- `step_completed` fires when workflow state is cleared on error

**`screen_type` note**

`WorkflowStep.screenType` is a new field added to the model (`List<String>`, defaults to `emptyList()`). The backend already stores this value per step (set by the editor) but does not yet include it in the SDK response. A follow-up khepri change is needed to expose it — once that ships, the field will populate automatically.

### Backend follow-up required

- `khepri/services/workflows/serializers/sdk.py` — add `screen_type` to `serialize_published_steps_as_dict()`
- `khepri/streaming/schemas/workflows_event.py` — add `workflow_type: str | None` to `WorkflowsEventBody`
- `WorkflowsEventsTransformer` — deliver `workflow_type` to 3rd-party integrations