### PR TITLE
[Galaxy Store]: Update GalaxyPurchasingData & GalaxyBillingMode API Shapes

### DIFF
--- a/api-tester/src/galaxy/kotlin/com/revenuecat/apitester/kotlin/GalaxyBillingModeAPI.kt
+++ b/api-tester/src/galaxy/kotlin/com/revenuecat/apitester/kotlin/GalaxyBillingModeAPI.kt
@@ -11,8 +11,8 @@ private class GalaxyBillingModeAPI {
             GalaxyBillingMode.PRODUCTION,
             GalaxyBillingMode.TEST,
             GalaxyBillingMode.ALWAYS_FAIL,
-            -> {
-            }
+            -> {}
+            else -> {}
         }.exhaustive
     }
 }

--- a/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
+++ b/examples/purchase-tester/src/main/java/com/revenuecat/purchasetester/ConfigureFragment.kt
@@ -249,12 +249,7 @@ class ConfigureFragment : Fragment() {
             val builder = constructor.newInstance(context, apiKey) as PurchasesConfiguration.Builder
             try {
                 val modeClass = Class.forName("com.revenuecat.purchases.galaxy.GalaxyBillingMode")
-
-                // We can't use the default Enum import (kotlin.Enum) since it doesn't have a valueOf() function.
-                // We need to
-                @Suppress("UNCHECKED_CAST")
-                val testMode =
-                    java.lang.Enum.valueOf(modeClass as Class<out Enum<*>>, "TEST")
+                val testMode = modeClass.getField("TEST").get(null)
                 val method = builderClass.getMethod("galaxyBillingMode", modeClass)
                 method.invoke(builder, testMode)
             } catch (e: ReflectiveOperationException) {

--- a/feature/galaxy/api.txt
+++ b/feature/galaxy/api.txt
@@ -10,7 +10,7 @@ package com.revenuecat.purchases.galaxy {
     ctor public GalaxyConfiguration.Builder(android.content.Context, String, com.revenuecat.purchases.galaxy.GalaxyBillingMode);
   }
 
-  public abstract sealed class GalaxyPurchasingData implements com.revenuecat.purchases.models.PurchasingData {
+  public abstract class GalaxyPurchasingData implements com.revenuecat.purchases.models.PurchasingData {
   }
 
   @dev.drewhamilton.poko.Poko public static final class GalaxyPurchasingData.Product extends com.revenuecat.purchases.galaxy.GalaxyPurchasingData {

--- a/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyPurchasingData.kt
+++ b/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyPurchasingData.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.galaxy
 import com.revenuecat.purchases.ProductType
 import com.revenuecat.purchases.models.PurchasingData
 import dev.drewhamilton.poko.Poko
-public sealed class GalaxyPurchasingData : PurchasingData {
+public abstract class GalaxyPurchasingData internal constructor() : PurchasingData {
 
     @Poko
     public class Product(

--- a/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/conversions/GalaxyBillingModeConversions.kt
+++ b/feature/galaxy/src/main/kotlin/com/revenuecat/purchases/galaxy/conversions/GalaxyBillingModeConversions.kt
@@ -1,12 +1,22 @@
 package com.revenuecat.purchases.galaxy.conversions
 
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.galaxy.GalaxyBillingMode
 import com.samsung.android.sdk.iap.lib.constants.HelperDefine
 
+@Throws(PurchasesException::class)
 internal fun GalaxyBillingMode.toSamsungIAPOperationMode(): HelperDefine.OperationMode {
     return when (this) {
         GalaxyBillingMode.PRODUCTION -> HelperDefine.OperationMode.OPERATION_MODE_PRODUCTION
         GalaxyBillingMode.TEST -> HelperDefine.OperationMode.OPERATION_MODE_TEST
         GalaxyBillingMode.ALWAYS_FAIL -> HelperDefine.OperationMode.OPERATION_MODE_TEST_FAILURE
+        else -> throw PurchasesException(
+            PurchasesError(
+                PurchasesErrorCode.UnsupportedError,
+                "Unsupported GalaxyBillingMode: $this",
+            ),
+        )
     }
 }

--- a/purchases/api-defaults-bc7.txt
+++ b/purchases/api-defaults-bc7.txt
@@ -1047,10 +1047,16 @@ package com.revenuecat.purchases.data {
 
 package com.revenuecat.purchases.galaxy {
 
-  public enum GalaxyBillingMode {
-    enum_constant public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode ALWAYS_FAIL;
-    enum_constant public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode PRODUCTION;
-    enum_constant public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode TEST;
+  public final class GalaxyBillingMode {
+    method public String getName();
+    property public final String name;
+    field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode ALWAYS_FAIL;
+    field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode.Companion Companion;
+    field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode PRODUCTION;
+    field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode TEST;
+  }
+
+  public static final class GalaxyBillingMode.Companion {
   }
 
 }

--- a/purchases/api-defaults-bc7.txt
+++ b/purchases/api-defaults-bc7.txt
@@ -1047,8 +1047,8 @@ package com.revenuecat.purchases.data {
 
 package com.revenuecat.purchases.galaxy {
 
-  public final class GalaxyBillingMode {
-    method public String getName();
+  public abstract class GalaxyBillingMode {
+    method public final String getName();
     property public final String name;
     field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode ALWAYS_FAIL;
     field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode.Companion Companion;

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -1047,10 +1047,16 @@ package com.revenuecat.purchases.data {
 
 package com.revenuecat.purchases.galaxy {
 
-  public enum GalaxyBillingMode {
-    enum_constant public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode ALWAYS_FAIL;
-    enum_constant public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode PRODUCTION;
-    enum_constant public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode TEST;
+  public final class GalaxyBillingMode {
+    method public String getName();
+    property public final String name;
+    field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode ALWAYS_FAIL;
+    field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode.Companion Companion;
+    field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode PRODUCTION;
+    field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode TEST;
+  }
+
+  public static final class GalaxyBillingMode.Companion {
   }
 
 }

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -1047,8 +1047,8 @@ package com.revenuecat.purchases.data {
 
 package com.revenuecat.purchases.galaxy {
 
-  public final class GalaxyBillingMode {
-    method public String getName();
+  public abstract class GalaxyBillingMode {
+    method public final String getName();
     property public final String name;
     field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode ALWAYS_FAIL;
     field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode.Companion Companion;

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -925,10 +925,16 @@ package com.revenuecat.purchases.customercenter {
 
 package com.revenuecat.purchases.galaxy {
 
-  public enum GalaxyBillingMode {
-    enum_constant public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode ALWAYS_FAIL;
-    enum_constant public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode PRODUCTION;
-    enum_constant public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode TEST;
+  public final class GalaxyBillingMode {
+    method public String getName();
+    property public final String name;
+    field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode ALWAYS_FAIL;
+    field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode.Companion Companion;
+    field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode PRODUCTION;
+    field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode TEST;
+  }
+
+  public static final class GalaxyBillingMode.Companion {
   }
 
 }

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -925,8 +925,8 @@ package com.revenuecat.purchases.customercenter {
 
 package com.revenuecat.purchases.galaxy {
 
-  public final class GalaxyBillingMode {
-    method public String getName();
+  public abstract class GalaxyBillingMode {
+    method public final String getName();
     property public final String name;
     field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode ALWAYS_FAIL;
     field public static final com.revenuecat.purchases.galaxy.GalaxyBillingMode.Companion Companion;

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingMode.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingMode.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.galaxy
 /**
  * Represents the operation mode used by the Galaxy Store.
  *
- * This enum allows you to specify whether the app should operate in
+ * This allows you to specify whether the app should operate in
  * real production mode, test mode, or a mode that forces failures for
  * debugging and QA purposes.
  *
@@ -13,27 +13,37 @@ package com.revenuecat.purchases.galaxy
  * Refer to https://developer.samsung.com/iap/programming-guide/iap-helper-programming.html
  * for more information.
  */
-public enum class GalaxyBillingMode {
-    /**
-     * Process purchases with the production environment. Financial transactions occur for successful requests.
-     * Use this mode when submitting your app for beta or production distribution.
-     */
-    PRODUCTION,
+public class GalaxyBillingMode internal constructor(
+    public val name: String,
+) {
 
-    /**
-     * Payment requests are processed normally, except no financial transactions occur, and successful purchase
-     * results are always returned.
-     *
-     * To test in-app purchases, testers must be added as License Testers in the seller’s Seller Portal
-     * account. When operating as a tester, in-app items are available at no cost. Users not designated as a
-     * tester will receive an error if they attempt to purchase an in-app product in this mode.
-     *
-     * Do not submit your app for beta or production distribution with this mode enabled.
-     */
-    TEST,
+    override fun toString(): String = name
 
-    /**
-     * All IAP requests fail in this mode. Useful for testing error scenarios.
-     */
-    ALWAYS_FAIL,
+    public companion object {
+        /**
+         * Process purchases with the production environment. Financial transactions occur for successful requests.
+         * Use this mode when submitting your app for beta or production distribution.
+         */
+        @JvmField
+        public val PRODUCTION: GalaxyBillingMode = GalaxyBillingMode("PRODUCTION")
+
+        /**
+         * Payment requests are processed normally, except no financial transactions occur, and successful purchase
+         * results are always returned.
+         *
+         * To test in-app purchases, testers must be added as License Testers in the seller’s Seller Portal
+         * account. When operating as a tester, in-app items are available at no cost. Users not designated as a
+         * tester will receive an error if they attempt to purchase an in-app product in this mode.
+         *
+         * Do not submit your app for beta or production distribution with this mode enabled.
+         */
+        @JvmField
+        public val TEST: GalaxyBillingMode = GalaxyBillingMode("TEST")
+
+        /**
+         * All IAP requests fail in this mode. Useful for testing error scenarios.
+         */
+        @JvmField
+        public val ALWAYS_FAIL: GalaxyBillingMode = GalaxyBillingMode("ALWAYS_FAIL")
+    }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingMode.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/galaxy/GalaxyBillingMode.kt
@@ -13,7 +13,7 @@ package com.revenuecat.purchases.galaxy
  * Refer to https://developer.samsung.com/iap/programming-guide/iap-helper-programming.html
  * for more information.
  */
-public class GalaxyBillingMode internal constructor(
+public abstract class GalaxyBillingMode internal constructor(
     public val name: String,
 ) {
 
@@ -25,7 +25,7 @@ public class GalaxyBillingMode internal constructor(
          * Use this mode when submitting your app for beta or production distribution.
          */
         @JvmField
-        public val PRODUCTION: GalaxyBillingMode = GalaxyBillingMode("PRODUCTION")
+        public val PRODUCTION: GalaxyBillingMode = object : GalaxyBillingMode("PRODUCTION") {}
 
         /**
          * Payment requests are processed normally, except no financial transactions occur, and successful purchase
@@ -38,12 +38,12 @@ public class GalaxyBillingMode internal constructor(
          * Do not submit your app for beta or production distribution with this mode enabled.
          */
         @JvmField
-        public val TEST: GalaxyBillingMode = GalaxyBillingMode("TEST")
+        public val TEST: GalaxyBillingMode = object : GalaxyBillingMode("TEST") {}
 
         /**
          * All IAP requests fail in this mode. Useful for testing error scenarios.
          */
         @JvmField
-        public val ALWAYS_FAIL: GalaxyBillingMode = GalaxyBillingMode("ALWAYS_FAIL")
+        public val ALWAYS_FAIL: GalaxyBillingMode = object : GalaxyBillingMode("ALWAYS_FAIL") {}
     }
 }


### PR DESCRIPTION
### Description
Migrates the API types for `GalaxyPurchasingData` & `GalaxyBillingMode` to make them be more future-proof for breaking changes.
- `GalaxyPurchasingData`: migrated to an abstract class
- `GalaxyBillingMode`: migrated to be an abstract class with static values

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public Galaxy Store-facing types change shape (`GalaxyBillingMode` enum -> class-like constants; `GalaxyPurchasingData` sealed -> abstract), which can break downstream source/binary compatibility and `when` exhaustiveness. Conversion logic now throws for unknown modes, which could surface new runtime errors if unexpected values are introduced.
> 
> **Overview**
> Updates Galaxy Store public API shapes to be more future-proof: `GalaxyBillingMode` is no longer an enum and is now an abstract class with `@JvmField` static instances and a `name`, and `GalaxyPurchasingData` is no longer sealed and is now an abstract base class.
> 
> Adjusts usages to match the new shapes: `GalaxyBillingMode` `when` checks add an `else` branch in the API tester, the purchase-tester’s reflection uses `getField("TEST")` instead of `Enum.valueOf`, and `toSamsungIAPOperationMode()` now throws a `PurchasesException` for unsupported/unknown modes. API signature snapshots are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6cdaceae56d2da4e253225097ff8581f683b68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->