### PR TITLE
Use latest non-null purchaseLogic if set when using `PurchasesAreCompletedBy.MY_APP`

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -192,8 +192,14 @@ internal class PaywallViewModelImpl(
     private val mode: PaywallMode
         get() = options.mode
 
+    // PaywallOptions.purchaseLogic is excluded from PaywallOptions.hashCode(), so a recomposition
+    // that rebuilds options without threading purchaseLogic through reuses this same VM and silently
+    // swaps options.purchaseLogic to null. Retain the last non-null value so MY_APP integrations
+    // remain functional across recompositions.
+    private var latestNonNullPurchaseLogic: PaywallPurchaseLogic? = options.purchaseLogic
+
     private val purchaseLogic: PaywallPurchaseLogic?
-        get() = options.purchaseLogic
+        get() = latestNonNullPurchaseLogic
 
     private var paywallPresentationData: PaywallEvent.Data? = null
 
@@ -253,6 +259,7 @@ internal class PaywallViewModelImpl(
         // Some properties not considered for equality (hashCode) may have changed
         // (e.g. the listener may change in some re-renderers)
         this.options = options
+        options.purchaseLogic?.let { latestNonNullPurchaseLogic = it }
         if (needsUpdateState) {
             updateState()
         }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModelTest.kt
@@ -522,6 +522,41 @@ class PaywallViewModelTest {
         assertThat(model.actionInProgress.value).isFalse
     }
 
+    @Test
+    fun `purchase uses newest non-null purchaseLogic when updateOptions supplies a different one`() = runTest {
+        every { purchases.purchasesAreCompletedBy } returns PurchasesAreCompletedBy.MY_APP
+
+        val originalPurchaseCalled = MutableStateFlow(false)
+        val originalPurchaseLogic = TestAppPurchaseLogicWithSuspend(
+            originalPurchaseCalled,
+            null,
+            PurchaseLogicResult.Success,
+            null,
+        )
+        val replacementPurchaseCalled = MutableStateFlow(false)
+        val replacementPurchaseLogic = TestAppPurchaseLogicWithSuspend(
+            replacementPurchaseCalled,
+            null,
+            PurchaseLogicResult.Success,
+            null,
+        )
+
+        val model = create(customPurchaseLogic = originalPurchaseLogic)
+
+        model.updateOptions(
+            PaywallOptions.Builder(dismissRequest = { dismissInvoked = true })
+                .setListener(listener)
+                .setPurchaseLogic(replacementPurchaseLogic)
+                .build(),
+        )
+
+        model.purchaseSelectedPackage(activity)
+        replacementPurchaseCalled.first { it }
+
+        assertThat(originalPurchaseCalled.value).isFalse
+        coVerify(exactly = 1) { purchases.awaitSyncPurchases() }
+    }
+
     // Deprecated PurchaseLogic backward compatibility tests
 
     @Suppress("DEPRECATION")


### PR DESCRIPTION
### Description
TODO