### PR TITLE
Add Workflows list endpoint

### DIFF
--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -1064,10 +1064,11 @@ internal class Backend(
     fun getWorkflows(
         appUserID: String,
         appInBackground: Boolean,
+        type: String? = null,
         onSuccess: (WorkflowsListResponse) -> Unit,
         onError: (PurchasesError) -> Unit,
     ) {
-        val endpoint = Endpoint.GetWorkflows(appUserID)
+        val endpoint = Endpoint.GetWorkflows(appUserID, type)
         val path = endpoint.getPath()
         val cacheKey = BackgroundAwareCallbackCacheKey(listOf(path), appInBackground)
         val call = object : Dispatcher.AsyncCall() {

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.common.remoteconfig.RemoteConfigResponse
 import com.revenuecat.purchases.common.verification.SignatureVerificationMode
 import com.revenuecat.purchases.common.workflows.WorkflowDetailResponse
 import com.revenuecat.purchases.common.workflows.WorkflowJsonParser
+import com.revenuecat.purchases.common.workflows.WorkflowsListResponse
 import com.revenuecat.purchases.customercenter.CustomerCenterConfigData
 import com.revenuecat.purchases.customercenter.CustomerCenterRoot
 import com.revenuecat.purchases.interfaces.RedeemWebPurchaseListener
@@ -104,6 +105,8 @@ internal typealias RemoteConfigCallback = Pair<(RemoteConfigResponse) -> Unit, (
 
 @OptIn(InternalRevenueCatAPI::class)
 internal typealias WorkflowDetailCallback = Pair<(WorkflowDetailResponse) -> Unit, (PurchasesError) -> Unit>
+
+internal typealias WorkflowsListCallback = Pair<(WorkflowsListResponse) -> Unit, (PurchasesError) -> Unit>
 
 internal enum class PostReceiptErrorHandlingBehavior {
     SHOULD_BE_MARKED_SYNCED,
@@ -189,6 +192,10 @@ internal class Backend(
     @get:Synchronized @set:Synchronized
     @Volatile var workflowDetailCallbacks =
         mutableMapOf<BackgroundAwareCallbackCacheKey, MutableList<WorkflowDetailCallback>>()
+
+    @get:Synchronized @set:Synchronized
+    @Volatile var workflowsListCallbacks =
+        mutableMapOf<BackgroundAwareCallbackCacheKey, MutableList<WorkflowsListCallback>>()
 
     @get:Synchronized @set:Synchronized
     @Volatile var remoteConfigCallbacks =
@@ -1045,6 +1052,67 @@ internal class Backend(
         synchronized(this@Backend) {
             val delay = if (appInBackground) Delay.DEFAULT else Delay.NONE
             workflowDetailCallbacks.addBackgroundAwareCallback(
+                call,
+                dispatcher,
+                cacheKey,
+                onSuccess to onError,
+                delay,
+            )
+        }
+    }
+
+    fun getWorkflows(
+        appUserID: String,
+        appInBackground: Boolean,
+        onSuccess: (WorkflowsListResponse) -> Unit,
+        onError: (PurchasesError) -> Unit,
+    ) {
+        val endpoint = Endpoint.GetWorkflows(appUserID)
+        val path = endpoint.getPath()
+        val cacheKey = BackgroundAwareCallbackCacheKey(listOf(path), appInBackground)
+        val call = object : Dispatcher.AsyncCall() {
+            override fun call(): HTTPResult {
+                return httpClient.performRequest(
+                    appConfig.baseURL,
+                    endpoint,
+                    body = null,
+                    postFieldsToSign = null,
+                    backendHelper.authenticationHeaders,
+                    fallbackBaseURLs = appConfig.fallbackBaseURLs,
+                )
+            }
+
+            override fun onError(error: PurchasesError) {
+                synchronized(this@Backend) {
+                    workflowsListCallbacks.remove(cacheKey)
+                }?.forEach { (_, onErrorHandler) ->
+                    onErrorHandler(error)
+                }
+            }
+
+            override fun onCompletion(result: HTTPResult) {
+                synchronized(this@Backend) {
+                    workflowsListCallbacks.remove(cacheKey)
+                }?.forEach { (onSuccessHandler, onErrorHandler) ->
+                    if (result.isSuccessful()) {
+                        try {
+                            onSuccessHandler(
+                                WorkflowJsonParser.parseWorkflowsListResponse(result.payload),
+                            )
+                        } catch (e: SerializationException) {
+                            onErrorHandler(e.toPurchasesError().also { errorLog(it) })
+                        } catch (e: IllegalArgumentException) {
+                            onErrorHandler(e.toPurchasesError().also { errorLog(it) })
+                        }
+                    } else {
+                        onErrorHandler(result.toPurchasesError().also { errorLog(it) })
+                    }
+                }
+            }
+        }
+        synchronized(this@Backend) {
+            val delay = if (appInBackground) Delay.DEFAULT else Delay.NONE
+            workflowsListCallbacks.addBackgroundAwareCallback(
                 call,
                 dispatcher,
                 cacheKey,

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -129,6 +129,7 @@ internal sealed class Endpoint(
             PostReceipt,
             is GetOfferings,
             is GetWorkflow,
+            is GetWorkflows,
             GetProductEntitlementMapping,
             PostRedeemWebPurchase,
             is GetVirtualCurrencies,
@@ -142,7 +143,6 @@ internal sealed class Endpoint(
             PostCreateSupportTicket,
             is WebBillingGetProducts,
             is AliasUsers,
-            is GetWorkflows,
             // WIP: Move to true when we have the final endpoint for remote config, and we can remove the fallback
             GetRemoteConfig,
             ->
@@ -161,6 +161,7 @@ internal sealed class Endpoint(
             is GetAmazonReceipt,
             is GetOfferings,
             is GetWorkflow,
+            is GetWorkflows,
             is PostAttributes,
             PostDiagnostics,
             PostEvents,
@@ -169,7 +170,6 @@ internal sealed class Endpoint(
             PostCreateSupportTicket,
             is WebBillingGetProducts,
             is AliasUsers,
-            is GetWorkflows,
             // WIP: Move to true when we have the final endpoint for remote config, and we can remove the fallback
             GetRemoteConfig,
             ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -35,12 +35,14 @@ internal sealed class Endpoint(
         override fun getPath(useFallback: Boolean) =
             pathTemplate.format(Uri.encode(userId), Uri.encode(workflowId))
     }
-    data class GetWorkflows(val userId: String) : Endpoint(
+    data class GetWorkflows(val userId: String, val type: String? = null) : Endpoint(
         "/v1/subscribers/%s/workflows",
         "get_workflows",
     ) {
-        override fun getPath(useFallback: Boolean) =
-            pathTemplate.format(Uri.encode(userId))
+        override fun getPath(useFallback: Boolean): String {
+            val base = pathTemplate.format(Uri.encode(userId))
+            return if (type != null) "$base?type=${Uri.encode(type)}" else base
+        }
     }
     object LogIn : Endpoint("/v1/subscribers/identify", "log_in") {
         override fun getPath(useFallback: Boolean) = pathTemplate

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/networking/Endpoint.kt
@@ -35,6 +35,13 @@ internal sealed class Endpoint(
         override fun getPath(useFallback: Boolean) =
             pathTemplate.format(Uri.encode(userId), Uri.encode(workflowId))
     }
+    data class GetWorkflows(val userId: String) : Endpoint(
+        "/v1/subscribers/%s/workflows",
+        "get_workflows",
+    ) {
+        override fun getPath(useFallback: Boolean) =
+            pathTemplate.format(Uri.encode(userId))
+    }
     object LogIn : Endpoint("/v1/subscribers/identify", "log_in") {
         override fun getPath(useFallback: Boolean) = pathTemplate
     }
@@ -133,6 +140,7 @@ internal sealed class Endpoint(
             PostCreateSupportTicket,
             is WebBillingGetProducts,
             is AliasUsers,
+            is GetWorkflows,
             // WIP: Move to true when we have the final endpoint for remote config, and we can remove the fallback
             GetRemoteConfig,
             ->
@@ -159,6 +167,7 @@ internal sealed class Endpoint(
             PostCreateSupportTicket,
             is WebBillingGetProducts,
             is AliasUsers,
+            is GetWorkflows,
             // WIP: Move to true when we have the final endpoint for remote config, and we can remove the fallback
             GetRemoteConfig,
             ->

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowJsonParser.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowJsonParser.kt
@@ -12,4 +12,7 @@ internal object WorkflowJsonParser {
 
     fun parseWorkflowDetailResponse(payload: String): WorkflowDetailResponse =
         JsonTools.json.decodeFromString<WorkflowDetailResponse>(payload)
+
+    fun parseWorkflowsListResponse(payload: String): WorkflowsListResponse =
+        JsonTools.json.decodeFromString<WorkflowsListResponse>(payload)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/workflows/WorkflowModels.kt
@@ -147,3 +147,16 @@ internal data class WorkflowDetailResponse(
     @SerialName("enrolled_variants")
     val enrolledVariants: Map<String, String>? = null,
 )
+
+@Serializable
+internal data class WorkflowSummary(
+    val id: String,
+    @SerialName("display_name") val displayName: String,
+    @SerialName("offering_id") val offeringId: String? = null,
+    val prefetch: Boolean = false,
+)
+
+@Serializable
+internal data class WorkflowsListResponse(
+    val workflows: List<WorkflowSummary>,
+)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
@@ -232,6 +232,35 @@ class BackendWorkflowsTest {
     }
 
     @Test
+    fun `getWorkflows with type passes type query parameter`() {
+        val listJson = """{"workflows": [{"id": "wf_1", "display_name": "Flow A", "prefetch": false}]}"""
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflows(appUserId, type = "paywall"),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } returns httpResult(RCHTTPStatusCodes.SUCCESS, listJson)
+
+        var success = false
+        backend.getWorkflows(
+            appUserID = appUserId,
+            appInBackground = false,
+            type = "paywall",
+            onSuccess = { response ->
+                assertThat(response.workflows).hasSize(1)
+                assertThat(response.workflows[0].id).isEqualTo("wf_1")
+                success = true
+            },
+            onError = { fail("unexpected error $it") },
+        )
+        assertThat(success).isTrue()
+    }
+
+    @Test
     fun `getWorkflows propagates HTTP errors`() {
         every {
             mockClient.performRequest(
@@ -257,6 +286,8 @@ class BackendWorkflowsTest {
     @Test
     fun `getWorkflows deduplicates concurrent calls`() {
         val listJson = """{"workflows": []}"""
+        val httpStarted = CountDownLatch(1)
+        val httpProceed = CountDownLatch(1)
         every {
             mockClient.performRequest(
                 baseURL = mockBaseURL,
@@ -267,22 +298,29 @@ class BackendWorkflowsTest {
                 fallbackBaseURLs = emptyList(),
             )
         } answers {
-            Thread.sleep(200)
+            httpStarted.countDown()
+            httpProceed.await(defaultTimeout, TimeUnit.MILLISECONDS)
             httpResult(RCHTTPStatusCodes.SUCCESS, listJson)
         }
 
-        val lock = CountDownLatch(3)
-        repeat(3) {
+        val resultLatch = CountDownLatch(3)
+        asyncBackend.getWorkflows(
+            appUserID = appUserId,
+            appInBackground = false,
+            onSuccess = { resultLatch.countDown() },
+            onError = { fail("unexpected error $it") },
+        )
+        assertThat(httpStarted.await(defaultTimeout, TimeUnit.MILLISECONDS)).isTrue()
+        repeat(2) {
             asyncBackend.getWorkflows(
                 appUserID = appUserId,
                 appInBackground = false,
-                onSuccess = { lock.countDown() },
+                onSuccess = { resultLatch.countDown() },
                 onError = { fail("unexpected error $it") },
             )
         }
-        val completed = lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
-        assertThat(completed).isTrue() // explicit timeout signal
-        assertThat(lock.count).isEqualTo(0)
+        httpProceed.countDown()
+        assertThat(resultLatch.await(defaultTimeout, TimeUnit.MILLISECONDS)).isTrue()
         verify(exactly = 1) {
             mockClient.performRequest(
                 baseURL = mockBaseURL,

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.VerificationResult
 import com.revenuecat.purchases.common.AppConfig
 import com.revenuecat.purchases.common.Backend
 import com.revenuecat.purchases.common.BackendHelper
+import com.revenuecat.purchases.common.Dispatcher
 import com.revenuecat.purchases.common.HTTPClient
 import com.revenuecat.purchases.common.SyncDispatcher
 import com.revenuecat.purchases.common.networking.Endpoint
@@ -22,6 +23,10 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.net.URL
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
 
 @OptIn(InternalRevenueCatAPI::class)
 @RunWith(RobolectricTestRunner::class)
@@ -47,6 +52,18 @@ class BackendWorkflowsTest {
         backendHelper,
     )
     private val appUserId = "user_1"
+    private val defaultTimeout = 2000L
+    private val asyncDispatcher = Dispatcher(
+        ThreadPoolExecutor(1, 2, 0, TimeUnit.MILLISECONDS, LinkedBlockingQueue()),
+    )
+    private val asyncBackendHelper = BackendHelper(apiKey, asyncDispatcher, mockAppConfig, mockClient)
+    private val asyncBackend = Backend(
+        mockAppConfig,
+        asyncDispatcher,
+        asyncDispatcher,
+        mockClient,
+        asyncBackendHelper,
+    )
 
     private val minimalUiConfigJson = """
         "ui_config": {
@@ -174,6 +191,107 @@ class BackendWorkflowsTest {
             onError = { errorCode = it.code },
         )
         assertThat(errorCode).isNotNull
+    }
+
+    @Test
+    fun `getWorkflows returns deserialized list response`() {
+        val listJson = """
+            {
+              "workflows": [
+                {"id": "wf_1", "display_name": "Flow A", "offering_id": "default", "prefetch": true},
+                {"id": "wf_2", "display_name": "Flow B", "prefetch": true}
+              ]
+            }
+        """.trimIndent()
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflows(appUserId),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } returns httpResult(RCHTTPStatusCodes.SUCCESS, listJson)
+
+        var success = false
+        backend.getWorkflows(
+            appUserID = appUserId,
+            appInBackground = false,
+            onSuccess = { response ->
+                assertThat(response.workflows).hasSize(2)
+                assertThat(response.workflows[0].id).isEqualTo("wf_1")
+                assertThat(response.workflows[0].offeringId).isEqualTo("default")
+                assertThat(response.workflows[1].id).isEqualTo("wf_2")
+                assertThat(response.workflows[1].offeringId).isNull()
+                success = true
+            },
+            onError = { fail("unexpected error $it") },
+        )
+        assertThat(success).isTrue()
+    }
+
+    @Test
+    fun `getWorkflows propagates HTTP errors`() {
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflows(appUserId),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } returns httpResult(RCHTTPStatusCodes.NOT_FOUND, """{"error": "not found"}""")
+
+        var errorCode: PurchasesErrorCode? = null
+        backend.getWorkflows(
+            appUserID = appUserId,
+            appInBackground = false,
+            onSuccess = { fail("expected error") },
+            onError = { errorCode = it.code },
+        )
+        assertThat(errorCode).isNotNull
+    }
+
+    @Test
+    fun `getWorkflows deduplicates concurrent calls`() {
+        val listJson = """{"workflows": []}"""
+        every {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflows(appUserId),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        } answers {
+            Thread.sleep(200)
+            httpResult(RCHTTPStatusCodes.SUCCESS, listJson)
+        }
+
+        val lock = CountDownLatch(3)
+        repeat(3) {
+            asyncBackend.getWorkflows(
+                appUserID = appUserId,
+                appInBackground = false,
+                onSuccess = { lock.countDown() },
+                onError = { fail("unexpected error $it") },
+            )
+        }
+        lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
+        assertThat(lock.count).isEqualTo(0)
+        verify(exactly = 1) {
+            mockClient.performRequest(
+                baseURL = mockBaseURL,
+                endpoint = Endpoint.GetWorkflows(appUserId),
+                body = null,
+                postFieldsToSign = null,
+                requestHeaders = defaultAuthHeaders,
+                fallbackBaseURLs = emptyList(),
+            )
+        }
     }
 
     private fun httpResult(responseCode: Int, payload: String) = HTTPResult(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendWorkflowsTest.kt
@@ -280,7 +280,8 @@ class BackendWorkflowsTest {
                 onError = { fail("unexpected error $it") },
             )
         }
-        lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
+        val completed = lock.await(defaultTimeout, TimeUnit.MILLISECONDS)
+        assertThat(completed).isTrue() // explicit timeout signal
         assertThat(lock.count).isEqualTo(0)
         verify(exactly = 1) {
             mockClient.performRequest(

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -64,6 +64,13 @@ class EndpointTest {
     }
 
     @Test
+    fun `GetWorkflows with type has correct path`() {
+        val endpoint = Endpoint.GetWorkflows("test user-id", type = "paywall")
+        val expectedPath = "/v1/subscribers/test%20user-id/workflows?type=paywall"
+        assertThat(endpoint.getPath()).isEqualTo(expectedPath)
+    }
+
+    @Test
     fun `LogIn has correct path`() {
         val endpoint = Endpoint.LogIn
         val expectedPath = "/v1/subscribers/identify"

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -168,6 +168,7 @@ class EndpointTest {
             Endpoint.PostReceipt,
             Endpoint.GetOfferings("test-user-id"),
             Endpoint.GetWorkflow("test-user-id", "wf_1"),
+            Endpoint.GetWorkflows("test-user-id"),
             Endpoint.GetProductEntitlementMapping,
             Endpoint.PostRedeemWebPurchase,
             Endpoint.GetVirtualCurrencies(userId = "test-user-id"),
@@ -188,7 +189,6 @@ class EndpointTest {
             Endpoint.PostEvents,
             Endpoint.WebBillingGetProducts("test-user-id", setOf("product1", "product2")),
             Endpoint.AliasUsers("test-user-id"),
-            Endpoint.GetWorkflows("test-user-id"),
             Endpoint.GetRemoteConfig,
         )
         for (endpoint in expectedNotSupportsValidationEndpoints) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/networking/EndpointTest.kt
@@ -23,6 +23,7 @@ class EndpointTest {
         Endpoint.PostRedeemWebPurchase,
         Endpoint.GetVirtualCurrencies("test-user-id"),
         Endpoint.GetWorkflow("test-user-id", "wf_test"),
+        Endpoint.GetWorkflows("test-user-id"),
         Endpoint.AliasUsers("test-user-id"),
         Endpoint.GetRemoteConfig,
     )
@@ -52,6 +53,13 @@ class EndpointTest {
     fun `GetWorkflow has correct path`() {
         val endpoint = Endpoint.GetWorkflow("test user-id", "wf abc")
         val expectedPath = "/v1/subscribers/test%20user-id/workflows/wf%20abc"
+        assertThat(endpoint.getPath()).isEqualTo(expectedPath)
+    }
+
+    @Test
+    fun `GetWorkflows has correct path`() {
+        val endpoint = Endpoint.GetWorkflows("test user-id")
+        val expectedPath = "/v1/subscribers/test%20user-id/workflows"
         assertThat(endpoint.getPath()).isEqualTo(expectedPath)
     }
 
@@ -173,6 +181,7 @@ class EndpointTest {
             Endpoint.PostEvents,
             Endpoint.WebBillingGetProducts("test-user-id", setOf("product1", "product2")),
             Endpoint.AliasUsers("test-user-id"),
+            Endpoint.GetWorkflows("test-user-id"),
             Endpoint.GetRemoteConfig,
         )
         for (endpoint in expectedNotSupportsValidationEndpoints) {
@@ -221,6 +230,7 @@ class EndpointTest {
             Endpoint.PostEvents,
             Endpoint.WebBillingGetProducts("test-user-id", setOf("product1", "product2")),
             Endpoint.AliasUsers("test-user-id"),
+            Endpoint.GetWorkflows("test-user-id"),
             Endpoint.GetRemoteConfig,
         )
         for (endpoint in expectedEndpoints) {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -1,9 +1,12 @@
+@file:OptIn(InternalRevenueCatAPI::class)
+
 package com.revenuecat.purchases.common.workflows
 
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
-class WorkflowModelsDeserializationTest {
+internal class WorkflowModelsDeserializationTest {
 
     @Test
     fun `WorkflowSummary deserializes with all fields`() {

--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowModelsDeserializationTest.kt
@@ -1,0 +1,64 @@
+package com.revenuecat.purchases.common.workflows
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class WorkflowModelsDeserializationTest {
+
+    @Test
+    fun `WorkflowSummary deserializes with all fields`() {
+        val json = """
+            {"workflows": [{"id": "wf_1", "display_name": "Flow A", "offering_id": "default", "prefetch": true}]}
+        """.trimIndent()
+        val result = WorkflowJsonParser.parseWorkflowsListResponse(json)
+        assertThat(result.workflows).hasSize(1)
+        with(result.workflows[0]) {
+            assertThat(id).isEqualTo("wf_1")
+            assertThat(displayName).isEqualTo("Flow A")
+            assertThat(offeringId).isEqualTo("default")
+            assertThat(prefetch).isTrue()
+        }
+    }
+
+    @Test
+    fun `WorkflowSummary deserializes with null offering_id when field is absent`() {
+        val json = """{"workflows": [{"id": "wf_2", "display_name": "Flow B", "prefetch": true}]}"""
+        val result = WorkflowJsonParser.parseWorkflowsListResponse(json)
+        assertThat(result.workflows[0].offeringId).isNull()
+    }
+
+    @Test
+    fun `WorkflowSummary deserializes with explicit null offering_id`() {
+        val json = """{"workflows": [{"id": "wf_3", "display_name": "Flow C", "offering_id": null, "prefetch": false}]}"""
+        val result = WorkflowJsonParser.parseWorkflowsListResponse(json)
+        assertThat(result.workflows[0].offeringId).isNull()
+    }
+
+    @Test
+    fun `WorkflowSummary defaults prefetch to false when field is absent`() {
+        val json = """{"workflows": [{"id": "wf_4", "display_name": "Flow D"}]}"""
+        val result = WorkflowJsonParser.parseWorkflowsListResponse(json)
+        assertThat(result.workflows[0].prefetch).isFalse()
+    }
+
+    @Test
+    fun `WorkflowsListResponse deserializes empty workflows array`() {
+        val json = """{"workflows": []}"""
+        val result = WorkflowJsonParser.parseWorkflowsListResponse(json)
+        assertThat(result.workflows).isEmpty()
+    }
+
+    @Test
+    fun `WorkflowsListResponse tolerates unknown top-level fields`() {
+        val json = """{"workflows": [], "ui_config": {}, "extra": "ignored"}"""
+        val result = WorkflowJsonParser.parseWorkflowsListResponse(json)
+        assertThat(result.workflows).isEmpty()
+    }
+
+    @Test
+    fun `WorkflowSummary tolerates unknown fields`() {
+        val json = """{"workflows": [{"id": "wf_5", "display_name": "Flow E", "unknown_field": "value"}]}"""
+        val result = WorkflowJsonParser.parseWorkflowsListResponse(json)
+        assertThat(result.workflows[0].id).isEqualTo("wf_5")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `WorkflowSummary` and `WorkflowsListResponse` models (`id`, `display_name`, `offering_id`, `prefetch`) with kotlinx.serialization and `ignoreUnknownKeys` for forward compatibility
- Adds `WorkflowJsonParser.parseWorkflowsListResponse()` 
- Adds `Endpoint.GetWorkflows` and `Backend.getWorkflows()` with background-aware callback deduplication (same pattern as the existing `getWorkflow()` implementation)

Part 1 of 2 — Part 2: #3508

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive networking and parsing alongside existing workflow detail APIs, with broad test coverage and no changes to purchase or auth flows.
> 
> **Overview**
> Adds client support for **listing subscriber workflows** via `GET /v1/subscribers/{userId}/workflows`, including an optional `type` query filter.
> 
> New kotlinx-serialization models `WorkflowSummary` and `WorkflowsListResponse` (with `parseWorkflowsListResponse`) describe list entries (`id`, `display_name`, `offering_id`, `prefetch`). `Endpoint.GetWorkflows` is wired for signature verification like the single-workflow endpoint, and **`Backend.getWorkflows`** performs the request with the same background-aware callback deduplication pattern as `getWorkflow`. Tests cover path encoding, deserialization edge cases, HTTP errors, and concurrent call coalescing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b27d7cdbb89f44573d87272a7cbdd37f19a4d8db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->