### PR TITLE
Fade the multipage paywall header during page transitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ libs/samsung-iap-*.aar
 
 # Claude Code
 .claude/
+
+# Superpowers brainstorming companion (local only)
+.superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,3 @@ libs/samsung-iap-*.aar
 
 # Claude Code
 .claude/
-
-# Superpowers brainstorming companion (local only)
-.superpowers/

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -97,9 +97,8 @@ internal fun LoadedWorkflowPaywall(
                     onClick = onClick,
                     modifier = Modifier
                         .fillMaxWidth()
-                        // animatable.value is a draw-phase state read (no recomposition per frame, same as
-                        // workflowTransition); headerRender.role is a plain closed-over value, refreshed when
-                        // a recomposition rebuilds this modifier (role only changes when the transition changes).
+                        // Read animatable.value inside graphicsLayer (draw phase), like workflowTransition,
+                        // so the fade stays in lock-step with the slide without recomposing every frame.
                         .graphicsLayer { alpha = headerAlpha(headerRender.role, transitionState.animatable.value) },
                 )
             }

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -31,6 +31,14 @@ internal data class WorkflowHeaderStepInfo(
     val hasHeader: Boolean,
 )
 
+internal enum class WorkflowHeaderTransitionRole { ENTERING, LEAVING, STABLE }
+
+internal fun headerAlpha(role: WorkflowHeaderTransitionRole, progress: Float): Float = when (role) {
+    WorkflowHeaderTransitionRole.ENTERING -> progress
+    WorkflowHeaderTransitionRole.LEAVING -> 1f - progress
+    WorkflowHeaderTransitionRole.STABLE -> 1f
+}
+
 @Suppress("LongParameterList")
 @Composable
 internal fun LoadedWorkflowPaywall(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -33,6 +33,11 @@ internal data class WorkflowHeaderStepInfo(
 
 internal enum class WorkflowHeaderTransitionRole { ENTERING, LEAVING, STABLE }
 
+internal data class WorkflowHeaderPresentation(
+    val headerStepId: String,
+    val role: WorkflowHeaderTransitionRole,
+)
+
 internal fun headerAlpha(role: WorkflowHeaderTransitionRole, progress: Float): Float = when (role) {
     WorkflowHeaderTransitionRole.ENTERING -> progress
     WorkflowHeaderTransitionRole.LEAVING -> 1f - progress
@@ -122,11 +127,11 @@ private fun workflowHeaderState(
             }
         }
     }
-    val headerStepId = selectWorkflowHeaderStepId(
+    val headerStepId = selectWorkflowHeaderPresentation(
         currentStepId = currentStepId,
         stepInfoByStepId = headerStepInfo,
         pendingTransition = pendingTransition,
-    )
+    ).headerStepId
 
     return stepStates[headerStepId] ?: currentState
 }
@@ -231,21 +236,35 @@ private fun WorkflowStepContent(
     }
 }
 
