### PR TITLE
Fix Tabs fill height sizing

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentView.kt
@@ -41,6 +41,7 @@ import com.revenuecat.purchases.ui.revenuecatui.components.PresentedOverride
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.background
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.border
 import com.revenuecat.purchases.ui.revenuecatui.components.modifier.shadow
+import com.revenuecat.purchases.ui.revenuecatui.components.modifier.size
 import com.revenuecat.purchases.ui.revenuecatui.components.previewEmptyState
 import com.revenuecat.purchases.ui.revenuecatui.components.previewTextComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.properties.BackgroundStyles
@@ -88,6 +89,7 @@ internal fun TabsComponentView(
     AnimatedContent(
         targetState = state.selectedTabIndex,
         modifier = modifier
+            .size(tabsState.size)
             .padding(tabsState.margin)
             .applyIfNotNull(shadowStyle) { shadow(it, tabsState.shape) }
             .applyIfNotNull(backgroundStyle) { background(it, tabsState.shape) }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentViewTests.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/tabs/TabsComponentViewTests.kt
@@ -1,8 +1,13 @@
 package com.revenuecat.purchases.ui.revenuecatui.components.tabs
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
@@ -12,8 +17,10 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Package
@@ -49,6 +56,8 @@ import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsConf
 import com.revenuecat.purchases.paywalls.components.common.PaywallComponentsData
 import com.revenuecat.purchases.paywalls.components.properties.ColorInfo
 import com.revenuecat.purchases.paywalls.components.properties.ColorScheme
+import com.revenuecat.purchases.paywalls.components.properties.Size
+import com.revenuecat.purchases.paywalls.components.properties.SizeConstraint.Fill
 import com.revenuecat.purchases.ui.revenuecatui.components.stack.StackComponentView
 import com.revenuecat.purchases.ui.revenuecatui.components.style.StackComponentStyle
 import com.revenuecat.purchases.ui.revenuecatui.components.style.TabsComponentStyle
@@ -77,6 +86,68 @@ class TabsComponentViewTests {
 
     private val defaultLocaleIdentifier = LocaleId("en_US")
     private val testAssetBaseURL = URL("https://assets.pawwalls.com")
+
+    @Test
+    fun `Should apply fill height to tabs component`(): Unit = with(composeTestRule) {
+        // Arrange
+        val textColor = ColorScheme(ColorInfo.Hex(Color.Black.toArgb()))
+        val tabControlKey = LocalizationKey("standard_tab_control")
+        val tabContentKey = LocalizationKey("contained_text")
+        val tabsComponent = TabsComponent(
+            size = Size(width = Fill, height = Fill),
+            tabs = listOf(
+                TabsComponent.Tab(
+                    id = "standard",
+                    stack = StackComponent(
+                        components = listOf(
+                            TabControlComponent,
+                            TextComponent(text = tabContentKey, color = textColor),
+                        ),
+                    ),
+                ),
+            ),
+            control = TabsComponent.TabControl.Buttons(
+                stack = StackComponent(
+                    components = listOf(
+                        TabControlButtonComponent(
+                            tabIndex = 0,
+                            tabId = "standard",
+                            stack = StackComponent(
+                                components = listOf(
+                                    TextComponent(text = tabControlKey, color = textColor),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val rootStack = StackComponent(components = listOf(tabsComponent))
+        val offering = Offering(rootStack = rootStack, packages = listOf(TestData.Packages.monthly))
+        val styleFactory = StyleFactory(offering)
+        val tabsComponentStyle = styleFactory.create(tabsComponent).getOrThrow().componentStyle as TabsComponentStyle
+        val state = paywallComponentsState(offering)
+        val parentHeight = 200.dp
+
+        // Act
+        setContent {
+            Box(
+                modifier = Modifier.requiredSize(width = 120.dp, height = parentHeight),
+            ) {
+                TabsComponentView(
+                    style = tabsComponentStyle,
+                    state = state,
+                    clickHandler = { },
+                    modifier = Modifier.testTag("tabs"),
+                )
+            }
+        }
+
+        // Assert
+        onNodeWithTag("tabs")
+            .assertIsDisplayed()
+            .assertHeightIsEqualTo(parentHeight)
+    }
 
     @Test
     fun `Should properly update selected state of tab control button children`(): Unit = with(composeTestRule) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
Tabs components carry a height setting, but the Android RevenueCatUI renderer was not applying the component size modifier. This made `Height: Fill` behave like fit-content for the Tabs wrapper instead of filling bounded parent height.

### Description
- Apply the resolved Tabs component size before margin/background/border/padding modifiers.
- Add a Compose regression test that renders a Tabs component with `height = Fill` inside a bounded parent and asserts it consumes the full parent height.

Testing:
- `./gradlew :ui:revenuecatui:testDefaultsBc8DebugUnitTest --tests "com.revenuecat.purchases.ui.revenuecatui.components.tabs.TabsComponentViewTests"`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [PWENG-42](https://linear.app/revenuecat/issue/PWENG-42/tabs-height-fill-has-no-effect-in-dashboard)

<div><a href="https://cursor.com/agents/bc-bdba34ff-c2f5-4fed-b242-8bff06151b13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdba34ff-c2f5-4fed-b242-8bff06151b13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

