### PR TITLE
refactor: extract Offering.presentedOfferingContext() helper and apply across SDK

### DIFF
--- a/purchases/api-defaults-bc7.txt
+++ b/purchases/api-defaults-bc7.txt
@@ -230,6 +230,7 @@ package com.revenuecat.purchases {
     method @kotlin.jvm.Throws(exceptionClasses=NoSuchElementException::class) public com.revenuecat.purchases.Package getPackage(String identifier) throws java.util.NoSuchElementException;
     method public com.revenuecat.purchases.paywalls.PaywallData? getPaywall();
     method public com.revenuecat.purchases.Offering.PaywallComponents? getPaywallComponents();
+    method public com.revenuecat.purchases.PresentedOfferingContext? getPresentedOfferingContext();
     method public String getServerDescription();
     method public com.revenuecat.purchases.Package? getSixMonth();
     method public com.revenuecat.purchases.Package? getThreeMonth();

--- a/purchases/api-defauts.txt
+++ b/purchases/api-defauts.txt
@@ -230,6 +230,7 @@ package com.revenuecat.purchases {
     method @kotlin.jvm.Throws(exceptionClasses=NoSuchElementException::class) public com.revenuecat.purchases.Package getPackage(String identifier) throws java.util.NoSuchElementException;
     method public com.revenuecat.purchases.paywalls.PaywallData? getPaywall();
     method public com.revenuecat.purchases.Offering.PaywallComponents? getPaywallComponents();
+    method public com.revenuecat.purchases.PresentedOfferingContext? getPresentedOfferingContext();
     method public String getServerDescription();
     method public com.revenuecat.purchases.Package? getSixMonth();
     method public com.revenuecat.purchases.Package? getThreeMonth();

--- a/purchases/api-entitlement.txt
+++ b/purchases/api-entitlement.txt
@@ -198,6 +198,7 @@ package com.revenuecat.purchases {
     method @kotlin.jvm.Throws(exceptionClasses=NoSuchElementException::class) public com.revenuecat.purchases.Package getPackage(String identifier) throws java.util.NoSuchElementException;
     method public com.revenuecat.purchases.paywalls.PaywallData? getPaywall();
     method public com.revenuecat.purchases.Offering.PaywallComponents? getPaywallComponents();
+    method public com.revenuecat.purchases.PresentedOfferingContext? getPresentedOfferingContext();
     method public String getServerDescription();
     method public com.revenuecat.purchases.Package? getSixMonth();
     method public com.revenuecat.purchases.Package? getThreeMonth();

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/Offering.kt
@@ -127,6 +127,14 @@ constructor(
         return this.metadata[key] as? String ?: default
     }
 
+    /**
+     * The presented offering context (placement and targeting information) derived from the
+     * first available package, if any.
+     */
+    @InternalRevenueCatAPI
+    public val presentedOfferingContext: PresentedOfferingContext?
+        get() = availablePackages.firstOrNull()?.presentedOfferingContext
+
     @InternalRevenueCatAPI
     public fun copy(presentedOfferingContext: PresentedOfferingContext): Offering {
         return Offering(

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/CustomPaywallImpressionParams.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/paywalls/events/CustomPaywallImpressionParams.kt
@@ -71,6 +71,6 @@ public class CustomPaywallImpressionParams @InternalRevenueCatAPI constructor(
     public constructor(paywallId: String? = null, offering: Offering) : this(
         paywallId = paywallId,
         offeringId = offering.identifier,
-        presentedOfferingContext = offering.availablePackages.firstOrNull()?.presentedOfferingContext,
+        presentedOfferingContext = offering.presentedOfferingContext,
     )
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/OfferingTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/OfferingTest.kt
@@ -1,0 +1,44 @@
+package com.revenuecat.purchases
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.revenuecat.purchases.utils.stubStoreProduct
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class OfferingTest {
+
+    @Test
+    @OptIn(InternalRevenueCatAPI::class)
+    fun `presentedOfferingContext returns context from first package`() {
+        val context = PresentedOfferingContext("my-offering")
+        val pkg = Package(
+            identifier = "\$rc_monthly",
+            packageType = PackageType.MONTHLY,
+            product = stubStoreProduct("monthly_product"),
+            presentedOfferingContext = context,
+        )
+        val offering = Offering(
+            identifier = "my-offering",
+            serverDescription = "",
+            metadata = emptyMap(),
+            availablePackages = listOf(pkg),
+        )
+
+        assertThat(offering.presentedOfferingContext).isEqualTo(context)
+    }
+
+    @Test
+    @OptIn(InternalRevenueCatAPI::class)
+    fun `presentedOfferingContext returns null when no packages`() {
+        val offering = Offering(
+            identifier = "empty-offering",
+            serverDescription = "",
+            metadata = emptyMap(),
+            availablePackages = emptyList(),
+        )
+
+        assertThat(offering.presentedOfferingContext).isNull()
+    }
+}

--- a/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/CustomPaywallEventTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/paywalls/events/CustomPaywallEventTest.kt
@@ -404,6 +404,20 @@ class CustomPaywallEventTest {
         assertThat(params.presentedOfferingContext).isEqualTo(expectedContext)
     }
 
+    @Test
+    fun `CustomPaywallImpressionParams Offering-based init with no packages has null presentedOfferingContext`() {
+        val offering = Offering(
+            identifier = "empty-offering",
+            serverDescription = "",
+            metadata = emptyMap(),
+            availablePackages = emptyList(),
+        )
+        val params = CustomPaywallImpressionParams(paywallId = "pw", offering = offering)
+
+        assertThat(params.offeringId).isEqualTo("empty-offering")
+        assertThat(params.presentedOfferingContext).isNull()
+    }
+
     // endregion
 
     // region Data: placement and targeting fields

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLaunchOptions.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLaunchOptions.kt
@@ -50,7 +50,7 @@ public class PaywallActivityLaunchOptions private constructor(
             )
             offering != null -> OfferingSelection.IdAndPresentedOfferingContext(
                 offeringId = offering.identifier,
-                presentedOfferingContext = offering.availablePackages.firstOrNull()?.presentedOfferingContext,
+                presentedOfferingContext = offering.presentedOfferingContext,
             )
             else -> null
         }
@@ -231,7 +231,7 @@ public class PaywallActivityLaunchIfNeededOptions private constructor(
             )
             offering != null -> OfferingSelection.IdAndPresentedOfferingContext(
                 offeringId = offering.identifier,
-                presentedOfferingContext = offering.availablePackages.firstOrNull()?.presentedOfferingContext,
+                presentedOfferingContext = offering.presentedOfferingContext,
             )
             else -> null
         }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/activity/PaywallActivityLauncher.kt
@@ -90,7 +90,7 @@ public class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultH
                 offeringIdAndPresentedOfferingContext = offering?.let {
                     OfferingSelection.IdAndPresentedOfferingContext(
                         offeringId = it.identifier,
-                        presentedOfferingContext = it.availablePackages.firstOrNull()?.presentedOfferingContext,
+                        presentedOfferingContext = it.presentedOfferingContext,
                     )
                 },
                 fontProvider = fontProvider,
@@ -211,7 +211,7 @@ public class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultH
                         offeringIdAndPresentedOfferingContext = offering?.let {
                             OfferingSelection.IdAndPresentedOfferingContext(
                                 offeringId = it.identifier,
-                                presentedOfferingContext = it.availablePackages.firstOrNull()?.presentedOfferingContext,
+                                presentedOfferingContext = it.presentedOfferingContext,
                             )
                         },
                         fontProvider = fontProvider,
@@ -345,7 +345,7 @@ public class PaywallActivityLauncher(resultCaller: ActivityResultCaller, resultH
                         offeringIdAndPresentedOfferingContext = offering?.let {
                             OfferingSelection.IdAndPresentedOfferingContext(
                                 offeringId = it.identifier,
-                                presentedOfferingContext = it.availablePackages.firstOrNull()?.presentedOfferingContext,
+                                presentedOfferingContext = it.presentedOfferingContext,
                             )
                         },
                         fontProvider = fontProvider,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/customercenter/viewmodel/CustomerCenterViewModel.kt
@@ -1430,7 +1430,7 @@ internal class CustomerCenterViewModelImpl(
             val paywallArgs = PaywallActivityArgs(
                 offeringIdAndPresentedOfferingContext = OfferingSelection.IdAndPresentedOfferingContext(
                     offeringId = offering.identifier,
-                    presentedOfferingContext = offering.availablePackages.firstOrNull()?.presentedOfferingContext,
+                    presentedOfferingContext = offering.presentedOfferingContext,
                 ),
                 shouldDisplayDismissButton = true,
             )

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -1271,7 +1271,7 @@ internal class PaywallViewModelImpl(
         val locale = _lastLocaleList.value.get(0) ?: Locale.getDefault()
         return PaywallEvent.Data(
             paywallIdentifier = paywallId,
-            presentedOfferingContext = offering.presentedOfferingContext,
+            presentedOfferingContext = offering.presentedOfferingContextOrDefault,
             paywallRevision = revision,
             sessionIdentifier = UUID.randomUUID(),
             displayMode = mode.name.lowercase(),
@@ -1288,7 +1288,7 @@ internal class PaywallViewModelImpl(
         }
         return PaywallEvent.Data(
             paywallIdentifier = paywallData.data.id,
-            presentedOfferingContext = offering.presentedOfferingContext,
+            presentedOfferingContext = offering.presentedOfferingContextOrDefault,
             paywallRevision = paywallData.data.revision,
             sessionIdentifier = UUID.randomUUID(),
             displayMode = mode.name.lowercase(),
@@ -1325,7 +1325,7 @@ internal class PaywallViewModelImpl(
         val locale = localeList.get(0) ?: Locale.getDefault()
         return PaywallPresentationFingerprint(
             paywallIdentifier = paywallId,
-            presentedOfferingContext = offering.presentedOfferingContext,
+            presentedOfferingContext = offering.presentedOfferingContextOrDefault,
             paywallRevision = revision,
             displayMode = mode.name.lowercase(),
             localeIdentifier = locale.toString(),
@@ -1340,7 +1340,7 @@ internal class PaywallViewModelImpl(
         val paywallData = offering.paywallComponents ?: return null
         return PaywallPresentationFingerprint(
             paywallIdentifier = paywallData.data.id,
-            presentedOfferingContext = offering.presentedOfferingContext,
+            presentedOfferingContext = offering.presentedOfferingContextOrDefault,
             paywallRevision = paywallData.data.revision,
             displayMode = mode.name.lowercase(),
             localeIdentifier = locale.toString(),
@@ -1366,6 +1366,6 @@ internal class PaywallViewModelImpl(
             ?.mapValues { (_, definition) -> CustomVariableValue.from(definition.defaultValue) }
             ?: emptyMap()
 
-    private val Offering.presentedOfferingContext: PresentedOfferingContext
-        get() = availablePackages.firstOrNull()?.presentedOfferingContext ?: PresentedOfferingContext(identifier)
+    private val Offering.presentedOfferingContextOrDefault: PresentedOfferingContext
+        get() = presentedOfferingContext ?: PresentedOfferingContext(identifier)
 }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/views/PaywallView.kt
@@ -73,7 +73,7 @@ public class PaywallView : CompatComposeView {
         offering?.let {
             setOfferingId(
                 offeringId = it.identifier,
-                presentedOfferingContext = it.availablePackages.firstOrNull()?.presentedOfferingContext,
+                presentedOfferingContext = it.presentedOfferingContext,
             )
         }
         this.shouldDisplayDismissButton = shouldDisplayDismissButton


### PR DESCRIPTION
Added a small helper function for getting the `PresentedOfferingContext` from an Offering object as a follow up on https://github.com/RevenueCat/purchases-android/pull/3424#discussion_r3318327894

Replacing all occurrences of 
```
offering.availablePackages.firstOrNull()?.presentedOfferingContext
```

with the use of the new helper
```
offering.presentedOfferingContext
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with equivalent semantics for offerings with packages; empty offerings still yield null context where callers pass it through directly.
> 
> **Overview**
> Adds an **`@InternalRevenueCatAPI`** `Offering.presentedOfferingContext` property (placement/targeting from the first available package, or **null** when there are no packages) and updates the public API stub files accordingly.
> 
> Call sites across **purchases** and **RevenueCat UI** that previously inlined `availablePackages.firstOrNull()?.presentedOfferingContext` now use `offering.presentedOfferingContext`, including custom paywall impressions, paywall activity launch options, and embedded paywall views. **`PaywallViewModel`** keeps a local `presentedOfferingContextOrDefault` extension that falls back to `PresentedOfferingContext(identifier)` for paywall analytics when the offering has no packages.
> 
> Unit tests cover the new property and the empty-offering case for `CustomPaywallImpressionParams`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 184c1371af274e0726fa1d78743389b51ca42a59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->