-internal fun selectWorkflowHeaderStepId(
+internal fun selectWorkflowHeaderPresentation(
     currentStepId: String,
     stepInfoByStepId: Map<String, WorkflowHeaderStepInfo>,
     pendingTransition: WorkflowPendingTransition?,
-): String {
+): WorkflowHeaderPresentation {
     val fromStepId = pendingTransition?.fromStepId
-    val direction = pendingTransition?.direction
-    val fromStepInfo = fromStepId?.let(stepInfoByStepId::get)
-    val toStepInfo = stepInfoByStepId[currentStepId]
-    val useOutgoingHeader = pendingTransition != null &&
-        fromStepInfo != null &&
-        toStepInfo != null &&
-        shouldUseOutgoingHeader(direction, fromStepInfo, toStepInfo)
+        ?: return WorkflowHeaderPresentation(currentStepId, WorkflowHeaderTransitionRole.STABLE)
+    val fromInfo = stepInfoByStepId[fromStepId]
+    val toInfo = stepInfoByStepId[currentStepId]
+    val fromHasHeader = fromInfo?.hasHeader == true
+    val toHasHeader = toInfo?.hasHeader == true
 
-    return if (useOutgoingHeader) fromStepId!! else currentStepId
+    return when {
+        fromHasHeader && !toHasHeader ->
+            WorkflowHeaderPresentation(fromStepId, WorkflowHeaderTransitionRole.LEAVING)
+        !fromHasHeader && toHasHeader ->
+            WorkflowHeaderPresentation(currentStepId, WorkflowHeaderTransitionRole.ENTERING)
+        fromHasHeader && toHasHeader -> {
+            // Both steps have a header: keep the existing selection, no fade.
+            // Crossfade between genuinely different headers is deferred until shared headers exist.
+            val stepId = if (shouldUseOutgoingHeader(pendingTransition.direction, fromInfo!!, toInfo!!)) {
+                fromStepId
+            } else {
+                currentStepId
+            }
+            WorkflowHeaderPresentation(stepId, WorkflowHeaderTransitionRole.STABLE)
+        }
+        else -> WorkflowHeaderPresentation(currentStepId, WorkflowHeaderTransitionRole.STABLE)
+    }
 }
 
 private fun shouldUseOutgoingHeader(

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -256,11 +256,9 @@ internal fun selectWorkflowHeaderPresentation(
         fromHasHeader && toHasHeader -> {
             // Both steps have a header: keep the existing selection, no fade.
             // Crossfade between genuinely different headers is deferred until shared headers exist.
-            val stepId = if (shouldUseOutgoingHeader(pendingTransition.direction, fromInfo!!, toInfo!!)) {
-                fromStepId
-            } else {
-                currentStepId
-            }
+            val keepOutgoing = fromInfo != null && toInfo != null &&
+                shouldUseOutgoingHeader(pendingTransition.direction, fromInfo, toInfo)
+            val stepId = if (keepOutgoing) fromStepId else currentStepId
             WorkflowHeaderPresentation(stepId, WorkflowHeaderTransitionRole.STABLE)
         }
         else -> WorkflowHeaderPresentation(currentStepId, WorkflowHeaderTransitionRole.STABLE)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -267,14 +267,14 @@ internal fun selectWorkflowHeaderPresentation(
             WorkflowHeaderPresentation(fromStepId, WorkflowHeaderTransitionRole.LEAVING)
         !fromHasHeader && toHasHeader ->
             WorkflowHeaderPresentation(currentStepId, WorkflowHeaderTransitionRole.ENTERING)
-        fromHasHeader && toHasHeader -> {
-            // Both steps have a header: keep the existing selection, no fade.
-            // Crossfade between genuinely different headers is deferred until shared headers exist.
-            // fromInfo/toInfo are non-null here (fromHasHeader/toHasHeader imply it); the explicit
-            // null checks are only to let the compiler smart-cast them into shouldUseOutgoingHeader.
-            val keepOutgoing = fromInfo != null && toInfo != null &&
-                shouldUseOutgoingHeader(pendingTransition.direction, fromInfo, toInfo)
-            val stepId = if (keepOutgoing) fromStepId else currentStepId
+        fromInfo != null && toInfo != null && fromHasHeader && toHasHeader -> {
+            // Both steps have a header: no fade, keep the existing selection. Animating a change
+            // between two different headers is a separate, deferred decision.
+            val stepId = if (shouldUseOutgoingHeader(pendingTransition.direction, fromInfo, toInfo)) {
+                fromStepId
+            } else {
+                currentStepId
+            }
             WorkflowHeaderPresentation(stepId, WorkflowHeaderTransitionRole.STABLE)
         }
         else -> WorkflowHeaderPresentation(currentStepId, WorkflowHeaderTransitionRole.STABLE)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -267,8 +267,7 @@ internal fun selectWorkflowHeaderPresentation(
         !fromHasHeader && toHasHeader ->
             WorkflowHeaderPresentation(currentStepId, WorkflowHeaderTransitionRole.ENTERING)
         fromInfo != null && toInfo != null && fromHasHeader && toHasHeader -> {
-            // Both steps have a header: no fade, keep the existing selection. Animating a change
-            // between two different headers is a separate, deferred decision.
+            // Both steps have a header, no fade
             val stepId = if (shouldUseOutgoingHeader(pendingTransition.direction, fromInfo, toInfo)) {
                 fromStepId
             } else {

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -80,34 +80,46 @@ internal fun LoadedWorkflowPaywall(
     val onClick: suspend (PaywallAction) -> Unit = { action ->
         handleClick(action, currentState, clickHandler, componentInteractionTracker)
     }
+
+    // When the header is LEAVING (fading out over an incoming step that has no header), routing it
+    // through HeaderOverlayLayout would write its measured height into currentState.headerHeightPx.
+    // The incoming step would then use that height as its hero ZLayer top inset instead of the
+    // status-bar fallback. To avoid this, LEAVING headers are rendered as a Box overlay inside the
+    // mainContent lambda — outside HeaderOverlayLayout — so currentState.headerHeightPx stays 0.
+    val isLeavingHeader = headerPresentation.role == WorkflowHeaderTransitionRole.LEAVING
+    val headerComposable: (@Composable () -> Unit)? = headerState.header?.let { headerStyle ->
+        {
+            ComponentView(
+                style = headerStyle,
+                state = headerState,
+                onClick = onClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    // Read animatable.value inside graphicsLayer (draw phase), like workflowTransition,
+                    // so the fade stays in lock-step with the slide without recomposing every frame.
+                    .graphicsLayer {
+                        alpha = headerAlpha(headerPresentation.role, transitionState.animatable.value)
+                    },
+            )
+        }
+    }
+
     PaywallComponentsScaffold(
         state = currentState,
         modifier = modifier,
         background = null,
-        headerContent = headerState.header?.let { headerStyle ->
-            {
-                ComponentView(
-                    style = headerStyle,
-                    state = headerState,
-                    onClick = onClick,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        // Read animatable.value inside graphicsLayer (draw phase), like workflowTransition,
-                        // so the fade stays in lock-step with the slide without recomposing every frame.
-                        .graphicsLayer {
-                            alpha = headerAlpha(headerPresentation.role, transitionState.animatable.value)
-                        },
-                )
-            }
-        },
+        headerContent = if (!isLeavingHeader) headerComposable else null,
     ) {
-        WorkflowStepsContent(
-            currentStepId = currentStepId,
-            stepStates = stepStates,
-            transitionState = transitionState,
-            clickHandler = clickHandler,
-            componentInteractionTracker = componentInteractionTracker,
-        )
+        Box(Modifier.fillMaxSize()) {
+            WorkflowStepsContent(
+                currentStepId = currentStepId,
+                stepStates = stepStates,
+                transitionState = transitionState,
+                clickHandler = clickHandler,
+                componentInteractionTracker = componentInteractionTracker,
+            )
+            if (isLeavingHeader) headerComposable?.invoke()
+        }
     }
 }
 
@@ -173,7 +185,8 @@ private fun WorkflowStepsContent(
 
 /**
  * Renders one workflow step's body and footer as a self-contained sliding surface.
- * Header is rendered at scaffold level and stays fixed.
+ * The header is rendered outside this surface (either via the scaffold's HeaderOverlayLayout or,
+ * when LEAVING, as a Box overlay in the main content — see [LoadedWorkflowPaywall]).
  * Off-screen (parked) steps still receive a click handler, but it short-circuits because they are
  * translated off-screen and can't receive touches.
  */

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -39,11 +39,6 @@ internal data class WorkflowHeaderPresentation(
     val role: WorkflowHeaderTransitionRole,
 )
 
-internal data class WorkflowHeaderRender(
-    val state: PaywallState.Loaded.Components,
-    val role: WorkflowHeaderTransitionRole,
-)
-
 internal fun headerAlpha(role: WorkflowHeaderTransitionRole, progress: Float): Float = when (role) {
     WorkflowHeaderTransitionRole.ENTERING -> progress
     WorkflowHeaderTransitionRole.LEAVING -> 1f - progress
@@ -76,12 +71,12 @@ internal fun LoadedWorkflowPaywall(
         transition = transition,
     )
 
-    val headerRender = workflowHeaderState(
+    val headerPresentation = workflowHeaderState(
         currentStepId = currentStepId,
-        currentState = currentState,
         stepStates = stepStates,
         transitionState = transitionState,
     )
+    val headerState = stepStates[headerPresentation.headerStepId] ?: currentState
     val onClick: suspend (PaywallAction) -> Unit = { action ->
         handleClick(action, currentState, clickHandler, componentInteractionTracker)
     }
@@ -89,17 +84,19 @@ internal fun LoadedWorkflowPaywall(
         state = currentState,
         modifier = modifier,
         background = null,
-        headerContent = headerRender.state.header?.let { headerStyle ->
+        headerContent = headerState.header?.let { headerStyle ->
             {
                 ComponentView(
                     style = headerStyle,
-                    state = headerRender.state,
+                    state = headerState,
                     onClick = onClick,
                     modifier = Modifier
                         .fillMaxWidth()
                         // Read animatable.value inside graphicsLayer (draw phase), like workflowTransition,
                         // so the fade stays in lock-step with the slide without recomposing every frame.
-                        .graphicsLayer { alpha = headerAlpha(headerRender.role, transitionState.animatable.value) },
+                        .graphicsLayer {
+                            alpha = headerAlpha(headerPresentation.role, transitionState.animatable.value)
+                        },
                 )
             }
         },
@@ -116,10 +113,9 @@ internal fun LoadedWorkflowPaywall(
 
 private fun workflowHeaderState(
     currentStepId: String,
-    currentState: PaywallState.Loaded.Components,
     stepStates: Map<String, PaywallState.Loaded.Components>,
     transitionState: WorkflowTransitionState,
-): WorkflowHeaderRender {
+): WorkflowHeaderPresentation {
     val headerStepInfo = stepStates.mapValues { (_, stepState) ->
         WorkflowHeaderStepInfo(
             hasHeroImage = stepState.mainStackHasHeroImage,
@@ -137,15 +133,10 @@ private fun workflowHeaderState(
             }
         }
     }
-    val presentation = selectWorkflowHeaderPresentation(
+    return selectWorkflowHeaderPresentation(
         currentStepId = currentStepId,
         stepInfoByStepId = headerStepInfo,
         pendingTransition = pendingTransition,
-    )
-
-    return WorkflowHeaderRender(
-        state = stepStates[presentation.headerStepId] ?: currentState,
-        role = presentation.role,
     )
 }
 
@@ -266,9 +257,10 @@ internal fun selectWorkflowHeaderPresentation(
             WorkflowHeaderPresentation(fromStepId, WorkflowHeaderTransitionRole.LEAVING)
         !fromHasHeader && toHasHeader ->
             WorkflowHeaderPresentation(currentStepId, WorkflowHeaderTransitionRole.ENTERING)
-        fromInfo != null && toInfo != null && fromHasHeader && toHasHeader -> {
+        fromHasHeader && toHasHeader -> {
             // Both steps have a header, no fade
-            val stepId = if (shouldUseOutgoingHeader(pendingTransition.direction, fromInfo, toInfo)) {
+            // !! safe: fromHasHeader/toHasHeader imply their info is non-null
+            val stepId = if (shouldUseOutgoingHeader(pendingTransition.direction, fromInfo!!, toInfo!!)) {
                 fromStepId
             } else {
                 currentStepId
@@ -283,6 +275,5 @@ private fun shouldUseOutgoingHeader(
     direction: NavigationDirection?,
     fromStepInfo: WorkflowHeaderStepInfo,
     toStepInfo: WorkflowHeaderStepInfo,
-): Boolean = fromStepInfo.hasHeader &&
-    !toStepInfo.hasHeroImage &&
+): Boolean = !toStepInfo.hasHeroImage &&
     (direction == NavigationDirection.BACKWARD || fromStepInfo.hasHeroImage)

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -80,6 +80,9 @@ internal fun LoadedWorkflowPaywall(
     val onClick: suspend (PaywallAction) -> Unit = { action ->
         handleClick(action, currentState, clickHandler, componentInteractionTracker)
     }
+    val headerOnClick: suspend (PaywallAction) -> Unit = { action ->
+        handleClick(action, headerState, clickHandler, componentInteractionTracker)
+    }
 
     // When the header is LEAVING (fading out over an incoming step that has no header), routing it
     // through HeaderOverlayLayout would write its measured height into currentState.headerHeightPx.
@@ -92,7 +95,7 @@ internal fun LoadedWorkflowPaywall(
             ComponentView(
                 style = headerStyle,
                 state = headerState,
-                onClick = onClick,
+                onClick = headerOnClick,
                 modifier = Modifier
                     .fillMaxWidth()
                     // Read animatable.value inside graphicsLayer (draw phase), like workflowTransition,

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -97,6 +97,9 @@ internal fun LoadedWorkflowPaywall(
                     onClick = onClick,
                     modifier = Modifier
                         .fillMaxWidth()
+                        // animatable.value is a draw-phase state read (no recomposition per frame, same as
+                        // workflowTransition); headerRender.role is a plain closed-over value, refreshed when
+                        // a recomposition rebuilds this modifier (role only changes when the transition changes).
                         .graphicsLayer { alpha = headerAlpha(headerRender.role, transitionState.animatable.value) },
                 )
             }
@@ -267,6 +270,8 @@ internal fun selectWorkflowHeaderPresentation(
         fromHasHeader && toHasHeader -> {
             // Both steps have a header: keep the existing selection, no fade.
             // Crossfade between genuinely different headers is deferred until shared headers exist.
+            // fromInfo/toInfo are non-null here (fromHasHeader/toHasHeader imply it); the explicit
+            // null checks are only to let the compiler smart-cast them into shouldUseOutgoingHeader.
             val keepOutgoing = fromInfo != null && toInfo != null &&
                 shouldUseOutgoingHeader(pendingTransition.direction, fromInfo, toInfo)
             val stepId = if (keepOutgoing) fromStepId else currentStepId

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalLayoutDirection
 import com.revenuecat.purchases.InternalRevenueCatAPI
@@ -35,6 +36,11 @@ internal enum class WorkflowHeaderTransitionRole { ENTERING, LEAVING, STABLE }
 
 internal data class WorkflowHeaderPresentation(
     val headerStepId: String,
+    val role: WorkflowHeaderTransitionRole,
+)
+
+internal data class WorkflowHeaderRender(
+    val state: PaywallState.Loaded.Components,
     val role: WorkflowHeaderTransitionRole,
 )
 
@@ -70,7 +76,7 @@ internal fun LoadedWorkflowPaywall(
         transition = transition,
     )
 
-    val headerState = workflowHeaderState(
+    val headerRender = workflowHeaderState(
         currentStepId = currentStepId,
         currentState = currentState,
         stepStates = stepStates,
@@ -83,13 +89,15 @@ internal fun LoadedWorkflowPaywall(
         state = currentState,
         modifier = modifier,
         background = null,
-        headerContent = headerState.header?.let { headerStyle ->
+        headerContent = headerRender.state.header?.let { headerStyle ->
             {
                 ComponentView(
                     style = headerStyle,
-                    state = headerState,
+                    state = headerRender.state,
                     onClick = onClick,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .graphicsLayer { alpha = headerAlpha(headerRender.role, transitionState.animatable.value) },
                 )
             }
         },
@@ -109,7 +117,7 @@ private fun workflowHeaderState(
     currentState: PaywallState.Loaded.Components,
     stepStates: Map<String, PaywallState.Loaded.Components>,
     transitionState: WorkflowTransitionState,
-): PaywallState.Loaded.Components {
+): WorkflowHeaderRender {
     val headerStepInfo = stepStates.mapValues { (_, stepState) ->
         WorkflowHeaderStepInfo(
             hasHeroImage = stepState.mainStackHasHeroImage,
@@ -127,13 +135,16 @@ private fun workflowHeaderState(
             }
         }
     }
-    val headerStepId = selectWorkflowHeaderPresentation(
+    val presentation = selectWorkflowHeaderPresentation(
         currentStepId = currentStepId,
         stepInfoByStepId = headerStepInfo,
         pendingTransition = pendingTransition,
-    ).headerStepId
+    )
 
-    return stepStates[headerStepId] ?: currentState
+    return WorkflowHeaderRender(
+        state = stepStates[presentation.headerStepId] ?: currentState,
+        role = presentation.role,
+    )
 }
 
 @Suppress("LongParameterList")

--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywall.kt
@@ -45,7 +45,7 @@ internal fun headerAlpha(role: WorkflowHeaderTransitionRole, progress: Float): F
     WorkflowHeaderTransitionRole.STABLE -> 1f
 }
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LongMethod")
 @Composable
 internal fun LoadedWorkflowPaywall(
     workflowState: WorkflowPaywallUiState,
@@ -110,7 +110,20 @@ internal fun LoadedWorkflowPaywall(
         background = null,
         headerContent = if (!isLeavingHeader) headerComposable else null,
     ) {
-        Box(Modifier.fillMaxSize()) {
+        if (isLeavingHeader && headerComposable != null) {
+            // Box required to overlay the LEAVING header above WorkflowStepsContent.
+            // Only present during a header→no-header transition; not added in the common case.
+            Box(Modifier.fillMaxSize()) {
+                WorkflowStepsContent(
+                    currentStepId = currentStepId,
+                    stepStates = stepStates,
+                    transitionState = transitionState,
+                    clickHandler = clickHandler,
+                    componentInteractionTracker = componentInteractionTracker,
+                )
+                headerComposable()
+            }
+        } else {
             WorkflowStepsContent(
                 currentStepId = currentStepId,
                 stepStates = stepStates,
@@ -118,7 +131,6 @@ internal fun LoadedWorkflowPaywall(
                 clickHandler = clickHandler,
                 componentInteractionTracker = componentInteractionTracker,
             )
-            if (isLeavingHeader) headerComposable?.invoke()
         }
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
@@ -186,6 +186,22 @@ internal class LoadedWorkflowPaywallHeaderSelectionTest {
     }
 
     @Test
+    fun `unknown current step treated as no header so outgoing header leaves`() {
+        val presentation = selectWorkflowHeaderPresentation(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                // "target" (the current step) is intentionally absent from the map, so it is
+                // treated as having no header: the outgoing "from" header fades out (LEAVING).
+                "from" to info(hasHeroImage = false, hasHeader = true),
+            ),
+            pendingTransition = transition(NavigationDirection.FORWARD),
+        )
+
+        assertThat(presentation.headerStepId).isEqualTo("from")
+        assertThat(presentation.role).isEqualTo(WorkflowHeaderTransitionRole.LEAVING)
+    }
+
+    @Test
     fun `idle state uses current step header stable`() {
         val presentation = selectWorkflowHeaderPresentation(
             currentStepId = "target",

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
@@ -171,6 +171,21 @@ internal class LoadedWorkflowPaywallHeaderSelectionTest {
     }
 
     @Test
+    fun `pending transition with unknown from step renders current step`() {
+        val presentation = selectWorkflowHeaderPresentation(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                // "from" is intentionally absent from the map
+                "target" to info(hasHeroImage = false, hasHeader = false),
+            ),
+            pendingTransition = transition(NavigationDirection.FORWARD),
+        )
+
+        assertThat(presentation.headerStepId).isEqualTo("target")
+        assertThat(presentation.role).isEqualTo(WorkflowHeaderTransitionRole.STABLE)
+    }
+
+    @Test
     fun `idle state uses current step header stable`() {
         val presentation = selectWorkflowHeaderPresentation(
             currentStepId = "target",

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/LoadedWorkflowPaywallHeaderSelectionTest.kt
@@ -7,114 +7,180 @@ import org.junit.Test
 
 internal class LoadedWorkflowPaywallHeaderSelectionTest {
 
+    private fun info(hasHeroImage: Boolean, hasHeader: Boolean) =
+        WorkflowHeaderStepInfo(hasHeroImage = hasHeroImage, hasHeader = hasHeader)
+
+    private fun transition(direction: NavigationDirection) =
+        WorkflowPendingTransition("from", direction, 1)
+
+    // --- present <-> absent: the cases the fade is for ---
+
     @Test
-    fun `hero to non-hero keeps outgoing hero header while animating`() {
-        val selected = selectWorkflowHeaderStepId(
+    fun `header to no-header fades the outgoing header out`() {
+        val presentation = selectWorkflowHeaderPresentation(
             currentStepId = "target",
             stepInfoByStepId = mapOf(
-                "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
-                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "from" to info(hasHeroImage = false, hasHeader = true),
+                "target" to info(hasHeroImage = false, hasHeader = false),
             ),
-            pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
+            pendingTransition = transition(NavigationDirection.FORWARD),
         )
 
-        assertThat(selected).isEqualTo("from")
+        assertThat(presentation.headerStepId).isEqualTo("from")
+        assertThat(presentation.role).isEqualTo(WorkflowHeaderTransitionRole.LEAVING)
     }
 
     @Test
-    fun `hero to non-hero switches to target header after animation`() {
-        val selected = selectWorkflowHeaderStepId(
+    fun `header to hero-without-header still fades the outgoing header out`() {
+        // Behavior change: previously this dropped the header (hero rule). Now it fades.
+        val presentation = selectWorkflowHeaderPresentation(
             currentStepId = "target",
             stepInfoByStepId = mapOf(
-                "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
-                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
+                "from" to info(hasHeroImage = false, hasHeader = true),
+                "target" to info(hasHeroImage = true, hasHeader = false),
+            ),
+            pendingTransition = transition(NavigationDirection.FORWARD),
+        )
+
+        assertThat(presentation.headerStepId).isEqualTo("from")
+        assertThat(presentation.role).isEqualTo(WorkflowHeaderTransitionRole.LEAVING)
+    }
+
+    @Test
+    fun `no-header to header fades the incoming header in`() {
+        val presentation = selectWorkflowHeaderPresentation(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to info(hasHeroImage = false, hasHeader = false),
+                "target" to info(hasHeroImage = false, hasHeader = true),
+            ),
+            pendingTransition = transition(NavigationDirection.FORWARD),
+        )
+
+        assertThat(presentation.headerStepId).isEqualTo("target")
+        assertThat(presentation.role).isEqualTo(WorkflowHeaderTransitionRole.ENTERING)
+    }
+
+    @Test
+    fun `missing outgoing hero header falls back to incoming header entering`() {
+        val presentation = selectWorkflowHeaderPresentation(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to info(hasHeroImage = true, hasHeader = false),
+                "target" to info(hasHeroImage = false, hasHeader = true),
+            ),
+            pendingTransition = transition(NavigationDirection.FORWARD),
+        )
+
+        assertThat(presentation.headerStepId).isEqualTo("target")
+        assertThat(presentation.role).isEqualTo(WorkflowHeaderTransitionRole.ENTERING)
+    }
+
+    // --- both present: existing selection preserved, no fade ---
+
+    @Test
+    fun `hero to non-hero both-header keeps outgoing header stable`() {
+        val presentation = selectWorkflowHeaderPresentation(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to info(hasHeroImage = true, hasHeader = true),
+                "target" to info(hasHeroImage = false, hasHeader = true),
+            ),
+            pendingTransition = transition(NavigationDirection.FORWARD),
+        )
+
+        assertThat(presentation.headerStepId).isEqualTo("from")
+        assertThat(presentation.role).isEqualTo(WorkflowHeaderTransitionRole.STABLE)
+    }
+
+    @Test
+    fun `non-hero to hero both-header forward uses incoming header stable`() {
+        val presentation = selectWorkflowHeaderPresentation(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to info(hasHeroImage = false, hasHeader = true),
+                "target" to info(hasHeroImage = true, hasHeader = true),
+            ),
+            pendingTransition = transition(NavigationDirection.FORWARD),
+        )
+
+        assertThat(presentation.headerStepId).isEqualTo("target")
+        assertThat(presentation.role).isEqualTo(WorkflowHeaderTransitionRole.STABLE)
+    }
+
+    @Test
+    fun `non-hero to hero both-header backward uses incoming header stable`() {
+        val presentation = selectWorkflowHeaderPresentation(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to info(hasHeroImage = false, hasHeader = true),
+                "target" to info(hasHeroImage = true, hasHeader = true),
+            ),
+            pendingTransition = transition(NavigationDirection.BACKWARD),
+        )
+
+        assertThat(presentation.headerStepId).isEqualTo("target")
+        assertThat(presentation.role).isEqualTo(WorkflowHeaderTransitionRole.STABLE)
+    }
+
+    @Test
+    fun `non-hero to non-hero both-header backward keeps outgoing header stable`() {
+        val presentation = selectWorkflowHeaderPresentation(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to info(hasHeroImage = false, hasHeader = true),
+                "target" to info(hasHeroImage = false, hasHeader = true),
+            ),
+            pendingTransition = transition(NavigationDirection.BACKWARD),
+        )
+
+        assertThat(presentation.headerStepId).isEqualTo("from")
+        assertThat(presentation.role).isEqualTo(WorkflowHeaderTransitionRole.STABLE)
+    }
+
+    @Test
+    fun `non-hero to non-hero both-header forward uses incoming header stable`() {
+        val presentation = selectWorkflowHeaderPresentation(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to info(hasHeroImage = false, hasHeader = true),
+                "target" to info(hasHeroImage = false, hasHeader = true),
+            ),
+            pendingTransition = transition(NavigationDirection.FORWARD),
+        )
+
+        assertThat(presentation.headerStepId).isEqualTo("target")
+        assertThat(presentation.role).isEqualTo(WorkflowHeaderTransitionRole.STABLE)
+    }
+
+    // --- degenerate cases ---
+
+    @Test
+    fun `no-header to no-header renders current step stable`() {
+        val presentation = selectWorkflowHeaderPresentation(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "from" to info(hasHeroImage = false, hasHeader = false),
+                "target" to info(hasHeroImage = false, hasHeader = false),
+            ),
+            pendingTransition = transition(NavigationDirection.FORWARD),
+        )
+
+        assertThat(presentation.headerStepId).isEqualTo("target")
+        assertThat(presentation.role).isEqualTo(WorkflowHeaderTransitionRole.STABLE)
+    }
+
+    @Test
+    fun `idle state uses current step header stable`() {
+        val presentation = selectWorkflowHeaderPresentation(
+            currentStepId = "target",
+            stepInfoByStepId = mapOf(
+                "target" to info(hasHeroImage = false, hasHeader = true),
             ),
             pendingTransition = null,
         )
 
-        assertThat(selected).isEqualTo("target")
-    }
-
-    @Test
-    fun `non-hero to hero uses incoming header immediately`() {
-        val selected = selectWorkflowHeaderStepId(
-            currentStepId = "target",
-            stepInfoByStepId = mapOf(
-                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
-                "target" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
-            ),
-            pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
-        )
-
-        assertThat(selected).isEqualTo("target")
-    }
-
-    @Test
-    fun `non-hero to hero backward transition uses incoming header while animating`() {
-        val selected = selectWorkflowHeaderStepId(
-            currentStepId = "target",
-            stepInfoByStepId = mapOf(
-                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
-                "target" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = true),
-            ),
-            pendingTransition = WorkflowPendingTransition("from", NavigationDirection.BACKWARD, 1),
-        )
-
-        assertThat(selected).isEqualTo("target")
-    }
-
-    @Test
-    fun `non-hero to non-hero backward transition keeps outgoing header while animating`() {
-        val selected = selectWorkflowHeaderStepId(
-            currentStepId = "target",
-            stepInfoByStepId = mapOf(
-                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
-                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
-            ),
-            pendingTransition = WorkflowPendingTransition("from", NavigationDirection.BACKWARD, 1),
-        )
-
-        assertThat(selected).isEqualTo("from")
-    }
-
-    @Test
-    fun `non-hero to non-hero forward transition uses incoming header while animating`() {
-        val selected = selectWorkflowHeaderStepId(
-            currentStepId = "target",
-            stepInfoByStepId = mapOf(
-                "from" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
-                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
-            ),
-            pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
-        )
-
-        assertThat(selected).isEqualTo("target")
-    }
-
-    @Test
-    fun `missing outgoing hero header falls back to target header`() {
-        val selected = selectWorkflowHeaderStepId(
-            currentStepId = "target",
-            stepInfoByStepId = mapOf(
-                "from" to WorkflowHeaderStepInfo(hasHeroImage = true, hasHeader = false),
-                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
-            ),
-            pendingTransition = WorkflowPendingTransition("from", NavigationDirection.FORWARD, 1),
-        )
-
-        assertThat(selected).isEqualTo("target")
-    }
-
-    @Test
-    fun `idle state always uses current step header`() {
-        val selected = selectWorkflowHeaderStepId(
-            currentStepId = "target",
-            stepInfoByStepId = mapOf(
-                "target" to WorkflowHeaderStepInfo(hasHeroImage = false, hasHeader = true),
-            ),
-            pendingTransition = null,
-        )
-
-        assertThat(selected).isEqualTo("target")
+        assertThat(presentation.headerStepId).isEqualTo("target")
+        assertThat(presentation.role).isEqualTo(WorkflowHeaderTransitionRole.STABLE)
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowHeaderAlphaTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowHeaderAlphaTest.kt
@@ -1,0 +1,29 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.Test
+
+internal class WorkflowHeaderAlphaTest {
+
+    @Test
+    fun `entering fades from 0 to 1 with progress`() {
+        assertThat(headerAlpha(WorkflowHeaderTransitionRole.ENTERING, 0f)).isEqualTo(0f)
+        assertThat(headerAlpha(WorkflowHeaderTransitionRole.ENTERING, 0.5f)).isEqualTo(0.5f, within(0.0001f))
+        assertThat(headerAlpha(WorkflowHeaderTransitionRole.ENTERING, 1f)).isEqualTo(1f)
+    }
+
+    @Test
+    fun `leaving fades from 1 to 0 with progress`() {
+        assertThat(headerAlpha(WorkflowHeaderTransitionRole.LEAVING, 0f)).isEqualTo(1f)
+        assertThat(headerAlpha(WorkflowHeaderTransitionRole.LEAVING, 0.5f)).isEqualTo(0.5f, within(0.0001f))
+        assertThat(headerAlpha(WorkflowHeaderTransitionRole.LEAVING, 1f)).isEqualTo(0f)
+    }
+
+    @Test
+    fun `stable is always fully opaque`() {
+        assertThat(headerAlpha(WorkflowHeaderTransitionRole.STABLE, 0f)).isEqualTo(1f)
+        assertThat(headerAlpha(WorkflowHeaderTransitionRole.STABLE, 0.5f)).isEqualTo(1f)
+        assertThat(headerAlpha(WorkflowHeaderTransitionRole.STABLE, 1f)).isEqualTo(1f)
+    }
+}


### PR DESCRIPTION
Multipage paywall headers used to pop. When one page has a header and the next doesn't, the header vanished the instant the slide finished (or snapped in at the start). Now the header rides the slide.

The header fades with the page transition:
- present → absent: the outgoing header fades out
- absent → present: the incoming header fades in
- both present, or neither: unchanged (no fade)

It rides the same `animatable.value` progress as the slide, read inside `graphicsLayer { alpha }`, so it stays in lock-step and adds no recompositions per frame. The old `!toHasHeroImage` special-case is dropped: the header now fades even when the incoming page has a hero image, instead of dropping abruptly.

https://github.com/user-attachments/assets/ab0e7516-5feb-4c1a-beee-284b87a5dcbe


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Paywall UI and transition animation only; layout workaround for leaving headers is localized but worth a quick visual pass on header↔no-header and header↔hero flows.
> 
> **Overview**
> Multipage workflow paywalls now **fade the header in sync with the slide** when a step gains or loses a header, instead of popping at the end of the transition.
> 
> Header selection returns a **`WorkflowHeaderPresentation`** (step id + **ENTERING / LEAVING / STABLE**). Present→absent uses the outgoing header with **LEAVING**; absent→present uses the incoming with **ENTERING**; when both steps have headers, behavior stays **STABLE** with the existing outgoing/incoming pick rules. The old case that **dropped the header immediately** when navigating to a hero page without a header is replaced by a **LEAVING** fade.
> 
> Alpha follows the same transition progress as the slide via **`graphicsLayer`** (no per-frame recomposition). **LEAVING** headers are drawn as a **Box overlay** in main content—not in the scaffold header slot—so **`headerHeightPx`** on the incoming step is not set from the fading header (hero top inset stays correct).
> 
> Tests cover presentation selection (including the hero behavior change) and **`headerAlpha`** mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f63293167bb9f5e0551e6613f898d08803a6d452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->