### PR TITLE
Add BuildConfig to RevenueCat to gate workflow prewarming

### DIFF
--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -65,6 +65,12 @@ android {
         )
 
         buildConfigField(
+            type = "boolean",
+            name = "WORKFLOWS_ENABLED",
+            value = (resolveProperty("revenuecat.useWorkflowsEndpoint") == "true").toString(),
+        )
+
+        buildConfigField(
             type = "String",
             name = "REMOTE_CONFIG_BASE_URL",
             value = "\"${(localProperties["REMOTE_CONFIG_BASE_URL"] as? String) ?: ""}\"",

--- a/purchases/build.gradle.kts
+++ b/purchases/build.gradle.kts
@@ -66,7 +66,7 @@ android {
 
         buildConfigField(
             type = "boolean",
-            name = "WORKFLOWS_ENABLED",
+            name = "USE_WORKFLOWS_ENDPOINT",
             value = (resolveProperty("revenuecat.useWorkflowsEndpoint") == "true").toString(),
         )
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -553,9 +553,9 @@ internal class PurchasesFactory(
         @VisibleForTesting
         internal fun createWorkflowPreWarmer(
             workflowManager: WorkflowManager,
-            workflowsEnabled: Boolean = BuildConfig.WORKFLOWS_ENABLED,
+            useWorkflowsEndpoint: Boolean = BuildConfig.USE_WORKFLOWS_ENDPOINT,
         ): WorkflowPreWarmer? {
-            return if (workflowsEnabled) {
+            return if (useWorkflowsEndpoint) {
                 { appUserID, offeringIdentifier, appInBackground ->
                     workflowManager.getWorkflow(
                         appUserID = appUserID,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.UserManagerCompat
+import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BackendHelper
@@ -42,6 +43,7 @@ import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.common.workflows.FileCachedWorkflowCdnFetcher
 import com.revenuecat.purchases.common.workflows.WorkflowDetailResolver
 import com.revenuecat.purchases.common.workflows.WorkflowManager
+import com.revenuecat.purchases.common.workflows.WorkflowPreWarmer
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.paywalls.FontLoader
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
@@ -377,15 +379,7 @@ internal class PurchasesFactory(
                 diagnosticsTracker,
                 offeringFontPreDownloader = offeringFontPreDownloader,
                 uiPreviewMode = appConfig.uiPreviewMode,
-                workflowPreWarmer = { appUserID, offeringIdentifier, appInBackground ->
-                    workflowManager.getWorkflow(
-                        appUserID = appUserID,
-                        workflowId = offeringIdentifier,
-                        appInBackground = appInBackground,
-                        onSuccess = {},
-                        onError = {},
-                    )
-                },
+                workflowPreWarmer = createWorkflowPreWarmer(workflowManager),
             )
 
             log(LogIntent.DEBUG) { ConfigureStrings.DEBUG_ENABLED }
@@ -554,5 +548,26 @@ internal class PurchasesFactory(
             diagnosticsEnabled: Boolean,
             uiPreviewMode: Boolean,
         ): Boolean = diagnosticsEnabled && !uiPreviewMode
+
+        @OptIn(InternalRevenueCatAPI::class)
+        @VisibleForTesting
+        internal fun createWorkflowPreWarmer(
+            workflowManager: WorkflowManager,
+            workflowsEnabled: Boolean = BuildConfig.WORKFLOWS_ENABLED,
+        ): WorkflowPreWarmer? {
+            return if (workflowsEnabled) {
+                { appUserID, offeringIdentifier, appInBackground ->
+                    workflowManager.getWorkflow(
+                        appUserID = appUserID,
+                        workflowId = offeringIdentifier,
+                        appInBackground = appInBackground,
+                        onSuccess = {},
+                        onError = {},
+                    )
+                }
+            } else {
+                null
+            }
+        }
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -201,19 +201,19 @@ class PurchasesFactoryTest {
     // region createWorkflowPreWarmer
 
     @Test
-    fun `createWorkflowPreWarmer returns null when workflows are disabled`() {
+    fun `createWorkflowPreWarmer returns null when workflows endpoint is disabled`() {
         val workflowManager = mockk<WorkflowManager>()
 
         val workflowPreWarmer = PurchasesFactory.createWorkflowPreWarmer(
             workflowManager = workflowManager,
-            workflowsEnabled = false,
+            useWorkflowsEndpoint = false,
         )
 
         assertThat(workflowPreWarmer).isNull()
     }
 
     @Test
-    fun `createWorkflowPreWarmer fetches workflow when workflows are enabled`() {
+    fun `createWorkflowPreWarmer fetches workflow when workflows endpoint is enabled`() {
         val workflowManager = mockk<WorkflowManager>()
         every {
             workflowManager.getWorkflow(
@@ -227,7 +227,7 @@ class PurchasesFactoryTest {
 
         val workflowPreWarmer = PurchasesFactory.createWorkflowPreWarmer(
             workflowManager = workflowManager,
-            workflowsEnabled = true,
+            useWorkflowsEndpoint = true,
         )
 
         workflowPreWarmer?.invoke("appUserID", "default", true)

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -20,10 +20,8 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
-@Config(sdk = [35], manifest = Config.NONE)
 class PurchasesFactoryTest {
 
     private val applicationMock = mockk<Context>()

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.common.workflows.WorkflowManager
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
@@ -19,8 +20,10 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
+@Config(sdk = [35], manifest = Config.NONE)
 class PurchasesFactoryTest {
 
     private val applicationMock = mockk<Context>()
@@ -191,6 +194,53 @@ class PurchasesFactoryTest {
     fun `shouldInitializeDiagnostics returns false when both diagnostics disabled and preview mode on`() {
         assertThat(PurchasesFactory.shouldInitializeDiagnostics(diagnosticsEnabled = false, uiPreviewMode = true))
             .isFalse
+    }
+
+    // endregion
+
+    // region createWorkflowPreWarmer
+
+    @Test
+    fun `createWorkflowPreWarmer returns null when workflows are disabled`() {
+        val workflowManager = mockk<WorkflowManager>()
+
+        val workflowPreWarmer = PurchasesFactory.createWorkflowPreWarmer(
+            workflowManager = workflowManager,
+            workflowsEnabled = false,
+        )
+
+        assertThat(workflowPreWarmer).isNull()
+    }
+
+    @Test
+    fun `createWorkflowPreWarmer fetches workflow when workflows are enabled`() {
+        val workflowManager = mockk<WorkflowManager>()
+        every {
+            workflowManager.getWorkflow(
+                appUserID = "appUserID",
+                workflowId = "default",
+                appInBackground = true,
+                onSuccess = any(),
+                onError = any(),
+            )
+        } just runs
+
+        val workflowPreWarmer = PurchasesFactory.createWorkflowPreWarmer(
+            workflowManager = workflowManager,
+            workflowsEnabled = true,
+        )
+
+        workflowPreWarmer?.invoke("appUserID", "default", true)
+
+        verify(exactly = 1) {
+            workflowManager.getWorkflow(
+                appUserID = "appUserID",
+                workflowId = "default",
+                appInBackground = true,
+                onSuccess = any(),
+                onError = any(),
+            )
+        }
     }
 
     // endregion

--- a/ui/revenuecatui/build.gradle.kts
+++ b/ui/revenuecatui/build.gradle.kts
@@ -16,13 +16,6 @@ val localProperties = Properties()
 val localPropertiesFile = rootProject.file("local.properties")
 if (localPropertiesFile.exists()) localProperties.load(FileInputStream(localPropertiesFile))
 
-// Resolves a property: Gradle -P flags take priority, then local.properties.
-fun resolveProperty(name: String, default: String = ""): String {
-    val projectProp = project.findProperty(name) as? String
-    if (projectProp != null) return projectProp
-    return localProperties.getProperty(name) ?: default
-}
-
 android {
     namespace = "com.revenuecat.purchases.ui.revenuecatui"
 
@@ -62,7 +55,7 @@ android {
         buildConfigField(
             type = "boolean",
             name = "USE_WORKFLOWS_ENDPOINT",
-            value = (resolveProperty("revenuecat.useWorkflowsEndpoint") == "true").toString(),
+            value = (localProperties["revenuecat.useWorkflowsEndpoint"] == "true").toString(),
         )
     }
 

--- a/ui/revenuecatui/build.gradle.kts
+++ b/ui/revenuecatui/build.gradle.kts
@@ -16,6 +16,13 @@ val localProperties = Properties()
 val localPropertiesFile = rootProject.file("local.properties")
 if (localPropertiesFile.exists()) localProperties.load(FileInputStream(localPropertiesFile))
 
+// Resolves a property: Gradle -P flags take priority, then local.properties.
+fun resolveProperty(name: String, default: String = ""): String {
+    val projectProp = project.findProperty(name) as? String
+    if (projectProp != null) return projectProp
+    return localProperties.getProperty(name) ?: default
+}
+
 android {
     namespace = "com.revenuecat.purchases.ui.revenuecatui"
 
@@ -55,7 +62,7 @@ android {
         buildConfigField(
             type = "boolean",
             name = "USE_WORKFLOWS_ENDPOINT",
-            value = (localProperties["revenuecat.useWorkflowsEndpoint"] == "true").toString(),
+            value = (resolveProperty("revenuecat.useWorkflowsEndpoint") == "true").toString(),
         )
     }
 


### PR DESCRIPTION
## Summary
A customer reported about 404's on `GET /v1/subscribers/<app_user_id>/workflows/<workflow_id>`

- Add `BuildConfig.USE_WORKFLOWS_ENDPOINT` to the `:purchases` module, using the existing `revenuecat.useWorkflowsEndpoint` property that was already used by RevenueCatUI.
- Gate automatic workflow pre-warming in `PurchasesFactory` behind that core module flag.

## Root Cause
`PurchasesFactory` always supplied a `workflowPreWarmer`, so every offerings fetch with a current offering called `getWorkflow` for that offering identifier. That created automatic workflow requests for apps that did not opt in to the workflows endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in behavior via an existing build flag (defaults off); only reduces unsolicited network calls unless workflows are explicitly enabled.
> 
> **Overview**
> Stops the core `:purchases` SDK from **always** pre-fetching workflows when offerings load, which was causing unwanted `GET /v1/subscribers/.../workflows/...` traffic and **404s** for apps that never enabled workflows.
> 
> The module now exposes **`BuildConfig.USE_WORKFLOWS_ENDPOINT`**, driven by the existing **`revenuecat.useWorkflowsEndpoint`** Gradle/local property (same knob RevenueCat UI already used). **`PurchasesFactory.createWorkflowPreWarmer`** only supplies a pre-warmer when that flag is true; otherwise **`OfferingsManager`** gets `null` and skips background **`getWorkflow`** calls. Unit tests cover both enabled and disabled paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc9242e4ff64bad40e946be5bde4e3144db6453e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->