### PR TITLE
chore: add CircleCI manual paywall tester build with configurable API key and workflows flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,12 @@ parameters:
     type: enum
     enum: [internal, alpha, beta, production]
     default: alpha
+  paywall_tester_api_key:
+    type: string
+    default: ""
+  paywall_tester_use_workflows_endpoint:
+    type: boolean
+    default: false
 
 commands:
   install-sdkman:
@@ -94,6 +100,13 @@ commands:
             --export-secret-keys > /home/circleci/.gnupg/secring.gpg
 
   build-paywall-tester:
+    parameters:
+      api_key:
+        type: string
+        default: ""
+      use_workflows_endpoint:
+        type: boolean
+        default: false
     steps:
       - android/accept_licenses
       - android/restore_gradle_cache
@@ -105,7 +118,7 @@ commands:
       - run:
           name: Create app bundle
           command: |
-            bundle exec fastlane android build_paywall_tester_bundle
+            bundle exec fastlane android build_paywall_tester_bundle api_key:'<< parameters.api_key >>' use_workflows_endpoint:'<< parameters.use_workflows_endpoint >>'
       - store_artifacts:
           path: examples/paywall-tester/build/outputs/bundle/release/paywall-tester-release.aab
       - android/save_gradle_cache
@@ -512,12 +525,20 @@ jobs:
     parameters:
       track:
         type: string
+      api_key:
+        type: string
+        default: ""
+      use_workflows_endpoint:
+        type: boolean
+        default: false
     steps:
       - checkout
       - install-sdkman
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
-      - build-paywall-tester
+      - build-paywall-tester:
+          api_key: << parameters.api_key >>
+          use_workflows_endpoint: << parameters.use_workflows_endpoint >>
       - run:
           name: Publish aab
           command: |
@@ -1210,6 +1231,8 @@ workflows:
     jobs:
         - publish-paywall-tester-release:
             track: << pipeline.parameters.paywall_tester_track >>
+            api_key: << pipeline.parameters.paywall_tester_api_key >>
+            use_workflows_endpoint: << pipeline.parameters.paywall_tester_use_workflows_endpoint >>
 
   manual-rct-tester-release:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,9 +101,6 @@ commands:
 
   build-paywall-tester:
     parameters:
-      api_key:
-        type: string
-        default: ""
       use_workflows_endpoint:
         type: boolean
         default: false
@@ -117,8 +114,10 @@ commands:
           command: echo $PAYWALL_TESTER_RELEASE_KEYSTORE | base64 -d > keystore
       - run:
           name: Create app bundle
+          environment:
+            PAYWALL_TESTER_OVERRIDE_API_KEY: << parameters.api_key >>
           command: |
-            bundle exec fastlane android build_paywall_tester_bundle api_key:'<< parameters.api_key >>' use_workflows_endpoint:'<< parameters.use_workflows_endpoint >>'
+            bundle exec fastlane android build_paywall_tester_bundle use_workflows_endpoint:'<< parameters.use_workflows_endpoint >>'
       - store_artifacts:
           path: examples/paywall-tester/build/outputs/bundle/release/paywall-tester-release.aab
       - android/save_gradle_cache
@@ -512,6 +511,7 @@ jobs:
             bundle exec fastlane android publish_purchase_tester aab_path:'examples/purchase-tester/build/outputs/bundle/bc8Release/purchase-tester-bc8-release.aab'
 
   assemble-paywall-tester-release:
+    # Used in the regular CI pipeline — always uses env-var defaults, not the manual ad-hoc params.
     <<: *android-executor
     steps:
       - checkout
@@ -525,9 +525,6 @@ jobs:
     parameters:
       track:
         type: string
-      api_key:
-        type: string
-        default: ""
       use_workflows_endpoint:
         type: boolean
         default: false
@@ -537,7 +534,6 @@ jobs:
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - build-paywall-tester:
-          api_key: << parameters.api_key >>
           use_workflows_endpoint: << parameters.use_workflows_endpoint >>
       - run:
           name: Publish aab

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,9 @@ commands:
 
   build-paywall-tester:
     parameters:
