### PR TITLE
feat(admob): correlate reward verification via SSV custom data

### DIFF
--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManager.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManager.kt
@@ -97,7 +97,6 @@ internal object RewardVerificationManager {
             .setUserId(appUserID)
             .build()
 
-    // JSON keys and ordering must stay in sync with the other RevenueCat SDKs that hit the same SSV endpoint.
     private fun customData(apiKey: String, clientTransactionId: String): String =
         JSONObject()
             .put("api_key", apiKey)

--- a/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManager.kt
+++ b/feature/admob/src/main/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManager.kt
@@ -3,12 +3,14 @@ package com.revenuecat.purchases.admob.rewardverification
 import android.os.Handler
 import android.os.Looper
 import com.google.android.gms.ads.rewarded.RewardedAd
+import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions
 import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.admob.Logger
 import com.revenuecat.purchases.admob.RewardVerificationResult
+import org.json.JSONObject
 import java.util.UUID
 
 @OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatAPI::class)
@@ -23,8 +25,10 @@ internal object RewardVerificationManager {
         Purchases.registerService(runtime)
     }
 
-    fun install(ad: RewardedAd) = installInternal(ad.responseInfo?.responseId)
-    fun install(ad: RewardedInterstitialAd) = installInternal(ad.responseInfo?.responseId)
+    fun install(ad: RewardedAd) = installInternal(ad.responseInfo?.responseId, ad::setServerSideVerificationOptions)
+
+    fun install(ad: RewardedInterstitialAd) =
+        installInternal(ad.responseInfo?.responseId, ad::setServerSideVerificationOptions)
 
     fun handleRewardEarned(
         ad: RewardedAd,
@@ -46,7 +50,7 @@ internal object RewardVerificationManager {
         rewardVerificationCompleted,
     )
 
-    private fun installInternal(adResponseId: String?) {
+    private fun installInternal(adResponseId: String?, attachOptions: (ServerSideVerificationOptions) -> Unit) {
         if (!Purchases.isConfigured) {
             Logger.e("Purchases is not configured. Call Purchases.configure() before enabling reward verification.")
             return
@@ -59,17 +63,46 @@ internal object RewardVerificationManager {
             return
         }
 
+        val purchases = Purchases.sharedInstance
+        val clientTransactionId = UUID.randomUUID().toString()
         val didStoreClientTransactionId = runtime.setClientTransactionId(
             adResponseId = adResponseId,
-            clientTransactionId = UUID.randomUUID().toString(),
+            clientTransactionId = clientTransactionId,
         )
-        if (!didStoreClientTransactionId) {
+        if (didStoreClientTransactionId) {
+            // Correlate the ad with the backend verification through AdMob's server-side verification options. The
+            // SSV callback forwards these to RevenueCat, which keys the verification by the client transaction id.
+            attachOptions(
+                serverSideVerificationOptions(
+                    apiKey = purchases.currentConfiguration.apiKey,
+                    appUserID = purchases.appUserID,
+                    clientTransactionId = clientTransactionId,
+                ),
+            )
+        } else {
             Logger.e(
                 "Reward verification setup is not ready. " +
                     "Try enabling reward verification after Purchases is configured.",
             )
         }
     }
+
+    private fun serverSideVerificationOptions(
+        apiKey: String,
+        appUserID: String,
+        clientTransactionId: String,
+    ): ServerSideVerificationOptions =
+        ServerSideVerificationOptions.Builder()
+            .setCustomData(customData(apiKey = apiKey, clientTransactionId = clientTransactionId))
+            .setUserId(appUserID)
+            .build()
+
+    // JSON keys and ordering must stay in sync with the other RevenueCat SDKs that hit the same SSV endpoint.
+    private fun customData(apiKey: String, clientTransactionId: String): String =
+        JSONObject()
+            .put("api_key", apiKey)
+            .put("client_transaction_id", clientTransactionId)
+            .toString()
 
     private fun handleRewardEarnedInternal(
         adResponseId: String?,

--- a/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
+++ b/feature/admob/src/test/kotlin/com/revenuecat/purchases/admob/rewardverification/RewardVerificationManagerTest.kt
@@ -6,8 +6,10 @@ package com.revenuecat.purchases.admob.rewardverification
 import android.app.Activity
 import android.os.Looper
 import com.google.android.gms.ads.OnUserEarnedRewardListener
-import com.google.android.gms.ads.rewarded.RewardedAd
 import com.google.android.gms.ads.rewarded.RewardItem
+import com.google.android.gms.ads.rewarded.RewardedAd
+import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions
+import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases
@@ -21,6 +23,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.unmockkAll
+import io.mockk.verify
+import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -61,7 +65,10 @@ internal class RewardVerificationManagerTest {
     fun `verified result flows from enable through show to completed callback via singleton`() {
         val verifiedReward = CoreVerifiedReward.VirtualCurrency(code = "gems", amount = 7)
         val mockPurchases = mockk<Purchases>(relaxed = true)
-        every { mockPurchases.getRewardVerificationResult(any(), any()) } answers {
+        val polledClientTransactionId = slot<String>()
+        every {
+            mockPurchases.getRewardVerificationResult(capture(polledClientTransactionId), any())
+        } answers {
             secondArg<GetRewardVerificationResultCallback>().onReceived(
                 CoreRewardVerificationResult.Verified(verifiedReward),
             )
@@ -69,16 +76,34 @@ internal class RewardVerificationManagerTest {
 
         // Configure Purchases and notify the default registry so the singleton manager's
         // runtime initializes.
+        every { mockPurchases.currentConfiguration.apiKey } returns "test_api_key"
+        every { mockPurchases.appUserID } returns "app-user-id"
         Purchases.backingFieldSharedInstance = mockPurchases
         originalServiceForwarder.initialize(mockPurchases)
 
         val ad = mockk<RewardedAd>(relaxed = true)
         every { ad.responseInfo.responseId } returns "ad-response-id"
+        val ssvOptions = slot<ServerSideVerificationOptions>()
+        every { ad.setServerSideVerificationOptions(capture(ssvOptions)) } answers {}
         val activity = mockk<Activity>(relaxed = true)
         val rewardListenerSlot = slot<OnUserEarnedRewardListener>()
         every { ad.show(activity, capture(rewardListenerSlot)) } answers {}
 
         ad.enableRewardVerification()
+
+        // enableRewardVerification() must attach the api key, app user id, and a client transaction id so the backend
+        // can correlate the reward.
+        assertTrue(ssvOptions.isCaptured)
+        assertEquals("app-user-id", ssvOptions.captured.userId)
+        val payload = JSONObject(ssvOptions.captured.customData)
+        assertEquals("test_api_key", payload.getString("api_key"))
+        val attachedClientTransactionId = payload.getString("client_transaction_id")
+        assertTrue(attachedClientTransactionId.isNotBlank())
+        // The serialized payload must match the format shared with the other SDKs hitting the same endpoint.
+        assertEquals(
+            "{\"api_key\":\"test_api_key\",\"client_transaction_id\":\"$attachedClientTransactionId\"}",
+            ssvOptions.captured.customData,
+        )
 
         var completedResult: RewardVerificationResult? = null
         val completed = CountDownLatch(1)
@@ -100,6 +125,62 @@ internal class RewardVerificationManagerTest {
             VerifiedReward.VirtualCurrency(code = "gems", amount = 7),
             completedResult!!.verifiedReward,
         )
+        // The id polled from the backend must match the custom data attached to the ad so correlation round-trips.
+        assertEquals(attachedClientTransactionId, polledClientTransactionId.captured)
+    }
+
+    @Test
+    fun `interstitial verified result flows from enable through show with custom data correlation`() {
+        val verifiedReward = CoreVerifiedReward.VirtualCurrency(code = "coins", amount = 3)
+        val mockPurchases = mockk<Purchases>(relaxed = true)
+        val polledClientTransactionId = slot<String>()
+        every {
+            mockPurchases.getRewardVerificationResult(capture(polledClientTransactionId), any())
+        } answers {
+            secondArg<GetRewardVerificationResultCallback>().onReceived(
+                CoreRewardVerificationResult.Verified(verifiedReward),
+            )
+        }
+
+        every { mockPurchases.currentConfiguration.apiKey } returns "test_api_key"
+        every { mockPurchases.appUserID } returns "app-user-id"
+        Purchases.backingFieldSharedInstance = mockPurchases
+        originalServiceForwarder.initialize(mockPurchases)
+
+        val ad = mockk<RewardedInterstitialAd>(relaxed = true)
+        every { ad.responseInfo.responseId } returns "interstitial-response-id"
+        val ssvOptions = slot<ServerSideVerificationOptions>()
+        every { ad.setServerSideVerificationOptions(capture(ssvOptions)) } answers {}
+        val activity = mockk<Activity>(relaxed = true)
+        val rewardListenerSlot = slot<OnUserEarnedRewardListener>()
+        every { ad.show(activity, capture(rewardListenerSlot)) } answers {}
+
+        ad.enableRewardVerification()
+
+        assertTrue(ssvOptions.isCaptured)
+        assertEquals("app-user-id", ssvOptions.captured.userId)
+        val payload = JSONObject(ssvOptions.captured.customData)
+        assertEquals("test_api_key", payload.getString("api_key"))
+        val attachedClientTransactionId = payload.getString("client_transaction_id")
+        assertTrue(attachedClientTransactionId.isNotBlank())
+
+        var completedResult: RewardVerificationResult? = null
+        val completed = CountDownLatch(1)
+        ad.showWithRewardVerification(activity = activity) { result ->
+            completedResult = result
+            completed.countDown()
+        }
+        rewardListenerSlot.captured.onUserEarnedReward(mockk<RewardItem>(relaxed = true))
+
+        val delivered = (1..10).any {
+            shadowOf(Looper.getMainLooper()).idle()
+            completed.await(100, TimeUnit.MILLISECONDS)
+        }
+
+        assertTrue(delivered)
+        assertNotNull(completedResult)
+        assertFalse(completedResult!!.failed)
+        assertEquals(attachedClientTransactionId, polledClientTransactionId.captured)
     }
 
     @Test
@@ -111,6 +192,9 @@ internal class RewardVerificationManagerTest {
         every { ad.show(activity, capture(rewardListenerSlot)) } answers {}
 
         ad.enableRewardVerification()
+
+        // Without a stored client transaction id there is nothing to correlate, so no SSV data is attached.
+        verify(exactly = 0) { ad.setServerSideVerificationOptions(any()) }
 
         var startedCount = 0
         var completedResult: RewardVerificationResult? = null


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-ios` and hybrids

### Motivation
`enableRewardVerification()` generated and stored a `client_transaction_id` and polled the backend for it, but never attached that id to the ad — so the SSV callback had nothing to correlate the reward against and the whole correlation mechanism was missing.

### Description
`install()` now attaches the id to the ad via AdMob's `ServerSideVerificationOptions`, so the SSV callback forwards it to RevenueCat, which keys the verification by the same id the poller queries. The custom data is a JSON payload (`{"api_key":"…","client_transaction_id":"…"}`) with the app user id set as the SSV user id, matching the `purchases-ios` AdMob adapter byte-for-byte since both SDKs hit the same endpoint. Covered by unit tests asserting the attached `userId`, the exact serialized payload format, and that the polled id round-trips; verified via `detektAll` and `:feature:admob:testDefaultsBc8DebugUnitTest`.

> **Note:** this branch is stacked on `admob-reward-verification`, so the PR targets that branch (not `main`) to keep the diff scoped to the correlation change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Sends the RevenueCat API key and client transaction id in AdMob SSV custom data; behavior is scoped to the AdMob reward-verification path with tests, but it affects how rewards are verified end-to-end.
> 
> **Overview**
> **AdMob reward verification** now wires the client-generated transaction id into the ad at enable time, so server-side verification (SSV) and backend polling use the same correlation key.
> 
> On successful `install()` for **rewarded** and **rewarded interstitial** ads, the SDK sets AdMob `ServerSideVerificationOptions`: **app user id** as SSV user id and **custom data** as JSON `{"api_key":"…","client_transaction_id":"…"}` (aligned with the iOS adapter for the shared endpoint). If Purchases is not configured or the id cannot be stored, SSV options are **not** attached (unchanged safe failure path).
> 
> Unit tests assert the attached payload, user id, id round-trip into `getRewardVerificationResult`, interstitial parity, and zero SSV calls when setup fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 640336c6e3b390dc0027c40204af4e8161d6ab07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->