### PR TITLE
Fix 1px seam between sliding multipage paywall pages

### DIFF
--- a/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowTransitionState.kt
+++ b/ui/revenuecatui/src/main/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowTransitionState.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.LayoutDirection
 import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.ui.revenuecatui.data.WorkflowPaywallUiState
 import com.revenuecat.purchases.ui.revenuecatui.workflow.NavigationDirection
+import kotlin.math.roundToInt
 
 /**
  * Snapshot of the data needed to render and animate the two-surface workflow paywall transition.
@@ -147,11 +148,40 @@ private fun GraphicsLayerScope.applyWorkflowTransition(
         val navigationDirectionFactor = if (state.animatingDirection == NavigationDirection.FORWARD) 1f else -1f
         val layoutDirectionFactor = if (layoutDirection == LayoutDirection.Rtl) -1f else 1f
         val directionFactor = navigationDirectionFactor * layoutDirectionFactor
-        translationX = when (stepId) {
-            state.animatingToStepId -> (1f - progress) * directionFactor * size.width
-            state.animatingFromStepId -> -progress * directionFactor * size.width
-            else -> 0f
-        }
+        translationX = workflowSlideTranslationX(
+            stepId = stepId,
+            animatingToStepId = state.animatingToStepId,
+            animatingFromStepId = state.animatingFromStepId,
+            progress = progress,
+            width = size.width,
+            directionFactor = directionFactor,
+        )
+    }
+}
+
+/**
+ * Horizontal offset for a workflow step's sliding surface.
+ *
+ * The incoming step's leading edge is snapped to a whole pixel, and the outgoing step's offset is
+ * derived from it (`incoming - directionFactor * width`) so the two surfaces share a byte-identical
+ * edge. Computing the two offsets from independent float expressions leaves a sub-pixel gap between
+ * the two graphics layers, which renders as a 1px seam (the background showing through) during the
+ * slide.
+ */
+@Suppress("LongParameterList")
+internal fun workflowSlideTranslationX(
+    stepId: String,
+    animatingToStepId: String,
+    animatingFromStepId: String?,
+    progress: Float,
+    width: Float,
+    directionFactor: Float,
+): Float {
+    val incomingTranslationX = ((1f - progress) * directionFactor * width).roundToInt().toFloat()
+    return when (stepId) {
+        animatingToStepId -> incomingTranslationX
+        animatingFromStepId -> incomingTranslationX - directionFactor * width
+        else -> 0f
     }
 }
 

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideTranslationXTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideTranslationXTest.kt
@@ -9,58 +9,17 @@ internal class WorkflowSlideTranslationXTest {
     private val from = "from"
 
     @Test
-    fun `incoming and outgoing surfaces stay exactly adjacent so there is no sub-pixel gap`() {
-        val width = 1001f
-        val directionFactor = 1f
-        listOf(0f, 0.2f, 0.333f, 0.5f, 0.6665f, 0.9f, 1f).forEach { progress ->
-            val toTx = workflowSlideTranslationX(to, to, from, progress, width, directionFactor)
-            val fromTx = workflowSlideTranslationX(from, to, from, progress, width, directionFactor)
-            // Outgoing sits exactly one width behind incoming in the slide direction: edges coincide.
-            assertThat(toTx - fromTx).isEqualTo(directionFactor * width)
-        }
-    }
-
-    @Test
     fun `both surfaces are snapped to whole pixels`() {
+        // progress = 0.3335 → (1 - p) * width = 0.6665 * 1001 = 667.1665, rounds to 667.
+        // Outgoing is derived from incoming so they share a byte-identical edge.
         val width = 1001f
         val directionFactor = 1f
-        val progress = 0.3335f // (1 - p) * width = 0.6665 * 1001 = 667.1665 -> rounds to 667
+        val progress = 0.3335f
         val toTx = workflowSlideTranslationX(to, to, from, progress, width, directionFactor)
         val fromTx = workflowSlideTranslationX(from, to, from, progress, width, directionFactor)
         assertThat(toTx).isEqualTo(667f)
         assertThat(fromTx).isEqualTo(667f - 1001f)
         assertThat(toTx % 1f).isEqualTo(0f)
         assertThat(fromTx % 1f).isEqualTo(0f)
-    }
-
-    @Test
-    fun `at progress 0 incoming is offscreen by one width and outgoing is centered`() {
-        val width = 1080f
-        val directionFactor = 1f
-        assertThat(workflowSlideTranslationX(to, to, from, 0f, width, directionFactor)).isEqualTo(1080f)
-        assertThat(workflowSlideTranslationX(from, to, from, 0f, width, directionFactor)).isEqualTo(0f)
-    }
-
-    @Test
-    fun `at progress 1 incoming is centered and outgoing is offscreen`() {
-        val width = 1080f
-        val directionFactor = 1f
-        assertThat(workflowSlideTranslationX(to, to, from, 1f, width, directionFactor)).isEqualTo(0f)
-        assertThat(workflowSlideTranslationX(from, to, from, 1f, width, directionFactor)).isEqualTo(-1080f)
-    }
-
-    @Test
-    fun `backward direction keeps surfaces adjacent`() {
-        val width = 1080f
-        val directionFactor = -1f
-        val progress = 0.4f
-        val toTx = workflowSlideTranslationX(to, to, from, progress, width, directionFactor)
-        val fromTx = workflowSlideTranslationX(from, to, from, progress, width, directionFactor)
-        assertThat(toTx - fromTx).isEqualTo(directionFactor * width)
-    }
-
-    @Test
-    fun `parked step has no offset`() {
-        assertThat(workflowSlideTranslationX("other", to, from, 0.5f, 1080f, 1f)).isEqualTo(0f)
     }
 }