+      api_key:
+        type: string
+        default: ""
       use_workflows_endpoint:
         type: boolean
         default: false
@@ -525,6 +528,9 @@ jobs:
     parameters:
       track:
         type: string
+      api_key:
+        type: string
+        default: ""
       use_workflows_endpoint:
         type: boolean
         default: false
@@ -534,6 +540,7 @@ jobs:
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - build-paywall-tester:
+          api_key: << parameters.api_key >>
           use_workflows_endpoint: << parameters.use_workflows_endpoint >>
       - run:
           name: Publish aab

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,6 @@ parameters:
   paywall_tester_api_key:
     type: string
     default: ""
-  paywall_tester_use_workflows_endpoint:
-    type: boolean
-    default: false
 
 commands:
   install-sdkman:
@@ -104,9 +101,6 @@ commands:
       api_key:
         type: string
         default: ""
-      use_workflows_endpoint:
-        type: boolean
-        default: false
     steps:
       - android/accept_licenses
       - android/restore_gradle_cache
@@ -120,7 +114,7 @@ commands:
           environment:
             PAYWALL_TESTER_OVERRIDE_API_KEY: << parameters.api_key >>
           command: |
-            bundle exec fastlane android build_paywall_tester_bundle use_workflows_endpoint:'<< parameters.use_workflows_endpoint >>'
+            bundle exec fastlane android build_paywall_tester_bundle
       - store_artifacts:
           path: examples/paywall-tester/build/outputs/bundle/release/paywall-tester-release.aab
       - android/save_gradle_cache
@@ -531,9 +525,6 @@ jobs:
       api_key:
         type: string
         default: ""
-      use_workflows_endpoint:
-        type: boolean
-        default: false
     steps:
       - checkout
       - install-sdkman
@@ -541,7 +532,6 @@ jobs:
           cache-version: v1
       - build-paywall-tester:
           api_key: << parameters.api_key >>
-          use_workflows_endpoint: << parameters.use_workflows_endpoint >>
       - run:
           name: Publish aab
           command: |
@@ -1235,7 +1225,6 @@ workflows:
         - publish-paywall-tester-release:
             track: << pipeline.parameters.paywall_tester_track >>
             api_key: << pipeline.parameters.paywall_tester_api_key >>
-            use_workflows_endpoint: << pipeline.parameters.paywall_tester_use_workflows_endpoint >>
 
   manual-rct-tester-release:
     when:

--- a/examples/paywall-tester/build.gradle.kts
+++ b/examples/paywall-tester/build.gradle.kts
@@ -71,11 +71,6 @@ android {
             "PAYWALL_TESTER_AUTO_OPEN_OFFERING_ID",
             "\"${resolveProperty("PAYWALL_TESTER_AUTO_OPEN_OFFERING_ID")}\"",
         )
