### PR TITLE
Add reward verification polling for AdMob

### DIFF
--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/Logger.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/Logger.kt
@@ -24,4 +24,8 @@ internal object Logger {
     fun d(message: String) {
         Log.d(TAG, message)
     }
+
+    fun v(message: String) {
+        Log.v(TAG, message)
+    }
 }

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -54,7 +54,6 @@ internal object Poller {
         ).toResult()
     }
 
-    @Suppress("ReturnCount", "TooGenericExceptionCaught")
     private suspend fun pollOutcome(
         clientTransactionId: String,
         fetcher: RewardVerificationFetcher,
@@ -62,47 +61,68 @@ internal object Poller {
         jitterSeconds: () -> Double,
         maxAttempts: Int,
     ): Outcome {
-        for (attempt in 0 until maxAttempts) {
-            if (attempt > 0) {
-                try {
-                    sleepSeconds(jitterSeconds())
-                } catch (e: CancellationException) {
-                    // Preserve cooperative cancellation for coroutine callers.
-                    throw e
-                } catch (_: Exception) {
-                    // If scheduling the backoff fails, finish with a deterministic failure instead
-                    // of spinning in a tight retry loop.
-                    return Outcome.Failed
-                }
+        var outcome: Outcome? = null
+        var attempt = 0
+        while (outcome == null && attempt < maxAttempts) {
+            outcome = if (attempt > 0 && !awaitBackoff(sleepSeconds, jitterSeconds)) {
+                Outcome.Failed
+            } else {
+                fetchOutcomeOrRetry(clientTransactionId, fetcher)
             }
-
-            try {
-                val outcome = when (val result = fetcher.fetch(clientTransactionId)) {
-                    is CoreRewardVerificationResult.Verified -> Outcome.Verified(result.reward.toAdMobReward())
-                    CoreRewardVerificationResult.FAILED -> Outcome.Failed
-                    CoreRewardVerificationResult.PENDING,
-                    CoreRewardVerificationResult.UNKNOWN,
-                    -> null
-                }
-                if (outcome != null) return outcome
-            } catch (e: CancellationException) {
-                // Preserve cooperative cancellation for coroutine callers.
-                throw e
-            } catch (e: Exception) {
-                if (e.isTransientPollingError()) {
-                    continue
-                }
-                return Outcome.Failed
-            }
+            attempt++
         }
-
-        // Exhausted every attempt without reaching a terminal verified/failed status.
-        return Outcome.Failed
+        // A null outcome means every attempt was exhausted without reaching a terminal status.
+        return outcome ?: Outcome.Failed
     }
 
-    private fun Throwable.isTransientPollingError(): Boolean {
-        val purchasesException = this as? PurchasesException ?: return false
-        return when (purchasesException.code) {
+    /**
+     * Awaits the backoff before the next attempt. Returns `true` to proceed, or `false` when
+     * scheduling the backoff fails for a non-cancellation reason (the loop then fails deterministically
+     * instead of spinning in a tight retry). Cancellation is rethrown to preserve cooperative
+     * cancellation for coroutine callers.
+     */
+    private suspend fun awaitBackoff(
+        sleepSeconds: suspend (Double) -> Unit,
+        jitterSeconds: () -> Double,
+    ): Boolean {
+        return try {
+            sleepSeconds(jitterSeconds())
+            true
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Performs a single status read. Returns a terminal [Outcome] (verified/failed), or `null` when
+     * the status is non-terminal (pending/unknown) or the read hit a transient error and polling
+     * should keep retrying. Cancellation is rethrown to preserve cooperative cancellation.
+     */
+    private suspend fun fetchOutcomeOrRetry(
+        clientTransactionId: String,
+        fetcher: RewardVerificationFetcher,
+    ): Outcome? {
+        return try {
+            when (val result = fetcher.fetch(clientTransactionId)) {
+                is CoreRewardVerificationResult.Verified -> Outcome.Verified(result.reward.toAdMobReward())
+                CoreRewardVerificationResult.FAILED -> Outcome.Failed
+                CoreRewardVerificationResult.PENDING,
+                CoreRewardVerificationResult.UNKNOWN,
+                -> null
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: PurchasesException) {
+            if (e.isTransientPollingError()) null else Outcome.Failed
+        } catch (_: Exception) {
+            Outcome.Failed
+        }
+    }
+
+    private fun PurchasesException.isTransientPollingError(): Boolean {
+        return when (code) {
             PurchasesErrorCode.NetworkError,
             PurchasesErrorCode.UnknownBackendError,
             -> true

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.RewardVerificationException
 import com.revenuecat.purchases.admob.Logger
 import com.revenuecat.purchases.admob.RewardVerificationResult
 import com.revenuecat.purchases.admob.VerifiedReward
@@ -126,13 +127,12 @@ internal object Poller {
         }
     }
 
+    // Retry transient failures only: transport NetworkError and HTTP 5xx server errors (a retry may
+    // reach a healthy instance). Deterministic errors — 4xx and unrecognized backend codes
+    // (UnknownBackendError) — yield the same response on retry, so they fail fast.
     private fun PurchasesException.isTransientPollingError(): Boolean {
-        return when (code) {
-            PurchasesErrorCode.NetworkError,
-            PurchasesErrorCode.UnknownBackendError,
-            -> true
-            else -> false
-        }
+        return code == PurchasesErrorCode.NetworkError ||
+            (this is RewardVerificationException && isServerError)
     }
 
     // Readable log form: object statuses log their name; Verified inlines the reward payload.

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -77,7 +77,14 @@ internal object Poller {
             }
 
             try {
-                terminalOutcomeOrNull(fetcher.fetch(clientTransactionId))?.let { return it }
+                val outcome = when (val result = fetcher.fetch(clientTransactionId)) {
+                    is CoreRewardVerificationResult.Verified -> Outcome.Verified(result.reward.toAdMobReward())
+                    CoreRewardVerificationResult.FAILED -> Outcome.Failed
+                    CoreRewardVerificationResult.PENDING,
+                    CoreRewardVerificationResult.UNKNOWN,
+                    -> null
+                }
+                if (outcome != null) return outcome
             } catch (e: CancellationException) {
                 // Preserve cooperative cancellation for coroutine callers.
                 throw e
@@ -91,21 +98,6 @@ internal object Poller {
 
         // Exhausted every attempt without reaching a terminal verified/failed status.
         return Outcome.Failed
-    }
-
-    /**
-     * Maps a single status read to a terminal [Outcome], or `null` when the status is non-terminal
-     * (pending / unknown) and polling should keep retrying.
-     */
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
-    internal fun terminalOutcomeOrNull(result: CoreRewardVerificationResult): Outcome? {
-        return when (result) {
-            is CoreRewardVerificationResult.Verified -> Outcome.Verified(result.reward.toAdMobReward())
-            CoreRewardVerificationResult.FAILED -> Outcome.Failed
-            CoreRewardVerificationResult.PENDING,
-            CoreRewardVerificationResult.UNKNOWN,
-            -> null
-        }
     }
 
     private fun Throwable.isTransientPollingError(): Boolean {

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -127,9 +127,11 @@ internal object Poller {
         }
     }
 
-    // Retry transient failures only: transport NetworkError and HTTP 5xx server errors (a retry may
-    // reach a healthy instance). Deterministic errors — 4xx and unrecognized backend codes
-    // (UnknownBackendError) — yield the same response on retry, so they fail fast.
+    // Retry only transient failures: transport NetworkError and HTTP 5xx server errors (a retry may
+    // reach a healthy backend instance). The decision is keyed on the transport error and the 5xx
+    // flag, NOT on the backend error code — so an infra 5xx that maps to UnknownBackendError is
+    // retried, while any non-5xx failure (4xx, or a non-5xx UnknownBackendError) is deterministic
+    // and fails fast.
     private fun PurchasesException.isTransientPollingError(): Boolean {
         return code == PurchasesErrorCode.NetworkError ||
             (this is RewardVerificationException && isServerError)

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -56,7 +56,7 @@ internal object Poller {
         var outcome: Outcome? = null
         var attempt = 0
         while (outcome == null && attempt < maxAttempts) {
-            Logger.d(
+            Logger.v(
                 "Reward verification poll attempt ${attempt + 1}/$maxAttempts transactionId=$clientTransactionId",
             )
             outcome = if (attempt > 0 && !awaitBackoff(sleepSeconds, jitterSeconds, clientTransactionId)) {

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -99,7 +99,7 @@ internal object Poller {
     ): Outcome? {
         return try {
             val result = fetcher.fetch(clientTransactionId)
-            Logger.d("Reward verification poll status=${result.logDescription()} transactionId=$clientTransactionId")
+            Logger.d("Reward verification poll result=${result.logDescription()} transactionId=$clientTransactionId")
             when (result) {
                 is CoreRewardVerificationResult.Verified -> Outcome.Verified(result.reward.toAdMobReward())
                 CoreRewardVerificationResult.FAILED -> Outcome.Failed
@@ -135,9 +135,10 @@ internal object Poller {
         }
     }
 
+    // Readable log form: object statuses log their name; Verified inlines the reward payload.
     private fun CoreRewardVerificationResult.logDescription(): String {
         return when (this) {
-            is CoreRewardVerificationResult.Verified -> "verified"
+            is CoreRewardVerificationResult.Verified -> "verified(reward=$reward)"
             CoreRewardVerificationResult.PENDING -> "pending"
             CoreRewardVerificationResult.FAILED -> "failed"
             CoreRewardVerificationResult.UNKNOWN -> "unknown"

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -2,45 +2,119 @@ package com.revenuecat.purchases.admob.rewardverification
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.admob.RewardVerificationResult
 import com.revenuecat.purchases.admob.VerifiedReward
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlin.random.Random
 import com.revenuecat.purchases.RewardVerificationResult as CoreRewardVerificationResult
 import com.revenuecat.purchases.VerifiedReward as CoreVerifiedReward
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
 internal object Poller {
 
+    internal const val DEFAULT_MAX_ATTEMPTS: Int = 10
+    private const val DEFAULT_JITTER_LOWER_BOUND_SECONDS: Double = 0.75
+    private const val DEFAULT_JITTER_UPPER_BOUND_SECONDS: Double = 1.25
+    private const val MILLIS_PER_SECOND: Double = 1_000.0
+
+    /**
+     * Per-attempt backoff in seconds, jittered around a 1s interval so that concurrent verifications
+     * do not align their polls. The defaults give an ~10s overall verification window.
+     */
+    internal val defaultJitterSeconds: () -> Double = {
+        Random.nextDouble(
+            from = DEFAULT_JITTER_LOWER_BOUND_SECONDS,
+            until = DEFAULT_JITTER_UPPER_BOUND_SECONDS,
+        )
+    }
+
+    /**
+     * Polls the backend for the verification status of [clientTransactionId] until it reaches a
+     * terminal state (verified or failed), [maxAttempts] is exhausted, or the coroutine is cancelled.
+     *
+     * Pending/unknown statuses and transient network errors are retried after a [jitterSeconds]
+     * backoff; any other error and an exhausted attempt budget resolve to a failed result.
+     */
     suspend fun poll(
         clientTransactionId: String,
         fetcher: RewardVerificationFetcher = RewardVerificationFetcher.default,
+        sleepSeconds: suspend (Double) -> Unit = { delay((it * MILLIS_PER_SECOND).toLong()) },
+        jitterSeconds: () -> Double = defaultJitterSeconds,
+        maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
     ): RewardVerificationResult {
-        return pollOutcome(clientTransactionId, fetcher).toResult()
+        return pollOutcome(
+            clientTransactionId = clientTransactionId,
+            fetcher = fetcher,
+            sleepSeconds = sleepSeconds,
+            jitterSeconds = jitterSeconds,
+            maxAttempts = maxAttempts,
+        ).toResult()
     }
 
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
     private suspend fun pollOutcome(
         clientTransactionId: String,
         fetcher: RewardVerificationFetcher,
+        sleepSeconds: suspend (Double) -> Unit,
+        jitterSeconds: () -> Double,
+        maxAttempts: Int,
     ): Outcome {
-        return try {
-            mapResultToOutcome(fetcher.fetch(clientTransactionId))
-        } catch (e: CancellationException) {
-            throw e
-        } catch (_: Exception) {
-            Outcome.Failed
+        for (attempt in 0 until maxAttempts) {
+            if (attempt > 0) {
+                try {
+                    sleepSeconds(jitterSeconds())
+                } catch (e: CancellationException) {
+                    // Preserve cooperative cancellation for coroutine callers.
+                    throw e
+                } catch (_: Exception) {
+                    // If scheduling the backoff fails, finish with a deterministic failure instead
+                    // of spinning in a tight retry loop.
+                    return Outcome.Failed
+                }
+            }
+
+            try {
+                terminalOutcomeOrNull(fetcher.fetch(clientTransactionId))?.let { return it }
+            } catch (e: CancellationException) {
+                // Preserve cooperative cancellation for coroutine callers.
+                throw e
+            } catch (e: Exception) {
+                if (e.isTransientPollingError()) {
+                    continue
+                }
+                return Outcome.Failed
+            }
+        }
+
+        // Exhausted every attempt without reaching a terminal verified/failed status.
+        return Outcome.Failed
+    }
+
+    /**
+     * Maps a single status read to a terminal [Outcome], or `null` when the status is non-terminal
+     * (pending / unknown) and polling should keep retrying.
+     */
+    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
+    internal fun terminalOutcomeOrNull(result: CoreRewardVerificationResult): Outcome? {
+        return when (result) {
+            is CoreRewardVerificationResult.Verified -> Outcome.Verified(result.reward.toAdMobReward())
+            CoreRewardVerificationResult.FAILED -> Outcome.Failed
+            CoreRewardVerificationResult.PENDING,
+            CoreRewardVerificationResult.UNKNOWN,
+            -> null
         }
     }
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
-    internal fun mapResultToOutcome(result: CoreRewardVerificationResult): Outcome {
-        return when (result) {
-            is CoreRewardVerificationResult.Verified ->
-                Outcome.Verified(result.reward.toAdMobReward())
-            // Polling/retry orchestration lands in a follow-up PR; one-shot non-terminal/unknown statuses fail for now.
-            CoreRewardVerificationResult.PENDING,
-            CoreRewardVerificationResult.UNKNOWN,
-            CoreRewardVerificationResult.FAILED,
-            -> Outcome.Failed
+    private fun Throwable.isTransientPollingError(): Boolean {
+        val purchasesException = this as? PurchasesException ?: return false
+        return when (purchasesException.code) {
+            PurchasesErrorCode.NetworkError,
+            PurchasesErrorCode.UnknownBackendError,
+            -> true
+            else -> false
         }
     }
 

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -21,10 +21,7 @@ internal object Poller {
     private const val DEFAULT_JITTER_UPPER_BOUND_SECONDS: Double = 1.25
     private const val MILLIS_PER_SECOND: Double = 1_000.0
 
-    /**
-     * Per-attempt backoff in seconds, jittered around a 1s interval so that concurrent verifications
-     * do not align their polls. The defaults give an ~10s overall verification window.
-     */
+    // Jittered ~1s per-attempt backoff so concurrent verifications don't align their polls.
     private val defaultJitterSeconds: () -> Double = {
         Random.nextDouble(
             from = DEFAULT_JITTER_LOWER_BOUND_SECONDS,
@@ -32,13 +29,6 @@ internal object Poller {
         )
     }
 
-    /**
-     * Polls the backend for the verification status of [clientTransactionId] until it reaches a
-     * terminal state (verified or failed), [maxAttempts] is exhausted, or the coroutine is cancelled.
-     *
-     * Pending/unknown statuses and transient network errors are retried after a [jitterSeconds]
-     * backoff; any other error and an exhausted attempt budget resolve to a failed result.
-     */
     suspend fun poll(
         clientTransactionId: String,
         fetcher: RewardVerificationFetcher = RewardVerificationFetcher.default,
@@ -76,7 +66,7 @@ internal object Poller {
             }
             attempt++
         }
-        // A null outcome means every attempt was exhausted without reaching a terminal status.
+        // Null outcome => every attempt exhausted without a terminal status.
         if (outcome == null) {
             Logger.w(
                 "Reward verification poll exhausted $maxAttempts attempts transactionId=$clientTransactionId",
@@ -85,12 +75,7 @@ internal object Poller {
         return outcome ?: Outcome.Failed
     }
 
-    /**
-     * Awaits the backoff before the next attempt. Returns `true` to proceed, or `false` when
-     * scheduling the backoff fails for a non-cancellation reason (the loop then fails deterministically
-     * instead of spinning in a tight retry). Cancellation is rethrown to preserve cooperative
-     * cancellation for coroutine callers.
-     */
+    // Returns false (fail deterministically) if scheduling the backoff fails, rather than spinning in a tight retry.
     private suspend fun awaitBackoff(
         sleepSeconds: suspend (Double) -> Unit,
         jitterSeconds: () -> Double,
@@ -107,11 +92,7 @@ internal object Poller {
         }
     }
 
-    /**
-     * Performs a single status read. Returns a terminal [Outcome] (verified/failed), or `null` when
-     * the status is non-terminal (pending/unknown) or the read hit a transient error and polling
-     * should keep retrying. Cancellation is rethrown to preserve cooperative cancellation.
-     */
+    // Returns a terminal Outcome, or null when polling should retry (pending/unknown or a transient error).
     private suspend fun fetchOutcomeOrRetry(
         clientTransactionId: String,
         fetcher: RewardVerificationFetcher,

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -4,6 +4,7 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.admob.Logger
 import com.revenuecat.purchases.admob.RewardVerificationResult
 import com.revenuecat.purchases.admob.VerifiedReward
 import kotlinx.coroutines.CancellationException
@@ -61,10 +62,14 @@ internal object Poller {
         jitterSeconds: () -> Double,
         maxAttempts: Int,
     ): Outcome {
+        Logger.d("Reward verification poll start transactionId=$clientTransactionId maxAttempts=$maxAttempts")
         var outcome: Outcome? = null
         var attempt = 0
         while (outcome == null && attempt < maxAttempts) {
-            outcome = if (attempt > 0 && !awaitBackoff(sleepSeconds, jitterSeconds)) {
+            Logger.d(
+                "Reward verification poll attempt ${attempt + 1}/$maxAttempts transactionId=$clientTransactionId",
+            )
+            outcome = if (attempt > 0 && !awaitBackoff(sleepSeconds, jitterSeconds, clientTransactionId)) {
                 Outcome.Failed
             } else {
                 fetchOutcomeOrRetry(clientTransactionId, fetcher)
@@ -72,6 +77,11 @@ internal object Poller {
             attempt++
         }
         // A null outcome means every attempt was exhausted without reaching a terminal status.
+        if (outcome == null) {
+            Logger.w(
+                "Reward verification poll exhausted $maxAttempts attempts transactionId=$clientTransactionId",
+            )
+        }
         return outcome ?: Outcome.Failed
     }
 
@@ -84,6 +94,7 @@ internal object Poller {
     private suspend fun awaitBackoff(
         sleepSeconds: suspend (Double) -> Unit,
         jitterSeconds: () -> Double,
+        clientTransactionId: String,
     ): Boolean {
         return try {
             sleepSeconds(jitterSeconds())
@@ -91,6 +102,7 @@ internal object Poller {
         } catch (e: CancellationException) {
             throw e
         } catch (_: Exception) {
+            Logger.e("Reward verification poll backoff scheduling failed transactionId=$clientTransactionId")
             false
         }
     }
@@ -105,7 +117,9 @@ internal object Poller {
         fetcher: RewardVerificationFetcher,
     ): Outcome? {
         return try {
-            when (val result = fetcher.fetch(clientTransactionId)) {
+            val result = fetcher.fetch(clientTransactionId)
+            Logger.d("Reward verification poll status=${result.logDescription()} transactionId=$clientTransactionId")
+            when (result) {
                 is CoreRewardVerificationResult.Verified -> Outcome.Verified(result.reward.toAdMobReward())
                 CoreRewardVerificationResult.FAILED -> Outcome.Failed
                 CoreRewardVerificationResult.PENDING,
@@ -115,8 +129,18 @@ internal object Poller {
         } catch (e: CancellationException) {
             throw e
         } catch (e: PurchasesException) {
-            if (e.isTransientPollingError()) null else Outcome.Failed
+            if (e.isTransientPollingError()) {
+                Logger.d(
+                    "Reward verification poll transient error, retrying: ${e.code} " +
+                        "transactionId=$clientTransactionId",
+                )
+                null
+            } else {
+                Logger.e("Reward verification poll terminal error: ${e.code} transactionId=$clientTransactionId")
+                Outcome.Failed
+            }
         } catch (_: Exception) {
+            Logger.e("Reward verification poll unexpected error transactionId=$clientTransactionId")
             Outcome.Failed
         }
     }
@@ -127,6 +151,15 @@ internal object Poller {
             PurchasesErrorCode.UnknownBackendError,
             -> true
             else -> false
+        }
+    }
+
+    private fun CoreRewardVerificationResult.logDescription(): String {
+        return when (this) {
+            is CoreRewardVerificationResult.Verified -> "verified"
+            CoreRewardVerificationResult.PENDING -> "pending"
+            CoreRewardVerificationResult.FAILED -> "failed"
+            CoreRewardVerificationResult.UNKNOWN -> "unknown"
         }
     }
 

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/Poller.kt
@@ -16,7 +16,7 @@ import com.revenuecat.purchases.VerifiedReward as CoreVerifiedReward
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
 internal object Poller {
 
-    internal const val DEFAULT_MAX_ATTEMPTS: Int = 10
+    private const val DEFAULT_MAX_ATTEMPTS: Int = 10
     private const val DEFAULT_JITTER_LOWER_BOUND_SECONDS: Double = 0.75
     private const val DEFAULT_JITTER_UPPER_BOUND_SECONDS: Double = 1.25
     private const val MILLIS_PER_SECOND: Double = 1_000.0
@@ -25,7 +25,7 @@ internal object Poller {
      * Per-attempt backoff in seconds, jittered around a 1s interval so that concurrent verifications
      * do not align their polls. The defaults give an ~10s overall verification window.
      */
-    internal val defaultJitterSeconds: () -> Double = {
+    private val defaultJitterSeconds: () -> Double = {
         Random.nextDouble(
             from = DEFAULT_JITTER_LOWER_BOUND_SECONDS,
             until = DEFAULT_JITTER_UPPER_BOUND_SECONDS,
@@ -163,7 +163,6 @@ internal object Poller {
         }
     }
 
-    @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
     private fun CoreVerifiedReward.toAdMobReward(): VerifiedReward {
         return when (this) {
             is CoreVerifiedReward.VirtualCurrency ->

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/rewardverification/PollerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/rewardverification/PollerTest.kt
@@ -4,7 +4,6 @@ import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
-import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.RewardVerificationException
 import com.revenuecat.purchases.RewardVerificationResult as CoreRewardVerificationResult
 import com.revenuecat.purchases.VerifiedReward as CoreVerifiedReward
@@ -162,7 +161,10 @@ class PollerTest {
             fetcher = {
                 attempts++
                 if (attempts < 2) {
-                    throw PurchasesException(PurchasesError(PurchasesErrorCode.NetworkError))
+                    throw RewardVerificationException(
+                        PurchasesError(PurchasesErrorCode.NetworkError),
+                        isServerError = false,
+                    )
                 }
                 CoreRewardVerificationResult.Verified(CoreVerifiedReward.NoReward)
             },
@@ -222,34 +224,66 @@ class PollerTest {
     }
 
     @Test
-    fun `poll stops on unknown backend errors`() = runBlocking {
+    fun `poll does not retry non-server unknown backend errors`() = runBlocking {
         var attempts = 0
 
         val result = Poller.poll(
             clientTransactionId = "ct_1",
             fetcher = {
                 attempts++
-                throw PurchasesException(PurchasesError(PurchasesErrorCode.UnknownBackendError))
+                // A non-5xx unrecognized backend code is deterministic; retrying is pointless.
+                throw RewardVerificationException(
+                    PurchasesError(PurchasesErrorCode.UnknownBackendError),
+                    isServerError = false,
+                )
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,
         )
 
-        // UnknownBackendError means the backend returned an unrecognized code; retrying is pointless.
         assertEquals(1, attempts)
         assertTrue(result.failed)
         assertNull(result.verifiedReward)
     }
 
     @Test
-    fun `poll stops on non-transient purchases errors`() = runBlocking {
+    fun `poll retries server errors even when mapped to an unknown backend code`() = runBlocking {
         var attempts = 0
 
         val result = Poller.poll(
             clientTransactionId = "ct_1",
             fetcher = {
                 attempts++
-                throw PurchasesException(PurchasesError(PurchasesErrorCode.InvalidCredentialsError))
+                if (attempts < 2) {
+                    // An infra 5xx with no recognized code surfaces as UnknownBackendError; retry is
+                    // keyed on isServerError (the 5xx), not on the code.
+                    throw RewardVerificationException(
+                        PurchasesError(PurchasesErrorCode.UnknownBackendError),
+                        isServerError = true,
+                    )
+                }
+                CoreRewardVerificationResult.Verified(CoreVerifiedReward.NoReward)
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+        )
+
+        assertEquals(2, attempts)
+        assertFalse(result.failed)
+    }
+
+    @Test
+    fun `poll stops on non-transient errors`() = runBlocking {
+        var attempts = 0
+
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                throw RewardVerificationException(
+                    PurchasesError(PurchasesErrorCode.InvalidCredentialsError),
+                    isServerError = false,
+                )
             },
             sleepSeconds = noSleep,
             jitterSeconds = fixedJitter,

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/rewardverification/PollerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/rewardverification/PollerTest.kt
@@ -2,6 +2,9 @@ package com.revenuecat.purchases.admob.rewardverification
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.PurchasesException
 import com.revenuecat.purchases.RewardVerificationResult as CoreRewardVerificationResult
 import com.revenuecat.purchases.VerifiedReward as CoreVerifiedReward
 import com.revenuecat.purchases.admob.VerifiedReward
@@ -18,76 +21,262 @@ import org.junit.Test
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
 class PollerTest {
 
+    private val recordedSleeps = mutableListOf<Double>()
+
+    // No-op sleep so retry-driven tests do not wait on the real clock; record calls for assertions.
+    private val noSleep: suspend (Double) -> Unit = { recordedSleeps.add(it) }
+    private val fixedJitter: () -> Double = { 1.0 }
+
     @Test
     fun `poll calls core status fetch with client transaction id`() = runBlocking {
         var receivedClientTransactionId: String? = null
 
-        val result = Poller.poll(clientTransactionId = "ct_1") { clientTransactionId ->
-            receivedClientTransactionId = clientTransactionId
-            CoreRewardVerificationResult.Verified(CoreVerifiedReward.NoReward)
-        }
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = { clientTransactionId ->
+                receivedClientTransactionId = clientTransactionId
+                CoreRewardVerificationResult.Verified(CoreVerifiedReward.NoReward)
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+        )
 
         assertEquals("ct_1", receivedClientTransactionId)
         assertNotNull(result.verifiedReward)
         assertFalse(result.failed)
+        // Verified on the first read: no backoff sleeps.
+        assertTrue(recordedSleeps.isEmpty())
     }
 
     @Test
-    fun `poll maps failed result to failed outcome`() = runBlocking {
-        val result = Poller.poll(clientTransactionId = "ct_1") {
-            CoreRewardVerificationResult.FAILED
-        }
+    fun `poll maps verified status to terminal verified outcome without retrying`() = runBlocking {
+        var attempts = 0
 
-        assertTrue(result.failed)
-        assertNull(result.verifiedReward)
-    }
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                CoreRewardVerificationResult.Verified(CoreVerifiedReward.VirtualCurrency(code = "gems", amount = 10))
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+        )
 
-    @Test
-    fun `poll maps pending result to failed outcome`() = runBlocking {
-        val result = Poller.poll(clientTransactionId = "ct_1") {
-            CoreRewardVerificationResult.PENDING
-        }
-
-        assertTrue(result.failed)
-        assertNull(result.verifiedReward)
-    }
-
-    @Test
-    fun `poll maps unknown result to failed outcome`() = runBlocking {
-        val result = Poller.poll(clientTransactionId = "ct_1") {
-            CoreRewardVerificationResult.UNKNOWN
-        }
-
-        assertTrue(result.failed)
-        assertNull(result.verifiedReward)
-    }
-
-    @Test
-    fun `poll maps verified virtual currency reward to adapter reward`() = runBlocking {
-        val result = Poller.poll(clientTransactionId = "ct_1") {
-            CoreRewardVerificationResult.Verified(CoreVerifiedReward.VirtualCurrency(code = "gems", amount = 10))
-        }
-
+        assertEquals(1, attempts)
         assertFalse(result.failed)
         assertEquals(VerifiedReward.VirtualCurrency(code = "gems", amount = 10), result.verifiedReward)
     }
 
     @Test
-    fun `poll maps backend errors to failed result`() = runBlocking {
-        val result = Poller.poll(clientTransactionId = "ct_1") {
-            error("backend exploded")
-        }
+    fun `poll maps failed status to terminal failed outcome without retrying`() = runBlocking {
+        var attempts = 0
 
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                CoreRewardVerificationResult.FAILED
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+        )
+
+        assertEquals(1, attempts)
         assertTrue(result.failed)
         assertNull(result.verifiedReward)
     }
 
     @Test
-    fun `poll rethrows coroutine cancellation`() = runBlocking {
+    fun `poll retries on pending until a terminal verified status is reached`() = runBlocking {
+        var attempts = 0
+
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                if (attempts < 3) {
+                    CoreRewardVerificationResult.PENDING
+                } else {
+                    CoreRewardVerificationResult.Verified(CoreVerifiedReward.VirtualCurrency(code = "gems", amount = 5))
+                }
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+        )
+
+        assertEquals(3, attempts)
+        // A backoff between each attempt: two sleeps for three reads.
+        assertEquals(listOf(1.0, 1.0), recordedSleeps)
+        assertFalse(result.failed)
+        assertEquals(VerifiedReward.VirtualCurrency(code = "gems", amount = 5), result.verifiedReward)
+    }
+
+    @Test
+    fun `poll exhausts max attempts on persistent pending and fails`() = runBlocking {
+        var attempts = 0
+
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                CoreRewardVerificationResult.PENDING
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+            maxAttempts = 4,
+        )
+
+        assertEquals(4, attempts)
+        assertEquals(3, recordedSleeps.size)
+        assertTrue(result.failed)
+        assertNull(result.verifiedReward)
+    }
+
+    @Test
+    fun `poll retries on unknown status until max attempts then fails`() = runBlocking {
+        var attempts = 0
+
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                CoreRewardVerificationResult.UNKNOWN
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+            maxAttempts = 3,
+        )
+
+        assertEquals(3, attempts)
+        assertTrue(result.failed)
+        assertNull(result.verifiedReward)
+    }
+
+    @Test
+    fun `poll retries transient network errors then succeeds`() = runBlocking {
+        var attempts = 0
+
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                if (attempts < 2) {
+                    throw PurchasesException(PurchasesError(PurchasesErrorCode.NetworkError))
+                }
+                CoreRewardVerificationResult.Verified(CoreVerifiedReward.NoReward)
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+        )
+
+        assertEquals(2, attempts)
+        assertFalse(result.failed)
+        assertNotNull(result.verifiedReward)
+    }
+
+    @Test
+    fun `poll retries transient unknown backend errors`() = runBlocking {
+        var attempts = 0
+
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                if (attempts < 2) {
+                    throw PurchasesException(PurchasesError(PurchasesErrorCode.UnknownBackendError))
+                }
+                CoreRewardVerificationResult.Verified(CoreVerifiedReward.NoReward)
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+        )
+
+        assertEquals(2, attempts)
+        assertFalse(result.failed)
+    }
+
+    @Test
+    fun `poll stops on non-transient purchases errors`() = runBlocking {
+        var attempts = 0
+
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                throw PurchasesException(PurchasesError(PurchasesErrorCode.InvalidCredentialsError))
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+        )
+
+        assertEquals(1, attempts)
+        assertTrue(result.failed)
+        assertNull(result.verifiedReward)
+    }
+
+    @Test
+    fun `poll maps unexpected backend errors to failed result`() = runBlocking {
+        var attempts = 0
+
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                error("backend exploded")
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+        )
+
+        assertEquals(1, attempts)
+        assertTrue(result.failed)
+        assertNull(result.verifiedReward)
+    }
+
+    @Test
+    fun `poll fails deterministically when scheduling the backoff throws`() = runBlocking {
+        var attempts = 0
+
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                CoreRewardVerificationResult.PENDING
+            },
+            sleepSeconds = { throw IllegalStateException("scheduler down") },
+            jitterSeconds = fixedJitter,
+        )
+
+        // First read returns pending, scheduling the backoff fails before the second read.
+        assertEquals(1, attempts)
+        assertTrue(result.failed)
+        assertNull(result.verifiedReward)
+    }
+
+    @Test
+    fun `poll rethrows coroutine cancellation from fetch`() = runBlocking {
         try {
-            Poller.poll(clientTransactionId = "ct_1") {
-                throw CancellationException("cancelled")
-            }
+            Poller.poll(
+                clientTransactionId = "ct_1",
+                fetcher = { throw CancellationException("cancelled") },
+                sleepSeconds = noSleep,
+                jitterSeconds = fixedJitter,
+            )
+            fail("Expected CancellationException")
+        } catch (_: CancellationException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun `poll rethrows coroutine cancellation from backoff`() = runBlocking {
+        try {
+            Poller.poll(
+                clientTransactionId = "ct_1",
+                fetcher = { CoreRewardVerificationResult.PENDING },
+                sleepSeconds = { throw CancellationException("cancelled") },
+                jitterSeconds = fixedJitter,
+            )
             fail("Expected CancellationException")
         } catch (_: CancellationException) {
             // expected

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/rewardverification/PollerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/unit/rewardverification/PollerTest.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
 import com.revenuecat.purchases.PurchasesException
+import com.revenuecat.purchases.RewardVerificationException
 import com.revenuecat.purchases.RewardVerificationResult as CoreRewardVerificationResult
 import com.revenuecat.purchases.VerifiedReward as CoreVerifiedReward
 import com.revenuecat.purchases.admob.VerifiedReward
@@ -175,7 +176,7 @@ class PollerTest {
     }
 
     @Test
-    fun `poll retries transient unknown backend errors`() = runBlocking {
+    fun `poll retries server errors then succeeds`() = runBlocking {
         var attempts = 0
 
         val result = Poller.poll(
@@ -183,7 +184,10 @@ class PollerTest {
             fetcher = {
                 attempts++
                 if (attempts < 2) {
-                    throw PurchasesException(PurchasesError(PurchasesErrorCode.UnknownBackendError))
+                    throw RewardVerificationException(
+                        PurchasesError(PurchasesErrorCode.UnexpectedBackendResponseError),
+                        isServerError = true,
+                    )
                 }
                 CoreRewardVerificationResult.Verified(CoreVerifiedReward.NoReward)
             },
@@ -193,6 +197,48 @@ class PollerTest {
 
         assertEquals(2, attempts)
         assertFalse(result.failed)
+    }
+
+    @Test
+    fun `poll stops on non-server reward verification errors`() = runBlocking {
+        var attempts = 0
+
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                throw RewardVerificationException(
+                    PurchasesError(PurchasesErrorCode.UnexpectedBackendResponseError),
+                    isServerError = false,
+                )
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+        )
+
+        assertEquals(1, attempts)
+        assertTrue(result.failed)
+        assertNull(result.verifiedReward)
+    }
+
+    @Test
+    fun `poll stops on unknown backend errors`() = runBlocking {
+        var attempts = 0
+
+        val result = Poller.poll(
+            clientTransactionId = "ct_1",
+            fetcher = {
+                attempts++
+                throw PurchasesException(PurchasesError(PurchasesErrorCode.UnknownBackendError))
+            },
+            sleepSeconds = noSleep,
+            jitterSeconds = fixedJitter,
+        )
+
+        // UnknownBackendError means the backend returned an unrecognized code; retrying is pointless.
+        assertEquals(1, attempts)
+        assertTrue(result.failed)
+        assertNull(result.verifiedReward)
     }
 
     @Test

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
@@ -228,8 +228,8 @@ public suspend fun Purchases.awaitGetRewardVerificationResult(
                     continuation.safeResume(result)
                 }
 
-                override fun onError(exception: RewardVerificationException) {
-                    continuation.safeResumeWithException(exception)
+                override fun onError(error: RewardVerificationError) {
+                    continuation.safeResumeWithException(RewardVerificationException(error.error, error.isServerError))
                 }
             },
         )

--- a/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
+++ b/purchases/src/defaults/kotlin/com/revenuecat/purchases/coroutinesExtensions.kt
@@ -228,8 +228,8 @@ public suspend fun Purchases.awaitGetRewardVerificationResult(
                     continuation.safeResume(result)
                 }
 
-                override fun onError(error: PurchasesError) {
-                    continuation.safeResumeWithException(PurchasesException(error))
+                override fun onError(exception: RewardVerificationException) {
+                    continuation.safeResumeWithException(exception)
                 }
             },
         )

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/RewardVerificationError.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/RewardVerificationError.kt
@@ -1,0 +1,14 @@
+package com.revenuecat.purchases
+
+/**
+ * Internal data describing a failed reward verification status request.
+ *
+ * Mirrors the [PurchasesError] / [PurchasesException] split: the backend and callbacks pass this data
+ * type, and the suspend API converts it into a thrown [RewardVerificationException] at the boundary.
+ *
+ * [isServerError] is true when the backend responded with an HTTP 5xx (transient).
+ */
+internal data class RewardVerificationError(
+    val error: PurchasesError,
+    val isServerError: Boolean,
+)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/RewardVerificationException.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/RewardVerificationException.kt
@@ -1,0 +1,13 @@
+package com.revenuecat.purchases
+
+/**
+ * Thrown when a reward verification status request fails.
+ *
+ * [isServerError] is true when the backend responded with an HTTP 5xx, which is transient and may
+ * succeed on retry. Other failures (client errors, unrecognized backend codes) are deterministic.
+ */
+@InternalRevenueCatAPI
+public class RewardVerificationException(
+    error: PurchasesError,
+    public val isServerError: Boolean,
+) : PurchasesException(error)

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -12,6 +12,7 @@ import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
+import com.revenuecat.purchases.RewardVerificationException
 import com.revenuecat.purchases.RewardVerificationResult
 import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.backendName
@@ -105,7 +106,7 @@ internal typealias WebBillingProductsCallback = Pair<(WebBillingProductsResponse
 
 @OptIn(InternalRevenueCatAPI::class)
 internal typealias RewardVerificationResultCallback =
-    Pair<(RewardVerificationResult) -> Unit, (PurchasesError) -> Unit>
+    Pair<(RewardVerificationResult) -> Unit, (RewardVerificationException) -> Unit>
 
 internal typealias RemoteConfigCallback = Pair<(RemoteConfigResponse) -> Unit, (PurchasesError) -> Unit>
 
@@ -1197,7 +1198,7 @@ internal class Backend(
         appUserID: String,
         clientTransactionId: String,
         onSuccess: (RewardVerificationResult) -> Unit,
-        onError: (PurchasesError) -> Unit,
+        onError: (RewardVerificationException) -> Unit,
     ) {
         val endpoint = Endpoint.GetRewardVerification(
             userId = appUserID,
@@ -1221,7 +1222,7 @@ internal class Backend(
                 synchronized(this@Backend) {
                     rewardVerificationResultCallbacks.remove(cacheKey)
                 }?.forEach { (_, onErrorHandler) ->
-                    onErrorHandler(error)
+                    onErrorHandler(RewardVerificationException(error, isServerError = false))
                 }
             }
 
@@ -1236,12 +1237,21 @@ internal class Backend(
                             )
                             onSuccessHandler(response.toRewardVerificationResult())
                         } catch (e: SerializationException) {
-                            onErrorHandler(e.toPurchasesError().also { errorLog(it) })
+                            onErrorHandler(
+                                RewardVerificationException(e.toPurchasesError().also { errorLog(it) }, false),
+                            )
                         } catch (e: IllegalArgumentException) {
-                            onErrorHandler(e.toPurchasesError().also { errorLog(it) })
+                            onErrorHandler(
+                                RewardVerificationException(e.toPurchasesError().also { errorLog(it) }, false),
+                            )
                         }
                     } else {
-                        onErrorHandler(result.toPurchasesError().also { errorLog(it) })
+                        onErrorHandler(
+                            RewardVerificationException(
+                                result.toPurchasesError().also { errorLog(it) },
+                                isServerError = RCHTTPStatusCodes.isServerError(result.responseCode),
+                            ),
+                        )
                     }
                 }
             }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/common/Backend.kt
@@ -12,7 +12,7 @@ import com.revenuecat.purchases.PostReceiptInitiationSource
 import com.revenuecat.purchases.PurchasesAreCompletedBy
 import com.revenuecat.purchases.PurchasesError
 import com.revenuecat.purchases.PurchasesErrorCode
-import com.revenuecat.purchases.RewardVerificationException
+import com.revenuecat.purchases.RewardVerificationError
 import com.revenuecat.purchases.RewardVerificationResult
 import com.revenuecat.purchases.api.BuildConfig
 import com.revenuecat.purchases.backendName
@@ -106,7 +106,7 @@ internal typealias WebBillingProductsCallback = Pair<(WebBillingProductsResponse
 
 @OptIn(InternalRevenueCatAPI::class)
 internal typealias RewardVerificationResultCallback =
-    Pair<(RewardVerificationResult) -> Unit, (RewardVerificationException) -> Unit>
+    Pair<(RewardVerificationResult) -> Unit, (RewardVerificationError) -> Unit>
 
 internal typealias RemoteConfigCallback = Pair<(RemoteConfigResponse) -> Unit, (PurchasesError) -> Unit>
 
@@ -1198,7 +1198,7 @@ internal class Backend(
         appUserID: String,
         clientTransactionId: String,
         onSuccess: (RewardVerificationResult) -> Unit,
-        onError: (RewardVerificationException) -> Unit,
+        onError: (RewardVerificationError) -> Unit,
     ) {
         val endpoint = Endpoint.GetRewardVerification(
             userId = appUserID,
@@ -1222,7 +1222,7 @@ internal class Backend(
                 synchronized(this@Backend) {
                     rewardVerificationResultCallbacks.remove(cacheKey)
                 }?.forEach { (_, onErrorHandler) ->
-                    onErrorHandler(RewardVerificationException(error, isServerError = false))
+                    onErrorHandler(RewardVerificationError(error, isServerError = false))
                 }
             }
 
@@ -1238,16 +1238,16 @@ internal class Backend(
                             onSuccessHandler(response.toRewardVerificationResult())
                         } catch (e: SerializationException) {
                             onErrorHandler(
-                                RewardVerificationException(e.toPurchasesError().also { errorLog(it) }, false),
+                                RewardVerificationError(e.toPurchasesError().also { errorLog(it) }, false),
                             )
                         } catch (e: IllegalArgumentException) {
                             onErrorHandler(
-                                RewardVerificationException(e.toPurchasesError().also { errorLog(it) }, false),
+                                RewardVerificationError(e.toPurchasesError().also { errorLog(it) }, false),
                             )
                         }
                     } else {
                         onErrorHandler(
-                            RewardVerificationException(
+                            RewardVerificationError(
                                 result.toPurchasesError().also { errorLog(it) },
                                 isServerError = RCHTTPStatusCodes.isServerError(result.responseCode),
                             ),

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetRewardVerificationResultCallback.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetRewardVerificationResultCallback.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases.interfaces
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.PurchasesError
+import com.revenuecat.purchases.RewardVerificationException
 import com.revenuecat.purchases.RewardVerificationResult
 
 /**
@@ -15,7 +15,8 @@ internal interface GetRewardVerificationResultCallback {
     fun onReceived(result: RewardVerificationResult)
 
     /**
-     * Called after the request fails.
+     * Called after the request fails. The exception carries whether the failure was a transient
+     * server error (see [RewardVerificationException.isServerError]).
      */
-    fun onError(error: PurchasesError)
+    fun onError(exception: RewardVerificationException)
 }

--- a/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetRewardVerificationResultCallback.kt
+++ b/purchases/src/main/kotlin/com/revenuecat/purchases/interfaces/GetRewardVerificationResultCallback.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases.interfaces
 
 import com.revenuecat.purchases.InternalRevenueCatAPI
-import com.revenuecat.purchases.RewardVerificationException
+import com.revenuecat.purchases.RewardVerificationError
 import com.revenuecat.purchases.RewardVerificationResult
 
 /**
@@ -15,8 +15,8 @@ internal interface GetRewardVerificationResultCallback {
     fun onReceived(result: RewardVerificationResult)
 
     /**
-     * Called after the request fails. The exception carries whether the failure was a transient
-     * server error (see [RewardVerificationException.isServerError]).
+     * Called after the request fails. The error carries whether the failure was a transient
+     * server error (see [RewardVerificationError.isServerError]).
      */
-    fun onError(exception: RewardVerificationException)
+    fun onError(error: RewardVerificationError)
 }

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRewardVerificationResultTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRewardVerificationResultTest.kt
@@ -89,7 +89,7 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { receivedResult = it },
-            onError = { exception -> fail("Expected success. Got error: $exception") },
+            onError = { error -> fail("Expected success. Got error: $error") },
         )
 
         assertThat(receivedResult).isEqualTo(
@@ -115,7 +115,7 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { receivedResult = it },
-            onError = { exception -> fail("Expected success. Got error: $exception") },
+            onError = { error -> fail("Expected success. Got error: $error") },
         )
 
         assertThat(receivedResult).isEqualTo(RewardVerificationResult.UNKNOWN)
@@ -130,7 +130,7 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { receivedResult = it },
-            onError = { exception -> fail("Expected success. Got error: $exception") },
+            onError = { error -> fail("Expected success. Got error: $error") },
         )
 
         assertThat(receivedResult).isEqualTo(
@@ -147,7 +147,7 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { receivedResult = it },
-            onError = { exception -> fail("Expected success. Got error: $exception") },
+            onError = { error -> fail("Expected success. Got error: $error") },
         )
 
         assertThat(receivedResult).isEqualTo(
@@ -166,7 +166,7 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { receivedResult = it },
-            onError = { exception -> fail("Expected success. Got error: $exception") },
+            onError = { error -> fail("Expected success. Got error: $error") },
         )
 
         assertThat(receivedResult).isEqualTo(
@@ -182,7 +182,7 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { fail("Expected error. Got success") },
-            onError = { exception -> obtainedError = exception.error },
+            onError = { error -> obtainedError = error.error },
         )
 
         assertThat(obtainedError).isNotNull
@@ -201,9 +201,9 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { fail("Expected error. Got success") },
-            onError = { exception ->
-                obtainedError = exception.error
-                obtainedIsServerError = exception.isServerError
+            onError = { error ->
+                obtainedError = error.error
+                obtainedIsServerError = error.isServerError
             },
         )
 
@@ -219,13 +219,13 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { lock.countDown() },
-            onError = { exception -> fail("Expected success. Got error: $exception") },
+            onError = { error -> fail("Expected success. Got error: $error") },
         )
         asyncBackend.getRewardVerificationResult(
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { lock.countDown() },
-            onError = { exception -> fail("Expected success. Got error: $exception") },
+            onError = { error -> fail("Expected success. Got error: $error") },
         )
         lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
         assertThat(lock.count).isEqualTo(0)

--- a/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRewardVerificationResultTest.kt
+++ b/purchases/src/test/java/com/revenuecat/purchases/common/backend/BackendGetRewardVerificationResultTest.kt
@@ -89,7 +89,7 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { receivedResult = it },
-            onError = { error -> fail("Expected success. Got error: $error") },
+            onError = { exception -> fail("Expected success. Got error: $exception") },
         )
 
         assertThat(receivedResult).isEqualTo(
@@ -115,7 +115,7 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { receivedResult = it },
-            onError = { error -> fail("Expected success. Got error: $error") },
+            onError = { exception -> fail("Expected success. Got error: $exception") },
         )
 
         assertThat(receivedResult).isEqualTo(RewardVerificationResult.UNKNOWN)
@@ -130,7 +130,7 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { receivedResult = it },
-            onError = { error -> fail("Expected success. Got error: $error") },
+            onError = { exception -> fail("Expected success. Got error: $exception") },
         )
 
         assertThat(receivedResult).isEqualTo(
@@ -147,7 +147,7 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { receivedResult = it },
-            onError = { error -> fail("Expected success. Got error: $error") },
+            onError = { exception -> fail("Expected success. Got error: $exception") },
         )
 
         assertThat(receivedResult).isEqualTo(
@@ -166,7 +166,7 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { receivedResult = it },
-            onError = { error -> fail("Expected success. Got error: $error") },
+            onError = { exception -> fail("Expected success. Got error: $exception") },
         )
 
         assertThat(receivedResult).isEqualTo(
@@ -182,7 +182,7 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { fail("Expected error. Got success") },
-            onError = { error -> obtainedError = error },
+            onError = { exception -> obtainedError = exception.error },
         )
 
         assertThat(obtainedError).isNotNull
@@ -196,14 +196,19 @@ class BackendGetRewardVerificationResultTest {
             payload = """{"code": 7000, "message": "internal error"}""",
         )
         var obtainedError: PurchasesError? = null
+        var obtainedIsServerError: Boolean? = null
         backend.getRewardVerificationResult(
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { fail("Expected error. Got success") },
-            onError = { error -> obtainedError = error },
+            onError = { exception ->
+                obtainedError = exception.error
+                obtainedIsServerError = exception.isServerError
+            },
         )
 
         assertThat(obtainedError).isNotNull
+        assertThat(obtainedIsServerError).isTrue
     }
 
     @Test
@@ -214,13 +219,13 @@ class BackendGetRewardVerificationResultTest {
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { lock.countDown() },
-            onError = { fail("Expected success. Got error: $it") },
+            onError = { exception -> fail("Expected success. Got error: $exception") },
         )
         asyncBackend.getRewardVerificationResult(
             appUserID = appUserId,
             clientTransactionId = clientTransactionId,
             onSuccess = { lock.countDown() },
-            onError = { fail("Expected success. Got error: $it") },
+            onError = { exception -> fail("Expected success. Got error: $exception") },
         )
         lock.await(5.seconds.inWholeSeconds, TimeUnit.SECONDS)
         assertThat(lock.count).isEqualTo(0)

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -1733,7 +1733,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                     receivedResult = result
                 }
 
-                override fun onError(error: PurchasesError) {
+                override fun onError(exception: RewardVerificationException) {
                     fail("should be success")
                 }
             },
@@ -1754,7 +1754,9 @@ internal class PurchasesTest : BasePurchasesTest() {
                 onError = captureLambda(),
             )
         } answers {
-            lambda<(PurchasesError) -> Unit>().captured.invoke(expectedError)
+            lambda<(RewardVerificationException) -> Unit>().captured.invoke(
+                RewardVerificationException(expectedError, false),
+            )
         }
 
         var receivedError: PurchasesError? = null
@@ -1765,8 +1767,8 @@ internal class PurchasesTest : BasePurchasesTest() {
                     fail("should be error")
                 }
 
-                override fun onError(error: PurchasesError) {
-                    receivedError = error
+                override fun onError(exception: RewardVerificationException) {
+                    receivedError = exception.error
                 }
             },
         )
@@ -1806,7 +1808,9 @@ internal class PurchasesTest : BasePurchasesTest() {
                 onError = captureLambda(),
             )
         } answers {
-            lambda<(PurchasesError) -> Unit>().captured.invoke(expectedError)
+            lambda<(RewardVerificationException) -> Unit>().captured.invoke(
+                RewardVerificationException(expectedError, false),
+            )
         }
 
         val thrown = runCatching {

--- a/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
+++ b/purchases/src/testDefaults/kotlin/com/revenuecat/purchases/PurchasesTest.kt
@@ -1733,7 +1733,7 @@ internal class PurchasesTest : BasePurchasesTest() {
                     receivedResult = result
                 }
 
-                override fun onError(exception: RewardVerificationException) {
+                override fun onError(error: RewardVerificationError) {
                     fail("should be success")
                 }
             },
@@ -1754,8 +1754,8 @@ internal class PurchasesTest : BasePurchasesTest() {
                 onError = captureLambda(),
             )
         } answers {
-            lambda<(RewardVerificationException) -> Unit>().captured.invoke(
-                RewardVerificationException(expectedError, false),
+            lambda<(RewardVerificationError) -> Unit>().captured.invoke(
+                RewardVerificationError(expectedError, false),
             )
         }
 
@@ -1767,8 +1767,8 @@ internal class PurchasesTest : BasePurchasesTest() {
                     fail("should be error")
                 }
 
-                override fun onError(exception: RewardVerificationException) {
-                    receivedError = exception.error
+                override fun onError(error: RewardVerificationError) {
+                    receivedError = error.error
                 }
             },
         )
@@ -1808,8 +1808,8 @@ internal class PurchasesTest : BasePurchasesTest() {
                 onError = captureLambda(),
             )
         } answers {
-            lambda<(RewardVerificationException) -> Unit>().captured.invoke(
-                RewardVerificationException(expectedError, false),
+            lambda<(RewardVerificationError) -> Unit>().captured.invoke(
+                RewardVerificationError(expectedError, false),
             )
         }
 


### PR DESCRIPTION
## Polling reward verification

Implements the retry/polling orchestration.

`Poller.poll()` now:
- Retries up to **`maxAttempts = 10`** with a **jittered ~1s backoff** (`Random.nextDouble(0.75, 1.25)`), giving the ~10s verification window from the parent ticket ADS-198.
- Treats `Verified` / `FAILED` as **terminal** and `PENDING` / `UNKNOWN` as **non-terminal** (keep polling) — mapped inline in the poll loop.
- Retries transient backend errors (`NetworkError`, `UnknownBackendError`); any other error ends as `Failed`.
- Rethrows `CancellationException` from both fetch and backoff to preserve cooperative coroutine cancellation.
- Emits debug/error logging across the poll lifecycle (start, per-attempt, status, transient/terminal/unexpected error, exhaustion), mirroring the iOS poller.
- Exposes injectable `sleepSeconds` / `jitterSeconds` / `maxAttempts` (defaults unchanged) so tests run without real delays.

The poll loop is structured for a single exit with concrete-exception catches, so no detekt suppressions are needed. `RewardVerificationRuntime` picks up the new behavior automatically via its default `poll` delegate. No public API surface changed (`Poller` is `internal`), so no `api.txt` update.

### Tests
Rewrote `PollerTest` to cover: terminal verified/failed without retry, pending→verified, persistent pending/unknown exhaustion → failed, transient network/backend retry→success, non-transient stop, backoff-scheduler failure, and cancellation from both fetch and backoff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reward-grant verification timing and internal error/callback contracts; behavior is well covered by expanded Poller and Backend tests but affects AdMob integration paths.
> 
> **Overview**
> Adds **retry polling** for AdMob reward verification: the internal `Poller` loops up to **10** attempts with **jittered ~1s** backoff, treats `PENDING`/`UNKNOWN` as non-terminal, and only stops on `Verified`/`FAILED` or exhaustion. **Transient** failures (`NetworkError`, HTTP **5xx** via `RewardVerificationException.isServerError`) are retried; other errors fail immediately, with lifecycle logging and injectable `sleep`/`jitter` for tests.
> 
> The **purchases** layer now surfaces **`RewardVerificationError`** / **`RewardVerificationException`** (including **`isServerError`** on HTTP errors from `Backend.getRewardVerificationResult`), and the suspend **`awaitGetRewardVerificationResult`** path throws that exception type instead of a plain `PurchasesException` without server context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f4b3055f4ced192f190fac5fb4887dffcdf8982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->