### PR TITLE
Wire workflows fetching and add cache persistence

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -156,6 +156,10 @@ internal class PurchasesFactory(
                 createEventsExecutor(),
                 runningIntegrationTests = runningIntegrationTests,
             )
+            val concurrentDispatcher = Dispatcher(
+                createConcurrentExecutor(),
+                runningIntegrationTests = runningIntegrationTests,
+            )
 
             var diagnosticsFileHelper: DiagnosticsFileHelper? = null
             var diagnosticsHelper: DiagnosticsHelper? = null
@@ -204,6 +208,7 @@ internal class PurchasesFactory(
                 eventsDispatcher,
                 httpClient,
                 backendHelper,
+                concurrentDispatcher = concurrentDispatcher,
             )
             val coilImageDownloader = CoilImageDownloader(application)
             val fileRepository = DefaultFileRepository(application)
@@ -536,6 +541,12 @@ internal class PurchasesFactory(
         return Executors.newSingleThreadScheduledExecutor(LowPriorityThreadFactory("revenuecat-events-thread"))
     }
 
+    // Bounded pool for backend calls that are issued many-at-a-time (workflow detail prefetch), so
+    // they run concurrently instead of serializing on the single-threaded default executor.
+    private fun createConcurrentExecutor(): ExecutorService {
+        return Executors.newScheduledThreadPool(CONCURRENT_BACKEND_CALLS)
+    }
+
     private class LowPriorityThreadFactory(private val threadName: String) : ThreadFactory {
         override fun newThread(r: Runnable?): Thread {
             val wrapperRunnable = Runnable {
@@ -549,6 +560,10 @@ internal class PurchasesFactory(
     }
 
     companion object {
+        // Size of the concurrent backend executor. Matches the workflow prefetch concurrency cap so
+        // the bounded prefetch fan-out is never starved for threads.
+        private const val CONCURRENT_BACKEND_CALLS = 4
+
         @VisibleForTesting
         internal fun shouldInitializeDiagnostics(
             diagnosticsEnabled: Boolean,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -260,7 +260,10 @@ internal class PurchasesFactory(
                 localeProvider = localeProvider,
             )
 
-            val workflowsCache = WorkflowsCache(deviceCache = cache)
+            // Gated on the same flag as workflowManager below: when workflows are disabled there is
+            // no writer for this cache, so we skip creating it (and the no-op clearCache work in
+            // IdentityManager) entirely. workflowsCache != null <=> workflowManager != null.
+            val workflowsCache = if (BuildConfig.USE_WORKFLOWS_ENDPOINT) WorkflowsCache(deviceCache = cache) else null
 
             val identityManager = IdentityManager(
                 cache,
@@ -358,19 +361,21 @@ internal class PurchasesFactory(
                 fontLoader = fontLoader,
             )
 
-            val workflowManager = WorkflowManager(
-                backend = backend,
-                workflowDetailResolver = WorkflowDetailResolver(
-                    workflowCdnFetcher = FileCachedWorkflowCdnFetcher(
-                        fileRepository = DefaultFileRepository(contextForStorage, "rc_compiled_workflows"),
+            val workflowManager = workflowsCache?.let {
+                WorkflowManager(
+                    backend = backend,
+                    workflowDetailResolver = WorkflowDetailResolver(
+                        workflowCdnFetcher = FileCachedWorkflowCdnFetcher(
+                            fileRepository = DefaultFileRepository(contextForStorage, "rc_compiled_workflows"),
+                        ),
                     ),
-                ),
-                workflowAssetPreDownloader = WorkflowAssetPreDownloader(
-                    paywallComponentsImagePreDownloader = paywallComponentsImagePreDownloader,
-                    offeringFontPreDownloader = offeringFontPreDownloader,
-                ),
-                workflowsCache = workflowsCache,
-            )
+                    workflowAssetPreDownloader = WorkflowAssetPreDownloader(
+                        paywallComponentsImagePreDownloader = paywallComponentsImagePreDownloader,
+                        offeringFontPreDownloader = offeringFontPreDownloader,
+                    ),
+                    workflowsCache = it,
+                )
+            }
 
             val offeringsManager = OfferingsManager(
                 offeringsCache,
@@ -383,7 +388,7 @@ internal class PurchasesFactory(
                 diagnosticsTracker,
                 offeringFontPreDownloader = offeringFontPreDownloader,
                 uiPreviewMode = appConfig.uiPreviewMode,
-                workflowManager = if (BuildConfig.USE_WORKFLOWS_ENDPOINT) workflowManager else null,
+                workflowManager = workflowManager,
             )
 
             log(LogIntent.DEBUG) { ConfigureStrings.DEBUG_ENABLED }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -380,7 +380,7 @@ internal class PurchasesFactory(
                 diagnosticsTracker,
                 offeringFontPreDownloader = offeringFontPreDownloader,
                 uiPreviewMode = appConfig.uiPreviewMode,
-                workflowManager = workflowManager,
+                workflowManager = if (BuildConfig.USE_WORKFLOWS_ENDPOINT) workflowManager else null,
             )
 
             log(LogIntent.DEBUG) { ConfigureStrings.DEBUG_ENABLED }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -380,7 +380,7 @@ internal class PurchasesFactory(
                 diagnosticsTracker,
                 offeringFontPreDownloader = offeringFontPreDownloader,
                 uiPreviewMode = appConfig.uiPreviewMode,
-                workflowPreWarmer = createWorkflowPreWarmer(workflowManager),
+                workflowManager = workflowManager,
             )
 
             log(LogIntent.DEBUG) { ConfigureStrings.DEBUG_ENABLED }
@@ -549,26 +549,5 @@ internal class PurchasesFactory(
             diagnosticsEnabled: Boolean,
             uiPreviewMode: Boolean,
         ): Boolean = diagnosticsEnabled && !uiPreviewMode
-
-        @OptIn(InternalRevenueCatAPI::class)
-        @VisibleForTesting
-        internal fun createWorkflowPreWarmer(
-            workflowManager: WorkflowManager,
-            useWorkflowsEndpoint: Boolean = BuildConfig.USE_WORKFLOWS_ENDPOINT,
-        ): WorkflowPreWarmer? {
-            return if (useWorkflowsEndpoint) {
-                { appUserID, offeringIdentifier, appInBackground ->
-                    workflowManager.getWorkflow(
-                        appUserID = appUserID,
-                        workflowId = offeringIdentifier,
-                        appInBackground = appInBackground,
-                        onSuccess = {},
-                        onError = {},
-                    )
-                }
-            } else {
-                null
-            }
-        }
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -156,10 +156,6 @@ internal class PurchasesFactory(
                 createEventsExecutor(),
                 runningIntegrationTests = runningIntegrationTests,
             )
-            val concurrentDispatcher = Dispatcher(
-                createConcurrentExecutor(),
-                runningIntegrationTests = runningIntegrationTests,
-            )
 
             var diagnosticsFileHelper: DiagnosticsFileHelper? = null
             var diagnosticsHelper: DiagnosticsHelper? = null
@@ -208,7 +204,6 @@ internal class PurchasesFactory(
                 eventsDispatcher,
                 httpClient,
                 backendHelper,
-                concurrentDispatcher = concurrentDispatcher,
             )
             val coilImageDownloader = CoilImageDownloader(application)
             val fileRepository = DefaultFileRepository(application)
@@ -376,6 +371,10 @@ internal class PurchasesFactory(
                         offeringFontPreDownloader = offeringFontPreDownloader,
                     ),
                     workflowsCache = it,
+                    prefetchDispatcher = Dispatcher(
+                        createConcurrentExecutor(),
+                        runningIntegrationTests = runningIntegrationTests,
+                    ),
                 )
             }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -43,6 +43,7 @@ import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.common.workflows.FileCachedWorkflowCdnFetcher
 import com.revenuecat.purchases.common.workflows.WorkflowDetailResolver
 import com.revenuecat.purchases.common.workflows.WorkflowManager
+import com.revenuecat.purchases.common.workflows.WorkflowsCache
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.paywalls.FontLoader
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
@@ -259,11 +260,14 @@ internal class PurchasesFactory(
                 localeProvider = localeProvider,
             )
 
+            val workflowsCache = WorkflowsCache()
+
             val identityManager = IdentityManager(
                 cache,
                 subscriberAttributesCache,
                 subscriberAttributesManager,
                 offeringsCache,
+                workflowsCache,
                 backend,
                 offlineEntitlementsManager,
                 dispatcher,
@@ -366,6 +370,7 @@ internal class PurchasesFactory(
                     offeringFontPreDownloader = offeringFontPreDownloader,
                 ),
                 deviceCache = cache,
+                workflowsCache = workflowsCache,
             )
 
             val offeringsManager = OfferingsManager(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -559,8 +559,6 @@ internal class PurchasesFactory(
     }
 
     companion object {
-        // Size of the concurrent backend executor. Matches the workflow prefetch concurrency cap so
-        // the bounded prefetch fan-out is never starved for threads.
         private const val CONCURRENT_BACKEND_CALLS = 4
 
         @VisibleForTesting

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -49,6 +49,7 @@ import com.revenuecat.purchases.paywalls.FontLoader
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
 import com.revenuecat.purchases.paywalls.PaywallPresentedCache
 import com.revenuecat.purchases.paywalls.events.PaywallStoredEvent
+import com.revenuecat.purchases.storage.DefaultFileCache
 import com.revenuecat.purchases.storage.DefaultFileRepository
 import com.revenuecat.purchases.strings.ConfigureStrings
 import com.revenuecat.purchases.strings.Emojis
@@ -64,6 +65,10 @@ import com.revenuecat.purchases.utils.PurchaseParamsValidator
 import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
 import com.revenuecat.purchases.utils.isAndroidNOrNewer
 import com.revenuecat.purchases.virtualcurrencies.VirtualCurrencyManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
 import java.net.URL
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -74,7 +79,11 @@ internal class PurchasesFactory(
     private val apiKeyValidator: APIKeyValidator = APIKeyValidator(),
 ) {
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+    @OptIn(
+        ExperimentalPreviewRevenueCatPurchasesAPI::class,
+        InternalRevenueCatAPI::class,
+        ExperimentalCoroutinesApi::class,
+    )
     @Suppress("LongMethod", "LongParameterList", "CyclomaticComplexMethod")
     fun createPurchases(
         configuration: PurchasesConfiguration,
@@ -363,7 +372,15 @@ internal class PurchasesFactory(
                     backend = backend,
                     workflowDetailResolver = WorkflowDetailResolver(
                         workflowCdnFetcher = FileCachedWorkflowCdnFetcher(
-                            fileRepository = DefaultFileRepository(contextForStorage, "rc_compiled_workflows"),
+                            // Dedicated FileRepository instance with a concurrency-limited scope, so workflow
+                            // CDN downloads are capped without affecting the instances used for images/video.
+                            fileRepository = DefaultFileRepository(
+                                fileCacheManager = DefaultFileCache(contextForStorage, "rc_compiled_workflows"),
+                                ioScope = CoroutineScope(
+                                    Dispatchers.IO.limitedParallelism(MAX_CONCURRENT_WORKFLOW_CDN_FETCHES) +
+                                        NonCancellable,
+                                ),
+                            ),
                         ),
                     ),
                     workflowAssetPreDownloader = WorkflowAssetPreDownloader(
@@ -560,6 +577,10 @@ internal class PurchasesFactory(
 
     companion object {
         private const val CONCURRENT_BACKEND_CALLS = 4
+
+        // Caps concurrent workflow CDN downloads on the dedicated workflows FileRepository scope, the
+        // same way CONCURRENT_BACKEND_CALLS caps concurrent workflow detail fetches on prefetchDispatcher.
+        private const val MAX_CONCURRENT_WORKFLOW_CDN_FETCHES = 4
 
         @VisibleForTesting
         internal fun shouldInitializeDiagnostics(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -260,9 +260,6 @@ internal class PurchasesFactory(
                 localeProvider = localeProvider,
             )
 
-            // Gated on the same flag as workflowManager below: when workflows are disabled there is
-            // no writer for this cache, so we skip creating it (and the no-op clearCache work in
-            // IdentityManager) entirely. workflowsCache != null <=> workflowManager != null.
             val workflowsCache = if (BuildConfig.USE_WORKFLOWS_ENDPOINT) WorkflowsCache(deviceCache = cache) else null
 
             val identityManager = IdentityManager(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -260,7 +260,7 @@ internal class PurchasesFactory(
                 localeProvider = localeProvider,
             )
 
-            val workflowsCache = WorkflowsCache()
+            val workflowsCache = WorkflowsCache(deviceCache = cache)
 
             val identityManager = IdentityManager(
                 cache,
@@ -369,7 +369,6 @@ internal class PurchasesFactory(
                     paywallComponentsImagePreDownloader = paywallComponentsImagePreDownloader,
                     offeringFontPreDownloader = offeringFontPreDownloader,
                 ),
-                deviceCache = cache,
                 workflowsCache = workflowsCache,
             )
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -366,6 +366,7 @@ internal class PurchasesFactory(
                     paywallComponentsImagePreDownloader = paywallComponentsImagePreDownloader,
                     offeringFontPreDownloader = offeringFontPreDownloader,
                 ),
+                deviceCache = cache,
             )
 
             val offeringsManager = OfferingsManager(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesFactory.kt
@@ -43,7 +43,6 @@ import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.common.workflows.FileCachedWorkflowCdnFetcher
 import com.revenuecat.purchases.common.workflows.WorkflowDetailResolver
 import com.revenuecat.purchases.common.workflows.WorkflowManager
-import com.revenuecat.purchases.common.workflows.WorkflowPreWarmer
 import com.revenuecat.purchases.identity.IdentityManager
 import com.revenuecat.purchases.paywalls.FontLoader
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -567,11 +567,7 @@ internal class PurchasesOrchestrator(
         onSuccess: (WorkflowDataResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
-        val workflowManager = workflowManager
         if (workflowManager == null) {
-            // The workflows feature is disabled (BuildConfig.USE_WORKFLOWS_ENDPOINT is false), so there
-            // is no manager to serve the request. Callers gate on the same flag, so this is effectively
-            // unreachable when configured consistently; we still surface an error instead of crashing.
             onError(
                 PurchasesError(
                     PurchasesErrorCode.ConfigurationError,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -567,21 +567,29 @@ internal class PurchasesOrchestrator(
         onSuccess: (WorkflowDataResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
+        // Deliver every outcome through dispatch so the callback always lands on the main thread,
+        // matching the rest of the SDK's callback APIs (e.g. getOfferings, getCustomerInfo).
+        // WorkflowManager.getWorkflow intentionally has no fixed delivery thread — a cache hit calls
+        // back synchronously on the caller's thread while a miss resolves on its IO scope, and the
+        // prefetch path routes detail callbacks onto a dedicated dispatcher — so normalizing here, at
+        // the consumer boundary, is what gives callers (including awaitGetWorkflow) a stable thread.
         if (workflowManager == null) {
-            onError(
-                PurchasesError(
-                    PurchasesErrorCode.ConfigurationError,
-                    "Workflows are not enabled.",
-                ),
-            )
+            dispatch {
+                onError(
+                    PurchasesError(
+                        PurchasesErrorCode.ConfigurationError,
+                        "Workflows are not enabled.",
+                    ),
+                )
+            }
             return
         }
         workflowManager.getWorkflow(
             appUserID = identityManager.currentAppUserID,
             workflowId = workflowId,
             appInBackground = state.appInBackground,
-            onSuccess = onSuccess,
-            onError = onError,
+            onSuccess = { dispatch { onSuccess(it) } },
+            onError = { dispatch { onError(it) } },
         )
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/PurchasesOrchestrator.kt
@@ -154,7 +154,7 @@ internal class PurchasesOrchestrator(
     private val virtualCurrencyManager: VirtualCurrencyManager,
     private val purchaseParamsValidator: PurchaseParamsValidator,
 
-    private val workflowManager: WorkflowManager,
+    private val workflowManager: WorkflowManager?,
     val processLifecycleOwnerProvider: () -> LifecycleOwner = { ProcessLifecycleOwner.get() },
     private val blockstoreHelper: BlockstoreHelper = BlockstoreHelper(application, identityManager),
     private val backupManager: BackupManager = BackupManager(application),
@@ -567,6 +567,19 @@ internal class PurchasesOrchestrator(
         onSuccess: (WorkflowDataResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
+        val workflowManager = workflowManager
+        if (workflowManager == null) {
+            // The workflows feature is disabled (BuildConfig.USE_WORKFLOWS_ENDPOINT is false), so there
+            // is no manager to serve the request. Callers gate on the same flag, so this is effectively
+            // unreachable when configured consistently; we still surface an error instead of crashing.
+            onError(
+                PurchasesError(
+                    PurchasesErrorCode.ConfigurationError,
+                    "Workflows are not enabled.",
+                ),
+            )
+            return
+        }
         workflowManager.getWorkflow(
             appUserID = identityManager.currentAppUserID,
             workflowId = workflowId,
@@ -807,7 +820,7 @@ internal class PurchasesOrchestrator(
             state = state.copy(purchaseCallbacksByProductId = Collections.emptyMap())
         }
         this.backend.close()
-        this.workflowManager.close()
+        this.workflowManager?.close()
 
         billing.close()
         updatedCustomerInfoListener = null // Do not call on state since the setter does more stuff

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -127,6 +127,10 @@ internal class Backend(
     private val eventsDispatcher: Dispatcher,
     private val httpClient: HTTPClient,
     private val backendHelper: BackendHelper,
+    // Dispatcher for calls that benefit from running concurrently rather than on the default
+    // single-threaded [dispatcher]. Defaults to [dispatcher] so callers that don't need parallelism
+    // keep the existing serialized behavior.
+    private val concurrentDispatcher: Dispatcher = dispatcher,
 ) {
     companion object {
         private const val APP_USER_ID = "app_user_id"
@@ -203,6 +207,9 @@ internal class Backend(
 
     fun close() {
         this.dispatcher.close()
+        // No-op when concurrentDispatcher is the default (same instance as dispatcher); closes the
+        // dedicated pool otherwise. Dispatcher.close() is idempotent, so the double call is safe.
+        this.concurrentDispatcher.close()
     }
 
     fun getCustomerInfo(
@@ -1053,7 +1060,9 @@ internal class Backend(
             val delay = if (appInBackground) Delay.DEFAULT else Delay.NONE
             workflowDetailCallbacks.addBackgroundAwareCallback(
                 call,
-                dispatcher,
+                // Detail fetches are issued many-at-a-time when prefetching a workflows list, so they
+                // run on the concurrent dispatcher to fan out instead of serializing on [dispatcher].
+                concurrentDispatcher,
                 cacheKey,
                 onSuccess to onError,
                 delay,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -127,10 +127,6 @@ internal class Backend(
     private val eventsDispatcher: Dispatcher,
     private val httpClient: HTTPClient,
     private val backendHelper: BackendHelper,
-    // Dispatcher for calls that benefit from running concurrently rather than on the default
-    // single-threaded [dispatcher]. Defaults to [dispatcher] so callers that don't need parallelism
-    // keep the existing serialized behavior.
-    private val concurrentDispatcher: Dispatcher = dispatcher,
 ) {
     companion object {
         private const val APP_USER_ID = "app_user_id"
@@ -207,9 +203,6 @@ internal class Backend(
 
     fun close() {
         this.dispatcher.close()
-        // No-op when concurrentDispatcher is the default (same instance as dispatcher); closes the
-        // dedicated pool otherwise. Dispatcher.close() is idempotent, so the double call is safe.
-        this.concurrentDispatcher.close()
     }
 
     fun getCustomerInfo(
@@ -1006,12 +999,17 @@ internal class Backend(
         }
     }
 
+    @Suppress("LongParameterList")
     fun getWorkflow(
         appUserID: String,
         workflowId: String,
         appInBackground: Boolean,
         onSuccess: (WorkflowDetailResponse) -> Unit,
         onError: (PurchasesError) -> Unit,
+        // Optional override for the dispatcher the call runs on. Defaults to the standard single-threaded
+        // [dispatcher]; callers that issue many fetches at once (workflows-list prefetch) pass a
+        // concurrent dispatcher so the fetches fan out instead of serializing.
+        callbackDispatcher: Dispatcher? = null,
     ) {
         val endpoint = Endpoint.GetWorkflow(appUserID, workflowId)
         val path = endpoint.getPath()
@@ -1060,9 +1058,7 @@ internal class Backend(
             val delay = if (appInBackground) Delay.DEFAULT else Delay.NONE
             workflowDetailCallbacks.addBackgroundAwareCallback(
                 call,
-                // Detail fetches are issued many-at-a-time when prefetching a workflows list, so they
-                // run on the concurrent dispatcher to fan out instead of serializing on [dispatcher].
-                concurrentDispatcher,
+                callbackDispatcher ?: dispatcher,
                 cacheKey,
                 onSuccess to onError,
                 delay,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -1006,10 +1006,7 @@ internal class Backend(
         appInBackground: Boolean,
         onSuccess: (WorkflowDetailResponse) -> Unit,
         onError: (PurchasesError) -> Unit,
-        // Optional override for the dispatcher the call runs on. Defaults to the standard single-threaded
-        // [dispatcher]; callers that issue many fetches at once (workflows-list prefetch) pass a
-        // concurrent dispatcher so the fetches fan out instead of serializing.
-        callbackDispatcher: Dispatcher? = null,
+        callbackDispatcher: Dispatcher = dispatcher,
     ) {
         val endpoint = Endpoint.GetWorkflow(appUserID, workflowId)
         val path = endpoint.getPath()
@@ -1058,7 +1055,7 @@ internal class Backend(
             val delay = if (appInBackground) Delay.DEFAULT else Delay.NONE
             workflowDetailCallbacks.addBackgroundAwareCallback(
                 call,
-                callbackDispatcher ?: dispatcher,
+                callbackDispatcher,
                 cacheKey,
                 onSuccess to onError,
                 delay,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/DeviceCache.kt
@@ -134,6 +134,8 @@ public open class DeviceCache(
 
     private val offeringsResponseCacheKey: String by lazy { "$apiKeyPrefix.offeringsResponse" }
 
+    private val workflowsListResponseCacheKey: String by lazy { "$apiKeyPrefix.workflowsListResponse" }
+
     internal fun startEditing(): SharedPreferences.Editor {
         return preferences.edit()
     }
@@ -605,6 +607,27 @@ public open class DeviceCache(
     @Synchronized
     internal fun clearOfferingsResponseCache() {
         preferences.edit().remove(offeringsResponseCacheKey).apply()
+    }
+
+    // endregion
+
+    // region workflows list response
+
+    @Synchronized
+    internal fun getWorkflowsListResponseCache(): String? {
+        return preferences.getString(workflowsListResponseCacheKey, null)
+    }
+
+    @Synchronized
+    internal fun cacheWorkflowsListResponse(payload: String) {
+        preferences.edit()
+            .putString(workflowsListResponseCacheKey, payload)
+            .apply()
+    }
+
+    @Synchronized
+    internal fun clearWorkflowsListResponseCache() {
+        preferences.edit().remove(workflowsListResponseCacheKey).apply()
     }
 
     // endregion

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/InMemoryCachedObject.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/caching/InMemoryCachedObject.kt
@@ -8,7 +8,7 @@ import java.util.Date
 internal class InMemoryCachedObject<T>
 @OptIn(InternalRevenueCatAPI::class)
 constructor(
-    internal var lastUpdatedAt: Date? = null,
+    @Volatile internal var lastUpdatedAt: Date? = null,
     private val dateProvider: DateProvider = DefaultDateProvider(),
 ) {
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
@@ -30,6 +30,7 @@ internal class OfferingsCache(
     fun clearCache() {
         offeringsCachedObject.clearCache()
         deviceCache.clearOfferingsResponseCache()
+        deviceCache.clearWorkflowsListResponseCache()
         cachedLanguageTags = null
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsCache.kt
@@ -30,7 +30,6 @@ internal class OfferingsCache(
     fun clearCache() {
         offeringsCachedObject.clearCache()
         deviceCache.clearOfferingsResponseCache()
-        deviceCache.clearWorkflowsListResponseCache()
         cachedLanguageTags = null
     }
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -155,11 +155,6 @@ internal class OfferingsManager(
             null,
         )
         val dispatchSuccess = { dispatch { onSuccess?.invoke(cachedOfferings) } }
-        // Ensure the workflows list (and its offeringId map) is loaded before delivering offerings,
-        // mirroring the network path so workflowIdForOfferingId is populated on a cache hit too.
-        // getWorkflowsList no-ops when the list is already fresh — the common case here, since
-        // offerings and workflows are fetched together and share a TTL — so it only does work when the
-        // map is missing or stale (e.g. a prior workflows fetch failed).
         workflowManager?.getWorkflowsList(appUserID, appInBackground, onComplete = dispatchSuccess)
             ?: dispatchSuccess()
         if (isCacheStale) {
@@ -271,11 +266,6 @@ internal class OfferingsManager(
                 offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
                 offeringsCache.cacheOfferings(offeringsResultData.offerings, offeringsJSON)
                 val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
-                // We just refreshed offerings from the network, so realign the workflows list with
-                // them: force it stale so getWorkflowsList refetches instead of skipping on its own
-                // TTL. Skipped on the disk-cache fallback, where offerings did not actually change and
-                // the backend is likely unavailable anyway. getWorkflowsList still dedups concurrent
-                // callers, so racing offerings fetches share a single workflows fetch.
                 if (!loadedFromDiskCache) {
                     workflowManager?.forceWorkflowsListCacheStale()
                 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -261,9 +261,9 @@ internal class OfferingsManager(
                 offeringsResultData.offerings.current?.let {
                     offeringImagePreDownloader.preDownloadOfferingImages(it)
                 }
-                workflowManager?.getWorkflowsList(appUserID, appInBackground)
                 offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
                 offeringsCache.cacheOfferings(offeringsResultData.offerings, offeringsJSON)
+                workflowManager?.getWorkflowsList(appUserID, appInBackground)
                 dispatch {
                     onSuccess?.invoke(offeringsResultData)
                 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -264,6 +264,14 @@ internal class OfferingsManager(
                 offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
                 offeringsCache.cacheOfferings(offeringsResultData.offerings, offeringsJSON)
                 val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
+                // We just refreshed offerings from the network, so realign the workflows list with
+                // them: force it stale so getWorkflowsList refetches instead of skipping on its own
+                // TTL. Skipped on the disk-cache fallback, where offerings did not actually change and
+                // the backend is likely unavailable anyway. getWorkflowsList still dedups concurrent
+                // callers, so racing offerings fetches share a single workflows fetch.
+                if (!loadedFromDiskCache) {
+                    workflowManager?.forceWorkflowsListCacheStale()
+                }
                 workflowManager?.getWorkflowsList(appUserID, appInBackground, onComplete = dispatchSuccess)
                     ?: dispatchSuccess()
             },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -154,7 +154,14 @@ internal class OfferingsManager(
             null,
             null,
         )
-        dispatch { onSuccess?.invoke(cachedOfferings) }
+        val dispatchSuccess = { dispatch { onSuccess?.invoke(cachedOfferings) } }
+        // Ensure the workflows list (and its offeringId map) is loaded before delivering offerings,
+        // mirroring the network path so workflowIdForOfferingId is populated on a cache hit too.
+        // getWorkflowsList no-ops when the list is already fresh — the common case here, since
+        // offerings and workflows are fetched together and share a TTL — so it only does work when the
+        // map is missing or stale (e.g. a prior workflows fetch failed).
+        workflowManager?.getWorkflowsList(appUserID, appInBackground, onComplete = dispatchSuccess)
+            ?: dispatchSuccess()
         if (isCacheStale) {
             log(LogIntent.DEBUG) {
                 if (appInBackground) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -17,7 +17,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.log
 import com.revenuecat.purchases.common.warnLog
-import com.revenuecat.purchases.common.workflows.WorkflowPreWarmer
+import com.revenuecat.purchases.common.workflows.WorkflowManager
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
 import com.revenuecat.purchases.strings.OfferingStrings
 import com.revenuecat.purchases.utils.OfferingImagePreDownloader
@@ -39,7 +39,7 @@ internal class OfferingsManager(
     private val dateProvider: DateProvider = DefaultDateProvider(),
     // This is nullable due to: https://github.com/RevenueCat/purchases-flutter/issues/408
     private val mainHandler: Handler? = Handler(Looper.getMainLooper()),
-    private val workflowPreWarmer: WorkflowPreWarmer? = null,
+    private val workflowManager: WorkflowManager? = null,
 ) {
 
     private val emptyOfferings: Offerings = Offerings(current = null, all = emptyMap())
@@ -260,8 +260,8 @@ internal class OfferingsManager(
             onSuccess = { offeringsResultData ->
                 offeringsResultData.offerings.current?.let {
                     offeringImagePreDownloader.preDownloadOfferingImages(it)
-                    workflowPreWarmer?.invoke(appUserID, it.identifier, appInBackground)
                 }
+                workflowManager?.getWorkflowsList(appUserID, appInBackground)
                 offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
                 offeringsCache.cacheOfferings(offeringsResultData.offerings, offeringsJSON)
                 dispatch {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/offerings/OfferingsManager.kt
@@ -263,10 +263,9 @@ internal class OfferingsManager(
                 }
                 offeringFontPreDownloader.preDownloadOfferingFontsIfNeeded(offeringsResultData.offerings)
                 offeringsCache.cacheOfferings(offeringsResultData.offerings, offeringsJSON)
-                workflowManager?.getWorkflowsList(appUserID, appInBackground)
-                dispatch {
-                    onSuccess?.invoke(offeringsResultData)
-                }
+                val dispatchSuccess = { dispatch { onSuccess?.invoke(offeringsResultData) } }
+                workflowManager?.getWorkflowsList(appUserID, appInBackground, onComplete = dispatchSuccess)
+                    ?: dispatchSuccess()
             },
         )
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -19,8 +19,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
 
 internal class WorkflowManager(
     private val backend: Backend,
@@ -33,22 +31,10 @@ internal class WorkflowManager(
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {
 
-    private companion object {
-        // Caps how many workflows are prefetched at once, so a long workflows list does not fan out
-        // into an unbounded number of concurrent CDN/asset downloads.
-        private const val MAX_CONCURRENT_PREFETCHES = 4
-    }
-
     // Tracks in-flight workflows-list fetches per appUserID so concurrent callers for the same user
     // join the running request, while a different user starts its own.
     private val callbackLock = Any()
     private val pendingCompletionCallbacks = mutableMapOf<String, MutableList<() -> Unit>>()
-
-    // A Semaphore, not a limitedParallelism dispatcher: a prefetch stays suspended almost the whole
-    // time (callback-based detail fetch, downloads on other scopes), and limitedParallelism only caps
-    // running coroutines, so a suspended prefetch would free its slot. The permit is held across the
-    // suspension points, bounding the in-flight pipeline end to end.
-    private val prefetchSemaphore = Semaphore(MAX_CONCURRENT_PREFETCHES)
 
     fun close() {
         scope.cancel()
@@ -156,15 +142,14 @@ internal class WorkflowManager(
 
                     val prefetchWorkflows = filtered.workflows.filter { it.prefetch }
                     scope.launch {
-                        // Prefetch with bounded concurrency, waiting for all before completing so
-                        // onComplete fires once the whole sequence settles. A failed prefetch is logged
-                        // and does not fail the others.
+                        // Wait for all prefetches before completing so onComplete fires once the whole
+                        // sequence settles. A failed prefetch is logged and does not fail the others.
+                        // Concurrency is bounded downstream, not here: detail fetches by prefetchDispatcher's
+                        // thread pool, CDN downloads by the workflows FileRepository's limited scope.
                         coroutineScope {
                             prefetchWorkflows.forEach { summary ->
                                 launch {
-                                    prefetchSemaphore.withPermit {
-                                        prefetchWorkflow(appUserID, summary.id, appInBackground)
-                                    }
+                                    prefetchWorkflow(appUserID, summary.id, appInBackground)
                                 }
                             }
                         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -84,7 +84,6 @@ internal class WorkflowManager(
             appInBackground = appInBackground,
             onSuccess = { response ->
                 workflowsListCachedObject.cacheInstance(response)
-                // Write-only: warms disk for future read-back; in-memory cache governs staleness within a session.
                 deviceCache.cacheWorkflowsListResponse(
                     JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), response),
                 )
@@ -109,6 +108,15 @@ internal class WorkflowManager(
             },
             onError = { error ->
                 errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
+                deviceCache.getWorkflowsListResponseCache()?.let { cached ->
+                    runCatching { WorkflowJsonParser.parseWorkflowsListResponse(cached) }
+                        .onSuccess { response ->
+                            offeringIdToWorkflowIdMap = response.workflows
+                                .mapNotNull { summary -> summary.offeringId?.let { it to summary.id } }
+                                .toMap()
+                        }
+                        .onFailure { errorLog(it) { "Failed to restore workflows list from disk cache" } }
+                }
             },
         )
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -109,6 +109,7 @@ internal class WorkflowManager(
         backend.getWorkflows(
             appUserID = appUserID,
             appInBackground = appInBackground,
+            type = "paywall",
             onSuccess = { response ->
                 workflowsListCachedObject.cacheInstance(response)
                 deviceCache.cacheWorkflowsListResponse(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -5,6 +5,7 @@ package com.revenuecat.purchases.common.workflows
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.safeResume
 import com.revenuecat.purchases.common.toPurchasesError
@@ -25,6 +26,10 @@ internal class WorkflowManager(
     private val workflowDetailResolver: WorkflowDetailResolver,
     private val workflowAssetPreDownloader: WorkflowAssetPreDownloader,
     private val workflowsCache: WorkflowsCache,
+    // Dispatcher the prefetch detail fetches run on, so they fan out instead of serializing on the
+    // backend's default single-threaded dispatcher. Only the prefetch path uses it; on-demand fetches
+    // stay on the default dispatcher.
+    private val prefetchDispatcher: Dispatcher,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {
 
@@ -46,20 +51,25 @@ internal class WorkflowManager(
     // scopes, not this one. A limitedParallelism dispatcher only caps actively-running coroutines, so
     // a suspended prefetch would free its slot and let the next one start — capping nothing. The
     // Semaphore holds its permit across those suspension points, bounding the in-flight pipeline end
-    // to end. The detail HTTP calls are separately parallelized and capped by the Backend concurrent
-    // dispatcher pool (also sized to MAX_CONCURRENT_PREFETCHES).
+    // to end. The detail HTTP calls themselves run on [prefetchDispatcher] so they fan out rather than
+    // serialize.
     private val prefetchSemaphore = Semaphore(MAX_CONCURRENT_PREFETCHES)
 
     fun close() {
         scope.cancel()
+        prefetchDispatcher.close()
     }
 
+    @Suppress("LongParameterList")
     fun getWorkflow(
         appUserID: String,
         workflowId: String,
         appInBackground: Boolean,
         onSuccess: (WorkflowDataResult) -> Unit,
         onError: (PurchasesError) -> Unit,
+        // Set by the prefetch path to fan the detail fetches out across [prefetchDispatcher]. Left null
+        // for on-demand fetches, which run on the backend's default dispatcher.
+        callbackDispatcher: Dispatcher? = null,
     ) {
         val cached = workflowsCache.cachedWorkflow(workflowId)
         if (cached != null && !workflowsCache.isWorkflowCacheStale(workflowId, appInBackground)) {
@@ -70,6 +80,7 @@ internal class WorkflowManager(
             appUserID = appUserID,
             workflowId = workflowId,
             appInBackground = appInBackground,
+            callbackDispatcher = callbackDispatcher,
             onSuccess = { response ->
                 scope.launch {
                     // resolve() can throw a range of exceptions (IllegalStateException, IOException,
@@ -187,6 +198,7 @@ internal class WorkflowManager(
                 appUserID = appUserID,
                 workflowId = workflowId,
                 appInBackground = appInBackground,
+                callbackDispatcher = prefetchDispatcher,
                 onSuccess = { continuation.safeResume(Unit) },
                 onError = { error ->
                     errorLog { "Failed to prefetch workflow $workflowId: ${error.underlyingErrorMessage}" }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -30,10 +30,11 @@ internal class WorkflowManager(
     private val useWorkflowsEndpoint: Boolean = BuildConfig.USE_WORKFLOWS_ENDPOINT,
 ) {
 
-    // Guards isFetchingWorkflowsList and pendingCompletionCallbacks together.
+    // Guards pendingCompletionCallbacks. A key is present while a workflows-list fetch (plus its
+    // prefetch) is in flight for that appUserID, so concurrent callers join only their own user's
+    // request — a different user starts its own fetch instead of receiving the wrong user's list.
     private val callbackLock = Any()
-    private var isFetchingWorkflowsList = false
-    private val pendingCompletionCallbacks = mutableListOf<() -> Unit>()
+    private val pendingCompletionCallbacks = mutableMapOf<String, MutableList<() -> Unit>>()
 
     fun close() {
         scope.cancel()
@@ -85,12 +86,13 @@ internal class WorkflowManager(
      * [onComplete] fires only after the list fetch AND all prefetch CDN fetches finish
      * (success or failure), making it safe to call [workflowIdForOfferingId] in [onComplete].
      *
-     * Concurrent callers while a request is in-flight are deduplicated: the second call queues
-     * its [onComplete] and returns without a new network request. All pending callbacks are
-     * drained together when the in-flight work finishes.
+     * Concurrent callers for the same [appUserID] while a request is in-flight are deduplicated:
+     * the second call queues its [onComplete] and returns without a new network request. All
+     * pending callbacks for that user are drained together when the in-flight work finishes.
+     * A call for a different user starts its own fetch rather than joining the in-flight one.
      */
     fun getWorkflowsList(appUserID: String, appInBackground: Boolean, onComplete: () -> Unit = {}) {
-        when (resolveWorkflowsListFetch(appInBackground, onComplete)) {
+        when (resolveWorkflowsListFetch(appUserID, appInBackground, onComplete)) {
             // Callback queued onto in-flight work; it drains when that work finishes.
             FetchDecision.JOIN -> return
             FetchDecision.COMPLETE_NOW -> {
@@ -112,7 +114,7 @@ internal class WorkflowManager(
 
                 val prefetchWorkflows = response.workflows.filter { it.prefetch }
                 if (prefetchWorkflows.isEmpty()) {
-                    drainCompletionCallbacks()
+                    drainCompletionCallbacks(appUserID)
                 } else {
                     val remaining = AtomicInteger(prefetchWorkflows.size)
                     prefetchWorkflows.forEach { summary ->
@@ -121,13 +123,13 @@ internal class WorkflowManager(
                             workflowId = summary.id,
                             appInBackground = appInBackground,
                             onSuccess = {
-                                if (remaining.decrementAndGet() == 0) drainCompletionCallbacks()
+                                if (remaining.decrementAndGet() == 0) drainCompletionCallbacks(appUserID)
                             },
                             onError = { error ->
                                 errorLog {
                                     "Failed to prefetch workflow ${summary.id}: ${error.underlyingErrorMessage}"
                                 }
-                                if (remaining.decrementAndGet() == 0) drainCompletionCallbacks()
+                                if (remaining.decrementAndGet() == 0) drainCompletionCallbacks(appUserID)
                             },
                         )
                     }
@@ -142,7 +144,7 @@ internal class WorkflowManager(
                         }
                         .onFailure { errorLog(it) { "Failed to restore workflows list from disk cache" } }
                 }
-                drainCompletionCallbacks()
+                drainCompletionCallbacks(appUserID)
             },
         )
     }
@@ -155,22 +157,28 @@ internal class WorkflowManager(
     /**
      * Decides how a [getWorkflowsList] call should proceed, queueing [onComplete] when it must wait.
      *
-     * Returns [FetchDecision.JOIN] when a fetch is already in flight: the call joins it regardless
-     * of list-cache freshness, because the list response refreshes the cache before its prefetch
-     * details finish — completing on a fresh cache would fire [onComplete] before the prefetched
-     * workflows land. [FetchDecision.COMPLETE_NOW] means there is no in-flight work to wait for.
+     * Returns [FetchDecision.JOIN] when a fetch for the same [appUserID] is already in flight: the
+     * call joins it regardless of list-cache freshness, because the list response refreshes the
+     * cache before its prefetch details finish — completing on a fresh cache would fire [onComplete]
+     * before the prefetched workflows land. A fetch in flight for a *different* user is not joined,
+     * so an identity switch starts its own fetch instead of inheriting the previous user's list.
+     * [FetchDecision.COMPLETE_NOW] means there is no in-flight work for this user to wait for.
      */
-    private fun resolveWorkflowsListFetch(appInBackground: Boolean, onComplete: () -> Unit): FetchDecision {
+    private fun resolveWorkflowsListFetch(
+        appUserID: String,
+        appInBackground: Boolean,
+        onComplete: () -> Unit,
+    ): FetchDecision {
         if (!useWorkflowsEndpoint) return FetchDecision.COMPLETE_NOW
         return synchronized(callbackLock) {
+            val inFlight = pendingCompletionCallbacks[appUserID]
             when {
-                isFetchingWorkflowsList -> {
-                    pendingCompletionCallbacks.add(onComplete)
+                inFlight != null -> {
+                    inFlight.add(onComplete)
                     FetchDecision.JOIN
                 }
                 workflowsCache.isWorkflowsListCacheStale(appInBackground) -> {
-                    pendingCompletionCallbacks.add(onComplete)
-                    isFetchingWorkflowsList = true
+                    pendingCompletionCallbacks[appUserID] = mutableListOf(onComplete)
                     FetchDecision.FETCH
                 }
                 else -> FetchDecision.COMPLETE_NOW
@@ -178,10 +186,9 @@ internal class WorkflowManager(
         }
     }
 
-    private fun drainCompletionCallbacks() {
+    private fun drainCompletionCallbacks(appUserID: String) {
         val callbacks = synchronized(callbackLock) {
-            isFetchingWorkflowsList = false
-            pendingCompletionCallbacks.toList().also { pendingCompletionCallbacks.clear() }
+            pendingCompletionCallbacks.remove(appUserID).orEmpty()
         }
         callbacks.forEach { it() }
     }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -90,17 +90,14 @@ internal class WorkflowManager(
      * drained together when the in-flight work finishes.
      */
     fun getWorkflowsList(appUserID: String, appInBackground: Boolean, onComplete: () -> Unit = {}) {
-        if (!useWorkflowsEndpoint ||
-            !workflowsCache.isWorkflowsListCacheStale(appInBackground)
-        ) {
-            onComplete()
-            return
-        }
-
-        synchronized(callbackLock) {
-            pendingCompletionCallbacks.add(onComplete)
-            if (isFetchingWorkflowsList) return
-            isFetchingWorkflowsList = true
+        when (resolveWorkflowsListFetch(appInBackground, onComplete)) {
+            // Callback queued onto in-flight work; it drains when that work finishes.
+            FetchDecision.JOIN -> return
+            FetchDecision.COMPLETE_NOW -> {
+                onComplete()
+                return
+            }
+            FetchDecision.FETCH -> Unit
         }
 
         backend.getWorkflows(
@@ -152,6 +149,34 @@ internal class WorkflowManager(
 
     fun workflowIdForOfferingId(offeringId: String): String? =
         workflowsCache.workflowIdForOfferingId(offeringId)
+
+    private enum class FetchDecision { FETCH, JOIN, COMPLETE_NOW }
+
+    /**
+     * Decides how a [getWorkflowsList] call should proceed, queueing [onComplete] when it must wait.
+     *
+     * Returns [FetchDecision.JOIN] when a fetch is already in flight: the call joins it regardless
+     * of list-cache freshness, because the list response refreshes the cache before its prefetch
+     * details finish — completing on a fresh cache would fire [onComplete] before the prefetched
+     * workflows land. [FetchDecision.COMPLETE_NOW] means there is no in-flight work to wait for.
+     */
+    private fun resolveWorkflowsListFetch(appInBackground: Boolean, onComplete: () -> Unit): FetchDecision {
+        if (!useWorkflowsEndpoint) return FetchDecision.COMPLETE_NOW
+        return synchronized(callbackLock) {
+            when {
+                isFetchingWorkflowsList -> {
+                    pendingCompletionCallbacks.add(onComplete)
+                    FetchDecision.JOIN
+                }
+                workflowsCache.isWorkflowsListCacheStale(appInBackground) -> {
+                    pendingCompletionCallbacks.add(onComplete)
+                    isFetchingWorkflowsList = true
+                    FetchDecision.FETCH
+                }
+                else -> FetchDecision.COMPLETE_NOW
+            }
+        }
+    }
 
     private fun drainCompletionCallbacks() {
         val callbacks = synchronized(callbackLock) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -151,12 +151,13 @@ internal class WorkflowManager(
                 appInBackground = appInBackground,
                 type = "paywall",
                 onSuccess = { response ->
-                    workflowsCache.cacheWorkflowsList(response, buildOfferingIdMap(response.workflows))
+                    // Drop workflows without an offeringId up front: they can't be reached via
+                    // workflowIdForOfferingId, so caching or prefetching them would be wasted work. The
+                    // backend should only return offering-tied workflows here; this is a guard on top.
+                    val filtered = response.onlyWorkflowsWithOfferingId()
+                    workflowsCache.cacheWorkflowsList(filtered, buildOfferingIdMap(filtered.workflows))
 
-                    // A workflow with no offeringId can't be reached via workflowIdForOfferingId, so
-                    // prefetching its assets would be wasted work. The backend should already only set
-                    // prefetch = true for workflows tied to an offering; this is a defensive guard on top.
-                    val prefetchWorkflows = response.workflows.filter { it.prefetch && it.offeringId != null }
+                    val prefetchWorkflows = filtered.workflows.filter { it.prefetch }
                     scope.launch {
                         // Prefetch workflows with bounded concurrency (at most MAX_CONCURRENT_PREFETCHES
                         // at a time) and wait for all of them before completing, so onComplete fires only
@@ -179,7 +180,8 @@ internal class WorkflowManager(
                     // Restore the in-memory cache from the disk copy without rewriting disk: the disk
                     // already holds this payload, so a write would just persist the same bytes again.
                     workflowsCache.cachedWorkflowsListResponseFromDisk()?.let { response ->
-                        workflowsCache.cacheWorkflowsListInMemory(response, buildOfferingIdMap(response.workflows))
+                        val filtered = response.onlyWorkflowsWithOfferingId()
+                        workflowsCache.cacheWorkflowsListInMemory(filtered, buildOfferingIdMap(filtered.workflows))
                     }
                     completePendingCallbacks(appUserID)
                 },
@@ -217,6 +219,9 @@ internal class WorkflowManager(
         }
         callbacks.forEach { it() }
     }
+
+    private fun WorkflowsListResponse.onlyWorkflowsWithOfferingId(): WorkflowsListResponse =
+        copy(workflows = workflows.filter { it.offeringId != null })
 
     private fun buildOfferingIdMap(workflows: List<WorkflowSummary>): Map<String, String> {
         val pairs = workflows.mapNotNull { summary -> summary.offeringId?.let { it to summary.id } }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -7,11 +7,7 @@ import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.common.Backend
-import com.revenuecat.purchases.common.DateProvider
-import com.revenuecat.purchases.common.DefaultDateProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
-import com.revenuecat.purchases.common.caching.InMemoryCachedObject
-import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.toPurchasesError
 import com.revenuecat.purchases.common.warnLog
@@ -29,17 +25,10 @@ internal class WorkflowManager(
     private val workflowDetailResolver: WorkflowDetailResolver,
     private val workflowAssetPreDownloader: WorkflowAssetPreDownloader,
     private val deviceCache: DeviceCache,
-    private val dateProvider: DateProvider = DefaultDateProvider(),
+    private val workflowsCache: WorkflowsCache,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
     private val useWorkflowsEndpoint: Boolean = BuildConfig.USE_WORKFLOWS_ENDPOINT,
 ) {
-
-    private val workflowsListCachedObject = InMemoryCachedObject<WorkflowsListResponse>(
-        dateProvider = dateProvider,
-    )
-
-    @Volatile
-    private var offeringIdToWorkflowIdMap: Map<String, String> = emptyMap()
 
     // Guards isFetchingWorkflowsList and pendingCompletionCallbacks together.
     private val callbackLock = Any()
@@ -57,6 +46,11 @@ internal class WorkflowManager(
         onSuccess: (WorkflowDataResult) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
+        val cached = workflowsCache.cachedWorkflow(workflowId)
+        if (cached != null && !workflowsCache.isWorkflowCacheStale(workflowId, appInBackground)) {
+            onSuccess(cached)
+            return
+        }
         backend.getWorkflow(
             appUserID = appUserID,
             workflowId = workflowId,
@@ -67,13 +61,14 @@ internal class WorkflowManager(
                     // SignatureVerificationException, and SerializationException from parsing CDN json).
                     // CancellationException is caught here intentionally: rethrowing it would skip the
                     // callback and deadlock the prefetch counter in getWorkflowsList. The scope is already
-                    // cancelled so further coroutine work in this scope will not execute regardless.
+                    // canceled so further coroutine work in this scope will not execute regardless.
                     val result = try {
                         workflowDetailResolver.resolve(response)
                     } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                         onError(e.toPurchasesError())
                         return@launch
                     }
+                    workflowsCache.cacheWorkflow(workflowId, result)
                     scope.launch {
                         runCatching { workflowAssetPreDownloader.preDownloadWorkflowAssets(result.workflow) }
                             .onFailure { errorLog(it) { "Failed to pre-download workflow assets" } }
@@ -96,7 +91,7 @@ internal class WorkflowManager(
      */
     fun getWorkflowsList(appUserID: String, appInBackground: Boolean, onComplete: () -> Unit = {}) {
         if (!useWorkflowsEndpoint ||
-            !workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)
+            !workflowsCache.isWorkflowsListCacheStale(appInBackground)
         ) {
             onComplete()
             return
@@ -113,11 +108,10 @@ internal class WorkflowManager(
             appInBackground = appInBackground,
             type = "paywall",
             onSuccess = { response ->
-                workflowsListCachedObject.cacheInstance(response)
+                workflowsCache.cacheWorkflowsList(response, buildOfferingIdMap(response.workflows))
                 deviceCache.cacheWorkflowsListResponse(
                     JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), response),
                 )
-                offeringIdToWorkflowIdMap = buildOfferingIdMap(response.workflows)
 
                 val prefetchWorkflows = response.workflows.filter { it.prefetch }
                 if (prefetchWorkflows.isEmpty()) {
@@ -147,8 +141,7 @@ internal class WorkflowManager(
                 deviceCache.getWorkflowsListResponseCache()?.let { cached ->
                     runCatching { WorkflowJsonParser.parseWorkflowsListResponse(cached) }
                         .onSuccess { response ->
-                            workflowsListCachedObject.cacheInstance(response)
-                            offeringIdToWorkflowIdMap = buildOfferingIdMap(response.workflows)
+                            workflowsCache.cacheWorkflowsList(response, buildOfferingIdMap(response.workflows))
                         }
                         .onFailure { errorLog(it) { "Failed to restore workflows list from disk cache" } }
                 }
@@ -158,7 +151,7 @@ internal class WorkflowManager(
     }
 
     fun workflowIdForOfferingId(offeringId: String): String? =
-        offeringIdToWorkflowIdMap[offeringId]
+        workflowsCache.workflowIdForOfferingId(offeringId)
 
     private fun drainCompletionCallbacks() {
         val callbacks = synchronized(callbackLock) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -106,7 +106,10 @@ internal class WorkflowManager(
             onSuccess = { response ->
                 workflowsCache.cacheWorkflowsList(response, buildOfferingIdMap(response.workflows))
 
-                val prefetchWorkflows = response.workflows.filter { it.prefetch }
+                // A workflow with no offeringId can't be reached via workflowIdForOfferingId, so
+                // prefetching its assets would be wasted work. The backend should already only set
+                // prefetch = true for workflows tied to an offering; this is a defensive guard on top.
+                val prefetchWorkflows = response.workflows.filter { it.prefetch && it.offeringId != null }
                 if (prefetchWorkflows.isEmpty()) {
                     completePendingCallbacks(appUserID)
                 } else {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -24,8 +24,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.io.IOException
 
-internal typealias WorkflowPreWarmer = (appUserID: String, offeringIdentifier: String, appInBackground: Boolean) -> Unit
-
 internal class WorkflowManager(
     private val backend: Backend,
     private val workflowDetailResolver: WorkflowDetailResolver,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -86,12 +86,13 @@ internal class WorkflowManager(
             appInBackground = appInBackground,
             onSuccess = { response ->
                 workflowsListCachedObject.cacheInstance(response)
+                // Write-only: warms disk for future read-back; in-memory cache governs staleness within a session.
                 deviceCache.cacheWorkflowsListResponse(
                     JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), response),
                 )
                 offeringIdToWorkflowIdMap = response.workflows
-                    .filter { it.offeringId != null }
-                    .associate { it.offeringId!! to it.id }
+                    .mapNotNull { summary -> summary.offeringId?.let { it to summary.id } }
+                    .toMap()
                 response.workflows
                     .filter { it.prefetch }
                     .forEach { summary ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -142,8 +142,10 @@ internal class WorkflowManager(
                 },
                 onError = { error ->
                     errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
+                    // Restore the in-memory cache from the disk copy without rewriting disk: the disk
+                    // already holds this payload, so a write would just persist the same bytes again.
                     workflowsCache.cachedWorkflowsListResponseFromDisk()?.let { response ->
-                        workflowsCache.cacheWorkflowsList(response, buildOfferingIdMap(response.workflows))
+                        workflowsCache.cacheWorkflowsListInMemory(response, buildOfferingIdMap(response.workflows))
                     }
                     completePendingCallbacks(appUserID)
                 },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -85,12 +85,12 @@ internal class WorkflowManager(
      *
      * Concurrent callers for the same [appUserID] while a request is in-flight are deduplicated:
      * the second call queues its [onComplete] and returns without a new network request. All
-     * pending callbacks for that user are drained together when the in-flight work finishes.
+     * pending callbacks for that user complete together when the in-flight work finishes.
      * A call for a different user starts its own fetch rather than joining the in-flight one.
      */
     fun getWorkflowsList(appUserID: String, appInBackground: Boolean, onComplete: () -> Unit = {}) {
         when (resolveWorkflowsListFetch(appUserID, appInBackground, onComplete)) {
-            // Callback queued onto in-flight work; it drains when that work finishes.
+            // Callback queued onto in-flight work; it completes when that work finishes.
             FetchDecision.JOIN -> return
             FetchDecision.COMPLETE_NOW -> {
                 onComplete()
@@ -108,7 +108,7 @@ internal class WorkflowManager(
 
                 val prefetchWorkflows = response.workflows.filter { it.prefetch }
                 if (prefetchWorkflows.isEmpty()) {
-                    drainCompletionCallbacks(appUserID)
+                    completePendingCallbacks(appUserID)
                 } else {
                     val remaining = AtomicInteger(prefetchWorkflows.size)
                     prefetchWorkflows.forEach { summary ->
@@ -117,13 +117,13 @@ internal class WorkflowManager(
                             workflowId = summary.id,
                             appInBackground = appInBackground,
                             onSuccess = {
-                                if (remaining.decrementAndGet() == 0) drainCompletionCallbacks(appUserID)
+                                if (remaining.decrementAndGet() == 0) completePendingCallbacks(appUserID)
                             },
                             onError = { error ->
                                 errorLog {
                                     "Failed to prefetch workflow ${summary.id}: ${error.underlyingErrorMessage}"
                                 }
-                                if (remaining.decrementAndGet() == 0) drainCompletionCallbacks(appUserID)
+                                if (remaining.decrementAndGet() == 0) completePendingCallbacks(appUserID)
                             },
                         )
                     }
@@ -134,7 +134,7 @@ internal class WorkflowManager(
                 workflowsCache.cachedWorkflowsListResponseFromDisk()?.let { response ->
                     workflowsCache.cacheWorkflowsList(response, buildOfferingIdMap(response.workflows))
                 }
-                drainCompletionCallbacks(appUserID)
+                completePendingCallbacks(appUserID)
             },
         )
     }
@@ -176,7 +176,7 @@ internal class WorkflowManager(
         }
     }
 
-    private fun drainCompletionCallbacks(appUserID: String) {
+    private fun completePendingCallbacks(appUserID: String) {
         val callbacks = synchronized(callbackLock) {
             pendingCompletionCallbacks.remove(appUserID).orEmpty()
         }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -3,8 +3,14 @@
 package com.revenuecat.purchases.common.workflows
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.caching.DeviceCache
+import com.revenuecat.purchases.common.caching.InMemoryCachedObject
+import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.toPurchasesError
 import com.revenuecat.purchases.common.verification.SignatureVerificationException
@@ -22,8 +28,17 @@ internal class WorkflowManager(
     private val backend: Backend,
     private val workflowDetailResolver: WorkflowDetailResolver,
     private val workflowAssetPreDownloader: WorkflowAssetPreDownloader,
+    private val deviceCache: DeviceCache,
+    private val dateProvider: DateProvider = DefaultDateProvider(),
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {
+
+    private val workflowsListCachedObject = InMemoryCachedObject<WorkflowsListResponse>(
+        dateProvider = dateProvider,
+    )
+
+    @Volatile
+    private var offeringIdToWorkflowIdMap: Map<String, String> = emptyMap()
 
     fun close() {
         scope.cancel()
@@ -61,4 +76,44 @@ internal class WorkflowManager(
             onError = onError,
         )
     }
+
+    fun getWorkflowsList(appUserID: String, appInBackground: Boolean) {
+        if (!workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)) {
+            return
+        }
+        backend.getWorkflows(
+            appUserID = appUserID,
+            appInBackground = appInBackground,
+            onSuccess = { response ->
+                workflowsListCachedObject.cacheInstance(response)
+                deviceCache.cacheWorkflowsListResponse(
+                    JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), response),
+                )
+                offeringIdToWorkflowIdMap = response.workflows
+                    .filter { it.offeringId != null }
+                    .associate { it.offeringId!! to it.id }
+                response.workflows
+                    .filter { it.prefetch }
+                    .forEach { summary ->
+                        getWorkflow(
+                            appUserID = appUserID,
+                            workflowId = summary.id,
+                            appInBackground = appInBackground,
+                            onSuccess = {},
+                            onError = { error ->
+                                errorLog {
+                                    "Failed to prefetch workflow ${summary.id}: ${error.underlyingErrorMessage}"
+                                }
+                            },
+                        )
+                    }
+            },
+            onError = { error ->
+                errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
+            },
+        )
+    }
+
+    fun workflowIdForOfferingId(offeringId: String): String? =
+        offeringIdToWorkflowIdMap[offeringId]
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -3,11 +3,9 @@
 package com.revenuecat.purchases.common.workflows
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.common.Backend
-import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.toPurchasesError
 import com.revenuecat.purchases.common.warnLog
@@ -24,7 +22,6 @@ internal class WorkflowManager(
     private val backend: Backend,
     private val workflowDetailResolver: WorkflowDetailResolver,
     private val workflowAssetPreDownloader: WorkflowAssetPreDownloader,
-    private val deviceCache: DeviceCache,
     private val workflowsCache: WorkflowsCache,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
     private val useWorkflowsEndpoint: Boolean = BuildConfig.USE_WORKFLOWS_ENDPOINT,
@@ -108,9 +105,6 @@ internal class WorkflowManager(
             type = "paywall",
             onSuccess = { response ->
                 workflowsCache.cacheWorkflowsList(response, buildOfferingIdMap(response.workflows))
-                deviceCache.cacheWorkflowsListResponse(
-                    JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), response),
-                )
 
                 val prefetchWorkflows = response.workflows.filter { it.prefetch }
                 if (prefetchWorkflows.isEmpty()) {
@@ -137,12 +131,8 @@ internal class WorkflowManager(
             },
             onError = { error ->
                 errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
-                deviceCache.getWorkflowsListResponseCache()?.let { cached ->
-                    runCatching { WorkflowJsonParser.parseWorkflowsListResponse(cached) }
-                        .onSuccess { response ->
-                            workflowsCache.cacheWorkflowsList(response, buildOfferingIdMap(response.workflows))
-                        }
-                        .onFailure { errorLog(it) { "Failed to restore workflows list from disk cache" } }
+                workflowsCache.cachedWorkflowsListResponseFromDisk()?.let { response ->
+                    workflowsCache.cacheWorkflowsList(response, buildOfferingIdMap(response.workflows))
                 }
                 drainCompletionCallbacks(appUserID)
             },

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -145,17 +145,37 @@ internal class WorkflowManager(
     fun workflowIdForOfferingId(offeringId: String): String? =
         workflowsCache.workflowIdForOfferingId(offeringId)
 
-    private enum class FetchDecision { FETCH, JOIN, COMPLETE_NOW }
+    /**
+     * What a [getWorkflowsList] call should do, decided under [callbackLock] by
+     * [resolveWorkflowsListFetch] and acted on *outside* the lock so the completion callback is
+     * never invoked while holding it.
+     */
+    private enum class FetchDecision {
+        /** No in-flight fetch and the list cache is stale: start a new backend request. */
+        FETCH,
+
+        /**
+         * A fetch for the same appUserID is already running. This call's completion callback was
+         * queued onto it and fires when that fetch and its prefetch finish, so the caller just
+         * returns without a new request. Joining is independent of cache freshness on purpose: the
+         * list response stamps the cache fresh before its prefetch details land, so completing on a
+         * fresh cache would fire the callback too early.
+         */
+        JOIN,
+
+        /**
+         * Nothing to wait for, so the completion callback fires right away. Either the workflows
+         * endpoint is disabled, or the list cache is fresh and no fetch is in flight.
+         */
+        COMPLETE_NOW,
+    }
 
     /**
      * Decides how a [getWorkflowsList] call should proceed, queueing [onComplete] when it must wait.
+     * See [FetchDecision] for what each outcome means.
      *
-     * Returns [FetchDecision.JOIN] when a fetch for the same [appUserID] is already in flight: the
-     * call joins it regardless of list-cache freshness, because the list response refreshes the
-     * cache before its prefetch details finish — completing on a fresh cache would fire [onComplete]
-     * before the prefetched workflows land. A fetch in flight for a *different* user is not joined,
-     * so an identity switch starts its own fetch instead of inheriting the previous user's list.
-     * [FetchDecision.COMPLETE_NOW] means there is no in-flight work for this user to wait for.
+     * The decision is keyed by [appUserID]: a call only joins an in-flight fetch for the *same*
+     * user, so an identity switch starts its own fetch instead of inheriting the previous one.
      */
     private fun resolveWorkflowsListFetch(
         appUserID: String,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -16,7 +16,6 @@ import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.toPurchasesError
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -66,13 +65,11 @@ internal class WorkflowManager(
                 scope.launch {
                     // resolve() can throw a range of exceptions (IllegalStateException, IOException,
                     // SignatureVerificationException, and SerializationException from parsing CDN json).
-                    // getWorkflow MUST always invoke exactly one of onSuccess/onError: the prefetch
-                    // counter in getWorkflowsList (and the offerings delivery gated on it) deadlocks if
-                    // a callback is ever skipped. Catch broadly so no unexpected type breaks that contract.
+                    // CancellationException is caught here intentionally: rethrowing it would skip the
+                    // callback and deadlock the prefetch counter in getWorkflowsList. The scope is already
+                    // cancelled so further coroutine work in this scope will not execute regardless.
                     val result = try {
                         workflowDetailResolver.resolve(response)
-                    } catch (e: CancellationException) {
-                        throw e
                     } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                         onError(e.toPurchasesError())
                         return@launch

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -67,8 +67,6 @@ internal class WorkflowManager(
         appInBackground: Boolean,
         onSuccess: (WorkflowDataResult) -> Unit,
         onError: (PurchasesError) -> Unit,
-        // Set by the prefetch path to fan the detail fetches out across [prefetchDispatcher]. Left null
-        // for on-demand fetches, which run on the backend's default dispatcher.
         callbackDispatcher: Dispatcher? = null,
     ) {
         val cached = workflowsCache.cachedWorkflow(workflowId)
@@ -76,34 +74,45 @@ internal class WorkflowManager(
             onSuccess(cached)
             return
         }
-        backend.getWorkflow(
-            appUserID = appUserID,
-            workflowId = workflowId,
-            appInBackground = appInBackground,
-            callbackDispatcher = callbackDispatcher,
-            onSuccess = { response ->
-                scope.launch {
-                    // resolve() can throw a range of exceptions (IllegalStateException, IOException,
-                    // SignatureVerificationException, and SerializationException from parsing CDN json).
-                    // CancellationException is caught here intentionally: rethrowing it would skip the
-                    // callback and deadlock the prefetch counter in getWorkflowsList. The scope is already
-                    // canceled so further coroutine work in this scope will not execute regardless.
-                    val result = try {
-                        workflowDetailResolver.resolve(response)
-                    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                        onError(e.toPurchasesError())
-                        return@launch
-                    }
-                    workflowsCache.cacheWorkflow(workflowId, result)
-                    scope.launch {
-                        runCatching { workflowAssetPreDownloader.preDownloadWorkflowAssets(result.workflow) }
-                            .onFailure { errorLog(it) { "Failed to pre-download workflow assets" } }
-                    }
-                    onSuccess(result)
+        val onSuccessHandler: (WorkflowDetailResponse) -> Unit = { response ->
+            scope.launch {
+                // resolve() can throw a range of exceptions (IllegalStateException, IOException,
+                // SignatureVerificationException, and SerializationException from parsing CDN json).
+                // CancellationException is caught here intentionally: rethrowing it would skip the
+                // callback and deadlock the prefetch counter in getWorkflowsList. The scope is already
+                // canceled so further coroutine work in this scope will not execute regardless.
+                val result = try {
+                    workflowDetailResolver.resolve(response)
+                } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                    onError(e.toPurchasesError())
+                    return@launch
                 }
-            },
-            onError = onError,
-        )
+                workflowsCache.cacheWorkflow(workflowId, result)
+                scope.launch {
+                    runCatching { workflowAssetPreDownloader.preDownloadWorkflowAssets(result.workflow) }
+                        .onFailure { errorLog(it) { "Failed to pre-download workflow assets" } }
+                }
+                onSuccess(result)
+            }
+        }
+        if (callbackDispatcher != null) {
+            backend.getWorkflow(
+                appUserID = appUserID,
+                workflowId = workflowId,
+                appInBackground = appInBackground,
+                callbackDispatcher = callbackDispatcher,
+                onSuccess = onSuccessHandler,
+                onError = onError,
+            )
+        } else {
+            backend.getWorkflow(
+                appUserID = appUserID,
+                workflowId = workflowId,
+                appInBackground = appInBackground,
+                onSuccess = onSuccessHandler,
+                onError = onError,
+            )
+        }
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -4,7 +4,6 @@ package com.revenuecat.purchases.common.workflows
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesError
-import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.safeResume
@@ -19,14 +18,12 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 
-@Suppress("LongParameterList")
 internal class WorkflowManager(
     private val backend: Backend,
     private val workflowDetailResolver: WorkflowDetailResolver,
     private val workflowAssetPreDownloader: WorkflowAssetPreDownloader,
     private val workflowsCache: WorkflowsCache,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
-    private val useWorkflowsEndpoint: Boolean = BuildConfig.USE_WORKFLOWS_ENDPOINT,
 ) {
 
     // Guards pendingCompletionCallbacks. A key is present while a workflows-list fetch (plus its
@@ -94,11 +91,6 @@ internal class WorkflowManager(
      * for a different user starts its own fetch rather than joining the in-flight one.
      */
     fun getWorkflowsList(appUserID: String, appInBackground: Boolean, onComplete: () -> Unit = {}) {
-        if (!useWorkflowsEndpoint) {
-            onComplete()
-            return
-        }
-
         // Decide under the lock and act outside it, so onComplete never fires while the lock is held.
         // The decision is keyed by appUserID: a call only joins an in-flight fetch for the *same* user,
         // so an identity switch starts its own fetch instead of inheriting the previous one.

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -22,8 +22,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.io.IOException
 
-internal typealias WorkflowPreWarmer = (appUserID: String, offeringIdentifier: String, appInBackground: Boolean) -> Unit
-
 internal class WorkflowManager(
     private val backend: Backend,
     private val workflowDetailResolver: WorkflowDetailResolver,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -11,6 +11,7 @@ import com.revenuecat.purchases.common.safeResume
 import com.revenuecat.purchases.common.toPurchasesError
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -26,9 +27,8 @@ internal class WorkflowManager(
     private val workflowDetailResolver: WorkflowDetailResolver,
     private val workflowAssetPreDownloader: WorkflowAssetPreDownloader,
     private val workflowsCache: WorkflowsCache,
-    // Dispatcher the prefetch detail fetches run on, so they fan out instead of serializing on the
-    // backend's default single-threaded dispatcher. Only the prefetch path uses it; on-demand fetches
-    // stay on the default dispatcher.
+    // Detail fetches in the prefetch path run here so they fan out instead of serializing on the
+    // backend's single-threaded dispatcher. On-demand fetches use the default dispatcher.
     private val prefetchDispatcher: Dispatcher,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {
@@ -39,20 +39,15 @@ internal class WorkflowManager(
         private const val MAX_CONCURRENT_PREFETCHES = 4
     }
 
-    // Guards pendingCompletionCallbacks. A key is present while a workflows-list fetch (plus its
-    // prefetch) is in flight for that appUserID, so concurrent callers join only their own user's
-    // request — a different user starts its own fetch instead of receiving the wrong user's list.
+    // Tracks in-flight workflows-list fetches per appUserID so concurrent callers for the same user
+    // join the running request, while a different user starts its own.
     private val callbackLock = Any()
     private val pendingCompletionCallbacks = mutableMapOf<String, MutableList<() -> Unit>>()
 
-    // A Semaphore rather than a limitedParallelism dispatcher (as RemoteConfig's TopicFetcher uses)
-    // because a single prefetch is suspended almost the whole time: the detail fetch is a callback
-    // suspending on backend.getWorkflow, and the CDN/asset downloads run on the FileRepository/Coil
-    // scopes, not this one. A limitedParallelism dispatcher only caps actively-running coroutines, so
-    // a suspended prefetch would free its slot and let the next one start — capping nothing. The
-    // Semaphore holds its permit across those suspension points, bounding the in-flight pipeline end
-    // to end. The detail HTTP calls themselves run on [prefetchDispatcher] so they fan out rather than
-    // serialize.
+    // A Semaphore, not a limitedParallelism dispatcher: a prefetch stays suspended almost the whole
+    // time (callback-based detail fetch, downloads on other scopes), and limitedParallelism only caps
+    // running coroutines, so a suspended prefetch would free its slot. The permit is held across the
+    // suspension points, bounding the in-flight pipeline end to end.
     private val prefetchSemaphore = Semaphore(MAX_CONCURRENT_PREFETCHES)
 
     fun close() {
@@ -76,13 +71,13 @@ internal class WorkflowManager(
         }
         val onSuccessHandler: (WorkflowDetailResponse) -> Unit = { response ->
             scope.launch {
-                // resolve() can throw a range of exceptions (IllegalStateException, IOException,
-                // SignatureVerificationException, and SerializationException from parsing CDN json).
-                // CancellationException is caught here intentionally: rethrowing it would skip the
-                // callback and deadlock the prefetch counter in getWorkflowsList. The scope is already
-                // canceled so further coroutine work in this scope will not execute regardless.
+                // resolve() can fail in several ways (missing inline data, CDN fetch/parse failures,
+                // signature verification), so surface any of them through onError. Cancellation is not
+                // a failure: let it propagate so the coroutine unwinds normally.
                 val result = try {
                     workflowDetailResolver.resolve(response)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                     onError(e.toPurchasesError())
                     return@launch
@@ -129,29 +124,23 @@ internal class WorkflowManager(
      * for a different user starts its own fetch rather than joining the in-flight one.
      */
     fun getWorkflowsList(appUserID: String, appInBackground: Boolean, onComplete: () -> Unit = {}) {
-        // Decide under the lock and act outside it, so onComplete never fires while the lock is held.
-        // The decision is keyed by appUserID: a call only joins an in-flight fetch for the *same* user,
-        // so an identity switch starts its own fetch instead of inheriting the previous one.
+        // Decide under the lock, act outside it so onComplete never fires while holding it.
         val startFetch = synchronized(callbackLock) {
             val inFlight = pendingCompletionCallbacks[appUserID]
             if (inFlight != null) {
-                // A fetch for this user is already running. Queue our callback onto it and return; it
-                // fires when that in-flight sequence finishes. Joining is independent of cache freshness
-                // on purpose: the list response stamps the cache fresh partway through the sequence
-                // (before its prefetch finishes), so a freshness-only check would let this caller
-                // complete early, before the sequence it joined is done.
+                // Already fetching for this user: queue onto it. Joining ignores cache freshness on
+                // purpose — the list response stamps the cache fresh mid-sequence, before its prefetch
+                // finishes, so a freshness check would let this caller complete early.
                 inFlight.add(onComplete)
                 return
             }
-            // Nothing in flight: register this callback as the head of a new batch, then fetch only if
-            // the cached list is stale. A fresh cache means there's nothing to wait for, so we complete
-            // the batch immediately below instead of starting a request.
+            // Nothing in flight: open a batch and fetch only if the cached list is stale.
             pendingCompletionCallbacks[appUserID] = mutableListOf(onComplete)
             workflowsCache.isWorkflowsListCacheStale(appInBackground)
         }
 
-        // Fresh cache and nothing in flight: nothing to wait for, so complete the batch right away.
-        // Otherwise start the request; its onSuccess/onError fire the queued callbacks when it settles.
+        // Fresh cache and nothing in flight: complete now. Otherwise the request's onSuccess/onError
+        // fire the queued callbacks when it settles.
         if (!startFetch) {
             completePendingCallbacks(appUserID)
         } else {
@@ -160,18 +149,16 @@ internal class WorkflowManager(
                 appInBackground = appInBackground,
                 type = "paywall",
                 onSuccess = { response ->
-                    // Drop workflows without an offeringId up front: they can't be reached via
-                    // workflowIdForOfferingId, so caching or prefetching them would be wasted work. The
-                    // backend should only return offering-tied workflows here; this is a guard on top.
+                    // Drop workflows without an offeringId: they can't be reached via
+                    // workflowIdForOfferingId, so caching or prefetching them is wasted work.
                     val filtered = response.onlyWorkflowsWithOfferingId()
                     workflowsCache.cacheWorkflowsList(filtered, buildOfferingIdMap(filtered.workflows))
 
                     val prefetchWorkflows = filtered.workflows.filter { it.prefetch }
                     scope.launch {
-                        // Prefetch workflows with bounded concurrency (at most MAX_CONCURRENT_PREFETCHES
-                        // at a time) and wait for all of them before completing, so onComplete fires only
-                        // once the whole sequence settles (empty list completes right away). A failed
-                        // prefetch is logged and does not fail the others.
+                        // Prefetch with bounded concurrency, waiting for all before completing so
+                        // onComplete fires once the whole sequence settles. A failed prefetch is logged
+                        // and does not fail the others.
                         coroutineScope {
                             prefetchWorkflows.forEach { summary ->
                                 launch {
@@ -186,8 +173,8 @@ internal class WorkflowManager(
                 },
                 onError = { error ->
                     errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
-                    // Restore the in-memory cache from the disk copy without rewriting disk: the disk
-                    // already holds this payload, so a write would just persist the same bytes again.
+                    // Restore the in-memory cache from disk without rewriting it — disk already holds
+                    // this payload.
                     workflowsCache.cachedWorkflowsListResponseFromDisk()?.let { response ->
                         val filtered = response.onlyWorkflowsWithOfferingId()
                         workflowsCache.cacheWorkflowsListInMemory(filtered, buildOfferingIdMap(filtered.workflows))

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -14,17 +14,17 @@ import com.revenuecat.purchases.common.caching.InMemoryCachedObject
 import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.toPurchasesError
-import com.revenuecat.purchases.common.verification.SignatureVerificationException
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import java.io.IOException
 import java.util.concurrent.atomic.AtomicInteger
 
+@Suppress("LongParameterList")
 internal class WorkflowManager(
     private val backend: Backend,
     private val workflowDetailResolver: WorkflowDetailResolver,
@@ -32,6 +32,7 @@ internal class WorkflowManager(
     private val deviceCache: DeviceCache,
     private val dateProvider: DateProvider = DefaultDateProvider(),
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    private val useWorkflowsEndpoint: Boolean = BuildConfig.USE_WORKFLOWS_ENDPOINT,
 ) {
 
     private val workflowsListCachedObject = InMemoryCachedObject<WorkflowsListResponse>(
@@ -63,20 +64,24 @@ internal class WorkflowManager(
             appInBackground = appInBackground,
             onSuccess = { response ->
                 scope.launch {
-                    try {
-                        val result = workflowDetailResolver.resolve(response)
-                        scope.launch {
-                            runCatching { workflowAssetPreDownloader.preDownloadWorkflowAssets(result.workflow) }
-                                .onFailure { errorLog(it) { "Failed to pre-download workflow assets" } }
-                        }
-                        onSuccess(result)
-                    } catch (e: IllegalStateException) {
+                    // resolve() can throw a range of exceptions (IllegalStateException, IOException,
+                    // SignatureVerificationException, and SerializationException from parsing CDN json).
+                    // getWorkflow MUST always invoke exactly one of onSuccess/onError: the prefetch
+                    // counter in getWorkflowsList (and the offerings delivery gated on it) deadlocks if
+                    // a callback is ever skipped. Catch broadly so no unexpected type breaks that contract.
+                    val result = try {
+                        workflowDetailResolver.resolve(response)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                         onError(e.toPurchasesError())
-                    } catch (e: IOException) {
-                        onError(e.toPurchasesError())
-                    } catch (e: SignatureVerificationException) {
-                        onError(e.toPurchasesError())
+                        return@launch
                     }
+                    scope.launch {
+                        runCatching { workflowAssetPreDownloader.preDownloadWorkflowAssets(result.workflow) }
+                            .onFailure { errorLog(it) { "Failed to pre-download workflow assets" } }
+                    }
+                    onSuccess(result)
                 }
             },
             onError = onError,
@@ -93,7 +98,7 @@ internal class WorkflowManager(
      * drained together when the in-flight work finishes.
      */
     fun getWorkflowsList(appUserID: String, appInBackground: Boolean, onComplete: () -> Unit = {}) {
-        if (!BuildConfig.USE_WORKFLOWS_ENDPOINT ||
+        if (!useWorkflowsEndpoint ||
             !workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)
         ) {
             onComplete()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -94,47 +94,69 @@ internal class WorkflowManager(
      * for a different user starts its own fetch rather than joining the in-flight one.
      */
     fun getWorkflowsList(appUserID: String, appInBackground: Boolean, onComplete: () -> Unit = {}) {
-        when (resolveWorkflowsListFetch(appUserID, appInBackground, onComplete)) {
-            // Callback queued onto in-flight work; it completes when that work finishes.
-            FetchDecision.JOIN -> return
-            FetchDecision.COMPLETE_NOW -> {
-                onComplete()
-                return
-            }
-            FetchDecision.FETCH -> Unit
+        if (!useWorkflowsEndpoint) {
+            onComplete()
+            return
         }
 
-        backend.getWorkflows(
-            appUserID = appUserID,
-            appInBackground = appInBackground,
-            type = "paywall",
-            onSuccess = { response ->
-                workflowsCache.cacheWorkflowsList(response, buildOfferingIdMap(response.workflows))
+        // Decide under the lock and act outside it, so onComplete never fires while the lock is held.
+        // The decision is keyed by appUserID: a call only joins an in-flight fetch for the *same* user,
+        // so an identity switch starts its own fetch instead of inheriting the previous one.
+        val startFetch = synchronized(callbackLock) {
+            val inFlight = pendingCompletionCallbacks[appUserID]
+            if (inFlight != null) {
+                // A fetch for this user is already running. Queue our callback onto it and return; it
+                // fires when that in-flight sequence finishes. Joining is independent of cache freshness
+                // on purpose: the list response stamps the cache fresh partway through the sequence
+                // (before its prefetch finishes), so a freshness-only check would let this caller
+                // complete early, before the sequence it joined is done.
+                inFlight.add(onComplete)
+                return
+            }
+            // Nothing in flight: register this callback as the head of a new batch, then fetch only if
+            // the cached list is stale. A fresh cache means there's nothing to wait for, so we complete
+            // the batch immediately below instead of starting a request.
+            pendingCompletionCallbacks[appUserID] = mutableListOf(onComplete)
+            workflowsCache.isWorkflowsListCacheStale(appInBackground)
+        }
 
-                // A workflow with no offeringId can't be reached via workflowIdForOfferingId, so
-                // prefetching its assets would be wasted work. The backend should already only set
-                // prefetch = true for workflows tied to an offering; this is a defensive guard on top.
-                val prefetchWorkflows = response.workflows.filter { it.prefetch && it.offeringId != null }
-                scope.launch {
-                    // Prefetch each workflow concurrently and wait for all of them before completing,
-                    // so onComplete fires only once the whole sequence settles (empty list completes
-                    // right away). A failed prefetch is logged and does not fail the others.
-                    coroutineScope {
-                        prefetchWorkflows.forEach { summary ->
-                            launch { prefetchWorkflow(appUserID, summary.id, appInBackground) }
+        // Fresh cache and nothing in flight: nothing to wait for, so complete the batch right away.
+        // Otherwise start the request; its onSuccess/onError fire the queued callbacks when it settles.
+        if (!startFetch) {
+            completePendingCallbacks(appUserID)
+        } else {
+            backend.getWorkflows(
+                appUserID = appUserID,
+                appInBackground = appInBackground,
+                type = "paywall",
+                onSuccess = { response ->
+                    workflowsCache.cacheWorkflowsList(response, buildOfferingIdMap(response.workflows))
+
+                    // A workflow with no offeringId can't be reached via workflowIdForOfferingId, so
+                    // prefetching its assets would be wasted work. The backend should already only set
+                    // prefetch = true for workflows tied to an offering; this is a defensive guard on top.
+                    val prefetchWorkflows = response.workflows.filter { it.prefetch && it.offeringId != null }
+                    scope.launch {
+                        // Prefetch each workflow concurrently and wait for all of them before completing,
+                        // so onComplete fires only once the whole sequence settles (empty list completes
+                        // right away). A failed prefetch is logged and does not fail the others.
+                        coroutineScope {
+                            prefetchWorkflows.forEach { summary ->
+                                launch { prefetchWorkflow(appUserID, summary.id, appInBackground) }
+                            }
                         }
+                        completePendingCallbacks(appUserID)
+                    }
+                },
+                onError = { error ->
+                    errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
+                    workflowsCache.cachedWorkflowsListResponseFromDisk()?.let { response ->
+                        workflowsCache.cacheWorkflowsList(response, buildOfferingIdMap(response.workflows))
                     }
                     completePendingCallbacks(appUserID)
-                }
-            },
-            onError = { error ->
-                errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
-                workflowsCache.cachedWorkflowsListResponseFromDisk()?.let { response ->
-                    workflowsCache.cacheWorkflowsList(response, buildOfferingIdMap(response.workflows))
-                }
-                completePendingCallbacks(appUserID)
-            },
-        )
+                },
+            )
+        }
     }
 
     /**
@@ -159,61 +181,6 @@ internal class WorkflowManager(
 
     fun workflowIdForOfferingId(offeringId: String): String? =
         workflowsCache.workflowIdForOfferingId(offeringId)
-
-    /**
-     * What a [getWorkflowsList] call should do, decided under [callbackLock] by
-     * [resolveWorkflowsListFetch] and acted on *outside* the lock so the completion callback is
-     * never invoked while holding it.
-     */
-    private enum class FetchDecision {
-        /** No in-flight fetch and the list cache is stale: start a new backend request. */
-        FETCH,
-
-        /**
-         * A fetch for the same appUserID is already running. This call's completion callback is
-         * queued onto it and fires when that in-flight sequence finishes, so the caller just returns
-         * without a new request. Joining is independent of cache freshness on purpose: the list
-         * response stamps the cache fresh partway through the sequence (before its prefetch
-         * finishes), so a freshness-only check would let this caller complete early, before the
-         * sequence it joined is done.
-         */
-        JOIN,
-
-        /**
-         * Nothing to wait for, so the completion callback fires right away. Either the workflows
-         * endpoint is disabled, or the list cache is fresh and no fetch is in flight.
-         */
-        COMPLETE_NOW,
-    }
-
-    /**
-     * Decides how a [getWorkflowsList] call should proceed, queueing [onComplete] when it must wait.
-     * See [FetchDecision] for what each outcome means.
-     *
-     * The decision is keyed by [appUserID]: a call only joins an in-flight fetch for the *same*
-     * user, so an identity switch starts its own fetch instead of inheriting the previous one.
-     */
-    private fun resolveWorkflowsListFetch(
-        appUserID: String,
-        appInBackground: Boolean,
-        onComplete: () -> Unit,
-    ): FetchDecision {
-        if (!useWorkflowsEndpoint) return FetchDecision.COMPLETE_NOW
-        return synchronized(callbackLock) {
-            val inFlight = pendingCompletionCallbacks[appUserID]
-            when {
-                inFlight != null -> {
-                    inFlight.add(onComplete)
-                    FetchDecision.JOIN
-                }
-                workflowsCache.isWorkflowsListCacheStale(appInBackground) -> {
-                    pendingCompletionCallbacks[appUserID] = mutableListOf(onComplete)
-                    FetchDecision.FETCH
-                }
-                else -> FetchDecision.COMPLETE_NOW
-            }
-        }
-    }
 
     private fun completePendingCallbacks(appUserID: String) {
         val callbacks = synchronized(callbackLock) {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 
 internal class WorkflowManager(
     private val backend: Backend,
@@ -26,11 +28,20 @@ internal class WorkflowManager(
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {
 
+    private companion object {
+        // Caps how many workflows are prefetched at once. The cap matters for the CDN/asset
+        // download work each prefetch kicks off on Dispatchers.IO, so a long workflows list does
+        // not fan out into an unbounded number of concurrent downloads.
+        private const val MAX_CONCURRENT_PREFETCHES = 4
+    }
+
     // Guards pendingCompletionCallbacks. A key is present while a workflows-list fetch (plus its
     // prefetch) is in flight for that appUserID, so concurrent callers join only their own user's
     // request — a different user starts its own fetch instead of receiving the wrong user's list.
     private val callbackLock = Any()
     private val pendingCompletionCallbacks = mutableMapOf<String, MutableList<() -> Unit>>()
+
+    private val prefetchSemaphore = Semaphore(MAX_CONCURRENT_PREFETCHES)
 
     fun close() {
         scope.cancel()
@@ -129,12 +140,17 @@ internal class WorkflowManager(
                     // prefetch = true for workflows tied to an offering; this is a defensive guard on top.
                     val prefetchWorkflows = response.workflows.filter { it.prefetch && it.offeringId != null }
                     scope.launch {
-                        // Prefetch each workflow concurrently and wait for all of them before completing,
-                        // so onComplete fires only once the whole sequence settles (empty list completes
-                        // right away). A failed prefetch is logged and does not fail the others.
+                        // Prefetch workflows with bounded concurrency (at most MAX_CONCURRENT_PREFETCHES
+                        // at a time) and wait for all of them before completing, so onComplete fires only
+                        // once the whole sequence settles (empty list completes right away). A failed
+                        // prefetch is logged and does not fail the others.
                         coroutineScope {
                             prefetchWorkflows.forEach { summary ->
-                                launch { prefetchWorkflow(appUserID, summary.id, appInBackground) }
+                                launch {
+                                    prefetchSemaphore.withPermit {
+                                        prefetchWorkflow(appUserID, summary.id, appInBackground)
+                                    }
+                                }
                             }
                         }
                         completePendingCallbacks(appUserID)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -213,6 +213,15 @@ internal class WorkflowManager(
     fun workflowIdForOfferingId(offeringId: String): String? =
         workflowsCache.workflowIdForOfferingId(offeringId)
 
+    /**
+     * Marks the workflows list stale so the next [getWorkflowsList] refetches it. Called when
+     * offerings are refetched off their normal TTL (forced/locale change) to keep the workflow map
+     * aligned with the offerings the caller just received.
+     */
+    fun forceWorkflowsListCacheStale() {
+        workflowsCache.forceWorkflowsListCacheStale()
+    }
+
     private fun completePendingCallbacks(appUserID: String) {
         val callbacks = synchronized(callbackLock) {
             pendingCompletionCallbacks.remove(appUserID).orEmpty()

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -7,6 +7,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.errorLog
+import com.revenuecat.purchases.common.safeResume
 import com.revenuecat.purchases.common.toPurchasesError
 import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
@@ -14,8 +15,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 @Suppress("LongParameterList")
 internal class WorkflowManager(
@@ -80,13 +82,16 @@ internal class WorkflowManager(
 
     /**
      * Fetches the workflows list, then prefetches all entries marked `prefetch = true`.
-     * [onComplete] fires only after the list fetch AND all prefetch CDN fetches finish
-     * (success or failure), making it safe to call [workflowIdForOfferingId] in [onComplete].
+     *
+     * Offerings delivery is gated on [onComplete] (see
+     * [com.revenuecat.purchases.common.offerings.OfferingsManager]): it is invoked once the whole
+     * sequence settles — list fetched, every prefetch finished or failed — so it must always fire
+     * exactly once, otherwise offerings would never be delivered to the caller.
      *
      * Concurrent callers for the same [appUserID] while a request is in-flight are deduplicated:
-     * the second call queues its [onComplete] and returns without a new network request. All
-     * pending callbacks for that user complete together when the in-flight work finishes.
-     * A call for a different user starts its own fetch rather than joining the in-flight one.
+     * the second call queues its [onComplete] and returns without a new network request, then all
+     * pending callbacks for that user fire together when the in-flight sequence finishes. A call
+     * for a different user starts its own fetch rather than joining the in-flight one.
      */
     fun getWorkflowsList(appUserID: String, appInBackground: Boolean, onComplete: () -> Unit = {}) {
         when (resolveWorkflowsListFetch(appUserID, appInBackground, onComplete)) {
@@ -110,26 +115,16 @@ internal class WorkflowManager(
                 // prefetching its assets would be wasted work. The backend should already only set
                 // prefetch = true for workflows tied to an offering; this is a defensive guard on top.
                 val prefetchWorkflows = response.workflows.filter { it.prefetch && it.offeringId != null }
-                if (prefetchWorkflows.isEmpty()) {
-                    completePendingCallbacks(appUserID)
-                } else {
-                    val remaining = AtomicInteger(prefetchWorkflows.size)
-                    prefetchWorkflows.forEach { summary ->
-                        getWorkflow(
-                            appUserID = appUserID,
-                            workflowId = summary.id,
-                            appInBackground = appInBackground,
-                            onSuccess = {
-                                if (remaining.decrementAndGet() == 0) completePendingCallbacks(appUserID)
-                            },
-                            onError = { error ->
-                                errorLog {
-                                    "Failed to prefetch workflow ${summary.id}: ${error.underlyingErrorMessage}"
-                                }
-                                if (remaining.decrementAndGet() == 0) completePendingCallbacks(appUserID)
-                            },
-                        )
+                scope.launch {
+                    // Prefetch each workflow concurrently and wait for all of them before completing,
+                    // so onComplete fires only once the whole sequence settles (empty list completes
+                    // right away). A failed prefetch is logged and does not fail the others.
+                    coroutineScope {
+                        prefetchWorkflows.forEach { summary ->
+                            launch { prefetchWorkflow(appUserID, summary.id, appInBackground) }
+                        }
                     }
+                    completePendingCallbacks(appUserID)
                 }
             },
             onError = { error ->
@@ -140,6 +135,26 @@ internal class WorkflowManager(
                 completePendingCallbacks(appUserID)
             },
         )
+    }
+
+    /**
+     * Suspends until [getWorkflow] for [workflowId] resolves. Prefetch is best-effort, so a failure
+     * is logged and the coroutine resumes normally instead of throwing, keeping one failed prefetch
+     * from cancelling its siblings in the surrounding [coroutineScope].
+     */
+    private suspend fun prefetchWorkflow(appUserID: String, workflowId: String, appInBackground: Boolean) {
+        suspendCancellableCoroutine { continuation ->
+            getWorkflow(
+                appUserID = appUserID,
+                workflowId = workflowId,
+                appInBackground = appInBackground,
+                onSuccess = { continuation.safeResume(Unit) },
+                onError = { error ->
+                    errorLog { "Failed to prefetch workflow $workflowId: ${error.underlyingErrorMessage}" }
+                    continuation.safeResume(Unit)
+                },
+            )
+        }
     }
 
     fun workflowIdForOfferingId(offeringId: String): String? =
@@ -155,11 +170,12 @@ internal class WorkflowManager(
         FETCH,
 
         /**
-         * A fetch for the same appUserID is already running. This call's completion callback was
-         * queued onto it and fires when that fetch and its prefetch finish, so the caller just
-         * returns without a new request. Joining is independent of cache freshness on purpose: the
-         * list response stamps the cache fresh before its prefetch details land, so completing on a
-         * fresh cache would fire the callback too early.
+         * A fetch for the same appUserID is already running. This call's completion callback is
+         * queued onto it and fires when that in-flight sequence finishes, so the caller just returns
+         * without a new request. Joining is independent of cache freshness on purpose: the list
+         * response stamps the cache fresh partway through the sequence (before its prefetch
+         * finishes), so a freshness-only check would let this caller complete early, before the
+         * sequence it joined is done.
          */
         JOIN,
 

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -5,6 +5,7 @@ package com.revenuecat.purchases.common.workflows
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
@@ -14,6 +15,7 @@ import com.revenuecat.purchases.common.caching.isCacheStale
 import com.revenuecat.purchases.common.errorLog
 import com.revenuecat.purchases.common.toPurchasesError
 import com.revenuecat.purchases.common.verification.SignatureVerificationException
+import com.revenuecat.purchases.common.warnLog
 import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -21,6 +23,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.io.IOException
+
+internal typealias WorkflowPreWarmer = (appUserID: String, offeringIdentifier: String, appInBackground: Boolean) -> Unit
 
 internal class WorkflowManager(
     private val backend: Backend,
@@ -37,6 +41,9 @@ internal class WorkflowManager(
 
     @Volatile
     private var offeringIdToWorkflowIdMap: Map<String, String> = emptyMap()
+
+    @Volatile
+    private var isFetchingWorkflowsList = false
 
     fun close() {
         scope.cancel()
@@ -76,20 +83,23 @@ internal class WorkflowManager(
     }
 
     fun getWorkflowsList(appUserID: String, appInBackground: Boolean) {
-        if (!workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)) {
+        if (!BuildConfig.USE_WORKFLOWS_ENDPOINT ||
+            !workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider) ||
+            isFetchingWorkflowsList
+        ) {
             return
         }
+        isFetchingWorkflowsList = true
         backend.getWorkflows(
             appUserID = appUserID,
             appInBackground = appInBackground,
             onSuccess = { response ->
+                isFetchingWorkflowsList = false
                 workflowsListCachedObject.cacheInstance(response)
                 deviceCache.cacheWorkflowsListResponse(
                     JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), response),
                 )
-                offeringIdToWorkflowIdMap = response.workflows
-                    .mapNotNull { summary -> summary.offeringId?.let { it to summary.id } }
-                    .toMap()
+                offeringIdToWorkflowIdMap = buildOfferingIdMap(response.workflows)
                 response.workflows
                     .filter { it.prefetch }
                     .forEach { summary ->
@@ -107,13 +117,13 @@ internal class WorkflowManager(
                     }
             },
             onError = { error ->
+                isFetchingWorkflowsList = false
                 errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
                 deviceCache.getWorkflowsListResponseCache()?.let { cached ->
                     runCatching { WorkflowJsonParser.parseWorkflowsListResponse(cached) }
                         .onSuccess { response ->
-                            offeringIdToWorkflowIdMap = response.workflows
-                                .mapNotNull { summary -> summary.offeringId?.let { it to summary.id } }
-                                .toMap()
+                            workflowsListCachedObject.cacheInstance(response)
+                            offeringIdToWorkflowIdMap = buildOfferingIdMap(response.workflows)
                         }
                         .onFailure { errorLog(it) { "Failed to restore workflows list from disk cache" } }
                 }
@@ -123,4 +133,16 @@ internal class WorkflowManager(
 
     fun workflowIdForOfferingId(offeringId: String): String? =
         offeringIdToWorkflowIdMap[offeringId]
+
+    private fun buildOfferingIdMap(workflows: List<WorkflowSummary>): Map<String, String> {
+        val pairs = workflows.mapNotNull { summary -> summary.offeringId?.let { it to summary.id } }
+        return pairs
+            .groupBy { it.first }
+            .also { grouped ->
+                grouped.filter { it.value.size > 1 }.keys.forEach { duplicateOfferingId ->
+                    warnLog { "Duplicate offeringId in workflows response: $duplicateOfferingId" }
+                }
+            }
+            .mapValues { it.value.last().second }
+    }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -29,9 +29,8 @@ internal class WorkflowManager(
 ) {
 
     private companion object {
-        // Caps how many workflows are prefetched at once. The cap matters for the CDN/asset
-        // download work each prefetch kicks off on Dispatchers.IO, so a long workflows list does
-        // not fan out into an unbounded number of concurrent downloads.
+        // Caps how many workflows are prefetched at once, so a long workflows list does not fan out
+        // into an unbounded number of concurrent CDN/asset downloads.
         private const val MAX_CONCURRENT_PREFETCHES = 4
     }
 
@@ -41,6 +40,14 @@ internal class WorkflowManager(
     private val callbackLock = Any()
     private val pendingCompletionCallbacks = mutableMapOf<String, MutableList<() -> Unit>>()
 
+    // A Semaphore rather than a limitedParallelism dispatcher (as RemoteConfig's TopicFetcher uses)
+    // because a single prefetch is suspended almost the whole time: the detail fetch is a callback
+    // suspending on backend.getWorkflow, and the CDN/asset downloads run on the FileRepository/Coil
+    // scopes, not this one. A limitedParallelism dispatcher only caps actively-running coroutines, so
+    // a suspended prefetch would free its slot and let the next one start — capping nothing. The
+    // Semaphore holds its permit across those suspension points, bounding the in-flight pipeline end
+    // to end. The detail HTTP calls are separately parallelized and capped by the Backend concurrent
+    // dispatcher pool (also sized to MAX_CONCURRENT_PREFETCHES).
     private val prefetchSemaphore = Semaphore(MAX_CONCURRENT_PREFETCHES)
 
     fun close() {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowManager.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicInteger
 
 internal class WorkflowManager(
     private val backend: Backend,
@@ -40,8 +41,10 @@ internal class WorkflowManager(
     @Volatile
     private var offeringIdToWorkflowIdMap: Map<String, String> = emptyMap()
 
-    @Volatile
+    // Guards isFetchingWorkflowsList and pendingCompletionCallbacks together.
+    private val callbackLock = Any()
     private var isFetchingWorkflowsList = false
+    private val pendingCompletionCallbacks = mutableListOf<() -> Unit>()
 
     fun close() {
         scope.cancel()
@@ -80,42 +83,63 @@ internal class WorkflowManager(
         )
     }
 
-    fun getWorkflowsList(appUserID: String, appInBackground: Boolean) {
+    /**
+     * Fetches the workflows list, then prefetches all entries marked `prefetch = true`.
+     * [onComplete] fires only after the list fetch AND all prefetch CDN fetches finish
+     * (success or failure), making it safe to call [workflowIdForOfferingId] in [onComplete].
+     *
+     * Concurrent callers while a request is in-flight are deduplicated: the second call queues
+     * its [onComplete] and returns without a new network request. All pending callbacks are
+     * drained together when the in-flight work finishes.
+     */
+    fun getWorkflowsList(appUserID: String, appInBackground: Boolean, onComplete: () -> Unit = {}) {
         if (!BuildConfig.USE_WORKFLOWS_ENDPOINT ||
-            !workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider) ||
-            isFetchingWorkflowsList
+            !workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)
         ) {
+            onComplete()
             return
         }
-        isFetchingWorkflowsList = true
+
+        synchronized(callbackLock) {
+            pendingCompletionCallbacks.add(onComplete)
+            if (isFetchingWorkflowsList) return
+            isFetchingWorkflowsList = true
+        }
+
         backend.getWorkflows(
             appUserID = appUserID,
             appInBackground = appInBackground,
             onSuccess = { response ->
-                isFetchingWorkflowsList = false
                 workflowsListCachedObject.cacheInstance(response)
                 deviceCache.cacheWorkflowsListResponse(
                     JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), response),
                 )
                 offeringIdToWorkflowIdMap = buildOfferingIdMap(response.workflows)
-                response.workflows
-                    .filter { it.prefetch }
-                    .forEach { summary ->
+
+                val prefetchWorkflows = response.workflows.filter { it.prefetch }
+                if (prefetchWorkflows.isEmpty()) {
+                    drainCompletionCallbacks()
+                } else {
+                    val remaining = AtomicInteger(prefetchWorkflows.size)
+                    prefetchWorkflows.forEach { summary ->
                         getWorkflow(
                             appUserID = appUserID,
                             workflowId = summary.id,
                             appInBackground = appInBackground,
-                            onSuccess = {},
+                            onSuccess = {
+                                if (remaining.decrementAndGet() == 0) drainCompletionCallbacks()
+                            },
                             onError = { error ->
                                 errorLog {
                                     "Failed to prefetch workflow ${summary.id}: ${error.underlyingErrorMessage}"
                                 }
+                                if (remaining.decrementAndGet() == 0) drainCompletionCallbacks()
                             },
                         )
                     }
+                }
             },
             onError = { error ->
-                isFetchingWorkflowsList = false
                 errorLog { "Failed to fetch workflows list: ${error.underlyingErrorMessage}" }
                 deviceCache.getWorkflowsListResponseCache()?.let { cached ->
                     runCatching { WorkflowJsonParser.parseWorkflowsListResponse(cached) }
@@ -125,12 +149,21 @@ internal class WorkflowManager(
                         }
                         .onFailure { errorLog(it) { "Failed to restore workflows list from disk cache" } }
                 }
+                drainCompletionCallbacks()
             },
         )
     }
 
     fun workflowIdForOfferingId(offeringId: String): String? =
         offeringIdToWorkflowIdMap[offeringId]
+
+    private fun drainCompletionCallbacks() {
+        val callbacks = synchronized(callbackLock) {
+            isFetchingWorkflowsList = false
+            pendingCompletionCallbacks.toList().also { pendingCompletionCallbacks.clear() }
+        }
+        callbacks.forEach { it() }
+    }
 
     private fun buildOfferingIdMap(workflows: List<WorkflowSummary>): Map<String, String> {
         val pairs = workflows.mapNotNull { summary -> summary.offeringId?.let { it to summary.id } }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -11,6 +11,13 @@ import com.revenuecat.purchases.common.caching.isCacheStale
  * workflows list (plus its derived offeringId → workflowId map). It is the single owner of this
  * state so that clearing it on identity transitions wipes everything at once, mirroring how
  * [com.revenuecat.purchases.common.offerings.OfferingsCache] owns the in-memory offerings cache.
+ *
+ * Why in-memory, like offerings: the durable copy of the workflows list already lives on disk in
+ * [com.revenuecat.purchases.common.caching.DeviceCache] (and is restored from there on backend
+ * failure). This layer exists on top of it for the same reason the offerings cache does — to serve
+ * already-fetched and prefetched data synchronously within a session, so opening a paywall reuses a
+ * resolved workflow instead of paying another backend/CDN round-trip. Time-based staleness
+ * ([isWorkflowsListCacheStale] / [isWorkflowCacheStale]) then decides when a refetch is due.
  */
 @OptIn(InternalRevenueCatAPI::class)
 internal class WorkflowsCache(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -46,6 +46,16 @@ internal class WorkflowsCache(
     fun isWorkflowsListCacheStale(appInBackground: Boolean): Boolean =
         workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)
 
+    /**
+     * Caches the workflows list unconditionally, the same way
+     * [com.revenuecat.purchases.common.offerings.OfferingsCache.cacheOfferings] caches offerings.
+     *
+     * This means workflows share the same accepted appUserID limitation as offerings: a fetch that
+     * is in flight during an identity transition can complete *after* [clearCache] and repopulate
+     * the cleared cache with the previous user's list (last-write-wins). It is not guarded here, so
+     * it self-heals on the next fetch, exactly as the offerings cache does. If we ever decide to
+     * close that window, it should be done consistently for both caches rather than only here.
+     */
     @Synchronized
     fun cacheWorkflowsList(response: WorkflowsListResponse, offeringIdMap: Map<String, String>) {
         workflowsListCachedObject.cacheInstance(response)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -73,11 +73,21 @@ internal class WorkflowsCache(
      */
     @Synchronized
     fun cacheWorkflowsList(response: WorkflowsListResponse, offeringIdMap: Map<String, String>) {
-        workflowsListCachedObject.cacheInstance(response)
-        offeringIdToWorkflowIdMap = offeringIdMap
+        cacheWorkflowsListInMemory(response, offeringIdMap)
         deviceCache.cacheWorkflowsListResponse(
             JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), response),
         )
+    }
+
+    /**
+     * Populates only the in-memory list cache and offeringId map, leaving disk untouched. Used to
+     * restore in-memory state from the disk copy after a backend failure, where the disk already
+     * holds this exact payload so rewriting it would be wasted work.
+     */
+    @Synchronized
+    fun cacheWorkflowsListInMemory(response: WorkflowsListResponse, offeringIdMap: Map<String, String>) {
+        workflowsListCachedObject.cacheInstance(response)
+        offeringIdToWorkflowIdMap = offeringIdMap
     }
 
     /**

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -1,0 +1,66 @@
+package com.revenuecat.purchases.common.workflows
+
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.caching.InMemoryCachedObject
+import com.revenuecat.purchases.common.caching.isCacheStale
+
+/**
+ * In-memory cache for all workflow data: the resolved per-workflow [WorkflowDataResult]s and the
+ * workflows list (plus its derived offeringId → workflowId map). It is the single owner of this
+ * state so that clearing it on identity transitions wipes everything at once, mirroring how
+ * [com.revenuecat.purchases.common.offerings.OfferingsCache] owns the in-memory offerings cache.
+ */
+@OptIn(InternalRevenueCatAPI::class)
+internal class WorkflowsCache(
+    private val dateProvider: DateProvider = DefaultDateProvider(),
+) {
+    private val cachedWorkflows = mutableMapOf<String, InMemoryCachedObject<WorkflowDataResult>>()
+    private val workflowsListCachedObject = InMemoryCachedObject<WorkflowsListResponse>(dateProvider = dateProvider)
+
+    @Volatile
+    private var offeringIdToWorkflowIdMap: Map<String, String> = emptyMap()
+
+    // region Workflow detail cache
+
+    @Synchronized
+    fun cachedWorkflow(workflowId: String): WorkflowDataResult? =
+        cachedWorkflows[workflowId]?.cachedInstance
+
+    @Synchronized
+    fun isWorkflowCacheStale(workflowId: String, appInBackground: Boolean): Boolean =
+        cachedWorkflows[workflowId]?.lastUpdatedAt?.isCacheStale(appInBackground, dateProvider) ?: true
+
+    @Synchronized
+    fun cacheWorkflow(workflowId: String, result: WorkflowDataResult) {
+        val cached = cachedWorkflows.getOrPut(workflowId) { InMemoryCachedObject(dateProvider = dateProvider) }
+        cached.cacheInstance(result)
+    }
+
+    // endregion Workflow detail cache
+
+    // region Workflows list cache
+
+    @Synchronized
+    fun isWorkflowsListCacheStale(appInBackground: Boolean): Boolean =
+        workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)
+
+    @Synchronized
+    fun cacheWorkflowsList(response: WorkflowsListResponse, offeringIdMap: Map<String, String>) {
+        workflowsListCachedObject.cacheInstance(response)
+        offeringIdToWorkflowIdMap = offeringIdMap
+    }
+
+    fun workflowIdForOfferingId(offeringId: String): String? =
+        offeringIdToWorkflowIdMap[offeringId]
+
+    // endregion Workflows list cache
+
+    @Synchronized
+    fun clearCache() {
+        cachedWorkflows.clear()
+        workflowsListCachedObject.clearCache()
+        offeringIdToWorkflowIdMap = emptyMap()
+    }
+}

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -1,10 +1,13 @@
 package com.revenuecat.purchases.common.workflows
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.JsonTools
 import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.DefaultDateProvider
+import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.caching.InMemoryCachedObject
 import com.revenuecat.purchases.common.caching.isCacheStale
+import com.revenuecat.purchases.common.errorLog
 
 /**
  * In-memory cache for all workflow data: the resolved per-workflow [WorkflowDataResult]s and the
@@ -12,15 +15,20 @@ import com.revenuecat.purchases.common.caching.isCacheStale
  * state so that clearing it on identity transitions wipes everything at once, mirroring how
  * [com.revenuecat.purchases.common.offerings.OfferingsCache] owns the in-memory offerings cache.
  *
- * Why in-memory, like offerings: the durable copy of the workflows list already lives on disk in
- * [com.revenuecat.purchases.common.caching.DeviceCache] (and is restored from there on backend
- * failure). This layer exists on top of it for the same reason the offerings cache does — to serve
- * already-fetched and prefetched data synchronously within a session, so opening a paywall reuses a
- * resolved workflow instead of paying another backend/CDN round-trip. Time-based staleness
+ * Why in-memory, like offerings: this layer sits on top of the durable copy that lives on disk in
+ * [DeviceCache], for the same reason the offerings cache does — to serve already-fetched and
+ * prefetched data synchronously within a session, so opening a paywall reuses a resolved workflow
+ * instead of paying another backend/CDN round-trip. Time-based staleness
  * ([isWorkflowsListCacheStale] / [isWorkflowCacheStale]) then decides when a refetch is due.
+ *
+ * It also owns the disk copy of the workflows list, mirroring how
+ * [com.revenuecat.purchases.common.offerings.OfferingsCache] owns the offerings response on disk:
+ * [cacheWorkflowsList] persists it, [cachedWorkflowsListResponseFromDisk] restores it on backend
+ * failure, and [clearCache] wipes it on identity transitions.
  */
 @OptIn(InternalRevenueCatAPI::class)
 internal class WorkflowsCache(
+    private val deviceCache: DeviceCache,
     private val dateProvider: DateProvider = DefaultDateProvider(),
 ) {
     private val cachedWorkflows = mutableMapOf<String, InMemoryCachedObject<WorkflowDataResult>>()
@@ -54,7 +62,7 @@ internal class WorkflowsCache(
         workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)
 
     /**
-     * Caches the workflows list unconditionally, the same way
+     * Caches the workflows list in memory and persists it to disk, the same way
      * [com.revenuecat.purchases.common.offerings.OfferingsCache.cacheOfferings] caches offerings.
      *
      * This means workflows share the same accepted appUserID limitation as offerings: a fetch that
@@ -67,7 +75,23 @@ internal class WorkflowsCache(
     fun cacheWorkflowsList(response: WorkflowsListResponse, offeringIdMap: Map<String, String>) {
         workflowsListCachedObject.cacheInstance(response)
         offeringIdToWorkflowIdMap = offeringIdMap
+        deviceCache.cacheWorkflowsListResponse(
+            JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), response),
+        )
     }
+
+    /**
+     * Reads the last workflows list persisted by [cacheWorkflowsList], or null when nothing is
+     * cached or the payload can't be parsed (the parse failure is logged). Used to recover the
+     * list after a backend failure, mirroring
+     * [com.revenuecat.purchases.common.offerings.OfferingsCache.cachedOfferingsResponse].
+     */
+    fun cachedWorkflowsListResponseFromDisk(): WorkflowsListResponse? =
+        deviceCache.getWorkflowsListResponseCache()?.let { cached ->
+            runCatching { WorkflowJsonParser.parseWorkflowsListResponse(cached) }
+                .onFailure { errorLog(it) { "Failed to restore workflows list from disk cache" } }
+                .getOrNull()
+        }
 
     fun workflowIdForOfferingId(offeringId: String): String? =
         offeringIdToWorkflowIdMap[offeringId]
@@ -79,5 +103,6 @@ internal class WorkflowsCache(
         cachedWorkflows.clear()
         workflowsListCachedObject.clearCache()
         offeringIdToWorkflowIdMap = emptyMap()
+        deviceCache.clearWorkflowsListResponseCache()
     }
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowsCache.kt
@@ -62,6 +62,18 @@ internal class WorkflowsCache(
         workflowsListCachedObject.lastUpdatedAt.isCacheStale(appInBackground, dateProvider)
 
     /**
+     * Marks the in-memory list cache stale so the next fetch refreshes it, mirroring
+     * [com.revenuecat.purchases.common.offerings.OfferingsCache.forceCacheStale]. The current list and
+     * offeringId map are kept (so [workflowIdForOfferingId] still resolves during the refetch); only
+     * the freshness timestamp is dropped. Used to keep workflows aligned with offerings when offerings
+     * are refetched off-cycle (forced/locale change), since workflows otherwise track only a time TTL.
+     */
+    @Synchronized
+    fun forceWorkflowsListCacheStale() {
+        workflowsListCachedObject.clearCacheTimestamp()
+    }
+
+    /**
      * Caches the workflows list in memory and persists it to disk, the same way
      * [com.revenuecat.purchases.common.offerings.OfferingsCache.cacheOfferings] caches offerings.
      *

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -20,6 +20,7 @@ import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsMa
 import com.revenuecat.purchases.common.safeResume
 import com.revenuecat.purchases.common.safeResumeWithException
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
+import com.revenuecat.purchases.common.workflows.WorkflowsCache
 import com.revenuecat.purchases.strings.IdentityStrings
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
@@ -34,6 +35,7 @@ internal class IdentityManager(
     private val subscriberAttributesCache: SubscriberAttributesCache,
     private val subscriberAttributesManager: SubscriberAttributesManager,
     private val offeringsCache: OfferingsCache,
+    private val workflowsCache: WorkflowsCache,
     private val backend: Backend,
     private val offlineEntitlementsManager: OfflineEntitlementsManager,
     private val dispatcher: Dispatcher,
@@ -102,6 +104,7 @@ internal class IdentityManager(
                             IdentityStrings.ALIAS_OLD_USER_ID_TO_CURRENT_SUCCESSFUL.format(oldAppUserID, newAppUserID)
                         }
                         offeringsCache.clearCache()
+                        workflowsCache.clearCache()
                         deviceCache.clearCustomerInfoCache(newAppUserID)
                         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
                     }
@@ -154,6 +157,7 @@ internal class IdentityManager(
                         }
                         deviceCache.clearCachesForAppUserID(oldAppUserID)
                         offeringsCache.clearCache()
+                        workflowsCache.clearCache()
                         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
 
                         deviceCache.cacheAppUserID(newAppUserID)
@@ -256,6 +260,7 @@ internal class IdentityManager(
     private fun resetAndSaveUserID(newUserID: String) {
         deviceCache.clearCachesForAppUserID(currentAppUserID)
         offeringsCache.clearCache()
+        workflowsCache.clearCache()
         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(currentAppUserID)
         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
         deviceCache.cacheAppUserID(newUserID)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/identity/IdentityManager.kt
@@ -35,7 +35,7 @@ internal class IdentityManager(
     private val subscriberAttributesCache: SubscriberAttributesCache,
     private val subscriberAttributesManager: SubscriberAttributesManager,
     private val offeringsCache: OfferingsCache,
-    private val workflowsCache: WorkflowsCache,
+    private val workflowsCache: WorkflowsCache?,
     private val backend: Backend,
     private val offlineEntitlementsManager: OfflineEntitlementsManager,
     private val dispatcher: Dispatcher,
@@ -104,7 +104,7 @@ internal class IdentityManager(
                             IdentityStrings.ALIAS_OLD_USER_ID_TO_CURRENT_SUCCESSFUL.format(oldAppUserID, newAppUserID)
                         }
                         offeringsCache.clearCache()
-                        workflowsCache.clearCache()
+                        workflowsCache?.clearCache()
                         deviceCache.clearCustomerInfoCache(newAppUserID)
                         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
                     }
@@ -157,7 +157,7 @@ internal class IdentityManager(
                         }
                         deviceCache.clearCachesForAppUserID(oldAppUserID)
                         offeringsCache.clearCache()
-                        workflowsCache.clearCache()
+                        workflowsCache?.clearCache()
                         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
 
                         deviceCache.cacheAppUserID(newAppUserID)
@@ -260,7 +260,7 @@ internal class IdentityManager(
     private fun resetAndSaveUserID(newUserID: String) {
         deviceCache.clearCachesForAppUserID(currentAppUserID)
         offeringsCache.clearCache()
-        workflowsCache.clearCache()
+        workflowsCache?.clearCache()
         subscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(currentAppUserID)
         offlineEntitlementsManager.resetOfflineCustomerInfoCache()
         deviceCache.cacheAppUserID(newUserID)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/storage/DefaultFileRepository.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/storage/DefaultFileRepository.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -128,19 +127,20 @@ internal class DefaultFileRepository(
             if (fileCacheManager.cachedContentExists(it)) it else null
         }
 
-    private suspend fun downloadFile(url: URL): UrlConnection = try {
-        withContext(Dispatchers.IO) {
-            verboseLog { "Downloading remote file from $url" }
+    // Runs on the ioScope's dispatcher (Dispatchers.IO by default). Callers that inject a
+    // concurrency-limited dispatcher rely on the whole download running here, so this must not
+    // switch dispatchers.
+    private fun downloadFile(url: URL): UrlConnection = try {
+        verboseLog { "Downloading remote file from $url" }
 
-            val connection = urlConnectionFactory.createConnection(url.toString())
+        val connection = urlConnectionFactory.createConnection(url.toString())
 
-            if (connection.responseCode != HttpURLConnection.HTTP_OK) {
-                connection.disconnect()
-                throw IOException("HTTP ${connection.responseCode} when downloading file at: $url")
-            }
-
-            return@withContext connection
+        if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+            connection.disconnect()
+            throw IOException("HTTP ${connection.responseCode} when downloading file at: $url")
         }
+
+        connection
     } catch (e: IOException) {
         val message = "Failed to fetch file from remote source: $url. Error: ${e.localizedMessage}"
         logHandler.e("FileRepository", message, e)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/storage/DefaultFileRepository.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/storage/DefaultFileRepository.kt
@@ -127,9 +127,6 @@ internal class DefaultFileRepository(
             if (fileCacheManager.cachedContentExists(it)) it else null
         }
 
-    // Runs on the ioScope's dispatcher (Dispatchers.IO by default). Callers that inject a
-    // concurrency-limited dispatcher rely on the whole download running here, so this must not
-    // switch dispatchers.
     private fun downloadFile(url: URL): UrlConnection = try {
         verboseLog { "Downloading remote file from $url" }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/BasePurchasesTest.kt
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.common.diagnostics.DiagnosticsSynchronizer
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
 import com.revenuecat.purchases.common.events.EventsManager
 import com.revenuecat.purchases.common.offerings.OfferingsManager
+import com.revenuecat.purchases.common.workflows.WorkflowManager
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.deeplinks.WebPurchaseRedemptionHelper
 import com.revenuecat.purchases.google.toInAppStoreProduct
@@ -91,6 +92,7 @@ internal open class BasePurchasesTest {
     internal val mockFontLoader = mockk<FontLoader>()
     internal val mockVirtualCurrencyManager = mockk<VirtualCurrencyManager>()
     internal val mockPurchaseParamsValidator = mockk<PurchaseParamsValidator>()
+    internal val mockWorkflowManager = mockk<WorkflowManager>(relaxed = true)
     private val mockBlockstoreHelper = mockk<BlockstoreHelper>()
     private val purchasesStateProvider = PurchasesStateCache(PurchasesState())
 
@@ -507,7 +509,7 @@ internal open class BasePurchasesTest {
             blockstoreHelper = mockBlockstoreHelper,
             backupManager = mockBackupManager,
             purchaseParamsValidator = mockPurchaseParamsValidator,
-            workflowManager = mockk(relaxed = true),
+            workflowManager = mockWorkflowManager,
         )
 
         purchases = Purchases(

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesCommonTest.kt
@@ -11,6 +11,7 @@ import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import com.revenuecat.purchases.common.Delay
 import com.revenuecat.purchases.common.ReplaceProductInfo
+import com.revenuecat.purchases.common.workflows.WorkflowDataResult
 import com.revenuecat.purchases.google.billingResponseToPurchasesError
 import com.revenuecat.purchases.google.toInAppStoreProduct
 import com.revenuecat.purchases.google.toStoreProduct
@@ -42,6 +43,7 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import io.mockk.verifyAll
@@ -2814,6 +2816,66 @@ internal class PurchasesCommonTest: BasePurchasesTest() {
 
         purchases.close()
         verifyClose()
+    }
+
+    // endregion
+
+    // region getWorkflow
+
+    @OptIn(InternalRevenueCatAPI::class)
+    @Test
+    fun `getWorkflow delivers the manager success result to the caller`() {
+        val expected = WorkflowDataResult(workflow = mockk(), enrolledVariants = null)
+        val successSlot = slot<(WorkflowDataResult) -> Unit>()
+        every {
+            mockWorkflowManager.getWorkflow(
+                appUserID = appUserId,
+                workflowId = "wf_1",
+                appInBackground = any(),
+                onSuccess = capture(successSlot),
+                onError = any(),
+                callbackDispatcher = any(),
+            )
+        } answers { successSlot.captured(expected) }
+
+        var received: WorkflowDataResult? = null
+        var receivedError: PurchasesError? = null
+        purchases.purchasesOrchestrator.getWorkflow(
+            workflowId = "wf_1",
+            onSuccess = { received = it },
+            onError = { receivedError = it },
+        )
+
+        assertThat(received).isEqualTo(expected)
+        assertThat(receivedError).isNull()
+    }
+
+    @OptIn(InternalRevenueCatAPI::class)
+    @Test
+    fun `getWorkflow delivers the manager error to the caller`() {
+        val expectedError = PurchasesError(PurchasesErrorCode.UnknownError, "boom")
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            mockWorkflowManager.getWorkflow(
+                appUserID = appUserId,
+                workflowId = "wf_1",
+                appInBackground = any(),
+                onSuccess = any(),
+                onError = capture(errorSlot),
+                callbackDispatcher = any(),
+            )
+        } answers { errorSlot.captured(expectedError) }
+
+        var received: WorkflowDataResult? = null
+        var receivedError: PurchasesError? = null
+        purchases.purchasesOrchestrator.getWorkflow(
+            workflowId = "wf_1",
+            onSuccess = { received = it },
+            onError = { receivedError = it },
+        )
+
+        assertThat(receivedError).isEqualTo(expectedError)
+        assertThat(received).isNull()
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/PurchasesFactoryTest.kt
@@ -6,12 +6,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.revenuecat.purchases.common.workflows.WorkflowManager
 import io.mockk.clearAllMocks
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
@@ -192,53 +189,6 @@ class PurchasesFactoryTest {
     fun `shouldInitializeDiagnostics returns false when both diagnostics disabled and preview mode on`() {
         assertThat(PurchasesFactory.shouldInitializeDiagnostics(diagnosticsEnabled = false, uiPreviewMode = true))
             .isFalse
-    }
-
-    // endregion
-
-    // region createWorkflowPreWarmer
-
-    @Test
-    fun `createWorkflowPreWarmer returns null when workflows endpoint is disabled`() {
-        val workflowManager = mockk<WorkflowManager>()
-
-        val workflowPreWarmer = PurchasesFactory.createWorkflowPreWarmer(
-            workflowManager = workflowManager,
-            useWorkflowsEndpoint = false,
-        )
-
-        assertThat(workflowPreWarmer).isNull()
-    }
-
-    @Test
-    fun `createWorkflowPreWarmer fetches workflow when workflows endpoint is enabled`() {
-        val workflowManager = mockk<WorkflowManager>()
-        every {
-            workflowManager.getWorkflow(
-                appUserID = "appUserID",
-                workflowId = "default",
-                appInBackground = true,
-                onSuccess = any(),
-                onError = any(),
-            )
-        } just runs
-
-        val workflowPreWarmer = PurchasesFactory.createWorkflowPreWarmer(
-            workflowManager = workflowManager,
-            useWorkflowsEndpoint = true,
-        )
-
-        workflowPreWarmer?.invoke("appUserID", "default", true)
-
-        verify(exactly = 1) {
-            workflowManager.getWorkflow(
-                appUserID = "appUserID",
-                workflowId = "default",
-                appInBackground = true,
-                onSuccess = any(),
-                onError = any(),
-            )
-        }
     }
 
     // endregion

--- a/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/DeviceCacheTest.kt
@@ -65,6 +65,7 @@ class DeviceCacheTest {
     private val productEntitlementMappingLastUpdatedCacheKey = "com.revenuecat.purchases.api_key.productEntitlementMappingLastUpdated"
     private val productEntitlementMappingCacheKey = "com.revenuecat.purchases.api_key.productEntitlementMapping"
     private val offeringsResponseCacheKey = "com.revenuecat.purchases.api_key.offeringsResponse"
+    private val workflowsListResponseCacheKey = "com.revenuecat.purchases.api_key.workflowsListResponse"
 
     private val slotForPutLong = slot<Long>()
 
@@ -718,6 +719,35 @@ class DeviceCacheTest {
     }
 
     // endregion offerings response
+
+    // region workflows list response
+
+    @Test
+    fun `getWorkflowsListResponseCache returns null when nothing is cached`() {
+        every { mockPrefs.getString(workflowsListResponseCacheKey, null) } returns null
+        assertThat(cache.getWorkflowsListResponseCache()).isNull()
+    }
+
+    @Test
+    fun `cacheWorkflowsListResponse stores string in preferences`() {
+        val payload = """{"workflows":[]}"""
+        cache.cacheWorkflowsListResponse(payload)
+        verifyAll {
+            mockEditor.putString(workflowsListResponseCacheKey, payload)
+            mockEditor.apply()
+        }
+    }
+
+    @Test
+    fun `clearWorkflowsListResponseCache removes key from preferences`() {
+        cache.clearWorkflowsListResponseCache()
+        verifyAll {
+            mockEditor.remove(workflowsListResponseCacheKey)
+            mockEditor.apply()
+        }
+    }
+
+    // endregion workflows list response
 
     // region storefront
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
@@ -335,16 +335,50 @@ class BackendWorkflowsTest {
     }
 
     @Test
-    fun `getWorkflow runs on the concurrent dispatcher, not the default one`() {
+    fun `getWorkflow runs on the provided callbackDispatcher when one is given`() {
         val mainDispatcher = CountingSyncDispatcher()
-        val concurrentDispatcher = CountingSyncDispatcher()
+        val overrideDispatcher = CountingSyncDispatcher()
         val routedBackend = Backend(
             mockAppConfig,
             mainDispatcher,
             mainDispatcher,
             mockClient,
             BackendHelper(apiKey, mainDispatcher, mockAppConfig, mockClient),
-            concurrentDispatcher = concurrentDispatcher,
+        )
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflow(appUserId, "wf_1"),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } returns httpResult(RCHTTPStatusCodes.SUCCESS, """{"action":"inline","data":null}""")
+
+        routedBackend.getWorkflow(
+            appUserID = appUserId,
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = {},
+            callbackDispatcher = overrideDispatcher,
+        )
+
+        assertThat(overrideDispatcher.enqueueCount).isEqualTo(1)
+        assertThat(mainDispatcher.enqueueCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `getWorkflow runs on the default dispatcher when no callbackDispatcher is given`() {
+        val mainDispatcher = CountingSyncDispatcher()
+        val overrideDispatcher = CountingSyncDispatcher()
+        val routedBackend = Backend(
+            mockAppConfig,
+            mainDispatcher,
+            mainDispatcher,
+            mockClient,
+            BackendHelper(apiKey, mainDispatcher, mockAppConfig, mockClient),
         )
         every {
             mockClient.performRequest(
@@ -365,42 +399,8 @@ class BackendWorkflowsTest {
             onError = {},
         )
 
-        assertThat(concurrentDispatcher.enqueueCount).isEqualTo(1)
-        assertThat(mainDispatcher.enqueueCount).isEqualTo(0)
-    }
-
-    @Test
-    fun `getWorkflows runs on the default dispatcher, not the concurrent one`() {
-        val mainDispatcher = CountingSyncDispatcher()
-        val concurrentDispatcher = CountingSyncDispatcher()
-        val routedBackend = Backend(
-            mockAppConfig,
-            mainDispatcher,
-            mainDispatcher,
-            mockClient,
-            BackendHelper(apiKey, mainDispatcher, mockAppConfig, mockClient),
-            concurrentDispatcher = concurrentDispatcher,
-        )
-        every {
-            mockClient.performRequest(
-                baseURL = mockBaseURL,
-                endpoint = Endpoint.GetWorkflows(appUserId),
-                body = null,
-                postFieldsToSign = null,
-                requestHeaders = defaultAuthHeaders,
-                fallbackBaseURLs = emptyList(),
-            )
-        } returns httpResult(RCHTTPStatusCodes.SUCCESS, """{"workflows":[]}""")
-
-        routedBackend.getWorkflows(
-            appUserID = appUserId,
-            appInBackground = false,
-            onSuccess = {},
-            onError = {},
-        )
-
         assertThat(mainDispatcher.enqueueCount).isEqualTo(1)
-        assertThat(concurrentDispatcher.enqueueCount).isEqualTo(0)
+        assertThat(overrideDispatcher.enqueueCount).isEqualTo(0)
     }
 
     private class CountingSyncDispatcher : Dispatcher(mockk()) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BackendHelper
+import com.revenuecat.purchases.common.Delay
 import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.SyncDispatcher
@@ -331,6 +332,85 @@ class BackendWorkflowsTest {
                 fallbackBaseURLs = emptyList(),
             )
         }
+    }
+
+    @Test
+    fun `getWorkflow runs on the concurrent dispatcher, not the default one`() {
+        val mainDispatcher = CountingSyncDispatcher()
+        val concurrentDispatcher = CountingSyncDispatcher()
+        val routedBackend = Backend(
+            mockAppConfig,
+            mainDispatcher,
+            mainDispatcher,
+            mockClient,
+            BackendHelper(apiKey, mainDispatcher, mockAppConfig, mockClient),
+            concurrentDispatcher = concurrentDispatcher,
+        )
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflow(appUserId, "wf_1"),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } returns httpResult(RCHTTPStatusCodes.SUCCESS, """{"action":"inline","data":null}""")
+
+        routedBackend.getWorkflow(
+            appUserID = appUserId,
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = {},
+        )
+
+        assertThat(concurrentDispatcher.enqueueCount).isEqualTo(1)
+        assertThat(mainDispatcher.enqueueCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `getWorkflows runs on the default dispatcher, not the concurrent one`() {
+        val mainDispatcher = CountingSyncDispatcher()
+        val concurrentDispatcher = CountingSyncDispatcher()
+        val routedBackend = Backend(
+            mockAppConfig,
+            mainDispatcher,
+            mainDispatcher,
+            mockClient,
+            BackendHelper(apiKey, mainDispatcher, mockAppConfig, mockClient),
+            concurrentDispatcher = concurrentDispatcher,
+        )
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflows(appUserId),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } returns httpResult(RCHTTPStatusCodes.SUCCESS, """{"workflows":[]}""")
+
+        routedBackend.getWorkflows(
+            appUserID = appUserId,
+            appInBackground = false,
+            onSuccess = {},
+            onError = {},
+        )
+
+        assertThat(mainDispatcher.enqueueCount).isEqualTo(1)
+        assertThat(concurrentDispatcher.enqueueCount).isEqualTo(0)
+    }
+
+    private class CountingSyncDispatcher : Dispatcher(mockk()) {
+        var enqueueCount = 0
+        override fun enqueue(command: Runnable, delay: Delay) {
+            enqueueCount++
+            command.run()
+        }
+        override fun close() = Unit
+        override fun isClosed() = false
     }
 
     private fun httpResult(responseCode: Int, payload: String) = HTTPResult(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
@@ -52,7 +52,6 @@ class OfferingsCacheTest {
     fun `clear cache clears offerings cache and offerings response cache`() {
         val offeringsResponse = JSONObject()
         every { deviceCache.clearOfferingsResponseCache() } just Runs
-        every { deviceCache.clearWorkflowsListResponseCache() } just Runs
         every { deviceCache.cacheOfferingsResponse(any()) } just Runs
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
@@ -63,7 +62,6 @@ class OfferingsCacheTest {
         assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = false)).isTrue
         assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = true)).isTrue
         verify(exactly = 1) { deviceCache.clearOfferingsResponseCache() }
-        verify(exactly = 1) { deviceCache.clearWorkflowsListResponseCache() }
     }
 
     @Test
@@ -256,7 +254,6 @@ class OfferingsCacheTest {
         val offeringsCache = OfferingsCache(deviceCache, dateProvider = dateProvider, localeProvider = localeProvider)
         mockDeviceCacheOfferingResponse()
         every { deviceCache.clearOfferingsResponseCache() } just Runs
-        every { deviceCache.clearWorkflowsListResponseCache() } just Runs
 
         // Act
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsCacheTest.kt
@@ -52,6 +52,7 @@ class OfferingsCacheTest {
     fun `clear cache clears offerings cache and offerings response cache`() {
         val offeringsResponse = JSONObject()
         every { deviceCache.clearOfferingsResponseCache() } just Runs
+        every { deviceCache.clearWorkflowsListResponseCache() } just Runs
         every { deviceCache.cacheOfferingsResponse(any()) } just Runs
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
             every { originalSource } returns HTTPResponseOriginalSource.MAIN
@@ -62,6 +63,7 @@ class OfferingsCacheTest {
         assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = false)).isTrue
         assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = true)).isTrue
         verify(exactly = 1) { deviceCache.clearOfferingsResponseCache() }
+        verify(exactly = 1) { deviceCache.clearWorkflowsListResponseCache() }
     }
 
     @Test
@@ -254,6 +256,7 @@ class OfferingsCacheTest {
         val offeringsCache = OfferingsCache(deviceCache, dateProvider = dateProvider, localeProvider = localeProvider)
         mockDeviceCacheOfferingResponse()
         every { deviceCache.clearOfferingsResponseCache() } just Runs
+        every { deviceCache.clearWorkflowsListResponseCache() } just Runs
 
         // Act
         offeringsCache.cacheOfferings(mockk<Offerings>().apply {
@@ -262,7 +265,7 @@ class OfferingsCacheTest {
         assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = false)).isFalse
         assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = true)).isFalse
         offeringsCache.clearCache()
-        
+
         // Assert
         assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = false)).isTrue
         assertThat(offeringsCache.isOfferingsCacheStale(appInBackground = true)).isTrue

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -579,6 +579,30 @@ class OfferingsManagerTest {
         verify(exactly = 1) {
             mockWorkflowManager.getWorkflowsList(appUserId, false, onComplete = any())
         }
+        // Offerings came fresh from the network, so the workflows list is realigned by being forced
+        // stale before the fetch, rather than skipped on its own TTL.
+        verify(exactly = 1) { mockWorkflowManager.forceWorkflowsListCacheStale() }
+    }
+
+    @Test
+    fun `getOfferings does not force workflows list stale on disk-cache fallback`() {
+        every { cache.cachedOfferings } returns null
+        every { cache.cacheOfferings(any(), any()) } just Runs
+        mockBackendResponseError()
+        every { cache.cachedOfferingsResponse } returns JSONObject(ONE_OFFERINGS_RESPONSE)
+        mockDeviceCache(wasSuccessful = false)
+        mockOfferingsFactory()
+
+        offeringsManager.getOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { fail("Should be success") },
+            onSuccess = {},
+        )
+
+        // Offerings were restored from disk (no real change, backend likely down), so we must not
+        // force a workflows refetch here.
+        verify(exactly = 0) { mockWorkflowManager.forceWorkflowsListCacheStale() }
     }
 
     @Test
@@ -1034,6 +1058,7 @@ class OfferingsManagerTest {
     @Test
     fun `getOfferings does not call onSuccess until getWorkflowsList completes`() {
         val mockWorkflowManager = mockk<WorkflowManager>()
+        every { mockWorkflowManager.forceWorkflowsListCacheStale() } just Runs
         val onCompleteSlot = slot<() -> Unit>()
         every {
             mockWorkflowManager.getWorkflowsList(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -64,6 +64,9 @@ class OfferingsManagerTest {
             every { preDownloadOfferingFontsIfNeeded(any()) } just Runs
         }
         mockWorkflowManager = mockk(relaxed = true)
+        every { mockWorkflowManager.getWorkflowsList(any(), any(), any()) } answers {
+            thirdArg<() -> Unit>().invoke()
+        }
 
         mockBackendResponseSuccess()
         mockDiagnosticsTracker()
@@ -125,7 +128,7 @@ class OfferingsManagerTest {
         mockOfferingsFactory()
         offeringsManager.onAppForeground(appUserID = "user_1")
         verify(exactly = 1) {
-            mockWorkflowManager.getWorkflowsList("user_1", appInBackground = false)
+            mockWorkflowManager.getWorkflowsList("user_1", appInBackground = false, onComplete = any())
         }
     }
 
@@ -574,7 +577,7 @@ class OfferingsManagerTest {
         )
 
         verify(exactly = 1) {
-            mockWorkflowManager.getWorkflowsList(appUserId, false)
+            mockWorkflowManager.getWorkflowsList(appUserId, false, onComplete = any())
         }
     }
 
@@ -592,7 +595,7 @@ class OfferingsManagerTest {
         )
 
         verify(exactly = 1) {
-            mockWorkflowManager.getWorkflowsList(appUserId, true)
+            mockWorkflowManager.getWorkflowsList(appUserId, true, onComplete = any())
         }
     }
 
@@ -610,7 +613,7 @@ class OfferingsManagerTest {
         )
 
         verify(exactly = 1) {
-            mockWorkflowManager.getWorkflowsList(appUserId, false)
+            mockWorkflowManager.getWorkflowsList(appUserId, false, onComplete = any())
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -117,6 +117,17 @@ class OfferingsManagerTest {
         }
     }
 
+    @Test
+    fun `onAppForeground triggers getWorkflowsList when offerings are stale`() {
+        mockCacheStale(offeringsStale = true)
+        mockDeviceCache()
+        mockOfferingsFactory()
+        offeringsManager.onAppForeground(appUserID = "user_1")
+        verify(exactly = 1) {
+            mockWorkflowManager.getWorkflowsList("user_1", appInBackground = false)
+        }
+    }
+
     // endregion onAppForeground
 
     // region getOfferings
@@ -422,6 +433,32 @@ class OfferingsManagerTest {
 
         assertThat(receivedError).isEqualTo(expectedError)
         verify(exactly = 1) { cache.forceCacheStale() }
+    }
+
+    @Test
+    fun `getOfferings succeeds without NPE when workflowManager is null`() {
+        val managerWithNoWorkflows = OfferingsManager(
+            offeringsCache = cache,
+            backend = backend,
+            offeringsFactory = offeringsFactory,
+            offeringImagePreDownloader = offeringImagePreDownloader,
+            diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
+            offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            workflowManager = null,
+        )
+        every { cache.cachedOfferings } returns null
+        mockOfferingsFactory()
+        mockDeviceCache()
+
+        var receivedOfferings: Offerings? = null
+        managerWithNoWorkflows.getOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { fail("Expected success but got error: $it") },
+            onSuccess = { receivedOfferings = it },
+        )
+
+        assertThat(receivedOfferings).isEqualTo(testOfferings)
     }
 
     // This situation shouldn't happen normally since we only cache when we have loaded the offerings at least once,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -21,6 +21,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -1024,4 +1024,76 @@ class OfferingsManagerTest {
             current = current,
             all = this.all,
         )
+
+    // region workflowManager onComplete integration
+
+    @Test
+    fun `getOfferings does not call onSuccess until getWorkflowsList completes`() {
+        val mockWorkflowManager = mockk<WorkflowManager>()
+        val onCompleteSlot = slot<() -> Unit>()
+        every {
+            mockWorkflowManager.getWorkflowsList(
+                appUserID = appUserId,
+                appInBackground = false,
+                onComplete = capture(onCompleteSlot),
+            )
+        } just Runs
+
+        val managerWithWorkflow = OfferingsManager(
+            offeringsCache = cache,
+            backend = backend,
+            offeringsFactory = offeringsFactory,
+            offeringImagePreDownloader = offeringImagePreDownloader,
+            diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
+            offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            workflowManager = mockWorkflowManager,
+        )
+
+        every { cache.cachedOfferings } returns null
+        mockOfferingsFactory()
+        mockDeviceCache()
+
+        var receivedOfferings: Offerings? = null
+        managerWithWorkflow.getOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { fail("should be success") },
+            onSuccess = { receivedOfferings = it },
+        )
+
+        assertThat(receivedOfferings).isNull()
+
+        onCompleteSlot.captured.invoke()
+
+        assertThat(receivedOfferings).isNotNull()
+    }
+
+    @Test
+    fun `getOfferings calls onSuccess immediately when workflowManager is null`() {
+        val managerWithoutWorkflow = OfferingsManager(
+            offeringsCache = cache,
+            backend = backend,
+            offeringsFactory = offeringsFactory,
+            offeringImagePreDownloader = offeringImagePreDownloader,
+            diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
+            offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            workflowManager = null,
+        )
+
+        every { cache.cachedOfferings } returns null
+        mockOfferingsFactory()
+        mockDeviceCache()
+
+        var receivedOfferings: Offerings? = null
+        managerWithoutWorkflow.getOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { fail("should be success") },
+            onSuccess = { receivedOfferings = it },
+        )
+
+        assertThat(receivedOfferings).isNotNull()
+    }
+
+    // endregion workflowManager onComplete integration
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -1124,5 +1124,47 @@ class OfferingsManagerTest {
         assertThat(receivedOfferings).isNotNull()
     }
 
+    @Test
+    fun `getOfferings from valid cache does not call onSuccess until getWorkflowsList completes`() {
+        val mockWorkflowManager = mockk<WorkflowManager>()
+        val onCompleteSlot = slot<() -> Unit>()
+        every {
+            mockWorkflowManager.getWorkflowsList(
+                appUserID = appUserId,
+                appInBackground = false,
+                onComplete = capture(onCompleteSlot),
+            )
+        } just Runs
+
+        val managerWithWorkflow = OfferingsManager(
+            offeringsCache = cache,
+            backend = backend,
+            offeringsFactory = offeringsFactory,
+            offeringImagePreDownloader = offeringImagePreDownloader,
+            diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
+            offeringFontPreDownloader = mockOfferingFontPreDownloader,
+            workflowManager = mockWorkflowManager,
+        )
+
+        every { cache.cachedOfferings } returns testOfferings
+        mockDeviceCache()
+        mockCacheStale(offeringsStale = false)
+
+        var receivedOfferings: Offerings? = null
+        managerWithWorkflow.getOfferings(
+            appUserId,
+            appInBackground = false,
+            onError = { fail("should be success") },
+            onSuccess = { receivedOfferings = it },
+        )
+
+        // Cache hit still waits for the workflows list so the offeringId map is populated on success.
+        assertThat(receivedOfferings).isNull()
+
+        onCompleteSlot.captured.invoke()
+
+        assertThat(receivedOfferings).isNotNull()
+    }
+
     // endregion workflowManager onComplete integration
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/offerings/OfferingsManagerTest.kt
@@ -9,6 +9,7 @@ import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.GetOfferingsErrorHandlingBehavior
 import com.revenuecat.purchases.common.HTTPResponseOriginalSource
 import com.revenuecat.purchases.common.diagnostics.DiagnosticsTracker
+import com.revenuecat.purchases.common.workflows.WorkflowManager
 import com.revenuecat.purchases.paywalls.OfferingFontPreDownloader
 import com.revenuecat.purchases.utils.ONE_OFFERINGS_RESPONSE
 import com.revenuecat.purchases.utils.OfferingImagePreDownloader
@@ -45,7 +46,7 @@ class OfferingsManagerTest {
     private lateinit var offeringImagePreDownloader: OfferingImagePreDownloader
     private lateinit var mockDiagnosticsTracker: DiagnosticsTracker
     private lateinit var mockOfferingFontPreDownloader: OfferingFontPreDownloader
-    private lateinit var mockWorkflowPreWarmer: (String, String, Boolean) -> Unit
+    private lateinit var mockWorkflowManager: WorkflowManager
 
     private lateinit var offeringsManager: OfferingsManager
 
@@ -61,9 +62,7 @@ class OfferingsManagerTest {
         mockOfferingFontPreDownloader = mockk<OfferingFontPreDownloader>().apply {
             every { preDownloadOfferingFontsIfNeeded(any()) } just Runs
         }
-        mockWorkflowPreWarmer = mockk<(String, String, Boolean) -> Unit>().apply {
-            every { this@apply(any(), any(), any()) } just Runs
-        }
+        mockWorkflowManager = mockk(relaxed = true)
 
         mockBackendResponseSuccess()
         mockDiagnosticsTracker()
@@ -75,7 +74,7 @@ class OfferingsManagerTest {
             offeringImagePreDownloader = offeringImagePreDownloader,
             diagnosticsTrackerIfEnabled = mockDiagnosticsTracker,
             offeringFontPreDownloader = mockOfferingFontPreDownloader,
-            workflowPreWarmer = mockWorkflowPreWarmer,
+            workflowManager = mockWorkflowManager,
         )
     }
 
@@ -524,7 +523,7 @@ class OfferingsManagerTest {
     }
 
     @Test
-    fun `getOfferings calls workflowPreWarmer with current offering identifier after offerings are fetched`() {
+    fun `getOfferings calls getWorkflowsList after offerings are fetched`() {
         every { cache.cachedOfferings } returns null
         mockOfferingsFactory()
         mockDeviceCache()
@@ -537,12 +536,12 @@ class OfferingsManagerTest {
         )
 
         verify(exactly = 1) {
-            mockWorkflowPreWarmer(appUserId, STUB_OFFERING_IDENTIFIER, false)
+            mockWorkflowManager.getWorkflowsList(appUserId, false)
         }
     }
 
     @Test
-    fun `getOfferings calls workflowPreWarmer with appInBackground true when app is in background`() {
+    fun `getOfferings calls getWorkflowsList with appInBackground true when app is in background`() {
         every { cache.cachedOfferings } returns null
         mockOfferingsFactory()
         mockDeviceCache()
@@ -555,12 +554,12 @@ class OfferingsManagerTest {
         )
 
         verify(exactly = 1) {
-            mockWorkflowPreWarmer(appUserId, STUB_OFFERING_IDENTIFIER, true)
+            mockWorkflowManager.getWorkflowsList(appUserId, true)
         }
     }
 
     @Test
-    fun `getOfferings does not call workflowPreWarmer if current offering is null`() {
+    fun `getOfferings calls getWorkflowsList even when current offering is null`() {
         every { cache.cachedOfferings } returns null
         mockOfferingsFactory(testOfferings.copy(current = null))
         mockDeviceCache()
@@ -572,8 +571,8 @@ class OfferingsManagerTest {
             onSuccess = {},
         )
 
-        verify(exactly = 0) {
-            mockWorkflowPreWarmer(any(), any(), any())
+        verify(exactly = 1) {
+            mockWorkflowManager.getWorkflowsList(appUserId, false)
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -5,6 +5,8 @@ import com.revenuecat.purchases.NoOpLogHandler
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.Backend
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
 import io.mockk.coEvery
@@ -20,12 +22,15 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
+import java.util.Date
 
 class WorkflowManagerTest {
 
     private val mockBackend: Backend = mockk(relaxed = true)
     private val mockResolver: WorkflowDetailResolver = mockk()
     private val mockAssetPreDownloader: WorkflowAssetPreDownloader = mockk(relaxed = true)
+    private val mockDeviceCache: DeviceCache = mockk(relaxed = true)
+    private val mockDateProvider: DateProvider = mockk()
     private lateinit var workflowManager: WorkflowManager
     private lateinit var originalLogHandler: LogHandler
 
@@ -33,10 +38,13 @@ class WorkflowManagerTest {
     fun setUp() {
         originalLogHandler = currentLogHandler
         currentLogHandler = NoOpLogHandler
+        every { mockDateProvider.now } returns Date(0) // ensures cache is always stale by default
         workflowManager = WorkflowManager(
             backend = mockBackend,
             workflowDetailResolver = mockResolver,
             workflowAssetPreDownloader = mockAssetPreDownloader,
+            deviceCache = mockDeviceCache,
+            dateProvider = mockDateProvider,
             scope = CoroutineScope(UnconfinedTestDispatcher()),
         )
     }
@@ -214,4 +222,136 @@ class WorkflowManagerTest {
         assertThat(error).isNotNull
         assertThat(error!!.code).isEqualTo(PurchasesErrorCode.NetworkError)
     }
+
+    // region getWorkflowsList
+
+    @Test
+    fun `getWorkflowsList calls backend and caches payload in DeviceCache`() {
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow A", offeringId = "default", prefetch = false),
+            ),
+        )
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(
+                appUserID = "user_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = any(),
+            )
+        } answers { successSlot.captured(response) }
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        verify(exactly = 1) {
+            mockBackend.getWorkflows(appUserID = "user_1", appInBackground = false, onSuccess = any(), onError = any())
+        }
+        verify(exactly = 1) { mockDeviceCache.cacheWorkflowsListResponse(any()) }
+    }
+
+    @Test
+    fun `getWorkflowsList skips network call when in-memory cache is fresh`() {
+        val response = WorkflowsListResponse(workflows = emptyList())
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+        } answers { successSlot.captured(response) }
+        // First call at t=0
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // Second call at t=1ms — still fresh (threshold is 5 minutes)
+        every { mockDateProvider.now } returns Date(1)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = any()) }
+    }
+
+    @Test
+    fun `getWorkflowsList triggers getWorkflow for each prefetch=true entry only`() {
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_prefetch", displayName = "A", prefetch = true),
+                WorkflowSummary(id = "wf_skip", displayName = "B", prefetch = false),
+                WorkflowSummary(id = "wf_also_prefetch", displayName = "C", prefetch = true),
+            ),
+        )
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+        } answers { successSlot.captured(response) }
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        verify(exactly = 1) {
+            mockBackend.getWorkflow(appUserID = "user_1", workflowId = "wf_prefetch", any(), any(), any())
+        }
+        verify(exactly = 0) {
+            mockBackend.getWorkflow(appUserID = "user_1", workflowId = "wf_skip", any(), any(), any())
+        }
+        verify(exactly = 1) {
+            mockBackend.getWorkflow(appUserID = "user_1", workflowId = "wf_also_prefetch", any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `getWorkflowsList silently logs error on backend failure`() {
+        val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers { errorSlot.captured(error) }
+
+        // Should not throw
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        verify(exactly = 0) { mockDeviceCache.cacheWorkflowsListResponse(any()) }
+    }
+
+    // endregion getWorkflowsList
+
+    // region workflowIdForOfferingId
+
+    @Test
+    fun `workflowIdForOfferingId returns null before list is fetched`() {
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isNull()
+    }
+
+    @Test
+    fun `workflowIdForOfferingId returns workflow id after list is fetched`() {
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_abc", displayName = "Flow", offeringId = "default", prefetch = false),
+            ),
+        )
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+        } answers { successSlot.captured(response) }
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_abc")
+        assertThat(workflowManager.workflowIdForOfferingId("premium")).isNull()
+    }
+
+    @Test
+    fun `workflowIdForOfferingId returns null for workflow with null offering_id`() {
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_no_offering", displayName = "Flow", offeringId = null, prefetch = false),
+            ),
+        )
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+        } answers { successSlot.captured(response) }
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isNull()
+    }
+
+    // endregion workflowIdForOfferingId
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -239,6 +239,7 @@ class WorkflowManagerTest {
             mockBackend.getWorkflows(
                 appUserID = "user_1",
                 appInBackground = false,
+                type = "paywall",
                 onSuccess = capture(successSlot),
                 onError = any(),
             )
@@ -247,7 +248,7 @@ class WorkflowManagerTest {
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
         verify(exactly = 1) {
-            mockBackend.getWorkflows(appUserID = "user_1", appInBackground = false, onSuccess = any(), onError = any())
+            mockBackend.getWorkflows(appUserID = "user_1", appInBackground = false, type = "paywall", onSuccess = any(), onError = any())
         }
         verify(exactly = 1) { mockDeviceCache.cacheWorkflowsListResponse(any()) }
         verify(exactly = 0) { mockBackend.getWorkflow(any(), any(), any(), any(), any()) }
@@ -258,7 +259,7 @@ class WorkflowManagerTest {
         val response = WorkflowsListResponse(workflows = emptyList())
         val successSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
         } answers { successSlot.captured(response) }
         // First call at t=0
         every { mockDateProvider.now } returns Date(0)
@@ -268,7 +269,7 @@ class WorkflowManagerTest {
         every { mockDateProvider.now } returns Date(1)
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
-        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = any()) }
+        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
     }
 
     @Test
@@ -282,7 +283,7 @@ class WorkflowManagerTest {
         )
         val successSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
         } answers { successSlot.captured(response) }
 
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
@@ -303,7 +304,7 @@ class WorkflowManagerTest {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
         val errorSlot = slot<(PurchasesError) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
         } answers { errorSlot.captured(error) }
 
         // Should not throw
@@ -318,7 +319,7 @@ class WorkflowManagerTest {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
         val errorSlot = slot<(PurchasesError) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
         } answers { errorSlot.captured(error) }
         every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
 
@@ -332,7 +333,7 @@ class WorkflowManagerTest {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
         val errorSlot = slot<(PurchasesError) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
         } answers { errorSlot.captured(error) }
         every { mockDeviceCache.getWorkflowsListResponseCache() } returns "not valid json"
 
@@ -360,7 +361,7 @@ class WorkflowManagerTest {
         )
         val successSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
         } answers { successSlot.captured(response) }
 
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
@@ -378,7 +379,7 @@ class WorkflowManagerTest {
         )
         val successSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
         } answers { successSlot.captured(response) }
 
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
@@ -397,7 +398,7 @@ class WorkflowManagerTest {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
         val errorSlot = slot<(PurchasesError) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
         } answers { errorSlot.captured(error) }
         every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
 
@@ -411,7 +412,7 @@ class WorkflowManagerTest {
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
         // Only one backend call total (the first one that failed)
-        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = any()) }
+        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
     }
 
     // Test A (continued) — re-fetch fires again after TTL expires
@@ -421,7 +422,7 @@ class WorkflowManagerTest {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
         val errorSlot = slot<(PurchasesError) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
         } answers { errorSlot.captured(error) }
         every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
 
@@ -435,7 +436,7 @@ class WorkflowManagerTest {
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
         // Two backend calls total: first failure + re-fetch after TTL
-        verify(exactly = 2) { mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = any()) }
+        verify(exactly = 2) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
     }
 
     // Test B — concurrent calls only fire one network request
@@ -444,7 +445,7 @@ class WorkflowManagerTest {
         // Hold the backend call without resolving it so the first call stays in-flight
         val successSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
         } answers { /* intentionally do not call successSlot to simulate in-flight */ }
 
         every { mockDateProvider.now } returns Date(0)
@@ -452,7 +453,7 @@ class WorkflowManagerTest {
         // Second call while first is still in-flight
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
-        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = any()) }
+        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
     }
 
     // Test C — duplicate offeringId: last value wins, no crash
@@ -466,7 +467,7 @@ class WorkflowManagerTest {
         )
         val successSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
         } answers { successSlot.captured(response) }
 
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
@@ -484,7 +485,7 @@ class WorkflowManagerTest {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
         val errorSlot = slot<(PurchasesError) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
         } answers { errorSlot.captured(error) }
         every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
 
@@ -507,7 +508,7 @@ class WorkflowManagerTest {
         ))
         val successSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
         } answers { successSlot.captured(response) }
 
         var completed = false
@@ -521,7 +522,7 @@ class WorkflowManagerTest {
         val response = WorkflowsListResponse(workflows = emptyList())
         val successSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
         } answers { successSlot.captured(response) }
 
         every { mockDateProvider.now } returns Date(0)
@@ -532,7 +533,7 @@ class WorkflowManagerTest {
         workflowManager.getWorkflowsList("user_1", false) { completed = true }
 
         assertThat(completed).isTrue()
-        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = any()) }
+        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
     }
 
     @Test
@@ -543,7 +544,7 @@ class WorkflowManagerTest {
         ))
         val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = capture(listSuccessSlot), onError = any())
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccessSlot), onError = any())
         } answers { listSuccessSlot.captured(response) }
 
         val detailSuccessA = slot<(WorkflowDetailResponse) -> Unit>()
@@ -577,7 +578,7 @@ class WorkflowManagerTest {
         ))
         val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = capture(listSuccessSlot), onError = any())
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccessSlot), onError = any())
         } answers { listSuccessSlot.captured(response) }
 
         val detailSuccessA = slot<(WorkflowDetailResponse) -> Unit>()
@@ -607,7 +608,7 @@ class WorkflowManagerTest {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "fail")
         val errorSlot = slot<(PurchasesError) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = capture(errorSlot))
         } answers { errorSlot.captured(error) }
 
         var completed = false
@@ -620,7 +621,7 @@ class WorkflowManagerTest {
     fun `getWorkflowsList concurrent in-flight calls both receive onComplete`() {
         val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
-            mockBackend.getWorkflows(any(), any(), onSuccess = capture(listSuccessSlot), onError = any())
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccessSlot), onError = any())
         } just Runs // hold the request in-flight
 
         var completed1 = false
@@ -635,7 +636,7 @@ class WorkflowManagerTest {
 
         assertThat(completed1).isTrue()
         assertThat(completed2).isTrue()
-        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = any()) }
+        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
     }
 
     // endregion onComplete callback

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -50,9 +50,6 @@ class WorkflowManagerTest {
             workflowAssetPreDownloader = mockAssetPreDownloader,
             workflowsCache = workflowsCache,
             scope = CoroutineScope(UnconfinedTestDispatcher()),
-            // Inject true so tests don't depend on BuildConfig.USE_WORKFLOWS_ENDPOINT, which is
-            // only true via local.properties and defaults to false on CI / clean checkouts.
-            useWorkflowsEndpoint = true,
         )
     }
 
@@ -682,26 +679,6 @@ class WorkflowManagerTest {
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
         assertThat(workflowManager.workflowIdForOfferingId("shared")).isEqualTo("wf_last")
-    }
-
-    // Test D — when useWorkflowsEndpoint is false, getWorkflowsList must short-circuit:
-    // no backend call, and onComplete still fires so offerings delivery is never blocked.
-    @Test
-    fun `getWorkflowsList does nothing and calls onComplete when useWorkflowsEndpoint is false`() {
-        val disabledManager = WorkflowManager(
-            backend = mockBackend,
-            workflowDetailResolver = mockResolver,
-            workflowAssetPreDownloader = mockAssetPreDownloader,
-            workflowsCache = workflowsCache,
-            scope = CoroutineScope(UnconfinedTestDispatcher()),
-            useWorkflowsEndpoint = false,
-        )
-
-        var completed = false
-        disabledManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completed = true }
-
-        assertThat(completed).isTrue()
-        verify(exactly = 0) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
     }
 
     // Clearing the workflows cache (e.g. on user switch) must drop the in-memory list cache and

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -43,12 +43,11 @@ class WorkflowManagerTest {
         originalLogHandler = currentLogHandler
         currentLogHandler = NoOpLogHandler
         every { mockDateProvider.now } returns Date(0) // ensures cache is always stale by default
-        workflowsCache = WorkflowsCache(dateProvider = mockDateProvider)
+        workflowsCache = WorkflowsCache(deviceCache = mockDeviceCache, dateProvider = mockDateProvider)
         workflowManager = WorkflowManager(
             backend = mockBackend,
             workflowDetailResolver = mockResolver,
             workflowAssetPreDownloader = mockAssetPreDownloader,
-            deviceCache = mockDeviceCache,
             workflowsCache = workflowsCache,
             scope = CoroutineScope(UnconfinedTestDispatcher()),
             // Inject true so tests don't depend on BuildConfig.USE_WORKFLOWS_ENDPOINT, which is
@@ -670,7 +669,6 @@ class WorkflowManagerTest {
             backend = mockBackend,
             workflowDetailResolver = mockResolver,
             workflowAssetPreDownloader = mockAssetPreDownloader,
-            deviceCache = mockDeviceCache,
             workflowsCache = workflowsCache,
             scope = CoroutineScope(UnconfinedTestDispatcher()),
             useWorkflowsEndpoint = false,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -18,6 +18,7 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.serialization.SerializationException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.junit.After
@@ -48,6 +49,9 @@ class WorkflowManagerTest {
             deviceCache = mockDeviceCache,
             dateProvider = mockDateProvider,
             scope = CoroutineScope(UnconfinedTestDispatcher()),
+            // Inject true so tests don't depend on BuildConfig.USE_WORKFLOWS_ENDPOINT, which is
+            // only true via local.properties and defaults to false on CI / clean checkouts.
+            useWorkflowsEndpoint = true,
         )
     }
 
@@ -127,6 +131,39 @@ class WorkflowManagerTest {
             data = null,
         )
         coEvery { mockResolver.resolve(response) } throws IllegalStateException("missing data")
+
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = any(),
+            )
+        } answers {
+            successSlot.captured(response)
+        }
+
+        var error: PurchasesError? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { fail("expected error") },
+            onError = { error = it },
+        )
+        assertThat(error).isNotNull
+        assertThat(error!!.code).isEqualTo(PurchasesErrorCode.UnknownError)
+    }
+
+    @Test
+    fun `getWorkflow calls onError when resolver throws SerializationException`() {
+        val response = WorkflowDetailResponse(
+            action = WorkflowResponseAction.USE_CDN,
+            url = "https://cdn.example.com/workflow.json",
+        )
+        coEvery { mockResolver.resolve(response) } throws SerializationException("malformed compiled workflow json")
 
         val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
         every {
@@ -494,8 +531,26 @@ class WorkflowManagerTest {
         assertThat(workflowManager.workflowIdForOfferingId("shared")).isEqualTo("wf_last")
     }
 
-    // Test D — BuildConfig.USE_WORKFLOWS_ENDPOINT is compile-time true in the test variant;
-    // testing the false branch requires making it injectable. Tracked as a future improvement.
+    // Test D — when useWorkflowsEndpoint is false, getWorkflowsList must short-circuit:
+    // no backend call, and onComplete still fires so offerings delivery is never blocked.
+    @Test
+    fun `getWorkflowsList does nothing and calls onComplete when useWorkflowsEndpoint is false`() {
+        val disabledManager = WorkflowManager(
+            backend = mockBackend,
+            workflowDetailResolver = mockResolver,
+            workflowAssetPreDownloader = mockAssetPreDownloader,
+            deviceCache = mockDeviceCache,
+            dateProvider = mockDateProvider,
+            scope = CoroutineScope(UnconfinedTestDispatcher()),
+            useWorkflowsEndpoint = false,
+        )
+
+        var completed = false
+        disabledManager.getWorkflowsList(appUserID = "user_1", appInBackground = false) { completed = true }
+
+        assertThat(completed).isTrue()
+        verify(exactly = 0) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
+    }
 
     // endregion issue fixes
 
@@ -600,6 +655,31 @@ class WorkflowManagerTest {
         assertThat(completed).isFalse()
 
         detailErrorB.captured(PurchasesError(PurchasesErrorCode.NetworkError, "fail"))
+        assertThat(completed).isTrue()
+    }
+
+    @Test
+    fun `getWorkflowsList calls onComplete when a prefetch workflow resolve throws unexpected exception`() {
+        val response = WorkflowsListResponse(workflows = listOf(
+            WorkflowSummary(id = "wf_a", displayName = "A", prefetch = true),
+        ))
+        val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccessSlot), onError = any())
+        } answers { listSuccessSlot.captured(response) }
+
+        val detailSuccessA = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccessA), any())
+        } just Runs
+        // resolve throws an exception type not in the explicit catch list (e.g. malformed CDN json)
+        coEvery { mockResolver.resolve(any()) } throws SerializationException("malformed compiled workflow json")
+
+        var completed = false
+        workflowManager.getWorkflowsList("user_1", false) { completed = true }
+
+        detailSuccessA.captured(WorkflowDetailResponse(action = WorkflowResponseAction.USE_CDN, url = "https://cdn.example.com/wf.json"))
+
         assertThat(completed).isTrue()
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -790,6 +790,38 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `getWorkflowsList second caller waits for in-flight prefetch when list cache is fresh`() {
+        val response = WorkflowsListResponse(workflows = listOf(
+            WorkflowSummary(id = "wf_a", displayName = "A", prefetch = true),
+        ))
+        val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccessSlot), onError = any())
+        } answers { listSuccessSlot.captured(response) }
+
+        val detailSuccess = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccess), any())
+        } just Runs
+        coEvery { mockResolver.resolve(any()) } returns mockk()
+
+        var firstCompleted = false
+        var secondCompleted = false
+        workflowManager.getWorkflowsList("user_1", false) { firstCompleted = true }
+
+        assertThat(firstCompleted).isFalse()
+
+        workflowManager.getWorkflowsList("user_1", false) { secondCompleted = true }
+
+        assertThat(secondCompleted).isFalse()
+
+        detailSuccess.captured(WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk()))
+
+        assertThat(firstCompleted).isTrue()
+        assertThat(secondCompleted).isTrue()
+    }
+
+    @Test
     fun `getWorkflowsList calls onComplete even if a prefetch workflow fails`() {
         val response = WorkflowsListResponse(workflows = listOf(
             WorkflowSummary(id = "wf_a", displayName = "A", prefetch = true),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -9,8 +9,10 @@ import com.revenuecat.purchases.common.DateProvider
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -491,9 +493,150 @@ class WorkflowManagerTest {
         assertThat(workflowManager.workflowIdForOfferingId("shared")).isEqualTo("wf_last")
     }
 
-    // Test D — BuildConfig.USE_WORKFLOWS_ENDPOINT is a compile-time constant.
-    // In the test variant it is always true, so we cannot test the false branch here.
-    // TODO: add a test for USE_WORKFLOWS_ENDPOINT=false once the flag can be injected at runtime.
+    // Test D — BuildConfig.USE_WORKFLOWS_ENDPOINT is compile-time true in the test variant;
+    // testing the false branch requires making it injectable. Tracked as a future improvement.
 
     // endregion issue fixes
+
+    // region onComplete callback
+
+    @Test
+    fun `getWorkflowsList calls onComplete after backend success with no prefetch workflows`() {
+        val response = WorkflowsListResponse(workflows = listOf(
+            WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+        ))
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+        } answers { successSlot.captured(response) }
+
+        var completed = false
+        workflowManager.getWorkflowsList("user_1", false) { completed = true }
+
+        assertThat(completed).isTrue()
+    }
+
+    @Test
+    fun `getWorkflowsList calls onComplete immediately when cache is fresh`() {
+        val response = WorkflowsListResponse(workflows = emptyList())
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+        } answers { successSlot.captured(response) }
+
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList("user_1", false)
+
+        every { mockDateProvider.now } returns Date(1) // still within TTL
+        var completed = false
+        workflowManager.getWorkflowsList("user_1", false) { completed = true }
+
+        assertThat(completed).isTrue()
+        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = any()) }
+    }
+
+    @Test
+    fun `getWorkflowsList calls onComplete only after all prefetch workflows complete`() {
+        val response = WorkflowsListResponse(workflows = listOf(
+            WorkflowSummary(id = "wf_a", displayName = "A", prefetch = true),
+            WorkflowSummary(id = "wf_b", displayName = "B", prefetch = true),
+        ))
+        val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = capture(listSuccessSlot), onError = any())
+        } answers { listSuccessSlot.captured(response) }
+
+        val detailSuccessA = slot<(WorkflowDetailResponse) -> Unit>()
+        val detailSuccessB = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccessA), any())
+        } just Runs
+        every {
+            mockBackend.getWorkflow("user_1", "wf_b", false, capture(detailSuccessB), any())
+        } just Runs
+        coEvery { mockResolver.resolve(any()) } returns mockk()
+
+        var completed = false
+        workflowManager.getWorkflowsList("user_1", false) { completed = true }
+
+        assertThat(completed).isFalse()
+
+        val detailResponse = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        detailSuccessA.captured(detailResponse)
+        assertThat(completed).isFalse()
+
+        detailSuccessB.captured(detailResponse)
+        assertThat(completed).isTrue()
+    }
+
+    @Test
+    fun `getWorkflowsList calls onComplete even if a prefetch workflow fails`() {
+        val response = WorkflowsListResponse(workflows = listOf(
+            WorkflowSummary(id = "wf_a", displayName = "A", prefetch = true),
+            WorkflowSummary(id = "wf_b", displayName = "B", prefetch = true),
+        ))
+        val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = capture(listSuccessSlot), onError = any())
+        } answers { listSuccessSlot.captured(response) }
+
+        val detailSuccessA = slot<(WorkflowDetailResponse) -> Unit>()
+        val detailErrorB = slot<(PurchasesError) -> Unit>()
+        every {
+            mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccessA), any())
+        } just Runs
+        every {
+            mockBackend.getWorkflow("user_1", "wf_b", false, any(), capture(detailErrorB))
+        } just Runs
+        coEvery { mockResolver.resolve(any()) } returns mockk()
+
+        var completed = false
+        workflowManager.getWorkflowsList("user_1", false) { completed = true }
+
+        assertThat(completed).isFalse()
+
+        detailSuccessA.captured(WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk()))
+        assertThat(completed).isFalse()
+
+        detailErrorB.captured(PurchasesError(PurchasesErrorCode.NetworkError, "fail"))
+        assertThat(completed).isTrue()
+    }
+
+    @Test
+    fun `getWorkflowsList calls onComplete after network error`() {
+        val error = PurchasesError(PurchasesErrorCode.NetworkError, "fail")
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers { errorSlot.captured(error) }
+
+        var completed = false
+        workflowManager.getWorkflowsList("user_1", false) { completed = true }
+
+        assertThat(completed).isTrue()
+    }
+
+    @Test
+    fun `getWorkflowsList concurrent in-flight calls both receive onComplete`() {
+        val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = capture(listSuccessSlot), onError = any())
+        } just Runs // hold the request in-flight
+
+        var completed1 = false
+        var completed2 = false
+        workflowManager.getWorkflowsList("user_1", false) { completed1 = true }
+        workflowManager.getWorkflowsList("user_1", false) { completed2 = true }
+
+        assertThat(completed1).isFalse()
+        assertThat(completed2).isFalse()
+
+        listSuccessSlot.captured(WorkflowsListResponse(workflows = emptyList()))
+
+        assertThat(completed1).isTrue()
+        assertThat(completed2).isTrue()
+        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = any()) }
+    }
+
+    // endregion onComplete callback
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -511,6 +511,27 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `getWorkflowsList does not cache workflows without an offeringId`() {
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_no_offering", displayName = "A", offeringId = null, prefetch = false),
+                WorkflowSummary(id = "wf_with_offering", displayName = "B", offeringId = "default", prefetch = false),
+            ),
+        )
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
+        } answers { successSlot.captured(response) }
+        val cachedJson = slot<String>()
+        every { mockDeviceCache.cacheWorkflowsListResponse(capture(cachedJson)) } just Runs
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        assertThat(cachedJson.captured).contains("wf_with_offering")
+        assertThat(cachedJson.captured).doesNotContain("wf_no_offering")
+    }
+
+    @Test
     fun `getWorkflowsList prefetches at most 4 workflows concurrently`() {
         val workflows = (0 until 10).map {
             WorkflowSummary(id = "wf_$it", displayName = "W$it", offeringId = "off_$it", prefetch = true)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -248,6 +248,7 @@ class WorkflowManagerTest {
             mockBackend.getWorkflows(appUserID = "user_1", appInBackground = false, onSuccess = any(), onError = any())
         }
         verify(exactly = 1) { mockDeviceCache.cacheWorkflowsListResponse(any()) }
+        verify(exactly = 0) { mockBackend.getWorkflow(any(), any(), any(), any(), any()) }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -385,4 +385,115 @@ class WorkflowManagerTest {
     }
 
     // endregion workflowIdForOfferingId
+
+    // region issue fixes
+
+    // Test A — disk-cache fallback stamps in-memory cache so re-fetch after TTL still fires once more
+    @Test
+    fun `getWorkflowsList after disk-cache restore does not re-fetch before TTL expires`() {
+        val cachedJson = """{"workflows":[{"id":"wf_1","display_name":"Flow","offering_id":"default","prefetch":false}]}"""
+        val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers { errorSlot.captured(error) }
+        every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
+
+        // First call fails → restores from disk
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_1")
+
+        // Second call immediately after — in-memory cache should be considered fresh (t=1ms)
+        every { mockDateProvider.now } returns Date(1)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // Only one backend call total (the first one that failed)
+        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = any()) }
+    }
+
+    // Test A (continued) — re-fetch fires again after TTL expires
+    @Test
+    fun `getWorkflowsList re-fetches after TTL expiry following disk-cache restore`() {
+        val cachedJson = """{"workflows":[{"id":"wf_1","display_name":"Flow","offering_id":"default","prefetch":false}]}"""
+        val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers { errorSlot.captured(error) }
+        every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
+
+        // First call at t=0 — fails, restores from disk, stamps in-memory cache at t=0
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // Second call well past TTL (6 minutes = 360_000ms) — should fire a new network request
+        val sixMinutesMs = 6L * 60 * 1000
+        every { mockDateProvider.now } returns Date(sixMinutesMs)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        // Two backend calls total: first failure + re-fetch after TTL
+        verify(exactly = 2) { mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = any()) }
+    }
+
+    // Test B — concurrent calls only fire one network request
+    @Test
+    fun `getWorkflowsList concurrent calls only fire one network request`() {
+        // Hold the backend call without resolving it so the first call stays in-flight
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+        } answers { /* intentionally do not call successSlot to simulate in-flight */ }
+
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+        // Second call while first is still in-flight
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = any()) }
+    }
+
+    // Test C — duplicate offeringId: last value wins, no crash
+    @Test
+    fun `getWorkflowsList with duplicate offeringId keeps last entry`() {
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_first", displayName = "First", offeringId = "shared", prefetch = false),
+                WorkflowSummary(id = "wf_last", displayName = "Last", offeringId = "shared", prefetch = false),
+            ),
+        )
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = capture(successSlot), onError = any())
+        } answers { successSlot.captured(response) }
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        assertThat(workflowManager.workflowIdForOfferingId("shared")).isEqualTo("wf_last")
+    }
+
+    // Test C (disk-cache path) — duplicate offeringId in restored disk cache: last value wins
+    @Test
+    fun `getWorkflowsList disk-cache restore with duplicate offeringId keeps last entry`() {
+        val cachedJson = """{"workflows":[
+            {"id":"wf_first","display_name":"First","offering_id":"shared","prefetch":false},
+            {"id":"wf_last","display_name":"Last","offering_id":"shared","prefetch":false}
+        ]}"""
+        val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers { errorSlot.captured(error) }
+        every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        assertThat(workflowManager.workflowIdForOfferingId("shared")).isEqualTo("wf_last")
+    }
+
+    // Test D — BuildConfig.USE_WORKFLOWS_ENDPOINT is a compile-time constant.
+    // In the test variant it is always true, so we cannot test the false branch here.
+    // TODO: add a test for USE_WORKFLOWS_ENDPOINT=false once the flag can be injected at runtime.
+
+    // endregion issue fixes
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -443,9 +443,9 @@ class WorkflowManagerTest {
     fun `getWorkflowsList triggers getWorkflow for each prefetch=true entry only`() {
         val response = WorkflowsListResponse(
             workflows = listOf(
-                WorkflowSummary(id = "wf_prefetch", displayName = "A", prefetch = true),
-                WorkflowSummary(id = "wf_skip", displayName = "B", prefetch = false),
-                WorkflowSummary(id = "wf_also_prefetch", displayName = "C", prefetch = true),
+                WorkflowSummary(id = "wf_prefetch", displayName = "A", offeringId = "default", prefetch = true),
+                WorkflowSummary(id = "wf_skip", displayName = "B", offeringId = "premium", prefetch = false),
+                WorkflowSummary(id = "wf_also_prefetch", displayName = "C", offeringId = "pro", prefetch = true),
             ),
         )
         val successSlot = slot<(WorkflowsListResponse) -> Unit>()
@@ -463,6 +463,29 @@ class WorkflowManagerTest {
         }
         verify(exactly = 1) {
             mockBackend.getWorkflow(appUserID = "user_1", workflowId = "wf_also_prefetch", any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `getWorkflowsList does not prefetch workflows without an offeringId`() {
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_no_offering", displayName = "A", offeringId = null, prefetch = true),
+                WorkflowSummary(id = "wf_with_offering", displayName = "B", offeringId = "default", prefetch = true),
+            ),
+        )
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
+        } answers { successSlot.captured(response) }
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        verify(exactly = 0) {
+            mockBackend.getWorkflow(appUserID = "user_1", workflowId = "wf_no_offering", any(), any(), any())
+        }
+        verify(exactly = 1) {
+            mockBackend.getWorkflow(appUserID = "user_1", workflowId = "wf_with_offering", any(), any(), any())
         }
     }
 
@@ -756,8 +779,8 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflowsList calls onComplete only after all prefetch workflows complete`() {
         val response = WorkflowsListResponse(workflows = listOf(
-            WorkflowSummary(id = "wf_a", displayName = "A", prefetch = true),
-            WorkflowSummary(id = "wf_b", displayName = "B", prefetch = true),
+            WorkflowSummary(id = "wf_a", displayName = "A", offeringId = "default", prefetch = true),
+            WorkflowSummary(id = "wf_b", displayName = "B", offeringId = "premium", prefetch = true),
         ))
         val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
@@ -790,7 +813,7 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflowsList second caller waits for in-flight prefetch when list cache is fresh`() {
         val response = WorkflowsListResponse(workflows = listOf(
-            WorkflowSummary(id = "wf_a", displayName = "A", prefetch = true),
+            WorkflowSummary(id = "wf_a", displayName = "A", offeringId = "default", prefetch = true),
         ))
         val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
@@ -822,8 +845,8 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflowsList calls onComplete even if a prefetch workflow fails`() {
         val response = WorkflowsListResponse(workflows = listOf(
-            WorkflowSummary(id = "wf_a", displayName = "A", prefetch = true),
-            WorkflowSummary(id = "wf_b", displayName = "B", prefetch = true),
+            WorkflowSummary(id = "wf_a", displayName = "A", offeringId = "default", prefetch = true),
+            WorkflowSummary(id = "wf_b", displayName = "B", offeringId = "premium", prefetch = true),
         ))
         val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {
@@ -855,7 +878,7 @@ class WorkflowManagerTest {
     @Test
     fun `getWorkflowsList calls onComplete when a prefetch workflow resolve throws unexpected exception`() {
         val response = WorkflowsListResponse(workflows = listOf(
-            WorkflowSummary(id = "wf_a", displayName = "A", prefetch = true),
+            WorkflowSummary(id = "wf_a", displayName = "A", offeringId = "default", prefetch = true),
         ))
         val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
         every {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -915,5 +915,39 @@ class WorkflowManagerTest {
         verify(exactly = 1) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
     }
 
+    @Test
+    fun `getWorkflowsList for a different user does not join an in-flight fetch for the previous user`() {
+        val user1Success = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows("user_1", any(), type = any(), onSuccess = capture(user1Success), onError = any())
+        } just Runs // hold user_1 in-flight
+
+        val user2Success = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows("user_2", any(), type = any(), onSuccess = capture(user2Success), onError = any())
+        } just Runs // hold user_2 in-flight
+
+        var user1Completed = false
+        var user2Completed = false
+        workflowManager.getWorkflowsList("user_1", false) { user1Completed = true }
+        workflowManager.getWorkflowsList("user_2", false) { user2Completed = true }
+
+        // user_2 must start its own fetch rather than join user_1's in-flight request.
+        verify(exactly = 1) {
+            mockBackend.getWorkflows("user_2", any(), type = any(), onSuccess = any(), onError = any())
+        }
+        assertThat(user1Completed).isFalse()
+        assertThat(user2Completed).isFalse()
+
+        // user_2's fetch landing completes only user_2, not user_1.
+        user2Success.captured(WorkflowsListResponse(workflows = emptyList()))
+        assertThat(user2Completed).isTrue()
+        assertThat(user1Completed).isFalse()
+
+        // user_1's fetch landing then completes user_1.
+        user1Success.captured(WorkflowsListResponse(workflows = emptyList()))
+        assertThat(user1Completed).isTrue()
+    }
+
     // endregion onComplete callback
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -567,7 +567,7 @@ class WorkflowManagerTest {
     }
 
     @Test
-    fun `getWorkflowsList prefetches at most 4 workflows concurrently`() {
+    fun `getWorkflowsList fetches every prefetch=true workflow`() {
         val workflows = (0 until 10).map {
             WorkflowSummary(id = "wf_$it", displayName = "W$it", offeringId = "off_$it", prefetch = true)
         }
@@ -577,13 +577,14 @@ class WorkflowManagerTest {
             mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccessSlot), onError = any())
         } answers { listSuccessSlot.captured(response) }
 
-        // Hold every prefetch in flight by never invoking its callback, so each one keeps its
-        // semaphore permit. Only as many fetches as there are permits can start.
+        // Hold every prefetch in flight by never invoking its callback. The manager does not cap
+        // concurrency itself: detail fetches are bounded by prefetchDispatcher's thread pool and CDN
+        // downloads by the workflows FileRepository scope, so every prefetch=true workflow is launched.
         every { mockBackend.getWorkflow(any(), any(), any(), any(), any(), any()) } answers { }
 
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
-        verify(exactly = 4) { mockBackend.getWorkflow(any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 10) { mockBackend.getWorkflow(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -34,6 +34,7 @@ class WorkflowManagerTest {
     private val mockAssetPreDownloader: WorkflowAssetPreDownloader = mockk(relaxed = true)
     private val mockDeviceCache: DeviceCache = mockk(relaxed = true)
     private val mockDateProvider: DateProvider = mockk()
+    private lateinit var workflowsCache: WorkflowsCache
     private lateinit var workflowManager: WorkflowManager
     private lateinit var originalLogHandler: LogHandler
 
@@ -42,12 +43,13 @@ class WorkflowManagerTest {
         originalLogHandler = currentLogHandler
         currentLogHandler = NoOpLogHandler
         every { mockDateProvider.now } returns Date(0) // ensures cache is always stale by default
+        workflowsCache = WorkflowsCache(dateProvider = mockDateProvider)
         workflowManager = WorkflowManager(
             backend = mockBackend,
             workflowDetailResolver = mockResolver,
             workflowAssetPreDownloader = mockAssetPreDownloader,
             deviceCache = mockDeviceCache,
-            dateProvider = mockDateProvider,
+            workflowsCache = workflowsCache,
             scope = CoroutineScope(UnconfinedTestDispatcher()),
             // Inject true so tests don't depend on BuildConfig.USE_WORKFLOWS_ENDPOINT, which is
             // only true via local.properties and defaults to false on CI / clean checkouts.
@@ -261,6 +263,135 @@ class WorkflowManagerTest {
         assertThat(error).isNotNull
         assertThat(error!!.code).isEqualTo(PurchasesErrorCode.NetworkError)
     }
+
+    // region getWorkflow cache
+
+    @Test
+    fun `getWorkflow caches result on success`() {
+        val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        val expectedResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        coEvery { mockResolver.resolve(response) } returns expectedResult
+
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = any(),
+            )
+        } answers { successSlot.captured(response) }
+
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(expectedResult)
+    }
+
+    @Test
+    fun `getWorkflow returns cached result without calling backend when cache is fresh`() {
+        val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        val expectedResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        coEvery { mockResolver.resolve(response) } returns expectedResult
+
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = any(),
+            )
+        } answers { successSlot.captured(response) }
+
+        // First call populates the cache (stamped at t=0).
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        // Second call within TTL should hit the cache and skip the backend.
+        var secondResult: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { secondResult = it },
+            onError = { fail("unexpected error $it") },
+        )
+
+        assertThat(secondResult).isSameAs(expectedResult)
+        verify(exactly = 1) {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `getWorkflow re-fetches when cache is stale`() {
+        val response = WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk())
+        val expectedResult = WorkflowDataResult(workflow = response.data!!, enrolledVariants = null)
+        coEvery { mockResolver.resolve(response) } returns expectedResult
+
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = any(),
+            )
+        } answers { successSlot.captured(response) }
+
+        // First call at t=0 populates the cache.
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        // Second call past the 5-minute foreground TTL should re-fetch.
+        val sixMinutesMs = 6L * 60 * 1000
+        every { mockDateProvider.now } returns Date(sixMinutesMs)
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = { fail("unexpected error $it") },
+        )
+
+        verify(exactly = 2) {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = any(),
+                onError = any(),
+            )
+        }
+    }
+
+    // endregion getWorkflow cache
 
     // region getWorkflowsList
 
@@ -540,7 +671,7 @@ class WorkflowManagerTest {
             workflowDetailResolver = mockResolver,
             workflowAssetPreDownloader = mockAssetPreDownloader,
             deviceCache = mockDeviceCache,
-            dateProvider = mockDateProvider,
+            workflowsCache = workflowsCache,
             scope = CoroutineScope(UnconfinedTestDispatcher()),
             useWorkflowsEndpoint = false,
         )
@@ -550,6 +681,39 @@ class WorkflowManagerTest {
 
         assertThat(completed).isTrue()
         verify(exactly = 0) { mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any()) }
+    }
+
+    // Clearing the workflows cache (e.g. on user switch) must drop the in-memory list cache and
+    // offeringId map so the next call re-fetches instead of serving the previous user's workflows.
+    @Test
+    fun `clearing workflows cache drops offeringId map and forces re-fetch within TTL`() {
+        val response = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+            ),
+        )
+        val successSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(successSlot), onError = any())
+        } answers { successSlot.captured(response) }
+
+        // First fetch at t=0 populates the list cache + offeringId map.
+        every { mockDateProvider.now } returns Date(0)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_1")
+
+        // Simulate a user switch clearing the cache.
+        workflowsCache.clearCache()
+
+        // The offeringId map must be gone.
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isNull()
+
+        // The next call within TTL must re-fetch because the in-memory list cache was cleared.
+        every { mockDateProvider.now } returns Date(1)
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+        verify(exactly = 2) {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = any(), onError = any())
+        }
     }
 
     // endregion issue fixes

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -487,6 +487,26 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `getWorkflowsList prefetches at most 4 workflows concurrently`() {
+        val workflows = (0 until 10).map {
+            WorkflowSummary(id = "wf_$it", displayName = "W$it", offeringId = "off_$it", prefetch = true)
+        }
+        val response = WorkflowsListResponse(workflows = workflows)
+        val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccessSlot), onError = any())
+        } answers { listSuccessSlot.captured(response) }
+
+        // Hold every prefetch in flight by never invoking its callback, so each one keeps its
+        // semaphore permit. Only as many fetches as there are permits can start.
+        every { mockBackend.getWorkflow(any(), any(), any(), any(), any()) } answers { }
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        verify(exactly = 4) { mockBackend.getWorkflow(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `getWorkflowsList silently logs error on backend failure`() {
         val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
         val errorSlot = slot<(PurchasesError) -> Unit>()

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -564,7 +564,7 @@ class WorkflowManagerTest {
         )
 
         verify(exactly = 1) {
-            mockBackend.getWorkflow("user_1", "wf_1", false, any(), any(), callbackDispatcher = null)
+            mockBackend.getWorkflow("user_1", "wf_1", false, any(), any())
         }
     }
 

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.currentLogHandler
 import com.revenuecat.purchases.utils.WorkflowAssetPreDownloader
@@ -34,6 +35,7 @@ class WorkflowManagerTest {
     private val mockAssetPreDownloader: WorkflowAssetPreDownloader = mockk(relaxed = true)
     private val mockDeviceCache: DeviceCache = mockk(relaxed = true)
     private val mockDateProvider: DateProvider = mockk()
+    private val mockPrefetchDispatcher: Dispatcher = mockk(relaxed = true)
     private lateinit var workflowsCache: WorkflowsCache
     private lateinit var workflowManager: WorkflowManager
     private lateinit var originalLogHandler: LogHandler
@@ -49,6 +51,7 @@ class WorkflowManagerTest {
             workflowDetailResolver = mockResolver,
             workflowAssetPreDownloader = mockAssetPreDownloader,
             workflowsCache = workflowsCache,
+            prefetchDispatcher = mockPrefetchDispatcher,
             scope = CoroutineScope(UnconfinedTestDispatcher()),
         )
     }
@@ -453,13 +456,27 @@ class WorkflowManagerTest {
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
         verify(exactly = 1) {
-            mockBackend.getWorkflow(appUserID = "user_1", workflowId = "wf_prefetch", any(), any(), any())
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_prefetch",
+                any(),
+                any(),
+                any(),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
         }
         verify(exactly = 0) {
-            mockBackend.getWorkflow(appUserID = "user_1", workflowId = "wf_skip", any(), any(), any())
+            mockBackend.getWorkflow(appUserID = "user_1", workflowId = "wf_skip", any(), any(), any(), any())
         }
         verify(exactly = 1) {
-            mockBackend.getWorkflow(appUserID = "user_1", workflowId = "wf_also_prefetch", any(), any(), any())
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_also_prefetch",
+                any(),
+                any(),
+                any(),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
         }
     }
 
@@ -479,10 +496,17 @@ class WorkflowManagerTest {
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
         verify(exactly = 0) {
-            mockBackend.getWorkflow(appUserID = "user_1", workflowId = "wf_no_offering", any(), any(), any())
+            mockBackend.getWorkflow(appUserID = "user_1", workflowId = "wf_no_offering", any(), any(), any(), any())
         }
         verify(exactly = 1) {
-            mockBackend.getWorkflow(appUserID = "user_1", workflowId = "wf_with_offering", any(), any(), any())
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_with_offering",
+                any(),
+                any(),
+                any(),
+                callbackDispatcher = mockPrefetchDispatcher,
+            )
         }
     }
 
@@ -499,11 +523,28 @@ class WorkflowManagerTest {
 
         // Hold every prefetch in flight by never invoking its callback, so each one keeps its
         // semaphore permit. Only as many fetches as there are permits can start.
-        every { mockBackend.getWorkflow(any(), any(), any(), any(), any()) } answers { }
+        every { mockBackend.getWorkflow(any(), any(), any(), any(), any(), any()) } answers { }
 
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
-        verify(exactly = 4) { mockBackend.getWorkflow(any(), any(), any(), any(), any()) }
+        verify(exactly = 4) { mockBackend.getWorkflow(any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `on-demand getWorkflow runs on the default dispatcher, not the prefetch one`() {
+        every { mockBackend.getWorkflow(any(), any(), any(), any(), any(), any()) } answers { }
+
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = {},
+            onError = {},
+        )
+
+        verify(exactly = 1) {
+            mockBackend.getWorkflow("user_1", "wf_1", false, any(), any(), callbackDispatcher = null)
+        }
     }
 
     @Test
@@ -789,10 +830,10 @@ class WorkflowManagerTest {
         val detailSuccessA = slot<(WorkflowDetailResponse) -> Unit>()
         val detailSuccessB = slot<(WorkflowDetailResponse) -> Unit>()
         every {
-            mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccessA), any())
+            mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccessA), any(), any())
         } just Runs
         every {
-            mockBackend.getWorkflow("user_1", "wf_b", false, capture(detailSuccessB), any())
+            mockBackend.getWorkflow("user_1", "wf_b", false, capture(detailSuccessB), any(), any())
         } just Runs
         coEvery { mockResolver.resolve(any()) } returns mockk()
 
@@ -821,7 +862,7 @@ class WorkflowManagerTest {
 
         val detailSuccess = slot<(WorkflowDetailResponse) -> Unit>()
         every {
-            mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccess), any())
+            mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccess), any(), any())
         } just Runs
         coEvery { mockResolver.resolve(any()) } returns mockk()
 
@@ -855,10 +896,10 @@ class WorkflowManagerTest {
         val detailSuccessA = slot<(WorkflowDetailResponse) -> Unit>()
         val detailErrorB = slot<(PurchasesError) -> Unit>()
         every {
-            mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccessA), any())
+            mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccessA), any(), any())
         } just Runs
         every {
-            mockBackend.getWorkflow("user_1", "wf_b", false, any(), capture(detailErrorB))
+            mockBackend.getWorkflow("user_1", "wf_b", false, any(), capture(detailErrorB), any())
         } just Runs
         coEvery { mockResolver.resolve(any()) } returns mockk()
 
@@ -886,7 +927,7 @@ class WorkflowManagerTest {
 
         val detailSuccessA = slot<(WorkflowDetailResponse) -> Unit>()
         every {
-            mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccessA), any())
+            mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccessA), any(), any())
         } just Runs
         // resolve throws an exception type not in the explicit catch list (e.g. malformed CDN json)
         coEvery { mockResolver.resolve(any()) } throws SerializationException("malformed compiled workflow json")

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -310,6 +310,36 @@ class WorkflowManagerTest {
         verify(exactly = 0) { mockDeviceCache.cacheWorkflowsListResponse(any()) }
     }
 
+    @Test
+    fun `getWorkflowsList restores offeringId map from disk cache on backend failure`() {
+        val cachedJson = """{"workflows":[{"id":"wf_1","display_name":"Flow","offering_id":"default","prefetch":false}]}"""
+        val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers { errorSlot.captured(error) }
+        every { mockDeviceCache.getWorkflowsListResponseCache() } returns cachedJson
+
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_1")
+    }
+
+    @Test
+    fun `getWorkflowsList silently ignores corrupt disk cache on backend failure`() {
+        val error = PurchasesError(PurchasesErrorCode.NetworkError, "network error")
+        val errorSlot = slot<(PurchasesError) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), onSuccess = any(), onError = capture(errorSlot))
+        } answers { errorSlot.captured(error) }
+        every { mockDeviceCache.getWorkflowsListResponseCache() } returns "not valid json"
+
+        // Should not throw
+        workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
+
+        assertThat(workflowManager.workflowIdForOfferingId("default")).isNull()
+    }
+
     // endregion getWorkflowsList
 
     // region workflowIdForOfferingId

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -513,6 +513,8 @@ class WorkflowManagerTest {
         workflowManager.getWorkflowsList(appUserID = "user_1", appInBackground = false)
 
         assertThat(workflowManager.workflowIdForOfferingId("default")).isEqualTo("wf_1")
+        // The disk copy is the source we restored from, so the recovery path must not rewrite it.
+        verify(exactly = 0) { mockDeviceCache.cacheWorkflowsListResponse(any()) }
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -17,6 +17,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.serialization.SerializationException
@@ -189,6 +190,40 @@ class WorkflowManagerTest {
         )
         assertThat(error).isNotNull
         assertThat(error!!.code).isEqualTo(PurchasesErrorCode.UnknownError)
+    }
+
+    @Test
+    fun `getWorkflow does not report cancellation as an error`() {
+        val response = WorkflowDetailResponse(
+            action = WorkflowResponseAction.USE_CDN,
+            url = "https://cdn.example.com/workflow.json",
+        )
+        coEvery { mockResolver.resolve(response) } throws CancellationException("scope cancelled")
+
+        val successSlot = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow(
+                appUserID = "user_1",
+                workflowId = "wf_1",
+                appInBackground = false,
+                onSuccess = capture(successSlot),
+                onError = any(),
+            )
+        } answers {
+            successSlot.captured(response)
+        }
+
+        var error: PurchasesError? = null
+        var result: WorkflowDataResult? = null
+        workflowManager.getWorkflow(
+            appUserID = "user_1",
+            workflowId = "wf_1",
+            appInBackground = false,
+            onSuccess = { result = it },
+            onError = { error = it },
+        )
+        assertThat(error).isNull()
+        assertThat(result).isNull()
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -3,6 +3,8 @@
 package com.revenuecat.purchases.common.workflows
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.JsonTools
+import kotlinx.serialization.encodeToString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -63,5 +65,42 @@ internal class WorkflowModelsDeserializationTest {
         val json = """{"workflows": [{"id": "wf_5", "display_name": "Flow E", "unknown_field": "value"}]}"""
         val result = WorkflowJsonParser.parseWorkflowsListResponse(json)
         assertThat(result.workflows[0].id).isEqualTo("wf_5")
+    }
+
+    // Round-trip tests: disk cache WRITE uses JsonTools.json.encodeToString, READ uses
+    // WorkflowJsonParser.parseWorkflowsListResponse. Both go through the same JsonTools.json
+    // instance today, but a round-trip test catches silent breakage if someone adds a custom
+    // serializer or changes JsonTools.json configuration.
+
+    @Test
+    fun `WorkflowsListResponse round-trips through disk cache encode and decode with offeringId and prefetch true`() {
+        val original = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_1", displayName = "Flow A", offeringId = "default", prefetch = true),
+            ),
+        )
+        val encoded = JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), original)
+        val decoded = WorkflowJsonParser.parseWorkflowsListResponse(encoded)
+        assertThat(decoded).isEqualTo(original)
+    }
+
+    @Test
+    fun `WorkflowsListResponse round-trips through disk cache encode and decode with null offeringId and prefetch false`() {
+        val original = WorkflowsListResponse(
+            workflows = listOf(
+                WorkflowSummary(id = "wf_2", displayName = "Flow B", offeringId = null, prefetch = false),
+            ),
+        )
+        val encoded = JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), original)
+        val decoded = WorkflowJsonParser.parseWorkflowsListResponse(encoded)
+        assertThat(decoded).isEqualTo(original)
+    }
+
+    @Test
+    fun `WorkflowsListResponse round-trips through disk cache encode and decode with empty workflows list`() {
+        val original = WorkflowsListResponse(workflows = emptyList())
+        val encoded = JsonTools.json.encodeToString(WorkflowsListResponse.serializer(), original)
+        val decoded = WorkflowJsonParser.parseWorkflowsListResponse(encoded)
+        assertThat(decoded).isEqualTo(original)
     }
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -1,0 +1,145 @@
+package com.revenuecat.purchases.common.workflows
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.utils.add
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Date
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+@OptIn(InternalRevenueCatAPI::class)
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34], manifest = Config.NONE)
+class WorkflowsCacheTest {
+
+    private val initialDate = Date(1685098228L) // Friday, May 26, 2023 10:50:28 AM GMT
+    private lateinit var currentDate: Date
+    private lateinit var dateProvider: DateProvider
+
+    private lateinit var workflowsCache: WorkflowsCache
+
+    @Before
+    fun setUp() {
+        currentDate = initialDate
+        dateProvider = object : DateProvider {
+            override val now: Date
+                get() = currentDate
+        }
+        workflowsCache = WorkflowsCache(dateProvider = dateProvider)
+    }
+
+    @Test
+    fun `cachedWorkflow returns null when nothing cached`() {
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isNull()
+    }
+
+    @Test
+    fun `cachedWorkflow returns cached value after cacheWorkflow`() {
+        val result = mockk<WorkflowDataResult>()
+        workflowsCache.cacheWorkflow("wf_1", result)
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(result)
+    }
+
+    @Test
+    fun `isWorkflowCacheStale is true when nothing cached`() {
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = true)).isTrue
+    }
+
+    @Test
+    fun `isWorkflowCacheStale is false right after caching in foreground`() {
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isFalse
+    }
+
+    @Test
+    fun `isWorkflowCacheStale is true after foreground TTL expires`() {
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        currentDate = currentDate.add(6.minutes)
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
+    }
+
+    @Test
+    fun `isWorkflowCacheStale is false after foreground TTL expires when in background`() {
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        currentDate = currentDate.add(6.minutes)
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = true)).isFalse
+    }
+
+    @Test
+    fun `isWorkflowCacheStale is true after background TTL expires`() {
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        currentDate = currentDate.add(26.hours)
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = true)).isTrue
+    }
+
+    @Test
+    fun `clearCache removes all cached workflows`() {
+        workflowsCache.cacheWorkflow("wf_1", mockk())
+        workflowsCache.cacheWorkflow("wf_2", mockk())
+        workflowsCache.clearCache()
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isNull()
+        assertThat(workflowsCache.cachedWorkflow("wf_2")).isNull()
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_2", appInBackground = false)).isTrue
+    }
+
+    @Test
+    fun `isWorkflowsListCacheStale is true initially and false after caching`() {
+        assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue
+        workflowsCache.cacheWorkflowsList(WorkflowsListResponse(workflows = emptyList()), emptyMap())
+        assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isFalse
+    }
+
+    @Test
+    fun `isWorkflowsListCacheStale is true after foreground TTL expires`() {
+        workflowsCache.cacheWorkflowsList(WorkflowsListResponse(workflows = emptyList()), emptyMap())
+        currentDate = currentDate.add(6.minutes)
+        assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue
+    }
+
+    @Test
+    fun `workflowIdForOfferingId returns mapped id or null`() {
+        workflowsCache.cacheWorkflowsList(
+            WorkflowsListResponse(workflows = emptyList()),
+            mapOf("default" to "wf_1"),
+        )
+        assertThat(workflowsCache.workflowIdForOfferingId("default")).isEqualTo("wf_1")
+        assertThat(workflowsCache.workflowIdForOfferingId("premium")).isNull()
+    }
+
+    @Test
+    fun `clearCache resets workflows list staleness and offeringId map`() {
+        workflowsCache.cacheWorkflowsList(
+            WorkflowsListResponse(workflows = emptyList()),
+            mapOf("default" to "wf_1"),
+        )
+        workflowsCache.clearCache()
+        assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue
+        assertThat(workflowsCache.workflowIdForOfferingId("default")).isNull()
+    }
+
+    @Test
+    fun `different workflowIds are cached independently`() {
+        val first = mockk<WorkflowDataResult>()
+        val second = mockk<WorkflowDataResult>()
+        workflowsCache.cacheWorkflow("wf_1", first)
+        currentDate = currentDate.add(6.minutes)
+        workflowsCache.cacheWorkflow("wf_2", second)
+
+        // Both values remain retrievable.
+        assertThat(workflowsCache.cachedWorkflow("wf_1")).isSameAs(first)
+        assertThat(workflowsCache.cachedWorkflow("wf_2")).isSameAs(second)
+
+        // wf_1 was cached 6 minutes ago so it is stale in foreground; wf_2 is fresh.
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_1", appInBackground = false)).isTrue
+        assertThat(workflowsCache.isWorkflowCacheStale("wf_2", appInBackground = false)).isFalse
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -111,6 +111,21 @@ class WorkflowsCacheTest {
     }
 
     @Test
+    fun `forceWorkflowsListCacheStale marks the list stale but keeps the offeringId map`() {
+        workflowsCache.cacheWorkflowsList(
+            WorkflowsListResponse(workflows = emptyList()),
+            mapOf("default" to "wf_1"),
+        )
+        assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isFalse
+
+        workflowsCache.forceWorkflowsListCacheStale()
+
+        assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue
+        // The map is kept so workflowIdForOfferingId still resolves while the refetch is in flight.
+        assertThat(workflowsCache.workflowIdForOfferingId("default")).isEqualTo("wf_1")
+    }
+
+    @Test
     fun `workflowIdForOfferingId returns mapped id or null`() {
         workflowsCache.cacheWorkflowsList(
             WorkflowsListResponse(workflows = emptyList()),

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -145,6 +145,21 @@ class WorkflowsCacheTest {
     }
 
     @Test
+    fun `cacheWorkflowsListInMemory populates in-memory state without writing to disk`() {
+        workflowsCache.cacheWorkflowsListInMemory(
+            WorkflowsListResponse(
+                workflows = listOf(
+                    WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+                ),
+            ),
+            mapOf("default" to "wf_1"),
+        )
+        assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isFalse
+        assertThat(workflowsCache.workflowIdForOfferingId("default")).isEqualTo("wf_1")
+        verify(exactly = 0) { deviceCache.cacheWorkflowsListResponse(any()) }
+    }
+
+    @Test
     fun `clearCache clears the disk cache`() {
         workflowsCache.clearCache()
         verify(exactly = 1) { deviceCache.clearWorkflowsListResponseCache() }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowsCacheTest.kt
@@ -3,8 +3,11 @@ package com.revenuecat.purchases.common.workflows
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.common.DateProvider
+import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.utils.add
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -22,6 +25,7 @@ class WorkflowsCacheTest {
     private val initialDate = Date(1685098228L) // Friday, May 26, 2023 10:50:28 AM GMT
     private lateinit var currentDate: Date
     private lateinit var dateProvider: DateProvider
+    private lateinit var deviceCache: DeviceCache
 
     private lateinit var workflowsCache: WorkflowsCache
 
@@ -32,7 +36,8 @@ class WorkflowsCacheTest {
             override val now: Date
                 get() = currentDate
         }
-        workflowsCache = WorkflowsCache(dateProvider = dateProvider)
+        deviceCache = mockk(relaxed = true)
+        workflowsCache = WorkflowsCache(deviceCache = deviceCache, dateProvider = dateProvider)
     }
 
     @Test
@@ -124,6 +129,46 @@ class WorkflowsCacheTest {
         workflowsCache.clearCache()
         assertThat(workflowsCache.isWorkflowsListCacheStale(appInBackground = false)).isTrue
         assertThat(workflowsCache.workflowIdForOfferingId("default")).isNull()
+    }
+
+    @Test
+    fun `cacheWorkflowsList persists the response to disk`() {
+        workflowsCache.cacheWorkflowsList(
+            WorkflowsListResponse(
+                workflows = listOf(
+                    WorkflowSummary(id = "wf_1", displayName = "Flow", offeringId = "default", prefetch = false),
+                ),
+            ),
+            mapOf("default" to "wf_1"),
+        )
+        verify(exactly = 1) { deviceCache.cacheWorkflowsListResponse(any()) }
+    }
+
+    @Test
+    fun `clearCache clears the disk cache`() {
+        workflowsCache.clearCache()
+        verify(exactly = 1) { deviceCache.clearWorkflowsListResponseCache() }
+    }
+
+    @Test
+    fun `cachedWorkflowsListResponseFromDisk parses the persisted response`() {
+        val cachedJson =
+            """{"workflows":[{"id":"wf_1","display_name":"Flow","offering_id":"default","prefetch":false}]}"""
+        every { deviceCache.getWorkflowsListResponseCache() } returns cachedJson
+        val response = workflowsCache.cachedWorkflowsListResponseFromDisk()
+        assertThat(response?.workflows?.single()?.id).isEqualTo("wf_1")
+    }
+
+    @Test
+    fun `cachedWorkflowsListResponseFromDisk returns null when nothing is cached`() {
+        every { deviceCache.getWorkflowsListResponseCache() } returns null
+        assertThat(workflowsCache.cachedWorkflowsListResponseFromDisk()).isNull()
+    }
+
+    @Test
+    fun `cachedWorkflowsListResponseFromDisk returns null when the payload is corrupt`() {
+        every { deviceCache.getWorkflowsListResponseCache() } returns "not valid json"
+        assertThat(workflowsCache.cachedWorkflowsListResponseFromDisk()).isNull()
     }
 
     @Test

--- a/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/identity/IdentityManagerTests.kt
@@ -13,6 +13,7 @@ import com.revenuecat.purchases.common.caching.DeviceCache
 import com.revenuecat.purchases.common.offerings.OfferingsCache
 import com.revenuecat.purchases.common.offlineentitlements.OfflineEntitlementsManager
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
+import com.revenuecat.purchases.common.workflows.WorkflowsCache
 import com.revenuecat.purchases.subscriberattributes.SubscriberAttributesManager
 import com.revenuecat.purchases.subscriberattributes.caching.SubscriberAttributesCache
 import com.revenuecat.purchases.utils.SyncDispatcher
@@ -41,6 +42,7 @@ class IdentityManagerTests {
     private lateinit var mockSubscriberAttributesCache: SubscriberAttributesCache
     private lateinit var mockSubscriberAttributesManager: SubscriberAttributesManager
     private lateinit var mockOfferingsCache: OfferingsCache
+    private lateinit var mockWorkflowsCache: WorkflowsCache
     private lateinit var mockBackend: Backend
     private lateinit var mockOfflineEntitlementsManager: OfflineEntitlementsManager
     private lateinit var identityManager: IdentityManager
@@ -72,6 +74,9 @@ class IdentityManagerTests {
         }
         mockSubscriberAttributesManager = mockk()
         mockOfferingsCache = mockk<OfferingsCache>().apply {
+            every { clearCache() } just Runs
+        }
+        mockWorkflowsCache = mockk<WorkflowsCache>().apply {
             every { clearCache() } just Runs
         }
 
@@ -245,6 +250,7 @@ class IdentityManagerTests {
             mockSubscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
+        verify(exactly = 1) { mockWorkflowsCache.clearCache() }
     }
 
     @Test
@@ -399,6 +405,7 @@ class IdentityManagerTests {
             )
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
+        verify(exactly = 1) { mockWorkflowsCache.clearCache() }
     }
 
     @Test
@@ -623,6 +630,7 @@ class IdentityManagerTests {
 
         verify(exactly = 1) { mockDeviceCache.clearCachesForAppUserID(oldAppUserID) }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
+        verify(exactly = 1) { mockWorkflowsCache.clearCache() }
         verify(exactly = 1) {
             mockSubscriberAttributesCache.clearSubscriberAttributesIfSyncedForSubscriber(oldAppUserID)
         }
@@ -754,6 +762,7 @@ class IdentityManagerTests {
             )
         }
         verify(exactly = 1) { mockOfferingsCache.clearCache() }
+        verify(exactly = 1) { mockWorkflowsCache.clearCache() }
         verify(exactly = 1) { mockDeviceCache.clearCustomerInfoCache(newAppUserId) }
         verify(exactly = 1) { mockOfflineEntitlementsManager.resetOfflineCustomerInfoCache() }
     }
@@ -792,6 +801,7 @@ class IdentityManagerTests {
             )
         }
         verify(exactly = 0) { mockOfferingsCache.clearCache() }
+        verify(exactly = 0) { mockWorkflowsCache.clearCache() }
         verify(exactly = 0) { mockDeviceCache.clearCustomerInfoCache(newAppUserId) }
         verify(exactly = 0) { mockOfflineEntitlementsManager.resetOfflineCustomerInfoCache() }
     }
@@ -885,6 +895,7 @@ class IdentityManagerTests {
         subscriberAttributesCache: SubscriberAttributesCache = mockSubscriberAttributesCache,
         subscriberAttributesManager: SubscriberAttributesManager = mockSubscriberAttributesManager,
         offeringsCache: OfferingsCache = mockOfferingsCache,
+        workflowsCache: WorkflowsCache = mockWorkflowsCache,
         backend: Backend = mockBackend,
         offlineEntitlementsManager: OfflineEntitlementsManager = mockOfflineEntitlementsManager,
         uiPreviewMode: Boolean = false,
@@ -894,6 +905,7 @@ class IdentityManagerTests {
             subscriberAttributesCache,
             subscriberAttributesManager,
             offeringsCache,
+            workflowsCache,
             backend,
             offlineEntitlementsManager,
             SyncDispatcher(),

--- a/purchases/src/test/java/com/revenuecat/purchases/storage/FileRepositoryTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/storage/FileRepositoryTest.kt
@@ -11,9 +11,12 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -24,12 +27,19 @@ import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URI
 import java.net.URL
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FileRepositoryTest : CoroutineTest() {
     private companion object {
         const val TEST_URL = "https://www.sample.com"
         const val TEST_URI = "data:sample/some/path"
+        const val CONCURRENCY_LIMIT = 2
+        const val TOTAL_DOWNLOADS = 6
+        const val LATCH_TIMEOUT_SECONDS = 5L
+        const val POLL_INTERVAL_MILLIS = 10L
         val cacheUri = URI(TEST_URI)
         val url: URL = URL(TEST_URL)
         val goodConnection = TestUrlConnection(
@@ -298,6 +308,61 @@ class FileRepositoryTest : CoroutineTest() {
         // Network was only called once
         assertThat(factory.createdConnections.size).isEqualTo(1)
         verify(exactly = 1) { mockCache.saveData(any<InputStream>(), cacheUri, null) }
+    }
+
+    @Test
+    fun `injected concurrency-limited scope caps concurrent downloads`() = runBlocking<Unit> {
+        val active = AtomicInteger(0)
+        val maxConcurrent = AtomicInteger(0)
+        val release = CountDownLatch(1)
+
+        // createConnection runs on the injected dispatcher (downloadFile no longer switches dispatchers),
+        // so blocking here holds a limited slot and makes the in-flight count observable.
+        val factory = TestUrlConnectionFactory(connectionProvider = {
+            maxConcurrent.accumulateAndGet(active.incrementAndGet()) { a, b -> maxOf(a, b) }
+            release.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            active.decrementAndGet()
+            TestUrlConnection(HttpURLConnection.HTTP_OK, ByteArrayInputStream(ByteArray(0)))
+        })
+
+        // A real fake (not a mock): MockK serializes concurrent invocations, which would mask the
+        // parallelism this test is measuring.
+        val fakeCache = object : LocalFileCache {
+            override fun generateLocalFilesystemURI(remoteURL: URL, checksum: Checksum?): URI =
+                URI("data:" + remoteURL.file)
+
+            override fun cachedContentExists(uri: URI): Boolean = false
+
+            override fun saveData(inputStream: InputStream, uri: URI, checksum: Checksum?) = Unit
+        }
+
+        val repository = DefaultFileRepository(
+            store = KeyedDeferredValueStore(),
+            fileCacheManager = fakeCache,
+            ioScope = CoroutineScope(Dispatchers.IO.limitedParallelism(CONCURRENCY_LIMIT)),
+            logHandler = mockk<LogHandler>(relaxed = true),
+            urlConnectionFactory = factory,
+        )
+
+        // Distinct URLs so the dedup store doesn't coalesce them into a single download. Dispatched on
+        // Dispatchers.Default so they run on real threads, independent of the polling thread below.
+        val downloads = (0 until TOTAL_DOWNLOADS).map { index ->
+            async(Dispatchers.Default) {
+                repository.generateOrGetCachedFileURL(URL("https://cdn.example.com/file_$index"))
+            }
+        }
+
+        // Let the dispatcher saturate, then release everything.
+        val deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(LATCH_TIMEOUT_SECONDS)
+        while (maxConcurrent.get() < CONCURRENCY_LIMIT && System.currentTimeMillis() < deadline) {
+            Thread.sleep(POLL_INTERVAL_MILLIS)
+        }
+        release.countDown()
+        val results = downloads.awaitAll()
+
+        // Never more than the limit ran at once, and every download still completed.
+        assertThat(maxConcurrent.get()).isEqualTo(CONCURRENCY_LIMIT)
+        assertThat(results).hasSize(TOTAL_DOWNLOADS)
     }
 
     // Checksum validation tests


### PR DESCRIPTION
## Summary

Wires paywall workflows fetching end-to-end and adds in-memory + disk caching for both the workflows list and individual workflow details.

**Workflows list (`WorkflowManager.getWorkflowsList`)**
- Fetches the paywall workflows list (`type=paywall`), persists the response to `DeviceCache`, and builds an in-memory `offeringId → workflowId` map exposed via `workflowIdForOfferingId()`.
- Prefetches workflow details for every entry marked `prefetch == true`.
- `onComplete` fires only after the list fetch **and** all prefetch CDN fetches finish, so `workflowIdForOfferingId()` is safe to call as soon as `getOfferings` succeeds.
- Concurrent callers are deduplicated (one network request, all callbacks drained together); on network failure the `offeringId → workflowId` map is restored from the disk cache.

**Workflow details + caching (`WorkflowsCache`)**
- New `WorkflowsCache` is the single owner of in-memory workflow state: resolved per-workflow `WorkflowDataResult`s and the workflows list with its `offeringId → workflowId` map.
- `getWorkflow` serves a fresh cached result without a backend round-trip, so a prefetched workflow is reused when its paywall opens instead of being re-fetched. Uses the same 5 min / 25 hr foreground/background TTL as offerings.
- `DeviceCache` gains `cacheWorkflowsListResponse` / `getWorkflowsListResponseCache` / `clearWorkflowsListResponseCache` for list persistence, following the offerings-response pattern.

**Lifecycle (mirrors offerings)**
- `getWorkflowsList()` runs after offerings are cached, and offerings `onSuccess` now waits for it to complete when the endpoint is enabled.
- Identity transitions (login, alias, switch/logout) clear the workflow caches alongside offerings: the in-memory `WorkflowsCache` and the disk list cache (via `OfferingsCache.clearCache`), so a user switch never serves the previous user's workflows.

**Gating**
- Behind the `USE_WORKFLOWS_ENDPOINT` build config flag (driven by the `revenuecat.useWorkflowsEndpoint` property, off on CI). When off, `WorkflowManager` is passed as `null` to `OfferingsManager`, so offerings timing is unchanged.
- Replaces the old per-current-offering `WorkflowPreWarmer`.

<details><summary>See this generated image for helpful context</summary>
<p>

<img width="2360" height="11300" alt="poster-full" src="https://github.com/user-attachments/assets/36a18edb-e6d6-4ed8-b652-46e5650e191e" />


</p>
</details> 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when getOfferings completes and adds concurrent prefetch/network paths; identity cache clearing is aligned with offerings but wrong timing could briefly serve stale workflow maps after user switch (documented same race as offerings).
> 
> **Overview**
> Replaces the per-offering **`WorkflowPreWarmer`** with a full workflows pipeline gated by **`USE_WORKFLOWS_ENDPOINT`**: when enabled, **`WorkflowManager`** + new **`WorkflowsCache`** own list/detail caching (memory + disk list in **`DeviceCache`**), prefetch of `prefetch=true` workflows, deduped in-flight list fetches, and an **`offeringId → workflowId`** map.
> 
> **`OfferingsManager`** now waits on **`getWorkflowsList`** before delivering offerings success (cache hits and network paths), and forces the workflows list stale when offerings are freshly fetched from the network (not disk fallback). **`IdentityManager`** clears **`WorkflowsCache`** on login, alias, switch, and logout like offerings.
> 
> **`getWorkflow`** gains detail caching/TTL, broader resolve error handling, and optional **`callbackDispatcher`** for bounded prefetch (4-thread pool + dedicated **`DefaultFileRepository`** with **`limitedParallelism(4)`** for CDN). **`PurchasesOrchestrator.getWorkflow`** is nullable when workflows are off, always **`dispatch`**es callbacks to the main thread, and reports a configuration error if disabled.
> 
> **`DefaultFileRepository`** accepts an injectable **`ioScope`**; downloads no longer wrap **`withContext(IO)`** so concurrency limits apply. **`InMemoryCachedObject.lastUpdatedAt`** is **`@Volatile`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ae7df77f9826f3e09f9939474bee914ec4a6ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



