### PR TITLE
Add workflow prefetch completion regression test

### DIFF
--- a/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/workflows/WorkflowManagerTest.kt
@@ -790,6 +790,38 @@ class WorkflowManagerTest {
     }
 
     @Test
+    fun `getWorkflowsList second caller waits for in-flight prefetch when list cache is fresh`() {
+        val response = WorkflowsListResponse(workflows = listOf(
+            WorkflowSummary(id = "wf_a", displayName = "A", prefetch = true),
+        ))
+        val listSuccessSlot = slot<(WorkflowsListResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflows(any(), any(), type = any(), onSuccess = capture(listSuccessSlot), onError = any())
+        } answers { listSuccessSlot.captured(response) }
+
+        val detailSuccess = slot<(WorkflowDetailResponse) -> Unit>()
+        every {
+            mockBackend.getWorkflow("user_1", "wf_a", false, capture(detailSuccess), any())
+        } just Runs
+        coEvery { mockResolver.resolve(any()) } returns mockk()
+
+        var firstCompleted = false
+        var secondCompleted = false
+        workflowManager.getWorkflowsList("user_1", false) { firstCompleted = true }
+
+        assertThat(firstCompleted).isFalse()
+
+        workflowManager.getWorkflowsList("user_1", false) { secondCompleted = true }
+
+        assertThat(secondCompleted).isFalse()
+
+        detailSuccess.captured(WorkflowDetailResponse(action = WorkflowResponseAction.INLINE, data = mockk()))
+
+        assertThat(firstCompleted).isTrue()
+        assertThat(secondCompleted).isTrue()
+    }
+
+    @Test
     fun `getWorkflowsList calls onComplete even if a prefetch workflow fails`() {
         val response = WorkflowsListResponse(workflows = listOf(
             WorkflowSummary(id = "wf_a", displayName = "A", prefetch = true),


### PR DESCRIPTION
## Summary

Adds a regression test for concurrent workflows-list callers when the first list response has already made the list cache fresh but prefetch workflow details are still in flight.

The test documents that a second caller should keep waiting until the in-flight prefetch completes instead of returning through the fresh-cache fast path.

## Validation

Expected failure on the current PR head:

```bash
./gradlew :purchases:testDefaultsBc8DebugUnitTest --tests "com.revenuecat.purchases.common.workflows.WorkflowManagerTest.getWorkflowsList second caller waits for in-flight prefetch when list cache is fresh"
```

Result:

```
WorkflowManagerTest > getWorkflowsList second caller waits for in-flight prefetch when list cache is fresh FAILED
    org.opentest4j.AssertionFailedError at WorkflowManagerTest.kt:816

1 test completed, 1 failed
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications; it documents expected concurrent prefetch completion behavior.
> 
> **Overview**
> Adds a **regression unit test** in `WorkflowManagerTest` for a race when two callers invoke `getWorkflowsList` back-to-back while the first request has already refreshed the workflows list cache but **prefetch workflow details are still loading**.
> 
> The test asserts that the **second** caller’s `onComplete` must **not** run until the in-flight prefetch finishes (same as the first caller), instead of completing immediately via the fresh in-memory list cache path. It is written to **fail on current behavior** (second callback completes too early at line 816), documenting the bug for a follow-up fix in `WorkflowManager`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8cfdcdbc4e78aec83bffccd22074492a5a8ca29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->