-        buildConfigField(
-            "boolean",
-            "USE_WORKFLOWS_ENDPOINT",
-            (resolveProperty("revenuecat.useWorkflowsEndpoint") == "true").toString(),
-        )
     }
 
     signingConfigs {

--- a/examples/paywall-tester/build.gradle.kts
+++ b/examples/paywall-tester/build.gradle.kts
@@ -71,6 +71,11 @@ android {
             "PAYWALL_TESTER_AUTO_OPEN_OFFERING_ID",
             "\"${resolveProperty("PAYWALL_TESTER_AUTO_OPEN_OFFERING_ID")}\"",
         )
+        buildConfigField(
+            "boolean",
+            "USE_WORKFLOWS_ENDPOINT",
+            (resolveProperty("revenuecat.useWorkflowsEndpoint") == "true").toString(),
+        )
     }
 
     signingConfigs {

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ConfigurePurchasesUseCase.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ConfigurePurchasesUseCase.kt
@@ -1,6 +1,8 @@
 package com.revenuecat.paywallstester
 
 import android.content.Context
+import com.revenuecat.purchases.DangerousSettings
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesConfiguration
@@ -9,11 +11,19 @@ internal class ConfigurePurchasesUseCase(
     private val context: Context,
 ) {
 
-    operator fun invoke(apiKey: String) {
+    @OptIn(InternalRevenueCatAPI::class)
+    operator fun invoke(apiKey: String, useWorkflows: Boolean = false) {
+        val dangerousSettings = if (useWorkflows) {
+            DangerousSettings.forWorkflows()
+        } else {
+            DangerousSettings()
+        }
+
         val builder = PurchasesConfiguration.Builder(context.applicationContext, apiKey)
             .purchasesAreCompletedBy(PurchasesAreCompletedBy.REVENUECAT)
             .appUserID(null)
             .diagnosticsEnabled(true)
+            .dangerousSettings(dangerousSettings)
 
         if (Constants.PREFERRED_UI_LOCALE_OVERRIDE.isNotEmpty()) {
             builder.preferredUILocaleOverride(

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainActivity.kt
@@ -5,6 +5,7 @@ package com.revenuecat.paywallstester
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
@@ -56,8 +57,8 @@ class MainActivity : ComponentActivity(), PaywallResultHandler {
     }
 
     override fun onActivityResult(result: PaywallResult) {
-        // TODO-PAYWALLS: Handle result
         Log.e(TAG, "LAUNCH PAYWALL RESULT: $result")
+        toast("Paywall result: ${result::class.simpleName}")
     }
 
     @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
@@ -70,38 +71,50 @@ class MainActivity : ComponentActivity(), PaywallResultHandler {
         paywallActivityLauncher.launchWithOptions(options)
     }
 
+    private fun toast(message: String) {
+        Toast.makeText(applicationContext, message, Toast.LENGTH_SHORT).show()
+    }
+
     private val paywallListener = object : PaywallListener {
         override fun onPurchasePackageInitiated(rcPackage: Package, resume: Resumable) {
             Log.d(TAG, "onPurchasePackageInitiated: ${rcPackage.identifier}")
             resume()
+            toast("onPurchasePackageInitiated: ${rcPackage.identifier}")
         }
 
         override fun onPurchaseStarted(rcPackage: Package) {
             Log.d(TAG, "onPurchaseStarted: ${rcPackage.identifier}")
+            toast("onPurchaseStarted: ${rcPackage.identifier}")
         }
 
         override fun onPurchaseCompleted(customerInfo: CustomerInfo, storeTransaction: StoreTransaction) {
             Log.d(TAG, "onPurchaseCompleted: ${storeTransaction.orderId}")
+            toast("onPurchaseCompleted: ${storeTransaction.orderId}")
         }
 
         override fun onPurchaseError(error: PurchasesError) {
             Log.d(TAG, "onPurchaseError: ${error.message}")
+            toast("onPurchaseError: ${error.message}")
         }
 
         override fun onPurchaseCancelled() {
             Log.d(TAG, "onPurchaseCancelled")
+            toast("onPurchaseCancelled")
         }
 
         override fun onRestoreStarted() {
             Log.d(TAG, "onRestoreStarted")
+            toast("onRestoreStarted")
         }
 
         override fun onRestoreCompleted(customerInfo: CustomerInfo) {
             Log.d(TAG, "onRestoreCompleted")
+            toast("onRestoreCompleted")
         }
 
         override fun onRestoreError(error: PurchasesError) {
             Log.d(TAG, "onRestoreError: ${error.message}")
+            toast("onRestoreError: ${error.message}")
         }
     }
 

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainApplication.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainApplication.kt
@@ -24,7 +24,7 @@ class MainApplication : Application() {
 
         val apiKeyStore = ApiKeyStore(this)
         val apiKey = apiKeyStore.getLastUsedApiKey()
-        val useWorkflows = apiKeyStore.getUseWorkflows(default = BuildConfig.USE_WORKFLOWS_ENDPOINT)
+        val useWorkflows = apiKeyStore.getUseWorkflows()
         val configurePurchases = ConfigurePurchasesUseCase(this)
         configurePurchases(apiKey, useWorkflows)
         Purchases.sharedInstance.debugEventListener = DebugEventListener { event ->

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainApplication.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/MainApplication.kt
@@ -22,9 +22,11 @@ class MainApplication : Application() {
 
         Purchases.logLevel = LogLevel.VERBOSE
 
-        val apiKey = ApiKeyStore(this).getLastUsedApiKey()
+        val apiKeyStore = ApiKeyStore(this)
+        val apiKey = apiKeyStore.getLastUsedApiKey()
+        val useWorkflows = apiKeyStore.getUseWorkflows(default = BuildConfig.USE_WORKFLOWS_ENDPOINT)
         val configurePurchases = ConfigurePurchasesUseCase(this)
-        configurePurchases(apiKey)
+        configurePurchases(apiKey, useWorkflows)
         Purchases.sharedInstance.debugEventListener = DebugEventListener { event ->
             Log.d(TAG, "DebugEvent: ${event.name} ${event.properties}")
         }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/data/ApiKeyStore.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/data/ApiKeyStore.kt
@@ -30,6 +30,6 @@ internal class ApiKeyStore(
         }
     }
 
-    fun getUseWorkflows(default: Boolean = false): Boolean =
+    fun getUseWorkflows(default: Boolean = true): Boolean =
         sharedPreferences.getBoolean(KEY_USE_WORKFLOWS, default)
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/data/ApiKeyStore.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/data/ApiKeyStore.kt
@@ -11,6 +11,7 @@ internal class ApiKeyStore(
     internal companion object {
         private const val SHARED_PREFERENCES_NAME = "com.revenuecat.paywallstester"
         private const val KEY_LAST_USED_API_KEY = "com.revenuecat.paywallstester.last_used_api_key"
+        private const val KEY_USE_WORKFLOWS = "com.revenuecat.paywallstester.use_workflows"
     }
 
     constructor(context: Context) : this(context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE))
@@ -22,4 +23,13 @@ internal class ApiKeyStore(
     }
 
     fun getLastUsedApiKey(): String = sharedPreferences.getString(KEY_LAST_USED_API_KEY, Constants.GOOGLE_API_KEY_A)!!
+
+    fun setUseWorkflows(useWorkflows: Boolean) {
+        sharedPreferences.edit {
+            putBoolean(KEY_USE_WORKFLOWS, useWorkflows)
+        }
+    }
+
+    fun getUseWorkflows(default: Boolean = false): Boolean =
+        sharedPreferences.getBoolean(KEY_USE_WORKFLOWS, default)
 }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/MainScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/MainScreen.kt
@@ -62,9 +62,9 @@ fun MainScreenPreview() {
 }
 
 private val bottomNavigationItems = listOf(
-    Tab.AppInfo,
-    Tab.Paywalls,
     Tab.Offerings,
+    Tab.Paywalls,
+    Tab.AppInfo,
     Tab.Locale,
 )
 
@@ -81,7 +81,7 @@ private fun MainNavHost(
 ) {
     NavHost(
         navController,
-        startDestination = Tab.Paywalls.route,
+        startDestination = Tab.Offerings.route,
         modifier = modifier,
     ) {
         composable(Tab.AppInfo.route) {

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
@@ -231,6 +231,7 @@ private fun LoginDialog(viewModel: AppInfoScreenViewModel, onDismissed: () -> Un
 
 @Composable
 private fun ApiKeyDialog(onApiKeyClick: (String) -> Unit, onDismissed: () -> Unit) {
+    var customApiKey by remember { mutableStateOf("") }
     Dialog(onDismissRequest = { onDismissed() }) {
         Surface(shape = MaterialTheme.shapes.medium) {
             Column(Modifier.padding(all = 16.dp)) {
@@ -246,6 +247,19 @@ private fun ApiKeyDialog(onApiKeyClick: (String) -> Unit, onDismissed: () -> Uni
                     onClick = onApiKeyClick,
                 )
 
+                Spacer(Modifier.size(8.dp))
+                Text(
+                    text = "Custom API key",
+                    style = MaterialTheme.typography.labelSmall,
+                )
+                OutlinedTextField(
+                    value = customApiKey,
+                    onValueChange = { customApiKey = it },
+                    label = { Text("Paste your API key") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
                 Spacer(Modifier.size(4.dp))
                 Row(
                     Modifier
@@ -255,6 +269,12 @@ private fun ApiKeyDialog(onApiKeyClick: (String) -> Unit, onDismissed: () -> Uni
                 ) {
                     TextButton(onClick = { onDismissed() }) {
                         Text("CANCEL")
+                    }
+                    TextButton(
+                        enabled = customApiKey.isNotBlank(),
+                        onClick = { onApiKeyClick(customApiKey.trim()) },
+                    ) {
+                        Text("USE CUSTOM")
                     }
                 }
             }

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreen.kt
@@ -91,9 +91,11 @@ fun AppInfoScreen(
         val currentApiKeyDescription by remember { derivedStateOf { state.apiKeyDescription } }
         val currentActiveEntitlements by remember { derivedStateOf { state.activeEntitlements } }
         Spacer(modifier = Modifier.weight(1f))
+        val useWorkflows by remember { derivedStateOf { state.useWorkflows } }
         Text(text = "Current user ID: $currentUserID")
         Text(text = "Current active entitlements: $currentActiveEntitlements")
         Text(text = "Current API key: $currentApiKeyDescription")
+        Text(text = "Workflows: ${if (useWorkflows) "enabled" else "disabled"}")
         Button(onClick = { showLogInDialog = true }) {
             Text(text = "Log in")
         }
@@ -102,6 +104,9 @@ fun AppInfoScreen(
         }
         Button(onClick = { showApiKeyDialog = true }) {
             Text(text = "Switch API key")
+        }
+        Button(onClick = { viewModel.toggleUseWorkflows() }) {
+            Text(text = if (useWorkflows) "Disable workflows" else "Enable workflows")
         }
         Button(
             enabled = !isClearingFileCache,
@@ -343,12 +348,14 @@ fun AppInfoScreenPreview() {
                         appUserID = "test-user-id",
                         apiKeyDescription = "test-api-key",
                         activeEntitlements = listOf("pro", "premium"),
+                        useWorkflows = false,
                     ),
                 )
 
             override fun logIn(newAppUserId: String) {}
             override fun logOut() {}
             override fun switchApiKey(newApiKey: String) {}
+            override fun toggleUseWorkflows() {}
             override fun refresh() {}
         },
         tappedOnCustomerCenter = {},

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreenViewModel.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreenViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.revenuecat.paywallstester.BuildConfig
 import com.revenuecat.paywallstester.ConfigurePurchasesUseCase
 import com.revenuecat.paywallstester.Constants
 import com.revenuecat.paywallstester.data.ApiKeyStore
@@ -25,12 +26,14 @@ interface AppInfoScreenViewModel {
         val appUserID: String,
         val apiKeyDescription: String,
         val activeEntitlements: List<String>,
+        val useWorkflows: Boolean,
     ) {
         companion object {
             val Empty = UiState(
                 appUserID = "",
                 apiKeyDescription = "",
                 activeEntitlements = emptyList(),
+                useWorkflows = false,
             )
         }
     }
@@ -40,6 +43,7 @@ interface AppInfoScreenViewModel {
     fun logIn(newAppUserId: String)
     fun logOut()
     fun switchApiKey(newApiKey: String)
+    fun toggleUseWorkflows()
     fun refresh()
 }
 
@@ -68,6 +72,7 @@ internal class AppInfoScreenViewModelImpl(
     init {
         updateAppUserID()
         updateApiKeyDescription()
+        updateUseWorkflows()
         viewModelScope.launch {
             updateActiveEntitlements()
         }
@@ -97,8 +102,15 @@ internal class AppInfoScreenViewModelImpl(
 
     override fun switchApiKey(newApiKey: String) {
         apiKeyStore.setLastUsedApiKey(newApiKey)
-        configurePurchases(newApiKey)
+        configurePurchases(newApiKey, apiKeyStore.getUseWorkflows(default = BuildConfig.USE_WORKFLOWS_ENDPOINT))
         updateApiKeyDescription()
+    }
+
+    override fun toggleUseWorkflows() {
+        val newValue = !apiKeyStore.getUseWorkflows(default = BuildConfig.USE_WORKFLOWS_ENDPOINT)
+        apiKeyStore.setUseWorkflows(newValue)
+        configurePurchases(Purchases.sharedInstance.currentConfiguration.apiKey, newValue)
+        updateUseWorkflows()
     }
 
     override fun refresh() {
@@ -121,6 +133,12 @@ internal class AppInfoScreenViewModelImpl(
                     else -> "Custom: $apiKey"
                 },
             )
+        }
+    }
+
+    private fun updateUseWorkflows() {
+        _state.update {
+            it.copy(useWorkflows = apiKeyStore.getUseWorkflows(default = BuildConfig.USE_WORKFLOWS_ENDPOINT))
         }
     }
 

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreenViewModel.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/main/appinfo/AppInfoScreenViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.revenuecat.paywallstester.BuildConfig
 import com.revenuecat.paywallstester.ConfigurePurchasesUseCase
 import com.revenuecat.paywallstester.Constants
 import com.revenuecat.paywallstester.data.ApiKeyStore
@@ -102,12 +101,12 @@ internal class AppInfoScreenViewModelImpl(
 
     override fun switchApiKey(newApiKey: String) {
         apiKeyStore.setLastUsedApiKey(newApiKey)
-        configurePurchases(newApiKey, apiKeyStore.getUseWorkflows(default = BuildConfig.USE_WORKFLOWS_ENDPOINT))
+        configurePurchases(newApiKey, apiKeyStore.getUseWorkflows(default = true))
         updateApiKeyDescription()
     }
 
     override fun toggleUseWorkflows() {
-        val newValue = !apiKeyStore.getUseWorkflows(default = BuildConfig.USE_WORKFLOWS_ENDPOINT)
+        val newValue = !apiKeyStore.getUseWorkflows(default = true)
         apiKeyStore.setUseWorkflows(newValue)
         configurePurchases(Purchases.sharedInstance.currentConfiguration.apiKey, newValue)
         updateUseWorkflows()
@@ -138,7 +137,7 @@ internal class AppInfoScreenViewModelImpl(
 
     private fun updateUseWorkflows() {
         _state.update {
-            it.copy(useWorkflows = apiKeyStore.getUseWorkflows(default = BuildConfig.USE_WORKFLOWS_ENDPOINT))
+            it.copy(useWorkflows = apiKeyStore.getUseWorkflows(default = true))
         }
     }
 

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreen.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreen.kt
@@ -2,7 +2,7 @@ package com.revenuecat.paywallstester.ui.screens.paywall
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.AlertDialog
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -82,7 +82,7 @@ private fun PurchaseAlertDialog(
         onDismissRequest = {
             viewModel.onDialogDismissed()
         },
-        buttons = {
+        confirmButton = {
             TextButton(
                 onClick = {
                     viewModel.onDialogDismissed()

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreenViewModel.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreenViewModel.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.paywallstester.ui.screens.paywall
 
 import android.app.Application
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
@@ -33,10 +34,15 @@ interface PaywallScreenViewModel : PaywallListener {
     fun refreshOffering()
 }
 
+@SuppressWarnings("TooManyFunctions")
 class PaywallScreenViewModelImpl(
     application: Application,
     savedStateHandle: SavedStateHandle,
 ) : AndroidViewModel(application), PaywallScreenViewModel {
+
+    companion object {
+        const val TAG = "PaywallScreenViewModel"
+    }
 
     override val state: StateFlow<PaywallScreenState>
         get() = _state.asStateFlow()
@@ -94,6 +100,14 @@ class PaywallScreenViewModelImpl(
                 )
             }
         }
+    }
+
+    override fun onPurchaseStarted(rcPackage: Package) {
+        Log.d(TAG, "onPurchaseStarted")
+    }
+
+    override fun onPurchaseCancelled() {
+        Log.d(TAG, "onPurchaseCancelled")
     }
 
     override fun onPurchaseError(error: PurchasesError) = Unit

--- a/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreenViewModel.kt
+++ b/examples/paywall-tester/src/main/java/com/revenuecat/paywallstester/ui/screens/paywall/PaywallScreenViewModel.kt
@@ -34,7 +34,7 @@ interface PaywallScreenViewModel : PaywallListener {
     fun refreshOffering()
 }
 
-@SuppressWarnings("TooManyFunctions")
+@Suppress("TooManyFunctions")
 class PaywallScreenViewModelImpl(
     application: Application,
     savedStateHandle: SavedStateHandle,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -398,16 +398,19 @@ platform :android do
   end
 
   desc "Build paywall tester app bundle"
-  lane :build_paywall_tester_bundle do
+  lane :build_paywall_tester_bundle do |options|
+    api_key_a = options[:api_key].to_s.empty? ? (ENV['PAYWALLS_V2_ALPHA_API_KEY'] || '') : options[:api_key]
+    use_workflows_endpoint = options[:use_workflows_endpoint].to_s == "true"
     build_bundle(
       build_task: 'examples:paywall-tester:bundleBc8',
       env_prefix: 'PAYWALL_TESTER',
       gradle_properties_prefix: 'paywallTester',
       extra_properties: {
-        "PAYWALL_TESTER_API_KEY_A" => ENV['PAYWALLS_V2_ALPHA_API_KEY'] || '',
+        "PAYWALL_TESTER_API_KEY_A" => api_key_a,
         "PAYWALL_TESTER_API_KEY_B" => ENV['PAYWALLS_V2_TEMPLATE_REPO_API_KEY'] || '',
         "PAYWALL_TESTER_API_KEY_A_LABEL" => "Paywalls V2 Alpha",
         "PAYWALL_TESTER_API_KEY_B_LABEL" => "Official Paywalls V2 Template Repo",
+        "revenuecat.useWorkflowsEndpoint" => use_workflows_endpoint.to_s,
       }
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -398,9 +398,8 @@ platform :android do
   end
 
   desc "Build paywall tester app bundle"
-  lane :build_paywall_tester_bundle do |options|
+  lane :build_paywall_tester_bundle do
     api_key_a = ENV['PAYWALL_TESTER_OVERRIDE_API_KEY'].to_s.empty? ? (ENV['PAYWALLS_V2_ALPHA_API_KEY'] || '') : ENV['PAYWALL_TESTER_OVERRIDE_API_KEY']
-    use_workflows_endpoint = options[:use_workflows_endpoint].to_s == "true"
     build_bundle(
       build_task: 'examples:paywall-tester:bundleBc8',
       env_prefix: 'PAYWALL_TESTER',
@@ -410,7 +409,6 @@ platform :android do
         "PAYWALL_TESTER_API_KEY_B" => ENV['PAYWALLS_V2_TEMPLATE_REPO_API_KEY'] || '',
         "PAYWALL_TESTER_API_KEY_A_LABEL" => "Paywalls V2 Alpha",
         "PAYWALL_TESTER_API_KEY_B_LABEL" => "Official Paywalls V2 Template Repo",
-        "revenuecat.useWorkflowsEndpoint" => use_workflows_endpoint.to_s,
       }
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -399,7 +399,7 @@ platform :android do
 
   desc "Build paywall tester app bundle"
   lane :build_paywall_tester_bundle do |options|
-    api_key_a = options[:api_key].to_s.empty? ? (ENV['PAYWALLS_V2_ALPHA_API_KEY'] || '') : options[:api_key]
+    api_key_a = ENV['PAYWALL_TESTER_OVERRIDE_API_KEY'].to_s.empty? ? (ENV['PAYWALLS_V2_ALPHA_API_KEY'] || '') : ENV['PAYWALL_TESTER_OVERRIDE_API_KEY']
     use_workflows_endpoint = options[:use_workflows_endpoint].to_s == "true"
     build_bundle(
       build_task: 'examples:paywall-tester:bundleBc8',

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/data/PaywallViewModel.kt
@@ -528,10 +528,6 @@ internal class PaywallViewModelImpl(
                         }
                     }
                 }
-
-                else -> {
-                    Logger.e("Unsupported purchase completion type: ${purchases.purchasesAreCompletedBy}")
-                }
             }
         } catch (e: PurchasesException) {
             Logger.e("Error restoring purchases: $e")
@@ -634,8 +630,7 @@ internal class PaywallViewModelImpl(
                         },
                         subscriptionOption = subscriptionOption,
                     )
-                    val result = myAppPurchaseLogic.performPurchase(activity, purchaseParams)
-                    when (result) {
+                    when (val result = myAppPurchaseLogic.performPurchase(activity, purchaseParams)) {
                         is PurchaseLogicResult.Success -> {
                             val customerInfo = purchases.awaitSyncPurchases()
                             _purchaseCompleted.value = true
@@ -687,9 +682,6 @@ internal class PaywallViewModelImpl(
                     Logger.d("Dismissing paywall after purchase")
                     trackCurrentWorkflowStepCompleted()
                     options.dismissRequest()
-                }
-                else -> {
-                    Logger.e("Unsupported purchase completion type: ${purchases.purchasesAreCompletedBy}")
                 }
             }
         } catch (e: PurchasesException) {


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation

Enables triggering an ad-hoc paywall tester build from any branch via the CircleCI API, passing a custom API key and the `USE_WORKFLOWS_ENDPOINT` flag as pipeline parameters — without modifying project-level environment variables. This makes it easy to test multipage paywalls from feature branches.

### Description

**CI / build plumbing:**
- Adds `paywall_tester_api_key` and `paywall_tester_use_workflows_endpoint` pipeline parameters to the `manual-paywall-tester-release` workflow. The API key is delivered via a step-level `PAYWALL_TESTER_OVERRIDE_API_KEY` env var (not echoed in the command log); when empty it falls back to the existing `PAYWALLS_V2_ALPHA_API_KEY` env var so main-branch and release builds are unaffected.
- Fixes `ui/revenuecatui/build.gradle.kts` to check Gradle `-P` project properties before `local.properties` for `USE_WORKFLOWS_ENDPOINT`, making it consistent with the `purchases` and `paywall-tester` modules.

**Paywall tester UX improvements:**
- Toast feedback for all `PaywallListener` callbacks (purchase, restore, cancel, errors)
- Custom API key text field in the API key dialog (enter any key at runtime without rebuilding)
- Tab order changed to Offerings → Paywalls → AppInfo; default start destination is Offerings
- Migrates `AlertDialog` from Material 1 (`buttons`) to Material 3 (`confirmButton`)
- Adds missing `onPurchaseStarted` / `onPurchaseCancelled` overrides in `PaywallScreenViewModel`
- Removes unreachable `else ->` branches in `PaywallViewModel` (exhaustive `when` over a two-value enum)

**Trigger example:**
```bash
curl -X POST \
  "https://circleci.com/api/v2/project/github/RevenueCat/purchases-android/pipeline" \
  -H "Circle-Token: $CIRCLE_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "branch": "cesar/valencia-v1",
    "parameters": {
      "action": "paywall_tester_release",
      "paywall_tester_track": "internal",
      "paywall_tester_api_key": "YOUR_API_KEY",
      "paywall_tester_use_workflows_endpoint": true
    }
  }'
```