--- a/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideTranslationXTest.kt
+++ b/ui/revenuecatui/src/test/kotlin/com/revenuecat/purchases/ui/revenuecatui/components/WorkflowSlideTranslationXTest.kt
@@ -1,0 +1,66 @@
+package com.revenuecat.purchases.ui.revenuecatui.components
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class WorkflowSlideTranslationXTest {
+
+    private val to = "to"
+    private val from = "from"
+
+    @Test
+    fun `incoming and outgoing surfaces stay exactly adjacent so there is no sub-pixel gap`() {
+        val width = 1001f
+        val directionFactor = 1f
+        listOf(0f, 0.2f, 0.333f, 0.5f, 0.6665f, 0.9f, 1f).forEach { progress ->
+            val toTx = workflowSlideTranslationX(to, to, from, progress, width, directionFactor)
+            val fromTx = workflowSlideTranslationX(from, to, from, progress, width, directionFactor)
+            // Outgoing sits exactly one width behind incoming in the slide direction: edges coincide.
+            assertThat(toTx - fromTx).isEqualTo(directionFactor * width)
+        }
+    }
+
+    @Test
+    fun `both surfaces are snapped to whole pixels`() {
+        val width = 1001f
+        val directionFactor = 1f
+        val progress = 0.3335f // (1 - p) * width = 0.6665 * 1001 = 667.1665 -> rounds to 667
+        val toTx = workflowSlideTranslationX(to, to, from, progress, width, directionFactor)
+        val fromTx = workflowSlideTranslationX(from, to, from, progress, width, directionFactor)
+        assertThat(toTx).isEqualTo(667f)
+        assertThat(fromTx).isEqualTo(667f - 1001f)
+        assertThat(toTx % 1f).isEqualTo(0f)
+        assertThat(fromTx % 1f).isEqualTo(0f)
+    }
+
+    @Test
+    fun `at progress 0 incoming is offscreen by one width and outgoing is centered`() {
+        val width = 1080f
+        val directionFactor = 1f
+        assertThat(workflowSlideTranslationX(to, to, from, 0f, width, directionFactor)).isEqualTo(1080f)
+        assertThat(workflowSlideTranslationX(from, to, from, 0f, width, directionFactor)).isEqualTo(0f)
+    }
+
+    @Test
+    fun `at progress 1 incoming is centered and outgoing is offscreen`() {
+        val width = 1080f
+        val directionFactor = 1f
+        assertThat(workflowSlideTranslationX(to, to, from, 1f, width, directionFactor)).isEqualTo(0f)
+        assertThat(workflowSlideTranslationX(from, to, from, 1f, width, directionFactor)).isEqualTo(-1080f)
+    }
+
+    @Test
+    fun `backward direction keeps surfaces adjacent`() {
+        val width = 1080f
+        val directionFactor = -1f
+        val progress = 0.4f
+        val toTx = workflowSlideTranslationX(to, to, from, progress, width, directionFactor)
+        val fromTx = workflowSlideTranslationX(from, to, from, progress, width, directionFactor)
+        assertThat(toTx - fromTx).isEqualTo(directionFactor * width)
+    }
+
+    @Test
+    fun `parked step has no offset`() {
+        assertThat(workflowSlideTranslationX("other", to, from, 0.5f, 1080f, 1f)).isEqualTo(0f)
+    }
+}


### PR DESCRIPTION
A 1px white line showed between the two pages during a multipage paywall slide. The two surfaces were positioned by independent `translationX` expressions, so their shared edge landed at a sub-pixel position and the two graphics layers didn't fully cover it, letting the background show through.

The problem was a calculation that output a float number, so the number wouldn't match between in and out transitions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Compose graphics-layer math for workflow paywall animations only; no purchase, auth, or data-path changes.
> 
> **Overview**
> Fixes a **1px seam** visible between multipage workflow paywall pages during horizontal slide transitions.
> 
> Slide `translationX` is no longer computed independently for incoming and outgoing steps. A new **`workflowSlideTranslationX`** helper rounds the **incoming** surface to whole pixels and sets the **outgoing** offset from that value so both layers share the same edge and sub-pixel gaps do not show the background. **`WorkflowSlideTranslationXTest`** locks in the rounding and derived-offset behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 665784f1e038bc4d5997818375f3810e694e0dce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->