### PR TITLE
Add WorkflowType enum with feedback-survey support

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -21,6 +21,30 @@ import kotlinx.serialization.json.JsonObject
 import java.net.URL
 
 @InternalRevenueCatAPI
+@Serializable(with = WorkflowTypeDeserializer::class)
+public enum class WorkflowType {
+    @SerialName("paywall")
+    PAYWALL,
+
+    @SerialName("web-funnel")
+    WEB_FUNNEL,
+
+    @SerialName("feedback-survey")
+    FEEDBACK_SURVEY,
+    UNKNOWN,
+}
+
+internal object WorkflowTypeDeserializer : EnumDeserializerWithDefault<WorkflowType>(
+    valuesByType = mapOf(
+        "paywall" to WorkflowType.PAYWALL,
+        "web-funnel" to WorkflowType.WEB_FUNNEL,
+        "feedback-survey" to WorkflowType.FEEDBACK_SURVEY,
+        "unknown" to WorkflowType.UNKNOWN,
+    ),
+    defaultValue = WorkflowType.UNKNOWN,
+)
+
+@InternalRevenueCatAPI
 @Serializable(with = WorkflowTriggerTypeDeserializer::class)
 public enum class WorkflowTriggerType {
     @SerialName("on_press")
@@ -105,6 +129,7 @@ public data class PublishedWorkflow(
     val metadata: Map<String, @Contextual Any> = emptyMap(),
     val hash: String? = null,
     @SerialName("single_step_fallback_id") val singleStepFallbackId: String? = null,
+    @SerialName("workflow_type") val workflowType: WorkflowType? = null,
 ) {
     @InternalRevenueCatAPI
     public val dismissExitOffer: WorkflowExitOffer?

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/PublishedWorkflowTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/PublishedWorkflowTest.kt
@@ -106,4 +106,63 @@ class PublishedWorkflowTest {
         offeringIdentifier = "offering",
         exitOffers = exitOfferingId?.let { ExitOffers(dismiss = ExitOffer(offeringId = it)) },
     )
+
+    // region workflowType JSON deserialization
+
+    @Test
+    fun `workflowType decodes feedback-survey to FEEDBACK_SURVEY`() {
+        val workflow = parseWorkflowWithType("feedback-survey")
+        assertThat(workflow.workflowType).isEqualTo(WorkflowType.FEEDBACK_SURVEY)
+    }
+
+    @Test
+    fun `workflowType decodes paywall to PAYWALL`() {
+        val workflow = parseWorkflowWithType("paywall")
+        assertThat(workflow.workflowType).isEqualTo(WorkflowType.PAYWALL)
+    }
+
+    @Test
+    fun `workflowType decodes web-funnel to WEB_FUNNEL`() {
+        val workflow = parseWorkflowWithType("web-funnel")
+        assertThat(workflow.workflowType).isEqualTo(WorkflowType.WEB_FUNNEL)
+    }
+
+    @Test
+    fun `workflowType decodes unknown string to UNKNOWN`() {
+        val workflow = parseWorkflowWithType("some-future-type")
+        assertThat(workflow.workflowType).isEqualTo(WorkflowType.UNKNOWN)
+    }
+
+    @Test
+    fun `workflowType is null when field is absent`() {
+        val json = minimalWorkflowJson()
+        val workflow = WorkflowJsonParser.parsePublishedWorkflow(json)
+        assertThat(workflow.workflowType).isNull()
+    }
+
+    private fun parseWorkflowWithType(type: String): PublishedWorkflow {
+        val json = minimalWorkflowJson(workflowType = type)
+        return WorkflowJsonParser.parsePublishedWorkflow(json)
+    }
+
+    private fun minimalWorkflowJson(workflowType: String? = null): String {
+        val typeField = workflowType?.let { """"workflow_type": "$it",""" } ?: ""
+        return """
+            {
+              "id": "wf_1",
+              "display_name": "Test",
+              "initial_step_id": "step_1",
+              $typeField
+              "steps": {},
+              "screens": {},
+              "ui_config": {
+                "app": { "colors": {}, "fonts": {} },
+                "localizations": {},
+                "variable_config": {}
+              }
+            }
+        """.trimIndent()
+    }
+
+    // endregion
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowEnumDeserializationTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowEnumDeserializationTests.kt
@@ -10,6 +10,31 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
+internal class WorkflowTypeDeserializationTests(
+    private val serialized: String,
+    private val expected: WorkflowType,
+) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun parameters(): Collection<*> = listOf(
+            arrayOf("\"paywall\"", WorkflowType.PAYWALL),
+            arrayOf("\"web-funnel\"", WorkflowType.WEB_FUNNEL),
+            arrayOf("\"feedback-survey\"", WorkflowType.FEEDBACK_SURVEY),
+            arrayOf("\"unknown\"", WorkflowType.UNKNOWN),
+            arrayOf("\"some-future-type\"", WorkflowType.UNKNOWN),
+        )
+    }
+
+    @Test
+    fun `Should properly deserialize WorkflowType`() {
+        val actual = JsonTools.json.decodeFromString<WorkflowType>(serialized)
+        assertThat(actual).isEqualTo(expected)
+    }
+}
+
+@RunWith(Parameterized::class)
 internal class WorkflowTriggerTypeDeserializationTests(
     private val serialized: String,
     private val expected: WorkflowTriggerType,


### PR DESCRIPTION
Port of https://github.com/RevenueCat/purchases-ios/pull/6815

## Summary

- Introduces `WorkflowType` enum (`PAYWALL`, `WEB_FUNNEL`, `FEEDBACK_SURVEY`, `UNKNOWN`) to `WorkflowModels.kt`
- Adds optional `workflowType: WorkflowType?` field to `PublishedWorkflow` so the Android SDK can identify feedback-survey workflows from the backend response
- Unknown values decode to `UNKNOWN` via `EnumDeserializerWithDefault` with an explicit key map (required because "web-funnel" and "feedback-survey" use hyphens, not underscores)
- Missing field decodes as `null` for backwards compatibility

## Deviations from iOS

- No warning log on unknown type — follows the existing Android pattern (`WorkflowTriggerType` also silently falls back to `UNKNOWN`)

## Test plan

- [ ] `WorkflowTypeDeserializationTests` covers all 3 known types, unknown type → `UNKNOWN`, and future unknown string → `UNKNOWN`
- [ ] `PublishedWorkflowTest` covers JSON decoding of all 3 known types, unknown string → `UNKNOWN`, and missing field → `null`
- [ ] `./gradlew :purchases:testDefaultsBc8DebugUnitTest --tests "com.revenuecat.purchases.common.workflows.*"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)