### PR TITLE
[DO NOT MERGE] flag-off baseline for build-cache CI measurement

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -57,4 +57,4 @@ SONATYPE_AUTOMATIC_RELEASE=true
 org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 
 # Enable the Gradle build cache (local task-output cache) for the main build.
-org.gradle.caching=true
+org.gradle.caching=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,3 +55,6 @@ SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=true
 
 org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
+
+# Enable the Gradle build cache (local task-output cache) for the main build.
+org.gradle.caching=true


### PR DESCRIPTION
Throwaway branch to measure flag-OFF vs flag-ON CI durations against #3523. Identical to that branch except `org.gradle.caching=false`. Will be closed once measurement is done — do not merge or review.